### PR TITLE
Filter non-actionable noise from Sentry

### DIFF
--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -8,5 +8,17 @@ if (dsn) {
     tracesSampleRate: 0.1,
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 0,
+    // Filter non-actionable noise:
+    // - Aborted fetches from bots/crawlers or users navigating away mid-request
+    // - Errors thrown by browser extensions (wallet proxies, etc.) — not our code
+    ignoreErrors: [
+      "TypeError: Failed to fetch",
+      "TypeError: NetworkError when attempting to fetch resource.",
+      "TypeError: Load failed",
+      // Browser extension proxy conflicts (TronLink, MetaMask, etc.)
+      /trap returned falsish for property/,
+    ],
+    // Drop errors with stacktraces that point only to extension-injected code
+    denyUrls: [/\/injected\/injected\.js/],
   });
 }


### PR DESCRIPTION
## Summary
Drops two categories of errors from Sentry that aren't actionable:

1. **Aborted fetches** (`TypeError: Failed to fetch` and browser variants) — typically bots/crawlers or users navigating away mid-request
2. **Browser extension proxy conflicts** — TronLink, MetaMask, etc. injecting code via `/injected/injected.js` that conflicts with other extensions on `window`

## Closes
- Fixes SPIRE-NEXTJS-9 (Failed to fetch — bot from AWS Boardman)
- Fixes SPIRE-NEXTJS-D (TronLink proxy trap conflict)
- Fixes SPIRE-NEXTJS-E (Failed to fetch — user navigated away on /deu/powers page)
