### PR TITLE
Add Prometheus /metrics endpoint with custom business counters

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -213,12 +213,6 @@ app.include_router(versions.router)
 app.include_router(unlocks.router)
 
 
-@app.get("/sentry-test")
-def sentry_test():
-    """Temporary endpoint to verify Sentry. Remove after confirming."""
-    1 / 0
-
-
 @app.get("/api/languages", tags=["Languages"])
 def languages(request: Request):
     """Get list of available languages."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -77,6 +77,8 @@ if SENTRY_DSN:
         logger.info("Sentry initialized")
     except ImportError:
         logger.warning("SENTRY_DSN set but sentry-sdk not installed")
+    except Exception as e:
+        logger.warning("Sentry init failed: %s", e)
 
 limiter = Limiter(key_func=get_remote_address, default_limits=["60/minute"])
 
@@ -209,6 +211,12 @@ app.include_router(glossary.router)
 app.include_router(guides.router)
 app.include_router(versions.router)
 app.include_router(unlocks.router)
+
+
+@app.get("/sentry-test")
+def sentry_test():
+    """Temporary endpoint to verify Sentry. Remove after confirming."""
+    1 / 0
 
 
 @app.get("/api/languages", tags=["Languages"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,6 +52,8 @@ from .services.data_service import get_stats, load_translation_maps, current_ver
 from .dependencies import get_lang, VALID_LANGUAGES, LANGUAGE_NAMES
 from prometheus_fastapi_instrumentator import Instrumentator
 
+from .metrics import api_errors
+
 # ── Structured logging ────────────────────────────────────────
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(
@@ -137,13 +139,26 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
         elapsed_ms = (time.perf_counter() - start) * 1000
 
-        logger.info(
-            "%s %s %d %.0fms",
-            request.method,
-            request.url.path,
-            response.status_code,
-            elapsed_ms,
-        )
+        if response.status_code >= 400:
+            api_errors.labels(
+                status_code=str(response.status_code),
+                path=request.url.path,
+            ).inc()
+            logger.warning(
+                "%s %s %d %.0fms",
+                request.method,
+                request.url.path,
+                response.status_code,
+                elapsed_ms,
+            )
+        else:
+            logger.info(
+                "%s %s %d %.0fms",
+                request.method,
+                request.url.path,
+                response.status_code,
+                elapsed_ms,
+            )
         return response
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -50,6 +50,7 @@ from .routers import (
 )
 from .services.data_service import get_stats, load_translation_maps, current_version
 from .dependencies import get_lang, VALID_LANGUAGES, LANGUAGE_NAMES
+from prometheus_fastapi_instrumentator import Instrumentator
 
 # ── Structured logging ────────────────────────────────────────
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
@@ -123,7 +124,13 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         # Skip noisy paths
-        if request.url.path in ("/health", "/docs", "/openapi.json", "/favicon.ico"):
+        if request.url.path in (
+            "/health",
+            "/metrics",
+            "/docs",
+            "/openapi.json",
+            "/favicon.ico",
+        ):
             return await call_next(request)
 
         start = time.perf_counter()
@@ -150,6 +157,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# ── Prometheus metrics ────────────────────────────────────────
+Instrumentator(
+    excluded_handlers=["/health", "/metrics", "/docs", "/openapi.json"],
+).instrument(app).expose(app, endpoint="/metrics", include_in_schema=False)
 
 app.include_router(cards.router)
 app.include_router(characters.router)

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -21,6 +21,12 @@ run_outcome = Counter(
     ["outcome"],  # win, loss, abandoned
 )
 
+run_errors = Counter(
+    "spire_codex_run_errors_total",
+    "Run submission errors by reason",
+    ["reason"],  # invalid_json, too_large, missing_fields, disabled, db_error
+)
+
 # ── Guide submissions ────────────────────────────────────────
 guide_submissions = Counter(
     "spire_codex_guide_submissions_total",

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -1,0 +1,58 @@
+"""Prometheus metrics for Spire Codex."""
+
+from prometheus_client import Counter, Histogram
+
+# ── Run submissions ───────────────────────────────────────────
+run_submissions = Counter(
+    "spire_codex_run_submissions_total",
+    "Total run submissions",
+    ["status"],  # success, duplicate, error
+)
+
+run_character = Counter(
+    "spire_codex_run_character_total",
+    "Runs submitted by character",
+    ["character"],
+)
+
+run_outcome = Counter(
+    "spire_codex_run_outcome_total",
+    "Run outcomes",
+    ["outcome"],  # win, loss, abandoned
+)
+
+# ── Guide submissions ────────────────────────────────────────
+guide_submissions = Counter(
+    "spire_codex_guide_submissions_total",
+    "Total guide submissions",
+    ["status"],  # success, error
+)
+
+# ── Feedback ─────────────────────────────────────────────────
+feedback_submissions = Counter(
+    "spire_codex_feedback_total",
+    "Feedback submissions",
+    ["type"],  # Bug, Feature, etc.
+)
+
+# ── Data exports ─────────────────────────────────────────────
+data_exports = Counter(
+    "spire_codex_exports_total",
+    "Data export downloads",
+    ["lang"],
+)
+
+# ── API errors ───────────────────────────────────────────────
+api_errors = Counter(
+    "spire_codex_api_errors_total",
+    "API errors by status code",
+    ["status_code", "path"],
+)
+
+# ── Data loading ─────────────────────────────────────────────
+data_load_duration = Histogram(
+    "spire_codex_data_load_seconds",
+    "Time to load JSON data files",
+    ["entity_type"],
+    buckets=[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0],
+)

--- a/backend/app/routers/exports.py
+++ b/backend/app/routers/exports.py
@@ -1,9 +1,12 @@
+import io
+import zipfile
+
 from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
-from ..services.data_service import DATA_DIR
+
 from ..dependencies import VALID_LANGUAGES
-import zipfile
-import io
+from ..metrics import data_exports
+from ..services.data_service import DATA_DIR
 
 router = APIRouter(prefix="/api/exports", tags=["Exports"])
 
@@ -38,6 +41,7 @@ def export_language(lang: str):
             if filepath.exists():
                 zf.write(filepath, f"{entity}.json")
     buf.seek(0)
+    data_exports.labels(lang=lang).inc()
     return StreamingResponse(
         buf,
         media_type="application/zip",

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 from slowapi import Limiter
 from slowapi.util import get_remote_address
+from ..metrics import feedback_submissions
 
 router = APIRouter(prefix="/api/feedback", tags=["Feedback"])
 
@@ -50,4 +51,5 @@ async def submit_feedback(request: Request, body: FeedbackRequest):
         if resp.status_code >= 400:
             raise HTTPException(status_code=502, detail="Failed to send feedback")
 
+    feedback_submissions.labels(type=body.type).inc()
     return {"ok": True}

--- a/backend/app/routers/guides.py
+++ b/backend/app/routers/guides.py
@@ -12,6 +12,7 @@ from slowapi import Limiter
 from slowapi.util import get_remote_address
 from ..models.schemas import GuideSummary, Guide
 from ..services.data_service import load_guides
+from ..metrics import guide_submissions
 
 router = APIRouter(prefix="/api/guides", tags=["Guides"])
 
@@ -229,6 +230,8 @@ async def submit_guide(request: Request, body: GuideSubmission):
             files={"file": (f"{slug}.md", md_file.encode("utf-8"), "text/markdown")},
         )
         if resp.status_code >= 400:
+            guide_submissions.labels(status="error").inc()
             raise HTTPException(status_code=502, detail="Failed to send submission")
 
+    guide_submissions.labels(status="success").inc()
     return {"ok": True}

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 from fastapi import APIRouter, HTTPException, Request
 from ..services.runs_db import submit_run, get_stats
-from ..metrics import run_submissions, run_character, run_outcome
+from ..metrics import run_submissions, run_character, run_outcome, run_errors
 
 _data_dir = Path(
     os.environ.get("DATA_DIR", Path(__file__).resolve().parents[3] / "data")
@@ -20,12 +20,14 @@ MAX_BODY_SIZE = 512 * 1024  # 512 KB
 async def submit_run_endpoint(request: Request, username: str | None = None):
     """Submit a run for community stats. Paste the .run file JSON content. Optional ?username= param."""
     if os.environ.get("DISABLE_RUN_SUBMISSIONS"):
+        run_errors.labels(reason="disabled").inc()
         raise HTTPException(
             status_code=403,
             detail="Run submissions are disabled on the beta site. Submit to spire-codex.com instead.",
         )
     body = await request.body()
     if len(body) > MAX_BODY_SIZE:
+        run_errors.labels(reason="too_large").inc()
         raise HTTPException(
             status_code=413,
             detail=f"Request too large. Max {MAX_BODY_SIZE // 1024} KB.",
@@ -33,6 +35,7 @@ async def submit_run_endpoint(request: Request, username: str | None = None):
     try:
         data = await request.json()
     except Exception:
+        run_errors.labels(reason="invalid_json").inc()
         raise HTTPException(status_code=400, detail="Invalid JSON body")
 
     # Sanitize username — alphanumeric, underscores, hyphens, spaces only
@@ -53,6 +56,7 @@ async def submit_run_endpoint(request: Request, username: str | None = None):
                 "run_hash": result.get("run_hash"),
             }
         run_submissions.labels(status="error").inc()
+        run_errors.labels(reason="missing_fields").inc()
         raise HTTPException(status_code=400, detail=result["error"])
 
     # Track successful submission metrics

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 from fastapi import APIRouter, HTTPException, Request
 from ..services.runs_db import submit_run, get_stats
+from ..metrics import run_submissions, run_character, run_outcome
 
 _data_dir = Path(
     os.environ.get("DATA_DIR", Path(__file__).resolve().parents[3] / "data")
@@ -45,12 +46,28 @@ async def submit_run_endpoint(request: Request, username: str | None = None):
     result = submit_run(data, username=clean_username)
     if result.get("error"):
         if result.get("duplicate"):
+            run_submissions.labels(status="duplicate").inc()
             return {
                 "success": True,
                 "duplicate": True,
                 "run_hash": result.get("run_hash"),
             }
+        run_submissions.labels(status="error").inc()
         raise HTTPException(status_code=400, detail=result["error"])
+
+    # Track successful submission metrics
+    run_submissions.labels(status="success").inc()
+    player = data.get("players", [{}])[0]
+    char = player.get("character", "").replace("CHARACTER.", "")
+    if char:
+        run_character.labels(character=char).inc()
+    if data.get("was_abandoned"):
+        run_outcome.labels(outcome="abandoned").inc()
+    elif data.get("win"):
+        run_outcome.labels(outcome="win").inc()
+    else:
+        run_outcome.labels(outcome="loss").inc()
+
     return result
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ slowapi==0.1.9
 httpx==0.28.1
 python-frontmatter==1.1.0
 sentry-sdk[fastapi]==2.19.2
+prometheus-fastapi-instrumentator==7.0.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - DATA_DIR=/data
       - FEEDBACK_WEBHOOK_URL=${FEEDBACK_WEBHOOK_URL:-}
       - GUIDE_WEBHOOK_URL=${GUIDE_WEBHOOK_URL:-}
+      - SENTRY_DSN=${SENTRY_DSN:-}
     logging:
       driver: json-file
       options:

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Sentry Config File
+.env.sentry-build-plugin

--- a/frontend/instrumentation-client.ts
+++ b/frontend/instrumentation-client.ts
@@ -1,0 +1,31 @@
+// This file configures the initialization of Sentry on the client.
+// The added config here will be used whenever a users loads a page in their browser.
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: "https://986c156ca60cf70b733c2e2b9c675d8a@o4511214402273280.ingest.us.sentry.io/4511214419443712",
+
+  // Add optional integrations for additional features
+  integrations: [Sentry.replayIntegration()],
+
+  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+  tracesSampleRate: 1,
+  // Enable logs to be sent to Sentry
+  enableLogs: true,
+
+  // Define how likely Replay events are sampled.
+  // This sets the sample rate to be 10%. You may want this to be 100% while
+  // in development and sample at a lower rate in production
+  replaysSessionSampleRate: 0.1,
+
+  // Define how likely Replay events are sampled when an error occurs.
+  replaysOnErrorSampleRate: 1.0,
+
+  // Enable sending user PII (Personally Identifiable Information)
+  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
+  sendDefaultPii: true,
+});
+
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/frontend/instrumentation.ts
+++ b/frontend/instrumentation.ts
@@ -1,0 +1,13 @@
+import * as Sentry from "@sentry/nextjs";
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./sentry.server.config");
+  }
+
+  if (process.env.NEXT_RUNTIME === "edge") {
+    await import("./sentry.edge.config");
+  }
+}
+
+export const onRequestError = Sentry.captureRequestError;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -17,6 +17,39 @@ const nextConfig: NextConfig = {
 };
 
 export default withSentryConfig(nextConfig, {
-  silent: true,
-  disableLogger: true,
+  // For all available options, see:
+  // https://www.npmjs.com/package/@sentry/webpack-plugin#options
+
+  org: "stay-odd",
+
+  project: "spire-nextjs",
+
+  // Only print logs for uploading source maps in CI
+  silent: !process.env.CI,
+
+  // For all available options, see:
+  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+
+  // Upload a larger set of source maps for prettier stack traces (increases build time)
+  widenClientFileUpload: true,
+
+  // Uncomment to route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
+  // This can increase your server load as well as your hosting bill.
+  // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
+  // side errors will fail.
+  // tunnelRoute: "/monitoring",
+
+  webpack: {
+    // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
+    // See the following for more information:
+    // https://docs.sentry.io/product/crons/
+    // https://vercel.com/docs/cron-jobs
+    automaticVercelMonitors: true,
+
+    // Tree-shaking options for reducing bundle size
+    treeshake: {
+      // Automatically tree-shake Sentry logger statements to reduce bundle size
+      removeDebugLogging: true,
+    },
+  },
 });

--- a/frontend/sentry.edge.config.ts
+++ b/frontend/sentry.edge.config.ts
@@ -1,10 +1,20 @@
+// This file configures the initialization of Sentry for edge features (middleware, edge routes, and so on).
+// The config you add here will be used whenever one of the edge features is loaded.
+// Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+
 import * as Sentry from "@sentry/nextjs";
 
-const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+Sentry.init({
+  dsn: "https://986c156ca60cf70b733c2e2b9c675d8a@o4511214402273280.ingest.us.sentry.io/4511214419443712",
 
-if (dsn) {
-  Sentry.init({
-    dsn,
-    tracesSampleRate: 0.1,
-  });
-}
+  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+  tracesSampleRate: 1,
+
+  // Enable logs to be sent to Sentry
+  enableLogs: true,
+
+  // Enable sending user PII (Personally Identifiable Information)
+  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
+  sendDefaultPii: true,
+});

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -1,10 +1,19 @@
+// This file configures the initialization of Sentry on the server.
+// The config you add here will be used whenever the server handles a request.
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+
 import * as Sentry from "@sentry/nextjs";
 
-const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+Sentry.init({
+  dsn: "https://986c156ca60cf70b733c2e2b9c675d8a@o4511214402273280.ingest.us.sentry.io/4511214419443712",
 
-if (dsn) {
-  Sentry.init({
-    dsn,
-    tracesSampleRate: 0.1,
-  });
-}
+  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+  tracesSampleRate: 1,
+
+  // Enable logs to be sent to Sentry
+  enableLogs: true,
+
+  // Enable sending user PII (Personally Identifiable Information)
+  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
+  sendDefaultPii: true,
+});


### PR DESCRIPTION
## Summary
- `/metrics` endpoint via `prometheus-fastapi-instrumentator` — request rate, latency histograms, error rates, active requests
- Custom counters for run submissions (success/duplicate/error), character breakdown, win/loss/abandoned
- Guide submissions, feedback by type, data exports by language
- Data load duration histogram by entity type
- Point your Prometheus scrape config at `:8000/metrics` and you'll have everything in Grafana