### PR TITLE
Remove hardcoded Windows path from runs page

### DIFF
--- a/frontend/app/runs/RunsClient.tsx
+++ b/frontend/app/runs/RunsClient.tsx
@@ -563,7 +563,7 @@ export default function RunsClient() {
       {tab === "submit" && !run && (
         <div className="space-y-4">
           <p className="text-xs text-[var(--text-muted)]">
-            Run files are located at <code className="bg-[var(--bg-primary)] px-1 py-0.5 rounded">%appdata%/Roaming/SlayTheSpire2/steam/&lt;steamid&gt;/profile#/saves/</code>
+            Submit your run data or browse community-submitted runs.
           </p>
 
           {/* Username */}


### PR DESCRIPTION
## Summary
- Replaced the Windows-only `%appdata%` path in the runs submit tab intro with generic description text
- Multi-platform paths (Windows, macOS, Linux/Steam Deck) already exist in the collapsible "Where are my .run files?" section

## Test plan
- [ ] Verify runs submit tab no longer shows Windows-only path at top
- [ ] Verify "Where are my .run files?" expander still shows all three OS paths