### PR TITLE
Fix Windows run path — drop redundant Roaming segment

### DIFF
--- a/frontend/app/runs/RunsClient.tsx
+++ b/frontend/app/runs/RunsClient.tsx
@@ -640,7 +640,7 @@ export default function RunsClient() {
               Upload .run files — select one or multiple
             </p>
             <div className="text-left mb-3 space-y-1 text-xs text-[var(--text-muted)]">
-              <p><strong className="text-[var(--text-secondary)]">Windows:</strong> <code className="bg-[var(--bg-primary)] px-1 rounded">%AppData%/Roaming/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history</code></p>
+              <p><strong className="text-[var(--text-secondary)]">Windows:</strong> <code className="bg-[var(--bg-primary)] px-1 rounded">%AppData%/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history</code></p>
               <p><strong className="text-[var(--text-secondary)]">macOS:</strong> <code className="bg-[var(--bg-primary)] px-1 rounded">~/Library/Application Support/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history</code></p>
               <p><strong className="text-[var(--text-secondary)]">Linux / Steam Deck:</strong> <code className="bg-[var(--bg-primary)] px-1 rounded">~/.local/share/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history</code></p>
             </div>


### PR DESCRIPTION
## Summary
`%AppData%` already expands to the `Roaming` directory on Windows, so `%AppData%/Roaming/SlayTheSpire2/...` was a double-nested path that doesn't resolve.

Before: `%AppData%/Roaming/SlayTheSpire2/steam/<steamid>/profile1/saves/history`
After: `%AppData%/SlayTheSpire2/steam/<steamid>/profile1/saves/history`

## Closes
Fixes #33
