### PR TITLE
Cut v1.0.20 changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ spire-codex/
 │   │   └── ...                 # Pages: cards, characters, relics, monsters, potions,
 │   │                           #   enchantments, encounters, events, powers, timeline,
 │   │                           #   reference, images, changelog, about, merchant, compare,
-│   │                           #   mechanics/[slug], guides/[slug], guides/submit, runs, meta
+│   │                           #   mechanics/[slug], guides/[slug], guides/submit,
+│   │                           #   leaderboards, leaderboards/submit, leaderboards/stats,
+│   │                           #   runs/[hash] (shared run view)
 │   │                           #   Detail pages: cards/[id], characters/[id], relics/[id],
 │   │                           #   monsters/[id], potions/[id], enchantments/[id],
 │   │                           #   encounters/[id], events/[id], powers/[id], keywords/[id],
@@ -180,8 +182,10 @@ spire-codex/
 | Guides | `/guides` | Community strategy guides with search/filter |
 | Guide Detail | `/guides/[slug]` | Full guide with markdown rendering + tooltip widget |
 | Submit Guide | `/guides/submit` | Guide submission form (Discord webhook) |
-| Runs | `/runs` | Community run browser with character/win filters |
-| Meta | `/meta` | Live community stats from submitted runs |
+| Leaderboards | `/leaderboards` | Three-tab browser: Fastest Wins, Highest Ascension, Browse Runs (search by seed/username, filter by character/win/loss/game version) |
+| Submit a Run | `/leaderboards/submit` | Drag-and-drop `.run` upload, JSON paste fallback, upload progress |
+| Stats | `/leaderboards/stats` | Ranked tables (pick rate, win rate, count) for cards, relics, potions, encounters. Filter by character / ascension / outcome |
+| Shared Run | `/runs/[hash]` | In-game-style victory/defeat summary with clickable map-node icons, relic strip, and tiny-card grid |
 | Reference | `/reference` | All items clickable — acts, ascensions, keywords, orbs, afflictions, intents, modifiers, achievements |
 | Images | `/images` | Browsable game assets with ZIP download per category |
 | Changelog | `/changelog` | Data diffs between game updates |
@@ -242,9 +246,11 @@ All data endpoints accept an optional `?lang=` query parameter (default: `eng`).
 | `GET /api/guides/{slug}` | Single guide (with markdown content) | — |
 | `POST /api/guides` | Submit guide (proxied to Discord) | — |
 | `POST /api/runs` | Submit a run (.run file JSON) | `username` |
-| `GET /api/runs/list` | List submitted runs | `character`, `win`, `username`, `page`, `limit` |
+| `GET /api/runs/list` | List submitted runs | `character`, `win`, `username`, `seed`, `build_id`, `sort`, `page`, `limit` |
 | `GET /api/runs/shared/{hash}` | Full run data by hash | — |
 | `GET /api/runs/stats` | Aggregated community stats | `character`, `win`, `ascension`, `game_mode`, `players` |
+| `GET /api/runs/leaderboard` | Ranked wins-only leaderboard | `category` (`fastest`, `highest_ascension`), `character`, `page`, `limit` |
+| `GET /api/runs/versions` | Distinct game versions across submitted runs | — |
 | `POST /api/feedback` | Submit feedback (proxied to Discord) | — |
 | `GET /api/versions` | Available data versions (beta multi-version) | — |
 

--- a/contributing/API_REFERENCE.md
+++ b/contributing/API_REFERENCE.md
@@ -59,9 +59,11 @@ All data endpoints accept `?lang=` (default: `eng`). Rate limited to 60 req/min 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `POST /api/runs` | POST | Submit a run. Optional `?username=` param (25 char max) |
-| `GET /api/runs/stats` | GET | Community stats. Filters: `character`, `win`, `ascension`, `game_mode`, `players` |
-| `GET /api/runs/list` | GET | Browse runs. Filters: `character`, `win`, `username`, `page`, `limit` |
+| `GET /api/runs/stats` | GET | Aggregated community stats. Filters: `character`, `win`, `ascension`, `game_mode`, `players` |
+| `GET /api/runs/list` | GET | Browse runs. Filters: `character`, `win`, `username`, `seed` (LIKE), `build_id`, `sort` (`date`, `time_asc`, `time_desc`, `ascension_desc`), `page`, `limit` |
 | `GET /api/runs/shared/{hash}` | GET | Retrieve a shared run by hash |
