### PR TITLE
Fix inverseDiff() not resolving in card descriptions

### DIFF
--- a/backend/app/parsers/description_resolver.py
+++ b/backend/app/parsers/description_resolver.py
@@ -230,7 +230,7 @@ def resolve_description(
         while True:
             # Match {Word: or {Word. pattern (conditional with nested braces)
             m = re.search(
-                r"\{(\w[\w.]*?)(?::(?!choose\(|cond:|diff\(\)|energyIcons|starIcons|plural:|show:|percentMore\(\)|percentLess\(\)))",
+                r"\{(\w[\w.]*?)(?::(?!choose\(|cond:|diff\(\)|inverseDiff\(\)|energyIcons|starIcons|plural:|show:|percentMore\(\)|percentLess\(\)))",
                 text,
             )
             if not m:
@@ -283,12 +283,13 @@ def resolve_description(
 
     text = re.sub(r"\{(\w+):percentLess\(\)\}", resolve_percent_less, text)
 
-    # Handle {Var:diff()} -> value
+    # Handle {Var:diff()} and {Var:inverseDiff()} -> value
+    # Both formatters just output the value; the difference is only UI highlight direction in-game
     def resolve_diff(m):
         val = _lookup(m.group(1), vars_dict)
         return str(val) if val is not None else "X"
 
-    text = re.sub(r"\{(\w+):diff\(\)\}", resolve_diff, text)
+    text = re.sub(r"\{(\w+):(?:diff|inverseDiff)\(\)\}", resolve_diff, text)
 
     # Strip trailing standalone "???" lines (unresolved rider enchantment slots)
     text = re.sub(r"\n\?\?\?$", "", text.strip())

--- a/data/deu/cards.json
+++ b/data/deu/cards.json
@@ -6672,7 +6672,7 @@
   {
     "id": "FRIENDSHIP",
     "name": "Freundschaft",
-    "description": "Verliere inverseDiff() [gold]Stärke[/gold].\nErhalte zu Beginn jedes Zuges [energy:1].",
+    "description": "Verliere 2 [gold]Stärke[/gold].\nErhalte zu Beginn jedes Zuges [energy:1].",
     "description_raw": "Verliere {StrengthPower:inverseDiff()} [gold]Stärke[/gold].\nErhalte zu Beginn jedes Zuges {Energy:energyIcons()}.",
     "cost": 1,
     "is_x_cost": null,
@@ -6709,7 +6709,7 @@
     "image_url": "/static/images/cards/friendship.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Verliere 1 [gold]Stärke[/gold].\nErhalte zu Beginn jedes Zuges [energy:1].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 297
@@ -14125,7 +14125,7 @@
   {
     "id": "PRECISE_CUT",
     "name": "Präziser Schnitt",
-    "description": "Füge 13 Schaden zu.\nFügt inverseDiff() weniger Schaden zu für jede weitere [gold]Handkarte[/gold].",
+    "description": "Füge 13 Schaden zu.\nFügt 2 weniger Schaden zu für jede weitere [gold]Handkarte[/gold].",
     "description_raw": "Füge {CalculatedDamage:diff()} Schaden zu.\nFügt {ExtraDamage:inverseDiff()} weniger Schaden zu für jede weitere [gold]Handkarte[/gold].",
     "cost": 0,
     "is_x_cost": null,

--- a/data/eng/cards.json
+++ b/data/eng/cards.json
@@ -8954,7 +8954,7 @@
   {
     "id": "FRIENDSHIP",
     "name": "Friendship",
-    "description": "Lose inverseDiff() [gold]Strength[/gold].\nGain [energy:1] at the start of each turn.",
+    "description": "Lose 2 [gold]Strength[/gold].\nGain [energy:1] at the start of each turn.",
     "description_raw": "Lose {StrengthPower:inverseDiff()} [gold]Strength[/gold].\nGain {Energy:energyIcons()} at the start of each turn.",
     "cost": 1,
     "is_x_cost": null,
@@ -8991,7 +8991,7 @@
     "image_url": "/static/images/cards/friendship.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Lose 1 [gold]Strength[/gold].\nGain [energy:1] at the start of each turn.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 304
@@ -15532,7 +15532,7 @@
   {
     "id": "PRECISE_CUT",
     "name": "Precise Cut",
-    "description": "Deal 13 damage.\nDeals inverseDiff() less damage for each other card in your [gold]Hand[/gold].",
+    "description": "Deal 13 damage.\nDeals 2 less damage for each other card in your [gold]Hand[/gold].",
     "description_raw": "Deal {CalculatedDamage:diff()} damage.\nDeals {ExtraDamage:inverseDiff()} less damage for each other card in your [gold]Hand[/gold].",
     "cost": 0,
     "is_x_cost": null,

--- a/data/esp/cards.json
+++ b/data/esp/cards.json
@@ -1039,7 +1039,7 @@
   {
     "id": "FRIENDSHIP",
     "name": "Amistad",
-    "description": "Pierdes inverseDiff() de [gold]fuerza[/gold].\nObtienes [energy:1] al inicio de cada turno.",
+    "description": "Pierdes 2 de [gold]fuerza[/gold].\nObtienes [energy:1] al inicio de cada turno.",
     "description_raw": "Pierdes {StrengthPower:inverseDiff()} de [gold]fuerza[/gold].\nObtienes {Energy:energyIcons()} al inicio de cada turno.",
     "cost": 1,
     "is_x_cost": null,
@@ -1076,7 +1076,7 @@
     "image_url": "/static/images/cards/friendship.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Pierdes 1 de [gold]fuerza[/gold].\nObtienes [energy:1] al inicio de cada turno.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 297
@@ -5039,7 +5039,7 @@
   {
     "id": "PRECISE_CUT",
     "name": "Corte preciso",
-    "description": "Infliges 13 de daño.\nInfliges inverseDiff() menos de daño por cada carta en tu [gold]mano[/gold].",
+    "description": "Infliges 13 de daño.\nInfliges 2 menos de daño por cada carta en tu [gold]mano[/gold].",
     "description_raw": "Infliges {CalculatedDamage:diff()} de daño.\nInfliges {ExtraDamage:inverseDiff()} menos de daño por cada carta en tu [gold]mano[/gold].",
     "cost": 0,
     "is_x_cost": null,

--- a/data/fra/cards.json
+++ b/data/fra/cards.json
@@ -629,7 +629,7 @@
   {
     "id": "FRIENDSHIP",
     "name": "Amitié",
-    "description": "Perdez inverseDiff() de [gold]Force[/gold].\nGagnez [energy:1] au début de chaque tour.",
+    "description": "Perdez 2 de [gold]Force[/gold].\nGagnez [energy:1] au début de chaque tour.",
     "description_raw": "Perdez {StrengthPower:inverseDiff()} de [gold]Force[/gold].\nGagnez {Energy:energyIcons()} au début de chaque tour.",
     "cost": 1,
     "is_x_cost": null,
@@ -666,7 +666,7 @@
     "image_url": "/static/images/cards/friendship.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Perdez 1 de [gold]Force[/gold].\nGagnez [energy:1] au début de chaque tour.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 316
@@ -7218,7 +7218,7 @@
   {
     "id": "PRECISE_CUT",
     "name": "Entaille",
-    "description": "Infligez 13 dégâts.\nInflige inverseDiff() dégâts en moins pour chaque autre carte dans votre [gold]Main[/gold].",
+    "description": "Infligez 13 dégâts.\nInflige 2 dégâts en moins pour chaque autre carte dans votre [gold]Main[/gold].",
     "description_raw": "Infligez {CalculatedDamage:diff()} dégâts.\nInflige {ExtraDamage:inverseDiff()} dégâts en moins pour chaque autre carte dans votre [gold]Main[/gold].",
     "cost": 0,
     "is_x_cost": null,

--- a/data/ita/cards.json
+++ b/data/ita/cards.json
@@ -735,7 +735,7 @@
   {
     "id": "FRIENDSHIP",
     "name": "Amicizia",
-    "description": "Perdi inverseDiff() di [gold]Forza[/gold].\nOttieni [energy:1] all'inizio di ogni turno.",
+    "description": "Perdi 2 di [gold]Forza[/gold].\nOttieni [energy:1] all'inizio di ogni turno.",
     "description_raw": "Perdi {StrengthPower:inverseDiff()} di [gold]Forza[/gold].\nOttieni {Energy:energyIcons()} all'inizio di ogni turno.",
     "cost": 1,
     "is_x_cost": null,
@@ -772,7 +772,7 @@
     "image_url": "/static/images/cards/friendship.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Perdi 1 di [gold]Forza[/gold].\nOttieni [energy:1] all'inizio di ogni turno.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 297
@@ -21314,7 +21314,7 @@
   {
     "id": "PRECISE_CUT",
     "name": "Taglio Preciso",
-    "description": "Infliggi 13 di danno.\nInfligge inverseDiff() di danno in meno per ogni altra carta nella tua [gold]mano[/gold].",
+    "description": "Infliggi 13 di danno.\nInfligge 2 di danno in meno per ogni altra carta nella tua [gold]mano[/gold].",
     "description_raw": "Infliggi {CalculatedDamage:diff()} di danno.\nInfligge {ExtraDamage:inverseDiff()} di danno in meno per ogni altra carta nella tua [gold]mano[/gold].",
     "cost": 0,
     "is_x_cost": null,

--- a/data/jpn/cards.json
+++ b/data/jpn/cards.json
@@ -5890,7 +5890,7 @@
   {
     "id": "FRIENDSHIP",
     "name": "フレンドシップ",
-    "description": "[gold]筋力[/gold]inverseDiff()を失う。\nターン開始時、[energy:1]を得る。",
+    "description": "[gold]筋力[/gold]2を失う。\nターン開始時、[energy:1]を得る。",
     "description_raw": "[gold]筋力[/gold]{StrengthPower:inverseDiff()}を失う。\nターン開始時、{Energy:energyIcons()}を得る。",
     "cost": 1,
     "is_x_cost": null,
@@ -5927,7 +5927,7 @@
     "image_url": "/static/images/cards/friendship.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "[gold]筋力[/gold]1を失う。\nターン開始時、[energy:1]を得る。",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 297
@@ -17860,7 +17860,7 @@
   {
     "id": "PRECISE_CUT",
     "name": "研ぎ澄まされた刃",
-    "description": "13ダメージを与える。\n[gold]手札[/gold]にある他のカード1枚につき、ダメージがinverseDiff()減少する。",
+    "description": "13ダメージを与える。\n[gold]手札[/gold]にある他のカード1枚につき、ダメージが2減少する。",
     "description_raw": "{CalculatedDamage:diff()}ダメージを与える。\n[gold]手札[/gold]にある他のカード1枚につき、ダメージが{ExtraDamage:inverseDiff()}減少する。",
     "cost": 0,
     "is_x_cost": null,

--- a/data/kor/cards.json
+++ b/data/kor/cards.json
@@ -14441,7 +14441,7 @@
   {
     "id": "FRIENDSHIP",
     "name": "우정",
-    "description": "[gold]힘[/gold]을 inverseDiff() 잃습니다.\n매 턴 시작 시 [energy:1]를 얻습니다.",
+    "description": "[gold]힘[/gold]을 2 잃습니다.\n매 턴 시작 시 [energy:1]를 얻습니다.",
     "description_raw": "[gold]힘[/gold]을 {StrengthPower:inverseDiff()} 잃습니다.\n매 턴 시작 시 {Energy:energyIcons()}를 얻습니다.",
     "cost": 1,
     "is_x_cost": null,
@@ -14478,7 +14478,7 @@
     "image_url": "/static/images/cards/friendship.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "[gold]힘[/gold]을 1 잃습니다.\n매 턴 시작 시 [energy:1]를 얻습니다.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 297
@@ -16901,7 +16901,7 @@
   {
     "id": "PRECISE_CUT",
     "name": "정밀한 베기",
-    "description": "피해를 13 줍니다.\n[gold]손[/gold]에 있는 다른 카드 1장당 피해량이 inverseDiff() 감소합니다.",
+    "description": "피해를 13 줍니다.\n[gold]손[/gold]에 있는 다른 카드 1장당 피해량이 2 감소합니다.",
     "description_raw": "피해를 {CalculatedDamage:diff()} 줍니다.\n[gold]손[/gold]에 있는 다른 카드 1장당 피해량이 {ExtraDamage:inverseDiff()} 감소합니다.",
     "cost": 0,
     "is_x_cost": null,

--- a/data/pol/cards.json
+++ b/data/pol/cards.json
@@ -12519,7 +12519,7 @@
   {
     "id": "PRECISE_CUT",
     "name": "Precyzyjne cięcie",
-    "description": "Zadaj 13 pkt. obrażeń.\nZadaje inverseDiff() pkt. obrażeń mniej za każdą kartę w [gold]ręce[/gold].",
+    "description": "Zadaj 13 pkt. obrażeń.\nZadaje 2 pkt. obrażeń mniej za każdą kartę w [gold]ręce[/gold].",
     "description_raw": "Zadaj {CalculatedDamage:diff()} pkt. obrażeń.\nZadaje {ExtraDamage:inverseDiff()} pkt. obrażeń mniej za każdą kartę w [gold]ręce[/gold].",
     "cost": 0,
     "is_x_cost": null,
@@ -13579,7 +13579,7 @@
   {
     "id": "FRIENDSHIP",
     "name": "Przyjaźń",
-    "description": "Utrać inverseDiff() pkt. [gold]Siły[/gold].\nZyskaj [energy:1] na początku każdej tury.",
+    "description": "Utrać 2 pkt. [gold]Siły[/gold].\nZyskaj [energy:1] na początku każdej tury.",
     "description_raw": "Utrać {StrengthPower:inverseDiff()} pkt. [gold]Siły[/gold].\nZyskaj {Energy:energyIcons()} na początku każdej tury.",
     "cost": 1,
     "is_x_cost": null,
@@ -13616,7 +13616,7 @@
     "image_url": "/static/images/cards/friendship.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Utrać 1 pkt. [gold]Siły[/gold].\nZyskaj [energy:1] na początku każdej tury.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 297

--- a/data/ptb/cards.json
+++ b/data/ptb/cards.json
@@ -937,7 +937,7 @@
   {
     "id": "FRIENDSHIP",
     "name": "Amizade",
-    "description": "Perca inverseDiff() de [gold]Força[/gold].\nReceba [energy:1] no início de cada turno.",
+    "description": "Perca 2 de [gold]Força[/gold].\nReceba [energy:1] no início de cada turno.",
     "description_raw": "Perca {StrengthPower:inverseDiff()} de [gold]Força[/gold].\nReceba {Energy:energyIcons()} no início de cada turno.",
     "cost": 1,
     "is_x_cost": null,
@@ -974,7 +974,7 @@
     "image_url": "/static/images/cards/friendship.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Perca 1 de [gold]Força[/gold].\nReceba [energy:1] no início de cada turno.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 297
@@ -4754,7 +4754,7 @@
   {
     "id": "PRECISE_CUT",
     "name": "Corte Preciso",
-    "description": "Cause 13 de dano.\nCausa inverseDiff() a menos de dano por cada outra carta na sua [gold]Mão[/gold].",
+    "description": "Cause 13 de dano.\nCausa 2 a menos de dano por cada outra carta na sua [gold]Mão[/gold].",
     "description_raw": "Cause {CalculatedDamage:diff()} de dano.\nCausa {ExtraDamage:inverseDiff()} a menos de dano por cada outra carta na sua [gold]Mão[/gold].",
     "cost": 0,
     "is_x_cost": null,

--- a/data/rus/cards.json
+++ b/data/rus/cards.json
@@ -2414,7 +2414,7 @@
   {
     "id": "FRIENDSHIP",
     "name": "Вечная дружба",
-    "description": "Вы теряете inverseDiff() [gold]силы[/gold].\nДает [energy:1] в начале хода.",
+    "description": "Вы теряете 2 [gold]силы[/gold].\nДает [energy:1] в начале хода.",
     "description_raw": "Вы теряете {StrengthPower:inverseDiff()} [gold]силы[/gold].\nДает {Energy:energyIcons()} в начале хода.",
     "cost": 1,
     "is_x_cost": null,
@@ -2451,7 +2451,7 @@
     "image_url": "/static/images/cards/friendship.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Вы теряете 1 [gold]силы[/gold].\nДает [energy:1] в начале хода.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 297
@@ -18219,7 +18219,7 @@
   {
     "id": "PRECISE_CUT",
     "name": "Скальпель",
-    "description": "Наносит 13 урона.\nНаносит на inverseDiff() урона меньше за каждую карту в [gold]руке[/gold], кроме себя.",
+    "description": "Наносит 13 урона.\nНаносит на 2 урона меньше за каждую карту в [gold]руке[/gold], кроме себя.",
     "description_raw": "Наносит {CalculatedDamage:diff()} урона.\nНаносит на {ExtraDamage:inverseDiff()} урона меньше за каждую карту в [gold]руке[/gold], кроме себя.",
     "cost": 0,
     "is_x_cost": null,

--- a/data/spa/cards.json
+++ b/data/spa/cards.json
@@ -1154,7 +1154,7 @@
   {
     "id": "FRIENDSHIP",
     "name": "Amistad",
-    "description": "Pierde inverseDiff() de [gold]Fuerza[/gold].\nGana [energy:1] al comienzo de cada turno.",
+    "description": "Pierde 2 de [gold]Fuerza[/gold].\nGana [energy:1] al comienzo de cada turno.",
     "description_raw": "Pierde {StrengthPower:inverseDiff()} de [gold]Fuerza[/gold].\nGana {Energy:energyIcons()} al comienzo de cada turno.",
     "cost": 1,
     "is_x_cost": null,
@@ -1191,7 +1191,7 @@
     "image_url": "/static/images/cards/friendship.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Pierde 1 de [gold]Fuerza[/gold].\nGana [energy:1] al comienzo de cada turno.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 297
@@ -5140,7 +5140,7 @@
   {
     "id": "PRECISE_CUT",
     "name": "Corte preciso",
-    "description": "Inflige 13 de daño.\nInflige inverseDiff() de daño menos por cada otra carta en tu [gold]Mano[/gold].",
+    "description": "Inflige 13 de daño.\nInflige 2 de daño menos por cada otra carta en tu [gold]Mano[/gold].",
     "description_raw": "Inflige {CalculatedDamage:diff()} de daño.\nInflige {ExtraDamage:inverseDiff()} de daño menos por cada otra carta en tu [gold]Mano[/gold].",
     "cost": 0,
     "is_x_cost": null,

--- a/data/tha/cards.json
+++ b/data/tha/cards.json
@@ -6731,7 +6731,7 @@
   {
     "id": "PRECISE_CUT",
     "name": "PreciseCut",
-    "description": "สร้างความเสียหาย 13\nสร้างความเสียหายน้อยลง inverseDiff() ตามจำนวนการ์ดอื่นใน[gold]มือ[/gold]",
+    "description": "สร้างความเสียหาย 13\nสร้างความเสียหายน้อยลง 2 ตามจำนวนการ์ดอื่นใน[gold]มือ[/gold]",
     "description_raw": "สร้างความเสียหาย {CalculatedDamage:diff()}\nสร้างความเสียหายน้อยลง {ExtraDamage:inverseDiff()} ตามจำนวนการ์ดอื่นใน[gold]มือ[/gold]",
     "cost": 0,
     "is_x_cost": null,
@@ -18148,7 +18148,7 @@
   {
     "id": "FRIENDSHIP",
     "name": "มิตรภาพ",
-    "description": "เสีย inverseDiff() [gold]ความแข็งแรง[/gold]\nได้รับ [energy:1] ตอนเริ่มต้นเทิร์น",
+    "description": "เสีย 2 [gold]ความแข็งแรง[/gold]\nได้รับ [energy:1] ตอนเริ่มต้นเทิร์น",
     "description_raw": "เสีย {StrengthPower:inverseDiff()} [gold]ความแข็งแรง[/gold]\nได้รับ {Energy:energyIcons()} ตอนเริ่มต้นเทิร์น",
     "cost": 1,
     "is_x_cost": null,
@@ -18185,7 +18185,7 @@
     "image_url": "/static/images/cards/friendship.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "เสีย 1 [gold]ความแข็งแรง[/gold]\nได้รับ [energy:1] ตอนเริ่มต้นเทิร์น",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 297

--- a/data/tur/cards.json
+++ b/data/tur/cards.json
@@ -673,7 +673,7 @@
   {
     "id": "FRIENDSHIP",
     "name": "Arkadaşlık",
-    "description": "inverseDiff() [gold]Kuvvet[/gold] kaybet.\nHer turun başında [energy:1] elde et.",
+    "description": "2 [gold]Kuvvet[/gold] kaybet.\nHer turun başında [energy:1] elde et.",
     "description_raw": "{StrengthPower:inverseDiff()} [gold]Kuvvet[/gold] kaybet.\nHer turun başında {Energy:energyIcons()} elde et.",
     "cost": 1,
     "is_x_cost": null,
@@ -710,7 +710,7 @@
     "image_url": "/static/images/cards/friendship.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "1 [gold]Kuvvet[/gold] kaybet.\nHer turun başında [energy:1] elde et.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 297
@@ -7090,7 +7090,7 @@
   {
     "id": "PRECISE_CUT",
     "name": "Hassas Kesim",
-    "description": "13 hasar ver.\n[gold]El[/gold]'indeki diğer her kart için inverseDiff() daha az hasar verir.",
+    "description": "13 hasar ver.\n[gold]El[/gold]'indeki diğer her kart için 2 daha az hasar verir.",
     "description_raw": "{CalculatedDamage:diff()} hasar ver.\n[gold]El[/gold]'indeki diğer her kart için {ExtraDamage:inverseDiff()} daha az hasar verir.",
     "cost": 0,
     "is_x_cost": null,

--- a/data/zhs/cards.json
+++ b/data/zhs/cards.json
@@ -3712,7 +3712,7 @@
   {
     "id": "FRIENDSHIP",
     "name": "友谊",
-    "description": "失去inverseDiff()点[gold]力量[/gold]。\n在每个回合开始时获得[energy:1]。",
+    "description": "失去2点[gold]力量[/gold]。\n在每个回合开始时获得[energy:1]。",
     "description_raw": "失去{StrengthPower:inverseDiff()}点[gold]力量[/gold]。\n在每个回合开始时获得{Energy:energyIcons()}。",
     "cost": 1,
     "is_x_cost": null,
@@ -3749,7 +3749,7 @@
     "image_url": "/static/images/cards/friendship.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "失去1点[gold]力量[/gold]。\n在每个回合开始时获得[energy:1]。",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 297
@@ -17256,7 +17256,7 @@
   {
     "id": "PRECISE_CUT",
     "name": "精确切击",
-    "description": "造成13点伤害。\n你的[gold]手牌[/gold]中每有一张牌，此牌的伤害就降低inverseDiff()点。",
+    "description": "造成13点伤害。\n你的[gold]手牌[/gold]中每有一张牌，此牌的伤害就降低2点。",
     "description_raw": "造成{CalculatedDamage:diff()}点伤害。\n你的[gold]手牌[/gold]中每有一张牌，此牌的伤害就降低{ExtraDamage:inverseDiff()}点。",
     "cost": 0,
     "is_x_cost": null,


### PR DESCRIPTION
## Summary
- `inverseDiff()` SmartFormat formatter wasn't being resolved — showed as literal text
- Root cause: the nested conditional resolver's negative lookahead excluded `diff()` but not `inverseDiff()`, so `{Var:inverseDiff()}` was consumed as a conditional instead of reaching the diff handler
- Added `inverseDiff()` to the lookahead exclusion list
- Affects 2 cards: **Precise Cut** ("Deals 2 less damage...") and **Friendship** ("Lose 2 Strength")

## Test plan
- [ ] Precise Cut description shows "Deals 2 less damage" not "inverseDiff()"
- [ ] Friendship description shows "Lose 2 Strength" not "inverseDiff()"