### PR TITLE
Surface images in global search

### DIFF
--- a/backend/app/routers/images.py
+++ b/backend/app/routers/images.py
@@ -155,6 +155,48 @@ def _extensions_in(images: list[dict[str, str]]) -> list[str]:
     return sorted(exts)
 
 
+@router.get("/search", tags=["Images"])
+def search_images(request: Request, search: str = "", limit: int = 10):
+    """Filename substring search across every image category.
+
+    Used by the global search modal so queries like "doormaker" surface image
+    results alongside entity pages. Matches every whitespace-separated token in
+    `search` against the basename (extension stripped, case-insensitive).
+    Results are deduped to one entry per asset (prefers webp, then gif, then
+    png) and capped at `limit` (max 50). Returns a flat list so the search
+    modal can treat it like any other category endpoint.
+    """
+    q = (search or "").strip().lower()
+    if not q:
+        return []
+
+    tokens = [t for t in q.split() if t]
+    capped = max(1, min(limit, 50))
+
+    matches: list[dict[str, str]] = []
+    for cat_id, (display_name, *_) in CATEGORIES.items():
+        all_files = _get_images_for_category(cat_id)
+        for img in _dedupe_for_gallery(all_files):
+            stem = img["filename"].rsplit(".", 1)[0].replace("_", " ").lower()
+            if all(tok in stem for tok in tokens):
+                matches.append(
+                    {
+                        # `id` + `name` keep the shape consistent with the other
+                        # entity search endpoints so the UI can reuse its row
+                        # rendering pipeline.
+                        "id": f"{cat_id}/{img['filename']}",
+                        "name": img["filename"].rsplit(".", 1)[0].replace("_", " "),
+                        "filename": img["filename"],
+                        "url": img["url"],
+                        "category_id": cat_id,
+                        "category_name": display_name,
+                    }
+                )
+                if len(matches) >= capped:
+                    return matches
+    return matches
+
+
 @router.get("", tags=["Images"])
 def list_image_categories(request: Request):
     """Return all image categories with their contents.

--- a/frontend/app/components/GlobalSearch.tsx
+++ b/frontend/app/components/GlobalSearch.tsx
@@ -18,6 +18,10 @@ interface CategoryConfig {
   endpoint: string;
   linkFn: (item: SearchResult) => string;
   subtitleFn?: (item: SearchResult) => string;
+  /** Absolute thumbnail URL — when present, the row renders it as a small preview. */
+  thumbFn?: (item: SearchResult) => string;
+  /** When true, activating the result opens it in a new tab instead of routing. */
+  openExternal?: boolean;
 }
 
 const CATEGORIES: CategoryConfig[] = [
@@ -83,6 +87,14 @@ const CATEGORIES: CategoryConfig[] = [
     endpoint: "/api/encounters",
     linkFn: (item) => `/encounters/${item.id.toLowerCase()}`,
     subtitleFn: (item) => (item.room_type ? String(item.room_type) : ""),
+  },
+  {
+    label: "Images",
+    endpoint: "/api/images/search",
+    linkFn: (item) => `${API}${item.url}`,
+    subtitleFn: (item) => (item.category_name ? String(item.category_name) : ""),
+    thumbFn: (item) => `${API}${item.url}`,
+    openExternal: true,
   },
 ];
 
@@ -230,7 +242,12 @@ export default function GlobalSearch() {
   const navigate = useCallback(
     (cat: CategoryConfig, item: SearchResult) => {
       setOpen(false);
-      router.push(cat.linkFn(item));
+      const href = cat.linkFn(item);
+      if (cat.openExternal) {
+        window.open(href, "_blank", "noopener,noreferrer");
+      } else {
+        router.push(href);
+      }
     },
     [router]
   );
@@ -376,10 +393,11 @@ export default function GlobalSearch() {
                   {items.map((item, i) => {
                     const globalIdx = startIndex + i;
                     const isSelected = globalIdx === selectedIndex;
+                    const thumb = cat.thumbFn?.(item);
                     return (
                       <button
                         key={item.id}
-                        className={`w-full text-left px-4 py-2 flex items-baseline gap-2 cursor-pointer transition-colors ${
+                        className={`w-full text-left px-4 py-2 flex items-center gap-3 cursor-pointer transition-colors ${
                           isSelected
                             ? "bg-[var(--bg-card-hover)]"
                             : "hover:bg-[var(--bg-card-hover)]"
@@ -387,6 +405,15 @@ export default function GlobalSearch() {
                         onClick={() => navigate(cat, item)}
                         onMouseEnter={() => setSelectedIndex(globalIdx)}
                       >
+                        {thumb && (
+                          <img
+                            src={thumb}
+                            alt=""
+                            className="w-8 h-8 object-contain shrink-0 rounded bg-[var(--bg-primary)]"
+                            crossOrigin="anonymous"
+                            loading="lazy"
+                          />
+                        )}
                         <span className="text-sm text-[var(--text-primary)] truncate">
                           {item.name}
                         </span>
@@ -394,6 +421,9 @@ export default function GlobalSearch() {
                           <span className="text-xs text-[var(--text-muted)] truncate shrink-0">
                             {cat.subtitleFn(item)}
                           </span>
+                        )}
+                        {cat.openExternal && (
+                          <span className="ml-auto text-[10px] text-[var(--text-muted)] shrink-0">↗</span>
                         )}
                       </button>
                     );


### PR DESCRIPTION
## Summary

Closes #60.

Search "doormaker" now surfaces an **Images** section alongside the existing Monster/Encounter/etc. results, so you can grab the sprite directly without navigating through the `/images` gallery.

## Backend

New `GET /api/images/search?search=<q>&limit=N` endpoint (caps at 50, defaults to 10):

- Multi-word filename match — all tokens in `search` must appear in the basename (underscores stripped, case-insensitive)
- Scans every image category, dedupes png+webp pairs to one entry (prefers webp)
- Returns a flat list so the global-search modal can treat it like any other category endpoint

Each result ships `{id, name, filename, url, category_id, category_name}`.

## Frontend

`GlobalSearch.tsx`:
- `CategoryConfig` gains optional `thumbFn` + `openExternal` flags
- New "Images" category wired to the search endpoint; rows render a 32×32 thumbnail on the left and a tiny `↗` indicator on the right
- Clicking an image result opens the asset URL in a new tab (`window.open` with `noopener,noreferrer`) instead of `router.push`
- Row layout realigned `items-baseline` → `items-center` so thumbnails and text line up

## Try it

Once deployed:

```
curl "https://spire-codex.com/api/images/search?search=doormaker&limit=5"
```

or open the `.` search modal and type `doormaker` — you'll see the Monsters page result **and** the sprite thumbnails from `Monsters` + `Bosses` + `Spine Renders` categories.
