### PR TITLE
Use container name for stable backend DNS to fix beta data leak

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,7 +32,7 @@ services:
     volumes:
       - ./data:/data:ro
     environment:
-      - API_INTERNAL_URL=http://backend:8000
+      - API_INTERNAL_URL=http://spire-codex-backend:8000
       - NEXT_PUBLIC_SITE_URL=https://spire-codex.com
     networks:
       - nginx_web-network


### PR DESCRIPTION
## Summary
The stable frontend was silently hitting the **beta** backend via the shared `nginx_web-network`, which is why beta-only entities (e.g. the "Not Yet" card from beta v0.103.0) showed up in stable's Recently Added section.

## Root cause
Both stable and beta attach to the external `nginx_web-network`. Each Docker Compose project registers its service name (`backend`) as a DNS alias on its networks. On a shared external network, two containers with the same alias creates a conflict — Docker DNS picks one, and stable was getting beta.

Beta already uses the explicit container name (`spire-codex-beta-backend`). Stable was still using the bare service name (`backend`).

## Fix
Change stable's `API_INTERNAL_URL` from `http://backend:8000` to `http://spire-codex-backend:8000`. Container names are unique across the shared network.

## Closes
The "Not Yet appears on stable" bug.
