### PR TITLE
Add diagnostics for invalid run file uploads

### DIFF
--- a/frontend/app/runs/RunsClient.tsx
+++ b/frontend/app/runs/RunsClient.tsx
@@ -445,7 +445,42 @@ export default function RunsClient() {
   }, [tab, browseChar, browseWin, browseUser, browsePage]);
 
   function isValidRunFile(data: any): boolean {
-    return data && typeof data === "object" && data.players && data.acts && data.map_point_history && "win" in data && "schema_version" in data;
+    return data && typeof data === "object" && data.players && data.acts && data.map_point_history && "win" in data;
+  }
+
+  function diagnoseRunFile(data: any): string {
+    if (!data || typeof data !== "object") return "not a JSON object";
+    const missing: string[] = [];
+    if (!data.players) missing.push("players");
+    if (!data.acts) missing.push("acts");
+    if (!data.map_point_history) missing.push("map_point_history");
+    if (!("win" in data)) missing.push("win");
+    return missing.length ? `missing fields: ${missing.join(", ")}` : "unknown";
+  }
+
+  async function reportInvalidRuns(failures: { filename: string; reason: string; keys?: string[]; schema?: number; build?: string }[]) {
+    if (failures.length === 0) return;
+    try {
+      const summary = failures.slice(0, 10).map((f) => {
+        let line = `${f.filename}: ${f.reason}`;
+        if (f.keys) line += ` [keys: ${f.keys.join(",")}]`;
+        if (f.schema) line += ` [schema: ${f.schema}]`;
+        if (f.build) line += ` [build: ${f.build}]`;
+        return line;
+      }).join("\n");
+      const body = failures.length > 10
+        ? `${summary}\n... and ${failures.length - 10} more`
+        : summary;
+      await fetch(`${API}/api/feedback`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: "Bug",
+          contact: "auto-report",
+          contents: `Run upload: ${failures.length} invalid out of batch\n\n${body}`,
+        }),
+      }).catch(() => {});
+    } catch {}
   }
 
   async function handleFileUpload(files: FileList) {
@@ -454,6 +489,7 @@ export default function RunsClient() {
     setUploadProgress({ total, done: 0, dupes: 0, errors: 0 });
 
     let done = 0, dupes = 0, errors = 0;
+    const failures: { filename: string; reason: string; keys?: string[]; schema?: number; build?: string }[] = [];
     const submitUrl = username.trim() ? `${API}/api/runs?username=${encodeURIComponent(username.trim())}` : `${API}/api/runs`;
 
     for (const file of Array.from(files)) {
@@ -462,6 +498,13 @@ export default function RunsClient() {
         const data = JSON.parse(text);
         if (!isValidRunFile(data)) {
           errors++;
+          failures.push({
+            filename: file.name,
+            reason: diagnoseRunFile(data),
+            keys: Object.keys(data).slice(0, 15),
+            schema: data?.schema_version,
+            build: data?.build_id,
+          });
         } else {
           const res = await fetch(submitUrl, {
             method: "POST",
@@ -469,13 +512,28 @@ export default function RunsClient() {
             body: text,
           });
           const result = await res.json().catch(() => null);
-          if (result?.duplicate) dupes++;
+          if (result?.duplicate) {
+            dupes++;
+          } else if (!res.ok) {
+            errors++;
+            failures.push({
+              filename: file.name,
+              reason: `backend ${res.status}: ${result?.detail || "unknown"}`,
+              schema: data?.schema_version,
+              build: data?.build_id,
+            });
+          }
         }
-      } catch {
+      } catch (e) {
         errors++;
+        failures.push({ filename: file.name, reason: `exception: ${e instanceof Error ? e.message : "parse/network error"}` });
       }
       done++;
       setUploadProgress({ total, done, dupes, errors });
+    }
+
+    if (failures.length > 0) {
+      reportInvalidRuns(failures);
     }
 
     // If only one file, also show the run detail


### PR DESCRIPTION
## Summary
- When run files fail client-side validation, capture exactly which fields are missing (players, acts, map_point_history, win)
- When the backend rejects a run (400), capture the status + detail (previously silently dropped)
- When parse/network errors occur, capture the exception message
- Auto-report a summary of failures (up to 10 samples with filename, reason, schema_version, build_id) to the feedback Discord webhook
- Includes the schema_version removal from #14 for older beta runs

## Context
A user reported 275 invalid runs — mix of stable and beta. We need visibility into what is actually failing to fix the root cause.

## Test plan
- [ ] Upload a batch of run files including some invalid ones
- [ ] Verify Discord webhook receives the diagnostic report
- [ ] Verify valid runs still submit correctly