### PR TITLE
Parallelize CI — split stable and beta build+deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,9 @@ jobs:
       - name: Ruff format check
         run: ruff format --check app/
 
-  # ── Build & Push (main only) ───────────────────────────
-  build-and-push:
-    name: Build & push Docker images
+  # ── Build & Push stable (main only) ─────────────────────
+  build-stable:
+    name: Build & push stable images
     runs-on: self-hosted
     needs: [secrets-check, frontend-lint, backend-lint]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -86,7 +86,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Stable images
       - name: Build & push backend (stable)
         uses: docker/build-push-action@v6
         with:
@@ -109,7 +108,24 @@ jobs:
             ptrlrd/spire-codex-frontend:latest
             ptrlrd/spire-codex-frontend:${{ github.sha }}
 
-      # Beta images (same code, different SITE_URL)
+  # ── Build & Push beta (main only) ──────────────────────
+  build-beta:
+    name: Build & push beta images
+    runs-on: self-hosted
+    needs: [secrets-check, frontend-lint, backend-lint]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build & push backend (beta)
         uses: docker/build-push-action@v6
         with:
@@ -132,14 +148,14 @@ jobs:
             ptrlrd/spire-codex-frontend:beta
             ptrlrd/spire-codex-frontend:beta-${{ github.sha }}
 
-  # ── Deploy stable + beta ────────────────────────────────
-  deploy:
-    name: Deploy stable + beta
+  # ── Deploy stable ───────────────────────────────────────
+  deploy-stable:
+    name: Deploy stable
     runs-on: self-hosted
-    needs: [build-and-push]
+    needs: [build-stable]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - name: Deploy via SSH
+      - name: Deploy stable via SSH
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.SSH_HOST }}
@@ -147,5 +163,28 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             cd /var/www/spire-codex
-            ./tools/startup.sh --beta
-            echo "Stable + beta deployed at $(date)"
+            git pull
+            docker compose -f docker-compose.prod.yml pull
+            docker compose -f docker-compose.prod.yml down
+            docker compose -f docker-compose.prod.yml up -d
+            echo "Stable deployed at $(date)"
+
+  # ── Deploy beta ─────────────────────────────────────────
+  deploy-beta:
+    name: Deploy beta
+    runs-on: self-hosted
+    needs: [build-beta]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Deploy beta via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd /var/www/spire-codex
+            docker compose -f docker-compose.beta.yml pull
+            docker compose -f docker-compose.beta.yml down
+            docker compose -f docker-compose.beta.yml up -d
+            echo "Beta deployed at $(date)"


### PR DESCRIPTION
## Summary
- Split `build-and-push` into `build-stable` and `build-beta` running in parallel
- Split `deploy` into `deploy-stable` and `deploy-beta`, each triggered by its own build
- Whichever build finishes first deploys first — no more waiting for both

## Pipeline
```
secrets-check ─┐
frontend-lint ─┼─→ build-stable ─→ deploy-stable
backend-lint  ─┤
               └─→ build-beta   ─→ deploy-beta
```

## Test plan
- [ ] CI workflow passes lint checks on PR
- [ ] On merge: both build jobs start in parallel
- [ ] Each deploy fires independently when its build completes