### PR TITLE
Sync /mechanics + i18n /merchant to v0.103.2; auto-count entity meta-descriptions

### DIFF
--- a/frontend/app/[lang]/merchant/page.tsx
+++ b/frontend/app/[lang]/merchant/page.tsx
@@ -83,8 +83,8 @@ export default async function LangMerchantPage({ params }: { params: Promise<{ l
     }),
     buildFAQPageJsonLd([
       { question: `How much do cards cost at the merchant in ${gameName}?`, answer: "Common cards cost 48-53 gold, Uncommon 71-79 gold, Rare 143-158 gold. Colorless cards have a 15% markup. One random card is on sale for half price." },
-      { question: `How much do relics cost at the shop in ${gameName}?`, answer: "Common relics cost 170-230 gold, Uncommon 213-288 gold, Rare 255-345 gold, and Shop relics 191-259 gold." },
-      { question: `How much does card removal cost in ${gameName}?`, answer: "Card removal starts at 75 gold and increases by 25 gold each time you use it (75, 100, 125, 150, etc.)." },
+      { question: `How much do relics cost at the shop in ${gameName}?`, answer: "Common relics cost 149-201 gold, Uncommon 191-259 gold, Rare 234-316 gold, and Shop relics 170-230 gold. Major Update #1 (v0.103.2) reduced every relic base price by 25 gold." },
+      { question: `How much does card removal cost in ${gameName}?`, answer: "Card removal starts at 75 gold and increases by 25 gold each time you use it. At Ascension 6 and above, the Inflation modifier raises the base to 100 gold and the increment to 50 gold (100, 150, 200, ...)." },
       { question: `What is the Fake Merchant in ${gameName}?`, answer: "The Fake Merchant is an event that sells counterfeit versions of popular relics for only 50 gold each. These fakes have weaker effects than the originals." },
     ]),
   ];
