### PR TITLE
Split-button downloads on /images — choose format or grab all

### DIFF
--- a/backend/app/routers/images.py
+++ b/backend/app/routers/images.py
@@ -113,6 +113,16 @@ def _get_images_for_category(category_id: str) -> list[dict[str, str]]:
     return images
 
 
+def _extensions_in(images: list[dict[str, str]]) -> list[str]:
+    """Return sorted unique file extensions (lowercase, no dot) present in the list."""
+    exts: set[str] = set()
+    for img in images:
+        name = img.get("filename", "")
+        if "." in name:
+            exts.add(name.rsplit(".", 1)[-1].lower())
+    return sorted(exts)
+
+
 @router.get("", tags=["Images"])
 def list_image_categories(request: Request):
     """Return all image categories with their contents."""
@@ -125,22 +135,34 @@ def list_image_categories(request: Request):
                 "name": display_name,
                 "count": len(images),
                 "images": images,
+                "formats": _extensions_in(images),
             }
         )
     return result
 
 
 @router.get("/{category}/download", tags=["Images"])
-def download_category_zip(category: str, request: Request):
-    """Download all images in a category as a zip file."""
+def download_category_zip(category: str, request: Request, format: str | None = None):
+    """Download all images in a category as a zip file.
+
+    Optional `?format=` query param filters to a single extension (e.g. `png`,
+    `webp`, `gif`). Omit to include every file in the category.
+    """
     if category not in CATEGORIES:
         raise HTTPException(status_code=404, detail=f"Category '{category}' not found")
 
     images = _get_images_for_category(category)
+    fmt = (format or "").lower().lstrip(".")
+    if fmt:
+        images = [img for img in images if img["filename"].lower().endswith(f".{fmt}")]
+
     if not images:
-        raise HTTPException(
-            status_code=404, detail=f"No images found for category '{category}'"
+        detail = (
+            f"No {fmt.upper()} images found for category '{category}'"
+            if fmt
+            else f"No images found for category '{category}'"
         )
+        raise HTTPException(status_code=404, detail=detail)
 
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
@@ -152,7 +174,8 @@ def download_category_zip(category: str, request: Request):
                 zf.write(file_path, arcname=img["filename"])
     buf.seek(0)
 
-    filename = f"spire-codex-{category}.zip"
+    suffix = f"-{fmt}" if fmt else ""
+    filename = f"spire-codex-{category}{suffix}.zip"
     return StreamingResponse(
         buf,
         media_type="application/zip",

--- a/frontend/app/images/page.tsx
+++ b/frontend/app/images/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -14,6 +14,84 @@ interface Category {
   name: string;
   count: number;
   images: ImageEntry[];
+  formats?: string[];
+}
+
+const FORMAT_LABELS: Record<string, string> = {
+  png: "PNG",
+  webp: "WebP",
+  gif: "GIF",
+  jpg: "JPG",
+  jpeg: "JPEG",
+};
+
+function DownloadSplitButton({ categoryId, formats }: { categoryId: string; formats: string[] }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) {
+      document.addEventListener("mousedown", onClickOutside);
+      return () => document.removeEventListener("mousedown", onClickOutside);
+    }
+  }, [open]);
+
+  const hasMultipleFormats = formats.length > 1;
+  const downloadUrl = `${API}/api/images/${categoryId}/download`;
+
+  return (
+    <div ref={ref} className="relative inline-flex" onClick={(e) => e.stopPropagation()}>
+      <a
+        href={downloadUrl}
+        className={`inline-flex items-center gap-1.5 px-3 py-1 text-xs font-medium bg-[var(--accent-gold)] text-[var(--bg-primary)] hover:opacity-90 transition-opacity ${
+          hasMultipleFormats ? "rounded-l-full" : "rounded-full"
+        }`}
+      >
+        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5m0 0l5-5m-5 5V3" />
+        </svg>
+        Download ZIP
+      </a>
+      {hasMultipleFormats && (
+        <>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              setOpen((v) => !v);
+            }}
+            aria-haspopup="true"
+            aria-expanded={open}
+            aria-label="Choose download format"
+            className="inline-flex items-center px-2 py-1 rounded-r-full text-xs font-medium bg-[var(--accent-gold)] text-[var(--bg-primary)] hover:opacity-90 transition-opacity border-l border-[var(--bg-primary)]/20"
+          >
+            <svg className={`w-3 h-3 transition-transform ${open ? "rotate-180" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          {open && (
+            <div className="absolute right-0 top-full mt-1 z-10 min-w-[140px] rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] shadow-lg py-1">
+              {formats.map((ext) => (
+                <a
+                  key={ext}
+                  href={`${downloadUrl}?format=${ext}`}
+                  onClick={() => setOpen(false)}
+                  className="block px-3 py-1.5 text-xs text-[var(--text-primary)] hover:bg-[var(--bg-card-hover)] transition-colors"
+                >
+                  {FORMAT_LABELS[ext] ?? ext.toUpperCase()} only
+                </a>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
 }
 
 export default function ImagesPage() {
@@ -75,16 +153,19 @@ export default function ImagesPage() {
                     </span>
                   </div>
 
-                  <a
-                    href={`${API}/api/images/${cat.id}/download`}
-                    onClick={(e) => e.stopPropagation()}
-                    className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium bg-[var(--accent-gold)] text-[var(--bg-primary)] hover:opacity-90 transition-opacity"
-                  >
-                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5m0 0l5-5m-5 5V3" />
-                    </svg>
-                    Download ZIP
-                  </a>
+                  <DownloadSplitButton
+                    categoryId={cat.id}
+                    formats={
+                      cat.formats ??
+                      Array.from(
+                        new Set(
+                          cat.images
+                            .map((img) => img.filename.split(".").pop()?.toLowerCase())
+                            .filter((ext): ext is string => Boolean(ext))
+                        )
+                      ).sort()
+                    }
+                  />
                 </div>
 
                 {isOpen && (


### PR DESCRIPTION
## Summary
Closes #46

Users who only want PNGs (or only WebPs) had to grab the whole bundle and filter locally. Now the **Download ZIP** button is a split button:

- **Main click** → `/api/images/{category}/download` → entire bundle (current behavior, unchanged)
- **Chevron** → dropdown with "PNG only", "WebP only", etc. → `?format=<ext>` filter

Single-format categories still render as a plain round button (no chevron).

## Backend
- Added optional `?format=` filter to `/api/images/{category}/download`
- `list_image_categories` now returns a `formats` array per category so the UI knows which options to surface

## Frontend
- New `DownloadSplitButton` component with click-outside-to-close menu
- Falls back to deriving formats from the images list if the backend is older than the UI (graceful deploy order)
