### PR TITLE
Fix #61 — leaderboard was reading wrong response key

### DIFF
--- a/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
+++ b/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
@@ -106,9 +106,14 @@ export default function LeaderboardBrowseClient() {
     params.set("page", String(lbPage));
     params.set("limit", "20");
     fetch(`${API}/api/runs/leaderboard?${params}&_t=${Date.now()}`)
-      .then((r) => (r.ok ? r.json() : { entries: [], total: 0, total_pages: 0 }))
+      .then((r) => (r.ok ? r.json() : { runs: [], total: 0, total_pages: 0 }))
       .then((data) => {
-        setLbEntries(data.entries || []);
+        // Backend returns the rows under `runs`; rank is computed client-side
+        // from pagination offset so row N on page 2 shows as #21.
+        const rows = (data.runs || []) as Omit<LeaderboardEntry, "rank">[];
+        const pageSize = 20;
+        const offset = (Math.max(lbPage, 1) - 1) * pageSize;
+        setLbEntries(rows.map((r, i) => ({ ...r, rank: offset + i + 1 })));
         setLbTotal(data.total || 0);
         setLbTotalPages(data.total_pages || 0);
       })


### PR DESCRIPTION
Closes #61.

## Problem

The /leaderboards page rendered "No leaderboard entries found." even though the backend had 1,151 winning runs.

```
$ curl "https://spire-codex.com/api/runs/leaderboard?category=fastest&limit=5"
{"runs":[{"run_hash":"84788cc3ceb49f44",...}], "total":1151, ...}
```

## Root cause

Frontend in `LeaderboardBrowseClient.tsx` was reading `data.entries`. Backend returns `data.runs`. They never connected.

## Fix

- `data.entries` → `data.runs`
- Also compute `rank` client-side from pagination offset (backend does not emit a rank column — row N on page 2 now shows as `#21`).

One file, 7 lines. Type check clean.