### PR TITLE
Image search results prefer PNG over webp

### DIFF
--- a/backend/app/routers/images.py
+++ b/backend/app/routers/images.py
@@ -162,9 +162,12 @@ def search_images(request: Request, search: str = "", limit: int = 10):
     Used by the global search modal so queries like "doormaker" surface image
     results alongside entity pages. Matches every whitespace-separated token in
     `search` against the basename (extension stripped, case-insensitive).
-    Results are deduped to one entry per asset (prefers webp, then gif, then
-    png) and capped at `limit` (max 50). Returns a flat list so the search
-    modal can treat it like any other category endpoint.
+
+    Results prefer the PNG sibling of any asset if one exists on disk — our
+    animated webp exports (monsters, spine renders) can render garbled when
+    opened directly, so search results route users to the static PNG instead.
+    Falls back to the gallery-preferred extension when no PNG is available.
+    Capped at `limit` (max 50).
     """
     q = (search or "").strip().lower()
     if not q:
@@ -176,24 +179,34 @@ def search_images(request: Request, search: str = "", limit: int = 10):
     matches: list[dict[str, str]] = []
     for cat_id, (display_name, *_) in CATEGORIES.items():
         all_files = _get_images_for_category(cat_id)
+        # Build a map from url-stem -> png variant if present, so we can rewrite
+        # the deduped entry to point at the png when one exists.
+        png_by_stem: dict[str, dict[str, str]] = {}
+        for img in all_files:
+            if img["filename"].lower().endswith(".png"):
+                png_by_stem[img["url"].rsplit(".", 1)[0]] = img
         for img in _dedupe_for_gallery(all_files):
-            stem = img["filename"].rsplit(".", 1)[0].replace("_", " ").lower()
-            if all(tok in stem for tok in tokens):
-                matches.append(
-                    {
-                        # `id` + `name` keep the shape consistent with the other
-                        # entity search endpoints so the UI can reuse its row
-                        # rendering pipeline.
-                        "id": f"{cat_id}/{img['filename']}",
-                        "name": img["filename"].rsplit(".", 1)[0].replace("_", " "),
-                        "filename": img["filename"],
-                        "url": img["url"],
-                        "category_id": cat_id,
-                        "category_name": display_name,
-                    }
-                )
-                if len(matches) >= capped:
-                    return matches
+            stem_name = img["filename"].rsplit(".", 1)[0]
+            stem_for_match = stem_name.replace("_", " ").lower()
+            if not all(tok in stem_for_match for tok in tokens):
+                continue
+            url_stem = img["url"].rsplit(".", 1)[0]
+            preferred = png_by_stem.get(url_stem, img)
+            matches.append(
+                {
+                    # `id` + `name` keep the shape consistent with the other
+                    # entity search endpoints so the UI can reuse its row
+                    # rendering pipeline.
+                    "id": f"{cat_id}/{preferred['filename']}",
+                    "name": stem_name.replace("_", " "),
+                    "filename": preferred["filename"],
+                    "url": preferred["url"],
+                    "category_id": cat_id,
+                    "category_name": display_name,
+                }
+            )
+            if len(matches) >= capped:
+                return matches
     return matches
 
 


### PR DESCRIPTION
## Summary

The `/api/images/search` endpoint was returning `.webp` URLs by default (inherited from `_dedupe_for_gallery`, which prefers webp for inline gallery rendering). Clicking a webp result from the global search modal could open a garbled / "symbols" view in some browsers — our static webp exports alongside PNGs are fine inline but flaky when opened directly.

This patch makes the search endpoint route to the **PNG sibling** of each asset whenever one exists on disk. Falls back to the gallery-preferred extension only for categories that are webp-only (e.g. `ui/animations/monsters/*.webp` — animated Spine renders with no static counterpart).

## Implementation

- `search_images` now builds a quick `url_stem → png_variant` lookup per category and rewrites the deduped entry to the PNG when available.
- `_dedupe_for_gallery` is untouched so the `/images` gallery listing still prefers webp for inline preview (unchanged UX).

## Verified

- `search=doormaker` → 6 results, all `.png`.
- `search=soul fysh` → 5 results, all `.png` (previously webp).
- `search=scroll of biting` → PNG for the static renders, webp only for the `ui/animations/*` entries that are genuinely animation-only.

If you want the webp-only entries dropped from search entirely rather than falling back, say the word and I'll tighten it to PNG-or-nothing.