@@ -120,7 +120,7 @@ export default async function LangMerchantPage({ params }: { params: Promise<{ l
             </div>
             <div className="bg-[var(--bg-primary)] rounded-lg p-3">
               <h3 className="font-semibold text-[var(--text-primary)] mb-1">Relics (3)</h3>
-              <p className="text-[var(--text-muted)]">2 random rarity rolls + 1 guaranteed Shop relic. The Courier and Old Coin are blacklisted.</p>
+              <p className="text-[var(--text-muted)]">2 random rarity rolls + 1 guaranteed Shop relic. The Courier, Old Coin, Lucky Fysh, Bowler Hat, and Amethyst Aubergine are blacklisted (gold-generating relics removed in Major Update #1).</p>
             </div>
             <div className="bg-[var(--bg-primary)] rounded-lg p-3">
               <h3 className="font-semibold text-[var(--text-primary)] mb-1">Potions (3)</h3>
@@ -198,32 +198,32 @@ export default async function LangMerchantPage({ params }: { params: Promise<{ l
             <tbody>
               <tr className="border-b border-[var(--border-subtle)]/50">
                 <td className="p-3 text-gray-300">{rr("Common")}</td>
+                <td className="p-3 text-right text-[var(--text-primary)]">175</td>
+                <td className="p-3 text-right text-[var(--accent-gold)]">149–201</td>
+                <td className="p-3 text-right text-[var(--text-muted)]">x0.85–1.15</td>
+              </tr>
+              <tr className="border-b border-[var(--border-subtle)]/50">
+                <td className="p-3 text-emerald-400">{rr("Shop")}</td>
                 <td className="p-3 text-right text-[var(--text-primary)]">200</td>
                 <td className="p-3 text-right text-[var(--accent-gold)]">170–230</td>
                 <td className="p-3 text-right text-[var(--text-muted)]">x0.85–1.15</td>
               </tr>
               <tr className="border-b border-[var(--border-subtle)]/50">
-                <td className="p-3 text-emerald-400">{rr("Shop")}</td>
+                <td className="p-3 text-blue-400">{rr("Uncommon")}</td>
                 <td className="p-3 text-right text-[var(--text-primary)]">225</td>
                 <td className="p-3 text-right text-[var(--accent-gold)]">191–259</td>
                 <td className="p-3 text-right text-[var(--text-muted)]">x0.85–1.15</td>
               </tr>
-              <tr className="border-b border-[var(--border-subtle)]/50">
-                <td className="p-3 text-blue-400">{rr("Uncommon")}</td>
-                <td className="p-3 text-right text-[var(--text-primary)]">250</td>
-                <td className="p-3 text-right text-[var(--accent-gold)]">213–288</td>
-                <td className="p-3 text-right text-[var(--text-muted)]">x0.85–1.15</td>
-              </tr>
               <tr>
                 <td className="p-3 text-[var(--accent-gold)]">{rr("Rare")}</td>
-                <td className="p-3 text-right text-[var(--text-primary)]">300</td>
-                <td className="p-3 text-right text-[var(--accent-gold)]">255–345</td>
+                <td className="p-3 text-right text-[var(--text-primary)]">275</td>
+                <td className="p-3 text-right text-[var(--accent-gold)]">234–316</td>
                 <td className="p-3 text-right text-[var(--text-muted)]">x0.85–1.15</td>
               </tr>
             </tbody>
           </table>
           <div className="px-3 py-2 text-xs text-[var(--text-muted)] border-t border-[var(--border-subtle)]/50">
-            Relics have a wider price variance (+-15%) than cards (+-5%). The Courier and Old Coin cannot appear in the shop.
+            Relics have a wider price variance (+-15%) than cards (+-5%). Major Update #1 (v0.103.2) reduced every relic base by 25 gold. Five relics are blacklisted from the shop pool: The Courier, Old Coin, Lucky Fysh, Bowler Hat, Amethyst Aubergine.
           </div>
         </div>
       </section>
@@ -273,24 +273,50 @@ export default async function LangMerchantPage({ params }: { params: Promise<{ l
         </h2>
         <div className="bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] p-5">
           <p className="text-sm text-[var(--text-secondary)] mb-4">
-            The merchant offers card removal at an escalating price. The cost increases by 25 gold each time you use it during the run.
+            The merchant offers card removal at an escalating price. The cost increases each time you use it during the run. No random variance.
           </p>
-          <div className="flex flex-wrap gap-2">
-            {[0, 1, 2, 3, 4, 5].map((i) => (
-              <div key={i} className="bg-[var(--bg-primary)] rounded-lg p-3 text-center min-w-[80px]">
-                <div className="text-xs text-[var(--text-muted)] mb-1">
-                  {i === 0 ? "1st" : i === 1 ? "2nd" : i === 2 ? "3rd" : `${i + 1}th`}
+
+          <div className="mb-4">
+            <h3 className="text-sm font-semibold text-[var(--text-primary)] mb-2">Ascension 0–5</h3>
+            <div className="flex flex-wrap gap-2">
+              {[0, 1, 2, 3, 4, 5].map((i) => (
+                <div key={i} className="bg-[var(--bg-primary)] rounded-lg p-3 text-center min-w-[80px]">
+                  <div className="text-xs text-[var(--text-muted)] mb-1">
+                    {i === 0 ? "1st" : i === 1 ? "2nd" : i === 2 ? "3rd" : `${i + 1}th`}
+                  </div>
+                  <div className="text-lg font-bold text-[var(--accent-gold)]">
+                    {75 + 25 * i}
+                  </div>
+                  <div className="text-xs text-[var(--text-muted)]">gold</div>
                 </div>
-                <div className="text-lg font-bold text-[var(--accent-gold)]">
-                  {75 + 25 * i}
-                </div>
-                <div className="text-xs text-[var(--text-muted)]">gold</div>
-              </div>
-            ))}
+              ))}
+            </div>
+            <p className="text-xs text-[var(--text-muted)] mt-2">
+              Formula: 75 + (25 x removals used).
+            </p>
           </div>
-          <p className="text-xs text-[var(--text-muted)] mt-3">
-            Formula: 75 + (25 x removals used). No random variance.
-          </p>
+
+          <div>
+            <h3 className="text-sm font-semibold text-[var(--text-primary)] mb-2">
+              Ascension 6+ — <span className="text-[var(--accent-gold)]">Inflation</span>
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {[0, 1, 2, 3, 4, 5].map((i) => (
+                <div key={i} className="bg-[var(--bg-primary)] rounded-lg p-3 text-center min-w-[80px]">
+                  <div className="text-xs text-[var(--text-muted)] mb-1">
+                    {i === 0 ? "1st" : i === 1 ? "2nd" : i === 2 ? "3rd" : `${i + 1}th`}
+                  </div>
+                  <div className="text-lg font-bold text-[var(--accent-gold)]">
+                    {100 + 50 * i}
+                  </div>
+                  <div className="text-xs text-[var(--text-muted)]">gold</div>
+                </div>
+              ))}
+            </div>
+            <p className="text-xs text-[var(--text-muted)] mt-2">
+              Formula: 100 + (50 x removals used). Major Update #1 reworked Ascension 6 from <span className="line-through">Gloom (less rest sites)</span> to Inflation, raising the base by 25 gold and the per-use increment by 25.
+            </p>
+          </div>
         </div>
       </section>
 

--- a/frontend/app/cards/layout.tsx
+++ b/frontend/app/cards/layout.tsx
@@ -1,18 +1,24 @@
 import type { Metadata } from "next";
+import { api } from "@/lib/api";
 
-export const metadata: Metadata = {
-  title: "Slay the Spire 2 Cards - Complete Card List | Spire Codex",
-  description:
-    "Browse all 576+ Slay the Spire 2 cards. Filter by character (Ironclad, Silent, Defect, Necrobinder, Regent), type, rarity, and keywords. View card art, stats, upgrades, and related cards.",
-  openGraph: {
+export async function generateMetadata(): Promise<Metadata> {
+  let count = "576+";
+  try {
+    const stats = await api.getStats();
+    count = String(stats.cards);
+  } catch {
+    // Fall back to the baseline count if the API is unreachable at build time.
+  }
+  return {
     title: "Slay the Spire 2 Cards - Complete Card List | Spire Codex",
-    description:
-      "Browse all 576+ Slay the Spire 2 cards. Filter by character, type, rarity, and keywords.",
-  },
-  alternates: {
-    canonical: "/cards",
-  },
-};
+    description: `Browse all ${count} Slay the Spire 2 cards. Filter by character (Ironclad, Silent, Defect, Necrobinder, Regent), type, rarity, and keywords. View card art, stats, upgrades, and related cards.`,
+    openGraph: {
+      title: "Slay the Spire 2 Cards - Complete Card List | Spire Codex",
+      description: `Browse all ${count} Slay the Spire 2 cards. Filter by character, type, rarity, and keywords.`,
+    },
+    alternates: { canonical: "/cards" },
+  };
+}
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return children;

--- a/frontend/app/encounters/layout.tsx
+++ b/frontend/app/encounters/layout.tsx
@@ -1,18 +1,24 @@
 import type { Metadata } from "next";
+import { api } from "@/lib/api";
 
-export const metadata: Metadata = {
-  title: "Slay the Spire 2 Encounters - All Combat Encounters | Spire Codex",
-  description:
-    "Slay the Spire 2 encounters — browse all 87 combat encounters including normal fights, elites, and bosses. View monster compositions, act assignments, and room types.",
-  openGraph: {
+export async function generateMetadata(): Promise<Metadata> {
+  let count = "87";
+  try {
+    const stats = await api.getStats();
+    count = String(stats.encounters);
+  } catch {
+    // Fall back to the baseline count if the API is unreachable at build time.
+  }
+  return {
     title: "Slay the Spire 2 Encounters - All Combat Encounters | Spire Codex",
-    description:
-      "Slay the Spire 2 encounters — browse all 87 combat encounters including normal fights, elites, and bosses.",
-  },
-  alternates: {
-    canonical: "/encounters",
-  },
-};
+    description: `Slay the Spire 2 encounters — browse all ${count} combat encounters including normal fights, elites, and bosses. View monster compositions, act assignments, and room types.`,
+    openGraph: {
+      title: "Slay the Spire 2 Encounters - All Combat Encounters | Spire Codex",
+      description: `Slay the Spire 2 encounters — browse all ${count} combat encounters including normal fights, elites, and bosses.`,
+    },
+    alternates: { canonical: "/encounters" },
+  };
+}
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return children;

--- a/frontend/app/events/layout.tsx
+++ b/frontend/app/events/layout.tsx
@@ -1,18 +1,24 @@
 import type { Metadata } from "next";
+import { api } from "@/lib/api";
 
-export const metadata: Metadata = {
-  title: "Slay the Spire 2 Events - All In-Game Events | Spire Codex",
-  description:
-    "Slay the Spire 2 events — browse all 66 shrine events, Ancient encounters, and story events. View choices, dialogue, relic offerings, and outcomes for every event.",
-  openGraph: {
+export async function generateMetadata(): Promise<Metadata> {
+  let count = "66";
+  try {
+    const stats = await api.getStats();
+    count = String(stats.events);
+  } catch {
+    // Fall back to the baseline count if the API is unreachable at build time.
+  }
+  return {
     title: "Slay the Spire 2 Events - All In-Game Events | Spire Codex",
-    description:
-      "Slay the Spire 2 events — browse all 66 shrine events, Ancient encounters, and story events with choices, dialogue, and outcomes.",
-  },
-  alternates: {
-    canonical: "/events",
-  },
-};
+    description: `Slay the Spire 2 events — browse all ${count} shrine events, Ancient encounters, and story events. View choices, dialogue, relic offerings, and outcomes for every event.`,
+    openGraph: {
+      title: "Slay the Spire 2 Events - All In-Game Events | Spire Codex",
+      description: `Slay the Spire 2 events — browse all ${count} shrine events, Ancient encounters, and story events with choices, dialogue, and outcomes.`,
+    },
+    alternates: { canonical: "/events" },
+  };
+}
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return children;

--- a/frontend/app/mechanics/[slug]/MechanicContent.tsx
+++ b/frontend/app/mechanics/[slug]/MechanicContent.tsx
@@ -140,13 +140,14 @@ export default function MechanicContent({ slug }: { slug: string }) {
             </div>
             <div>
               <h3 className={h3}>Card Removal Cost</h3>
-              <table className={tbl}><thead><tr className={thr}><th className={th}>Removals Used</th><th className={thr2}>Cost</th></tr></thead><tbody>
-                <tr className={tr}><td className={td}>0 (first)</td><td className={gold}>75g</td></tr>
-                <tr className={tr}><td className={td}>1</td><td className={gold}>100g</td></tr>
-                <tr className={tr}><td className={td}>2</td><td className={gold}>125g</td></tr>
-                <tr className={tr}><td className={td}>3</td><td className={gold}>150g</td></tr>
-                <tr><td className={td}>n</td><td className={gold}>75 + 25n</td></tr>
+              <table className={tbl}><thead><tr className={thr}><th className={th}>Removals Used</th><th className={thr2}>A0–5</th><th className={thr2}>A6+ (Inflation)</th></tr></thead><tbody>
+                <tr className={tr}><td className={td}>0 (first)</td><td className={gold}>75g</td><td className={gold}>100g</td></tr>
+                <tr className={tr}><td className={td}>1</td><td className={gold}>100g</td><td className={gold}>150g</td></tr>
+                <tr className={tr}><td className={td}>2</td><td className={gold}>125g</td><td className={gold}>200g</td></tr>
+                <tr className={tr}><td className={td}>3</td><td className={gold}>150g</td><td className={gold}>250g</td></tr>
+                <tr><td className={td}>n</td><td className={gold}>75 + 25n</td><td className={gold}>100 + 50n</td></tr>
               </tbody></table>
+              <p className={note}>Major Update #1 (v0.103.2) reworked Ascension 6 from Gloom (1 fewer rest site) into Inflation, which raises the base removal price by 25 gold and the per-use increment by 25.</p>
             </div>
           </div>
         </div>
@@ -352,16 +353,16 @@ export default function MechanicContent({ slug }: { slug: string }) {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <h3 className={`${h3} text-sm`}>Positive Pool (2 picked)</h3>
-              <p className="text-xs text-[var(--text-secondary)]">Arcane Scroll, Booming Conch, Pomander, Golden Pearl, Lead Paperweight, New Leaf, Neow&apos;s Torment, Precise Scissors, Lost Coffer</p>
-              <p className="text-xs text-[var(--text-muted)] mt-1">Plus one of: Nutritious Oyster / Stone Humidifier (50/50) and one of: Lava Rock / Small Capsule (50/50)</p>
+              <p className="text-xs text-[var(--text-secondary)]">Arcane Scroll, Booming Conch, Golden Pearl, Lead Paperweight, Lost Coffer, Massive Scroll, Neow&apos;s Torment, New Leaf, Phial Holster, Precise Scissors, Winged Boots</p>
+              <p className="text-xs text-[var(--text-muted)] mt-1">Plus one of each pair (50/50 each): Lava Rock / Small Capsule · Nutritious Oyster / Stone Humidifier · Neow&apos;s Talisman / Pomander</p>
             </div>
             <div>
               <h3 className={`${h3} text-sm`}>Curse Pool (1 picked)</h3>
-              <p className="text-xs text-[var(--text-secondary)]">Cursed Pearl, Large Capsule, Leafy Poultice, Precarious Shears, Scroll Boxes (conditional), Silver Crucible (singleplayer only)</p>
-              <p className="text-xs text-[var(--text-muted)] mt-1">Conflicting pairs are removed (e.g. Cursed Pearl excludes Golden Pearl).</p>
+              <p className="text-xs text-[var(--text-secondary)]">Cursed Pearl, Hefty Tablet, Large Capsule, Leafy Poultice, Neow&apos;s Bones, Precarious Shears, Scroll Boxes (conditional), Silver Crucible (singleplayer only)</p>
+              <p className="text-xs text-[var(--text-muted)] mt-1">Conflicting pairs are removed (e.g. Cursed Pearl excludes Golden Pearl, Hefty Tablet excludes Arcane Scroll, Leafy Poultice excludes New Leaf, Precarious Shears excludes Precise Scissors). If Large Capsule rolls as the curse, both the Lava Rock / Small Capsule pair are skipped.</p>
             </div>
           </div>
-          <p className={note}>Before the event, you are healed to full HP. On A2+, heal is only 80% of missing HP.</p>
+          <p className={note}>Before the event, you are healed to full HP. On A2+, heal is only 80% of missing HP. Major Update #1 (v0.103.2) expanded both pools — Phial Holster, Winged Boots, Massive Scroll, and Neow&apos;s Talisman joined the positive side; Hefty Tablet and Neow&apos;s Bones joined the curse side.</p>
         </div>
       );
 
@@ -374,7 +375,7 @@ export default function MechanicContent({ slug }: { slug: string }) {
             <tr className={tr}><td className={td}>3</td><td className={td}>Poverty</td><td className={tdr}>Gold rewards x0.75</td></tr>
             <tr className={tr}><td className={td}>4</td><td className={td}>Tight Belt</td><td className={tdr}>3 → 2 potion slots</td></tr>
             <tr className={tr}><td className={td}>5</td><td className={td}>Ascender&apos;s Bane</td><td className={tdr}>Start with Ascender&apos;s Bane curse</td></tr>
-            <tr className={tr}><td className={td}>6</td><td className={td}>Gloom</td><td className={tdr}>1 fewer rest site on map</td></tr>
+            <tr className={tr}><td className={td}>6</td><td className={td}>Inflation</td><td className={tdr}>Card removal at the Merchant is more expensive (base 100g, +50g per use)</td></tr>
             <tr className={tr}><td className={td}>7</td><td className={td}>Scarcity</td><td className={tdr}>~50% rarer cards, slower pity</td></tr>
             <tr className={tr}><td className={td}>8</td><td className={td}>Tough Enemies</td><td className={tdr}>Enemy HP increases (per-enemy)</td></tr>
             <tr className={tr}><td className={td}>9</td><td className={td}>Deadly Enemies</td><td className={tdr}>Enemy damage increases (per-enemy)</td></tr>
@@ -388,13 +389,12 @@ export default function MechanicContent({ slug }: { slug: string }) {
         <div className={card}>
           <table className={tbl}><thead><tr className={thr}><th className={th}>Component</th><th className={thr2}>Value</th></tr></thead><tbody>
             <tr className={tr}><td className={td}>Rooms visited</td><td className={tdr}>10 pts per room per act (x1/x2/x3)</td></tr>
-            <tr className={tr}><td className={td}>Win bonus</td><td className={gold}>+300</td></tr>
-            <tr className={tr}><td className={td}>Act 3 death</td><td className={tdr}>+200</td></tr>
-            <tr className={tr}><td className={td}>Act 2 death</td><td className={tdr}>+100</td></tr>
-            <tr className={tr}><td className={td}>Act 1 death</td><td className={tdr}>+0</td></tr>
+            <tr className={tr}><td className={td}>Gold gained</td><td className={tdr}>+1 pt per 100 gold (divided by player count)</td></tr>
+            <tr className={tr}><td className={td}>Elites killed</td><td className={gold}>+50 each (the elite you died to doesn&apos;t count)</td></tr>
+            <tr className={tr}><td className={td}>Bosses slain</td><td className={gold}>+100 each (3 on a win, fewer if you die earlier; A10 wins count 4)</td></tr>
             <tr><td className={td}>Ascension multiplier</td><td className={gold}>x(1 + ascension x 0.1)</td></tr>
           </tbody></table>
-          <p className={note}>At Ascension 10, your score is doubled. The final boss scene uses your score to determine the visual damage numbers.</p>
+          <p className={note}>Total = (rooms + gold + elites + bosses) x (1 + ascension x 0.1). At Ascension 10, your score is doubled. Daily-run scoring also encodes badge count and run time on top of this base. The final boss scene uses your score to determine the visual damage numbers.</p>
         </div>
       );
 
@@ -470,7 +470,7 @@ export default function MechanicContent({ slug }: { slug: string }) {
       return (
         <div className={card}>
           <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
-            <strong className={bold}>The Courier</strong> and <strong className={bold}>Old Coin</strong> are hardcoded into the merchant relic blacklist and can never appear in shops. Both would break the shop economy.
+            Five relics override <code className="bg-[var(--bg-primary)] px-1 rounded text-xs text-[var(--accent-gold)]">IsAllowedInShops =&gt; false</code> and never appear in the merchant pool: <strong className={bold}>The Courier</strong>, <strong className={bold}>Old Coin</strong>, <strong className={bold}>Lucky Fysh</strong>, <strong className={bold}>Bowler Hat</strong>, and <strong className={bold}>Amethyst Aubergine</strong>. Major Update #1 (v0.103.2) added the last three after gold-generating relics broke shop economy testing — they remain craftable through other sources but are walled off from the merchant.
           </p>
         </div>
       );

--- a/frontend/app/monsters/layout.tsx
+++ b/frontend/app/monsters/layout.tsx
@@ -1,18 +1,24 @@
 import type { Metadata } from "next";
+import { api } from "@/lib/api";
 
-export const metadata: Metadata = {
-  title: "Slay the Spire 2 Monsters - Complete Monster List | Spire Codex",
-  description:
-    "Slay the Spire 2 monsters — browse all 111 normals, elites, and bosses. View HP values, moves, damage stats, and ascension scaling.",
-  openGraph: {
+export async function generateMetadata(): Promise<Metadata> {
+  let count = "111";
+  try {
+    const stats = await api.getStats();
+    count = String(stats.monsters);
+  } catch {
+    // Fall back to the baseline count if the API is unreachable at build time.
+  }
+  return {
     title: "Slay the Spire 2 Monsters - Complete Monster List | Spire Codex",
-    description:
-      "Slay the Spire 2 monsters — browse all 111 normals, elites, and bosses. View HP, moves, and ascension scaling.",
-  },
-  alternates: {
-    canonical: "/monsters",
-  },
-};
+    description: `Slay the Spire 2 monsters — browse all ${count} normals, elites, and bosses. View HP values, moves, damage stats, and ascension scaling.`,
+    openGraph: {
+      title: "Slay the Spire 2 Monsters - Complete Monster List | Spire Codex",
+      description: `Slay the Spire 2 monsters — browse all ${count} normals, elites, and bosses. View HP, moves, and ascension scaling.`,
+    },
+    alternates: { canonical: "/monsters" },
+  };
+}
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return children;

--- a/frontend/app/potions/layout.tsx
+++ b/frontend/app/potions/layout.tsx
@@ -1,18 +1,24 @@
 import type { Metadata } from "next";
+import { api } from "@/lib/api";
 
-export const metadata: Metadata = {
-  title: "Slay the Spire 2 Potions - Complete Potion List | Spire Codex",
-  description:
-    "Browse all 63+ Slay the Spire 2 potions. Filter by rarity (Common, Uncommon, Rare) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View potion effects and descriptions.",
-  openGraph: {
+export async function generateMetadata(): Promise<Metadata> {
+  let count = "63+";
+  try {
+    const stats = await api.getStats();
+    count = String(stats.potions);
+  } catch {
+    // Fall back to the baseline count if the API is unreachable at build time.
+  }
+  return {
     title: "Slay the Spire 2 Potions - Complete Potion List | Spire Codex",
-    description:
-      "Browse all 63+ Slay the Spire 2 potions. Filter by rarity and character pool.",
-  },
-  alternates: {
-    canonical: "/potions",
-  },
-};
+    description: `Browse all ${count} Slay the Spire 2 potions. Filter by rarity (Common, Uncommon, Rare) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View potion effects and descriptions.`,
+    openGraph: {
+      title: "Slay the Spire 2 Potions - Complete Potion List | Spire Codex",
+      description: `Browse all ${count} Slay the Spire 2 potions. Filter by rarity and character pool.`,
+    },
+    alternates: { canonical: "/potions" },
+  };
+}
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return children;

--- a/frontend/app/powers/layout.tsx
+++ b/frontend/app/powers/layout.tsx
@@ -1,18 +1,24 @@
 import type { Metadata } from "next";
+import { api } from "@/lib/api";
 
-export const metadata: Metadata = {
-  title: "Slay the Spire 2 Powers - Complete Power List | Spire Codex",
-  description:
-    "Browse all 260 Slay the Spire 2 powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior. View descriptions, icons, and details for every power.",
-  openGraph: {
+export async function generateMetadata(): Promise<Metadata> {
+  let count = "260";
+  try {
+    const stats = await api.getStats();
+    count = String(stats.powers);
+  } catch {
+    // Fall back to the baseline count if the API is unreachable at build time.
+  }
+  return {
     title: "Slay the Spire 2 Powers - Complete Power List | Spire Codex",
-    description:
-      "Browse all 260 Slay the Spire 2 powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior.",
-  },
-  alternates: {
-    canonical: "/powers",
-  },
-};
+    description: `Browse all ${count} Slay the Spire 2 powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior. View descriptions, icons, and details for every power.`,
+    openGraph: {
+      title: "Slay the Spire 2 Powers - Complete Power List | Spire Codex",
+      description: `Browse all ${count} Slay the Spire 2 powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior.`,
+    },
+    alternates: { canonical: "/powers" },
+  };
+}
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return children;

--- a/frontend/app/relics/layout.tsx
+++ b/frontend/app/relics/layout.tsx
@@ -1,18 +1,24 @@
 import type { Metadata } from "next";
+import { api } from "@/lib/api";
 
-export const metadata: Metadata = {
-  title: "Slay the Spire 2 Relics - Complete Relic List | Spire Codex",
-  description:
-    "Browse all 289+ Slay the Spire 2 relics. Filter by rarity (Common, Uncommon, Rare, Shop, Event, Ancient) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View relic effects, flavor text, and images.",
-  openGraph: {
+export async function generateMetadata(): Promise<Metadata> {
+  let count = "289+";
+  try {
+    const stats = await api.getStats();
+    count = String(stats.relics);
+  } catch {
+    // Fall back to the baseline count if the API is unreachable at build time.
+  }
+  return {
     title: "Slay the Spire 2 Relics - Complete Relic List | Spire Codex",
-    description:
-      "Browse all 289+ Slay the Spire 2 relics. Filter by rarity and character pool. View relic effects and images.",
-  },
-  alternates: {
-    canonical: "/relics",
-  },
-};
+    description: `Browse all ${count} Slay the Spire 2 relics. Filter by rarity (Common, Uncommon, Rare, Shop, Event, Ancient) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View relic effects, flavor text, and images.`,
+    openGraph: {
+      title: "Slay the Spire 2 Relics - Complete Relic List | Spire Codex",
+      description: `Browse all ${count} Slay the Spire 2 relics. Filter by rarity and character pool. View relic effects and images.`,
+    },
+    alternates: { canonical: "/relics" },
+  };
+}
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return children;


### PR DESCRIPTION
## Summary

Audit of every hardcoded-content page against v0.103.2 patch state.

**Mechanics page** (`/mechanics/<slug>`) had five sections out of date:

- **ascension-modifiers** — A6 was Gloom (1 fewer rest site); patch swapped it for **Inflation** (card removal more expensive).
- **shop-inventory** — card-removal table now splits A0–5 (75 + 25n) and A6+ Inflation (100 + 50n) tiers.
- **merchant-blacklist** — five relics override `IsAllowedInShops` now (added Lucky Fysh, Bowler Hat, Amethyst Aubergine after the gold-relic reworks), not the two listed before.
- **neow** — positive pool gained Phial Holster, Winged Boots, Massive Scroll, Neow's Talisman; curse pool gained Hefty Tablet, Neow's Bones; Pomander is now a 50/50 with Talisman, not always-on. Added the new conflicting-pair rules from `Neow.cs`.
- **score-formula** — old "win bonus +300 / Act 2 death +100" framing replaced with the actual `ScoreUtility` breakdown: rooms × 10 × act + gold/(100×p) + elites × 50 + bosses × 100, all × (1 + asc × 0.1). The page was missing the elites and gold components entirely.

**Merchant page (i18n)** — `/[lang]/merchant` was still serving the pre-patch relic prices and two-relic blacklist. PR #85 only updated the English page; this syncs the i18n wrapper to match (common 175 / 149–201, shop 200 / 170–230, uncommon 225 / 191–259, rare 275 / 234–316, plus the A6 Inflation removal tier).

**Auto-counted metadata** — instead of hardcoding "289+ relics" / "111 monsters" / etc. in `<meta name="description">` (which silently rot every patch), all entity-list layouts now pull live counts from `/api/stats` via async `generateMetadata`. Cards / relics / monsters / potions / powers / encounters / events all auto-update. Each keeps its previous value as a build-time fallback if the API is unreachable.

**Verified up-to-date** (no changes needed): card-rarity, relic-distribution, potion-drop-rates, gold-rewards, map-generation, unknown-rooms, bosses-and-elites (all 12 bosses + 12 elites match), combat-mechanics, character-stats, orb-mechanics, campfire-options, foul-potion, wongo-loyalty, crystal-sphere, reflections, the-architect, byrdpip, autoslay, dev-console, the-deprived. Home / about / developers / showcase / changelog were already clean.

## Files touched

- `frontend/app/mechanics/[slug]/MechanicContent.tsx` — five sections rewritten
- `frontend/app/[lang]/merchant/page.tsx` — synced to PR #85 prices and blacklist
- `frontend/app/{cards,relics,monsters,potions,powers,encounters,events}/layout.tsx` — converted to `generateMetadata` with `/api/stats` lookup
