### PR TITLE
Fix CI deploy path to /var/www/spire-codex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,6 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            cd ~/spire-codex
+            cd /var/www/spire-codex
             ./tools/startup.sh --beta
             echo "Stable + beta deployed at $(date)"


### PR DESCRIPTION
## Summary
- Deploy SSH step was using ~/spire-codex which does not exist on the server
- Changed to /var/www/spire-codex (actual server path)
- The cd failure was masked because the final echo succeeded, so the step reported success despite not actually deploying

## Test plan
- [ ] Merge and verify deploy step succeeds with correct path in CI logs