### PR TITLE
Clean v0.103.1 changelog display — from_ref leak + empty-state UI

### DIFF
--- a/data-beta/v0.103.1/changelogs/0.103.1.json
+++ b/data-beta/v0.103.1/changelogs/0.103.1.json
@@ -5,7 +5,7 @@
   "tag": "0.103.1",
   "date": "2026-04-15",
   "title": "Beta v0.103.1",
-  "from_ref": "/tmp/test/reparse-v0.103.0/eng",
+  "from_ref": "data-beta/v0.103.0/eng",
   "to_ref": "data-beta/v0.103.1/eng",
   "summary": {
     "added": 0,

--- a/frontend/app/changelog/page.tsx
+++ b/frontend/app/changelog/page.tsx
@@ -384,6 +384,21 @@ export default function ChangelogPage() {
                   {selected.categories.map((cat) => (
                     <CategorySection key={cat.id} cat={cat} />
                   ))}
+
+                  {selected.categories.length === 0 &&
+                    !selected.features?.length &&
+                    !selected.fixes?.length &&
+                    !selected.api_changes?.length &&
+                    selected.summary.added === 0 &&
+                    selected.summary.removed === 0 &&
+                    selected.summary.changed === 0 && (
+                      <div className="border border-[var(--border-subtle)] rounded-lg px-4 py-6 text-center text-sm text-[var(--text-muted)]">
+                        No entity changes detected in this build.
+                        <div className="mt-1 text-xs">
+                          Likely an internal refactor with no gameplay-facing data.
+                        </div>
+                      </div>
+                    )}
                 </div>
               </>
             ) : (


### PR DESCRIPTION
## Summary

Follow-up to #56. Two small fixes to the v0.103.1 changelog that landed at the same time but weren't in the merged branch when #56 was merged.

## Changes

- **`from_ref` leak fix**: the committed `data-beta/v0.103.1/changelogs/0.103.1.json` had `"from_ref": "/tmp/test/reparse-v0.103.0/eng"` (my local temp path from the clean-reparse workflow). Replaced with the canonical `"data-beta/v0.103.0/eng"` to match the pattern every other beta changelog uses (`v0.102.0`, `v0.101.0`, `v0.100.0`).
- **Empty-state UI**: `/changelog?version=v0.103.1` currently renders as a blank region below the header because v0.103.1 has zero entity changes (it's a pure internal refactor). The renderer now shows a muted centered message when a changelog has `0/0/0` summary and no manual `features`/`fixes`/`api_changes` notes:

  > No entity changes detected in this build.
  > Likely an internal refactor with no gameplay-facing data.

  Handles future "empty" releases the same way.

## Files

- `data-beta/v0.103.1/changelogs/0.103.1.json` — `from_ref`/`to_ref` updated
- `frontend/app/changelog/page.tsx` — empty-state fallback added