+| `GET /api/runs/leaderboard` | GET | Ranked wins-only leaderboard. Filters: `category` (`fastest`, `highest_ascension`), `character`, `page`, `limit` |
+| `GET /api/runs/versions` | GET | Distinct `build_id` values across submitted runs — powers the version filter dropdown |
 
 ## Utility
 

--- a/contributing/ARCHITECTURE.md
+++ b/contributing/ARCHITECTURE.md
@@ -93,7 +93,7 @@ All endpoints accept `?lang=` (default: `eng`). Responses are GZip-compressed wi
 
 - **List endpoints**: `GET /api/cards`, `GET /api/monsters`, etc. with filters
 - **Detail endpoints**: `GET /api/cards/{id}`, `GET /api/monsters/{id}`, etc.
-- **Runs**: `POST /api/runs` (submit), `GET /api/runs/stats` (aggregated meta), `GET /api/runs/list` (browse)
+- **Runs**: `POST /api/runs` (submit), `GET /api/runs/stats` (aggregated meta), `GET /api/runs/list` (browse — accepts `seed`, `build_id`, `sort` filters), `GET /api/runs/leaderboard` (ranked wins-only), `GET /api/runs/versions` (distinct game versions), `GET /api/runs/shared/{hash}` (shared run detail)
 - **Guides**: `GET /api/guides` (list with filters), `GET /api/guides/{slug}` (detail), `POST /api/guides` (Discord webhook submission)
 - **Docs**: `http://localhost:8000/docs` (Swagger UI)
 

--- a/contributing/CLAUDE.md
+++ b/contributing/CLAUDE.md
@@ -82,8 +82,12 @@ spire-codex/
       guides/page.tsx        # Community guides list with search/filter
       guides/[slug]/         # Guide detail with markdown rendering + tooltip widget
       guides/submit/         # Guide submission form → Discord webhook
-      runs/page.tsx          # Community run browser + submission
-      meta/page.tsx          # Live community stats from submitted runs
+      leaderboards/page.tsx  # Three-tab browser — Fastest Wins, Highest Ascension, Browse Runs
+      leaderboards/submit/   # Drag-and-drop .run upload
+      leaderboards/stats/    # Ranked-table stats (cards/relics/potions/encounters pick + win rates)
+      runs/[hash]/           # Shared-run detail — in-game-style summary with TinyCard grid, clickable map nodes
+      runs/page.tsx          # Redirect to /leaderboards (old URL preserved)
+      meta/page.tsx          # Redirect to /leaderboards/stats (old URL preserved)
       showcase/page.tsx      # Community project gallery
       developers/page.tsx    # API docs, widget docs, data exports
       timeline/page.tsx reference/page.tsx images/page.tsx
@@ -94,12 +98,19 @@ spire-codex/
         CardGrid.tsx         # Card grid with inline icons, upgrade rendering
         RichDescription.tsx  # Tokenizer + tree builder for nested rich text tags
         SearchFilter.tsx     # Reusable search + filter + sort bar
+        SearchTrigger.tsx    # Input-styled trigger for the global search modal (hero/nav/icon variants)
+        GlobalSearch.tsx     # Centralized cmd-K–style search modal (opens on ".")
+        TinyCard.tsx         # In-game card thumbnail primitive — 6-layer mask composite, pool/rarity colors from decompiled C#
         JsonLd.tsx           # Server component for JSON-LD
-        Navbar.tsx           # In-game compendium names (Card Library, Bestiary, etc.)
+        Navbar.tsx           # Nav groups (Database, Game Info, Tools, About) + middle search on non-home pages
         Footer.tsx           # API, Developers, GitHub, Discord, Feedback
         LocalizedNames.tsx   # Collapsible cross-language name display
         EntityHistory.tsx    # Collapsible version history timeline
         RelatedCards.tsx     # Cards sharing keywords/tags
+      runs/[hash]/
+        RunSummary.tsx       # In-game-style summary — stats bar + act rows + relic strip + TinyCard grid
+        RunPills.tsx         # CardPill / RelicPill / PotionPill — hover tooltips with full entity info
+        SharedRunClient.tsx  # Run hash loader + top-level layout
     lib/
       api.ts                # API client + TypeScript interfaces (with compendium_order)
       seo.ts                # stripTags, SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE
