### PR TITLE
SSR all entity detail pages — eliminate client-side loading state

### DIFF
--- a/frontend/app/[lang]/achievements/[id]/page.tsx
+++ b/frontend/app/[lang]/achievements/[id]/page.tsx
@@ -41,10 +41,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let data = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/achievements/${id}?lang=${lang}`);
     if (res.ok) {
-      const data = await res.json();
+      data = await res.json();
       const desc = stripTags(data.description || "");
       const name = data.name || id;
       const detailJsonLd = buildDetailPageJsonLd({
@@ -58,7 +59,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <AchievementDetail />
+      <AchievementDetail initialAchievement={data} />
     </>
   );
 }

--- a/frontend/app/[lang]/acts/[id]/page.tsx
+++ b/frontend/app/[lang]/acts/[id]/page.tsx
@@ -39,10 +39,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let act = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/acts/${id}?lang=${lang}`);
     if (res.ok) {
-      const act = await res.json();
+      act = await res.json();
       jsonLd = buildDetailPageJsonLd({
         name: act.name,
         description: `${act.name} act with ${act.encounters.length} encounters and ${act.bosses.length} bosses.`,
@@ -59,7 +60,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <ActDetail />
+      <ActDetail initialAct={act} />
     </>
   );
 }

--- a/frontend/app/[lang]/afflictions/[id]/page.tsx
+++ b/frontend/app/[lang]/afflictions/[id]/page.tsx
@@ -41,10 +41,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let data = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/afflictions/${id}?lang=${lang}`);
     if (res.ok) {
-      const data = await res.json();
+      data = await res.json();
       const desc = stripTags(data.description || "");
       const name = data.name || id;
       const detailJsonLd = buildDetailPageJsonLd({
@@ -58,7 +59,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <AfflictionDetail />
+      <AfflictionDetail initialAffliction={data} />
     </>
   );
 }

--- a/frontend/app/[lang]/ascensions/[id]/page.tsx
+++ b/frontend/app/[lang]/ascensions/[id]/page.tsx
@@ -39,10 +39,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let asc = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/ascensions/${id}?lang=${lang}`);
     if (res.ok) {
-      const asc = await res.json();
+      asc = await res.json();
       const desc = stripTags(asc.description);
       const langCode = lang as LangCode;
       const gameName = LANG_GAME_NAME[langCode];
@@ -66,7 +67,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <AscensionDetail />
+      <AscensionDetail initialAscension={asc} />
     </>
   );
 }

--- a/frontend/app/[lang]/cards/[id]/page.tsx
+++ b/frontend/app/[lang]/cards/[id]/page.tsx
@@ -44,12 +44,12 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let card = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/cards/${id}?lang=${lang}`);
     if (res.ok) {
-      const card = await res.json();
+      card = await res.json();
       const desc = stripTags(card.description || "");
-      const langCode = lang as LangCode;
       const detailJsonLd = buildDetailPageJsonLd({
         name: card.name, description: desc || card.name, path: `/${lang}/cards/${id}`,
         imageUrl: card.image_url ? `${API_PUBLIC}${card.image_url}` : undefined, category: "Card",
@@ -61,7 +61,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <CardDetail />
+      <CardDetail initialCard={card} />
     </>
   );
 }

--- a/frontend/app/[lang]/characters/[id]/page.tsx
+++ b/frontend/app/[lang]/characters/[id]/page.tsx
@@ -42,10 +42,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let data = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/characters/${id}?lang=${lang}`);
     if (res.ok) {
-      const data = await res.json();
+      data = await res.json();
       const desc = stripTags(data.description || "");
       const name = data.name || data.title || id;
       const detailJsonLd = buildDetailPageJsonLd({
@@ -59,7 +60,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <CharacterDetail />
+      <CharacterDetail initialCharacter={data} />
     </>
   );
 }

--- a/frontend/app/[lang]/enchantments/[id]/page.tsx
+++ b/frontend/app/[lang]/enchantments/[id]/page.tsx
@@ -42,10 +42,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let data = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/enchantments/${id}?lang=${lang}`);
     if (res.ok) {
-      const data = await res.json();
+      data = await res.json();
       const desc = stripTags(data.description || "");
       const name = data.name || id;
       const detailJsonLd = buildDetailPageJsonLd({
@@ -59,7 +60,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <EnchantmentDetail />
+      <EnchantmentDetail initialEnchantment={data} />
     </>
   );
 }

--- a/frontend/app/[lang]/encounters/[id]/page.tsx
+++ b/frontend/app/[lang]/encounters/[id]/page.tsx
@@ -40,10 +40,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let data = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/encounters/${id}?lang=${lang}`);
     if (res.ok) {
-      const data = await res.json();
+      data = await res.json();
       const name = data.name || id;
       const desc = data.monsters?.length
         ? `${name} is a ${data.room_type} encounter featuring ${data.monsters.map((m: { name: string }) => m.name).join(", ")}.`
@@ -59,7 +60,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <EncounterDetail />
+      <EncounterDetail initialEncounter={data} />
     </>
   );
 }

