### PR TITLE
Polish /badges theme + add home-page tile

### DIFF
--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -40,6 +40,7 @@ const FALLBACK_DESCS: Record<string, string> = {
   timeline: "Explore the Slay the Spire 2 timeline — epochs, story arcs, and unlockable content.",
   images: "Browse and download Slay the Spire 2 game art — card portraits, relic icons, monster sprites.",
   reference: "Slay the Spire 2 reference — keywords, orbs, afflictions, intents, acts, ascension, and more.",
+  badges: "Run-end badges from Slay the Spire 2 — Bronze, Silver, and Gold tier mini-achievements awarded on the Game Over screen.",
   guides: "Community strategy guides — character breakdowns, boss strategies, deckbuilding tips, and more.",
   leaderboards: "Fastest wins and highest ascensions from the community. Browse every submitted run.",
   submit: "Upload your .run files to contribute to leaderboards and community stats.",
@@ -88,6 +89,7 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
     monsters: "Bestiary", potions: "Potion Lab", enchantments: "Enchantments",
     encounters: "Encounters", events: "Events", powers: "Powers",
     timeline: "Timeline", images: "Images", reference: "Reference",
+    badges: "Badges",
     guides: "Guides", leaderboards: "Leaderboard", submit: "Submit a Run", stats: "Stats",
   };
   const ENGLISH_FALLBACKS = new Set(Object.values(SECTION_LABEL_MAP).map(v => v.toLowerCase()));
@@ -193,6 +195,12 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
           (stats.ascensions ?? 0)
         : "–",
       color: "#596068",  // muted