@@ -134,16 +145,16 @@ spire-codex/
   docker-compose.beta.yml   # Beta site (beta.spire-codex.com, :beta images + data-beta)
 ```
 
-## Data Parsed
+## Data Parsed (stable — beta counts may vary)
 - **576 cards** — cost, type, rarity, target, damage, block, keywords, tags, upgrades, X-cost, vars, resolved descriptions, compendium_order
 - **5 characters** — Ironclad, Silent, Defect, Necrobinder, Regent (HP, gold, energy, deck, relics)
-- **289 relics** — rarity, pool (with upgraded starter relic mapping from TouchOfOrobas), compendium_order
-- **111 monsters** — HP ranges, ascension scaling, moves, damage values, hit counts, innate powers (42 monsters), idle pose sprites
+- **293 relics** — rarity, pool (with upgraded starter relic mapping from TouchOfOrobas), compendium_order
+- **115 monsters** — HP ranges, ascension scaling, moves, damage values, hit counts, innate powers (42+ monsters), idle pose sprites
 - **63 potions** — rarity, pool, resolved descriptions, compendium_order
 - **22 enchantments** — card type restrictions, stackability, descriptions
 - **87 encounters** — monster compositions, room type, act placement, tags
-- **66 events** — multi-page decision trees, choices in C# source order, runtime-computed values (escalating costs, gold ranges)
-- **257 powers** — type (Buff/Debuff), stack type, descriptions (3 abstract bases excluded, 19 inherited powers resolved)
+- **66 events** — multi-page decision trees, choices in C# source order, runtime-computed values (escalating costs, gold ranges), preconditions (`IsAllowed` / `IRunState` bodies translated to human-readable strings)
+- **259 powers** — type (Buff/Debuff), stack type, descriptions (3 abstract bases excluded, 19 inherited powers resolved)
 - **8 keywords** — Exhaust, Ethereal, Innate, Retain, Sly, Eternal, Unplayable (+ Period)
 - **14 intents** · **5 orbs** · **9 afflictions** · **16 modifiers** · **33 achievements** (with unlock conditions, thresholds, categories)
 
@@ -167,7 +178,9 @@ spire-codex/
 - `GET /api/changelogs` / `GET /api/changelogs/{tag}` — Version changelogs
 - `GET /api/guides?category=&difficulty=&tag=&search=` / `GET /api/guides/{slug}` — Guides
 - `POST /api/guides` — Guide submission (Discord webhook, rate-limited)
-- `POST /api/runs` — Run submission / `GET /api/runs/list` / `GET /api/runs/shared/{hash}` / `GET /api/runs/stats`
+- `POST /api/runs` — Run submission / `GET /api/runs/list` (filters: character, win, username, seed, build_id, sort, page, limit) / `GET /api/runs/shared/{hash}` / `GET /api/runs/stats`
+- `GET /api/runs/leaderboard` — ranked wins-only list (category: fastest|highest_ascension, character, page, limit)
+- `GET /api/runs/versions` — distinct build_ids across submitted runs
 - `GET /api/languages` / `GET /api/translations`
 - All endpoints accept `?lang=` (default: eng) — 14 languages supported
 - Docs: `http://localhost:8000/docs`
@@ -293,7 +306,7 @@ Parallel deployment for Steam beta branch data. Uses same codebase/images but se
 
 ## Versioning
 Uses `1.X.Y` — 1=codex major, X=bumps on Mega Crit game patch, Y=our fixes/improvements.
-Current: **v1.0.17**
+Current: **v1.0.20**
 
 ## Known Limitations
 - 6 monsters lack images entirely (Crusher, Doormaker, Flyconid, Ovicopter, Rocket, Decimillipede)
@@ -331,6 +344,13 @@ Current: **v1.0.17**
 - ~~Achievement unlock conditions~~ ✅ — category, character, threshold, condition from C# source
 - ~~Card upgrade descriptions~~ ✅ — upgrade_description for all 403 upgradable cards
 - ~~Event dynamic values~~ ✅ — escalating costs, gold ranges, heal-to-full resolved correctly
