### PR TITLE
Add Recently Added section to entity list pages

### DIFF
--- a/backend/app/routers/changelogs.py
+++ b/backend/app/routers/changelogs.py
@@ -45,6 +45,64 @@ def list_changelogs(request: Request):
     ]
 
 
+@router.get("/recent-additions", tags=["Changelogs"])
+def recent_additions(
+    request: Request,
+    entity_type: str | None = None,
+    limit: int = 12,
+    max_versions: int = 5,
+):
+    """Return the most recent entity additions, scanning newest changelogs first.
+
+    - entity_type: optional filter (e.g. "cards", "relics") — if omitted, returns a
+      dict keyed by entity type.
+    - limit: max items to return per entity type.
+    - max_versions: stop scanning after this many changelogs.
+
+    Each item is enriched with `version`, `version_tag`, and `version_date` so the
+    UI can render a "Added in vX.Y.Z" badge.
+    """
+    logs = _load_changelogs()[:max_versions]
+
+    def _collect(target_type: str) -> list[dict]:
+        items: list[dict] = []
+        for log in logs:
+            tag = log.get("tag") or log.get("game_version", "")
+            date = log.get("date", "")
+            for cat in log.get("categories", []):
+                if cat.get("id") != target_type:
+                    continue
+                for item in cat.get("added", []):
+                    items.append(
+                        {
+                            **item,
+                            "version_tag": tag,
+                            "version_date": date,
+                        }
+                    )
+                    if len(items) >= limit:
+                        return items
+            if len(items) >= limit:
+                return items
+        return items
+
+    if entity_type:
+        return {"items": _collect(entity_type)}
+
+    # Return all common types
+    types = (
+        "cards",
+        "relics",
+        "potions",
+        "monsters",
+        "events",
+        "encounters",
+        "powers",
+        "enchantments",
+    )
+    return {t: _collect(t) for t in types}
+
+
 @router.get("/{tag:path}", tags=["Changelogs"])
 def get_changelog(tag: str, request: Request):
     """Return full changelog for a specific tag (e.g. '1.0.3')."""