--- a/frontend/app/[lang]/events/[id]/page.tsx
+++ b/frontend/app/[lang]/events/[id]/page.tsx
@@ -42,10 +42,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let data = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/events/${id}?lang=${lang}`);
     if (res.ok) {
-      const data = await res.json();
+      data = await res.json();
       const desc = stripTags(data.description || "");
       const name = data.name || data.title || id;
       const detailJsonLd = buildDetailPageJsonLd({
@@ -59,7 +60,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <EventDetail />
+      <EventDetail initialEvent={data} />
     </>
   );
 }

--- a/frontend/app/[lang]/intents/[id]/page.tsx
+++ b/frontend/app/[lang]/intents/[id]/page.tsx
@@ -41,10 +41,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let data = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/intents/${id}?lang=${lang}`);
     if (res.ok) {
-      const data = await res.json();
+      data = await res.json();
       const desc = stripTags(data.description || "");
       const name = data.name || id;
       const detailJsonLd = buildDetailPageJsonLd({
@@ -58,7 +59,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <IntentDetail />
+      <IntentDetail initialIntent={data} />
     </>
   );
 }

--- a/frontend/app/[lang]/keywords/[id]/page.tsx
+++ b/frontend/app/[lang]/keywords/[id]/page.tsx
@@ -44,10 +44,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let kw = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/keywords/${id}?lang=${lang}`);
     if (res.ok) {
-      const kw = await res.json();
+      kw = await res.json();
       const desc = stripTags(kw.description);
       const langCode = lang as LangCode;
       const gameName = LANG_GAME_NAME[langCode];
@@ -72,7 +73,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <KeywordDetail />
+      <KeywordDetail initialResult={kw ? { type: "keyword", data: kw } : null} />
     </>
   );
 }

--- a/frontend/app/[lang]/modifiers/[id]/page.tsx
+++ b/frontend/app/[lang]/modifiers/[id]/page.tsx
@@ -41,10 +41,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let data = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/modifiers/${id}?lang=${lang}`);
     if (res.ok) {
-      const data = await res.json();
+      data = await res.json();
       const desc = stripTags(data.description || "");
       const name = data.name || id;
       const detailJsonLd = buildDetailPageJsonLd({
@@ -58,7 +59,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <ModifierDetail />
+      <ModifierDetail initialModifier={data} />
     </>
   );
 }

--- a/frontend/app/[lang]/monsters/[id]/page.tsx
+++ b/frontend/app/[lang]/monsters/[id]/page.tsx
@@ -42,10 +42,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let data = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/monsters/${id}?lang=${lang}`);
     if (res.ok) {
-      const data = await res.json();
+      data = await res.json();
       const desc = stripTags(data.description || "");
       const name = data.name || data.title || id;
       const detailJsonLd = buildDetailPageJsonLd({
@@ -59,7 +60,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <MonsterDetail />
+      <MonsterDetail initialMonster={data} />
     </>
   );
 }

--- a/frontend/app/[lang]/orbs/[id]/page.tsx
+++ b/frontend/app/[lang]/orbs/[id]/page.tsx
@@ -41,10 +41,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let data = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/orbs/${id}?lang=${lang}`);
     if (res.ok) {
-      const data = await res.json();
+      data = await res.json();
       const desc = stripTags(data.description || "");
       const name = data.name || id;
       const detailJsonLd = buildDetailPageJsonLd({
@@ -58,7 +59,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <OrbDetail />
+      <OrbDetail initialOrb={data} />
     </>
   );
 }

--- a/frontend/app/[lang]/potions/[id]/page.tsx
+++ b/frontend/app/[lang]/potions/[id]/page.tsx
@@ -42,10 +42,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let data = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/potions/${id}?lang=${lang}`);
     if (res.ok) {
-      const data = await res.json();
+      data = await res.json();
       const desc = stripTags(data.description || "");
       const name = data.name || data.title || id;
       const detailJsonLd = buildDetailPageJsonLd({
@@ -59,7 +60,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <PotionDetail />
+      <PotionDetail initialPotion={data} />
     </>
   );
 }

--- a/frontend/app/[lang]/powers/[id]/page.tsx
+++ b/frontend/app/[lang]/powers/[id]/page.tsx
@@ -42,10 +42,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let data = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/powers/${id}?lang=${lang}`);
     if (res.ok) {
-      const data = await res.json();
+      data = await res.json();
       const desc = stripTags(data.description || "");
       const name = data.name || data.title || id;
       const detailJsonLd = buildDetailPageJsonLd({
@@ -59,7 +60,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <PowerDetail />
+      <PowerDetail initialPower={data} />
     </>
   );
 }

--- a/frontend/app/[lang]/relics/[id]/page.tsx
+++ b/frontend/app/[lang]/relics/[id]/page.tsx
@@ -42,10 +42,11 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   let jsonLd = null;
+  let data = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/relics/${id}?lang=${lang}`);
     if (res.ok) {
-      const data = await res.json();
+      data = await res.json();
       const desc = stripTags(data.description || "");
       const name = data.name || data.title || id;
       const detailJsonLd = buildDetailPageJsonLd({
@@ -59,7 +60,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <RelicDetail />
+      <RelicDetail initialRelic={data} />
     </>
   );
 }

--- a/frontend/app/achievements/[id]/AchievementDetail.tsx
+++ b/frontend/app/achievements/[id]/AchievementDetail.tsx
@@ -14,13 +14,13 @@ import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
-export default function AchievementDetail() {
+export default function AchievementDetail({ initialAchievement }: { initialAchievement?: Achievement | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
   const lp = useLangPrefix();
-  const [achievement, setAchievement] = useState<Achievement | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [achievement, setAchievement] = useState<Achievement | null>(initialAchievement ?? null);
+  const [loading, setLoading] = useState(!initialAchievement);
   const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {

--- a/frontend/app/achievements/[id]/page.tsx
+++ b/frontend/app/achievements/[id]/page.tsx
@@ -35,10 +35,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let achievement = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/achievements/${id}`);
     if (res.ok) {
-      const achievement = await res.json();
+      achievement = await res.json();
       const desc = stripTags(achievement.description || "");
       const detailJsonLd = buildDetailPageJsonLd({
         name: achievement.name,
@@ -60,7 +61,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <AchievementDetail />
+      <AchievementDetail initialAchievement={achievement} />
     </>
   );
 }

--- a/frontend/app/acts/[id]/ActDetail.tsx
+++ b/frontend/app/acts/[id]/ActDetail.tsx
@@ -12,13 +12,13 @@ import EntityHistory from "@/app/components/EntityHistory";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
-export default function ActDetail() {
+export default function ActDetail({ initialAct }: { initialAct?: Act | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
   const lp = useLangPrefix();
-  const [act, setAct] = useState<Act | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [act, setAct] = useState<Act | null>(initialAct ?? null);
+  const [loading, setLoading] = useState(!initialAct);
   const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {

--- a/frontend/app/acts/[id]/page.tsx
+++ b/frontend/app/acts/[id]/page.tsx
@@ -33,10 +33,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let act = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/acts/${id}`);
     if (res.ok) {
-      const act = await res.json();
+      act = await res.json();
       jsonLd = buildDetailPageJsonLd({
         name: act.name,
         description: `${act.name} act in Slay the Spire 2 with ${act.encounters.length} encounters and ${act.bosses.length} bosses.`,
@@ -53,7 +54,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <ActDetail />
+      <ActDetail initialAct={act} />
     </>
   );
 }

--- a/frontend/app/afflictions/[id]/AfflictionDetail.tsx
+++ b/frontend/app/afflictions/[id]/AfflictionDetail.tsx
@@ -14,13 +14,13 @@ import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
-export default function AfflictionDetail() {
+export default function AfflictionDetail({ initialAffliction }: { initialAffliction?: Affliction | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
   const lp = useLangPrefix();
-  const [affliction, setAffliction] = useState<Affliction | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [affliction, setAffliction] = useState<Affliction | null>(initialAffliction ?? null);
+  const [loading, setLoading] = useState(!initialAffliction);
   const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {

--- a/frontend/app/afflictions/[id]/page.tsx
+++ b/frontend/app/afflictions/[id]/page.tsx
@@ -35,10 +35,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let affliction = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/afflictions/${id}`);
     if (res.ok) {
-      const affliction = await res.json();
+      affliction = await res.json();
       const desc = stripTags(affliction.description || "");
       const detailJsonLd = buildDetailPageJsonLd({
         name: affliction.name,
@@ -61,7 +62,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <AfflictionDetail />
+      <AfflictionDetail initialAffliction={affliction} />
     </>
   );
 }

--- a/frontend/app/ascensions/[id]/AscensionDetail.tsx
+++ b/frontend/app/ascensions/[id]/AscensionDetail.tsx
@@ -13,14 +13,14 @@ import EntityHistory from "@/app/components/EntityHistory";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
-export default function AscensionDetail() {
+export default function AscensionDetail({ initialAscension }: { initialAscension?: Ascension | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
   const lp = useLangPrefix();
-  const [ascension, setAscension] = useState<Ascension | null>(null);
+  const [ascension, setAscension] = useState<Ascension | null>(initialAscension ?? null);
   const [allAscensions, setAllAscensions] = useState<Ascension[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!initialAscension);
   const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {

--- a/frontend/app/ascensions/[id]/page.tsx
+++ b/frontend/app/ascensions/[id]/page.tsx
@@ -34,10 +34,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let asc = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/ascensions/${id}`);
     if (res.ok) {
-      const asc = await res.json();
+      asc = await res.json();
       const desc = stripTags(asc.description);
       const detailJsonLd = buildDetailPageJsonLd({
         name: `Ascension ${asc.level}: ${asc.name}`,
@@ -59,7 +60,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <AscensionDetail />
+      <AscensionDetail initialAscension={asc} />
     </>
   );
 }

--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -272,16 +272,16 @@ function getUpgradedDescription(card: Card, upgraded: boolean): string {
 
 type Tab = "overview" | "details" | "info";
 
-export default function CardDetail() {
+export default function CardDetail({ initialCard }: { initialCard?: Card | null } = {}) {
   const params = useParams();
   const router = useRouter();
   const id = params.id as string;
   const { lang } = useLanguage();
 
-    const lp = useLangPrefix();
-const [card, setCard] = useState<Card | null>(null);
+  const lp = useLangPrefix();
+  const [card, setCard] = useState<Card | null>(initialCard ?? null);
   const [spawnedCards, setSpawnedCards] = useState<Card[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!initialCard);
   const [notFound, setNotFound] = useState(false);
   const [upgraded, setUpgraded] = useState(false);
   const [betaArt, setBetaArt] = useState(false);

--- a/frontend/app/cards/[id]/page.tsx
+++ b/frontend/app/cards/[id]/page.tsx
@@ -40,10 +40,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let card = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/cards/${id}`);
     if (res.ok) {
-      const card = await res.json();
+      card = await res.json();
       const desc = stripTags(card.description || "");
       const detailJsonLd = buildDetailPageJsonLd({
         name: card.name,
@@ -72,7 +73,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <CardDetail />
+      <CardDetail initialCard={card} />
     </>
   );
 }

--- a/frontend/app/characters/[id]/CharacterDetail.tsx
+++ b/frontend/app/characters/[id]/CharacterDetail.tsx
@@ -30,16 +30,16 @@ const QUOTE_LABELS: Record<string, { label: string; icon: string }> = {
   banter_dead: { label: "Last Words", icon: "skull" },
 };
 
-export default function CharacterDetail() {
+export default function CharacterDetail({ initialCharacter }: { initialCharacter?: Character | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
-  const [char, setChar] = useState<Character | null>(null);
+  const [char, setChar] = useState<Character | null>(initialCharacter ?? null);
   const [cards, setCards] = useState<Record<string, Card>>({});
   const [relics, setRelics] = useState<Record<string, Relic>>({});
   const [allCards, setAllCards] = useState<Card[]>([]);
   const [poolRelics, setPoolRelics] = useState<Relic[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!initialCharacter);
   const [notFound, setNotFound] = useState(false);
   const [expandedAncient, setExpandedAncient] = useState<string | null>(null);
   const [cardsExpanded, setCardsExpanded] = useState(true);

--- a/frontend/app/characters/[id]/page.tsx
+++ b/frontend/app/characters/[id]/page.tsx
@@ -37,10 +37,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let char = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/characters/${id}`);
     if (res.ok) {
-      const char = await res.json();
+      char = await res.json();
       const desc = stripTags(char.description || "");
       jsonLd = buildDetailPageJsonLd({
         name: char.name,
@@ -59,7 +60,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <CharacterDetail />
+      <CharacterDetail initialCharacter={char} />
     </>
   );
 }

--- a/frontend/app/enchantments/[id]/EnchantmentDetail.tsx
+++ b/frontend/app/enchantments/[id]/EnchantmentDetail.tsx
@@ -22,13 +22,13 @@ const cardTypeColors: Record<string, string> = {
 
 type Tab = "overview" | "info";
 
-export default function EnchantmentDetail() {
+export default function EnchantmentDetail({ initialEnchantment }: { initialEnchantment?: Enchantment | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
   const lp = useLangPrefix();
-  const [enchantment, setEnchantment] = useState<Enchantment | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [enchantment, setEnchantment] = useState<Enchantment | null>(initialEnchantment ?? null);
+  const [loading, setLoading] = useState(!initialEnchantment);
   const [notFound, setNotFound] = useState(false);
   const [tab, setTab] = useState<Tab>("overview");
 

--- a/frontend/app/enchantments/[id]/page.tsx
+++ b/frontend/app/enchantments/[id]/page.tsx
@@ -37,10 +37,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let enchantment = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/enchantments/${id}`);
     if (res.ok) {
-      const enchantment = await res.json();
+      enchantment = await res.json();
       const desc = stripTags(enchantment.description || "");
       const detailJsonLd = buildDetailPageJsonLd({
         name: enchantment.name,
@@ -64,7 +65,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <EnchantmentDetail />
+      <EnchantmentDetail initialEnchantment={enchantment} />
     </>
   );
 }

--- a/frontend/app/encounters/[id]/EncounterDetail.tsx
+++ b/frontend/app/encounters/[id]/EncounterDetail.tsx
@@ -22,13 +22,13 @@ const roomTypeBadge: Record<string, string> = {
 
 type Tab = "overview" | "info";
 
-export default function EncounterDetail() {
+export default function EncounterDetail({ initialEncounter }: { initialEncounter?: Encounter | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
   const lp = useLangPrefix();
-  const [encounter, setEncounter] = useState<Encounter | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [encounter, setEncounter] = useState<Encounter | null>(initialEncounter ?? null);
+  const [loading, setLoading] = useState(!initialEncounter);
   const [notFound, setNotFound] = useState(false);
   const [tab, setTab] = useState<Tab>("overview");
 

--- a/frontend/app/encounters/[id]/page.tsx
+++ b/frontend/app/encounters/[id]/page.tsx
@@ -37,10 +37,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let encounter = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/encounters/${id}`);
     if (res.ok) {
-      const encounter = await res.json();
+      encounter = await res.json();
       const desc = encounter.monsters?.length
         ? `${encounter.name} is a ${encounter.room_type} encounter featuring ${encounter.monsters.map((m: { name: string }) => m.name).join(", ")}.`
         : `${encounter.name} encounter from Slay the Spire 2`;
@@ -65,7 +66,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <EncounterDetail />
+      <EncounterDetail initialEncounter={encounter} />
     </>
   );
 }

--- a/frontend/app/events/[id]/EventDetail.tsx
+++ b/frontend/app/events/[id]/EventDetail.tsx
@@ -68,12 +68,12 @@ function PageBlock({ page, index }: { page: EventPage; index: number }) {
   );
 }
 
-export default function EventDetail() {
+export default function EventDetail({ initialEvent }: { initialEvent?: GameEvent | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
-  const [event, setEvent] = useState<GameEvent | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [event, setEvent] = useState<GameEvent | null>(initialEvent ?? null);
+  const [loading, setLoading] = useState(!initialEvent);
   const [notFound, setNotFound] = useState(false);
   const [relicMap, setRelicMap] = useState<
     Record<string, { id: string; name: string; description: string; image_url: string | null }>

--- a/frontend/app/events/[id]/page.tsx
+++ b/frontend/app/events/[id]/page.tsx
@@ -37,10 +37,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let event = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/events/${id}`);
     if (res.ok) {
-      const event = await res.json();
+      event = await res.json();
       const desc = stripTags(event.description || "");
       const detailJsonLd = buildDetailPageJsonLd({
         name: event.name,
@@ -67,7 +68,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <EventDetail />
+      <EventDetail initialEvent={event} />
     </>
   );
 }

--- a/frontend/app/intents/[id]/IntentDetail.tsx
+++ b/frontend/app/intents/[id]/IntentDetail.tsx
@@ -14,13 +14,13 @@ import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
-export default function IntentDetail() {
+export default function IntentDetail({ initialIntent }: { initialIntent?: Intent | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
   const lp = useLangPrefix();
-  const [intent, setIntent] = useState<Intent | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [intent, setIntent] = useState<Intent | null>(initialIntent ?? null);
+  const [loading, setLoading] = useState(!initialIntent);
   const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {

--- a/frontend/app/intents/[id]/page.tsx
+++ b/frontend/app/intents/[id]/page.tsx
@@ -35,10 +35,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let intent = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/intents/${id}`);
     if (res.ok) {
-      const intent = await res.json();
+      intent = await res.json();
       const desc = stripTags(intent.description || "");
       const detailJsonLd = buildDetailPageJsonLd({
         name: intent.name,
@@ -60,7 +61,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <IntentDetail />
+      <IntentDetail initialIntent={intent} />
     </>
   );
 }

--- a/frontend/app/keywords/[id]/KeywordDetail.tsx
+++ b/frontend/app/keywords/[id]/KeywordDetail.tsx
@@ -42,18 +42,23 @@ const CATEGORY_LABELS: Record<string, string> = {
   rooms: "Map Rooms",
 };
 
-export default function KeywordDetail() {
+type InitialResult =
+  | { type: "keyword"; data: Keyword }
+  | { type: "glossary"; data: GlossaryTerm }
+  | null;
+
+export default function KeywordDetail({ initialResult }: { initialResult?: InitialResult } = {}) {
   const params = useParams();
   const id = params.id as string;
   const router = useRouter();
   const { lang } = useLanguage();
 
-  const [keyword, setKeyword] = useState<Keyword | null>(null);
-  const [glossary, setGlossary] = useState<GlossaryTerm | null>(null);
+  const [keyword, setKeyword] = useState<Keyword | null>(initialResult?.type === "keyword" ? initialResult.data : null);
+  const [glossary, setGlossary] = useState<GlossaryTerm | null>(initialResult?.type === "glossary" ? initialResult.data : null);
   const [cards, setCards] = useState<Card[]>([]);
   const [search, setSearch] = useState("");
   const [color, setColor] = useState("");
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!initialResult);
   const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {

--- a/frontend/app/keywords/[id]/page.tsx
+++ b/frontend/app/keywords/[id]/page.tsx
@@ -109,7 +109,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <KeywordDetail />
+      <KeywordDetail initialResult={result} />
     </>
   );
 }

--- a/frontend/app/modifiers/[id]/ModifierDetail.tsx
+++ b/frontend/app/modifiers/[id]/ModifierDetail.tsx
@@ -14,13 +14,13 @@ import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
-export default function ModifierDetail() {
+export default function ModifierDetail({ initialModifier }: { initialModifier?: Modifier | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
   const lp = useLangPrefix();
-  const [modifier, setModifier] = useState<Modifier | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [modifier, setModifier] = useState<Modifier | null>(initialModifier ?? null);
+  const [loading, setLoading] = useState(!initialModifier);
   const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {

--- a/frontend/app/modifiers/[id]/page.tsx
+++ b/frontend/app/modifiers/[id]/page.tsx
@@ -35,10 +35,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let modifier = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/modifiers/${id}`);
     if (res.ok) {
-      const modifier = await res.json();
+      modifier = await res.json();
       const desc = stripTags(modifier.description || "");
       const detailJsonLd = buildDetailPageJsonLd({
         name: modifier.name,
@@ -60,7 +61,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <ModifierDetail />
+      <ModifierDetail initialModifier={modifier} />
     </>
   );
 }

--- a/frontend/app/monsters/[id]/MonsterDetail.tsx
+++ b/frontend/app/monsters/[id]/MonsterDetail.tsx
@@ -192,14 +192,14 @@ function MoveCard({
   );
 }
 
-export default function MonsterDetail() {
+export default function MonsterDetail({ initialMonster }: { initialMonster?: Monster | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
   const lp = useLangPrefix();
-  const [monster, setMonster] = useState<Monster | null>(null);
+  const [monster, setMonster] = useState<Monster | null>(initialMonster ?? null);
   const [powerData, setPowerData] = useState<Record<string, Power>>({});
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!initialMonster);
   const [notFound, setNotFound] = useState(false);
   const [betaArt, setBetaArt] = useState(false);
 

--- a/frontend/app/monsters/[id]/page.tsx
+++ b/frontend/app/monsters/[id]/page.tsx
@@ -37,10 +37,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let monster = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/monsters/${id}`);
     if (res.ok) {
-      const monster = await res.json();
+      monster = await res.json();
       const hpText = monster.min_hp ? `${monster.min_hp}${monster.max_hp && monster.max_hp !== monster.min_hp ? `\u2013${monster.max_hp}` : ""} HP` : "";
       const desc = `${monster.type} monster${hpText ? ` \u00b7 ${hpText}` : ""}`;
       const detailJsonLd = buildDetailPageJsonLd({
@@ -65,7 +66,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <MonsterDetail />
+      <MonsterDetail initialMonster={monster} />
     </>
   );
 }

--- a/frontend/app/orbs/[id]/OrbDetail.tsx
+++ b/frontend/app/orbs/[id]/OrbDetail.tsx
@@ -14,13 +14,13 @@ import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
-export default function OrbDetail() {
+export default function OrbDetail({ initialOrb }: { initialOrb?: Orb | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
   const lp = useLangPrefix();
-  const [orb, setOrb] = useState<Orb | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [orb, setOrb] = useState<Orb | null>(initialOrb ?? null);
+  const [loading, setLoading] = useState(!initialOrb);
   const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {

--- a/frontend/app/orbs/[id]/page.tsx
+++ b/frontend/app/orbs/[id]/page.tsx
@@ -35,10 +35,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let orb = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/orbs/${id}`);
     if (res.ok) {
-      const orb = await res.json();
+      orb = await res.json();
       const desc = stripTags(orb.description || "");
       const detailJsonLd = buildDetailPageJsonLd({
         name: orb.name,
@@ -60,7 +61,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <OrbDetail />
+      <OrbDetail initialOrb={orb} />
     </>
   );
 }

--- a/frontend/app/potions/[id]/PotionDetail.tsx
+++ b/frontend/app/potions/[id]/PotionDetail.tsx
@@ -35,13 +35,13 @@ function getPotionMerchantPriceRange(rarity: string): { min: number; max: number
 
 type Tab = "overview" | "details" | "info";
 
-export default function PotionDetail() {
+export default function PotionDetail({ initialPotion }: { initialPotion?: Potion | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
-    const lp = useLangPrefix();
-const [potion, setPotion] = useState<Potion | null>(null);
-  const [loading, setLoading] = useState(true);
+  const lp = useLangPrefix();
+  const [potion, setPotion] = useState<Potion | null>(initialPotion ?? null);
+  const [loading, setLoading] = useState(!initialPotion);
   const [notFound, setNotFound] = useState(false);
   const [tab, setTab] = useState<Tab>("overview");
 

--- a/frontend/app/potions/[id]/page.tsx
+++ b/frontend/app/potions/[id]/page.tsx
@@ -37,10 +37,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let potion = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/potions/${id}`);
     if (res.ok) {
-      const potion = await res.json();
+      potion = await res.json();
       const desc = stripTags(potion.description || "");
       const detailJsonLd = buildDetailPageJsonLd({
         name: potion.name,
@@ -64,7 +65,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <PotionDetail />
+      <PotionDetail initialPotion={potion} />
     </>
   );
 }

--- a/frontend/app/powers/[id]/PowerDetail.tsx
+++ b/frontend/app/powers/[id]/PowerDetail.tsx
@@ -19,14 +19,14 @@ const typeColors: Record<string, string> = {
   None: "text-gray-400",
 };
 
-export default function PowerDetail() {
+export default function PowerDetail({ initialPower }: { initialPower?: Power | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
-    const lp = useLangPrefix();
-const [power, setPower] = useState<Power | null>(null);
+  const lp = useLangPrefix();
+  const [power, setPower] = useState<Power | null>(initialPower ?? null);
   const [allCards, setAllCards] = useState<Card[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!initialPower);
   const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {

--- a/frontend/app/powers/[id]/page.tsx
+++ b/frontend/app/powers/[id]/page.tsx
@@ -37,10 +37,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let power = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/powers/${id}`);
     if (res.ok) {
-      const power = await res.json();
+      power = await res.json();
       const desc = stripTags(power.description || "");
       const detailJsonLd = buildDetailPageJsonLd({
         name: power.name,
@@ -64,7 +65,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <PowerDetail />
+      <PowerDetail initialPower={power} />
     </>
   );
 }

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -27,15 +27,15 @@ const rarityColorMap: Record<string, string> = {
 
 type Tab = "overview" | "details" | "info";
 
-export default function RelicDetail() {
+export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
-    const lp = useLangPrefix();
-const [relic, setRelic] = useState<Relic | null>(null);
+  const lp = useLangPrefix();
+  const [relic, setRelic] = useState<Relic | null>(initialRelic ?? null);
   const [selectedVariant, setSelectedVariant] = useState<string | null>(null);
   const [selectedChar, setSelectedChar] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!initialRelic);
   const [notFound, setNotFound] = useState(false);
   const [tab, setTab] = useState<Tab>("overview");
 

--- a/frontend/app/relics/[id]/page.tsx
+++ b/frontend/app/relics/[id]/page.tsx
@@ -37,10 +37,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let relic = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/relics/${id}`);
     if (res.ok) {
-      const relic = await res.json();
+      relic = await res.json();
       const desc = stripTags(relic.description || "");
       const detailJsonLd = buildDetailPageJsonLd({
         name: relic.name,
@@ -65,7 +66,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <RelicDetail />
+      <RelicDetail initialRelic={relic} />
     </>
   );
 }

--- a/frontend/app/timeline/[id]/EpochDetail.tsx
+++ b/frontend/app/timeline/[id]/EpochDetail.tsx
@@ -40,14 +40,14 @@ function cleanDescription(desc: string): string {
   return desc.replace(/\{[^}]+\}/g, "X");
 }
 
-export default function EpochDetail() {
+export default function EpochDetail({ initialEpoch }: { initialEpoch?: Epoch | null } = {}) {
   const params = useParams();
   const router = useRouter();
   const id = params.id as string;
   const { lang } = useLanguage();
 
-  const [epoch, setEpoch] = useState<Epoch | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [epoch, setEpoch] = useState<Epoch | null>(initialEpoch ?? null);
+  const [loading, setLoading] = useState(!initialEpoch);
   const [notFound, setNotFound] = useState(false);
   const [cardMap, setCardMap] = useState<Record<string, Card>>({});
   const [relicMap, setRelicMap] = useState<Record<string, Relic>>({});

--- a/frontend/app/timeline/[id]/page.tsx
+++ b/frontend/app/timeline/[id]/page.tsx
@@ -37,10 +37,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
+  let epoch = null;
   try {
     const res = await fetch(`${API_INTERNAL}/api/epochs/${id}`);
     if (res.ok) {
-      const epoch = await res.json();
+      epoch = await res.json();
       const desc = stripTags(epoch.description || "");
       const detailJsonLd = buildDetailPageJsonLd({
         name: epoch.title,
@@ -62,7 +63,7 @@ export default async function Page({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <EpochDetail />
+      <EpochDetail initialEpoch={epoch} />
     </>
   );
 }


### PR DESCRIPTION
## Summary
Detail pages were rendering content client-side: the server generated meta tags and JSON-LD correctly, but the visible body started as "Loading..." until the client-side fetch completed. **Google saw thin HTML when crawling, likely depressing rankings on every detail page.**

## The fix
Server `page.tsx` files already fetched the entity for JSON-LD generation. Just pass that data to the client component as `initialXxx` prop. The client component initializes state from the prop instead of `null`, eliminating the loading flash and giving the crawler real content in the initial HTML.

`useEffect` still runs on language change (so switching languages refetches translations). The "wasted" first fetch on default language stays as-is — it's a single request that doesn't affect the rendered HTML and warms the client cache.

## Coverage
Applied to **17 entity types**, both default and `/[lang]/` variants (53 files total):

| Entity | High-traffic? |
|---|---|
| cards, monsters, relics, events, potions, powers, characters | Yes |
| encounters, enchantments | Yes |
| achievements, acts, afflictions, ascensions, intents, modifiers, orbs, timeline (epochs) | Lower |
| keywords | Special — initial prop carries both type tag and data (keyword vs glossary) |

## Closes
None — this is preventative SEO, not a specific issue.