+- ~~Event preconditions~~ ✅ — `IsAllowed` bodies translated to human-readable strings (gold thresholds, act restrictions, deck requirements); handles both `RunState` and `IRunState` signatures
+- ~~Monster attack patterns~~ ✅ — cycle/random/conditional move-machine parsing from `GenerateMoveStateMachine`
+- ~~Multi-version beta browsing~~ ✅ — versioned `data-beta/vX.Y.Z/` dirs with `latest` symlink, version-aware loader
+- ~~Leaderboards + run browser revamp~~ ✅ — `/leaderboards` 3-tab page (Fastest Wins, Highest Ascension, Browse), drag-and-drop submit, ranked-table stats replacing `/meta`, filter by seed/username/character/win/version/sort
+- ~~In-game-style run summary~~ ✅ — `/runs/[hash]` mimics the end-of-run screen with map-node rows, clickable encounter/event links, tiny-card deck grid
+- ~~TinyCard primitive + docs~~ ✅ — shared React component reproducing the in-game card thumbnail; live preview + recipes on `/developers`
+- ~~Search bar redesign~~ ✅ — hero search on home, middle-of-nav on other pages, icon-only on mobile
 - i18n refactor — migrate from manual t() calls to `next-intl` for complete translation coverage
   - Known gaps: compare graphs (keyword matching), merchant prose, about/changelog content, scattered client component strings
   - Current t() approach doesn't scale — hundreds of strings across dozens of components