--- a/frontend/app/[lang]/cards/page.tsx
+++ b/frontend/app/[lang]/cards/page.tsx
@@ -3,6 +3,7 @@ import type { Card } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
 import CardsClient from "@/app/cards/CardsClient";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import {
   isValidLang,
   LANG_GAME_NAME,
@@ -92,6 +93,8 @@ export default async function LangCardsPage({ params }: { params: Promise<{ lang
       <p className="text-sm text-[var(--text-muted)] mb-6">
         {t("cards_tagline", lang)}
       </p>
+
+      <RecentlyAdded entityType="cards" label="Card" pathPrefix={`/${lang}/cards`} />
 
       <CardsClient initialCards={cards} />
     </div>

--- a/frontend/app/[lang]/enchantments/page.tsx
+++ b/frontend/app/[lang]/enchantments/page.tsx
@@ -3,6 +3,7 @@ import type { Enchantment } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
 import EnchantmentsClient from "@/app/enchantments/EnchantmentsClient";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import {
   isValidLang,
   LANG_GAME_NAME,
@@ -91,6 +92,8 @@ export default async function LangEnchantmentsPage({ params }: { params: Promise
       <p className="text-sm text-[var(--text-muted)] mb-6">
         {t("enchantments_tagline", lang)}
       </p>
+
+      <RecentlyAdded entityType="enchantments" label="Enchantment" pathPrefix={`/${lang}/enchantments`} />
 
       <EnchantmentsClient initialEnchantments={enchantments} />
     </div>

--- a/frontend/app/[lang]/encounters/page.tsx
+++ b/frontend/app/[lang]/encounters/page.tsx
@@ -3,6 +3,7 @@ import type { Encounter } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
 import EncountersClient from "@/app/encounters/EncountersClient";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import {
   isValidLang,
   LANG_GAME_NAME,
@@ -91,6 +92,8 @@ export default async function LangEncountersPage({ params }: { params: Promise<{
       <p className="text-sm text-[var(--text-muted)] mb-6">
         {t("encounters_tagline", lang)}
       </p>
+
+      <RecentlyAdded entityType="encounters" label="Encounter" pathPrefix={`/${lang}/encounters`} />
 
       <EncountersClient initialEncounters={encounters} />
     </div>

--- a/frontend/app/[lang]/events/page.tsx
+++ b/frontend/app/[lang]/events/page.tsx
@@ -3,6 +3,7 @@ import type { GameEvent } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
 import EventsClient from "@/app/events/EventsClient";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import {
   isValidLang,
   LANG_GAME_NAME,
@@ -92,6 +93,8 @@ export default async function LangEventsPage({ params }: { params: Promise<{ lan
       <p className="text-sm text-[var(--text-muted)] mb-6">
         {t("events_tagline", lang)}
       </p>
+
+      <RecentlyAdded entityType="events" label="Event" pathPrefix={`/${lang}/events`} />
 
       <EventsClient initialEvents={events} />
     </div>

--- a/frontend/app/[lang]/monsters/page.tsx
+++ b/frontend/app/[lang]/monsters/page.tsx
@@ -3,6 +3,7 @@ import type { Monster } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
 import MonstersClient from "@/app/monsters/MonstersClient";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import {
   isValidLang,
   LANG_GAME_NAME,
@@ -92,6 +93,8 @@ export default async function LangMonstersPage({ params }: { params: Promise<{ l
       <p className="text-sm text-[var(--text-muted)] mb-6">
         {t("monsters_tagline", lang)}
       </p>
+
+      <RecentlyAdded entityType="monsters" label="Monster" pathPrefix={`/${lang}/monsters`} />
 
       <MonstersClient initialMonsters={monsters} />
     </div>

--- a/frontend/app/[lang]/potions/page.tsx
+++ b/frontend/app/[lang]/potions/page.tsx
@@ -3,6 +3,7 @@ import type { Potion } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
 import PotionsClient from "@/app/potions/PotionsClient";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import {
   isValidLang,
   LANG_GAME_NAME,
@@ -92,6 +93,8 @@ export default async function LangPotionsPage({ params }: { params: Promise<{ la
       <p className="text-sm text-[var(--text-muted)] mb-6">
         {t("potions_tagline", lang)}
       </p>
+
+      <RecentlyAdded entityType="potions" label="Potion" pathPrefix={`/${lang}/potions`} />
 
       <PotionsClient initialPotions={potions} />
     </div>

--- a/frontend/app/[lang]/powers/page.tsx
+++ b/frontend/app/[lang]/powers/page.tsx
@@ -3,6 +3,7 @@ import type { Power } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
 import PowersClient from "@/app/powers/PowersClient";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import {
   isValidLang,
   LANG_GAME_NAME,
@@ -92,6 +93,8 @@ export default async function LangPowersPage({ params }: { params: Promise<{ lan
       <p className="text-sm text-[var(--text-muted)] mb-6">
         {t("powers_tagline", lang)}
       </p>
+
+      <RecentlyAdded entityType="powers" label="Power" pathPrefix={`/${lang}/powers`} />
 
       <PowersClient initialPowers={powers} />
     </div>

--- a/frontend/app/[lang]/relics/page.tsx
+++ b/frontend/app/[lang]/relics/page.tsx
@@ -3,6 +3,7 @@ import type { Relic } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
 import RelicsClient from "@/app/relics/RelicsClient";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import {
   isValidLang,
   LANG_GAME_NAME,
@@ -92,6 +93,8 @@ export default async function LangRelicsPage({ params }: { params: Promise<{ lan
       <p className="text-sm text-[var(--text-muted)] mb-6">
         {t("relics_tagline", lang)}
       </p>
+
+      <RecentlyAdded entityType="relics" label="Relic" pathPrefix={`/${lang}/relics`} />
 
       <RelicsClient initialRelics={relics} />
     </div>

--- a/frontend/app/cards/page.tsx
+++ b/frontend/app/cards/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import type { Card } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import CardsClient from "./CardsClient";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -35,6 +36,8 @@ export default async function CardsPage() {
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every card across Ironclad, Silent, Defect, Necrobinder, and Regent. Filter by character, type, rarity, and keywords.
       </p>
+
+      <RecentlyAdded entityType="cards" label="Card" pathPrefix="/cards" />
 
       <Suspense>
         <CardsClient initialCards={cards} />

--- a/frontend/app/components/RecentlyAdded.tsx
+++ b/frontend/app/components/RecentlyAdded.tsx
@@ -1,0 +1,105 @@
+/**
+ * Server component that highlights entities added in recent game patches.
+ * Fetches /api/changelogs/recent-additions and renders a section above
+ * the main entity list. Renders nothing if no recent additions exist.
+ */
+
+import Link from "next/link";
+
+const API_INTERNAL =
+  process.env.API_INTERNAL_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://localhost:8000";
+
+interface RecentItem {
+  id: string;
+  name: string;
+  version_tag: string;
+  version_date?: string;
+  rarity?: string;
+  type?: string;
+  cost?: number;
+}
+
+interface Props {
+  /** Entity type matching backend changelog category id (e.g. "cards", "relics"). */
+  entityType: string;
+  /** Singular label shown in the header (e.g. "Card", "Relic"). */
+  label: string;
+  /** Path prefix for entity detail links (e.g. "/cards", "/[lang]/cards"). */
+  pathPrefix: string;
+  /** Max items to show. Default 8. */
+  limit?: number;
+}
+
+export default async function RecentlyAdded({
+  entityType,
+  label,
+  pathPrefix,
+  limit = 8,
+}: Props) {
+  let items: RecentItem[] = [];
+  try {
+    const res = await fetch(
+      `${API_INTERNAL}/api/changelogs/recent-additions?entity_type=${entityType}&limit=${limit}`,
+      { next: { revalidate: 600 } },
+    );
+    if (res.ok) {
+      const data = await res.json();
+      items = data.items ?? [];
+    }
+  } catch {
+    // Endpoint optional — render nothing on failure
+  }
+
+  if (items.length === 0) return null;
+
+  // Group by version so we can show "Added in vX.Y.Z" once per group
+  const byVersion = new Map<string, RecentItem[]>();
+  for (const item of items) {
+    const v = item.version_tag || "unknown";
+    if (!byVersion.has(v)) byVersion.set(v, []);
+    byVersion.get(v)!.push(item);
+  }
+
+  return (
+    <section className="mb-8 rounded-xl border border-emerald-700/30 bg-emerald-950/20 p-4 sm:p-6">
+      <div className="flex items-center gap-2 mb-3">
+        <span className="inline-block w-2 h-2 rounded-full bg-emerald-400 animate-pulse" />
+        <h2 className="text-lg font-bold text-emerald-300">
+          Recently Added {label}s
+        </h2>
+      </div>
+
+      {[...byVersion.entries()].map(([version, group]) => (
+        <div key={version} className="mb-3 last:mb-0">
+          <p className="text-xs uppercase tracking-wider text-emerald-400/70 mb-2">
+            New in v{version}
+          </p>
+          <ul className="flex flex-wrap gap-2">
+            {group.map((item) => (
+              <li key={item.id}>
+                <Link
+                  href={`${pathPrefix}/${item.id.toLowerCase()}`}
+                  className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--bg-card)] border border-emerald-800/40 hover:border-emerald-500/60 text-sm text-[var(--text-primary)] hover:text-emerald-300 transition-colors"
+                >
+                  <span className="font-medium">{item.name}</span>
+                  {item.rarity && (
+                    <span className="text-xs text-[var(--text-muted)]">
+                      {item.rarity}
+                    </span>
+                  )}
+                  {item.type && (
+                    <span className="text-xs text-[var(--text-muted)]">
+                      {item.type}
+                    </span>
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/frontend/app/enchantments/page.tsx
+++ b/frontend/app/enchantments/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import type { Enchantment } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import EnchantmentsClient from "./EnchantmentsClient";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -34,6 +35,8 @@ export default async function EnchantmentsPage() {
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every enchantment in Slay the Spire 2. Filter by card type and view effects, stackability, and extra card text.
       </p>
+
+      <RecentlyAdded entityType="enchantments" label="Enchantment" pathPrefix="/enchantments" />
 
       <Suspense>
         <EnchantmentsClient initialEnchantments={enchantments} />

--- a/frontend/app/encounters/page.tsx
+++ b/frontend/app/encounters/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import type { Encounter } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import EncountersClient from "./EncountersClient";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -34,6 +35,8 @@ export default async function EncountersPage() {
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every combat encounter in Slay the Spire 2. Filter by room type (Monster, Elite, Boss) and act to find specific fights and monster compositions.
       </p>
+
+      <RecentlyAdded entityType="encounters" label="Encounter" pathPrefix="/encounters" />
 
       <Suspense>
         <EncountersClient initialEncounters={encounters} />

--- a/frontend/app/events/page.tsx
+++ b/frontend/app/events/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import type { GameEvent } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import EventsClient from "./EventsClient";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -35,6 +36,8 @@ export default async function EventsPage() {
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every Slay the Spire 2 event including shrine events, Ancient encounters, and story events. View choices, dialogue, and outcomes.
       </p>
+
+      <RecentlyAdded entityType="events" label="Event" pathPrefix="/events" />
 
       <Suspense>
         <EventsClient initialEvents={events} />

--- a/frontend/app/monsters/page.tsx
+++ b/frontend/app/monsters/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import type { Monster } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import MonstersClient from "./MonstersClient";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -35,6 +36,8 @@ export default async function MonstersPage() {
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every monster in Slay the Spire 2 — normals, elites, and bosses. View HP values, moves, damage stats, and ascension scaling.
       </p>
+
+      <RecentlyAdded entityType="monsters" label="Monster" pathPrefix="/monsters" />
 
       <Suspense>
         <MonstersClient initialMonsters={monsters} />

--- a/frontend/app/potions/page.tsx
+++ b/frontend/app/potions/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import type { Potion } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import PotionsClient from "./PotionsClient";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -35,6 +36,8 @@ export default async function PotionsPage() {
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every potion across Ironclad, Silent, Defect, Necrobinder, and Regent. Filter by rarity and character pool.
       </p>
+
+      <RecentlyAdded entityType="potions" label="Potion" pathPrefix="/potions" />
 
       <Suspense>
         <PotionsClient initialPotions={potions} />

--- a/frontend/app/powers/page.tsx
+++ b/frontend/app/powers/page.tsx
@@ -1,6 +1,7 @@
 import type { Power } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import PowersClient from "./PowersClient";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -34,6 +35,8 @@ export default async function PowersPage() {
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every power in Slay the Spire 2 — buffs, debuffs, and neutral effects. Filter by type and stack behavior.
       </p>
+
+      <RecentlyAdded entityType="powers" label="Power" pathPrefix="/powers" />
 
       <PowersClient initialPowers={powers} />
     </div>

--- a/frontend/app/relics/page.tsx
+++ b/frontend/app/relics/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import type { Relic } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildCollectionPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import RecentlyAdded from "@/app/components/RecentlyAdded";
 import RelicsClient from "./RelicsClient";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -35,6 +36,8 @@ export default async function RelicsPage() {
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every relic across Ironclad, Silent, Defect, Necrobinder, and Regent. Filter by rarity and character pool.
       </p>
+
+      <RecentlyAdded entityType="relics" label="Relic" pathPrefix="/relics" />
 
       <Suspense>
         <RelicsClient initialRelics={relics} />


### PR DESCRIPTION
## Summary
Adds a "Recently Added" section to entity list pages, surfacing entities added in recent game patches.

The Tunneling Twosome data showed that **new content drives traffic** — that one encounter accounted for ~1,000 of last month's clicks. Right now that traffic lands on detail pages only. This change captures patch-curiosity traffic on the main list pages too (`/cards`, `/relics`, etc.) and gives Google a fresh-content signal on every release.

## How it works
- New backend endpoint: `GET /api/changelogs/recent-additions?entity_type=cards&limit=8`
  - Scans changelogs newest-first
  - Returns added entities grouped by version tag
  - Stops after `max_versions` (default 5) to avoid showing ancient additions
- New `<RecentlyAdded />` server component
  - Fetches the endpoint at request time (5min revalidate)
  - Renders nothing if no recent additions exist (stable site stays clean during quiet patches)
  - On beta site, populates on every beta drop
- Added to **8 entity types × 2 (default + /[lang]/)** = 16 list pages

## Stable vs beta
The same endpoint serves both — version routing is handled by the existing `VersionMiddleware`. Beta site reads from `data-beta/v0.103.0/changelogs/`, stable from `data/changelogs/`.

Stable currently shows 5 monster additions from older patches. Future stable patches with new content will populate cards/relics/etc.

## Closes
None — preventative SEO + UX improvement.
