### PR TITLE
Fix ruff format for WebP parser changes

### DIFF
--- a/backend/app/parsers/card_parser.py
+++ b/backend/app/parsers/card_parser.py
@@ -395,7 +395,11 @@ def parse_single_card(
                 v_entry["block"] = block
             # Variant-specific image
             variant_base = f"{card_id.lower()}_{vtype.lower()}"
-            variant_img = f"{variant_base}.webp" if (STATIC_IMAGES / f"{variant_base}.webp").exists() else f"{variant_base}.png"
+            variant_img = (
+                f"{variant_base}.webp"
+                if (STATIC_IMAGES / f"{variant_base}.webp").exists()
+                else f"{variant_base}.png"
+            )
             if (STATIC_IMAGES / variant_img).exists():
                 v_entry["image_url"] = f"/static/images/cards/{variant_img}"
             # Rider sub-variants

--- a/backend/app/parsers/potion_parser.py
+++ b/backend/app/parsers/potion_parser.py
@@ -55,9 +55,7 @@ def parse_single_potion(filepath: Path, localization: dict) -> dict | None:
     if not image_file.exists():
         image_file = STATIC_IMAGES / f"{potion_base}.png"
     image_url = (
-        f"/static/images/potions/{image_file.name}"
-        if image_file.exists()
-        else None
+        f"/static/images/potions/{image_file.name}" if image_file.exists() else None
     )
 
     return {

--- a/backend/app/parsers/relic_parser.py
+++ b/backend/app/parsers/relic_parser.py
@@ -167,9 +167,7 @@ def parse_single_relic(
         if not variant_file.exists():
             variant_file = STATIC_IMAGES / f"{relic_base}_{suffix}.png"
         if variant_file.exists():
-            image_variants[char_name] = (
-                f"/static/images/relics/{variant_file.name}"
-            )
+            image_variants[char_name] = f"/static/images/relics/{variant_file.name}"
 
     return {
         "id": relic_id,


### PR DESCRIPTION
## Summary
- Fixes ruff formatting in `card_parser.py`, `potion_parser.py`, and `relic_parser.py` after the WebP migration

## Test plan
- CI ruff format check should pass