### PR TITLE
Search bar redesign — hero on home, inline middle-of-nav elsewhere

### DIFF
--- a/frontend/app/components/GlobalSearch.tsx
+++ b/frontend/app/components/GlobalSearch.tsx
@@ -271,7 +271,7 @@ export default function GlobalSearch() {
   return (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm flex items-start justify-center pt-[15vh]"
+      className="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm flex items-start justify-center px-4 sm:px-6 pt-[10vh] sm:pt-[15vh]"
       onClick={(e) => {
         if (e.target === overlayRef.current) setOpen(false);
       }}

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import LanguageSelector from "./LanguageSelector";
+import SearchTrigger from "./SearchTrigger";
 import VersionSelector from "./VersionSelector";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
@@ -84,6 +85,7 @@ export default function Navbar() {
   const currentLang = LANG_CODES.has(pathLang) ? pathLang : null;
   const langPrefix = currentLang ? `/${currentLang}` : "";
   const strippedPath = currentLang ? pathname.replace(`/${currentLang}`, "") || "/" : pathname;
+  const isHome = strippedPath === "/";
   const [open, setOpen] = useState(false);
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const menuRef = useRef<HTMLDivElement>(null);
@@ -131,8 +133,8 @@ export default function Navbar() {
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 border-b border-[var(--border-subtle)] bg-[var(--bg-primary)]/95 backdrop-blur-sm">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-between h-16">
-          <Link href={`${langPrefix}/`} className="flex items-center gap-2">
+        <div className="flex items-center justify-between gap-3 sm:gap-4 h-16">
+          <Link href={`${langPrefix}/`} className="flex items-center gap-2 shrink-0">
             <span className="text-xl font-bold text-[var(--accent-gold)]">
               SPIRE
             </span>
@@ -141,19 +143,14 @@ export default function Navbar() {
             </span>
           </Link>
 
-          <div className="flex items-center gap-2">
-            {/* Search trigger */}
-            <button
-              onClick={() => document.dispatchEvent(new KeyboardEvent("keydown", { key: ".", bubbles: true }))}
-              className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] text-sm text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:border-[var(--border-accent)] transition-colors"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
-              <span className="hidden sm:inline">Press</span>
-              <kbd className="text-xs border border-[var(--border-subtle)] rounded px-1.5 py-0.5">.</kbd>
-            </button>
+          {/* Middle search — non-home pages only. Takes ~40% of the bar on desktop. */}
+          {!isHome && (
+            <div className="hidden md:flex flex-1 max-w-md">
+              <SearchTrigger variant="nav" />
+            </div>
+          )}
 
+          <div className="flex items-center gap-2 shrink-0">
             {IS_BETA ? (
               <a
                 href="https://spire-codex.com"
@@ -172,6 +169,13 @@ export default function Navbar() {
 
             {IS_BETA && <VersionSelector />}
             <LanguageSelector />
+
+            {/* Mobile icon-only search — non-home pages only, sits next to the language selector */}
+            {!isHome && (
+              <div className="md:hidden">
+                <SearchTrigger variant="icon" />
+              </div>
+            )}
 
           {/* Burger button */}
           <div className="relative">

--- a/frontend/app/components/SearchTrigger.tsx
+++ b/frontend/app/components/SearchTrigger.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+/**
+ * Input-styled trigger that opens the GlobalSearch modal.
+ *
+ * GlobalSearch (rendered once in layout.tsx) listens for the "." keydown
+ * event — dispatching that event is how we open it from anywhere.
+ */
+
+type Variant = "hero" | "nav" | "icon";
+
+function openGlobalSearch() {
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: ".", bubbles: true }));
+}
+
+function SearchIcon({ className }: { className: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+      />
+    </svg>
+  );
+}
+
+interface Props {
+  variant: Variant;
+  className?: string;
+  placeholder?: string;
+}
+
+export default function SearchTrigger({ variant, className = "", placeholder }: Props) {
+  if (variant === "icon") {
+    return (
+      <button
+        type="button"
+        onClick={openGlobalSearch}
+        aria-label="Search"
+        className={`p-2 rounded-md text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-card)] transition-colors ${className}`}
+      >
+        <SearchIcon className="w-5 h-5" />
+      </button>
+    );
+  }
+
+  if (variant === "hero") {
+    return (
+      <button
+        type="button"
+        onClick={openGlobalSearch}
+        className={`group w-full flex items-center gap-3 px-5 py-3.5 rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-card)] text-left hover:border-[var(--border-accent)] hover:bg-[var(--bg-card-hover)] transition-colors ${className}`}
+      >
+        <SearchIcon className="w-5 h-5 text-[var(--text-muted)] group-hover:text-[var(--accent-gold)] transition-colors shrink-0" />
+        <span className="flex-1 text-base text-[var(--text-muted)] truncate">
+          {placeholder ?? "Find your next card, relic, or potion..."}
+        </span>
+        <kbd className="hidden sm:inline-block text-xs text-[var(--text-muted)] border border-[var(--border-subtle)] rounded px-1.5 py-0.5 shrink-0">
+          Press .
+        </kbd>
+      </button>
+    );
+  }
+
+  // nav variant — mid-navbar, 40%-ish wide
+  return (
+    <button
+      type="button"
+      onClick={openGlobalSearch}
+      className={`group w-full flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] text-sm hover:border-[var(--border-accent)] hover:bg-[var(--bg-card-hover)] transition-colors ${className}`}
+    >
+      <SearchIcon className="w-4 h-4 text-[var(--text-muted)] group-hover:text-[var(--accent-gold)] transition-colors shrink-0" />
+      <span className="flex-1 text-left text-[var(--text-muted)] truncate">
+        {placeholder ?? "Search cards, relics, monsters..."}
+      </span>
+      <kbd className="text-xs text-[var(--text-muted)] border border-[var(--border-subtle)] rounded px-1.5 py-0.5 shrink-0">
+        .
+      </kbd>
+    </button>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import type { Stats } from "@/lib/api";
 import HomeClient from "./HomeClient";
 import JsonLd from "./components/JsonLd";
+import SearchTrigger from "./components/SearchTrigger";
 import { buildWebSiteJsonLd, buildVideoGameJsonLd } from "@/lib/jsonld";
 import { SITE_NAME, IS_BETA } from "@/lib/seo";
 
@@ -65,11 +66,14 @@ export default async function Home() {
                 </span>
               )}
             </h1>
-            <p className="text-lg text-[var(--text-secondary)] max-w-2xl mx-auto mb-2">
+            <p className="text-lg text-[var(--text-secondary)] max-w-2xl mx-auto mb-6">
               {IS_BETA
                 ? "Preview of upcoming Slay the Spire 2 content"
                 : "The complete database for Slay the Spire 2"}
             </p>
+            <div className="max-w-xl mx-auto">
+              <SearchTrigger variant="hero" />
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
Addresses #31.

## What changed

- New `SearchTrigger` component with three variants (`hero`, `nav`, `icon`) — all dispatch the same "." keydown that GlobalSearch already listens for, so the modal itself is untouched.
- Home page (`/`) now has a prominent hero-sized search bar below the "The complete database for Slay the Spire 2" tagline, and no search in the navbar. Placeholder: "Find your next card, relic, or potion..." with a trailing "Press ." kbd hint.
- Every other page renders the search in the middle of the navbar, flex-1 capped at max-w-md (≈40% of the bar on desktop). Placeholder reads "Search cards, relics, monsters..." with a trailing "." kbd.
- Mobile (non-home): navbar search collapses to a single magnifier icon, placed next to the language selector on the right side of the bar instead of being crammed to the left.
- GlobalSearch modal gets side padding on mobile (px-4 / sm:px-6) so the panel no longer goes edge-to-edge, and the top offset drops from 15vh to 10vh on small screens.

## Why

- The old "Press ." pill in the navbar was easy to miss and felt cramped on desktop. Moving it to the center of the bar gives it visual weight without dominating.
- Users who land on the home page should see search as a primary action, not a sidelined pill — the hero placement mirrors how search-first sites invite a query immediately.
- On mobile the full text container wasted space and the modal going edge-to-edge looked broken next to the rounded card chrome.