### PR TITLE
Cap recent-additions to a rolling 7-day window

### DIFF
--- a/backend/app/routers/changelogs.py
+++ b/backend/app/routers/changelogs.py
@@ -1,6 +1,7 @@
 """Changelog API endpoints."""
 
 import json
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
@@ -51,18 +52,33 @@ def recent_additions(
     entity_type: str | None = None,
     limit: int = 12,
     max_versions: int = 5,
+    max_age_days: int = 7,
 ):
     """Return the most recent entity additions, scanning newest changelogs first.
 
     - entity_type: optional filter (e.g. "cards", "relics") — if omitted, returns a
       dict keyed by entity type.
     - limit: max items to return per entity type.
-    - max_versions: stop scanning after this many changelogs.
+    - max_versions: stop scanning after this many changelogs (safety cap).
+    - max_age_days: only surface items from changelogs dated within this many
+      days from today (default 7). Pass 0 to disable the time filter.
 
     Each item is enriched with `version`, `version_tag`, and `version_date` so the
     UI can render a "Added in vX.Y.Z" badge.
     """
     logs = _load_changelogs()[:max_versions]
+    if max_age_days > 0:
+        cutoff = date.today() - timedelta(days=max_age_days)
+
+        def _within_window(log: dict) -> bool:
+            raw = log.get("date") or ""
+            try:
+                return datetime.fromisoformat(raw).date() >= cutoff
+            except ValueError:
+                # Missing / malformed date — include rather than silently drop it.
+                return True
+
+        logs = [log for log in logs if _within_window(log)]
 
     def _collect(target_type: str) -> list[dict]:
         items: list[dict] = []


### PR DESCRIPTION
## Summary

Closes #59.

The "Recently Added" callout on each entity list page (cards, relics, potions, etc.) was driven by `/api/changelogs/recent-additions` which scanned the last 5 changelogs with **no time bound**. That meant if a couple of small patches shipped in quick succession after a content drop, the "new in vX.Y.Z" section could vanish within a day or two even though the items were genuinely fresh.

## Change

Added an optional `max_age_days` query param (default **7**) to `/api/changelogs/recent-additions`:

- Filters by each changelog's `date` field before collecting additions
- `max_versions` still applies as a safety cap
- Pass `max_age_days=0` to disable the time filter (old behavior)

## Effect

`RecentlyAdded.tsx` needs no changes — it already uses the default args, so the section now persists for a full week after each changelog release regardless of how many intermediate patches ship.

## Verified against real data

Today `2026-04-16`, 7-day cutoff `2026-04-09`:

| Tag    | Date       | Within window |
|--------|------------|---------------|
| 1.0.20 | 2026-04-15 | ✓             |
| 1.0.19 | 2026-04-11 | ✓             |
| 1.0.18 | 2026-04-09 | ✓             |
| 1.0.17 | 2026-04-06 |               |
| 1.0.15 | 2026-04-02 |               |

One-file, 17-line backend change.
