### PR TITLE
Fix badge images pointing to localhost in production

### DIFF
--- a/frontend/app/badges/[id]/page.tsx
+++ b/frontend/app/badges/[id]/page.tsx
@@ -14,7 +14,18 @@ const API_INTERNAL =
   process.env.NEXT_PUBLIC_API_URL ||
   "http://localhost:8000";
 
-const STATIC_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+// Inline <img> src — relative path in prod (NEXT_PUBLIC_API_URL is "") so the
+// browser hits the same origin. ?? (not ||) is critical: with || an empty
+// string falls through to the localhost fallback in production.
+const STATIC_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+// OG / JSON-LD images need ABSOLUTE URLs (social crawlers don't resolve
+// relative paths), so prefer NEXT_PUBLIC_SITE_URL — which is set to
+// https://spire-codex.com in prod CI.
+const ABSOLUTE_BASE =
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://localhost:8000";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -60,7 +71,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title,
       description: metaDesc,
       images: badge.image_url
-        ? [{ url: `${STATIC_BASE}${badge.image_url}` }]
+        ? [{ url: `${ABSOLUTE_BASE}${badge.image_url}` }]
         : [],
     },
     twitter: { card: "summary_large_image" },
@@ -78,7 +89,7 @@ export default async function BadgePage({ params }: Props) {
     name: badge.name,
     description: desc || `${badge.name} run-end badge from Slay the Spire 2`,
     path: `/badges/${id}`,
-    imageUrl: badge.image_url ? `${STATIC_BASE}${badge.image_url}` : undefined,
+    imageUrl: badge.image_url ? `${ABSOLUTE_BASE}${badge.image_url}` : undefined,
     category: "Badge",
     breadcrumbs: [
       { name: "Home", href: "/" },

--- a/frontend/app/badges/page.tsx
+++ b/frontend/app/badges/page.tsx
@@ -14,7 +14,10 @@ const API =
   process.env.NEXT_PUBLIC_API_URL ||
   "http://localhost:8000";
 
-const STATIC_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+// Use ?? not || so an empty NEXT_PUBLIC_API_URL (production sets it to "")
+// passes through and image src becomes a relative `/static/...` URL — falling
+// back on `||` would route prod traffic at http://localhost:8000.
+const STATIC_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 const TOP_TIER_BORDER: Record<string, string> = {
   bronze: "border-[#a87a3d]",


### PR DESCRIPTION
## Summary

Hotfix: badge images on production `/badges` were rendered with absolute `src="http://localhost:8000/static/images/badges/..."` URLs, breaking every badge icon.

## Cause

`STATIC_BASE` used `||` instead of `??`:

```ts
const STATIC_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
```

In production CI the build arg is set to **empty string** (`NEXT_PUBLIC_API_URL=`) so the frontend can use relative `/static/...` URLs that nginx routes back to the backend. Empty string is falsy under `||`, so STATIC_BASE fell back to `http://localhost:8000` and every `<img src>` got a localhost prefix.

Verified live:

```
$ curl -s https://spire-codex.com/badges | grep src.*badge
src="http://localhost:8000/static/images/badges/badge_big_deck.png"
src="http://localhost:8000/static/images/badges/badge_elite.png"
...

$ curl -s https://spire-codex.com/relics/snecko_eye | grep src.*relic
src="/static/images/relics/snecko_eye.webp"   ← what we want
```

## Fix

- `STATIC_BASE` now uses `??` (nullish coalescing). Empty string passes through; only `null` / `undefined` falls back to localhost. This matches the `cards` / `relics` / `monsters` pattern.
- Split out a separate `ABSOLUTE_BASE` (built from `NEXT_PUBLIC_SITE_URL` first) for OG / JSON-LD `imageUrl` — those need fully-qualified URLs for Twitter / Facebook crawlers, so they keep using `https://spire-codex.com/...` rather than the relative form.

Applied to both `app/badges/page.tsx` and `app/badges/[id]/page.tsx`.