--- a/data/changelogs/1.0.20.json
+++ b/data/changelogs/1.0.20.json
@@ -1,0 +1,121 @@
+{
+  "app_id": 2868840,
+  "game_version": "1.0.20",
+  "build_id": "",
+  "tag": "1.0.20",
+  "date": "2026-04-15",
+  "title": "Runs revamp, search redesign, tiny-card primitive",
+  "from_ref": "v1.0.19",
+  "to_ref": "current",
+  "summary": {
+    "added": 0,
+    "removed": 0,
+    "changed": 5
+  },
+  "categories": [
+    {
+      "id": "cards",
+      "name": "Cards",
+      "old_count": 576,
+      "new_count": 576,
+      "changed": [
+        {
+          "id": "FRIENDSHIP",
+          "name": "Friendship",
+          "changes": [
+            {
+              "field": "upgrade_description",
+              "old": "none",
+              "new": "Lose 1 [gold]Strength[/gold].\nGain [energy:1] at the start of each turn."
+            },
+            {
+              "field": "description",
+              "old": "Lose inverseDiff() [gold]Strength[/gold].\nGain [energy:1] at the start of eac...",
+              "new": "Lose 2 [gold]Strength[/gold].\nGain [energy:1] at the start of each turn."
+            }
+          ]
+        },
+        {
+          "id": "MAD_SCIENCE",
+          "name": "Mad Science",
+          "changes": [
+            {
+              "field": "type_variants",
+              "old": "3 fields",
+              "new": "3 fields"
+            }
+          ]
+        },
+        {
+          "id": "PRECISE_CUT",
+          "name": "Precise Cut",
+          "changes": [
+            {
+              "field": "description",
+              "old": "Deal 13 damage.\nDeals inverseDiff() less damage for each other card in your [...",
+              "new": "Deal 13 damage.\nDeals 2 less damage for each other card in your [gold]Hand[/g..."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "relics",
+      "name": "Relics",
+      "old_count": 288,
+      "new_count": 288,
+      "changed": [
+        {
+          "id": "TOY_BOX",
+          "name": "Toy Box",
+          "changes": [
+            {
+              "field": "notes",
+              "old": "none",
+              "new": "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed., Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll)., All wax relics melt after 12 total combats, then Toy Box is used up."
+            }
+          ]
+        },
+        {
+          "id": "YUMMY_COOKIE",
+          "name": "Yummy Cookie",
+          "changes": [
+            {
+              "field": "image_variants",
+              "old": "5 fields",
+              "new": "5 fields"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "features": [
+    "Leaderboards: new /leaderboards page with Fastest Wins, Highest Ascension, and Browse Runs tabs — replaces /runs.",
+    "Submit a Run: new /leaderboards/submit with drag-and-drop .run upload; files can be dropped anywhere on the page.",
+    "Stats rebuild: /leaderboards/stats replaces /meta with ranked-table tabs (Overview, Cards, Relics, Potions, Encounters) — sortable columns, per-tab filters, win-rate color coding.",
+    "Browse Runs filters: search by seed or username, filter by character, win/loss, and game version; sort by newest/fastest/slowest/highest ascension.",
+    "Individual run pages rebuilt to match the in-game victory/defeat screen — character portrait, stats bar (HP/gold/floors/time/ascension/potions), three act rows of real map-node icons with tier-colored outlines, relic strip, in-game-accurate card grid.",
+    "Map-node tooltips show floor context, monsters faced, HP/gold delta, card picks, and relic picks; the whole node is a link to the encounter or event detail page.",
+    "Potion slots on run pages now show the actual potion art with a hover tooltip for name, rarity, and description.",
+    "Tiny-card sprite: new shared React component that reproduces the in-game card thumbnail using the real game sprites. Exported as a documented primitive on /developers with a live preview, per-pool and per-rarity color swatches, and copy-pasteable HTML/CSS + React recipes for anyone building third-party tools.",
+    "Search bar redesign: big hero-sized search on the home page below the tagline, 40%-wide inline search in the middle of the navbar on other pages, icon-only search on mobile.",
+    "Home tiles reordered: Leaderboard, Submit a Run (with live run count), Stats, Guides.",
+    "/images gallery now dedupes png+webp pairs (one entry per asset, prefers webp) — split-button download still offers PNG-only ZIPs."
+  ],
+  "fixes": [
+    "Beta /ancients page now correctly loads version-aware ancient pool data.",
+    "Windows run-submission path fixed — dropped the redundant Roaming segment from the AppData instructions.",
+    "Stable backend service discovery fixed by switching the frontend to the backend's container name (eliminates intermittent DNS failures on deploy).",
+    "Card upgrade display parity corrected so upgraded values match the actual in-game behavior (RayaCoo).",
+    "Toy Box wax relic mechanics now documented on its detail page (pool rules, rarity odds, wax melt schedule).",
+    "Search modal on mobile no longer extends edge-to-edge and sits lower in the viewport to stay clear of the keyboard."
+  ],
+  "api_changes": [
+    "New GET /api/runs/leaderboard — ranked wins-only list, params: category (fastest|highest_ascension), character, page, limit.",
+    "New GET /api/runs/versions — returns distinct game versions across submitted runs, used by the version filter dropdown.",
+    "GET /api/runs/list gains seed (LIKE match), sort (date|time_asc|time_desc|ascension_desc), and build_id (exact match) query params; build_id is now returned in results.",
+    "/runs → /leaderboards and /meta → /leaderboards/stats redirects added (old links continue to resolve).",
+    "New /static/images/ui/run_history_card/ sprite assets served CORS-open for third-party tiny-card compositing."
+  ]
+}


### PR DESCRIPTION
## Summary

Cumulative stable changelog for everything that's landed on main since v1.0.19. Feature-heavy release.

## Highlights

**New**
- **Leaderboards** — new `/leaderboards` page with Fastest Wins / Highest Ascension / Browse Runs tabs
- **Submit a Run** — `/leaderboards/submit` with drag-and-drop `.run` upload (works anywhere on the page)
- **Stats rebuild** — `/leaderboards/stats` replaces `/meta` with ranked-table tabs (Overview, Cards, Relics, Potions, Encounters) — sortable columns, per-tab filters, win-rate color coding
- **In-game-style run pages** — individual run views now mimic the end-of-run screen: character portrait, stats bar, three act rows of real map-node icons with tier-colored outlines, clickable nodes linking to encounter/event pages, relic strip, in-game-accurate card grid
- **TinyCard sprite primitive** — shared React component that reproduces the in-game card thumbnail; documented on `/developers` with live preview, pool/rarity color swatches, and copy-pasteable HTML+CSS / React recipes
- **Search redesign** — hero-sized search on the home page, 40%-wide inline search in the middle of the navbar on other pages, icon-only on mobile
- **/images dedupe** — gallery collapses png+webp pairs (split-button still offers PNG-only ZIPs)
- **Home tile reorder** — Leaderboard, Submit a Run (with live count), Stats, Guides

**Fixes**
- Beta `/ancients` version-aware loader
- Windows run-path instructions (dropped redundant Roaming segment)
- Stable backend DNS via container name
- Card upgrade display parity (RayaCoo)
- Toy Box wax-relic mechanics documented on its detail page
- Mobile search modal no longer edge-to-edge

**API**
- `GET /api/runs/leaderboard` — ranked wins-only list
- `GET /api/runs/versions` — distinct build_id values for the filter dropdown
- `/api/runs/list` accepts `seed`, `sort`, `build_id` params; result includes `build_id`
- `/runs` → `/leaderboards`, `/meta` → `/leaderboards/stats` redirects (old links still work)
- Tiny-card sprite assets served CORS-open from `/static/images/ui/run_history_card/`

## Notes

Auto-diff picked up 5 entity entries (Friendship / Mad Science / Precise Cut / Toy Box / Yummy Cookie) that are parser-drift artifacts (image extensions, derived fields), not real game tweaks. Left in the data block for completeness but they're not part of the headline release.

Tag v1.0.20 will be cut on merge.