+    },
+    {
+      href: "/badges",
+      key: "badges",
+      count: stats?.badges ?? "–",
+      color: "#c5894a",  // bronze
     },
     ...(!IS_BETA ? [
       {

--- a/frontend/app/badges/[id]/page.tsx
+++ b/frontend/app/badges/[id]/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import JsonLd from "@/app/components/JsonLd";
 import RichDescription from "@/app/components/RichDescription";
-import { buildDetailPageJsonLd } from "@/lib/jsonld";
+import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { stripTags } from "@/lib/seo";
 import type { Badge } from "@/lib/api";
 
@@ -24,10 +24,16 @@ const RARITY_LABEL: Record<string, string> = {
   gold: "Gold",
 };
 
-const RARITY_TINT: Record<string, string> = {
-  bronze: "text-[#c5894a] border-[#a87a3d]",
-  silver: "text-[#cfd6e0] border-[#9ca6b4]",
-  gold: "text-[var(--accent-gold)] border-[var(--accent-gold)]",
+const RARITY_TEXT: Record<string, string> = {
+  bronze: "text-[#c5894a]",
+  silver: "text-[#cfd6e0]",
+  gold: "text-[var(--accent-gold)]",
+};
+
+const RARITY_BORDER: Record<string, string> = {
+  bronze: "border-l-[#a87a3d]",
+  silver: "border-l-[#9ca6b4]",
+  gold: "border-l-[var(--accent-gold)]",
 };
 
 async function fetchBadge(id: string): Promise<Badge | null> {
@@ -44,12 +50,19 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!badge) return { title: "Badge Not Found - Spire Codex" };
 
   const desc = stripTags(badge.description);
-  const title = `Slay the Spire 2 Badge - ${badge.name} | Spire Codex`;
+  const subtype = badge.tiered ? "Tiered" : "Badge";
+  const title = `Slay the Spire 2 Badge - ${badge.name} - ${subtype} | Spire Codex`;
   const metaDesc = `${badge.name} run-end badge in Slay the Spire 2: ${desc}`;
   return {
     title,
     description: metaDesc,
-    openGraph: { title, description: metaDesc },
+    openGraph: {
+      title,
+      description: metaDesc,
+      images: badge.image_url
+        ? [{ url: `${STATIC_BASE}${badge.image_url}` }]
+        : [],
+    },
     twitter: { card: "summary_large_image" },
     alternates: { canonical: `/badges/${id}` },
   };
@@ -60,10 +73,12 @@ export default async function BadgePage({ params }: Props) {
   const badge = await fetchBadge(id);
   if (!badge) notFound();
 
-  const jsonLd = buildDetailPageJsonLd({
-    name: `Slay the Spire 2 Badge - ${badge.name}`,
-    description: stripTags(badge.description),
+  const desc = stripTags(badge.description);
+  const detailJsonLd = buildDetailPageJsonLd({
+    name: badge.name,
+    description: desc || `${badge.name} run-end badge from Slay the Spire 2`,
     path: `/badges/${id}`,
+    imageUrl: badge.image_url ? `${STATIC_BASE}${badge.image_url}` : undefined,
     category: "Badge",
     breadcrumbs: [
       { name: "Home", href: "/" },
@@ -72,81 +87,109 @@ export default async function BadgePage({ params }: Props) {
     ],
   });
 
+  const faqQuestions = [
+    {
+      question: `How do you earn the ${badge.name} badge in Slay the Spire 2?`,
+      answer: desc || `${badge.name} is a run-end badge in Slay the Spire 2.`,
+    },
+    {
+      question: `Is ${badge.name} a tiered badge?`,
+      answer: badge.tiered
+        ? `Yes — ${badge.name} has ${badge.tiers.length} tiers (${badge.tiers.map((t) => RARITY_LABEL[t.rarity] ?? t.rarity).join(", ")}).`
+        : `No — ${badge.name} has a single tier.`,
+    },
+    {
+      question: `Can ${badge.name} be earned in single-player?`,
+      answer: badge.multiplayer_only
+        ? `No — ${badge.name} is only earnable in multiplayer runs.`
+        : `Yes — ${badge.name} can be earned in both single-player and multiplayer.`,
+    },
+  ];
+
+  const jsonLd = [...detailJsonLd, buildFAQPageJsonLd(faqQuestions)];
+
   return (
-    <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div className="max-w-2xl mx-auto px-4 py-8">
       <JsonLd data={jsonLd} />
 
       <Link
         href="/badges"
-        className="inline-flex items-center gap-1 text-sm text-[var(--text-muted)] hover:text-[var(--accent-gold)] mb-4"
+        className="inline-flex items-center gap-1 text-sm text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors mb-6"
       >
-        ← All badges
+        &larr; Back to Badges
       </Link>
 
-      <header className="flex gap-6 items-start mb-8">
+      <div className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-6">
         {badge.image_url && (
-          <img
-            src={`${STATIC_BASE}${badge.image_url}`}
-            alt={`Slay the Spire 2 ${badge.name} badge`}
-            className="w-28 h-28 object-contain shrink-0"
-          />
+          <div className="flex justify-center mb-6">
+            <img
+              src={`${STATIC_BASE}${badge.image_url}`}
+              alt={`Slay the Spire 2 ${badge.name} badge`}
+              className="w-24 h-24 object-contain"
+            />
+          </div>
         )}
-        <div>
-          <h1 className="text-3xl font-bold text-[var(--text-primary)] mb-2">
-            {badge.name}
-          </h1>
-          <p className="text-[var(--text-secondary)] mb-3">
-            <RichDescription text={badge.description} />
-          </p>
-          <div className="flex flex-wrap gap-2 text-xs">
-            {badge.tiered && (
-              <span className="px-2 py-1 rounded-full border border-[var(--border-subtle)]">
-                Tiered ({badge.tiers.length})
-              </span>
-            )}
-            {badge.requires_win && (
-              <span className="px-2 py-1 rounded-full border border-[var(--border-subtle)]">
-                Requires win
-              </span>
-            )}
-            {badge.multiplayer_only && (
-              <span className="px-2 py-1 rounded-full border border-[var(--border-subtle)] text-[var(--accent-gold)]">
-                Multiplayer only
-              </span>
-            )}
-          </div>
-        </div>
-      </header>
 
-      {badge.tiered && (
-        <section>
-          <h2 className="text-xl font-bold text-[var(--text-primary)] mb-4">
-            Tiers
-          </h2>
-          <div className="space-y-3">
-            {badge.tiers.map((t) => (
-              <div
-                key={t.rarity}
-                className={`bg-[var(--bg-card)] rounded-xl border-l-4 ${RARITY_TINT[t.rarity] ?? ""} border-y border-r border-[var(--border-subtle)] p-5`}
-              >
-                <div className="flex items-baseline gap-3 mb-2">
-                  <span
-                    className={`text-xs uppercase tracking-wider font-semibold ${RARITY_TINT[t.rarity]?.split(" ")[0] ?? ""}`}
-                  >
-                    {RARITY_LABEL[t.rarity] ?? t.rarity}
-                  </span>
-                  <h3 className="text-lg font-semibold text-[var(--text-primary)]">
-                    {t.title}
-                  </h3>
+        <h1 className="text-2xl font-bold text-[var(--text-primary)] text-center mb-3">
+          {badge.name}
+        </h1>
+
+        <div className="flex items-center justify-center gap-3 mb-5 text-sm flex-wrap">
+          {badge.tiered ? (
+            <span className="text-[var(--text-muted)]">
+              {badge.tiers.length} tiers
+            </span>
+          ) : (
+            <span className="text-[var(--text-muted)]">Single tier</span>
+          )}
+          {badge.requires_win && (
+            <>
+              <span className="text-[var(--text-muted)]">·</span>
+              <span className="text-[var(--text-muted)]">Requires win</span>
+            </>
+          )}
+          {badge.multiplayer_only && (
+            <>
+              <span className="text-[var(--text-muted)]">·</span>
+              <span className="text-[var(--accent-gold)]">Multiplayer only</span>
+            </>
+          )}
+        </div>
+
+        <div className="text-[var(--text-secondary)] leading-relaxed text-center mb-6">
+          <RichDescription text={badge.description} />
+        </div>
+
+        {badge.tiered && (
+          <>
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-3">
+              Tiers
+            </h2>
+            <div className="space-y-3">
+              {badge.tiers.map((t) => (
+                <div
+                  key={t.rarity}
+                  className={`rounded-lg border-l-4 ${RARITY_BORDER[t.rarity] ?? "border-l-[var(--border-subtle)]"} border-y border-r border-[var(--border-subtle)] bg-[var(--bg-primary)] p-4`}
+                >
+                  <div className="flex items-baseline gap-3 mb-1">
+                    <span
+                      className={`text-xs uppercase tracking-wider font-semibold ${RARITY_TEXT[t.rarity] ?? ""}`}
+                    >
+                      {RARITY_LABEL[t.rarity] ?? t.rarity}
+                    </span>
+                    <h3 className="text-base font-semibold text-[var(--text-primary)]">
+                      {t.title}
+                    </h3>
+                  </div>
+                  <p className="text-sm text-[var(--text-secondary)] leading-snug">
+                    <RichDescription text={t.description} />
+                  </p>
                 </div>
-                <p className="text-sm text-[var(--text-secondary)]">
-                  <RichDescription text={t.description} />
-                </p>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
+              ))}
+            </div>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/app/badges/page.tsx
+++ b/frontend/app/badges/page.tsx
@@ -1,7 +1,10 @@
 import Link from "next/link";
 import JsonLd from "@/app/components/JsonLd";
 import RichDescription from "@/app/components/RichDescription";
-import { buildCollectionPageJsonLd } from "@/lib/jsonld";
+import {
+  buildBreadcrumbJsonLd,
+  buildCollectionPageJsonLd,
+} from "@/lib/jsonld";
 import type { Badge } from "@/lib/api";
 
 export const dynamic = "force-dynamic";
@@ -13,7 +16,7 @@ const API =
 
 const STATIC_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
-const RARITY_BORDER: Record<string, string> = {
+const TOP_TIER_BORDER: Record<string, string> = {
   bronze: "border-[#a87a3d]",
   silver: "border-[#9ca6b4]",
   gold: "border-[var(--accent-gold)]",
@@ -26,36 +29,42 @@ export default async function BadgesPage() {
     if (res.ok) badges = await res.json();
   } catch {}
 
-  const single = badges.filter((b) => !b.tiered);
   const tiered = badges.filter((b) => b.tiered);
+  const single = badges.filter((b) => !b.tiered);
   const multiplayerOnly = badges.filter((b) => b.multiplayer_only);
 
-  const jsonLd = buildCollectionPageJsonLd({
-    name: "Slay the Spire 2 Badges - Run-End Awards | Spire Codex",
-    description:
-      "All run-end badges in Slay the Spire 2 — mini-achievements awarded on the Game Over screen. Bronze, Silver, and Gold tiers.",
-    path: "/badges",
-    items: badges.map((b) => ({
-      name: b.name,
-      path: `/badges/${b.id.toLowerCase()}`,
-    })),
-  });
+  const jsonLd = [
+    buildBreadcrumbJsonLd([
+      { name: "Home", href: "/" },
+      { name: "Badges", href: "/badges" },
+    ]),
+    buildCollectionPageJsonLd({
+      name: "Slay the Spire 2 Badges",
+      description:
+        "All run-end badges in Slay the Spire 2 — Bronze, Silver, and Gold tier mini-achievements awarded on the Game Over screen.",
+      path: "/badges",
+      items: badges.map((b) => ({
+        name: b.name,
+        path: `/badges/${b.id.toLowerCase()}`,
+      })),
+    }),
+  ];
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
-      <h1 className="text-3xl font-bold text-[var(--text-primary)] mb-2">
-        Badges
+      <h1 className="text-3xl font-bold mb-2">
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 Badges</span>
       </h1>
-      <p className="text-[var(--text-secondary)] mb-8 max-w-3xl">
+      <p className="text-sm text-[var(--text-muted)] mb-6">
         Run-end badges are mini-achievements awarded on the Game Over screen.
         Some have Bronze / Silver / Gold tiers; a handful are only attainable
         in multiplayer. Badges contribute to your Daily Leaderboard score.
       </p>
 
       {tiered.length > 0 && (
-        <section className="mb-12">
-          <h2 className="text-xl font-bold text-[var(--text-primary)] mb-4">
+        <section className="mb-10">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-3">
             Tiered Badges
           </h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -67,8 +76,8 @@ export default async function BadgesPage() {
       )}
 
       {single.length > 0 && (
-        <section className="mb-12">
-          <h2 className="text-xl font-bold text-[var(--text-primary)] mb-4">
+        <section className="mb-10">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-3">
             Single-Tier Badges
           </h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -80,11 +89,11 @@ export default async function BadgesPage() {
       )}
 
       {multiplayerOnly.length > 0 && (
-        <section className="mb-4">
-          <h2 className="text-xl font-bold text-[var(--text-primary)] mb-2">
+        <section>
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">
             Multiplayer-Only
           </h2>
-          <p className="text-sm text-[var(--text-muted)] mb-4">
+          <p className="text-xs text-[var(--text-muted)] mb-3">
             These badges can only be earned in multiplayer runs.
           </p>
           <div className="flex flex-wrap gap-2">
@@ -92,7 +101,7 @@ export default async function BadgesPage() {
               <Link
                 key={b.id}
                 href={`/badges/${b.id.toLowerCase()}`}
-                className="text-sm px-3 py-1 rounded-full border border-[var(--border-subtle)] bg-[var(--bg-card)] hover:border-[var(--border-accent)]"
+                className="text-sm px-3 py-1 rounded-full border border-[var(--border-subtle)] bg-[var(--bg-card)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50 hover:text-[var(--accent-gold)] transition-colors"
               >
                 {b.name}
               </Link>
@@ -106,39 +115,40 @@ export default async function BadgesPage() {
 
 function BadgeCard({ badge }: { badge: Badge }) {
   const topTier = badge.tiers[badge.tiers.length - 1] ?? badge.tiers[0];
-  const borderClass = RARITY_BORDER[topTier?.rarity ?? "bronze"];
+  const borderClass =
+    (badge.tiered && TOP_TIER_BORDER[topTier?.rarity ?? "bronze"]) ||
+    "border-[var(--border-subtle)]";
   return (
     <Link
       href={`/badges/${badge.id.toLowerCase()}`}
-      className={`bg-[var(--bg-card)] rounded-xl border ${borderClass} p-5 hover:bg-[var(--bg-card-hover)] transition-all flex gap-4`}
+      className={`bg-[var(--bg-card)] rounded-lg border ${borderClass} p-4 hover:bg-[var(--bg-card-hover)] hover:border-[var(--border-accent)] transition-all flex gap-4 group`}
     >
       {badge.image_url && (
         <img
           src={`${STATIC_BASE}${badge.image_url}`}
           alt={`Slay the Spire 2 ${badge.name} badge`}
-          className="w-16 h-16 object-contain shrink-0"
+          className="w-14 h-14 object-contain shrink-0"
           loading="lazy"
         />
       )}
-      <div className="min-w-0">
-        <h3 className="text-lg font-semibold text-[var(--accent-gold)] mb-1 truncate">
+      <div className="min-w-0 flex-1">
+        <h3 className="text-base font-semibold text-[var(--accent-gold)] mb-1 truncate">
           {badge.name}
         </h3>
         <p className="text-sm text-[var(--text-secondary)] leading-snug">
           <RichDescription text={badge.description} />
         </p>
-        {badge.tiered && (
+        {(badge.tiered || badge.requires_win || badge.multiplayer_only) && (
           <p className="text-xs text-[var(--text-muted)] mt-2">
-            {badge.tiers.length} tier{badge.tiers.length === 1 ? "" : "s"}
-            {badge.requires_win ? " · requires win" : ""}
-            {badge.multiplayer_only ? " · multiplayer only" : ""}
-          </p>
-        )}
-        {!badge.tiered && (badge.requires_win || badge.multiplayer_only) && (
-          <p className="text-xs text-[var(--text-muted)] mt-2">
-            {badge.requires_win ? "Requires win" : ""}
-            {badge.requires_win && badge.multiplayer_only ? " · " : ""}
-            {badge.multiplayer_only ? "Multiplayer only" : ""}
+            {[
+              badge.tiered
+                ? `${badge.tiers.length} tier${badge.tiers.length === 1 ? "" : "s"}`
+                : null,
+              badge.requires_win ? "requires win" : null,
+              badge.multiplayer_only ? "multiplayer only" : null,
+            ]
+              .filter(Boolean)
+              .join(" · ")}
           </p>
         )}
       </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -407,6 +407,7 @@ export interface Stats {
   afflictions: number;
   modifiers: number;
   achievements: number;
+  badges: number;
   epochs: number;
   acts: number;
   ascensions: number;


### PR DESCRIPTION
## Summary

Follow-up to #72 — adds the `/badges` tile to the home page grid, and polishes the `/badges` list + detail pages to match the site theme used by `/cards`, `/relics`, etc.

## Changes

**Home page tile** (`HomeClient.tsx`, `lib/api.ts`)
- New section entry for `badges` (count `stats.badges`, bronze `#c5894a` accent, label + fallback description).
- Positioned after Reference — same "last in Database" order as the navbar.
- `Stats` interface gains `badges: number`.

**List page theme alignment** (`app/badges/page.tsx`)
- Heading: `<span className="text-[var(--accent-gold)]">Slay the Spire 2 Badges</span>` wrapped in `text-3xl font-bold mb-2` — matches Cards / Relics / Monsters.
- Subtitle: `text-sm text-[var(--text-muted)] mb-6`.
- Section headings use the uppercase muted tracker style (`text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)]`).
- Added `buildBreadcrumbJsonLd` alongside `buildCollectionPageJsonLd`.
- Tile: smaller 14×14 icon, gold name, muted meta line.

**Detail page theme alignment** (`app/badges/[id]/page.tsx`)
- Container narrowed to `max-w-2xl mx-auto px-4 py-8` — matches Relic detail.
- Wrapping `bg-[var(--bg-card)] rounded-lg border ... p-6` card with centered icon, centered `text-2xl font-bold` name, and centered meta row.
- Tier rows use `border-l-4` with rarity tint (`#a87a3d` / `#9ca6b4` / gold).
- Added `FAQPage` JSON-LD (earn conditions, tiered?, single-player?) — same SEO treatment as other detail pages.

## Verification

Re-screenshotted list + detail locally against the dev stack — layout now matches `/cards`, `/relics`. Typecheck passes.
