### PR TITLE
Localize character filter buttons + dropdown options on /leaderboards

### DIFF
--- a/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
+++ b/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
@@ -239,7 +239,7 @@ export default function LeaderboardBrowseClient() {
                     : undefined
                 }
               >
-                {ch}
+                {charName(ch)}
               </button>
             ))}
           </div>
@@ -325,11 +325,9 @@ export default function LeaderboardBrowseClient() {
               className="text-sm px-3 py-1.5 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)] w-full sm:w-auto"
             >
               <option value="">{t("All Characters", lang)}</option>
-              <option value="IRONCLAD">Ironclad</option>
-              <option value="SILENT">Silent</option>
-              <option value="DEFECT">Defect</option>
-              <option value="NECROBINDER">Necrobinder</option>
-              <option value="REGENT">Regent</option>
+              {CHARACTERS.map((ch) => (
+                <option key={ch} value={ch.toUpperCase()}>{charName(ch)}</option>
+              ))}
             </select>
 
             <select


### PR DESCRIPTION
The character toggle row above the leaderboard table and the Browse Runs character-filter dropdown were rendering the canonical English names (Ironclad, Silent, Defect, Necrobinder, Regent) as button labels even on /[lang]/leaderboards. Pipe both through the charName() lookup added in the previous commit so the labels read in the active locale — filter values still use the English UPPER_CASE id, only the display text changes.