### PR TITLE
Guard data/changelogs/ from accidental edits + cut-release skill

### DIFF
--- a/.github/workflows/changelog-guard.yml
+++ b/.github/workflows/changelog-guard.yml
@@ -1,0 +1,87 @@
+name: Changelog Guard
+
+# Existing changelog files in data/changelogs/ are write-once historical
+# records — modifying or deleting them silently loses release history. This
+# workflow inspects every PR against main and fails if any existing changelog
+# was changed without an explicit override label.
+#
+# Override: add the `changelog-edit-approved` label to the PR. Re-runs on
+# label change, so the check turns green once the label is added.
+#
+# What's allowed without the label:
+#   - Adding a new file:    A data/changelogs/X.json   ← green
+# What's blocked without the label:
+#   - Modifying an existing file: M data/changelogs/X.json   ← red
+#   - Deleting an existing file:  D data/changelogs/X.json   ← red
+
+on:
+  pull_request:
+    branches: [main]
+    paths: ["data/changelogs/**"]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  guard:
+    name: Block edits to historical changelogs
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect modified or deleted changelog files
+        id: scan
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+
+          # Walk the merge-base diff so we only see what THIS PR changes.
+          merge_base=$(git merge-base "$base" "$head")
+          changed=$(
+            git diff --name-status "$merge_base" "$head" -- data/changelogs/ \
+              | awk '$1 ~ /^[MD]/ { print $1, $2 }'
+          )
+
+          if [ -z "$changed" ]; then
+            echo "✅ No existing changelog files modified or deleted."
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "🚫 Existing changelog files modified or deleted:"
+          echo "$changed" | sed 's/^/  /'
+          # Save for the next step's annotation message
+          {
+            echo "blocked=true"
+            echo "changed_files<<EOF"
+            echo "$changed"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Allow if override label present
+        if: steps.scan.outputs.blocked == 'true'
+        run: |
+          set -euo pipefail
+          labels='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          if echo "$labels" | grep -q '"changelog-edit-approved"'; then
+            echo "✅ \`changelog-edit-approved\` label present — bypassing guard."
+            exit 0
+          fi
+
+          cat <<MSG
+          ::error::Historical changelog files in data/changelogs/ are write-once.
+          The following files were modified or deleted by this PR:
+
+          ${{ steps.scan.outputs.changed_files }}
+
+          If this is intentional (typo fix, regen of a tag's data diff,
+          one-time format normalization, etc.), add the
+          \`changelog-edit-approved\` label to the PR and the check will
+          re-run. See CONTRIBUTING.md → "Changelog retention" for context.
+          MSG
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,50 @@ If a card description, damage value, or relic effect is wrong:
 - Section metadata in `frontend/app/mechanics/sections.ts`
 - Content components in `frontend/app/mechanics/[slug]/MechanicContent.tsx`
 
+## Changelog Retention
+
+Files under `data/changelogs/` are the **only durable record of per-version
+data history** — every entity-detail page reads them through `/api/history/`
+to render its version-history rail. Once a tag's changelog is in `main`, it
+is **write-once**. CI (`.github/workflows/changelog-guard.yml`) blocks any
+PR that modifies or deletes an existing file under `data/changelogs/`.
+
+**Adding a new tag** — always allowed:
+
+```bash
+# After parsing the new game data into data/eng/...
+python3 tools/diff_data.py vPREV --format json \
+  --game-version NEW --date YYYY-MM-DD --title "Update title"
+# Hand-edit data/changelogs/NEW.json to add `features`, `fixes`,
+# `api_changes` arrays. Commit + PR.
+```
+
+The PR shows `A data/changelogs/NEW.json` → guard passes.
+
+**Editing an existing changelog** — requires the `changelog-edit-approved`
+label. Legitimate cases:
+
+- Typo / metadata fix in `title`, `date`, etc.
+- Re-running `diff_data.py` against a tag (e.g. after fixing a parser bug
+  that produced incorrect values). Hand-curated `features` / `fixes` /
+  `api_changes` are preserved through regen — `diff_data.py` merges them
+  back in if the file already exists.
+- One-time format normalization across all historical changelogs.
+
+Add the label on the GitHub PR page — the check re-runs on label change
+and turns green. The bar isn't "you can't edit", it's "you must consciously
+say you meant to."
+
+**What this protects against**
+
+- Regen-by-accident (running `diff_data.py vWRONG_TAG` and silently
+  overwriting last month's release notes)
+- Merge-conflict resolutions that drop a hand-curated section
+- Scripts that loop over `data/changelogs/*.json` and rewrite them
+
+The changelog files survive in git history, but the guard catches the
+mistake at PR review rather than after-the-fact.
+
 ## Code Style
 
 - **Python**: Standard formatting, type hints where practical


### PR DESCRIPTION
## Summary

Closes the loop on changelog data integrity flagged in chat.

### `.github/workflows/changelog-guard.yml` — CI guard

Runs on every PR that touches `data/changelogs/`. Inspects the diff:

- **`A` (added)** → green. New release file is fine.
- **`M` (modified)** or **`D` (deleted)** → red, with an annotation pointing at the policy.

Override: add the `changelog-edit-approved` label to the PR. The workflow listens for `labeled` / `unlabeled` events and re-runs, so the check turns green once the label is present. Trips happen at PR review rather than after merge.

### `CONTRIBUTING.md` → "Changelog Retention" section

Walks contributors through:
- Which edit paths are allowed without the label (new file = `A`)
- Which require the label (typo fix, `diff_data.py` regen, format normalization)
- What the guard protects against (regen-by-accident, conflict resolutions that drop a hand-curated section, scripts that loop over `data/changelogs/*.json`)
- Reminds that `tools/diff_data.py` already merges existing `features` / `fixes` / `api_changes` arrays so a regen doesn't silently destroy curated content — but the modification still trips the guard, by design.

## Test plan

Open a follow-up PR that touches an existing changelog (e.g. fixing a typo in `1.0.20.json`) — should land red. Add the `changelog-edit-approved` label — should turn green on re-run.
