### PR TITLE
Hotfix: bound /api/stats fetch in generateMetadata so build doesn't hang

### DIFF
--- a/frontend/app/cards/layout.tsx
+++ b/frontend/app/cards/layout.tsx
@@ -4,7 +4,7 @@ import { api } from "@/lib/api";
 export async function generateMetadata(): Promise<Metadata> {
   let count = "576+";
   try {
-    const stats = await api.getStats();
+    const stats = await api.getStatsBounded();
     count = String(stats.cards);
   } catch {
     // Fall back to the baseline count if the API is unreachable at build time.

--- a/frontend/app/encounters/layout.tsx
+++ b/frontend/app/encounters/layout.tsx
@@ -4,7 +4,7 @@ import { api } from "@/lib/api";
 export async function generateMetadata(): Promise<Metadata> {
   let count = "87";
   try {
-    const stats = await api.getStats();
+    const stats = await api.getStatsBounded();
     count = String(stats.encounters);
   } catch {
     // Fall back to the baseline count if the API is unreachable at build time.

--- a/frontend/app/events/layout.tsx
+++ b/frontend/app/events/layout.tsx
@@ -4,7 +4,7 @@ import { api } from "@/lib/api";
 export async function generateMetadata(): Promise<Metadata> {
   let count = "66";
   try {
-    const stats = await api.getStats();
+    const stats = await api.getStatsBounded();
     count = String(stats.events);
   } catch {
     // Fall back to the baseline count if the API is unreachable at build time.

--- a/frontend/app/monsters/layout.tsx
+++ b/frontend/app/monsters/layout.tsx
@@ -4,7 +4,7 @@ import { api } from "@/lib/api";
 export async function generateMetadata(): Promise<Metadata> {
   let count = "111";
   try {
-    const stats = await api.getStats();
+    const stats = await api.getStatsBounded();
     count = String(stats.monsters);
   } catch {
     // Fall back to the baseline count if the API is unreachable at build time.

--- a/frontend/app/potions/layout.tsx
+++ b/frontend/app/potions/layout.tsx
@@ -4,7 +4,7 @@ import { api } from "@/lib/api";
 export async function generateMetadata(): Promise<Metadata> {
   let count = "63+";
   try {
-    const stats = await api.getStats();
+    const stats = await api.getStatsBounded();
     count = String(stats.potions);
   } catch {
     // Fall back to the baseline count if the API is unreachable at build time.

--- a/frontend/app/powers/layout.tsx
+++ b/frontend/app/powers/layout.tsx
@@ -4,7 +4,7 @@ import { api } from "@/lib/api";
 export async function generateMetadata(): Promise<Metadata> {
   let count = "260";
   try {
-    const stats = await api.getStats();
+    const stats = await api.getStatsBounded();
     count = String(stats.powers);
   } catch {
     // Fall back to the baseline count if the API is unreachable at build time.

--- a/frontend/app/relics/layout.tsx
+++ b/frontend/app/relics/layout.tsx
@@ -4,7 +4,7 @@ import { api } from "@/lib/api";
 export async function generateMetadata(): Promise<Metadata> {
   let count = "289+";
   try {
-    const stats = await api.getStats();
+    const stats = await api.getStatsBounded();
     count = String(stats.relics);
   } catch {
     // Fall back to the baseline count if the API is unreachable at build time.

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -6,6 +6,24 @@ async function fetchApi<T>(path: string): Promise<T> {
   return res.json();
 }
 
+// Variant for build-time metadata fetches: bounded so a stuck connection
+// can't hang `next build`. Used by layout `generateMetadata` calls — those
+// run during static generation where the backend may not be reachable.
+async function fetchApiBounded<T>(path: string, timeoutMs = 3000): Promise<T> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${API_BASE}${path}`, {
+      signal: ctrl.signal,
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) throw new Error(`API error: ${res.status}`);
+    return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export interface CardRiderEffect {
   id: string;
   name: string;
@@ -416,6 +434,11 @@ export interface Stats {
 
 export const api = {
   getStats: () => fetchApi<Stats>("/api/stats"),
+  // Bounded variant for use inside `generateMetadata` — won't hang the
+  // build if the backend is unreachable. Caller should wrap in try/catch
+  // and fall through to a hardcoded baseline.
+  getStatsBounded: (timeoutMs?: number) =>
+    fetchApiBounded<Stats>("/api/stats", timeoutMs),
   getCards: (params?: string) => fetchApi<Card[]>(`/api/cards${params ? `?${params}` : ""}`),
   getCard: (id: string) => fetchApi<Card>(`/api/cards/${id}`),
   getCharacters: () => fetchApi<Character[]>("/api/characters"),


### PR DESCRIPTION
## Summary

Hotfix for the failing CI build on `main` (the build for the PR #86 merge commit `c2d1de5` is timing out on `/cards`, `/relics`, `/potions`, `/powers` static generation).

**Root cause:** PR #86 made every entity-list `layout.tsx` `generateMetadata` async and call `api.getStats()` so the count in the meta description stays in sync. Each call wraps the fetch in `try/catch` to fall back to a hardcoded baseline if the API is unreachable — but the underlying `fetchApi` had no timeout. During `next build`, the build container can't reach the backend (it's a separate container that isn't up at image-build time), and `fetch()` hangs until Next.js's per-page 60s static-generation timeout fires. Each page then retries up to 3× (another 60s each), so /cards/relics/potions/powers all blow through their build budgets.

**Fix:** add a `fetchApiBounded` variant in `lib/api.ts` that wires an `AbortController` with a 3s timeout, expose it via `api.getStatsBounded(timeoutMs?)`, and point the seven layouts at it. The `try/catch` now actually catches on unreachable backends — abort flips fetch into reject mode within 3s and the existing fallback path takes over. The hardcoded baseline ships in the meta description until the next revalidation succeeds.

`fetchApi` itself is unchanged; only the bounded variant is new. Used only by `generateMetadata`.

## Files

- `frontend/lib/api.ts` — adds `fetchApiBounded` and `api.getStatsBounded`.
- `frontend/app/{cards,relics,monsters,potions,powers,encounters,events}/layout.tsx` — swap `api.getStats()` for `api.getStatsBounded()`.

Type-check is clean. No behavior change when the API is reachable; bounded falls back ≤3s after the call when it isn't.
