### PR TITLE
Fix card upgrade display parity between list and detail views

### DIFF
--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import type { Card } from "@/lib/api";
 import RichDescription from "@/app/components/RichDescription";
 import type { RelatedCard } from "@/app/components/RichDescription";
+import { getCardDisplayModel } from "@/lib/card-display";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
@@ -60,7 +61,7 @@ const keywordTooltips: Record<string, string> = {
 };
 
 function buildInteractiveWords(
-  card: Card,
+  keywords: string[],
   powerData: Record<string, { id: string; name: string; description: string; type: string; image_url: string | null }>,
   keywordData: Record<string, { id: string; name: string; description: string }>,
   glossaryData: Record<string, { id: string; name: string; description: string }>,
@@ -69,12 +70,10 @@ function buildInteractiveWords(
 ): Record<string, { tooltip: string; href: string }> {
   const words: Record<string, { tooltip: string; href: string }> = {};
   // Add keyword names (Sly, Exhaust, Ethereal, etc.)
-  if (card.keywords) {
-    for (const kw of card.keywords) {
-      const data = keywordData[kw.toLowerCase()];
-      const desc = data?.description || keywordTooltips[kw] || "";
-      words[kw] = { tooltip: desc, href: `${lp}/keywords/${kw.toLowerCase()}` };
-    }
+  for (const kw of keywords) {
+    const data = keywordData[kw.toLowerCase()];
+    const desc = data?.description || keywordTooltips[kw] || "";
+    words[kw] = { tooltip: desc, href: `${lp}/keywords/${kw.toLowerCase()}` };
   }
   // Add power names from [gold] tagged text (Dexterity, Thorns, Block, Strength, etc.)
   for (const [name, data] of Object.entries(powerData)) {
@@ -146,128 +145,6 @@ function getMerchantPriceRange(rarity: string, color: string): { min: number; ma
   }
   if (isColorless) base = Math.round(base * 1.15);
   return { min: Math.floor(base * 0.95), max: Math.ceil(base * 1.05) };
-}
-
-function getUpgradedValue(
-  base: number | null,
-  upgradeVal: string | number | null | undefined
-): number | null {
-  if (base == null || upgradeVal == null) return base;
-  if (typeof upgradeVal === "number") return upgradeVal;
-  if (typeof upgradeVal === "string" && upgradeVal.startsWith("+"))
-    return base + parseInt(upgradeVal);
-  return base;
-}
-
-function getUpgradedDescription(card: Card, upgraded: boolean): string {
-  // Use upgrade_description as base text when upgraded (handles text-based upgrades like "X+1", "ALL cards", etc.)
-  let desc = (upgraded && card.upgrade_description ? card.upgrade_description : card.description || "").replace(/\n/g, " ");
-  const u = upgraded && card.upgrade ? card.upgrade : null;
-  const vars = card.vars || {};
-
-  if (u) {
-    // Collect all replacements first to avoid cascading (e.g. Spur: 3→5 then 5→7)
-    const replacements: { base: string; upgraded: string; varKey: string }[] = [];
-
-    for (const [key, upVal] of Object.entries(u)) {
-      if (upVal == null) continue;
-      const kl = key.toLowerCase();
-      // Handle icon tag upgrades first — skip general replacement to avoid corrupting tags
-      if (kl === "energy") {
-        const baseEnergy = vars["Energy"] ?? 1;
-        const upEnergy = getUpgradedValue(baseEnergy, upVal) ?? baseEnergy;
-        if (upEnergy !== baseEnergy) desc = desc.replace(/\[energy:(\d+)\]/, `[energy:${upEnergy}]`);
-        continue;
-      }
-      if (kl === "stars" || kl === "starnextturnpower") {
-        const starVar = kl === "stars" ? "Stars" : "StarNextTurnPower";
-        const baseStar = vars[starVar] ?? 1;
-        const upStar = getUpgradedValue(baseStar, upVal) ?? baseStar;
-        if (upStar !== baseStar) desc = desc.replace(`[star:${baseStar}]`, `[star:${upStar}]`);
-        continue;
-      }
-      // Handle repeat/hit count upgrades with contextual replacement ("N times")
-      if (kl === "repeat" && vars["Repeat"] != null) {
-        const base = vars["Repeat"];
-        const upgradedRepeat = getUpgradedValue(base, upVal);
-        if (upgradedRepeat !== null && upgradedRepeat !== base) {
-          // When using upgrade_description, search for the upgraded value instead of base
-          const searchVal = (upgraded && card.upgrade_description) ? upgradedRepeat : base;
-          if (new RegExp(`\\b${searchVal}\\b\\s*times`, "i").test(desc)) {
-            desc = desc.replace(new RegExp(`\\b${searchVal}\\b(\\s*times)`, "i"), `[green]${upgradedRepeat}[/green]$1`);
-            continue;
-          }
-          // Fall through to general replacement for non-"times" repeat vars (e.g. "2 Orb Slots", "1 random Orb")
-        } else {
-          continue;
-        }
-      }
-      const varKey = Object.keys(vars).find(
-        (k) => k.toLowerCase() === kl
-      );
-      if (varKey && vars[varKey] != null) {
-        const base = vars[varKey];
-        const upgradedVal = getUpgradedValue(base, upVal);
-        if (upgradedVal !== null && upgradedVal !== base) {
-          replacements.push({ base: String(base), upgraded: String(upgradedVal), varKey });
-        }
-      }
-    }
-
-    // When using upgrade_description, the text already has upgraded values —
-    // find them and wrap in [green] instead of replacing base values
-    const usingUpgradeDesc = upgraded && !!card.upgrade_description;
-
-    // Apply replacements in a single pass — skip ambiguous values (same number appears multiple times)
-    if (replacements.length > 0) {
-      const replMap = usingUpgradeDesc
-        ? new Map(replacements.map((r) => [r.upgraded, r.upgraded]))
-        : new Map(replacements.map((r) => [r.base, r.upgraded]));
-      const pattern = replacements
-        .map((r) => usingUpgradeDesc ? r.upgraded : r.base)
-        .sort((a, b) => b.length - a.length)
-        .map((s) => `\\b${s}\\b`)
-        .join("|");
-      const occurrences = new Map<string, number>();
-      desc.replace(new RegExp(pattern, "g"), (match) => {
-        occurrences.set(match, (occurrences.get(match) || 0) + 1);
-        return match;
-      });
-      const used = new Set<string>();
-      desc = desc.replace(new RegExp(pattern, "g"), (match) => {
-        if (used.has(match)) return match;
-        if ((occurrences.get(match) || 0) > 1) {
-          // Allow replacement when all upgrades for this value are the same
-          // (e.g. Bulk Up: both Strength and Dexterity go 2→3)
-          const allSame = replacements.filter(r => r.base === match).every(r => r.upgraded === replMap.get(match));
-          if (!allSame) return match;
-          return `[green]${replMap.get(match)}[/green]`;
-        }
-        used.add(match);
-        const repl = replMap.get(match);
-        return repl ? `[green]${repl}[/green]` : match;
-      });
-
-      // Contextual replacement for ambiguous values (e.g. Coolheaded: "Channel 1 Frost. Draw 1 card." → only "Draw" changes)
-      for (const r of replacements) {
-        if ((occurrences.get(r.base) || 0) <= 1) continue;
-        if (used.has(r.base)) continue;
-        const context = r.varKey.toLowerCase().replace(/s$/, "");
-        const fwd = new RegExp(`\\b${r.base}\\b(\\s+${context})(s?)`, "i");
-        if (fwd.test(desc)) {
-          const plural = parseInt(r.upgraded) === 1 ? "" : "s";
-          desc = desc.replace(fwd, `[green]${r.upgraded}[/green]$1${plural}`);
-          continue;
-        }
-        const bwd = new RegExp(`(${context}\\s+)\\b${r.base}\\b`, "i");
-        if (bwd.test(desc)) {
-          desc = desc.replace(bwd, `$1[green]${r.upgraded}[/green]`);
-        }
-      }
-    }
-  }
-
-  return desc;
 }
 
 type Tab = "overview" | "details" | "info";
@@ -370,14 +247,14 @@ export default function CardDetail({ initialCard }: { initialCard?: Card | null 
     );
   }
 
-  const u = upgraded && card.upgrade ? card.upgrade : null;
+  const display = getCardDisplayModel(card, upgraded);
   const activeVariant = selectedVariant && card.type_variants ? card.type_variants[selectedVariant] : null;
-  const dmg = activeVariant ? activeVariant.damage : (u ? getUpgradedValue(card.damage, u.damage) : card.damage);
-  const blk = activeVariant ? activeVariant.block : (u ? getUpgradedValue(card.block, u.block) : card.block);
-  const hitCount = u?.repeat ? getUpgradedValue(card.hit_count, u.repeat) : card.hit_count;
-  const cost = u && u.cost != null ? (u.cost as number) : card.cost;
+  const dmg = activeVariant ? activeVariant.damage : display.damage;
+  const blk = activeVariant ? activeVariant.block : display.block;
+  const hitCount = activeVariant ? card.hit_count : display.hitCount;
+  const cost = activeVariant ? card.cost : display.cost;
   const displayType = activeVariant ? activeVariant.type : card.type;
-  const isUpgraded = upgraded && card.upgrade != null;
+  const isUpgraded = display.isUpgraded;
   const hasBetaArt = !!card.beta_image_url;
   const hasUpgrade = !!card.upgrade;
   const hasVariants = !!card.type_variants;
@@ -389,9 +266,11 @@ export default function CardDetail({ initialCard }: { initialCard?: Card | null 
       ? card.beta_image_url
       : card.image_url || card.beta_image_url;
 
-  const descText = activeVariant ? activeVariant.description : getUpgradedDescription(card, upgraded);
+  const descText = activeVariant ? activeVariant.description : display.descriptionText;
+  const keywordText = activeVariant ? "" : display.keywordText;
   const energyIcon = energyIconMap[card.color] || "colorless";
   const priceRange = getMerchantPriceRange(card.rarity_key || card.rarity, card.color);
+  const displayKeywords = [...display.visibleKeywords, ...display.addedKeywords];
 
   const tabs: { key: Tab; label: string }[] = [
     { key: "overview", label: t("Overview", lang) },
@@ -437,7 +316,7 @@ export default function CardDetail({ initialCard }: { initialCard?: Card | null 
             <div className="ml-3 flex-shrink-0 flex items-center gap-1.5">
               <span
                 className={`inline-flex items-center justify-center w-10 h-10 rounded-full bg-[var(--bg-primary)] border text-xl font-bold ${
-                  isUpgraded && u?.cost != null
+                  isUpgraded && display.upgrade?.cost != null
                     ? "border-emerald-700/50 text-emerald-400"
                     : "border-[var(--border-subtle)] text-[var(--accent-gold)]"
                 }`}
@@ -593,20 +472,31 @@ export default function CardDetail({ initialCard }: { initialCard?: Card | null 
                   })}
                 </div>
               ) : (
-                <div className="text-sm text-[var(--text-secondary)] leading-relaxed mb-5">
-                  <RichDescription
-                    text={descText + (card.keywords && card.keywords.length > 0 ? "\n" + card.keywords.filter((kw) => !(isUpgraded && u?.remove_exhaust && kw === "Exhaust") && !(isUpgraded && u?.remove_ethereal && kw === "Ethereal")).map((kw) => `[gold]${kw}[/gold]`).join(". ") + "." : "") + (isUpgraded && u?.add_innate && !card.keywords?.includes("Innate") ? "\n[green]Innate[/green]." : "") + (isUpgraded && u?.add_retain && !card.keywords?.includes("Retain") ? "\n[green]Retain[/green]." : "")}
-                    energyIcon={energyIcon}
-                    relatedCards={spawnedCards.map((sc): RelatedCard => ({
-                      id: sc.id,
-                      name: sc.name,
-                      image_url: sc.image_url,
-                      type: sc.type,
-                      rarity: sc.rarity,
-                      cost: sc.cost,
-                    }))}
-                    interactiveWords={buildInteractiveWords(card, powerData, keywordData, glossaryData, orbData, lp)}
-                  />
+                <div className="text-sm text-[var(--text-secondary)] leading-relaxed mb-5 space-y-2">
+                  <div>
+                    <RichDescription
+                      text={descText}
+                      energyIcon={energyIcon}
+                      relatedCards={spawnedCards.map((sc): RelatedCard => ({
+                        id: sc.id,
+                        name: sc.name,
+                        image_url: sc.image_url,
+                        type: sc.type,
+                        rarity: sc.rarity,
+                        cost: sc.cost,
+                      }))}
+                      interactiveWords={buildInteractiveWords(displayKeywords, powerData, keywordData, glossaryData, orbData, lp)}
+                    />
+                  </div>
+                  {keywordText && (
+                    <div>
+                      <RichDescription
+                        text={keywordText}
+                        energyIcon={energyIcon}
+                        interactiveWords={buildInteractiveWords(displayKeywords, powerData, keywordData, glossaryData, orbData, lp)}
+                      />
+                    </div>
+                  )}
                 </div>
               )}
 
@@ -661,7 +551,7 @@ export default function CardDetail({ initialCard }: { initialCard?: Card | null 
               {/* Related Cards */}
               <RelatedCards
                 currentId={id}
-                keywords={card.keywords}
+                keywords={displayKeywords}
                 tags={card.tags}
                 color={card.color}
               />

--- a/frontend/app/components/CardGrid.tsx
+++ b/frontend/app/components/CardGrid.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import Link from "next/link";
 import type { Card } from "@/lib/api";
+import { getCardDisplayModel } from "@/lib/card-display";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -31,135 +32,21 @@ const rarityColors: Record<string, string> = {
   Quest: "text-amber-400",
 };
 
-const typeIcons: Record<string, string> = {
-  Attack: "⚔",
-  Skill: "🛡",
-  Power: "✦",
-  Status: "◆",
-  Curse: "☠",
-  Quest: "★",
-};
-
-const keywordTooltips: Record<string, string> = {
-  Exhaust: "Remove this card from your deck when played.",
-  Ethereal: "If this card is in your hand at end of turn, discard it.",
-  Innate: "Always appears in your opening hand.",
-  Unplayable: "Cannot be played from your hand.",
-  Retain: "Keep this card in your hand at end of turn.",
-  Sly: "Can be played from the discard pile.",
-  Eternal: "Cannot be removed from your deck.",
-};
-
 const energyIconMap: Record<string, string> = {
   ironclad: "ironclad", silent: "silent", defect: "defect",
   necrobinder: "necrobinder", regent: "regent", colorless: "colorless",
 };
 
-function renderDescription(card: Card, upgraded: boolean): React.ReactNode {
-  const desc = (upgraded && card.upgrade_description ? card.upgrade_description : card.description || "").replace(/\n/g, " ");
-  const u = upgraded && card.upgrade ? card.upgrade : null;
-  const vars = card.vars || {};
-
-  let text = desc;
-  if (u) {
-    const replacements: { base: string; upgraded: string; varKey: string }[] = [];
-
-    for (const [key, upVal] of Object.entries(u)) {
-      if (upVal == null) continue;
-      const kl = key.toLowerCase();
-      // Handle icon tag upgrades first — skip general replacement to avoid corrupting tags
-      if (kl === "energy") {
-        const baseEnergy = vars["Energy"] ?? 1;
-        const upEnergy = getUpgradedValue(baseEnergy, upVal) ?? baseEnergy;
-        if (upEnergy !== baseEnergy) text = text.replace(/\[energy:(\d+)\]/, `[energy:${upEnergy}]`);
-        continue;
-      }
-      if (kl === "stars" || kl === "starnextturnpower") {
-        const starVar = kl === "stars" ? "Stars" : "StarNextTurnPower";
-        const baseStar = vars[starVar] ?? 1;
-        const upStar = getUpgradedValue(baseStar, upVal) ?? baseStar;
-        if (upStar !== baseStar) text = text.replace(`[star:${baseStar}]`, `[star:${upStar}]`);
-        continue;
-      }
-      if (kl === "repeat" && vars["Repeat"] != null) {
-        const base = vars["Repeat"];
-        const upgradedVal = getUpgradedValue(base, upVal);
-        if (upgradedVal !== null && upgradedVal !== base) {
-          if (new RegExp(`\\b${base}\\b\\s*times`, "i").test(text)) {
-            text = text.replace(new RegExp(`\\b${base}\\b(\\s*times)`, "i"), `[green]${upgradedVal}[/green]$1`);
-            continue;
-          }
-        } else {
-          continue;
-        }
-      }
-      const varKey = Object.keys(vars).find(k => k.toLowerCase() === kl);
-      if (varKey && vars[varKey] != null) {
-        const base = vars[varKey];
-        const upgradedVal = getUpgradedValue(base, upVal);
-        if (upgradedVal !== null && upgradedVal !== base) {
-          replacements.push({ base: String(base), upgraded: String(upgradedVal), varKey });
-        }
-      }
-    }
-
-    if (replacements.length > 0) {
-      const occurrences = new Map<string, number>();
-      for (const r of replacements) {
-        const count = (text.match(new RegExp(`\\b${r.base}\\b`, "g")) || []).length;
-        occurrences.set(r.base, Math.max(occurrences.get(r.base) || 0, count));
-      }
-
-      // Single-pass for unambiguous values + ambiguous values where all upgrades are the same
-      // (e.g. Bulk Up: both Strength and Dexterity go 2→3, Capture Spirit: both Damage and Cards go 3→4)
-      const sameUpgradeAmbiguous = replacements.filter(r => {
-        if ((occurrences.get(r.base) || 0) <= 1) return false;
-        return replacements.filter(r2 => r2.base === r.base).every(r2 => r2.upgraded === r.upgraded);
-      });
-      const eligible = [...replacements.filter(r => (occurrences.get(r.base) || 0) === 1), ...sameUpgradeAmbiguous];
-      if (eligible.length > 0) {
-        const replMap = new Map(eligible.map(r => [r.base, r.upgraded]));
-        const pattern = eligible.map(r => r.base).sort((a, b) => b.length - a.length).map(s => `\\b${s}\\b`).join("|");
-        const used = new Set<string>();
-        text = text.replace(new RegExp(pattern, "g"), (match) => {
-          // For same-upgrade-ambiguous values, replace all occurrences
-          if (sameUpgradeAmbiguous.some(r => r.base === match)) {
-            return `[green]${replMap.get(match)}[/green]`;
-          }
-          if (used.has(match)) return match;
-          used.add(match);
-          const repl = replMap.get(match);
-          return repl ? `[green]${repl}[/green]` : match;
-        });
-      }
-
-      // Contextual replacement for ambiguous values
-      for (const r of replacements) {
-        if ((occurrences.get(r.base) || 0) <= 1) continue;
-        if (sameUpgradeAmbiguous.some(r2 => r2.base === r.base)) continue;
-        const context = r.varKey.toLowerCase().replace(/s$/, "");
-        const fwd = new RegExp(`\\b${r.base}\\b(\\s+${context})(s?)`, "i");
-        if (fwd.test(text)) {
-          const plural = parseInt(r.upgraded) === 1 ? "" : "s";
-          text = text.replace(fwd, `[green]${r.upgraded}[/green]$1${plural}`);
-          continue;
-        }
-        const bwd = new RegExp(`(${context}\\s+)\\b${r.base}\\b`, "i");
-        if (bwd.test(text)) {
-          text = text.replace(bwd, `$1[green]${r.upgraded}[/green]`);
-        }
-      }
-    }
-  }
-
+function renderDescription(card: Card, text: string): React.ReactNode {
+  const normalizedText = text.replace(/\n/g, " ");
   const parts: React.ReactNode[] = [];
   const regex = /(\[gold\].*?\[\/gold\]|\[green\].*?\[\/green\]|\[energy:(\d+)\]|\[star:(\d+)\])/g;
   let lastIndex = 0;
   let matchArr: RegExpExecArray | null;
 
-  while ((matchArr = regex.exec(text)) !== null) {
+  while ((matchArr = regex.exec(normalizedText)) !== null) {
     if (matchArr.index > lastIndex) {
-      parts.push(text.slice(lastIndex, matchArr.index));
+      parts.push(normalizedText.slice(lastIndex, matchArr.index));
     }
 
     const segment = matchArr[0];
@@ -195,30 +82,20 @@ function renderDescription(card: Card, upgraded: boolean): React.ReactNode {
     lastIndex = regex.lastIndex;
   }
 
-  if (lastIndex < text.length) {
-    parts.push(text.slice(lastIndex));
+  if (lastIndex < normalizedText.length) {
+    parts.push(normalizedText.slice(lastIndex));
   }
 
   return parts;
-}
-
-function getUpgradedValue(base: number | null, upgradeVal: string | number | null | undefined): number | null {
-  if (base == null || upgradeVal == null) return base;
-  if (typeof upgradeVal === "number") return upgradeVal;
-  if (typeof upgradeVal === "string" && upgradeVal.startsWith("+")) return base + parseInt(upgradeVal);
-  return base;
 }
 
 function CardItem({ card }: { card: Card }) {
   const lp = useLangPrefix();
   const [upgraded, setUpgraded] = useState(false);
   const [betaArt, setBetaArt] = useState(false);
+  const display = getCardDisplayModel(card, upgraded);
 
-  const u = upgraded && card.upgrade ? card.upgrade : null;
-  const dmg = u ? getUpgradedValue(card.damage, u.damage) : card.damage;
-  const blk = u ? getUpgradedValue(card.block, u.block) : card.block;
-  const cost = u && u.cost != null ? u.cost as number : card.cost;
-  const isUpgraded = upgraded && card.upgrade != null;
+  const isUpgraded = display.isUpgraded;
   const hasBetaArt = !!card.beta_image_url;
   const hasUpgrade = !!card.upgrade;
 
@@ -252,9 +129,9 @@ function CardItem({ card }: { card: Card }) {
         </h3>
         <div className="ml-2 flex-shrink-0 flex items-center gap-1">
           <span className={`inline-flex items-center justify-center w-7 h-7 rounded-full bg-[var(--bg-primary)] border text-sm font-bold ${
-            isUpgraded && u?.cost != null ? "border-emerald-700/50 text-emerald-400" : "border-[var(--border-subtle)] text-[var(--accent-gold)]"
+            isUpgraded && display.upgrade?.cost != null ? "border-emerald-700/50 text-emerald-400" : "border-[var(--border-subtle)] text-[var(--accent-gold)]"
           }`}>
-            {card.is_x_cost ? "X" : cost != null && cost < 0 ? "U" : cost}
+            {card.is_x_cost ? "X" : display.cost != null && display.cost < 0 ? "U" : display.cost}
           </span>
           {(card.star_cost != null || card.is_x_star_cost) && (
             <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-[var(--bg-primary)] border border-amber-700/40 text-xs font-bold text-amber-300">
@@ -282,28 +159,10 @@ function CardItem({ card }: { card: Card }) {
       </div>
 
       {/* Description */}
-      <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
-        {renderDescription(card, upgraded)}
-        {card.keywords && card.keywords.length > 0 && (
-          <>
-            {" "}
-            {card.keywords
-              .filter((kw) => !(isUpgraded && u?.remove_exhaust && kw === "Exhaust") && !(isUpgraded && u?.remove_ethereal && kw === "Ethereal"))
-              .map((kw, i) => (
-                <span key={kw}>
-                  <span className="text-[var(--accent-gold)]">{kw}</span>
-                  {i < card.keywords!.filter((k) => !(isUpgraded && u?.remove_exhaust && k === "Exhaust") && !(isUpgraded && u?.remove_ethereal && k === "Ethereal")).length - 1 ? ". " : "."}
-                </span>
-              ))}
-            {isUpgraded && u?.add_innate && !card.keywords?.includes("Innate") && (
-              <span> <span className="text-emerald-400">Innate</span>.</span>
-            )}
-            {isUpgraded && u?.add_retain && !card.keywords?.includes("Retain") && (
-              <span> <span className="text-emerald-400">Retain</span>.</span>
-            )}
-          </>
-        )}
-      </p>
+      <div className="space-y-1.5 text-sm text-[var(--text-secondary)] leading-relaxed">
+        <p>{renderDescription(card, display.descriptionText)}</p>
+        {display.keywordText && <p>{renderDescription(card, display.keywordText)}</p>}
+      </div>
 
 
       {/* Spacer to push buttons to bottom */}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -48,7 +48,7 @@ export interface Card {
   tags: string[] | null;
   spawns_cards: string[] | null;
   vars: Record<string, number> | null;
-  upgrade: Record<string, string | number | null> | null;
+  upgrade: Record<string, string | number | boolean | null> | null;
   upgrade_description: string | null;
   image_url: string | null;
   beta_image_url: string | null;

--- a/frontend/lib/card-display.test.ts
+++ b/frontend/lib/card-display.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { Card } from "./api";
+import { getCardDisplayModel } from "./card-display";
+
+function createCard(overrides: Partial<Card> = {}): Card {
+  return {
+    id: "test-card",
+    name: "Test Card",
+    description: "Deal 6 damage.",
+    description_raw: null,
+    cost: 1,
+    is_x_cost: false,
+    is_x_star_cost: false,
+    star_cost: null,
+    type: "Attack",
+    type_key: null,
+    rarity: "Common",
+    rarity_key: null,
+    target: "Enemy",
+    color: "ironclad",
+    damage: 6,
+    block: null,
+    hit_count: null,
+    powers_applied: null,
+    cards_draw: null,
+    energy_gain: null,
+    hp_loss: null,
+    keywords: null,
+    keywords_key: null,
+    tags: null,
+    spawns_cards: null,
+    vars: { Damage: 6 },
+    upgrade: null,
+    upgrade_description: null,
+    image_url: null,
+    beta_image_url: null,
+    type_variants: null,
+    compendium_order: 1,
+    ...overrides,
+  };
+}
+
+describe("getCardDisplayModel", () => {
+  it("keeps keyword text separate from the main description", () => {
+    const card = createCard({
+      description: "Whenever you play a card, gain 1 Block.",
+      damage: null,
+      block: 1,
+      vars: { Block: 1 },
+      upgrade: { add_innate: true },
+    });
+
+    const display = getCardDisplayModel(card, true);
+
+    expect(display.descriptionText).toBe("Whenever you play a card, gain 1 Block.");
+    expect(display.keywordText).toBe("[green]Innate[/green].");
+    expect(display.addedKeywords).toEqual(["Innate"]);
+  });
+
+  it("highlights repeated upgraded values in the description body", () => {
+    const card = createCard({
+      description: "Deal 3 damage. Gain 3 Block.",
+      damage: 3,
+      block: 3,
+      vars: { Damage: 3, Block: 3 },
+      upgrade: { damage: "+1", block: "+1" },
+    });
+
+    const display = getCardDisplayModel(card, true);
+
+    expect(display.descriptionText).toBe("Deal [green]4[/green] damage. Gain [green]4[/green] Block.");
+    expect(display.keywordText).toBe("");
+  });
+
+  it("removes hidden keywords from the visible keyword output", () => {
+    const card = createCard({
+      description: "Gain 8 Block.",
+      damage: null,
+      block: 8,
+      keywords: ["Exhaust"],
+      vars: { Block: 8 },
+      upgrade: { remove_exhaust: true, add_innate: true },
+    });
+
+    const display = getCardDisplayModel(card, true);
+
+    expect(display.visibleKeywords).toEqual([]);
+    expect(display.addedKeywords).toEqual(["Innate"]);
+    expect(display.removedKeywords).toEqual(["Exhaust"]);
+    expect(display.keywordText).toBe("[green]Innate[/green].");
+  });
+
+it("highlights values inside upgrade_description without replacing from the base description", () => {
+  const card = createCard({
+    description: "Draw 1 card.",
+    damage: null,
+    block: null,
+    vars: { Draw: 1 },
+    upgrade: { draw: "+1" },
+    upgrade_description: "Draw 2 cards.",
+  });
+
+  const display = getCardDisplayModel(card, true);
+
+  expect(display.descriptionText).toBe("Draw [green]2[/green] cards.");
+  expect(display.keywordText).toBe("");
+  });
+  
+});

--- a/frontend/lib/card-display.ts
+++ b/frontend/lib/card-display.ts
@@ -1,0 +1,244 @@
+import type { Card } from "./api";
+
+export interface CardDisplayModel {
+  isUpgraded: boolean;
+  upgrade: Card["upgrade"];
+  cost: number;
+  damage: number | null;
+  block: number | null;
+  hitCount: number | null;
+  descriptionText: string;
+  keywordText: string;
+  visibleKeywords: string[];
+  addedKeywords: string[];
+  removedKeywords: string[];
+}
+
+const REMOVED_KEYWORD_FLAGS = {
+  remove_exhaust: "Exhaust",
+  remove_ethereal: "Ethereal",
+} as const;
+
+const ADDED_KEYWORD_FLAGS = {
+  add_innate: "Innate",
+  add_retain: "Retain",
+} as const;
+
+const removedKeywordEntries = Object.entries(REMOVED_KEYWORD_FLAGS) as Array<
+  [keyof typeof REMOVED_KEYWORD_FLAGS, (typeof REMOVED_KEYWORD_FLAGS)[keyof typeof REMOVED_KEYWORD_FLAGS]]
+>;
+
+const addedKeywordEntries = Object.entries(ADDED_KEYWORD_FLAGS) as Array<
+  [keyof typeof ADDED_KEYWORD_FLAGS, (typeof ADDED_KEYWORD_FLAGS)[keyof typeof ADDED_KEYWORD_FLAGS]]
+>;
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function getUpgradedValue(
+  base: number | null,
+  upgradeVal: string | number | null | undefined
+): number | null {
+  if (base == null || upgradeVal == null) return base;
+  if (typeof upgradeVal === "number") return upgradeVal;
+  if (
+    typeof upgradeVal === "string" &&
+    (upgradeVal.startsWith("+") || upgradeVal.startsWith("-"))
+  ) {
+    return base + parseInt(upgradeVal, 10);
+  }
+  return base;
+}
+
+function buildVisibleKeywords(card: Card, isUpgraded: boolean): {
+  visibleKeywords: string[];
+  addedKeywords: string[];
+  removedKeywords: string[];
+  keywordText: string;
+} {
+  const baseKeywords = card.keywords ?? [];
+  const upgrade = isUpgraded ? card.upgrade : null;
+
+  const removedKeywords: string[] = removedKeywordEntries
+    .filter(([flag]) => Boolean(upgrade?.[flag]))
+    .map(([, keyword]) => keyword)
+    .filter((keyword) => baseKeywords.includes(keyword));
+
+  const visibleKeywords = baseKeywords.filter((keyword) => !removedKeywords.includes(keyword));
+
+  const addedKeywords: string[] = addedKeywordEntries
+    .filter(([flag, keyword]) => Boolean(upgrade?.[flag]) && !baseKeywords.includes(keyword))
+    .map(([, keyword]) => keyword);
+
+  const richTextParts: string[] = [];
+  if (visibleKeywords.length > 0) {
+    richTextParts.push(visibleKeywords.map((keyword) => `[gold]${keyword}[/gold]`).join(". ") + ".");
+  }
+  richTextParts.push(...addedKeywords.map((keyword) => `[green]${keyword}[/green].`));
+
+  return {
+    visibleKeywords,
+    addedKeywords,
+    removedKeywords,
+    keywordText: richTextParts.join("\n"),
+  };
+}
+
+function buildUpgradedDescription(card: Card, isUpgraded: boolean): string {
+  let description = (isUpgraded && card.upgrade_description ? card.upgrade_description : card.description || "").replace(/\n/g, " ");
+  const upgrade = isUpgraded ? card.upgrade : null;
+  const vars = card.vars || {};
+
+  if (!upgrade) return description;
+
+  const usingUpgradeDescription = isUpgraded && !!card.upgrade_description;
+  const replacements: Array<{ search: string; upgraded: string; varKey: string }> = [];
+
+  for (const [key, upgradeValue] of Object.entries(upgrade)) {
+    if (upgradeValue == null || typeof upgradeValue === "boolean") continue;
+
+    const normalizedKey = key.toLowerCase();
+
+    if (normalizedKey === "energy") {
+      const baseEnergy = vars["Energy"] ?? 1;
+      const upgradedEnergy = getUpgradedValue(baseEnergy, upgradeValue) ?? baseEnergy;
+      if (upgradedEnergy !== baseEnergy) {
+        description = description.replace(/\[energy:(\d+)\]/, `[energy:${upgradedEnergy}]`);
+      }
+      continue;
+    }
+
+    if (normalizedKey === "stars" || normalizedKey === "starnextturnpower") {
+      const starVar = normalizedKey === "stars" ? "Stars" : "StarNextTurnPower";
+      const baseStars = vars[starVar] ?? 1;
+      const upgradedStars = getUpgradedValue(baseStars, upgradeValue) ?? baseStars;
+      if (upgradedStars !== baseStars) {
+        description = description.replace(`[star:${baseStars}]`, `[star:${upgradedStars}]`);
+      }
+      continue;
+    }
+
+    if (normalizedKey === "repeat" && vars["Repeat"] != null) {
+      const baseRepeat = vars["Repeat"];
+      const upgradedRepeat = getUpgradedValue(baseRepeat, upgradeValue);
+      if (upgradedRepeat === null || upgradedRepeat === baseRepeat) continue;
+
+      const searchValue = String(usingUpgradeDescription ? upgradedRepeat : baseRepeat);
+      const repeatedTimesPattern = new RegExp(`\\b${escapeRegex(searchValue)}\\b(\\s*times)`, "i");
+      if (repeatedTimesPattern.test(description)) {
+        description = description.replace(repeatedTimesPattern, `[green]${upgradedRepeat}[/green]$1`);
+        continue;
+      }
+    }
+
+    const varKey = Object.keys(vars).find((candidate) => candidate.toLowerCase() === normalizedKey);
+    if (!varKey || vars[varKey] == null) continue;
+
+    const upgradedValue = getUpgradedValue(vars[varKey], upgradeValue);
+    if (upgradedValue === null || upgradedValue === vars[varKey]) continue;
+
+    replacements.push({
+      search: String(usingUpgradeDescription ? upgradedValue : vars[varKey]),
+      upgraded: String(upgradedValue),
+      varKey,
+    });
+  }
+
+  if (replacements.length === 0) return description;
+
+  const occurrences = new Map<string, number>();
+  for (const replacement of replacements) {
+    const pattern = new RegExp(`\\b${escapeRegex(replacement.search)}\\b`, "g");
+    const count = (description.match(pattern) || []).length;
+    occurrences.set(replacement.search, Math.max(occurrences.get(replacement.search) || 0, count));
+  }
+
+  const sameUpgradeAmbiguous = replacements.filter((replacement) => {
+    if ((occurrences.get(replacement.search) || 0) <= 1) return false;
+    return replacements
+      .filter((candidate) => candidate.search === replacement.search)
+      .every((candidate) => candidate.upgraded === replacement.upgraded);
+  });
+
+  const eligible = [
+    ...replacements.filter((replacement) => (occurrences.get(replacement.search) || 0) === 1),
+    ...sameUpgradeAmbiguous,
+  ];
+
+  if (eligible.length > 0) {
+    const replacementMap = new Map(eligible.map((replacement) => [replacement.search, replacement.upgraded]));
+    const pattern = eligible
+      .map((replacement) => replacement.search)
+      .sort((a, b) => b.length - a.length)
+      .map((value) => `\\b${escapeRegex(value)}\\b`)
+      .join("|");
+
+    const used = new Set<string>();
+    description = description.replace(new RegExp(pattern, "g"), (match) => {
+      if (sameUpgradeAmbiguous.some((replacement) => replacement.search === match)) {
+        return `[green]${replacementMap.get(match)}[/green]`;
+      }
+      if (used.has(match)) return match;
+      used.add(match);
+      const upgradedValue = replacementMap.get(match);
+      return upgradedValue ? `[green]${upgradedValue}[/green]` : match;
+    });
+  }
+
+  for (const replacement of replacements) {
+    if ((occurrences.get(replacement.search) || 0) <= 1) continue;
+    if (sameUpgradeAmbiguous.some((candidate) => candidate.search === replacement.search)) continue;
+
+    const context = replacement.varKey.toLowerCase().replace(/s$/, "");
+    const forwardPattern = new RegExp(`\\b${escapeRegex(replacement.search)}\\b(\\s+${escapeRegex(context)})(s?)`, "i");
+    if (forwardPattern.test(description)) {
+      const plural = parseInt(replacement.upgraded, 10) === 1 ? "" : "s";
+      description = description.replace(forwardPattern, `[green]${replacement.upgraded}[/green]$1${plural}`);
+      continue;
+    }
+
+    const backwardPattern = new RegExp(`(${escapeRegex(context)}\\s+)\\b${escapeRegex(replacement.search)}\\b`, "i");
+    if (backwardPattern.test(description)) {
+      description = description.replace(backwardPattern, `$1[green]${replacement.upgraded}[/green]`);
+    }
+  }
+
+  return description;
+}
+
+export function getCardDisplayModel(card: Card, upgraded: boolean): CardDisplayModel {
+  const isUpgraded = upgraded && card.upgrade != null;
+  const upgrade = isUpgraded ? card.upgrade : null;
+  const keywordDisplay = buildVisibleKeywords(card, isUpgraded);
+  const upgradedCost = upgrade?.cost;
+  const upgradedDamage = upgrade?.damage;
+  const upgradedBlock = upgrade?.block;
+  const upgradedRepeat = upgrade?.repeat;
+
+  return {
+    isUpgraded,
+    upgrade,
+    cost:
+      upgrade && upgradedCost != null && typeof upgradedCost !== "boolean"
+        ? getUpgradedValue(card.cost, upgradedCost) ?? card.cost
+        : card.cost,
+    damage:
+      upgrade && typeof upgradedDamage !== "boolean"
+        ? getUpgradedValue(card.damage, upgradedDamage)
+        : card.damage,
+    block:
+      upgrade && typeof upgradedBlock !== "boolean"
+        ? getUpgradedValue(card.block, upgradedBlock)
+        : card.block,
+    hitCount:
+      upgrade && upgradedRepeat != null && typeof upgradedRepeat !== "boolean"
+        ? getUpgradedValue(card.hit_count, upgradedRepeat)
+        : card.hit_count,
+    descriptionText: buildUpgradedDescription(card, isUpgraded),
+    keywordText: keywordDisplay.keywordText,
+    visibleKeywords: keywordDisplay.visibleKeywords,
+    addedKeywords: keywordDisplay.addedKeywords,
+    removedKeywords: keywordDisplay.removedKeywords,
+  };
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,8 @@
         "eslint-config-next": "16.1.6",
         "eslint-plugin-react-compiler": "^19.1.0-rc.2",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -418,6 +419,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3192,6 +3635,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -3272,6 +3726,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -3995,6 +4456,131 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -4478,6 +5064,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -4624,6 +5220,16 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -4714,6 +5320,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4769,6 +5392,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -5095,6 +5728,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -5431,6 +6074,48 @@
         "docs",
         "benchmarks"
       ]
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -5956,6 +6641,16 @@
       "peer": true,
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -7660,6 +8355,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -9093,6 +9795,23 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -10013,6 +10732,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10060,6 +10786,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stacktrace-parser": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
@@ -10071,6 +10804,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -10236,6 +10976,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -10382,6 +11142,20 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -10428,6 +11202,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -10898,6 +11702,228 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
@@ -11113,6 +12139,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@sentry/nextjs": "^10.48.0",
@@ -26,6 +27,7 @@
     "eslint-config-next": "16.1.6",
     "eslint-plugin-react-compiler": "^19.1.0-rc.2",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.4"
   }
 }


### PR DESCRIPTION
fix #30 

After testing this locally, I found that the main problem was in the card grid:

- many upgraded numeric values were not highlighted in green
- some keyword-only upgrades were also missing in the grid, cards like `Afterimage` and `Aggression` did not show added `Innate` correctly after upgrading
- after checking more cards, the actual numeric upgrade values were mostly correct, but the grid and detail page were clearly not deriving upgraded display state in the same way

This change fixes that by moving upgraded card display derivation into a shared helper and having both views use the same display model.

Changes in this PR:
- added a shared `getCardDisplayModel()` helper
- unified upgraded value handling for cost / damage / block / repeat
- separated description text from keyword text and let each view render them separately
- fixed keyword flag cases like `add_innate`, `add_retain`, `remove_exhaust`, and `remove_ethereal`
- added a small unit test file for the shared helper

By the way, I checked this locally after the changes, and the frontend looks good now.