### PR TITLE
Fix card upgrade rendering: stray |} in IfUpgraded + missing power-suffix bumps

### DIFF
--- a/backend/app/parsers/card_parser.py
+++ b/backend/app/parsers/card_parser.py
@@ -530,12 +530,19 @@ def parse_single_card(
                     diff = int(val)
                 except ValueError:
                     continue
+                # Bump every numeric var whose name matches the upgrade key.
+                # Power-applying cards register both the bare name (`Weak`)
+                # and the C# class name (`WeakPower`) in their var dict —
+                # the description usually references {WeakPower:diff()} but
+                # the upgrade key is the bare `weak`. We need to bump both
+                # variants so the rendered description shows the new value.
+                key_l = key.lower()
                 for vk in upgraded_vars:
-                    if vk.lower() == key.lower() and isinstance(
-                        upgraded_vars[vk], (int, float)
-                    ):
+                    if not isinstance(upgraded_vars[vk], (int, float)):
+                        continue
+                    vk_l = vk.lower()
+                    if vk_l == key_l or vk_l == key_l + "power":
                         upgraded_vars[vk] += diff
-                        break
     up_desc = shared_resolve_description(description, upgraded_vars, is_upgraded=True)
     if up_desc != desc_rendered:
         card["upgrade_description"] = up_desc

--- a/backend/app/parsers/description_resolver.py
+++ b/backend/app/parsers/description_resolver.py
@@ -80,15 +80,37 @@ def resolve_description(
 
     text = resolve_all_choose(text)
 
-    # Handle {IfUpgraded:show:A|B} or {IfUpgraded:show:A}
-    def resolve_if_upgraded(m):
-        parts = m.group(1)
-        if "|" in parts:
-            a, b = parts.split("|", 1)
-            return a if is_upgraded else b
-        return parts if is_upgraded else ""
+    # Handle {IfUpgraded:show:A|B} or {IfUpgraded:show:A}.
+    # Manual brace-counting because A often contains nested {Var} tokens
+    # (e.g. {IfUpgraded:show: +{CalculationBase}|}) — a flat `[^}]*` regex
+    # would stop at the first inner `}` and leave a stray `|}` in the
+    # output. Splits the inner body on `|` at depth 0 only.
+    def resolve_all_if_upgraded(text: str) -> str:
+        while True:
+            idx = text.find("{IfUpgraded:show:")
+            if idx < 0:
+                break
+            rest_start = idx + len("{IfUpgraded:show:")
+            depth = 1
+            i = rest_start
+            while i < len(text) and depth > 0:
+                if text[i] == "{":
+                    depth += 1
+                elif text[i] == "}":
+                    depth -= 1
+                i += 1
+            if depth != 0:
+                # Unbalanced — bail to avoid an infinite loop.
+                break
+            inner = text[rest_start : i - 1]
+            parts = _split_pipes_at_depth0(inner)
+            true_val = parts[0] if parts else ""
+            false_val = parts[1] if len(parts) > 1 else ""
+            result = true_val if is_upgraded else false_val
+            text = text[:idx] + result + text[i:]
+        return text
 
-    text = re.sub(r"\{IfUpgraded:show:([^}]*)\}", resolve_if_upgraded, text)
+    text = resolve_all_if_upgraded(text)
 
     # Handle {Var:energyIcons()} and {Var:energyIcons(N)} -> [energy:N]
     def resolve_energy_icons(m):

--- a/data/deu/cards.json
+++ b/data/deu/cards.json
@@ -77,7 +77,7 @@
     "image_url": "/static/images/cards/oblivion.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Immer wenn du diesen Zug eine Karte spielst, wende 4 [gold]Verderben[/gold] auf den Gegner an.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 313
@@ -785,7 +785,7 @@
     "image_url": "/static/images/cards/anticipate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Erhalte für diesen Zug 3 [gold]Geschicklichkeit[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 93
@@ -1127,7 +1127,7 @@
     "image_url": "/static/images/cards/assassinate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Füge 13 Schaden zu.\nWende 1 [gold]Verwundbar[/gold] an.",
+    "upgrade_description": "Füge 13 Schaden zu.\nWende 2 [gold]Verwundbar[/gold] an.",
     "type_key": "Attack",
     "rarity_key": "Rare",
     "keywords_key": [
@@ -2183,7 +2183,7 @@
     "image_url": "/static/images/cards/footwork.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Erhalte 3 [gold]Geschicklichkeit[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 125
@@ -2667,7 +2667,7 @@
     "image_url": "/static/images/cards/bubble_bubble.webp",
     "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Falls der Gegner [gold]Gift[/gold] hat, wende 12 [gold]Gift[/gold] an.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 101
@@ -2711,7 +2711,7 @@
     "image_url": "/static/images/cards/rupture.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Immer wenn du in deinem Zug TP verlierst, erhalte 2 [gold]Stärke[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -3069,7 +3069,7 @@
     "image_url": "/static/images/cards/brand.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Verliere 1 TP.\n[gold]Erschöpfe[/gold] 1 Karte.\nErhalte 2 [gold]Stärke[/gold].",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 11
@@ -3115,7 +3115,7 @@
     "image_url": "/static/images/cards/break.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Füge 30 Schaden zu.\nWende 5 [gold]Verwundbar[/gold] an.",
+    "upgrade_description": "Füge 30 Schaden zu.\nWende 7 [gold]Verwundbar[/gold] an.",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "compendium_order": 12
@@ -4557,7 +4557,7 @@
     "image_url": "/static/images/cards/haze.webp",
     "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Wende auf ALLE Gegner 6 [gold]Gift[/gold] an.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "keywords_key": [
@@ -6586,7 +6586,7 @@
     "image_url": "/static/images/cards/feeding_frenzy.webp",
     "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Erhalte für diesen Zug 7 [gold]Stärke[/gold].",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 532
@@ -6679,7 +6679,7 @@
     "image_url": "/static/images/cards/fear.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Füge 8 Schaden zu.\nWende 1 [gold]Verwundbar[/gold] an.",
+    "upgrade_description": "Füge 8 Schaden zu.\nWende 2 [gold]Verwundbar[/gold] an.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "keywords_key": [
@@ -6763,7 +6763,7 @@
     "image_url": "/static/images/cards/leg_sweep.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Wende 2 [gold]Schwach[/gold] an.\nErhalte 14 [gold]Block[/gold].",
+    "upgrade_description": "Wende 3 [gold]Schwach[/gold] an.\nErhalte 14 [gold]Block[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 133
@@ -7233,7 +7233,7 @@
     "image_url": "/static/images/cards/scourge.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Wende 13 [gold]Verderben[/gold] an.\nZiehe 2 Karten.",
+    "upgrade_description": "Wende 16 [gold]Verderben[/gold] an.\nZiehe 2 Karten.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 328
@@ -7727,7 +7727,7 @@
     "image_url": "/static/images/cards/poisoned_stab.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Füge 8 Schaden zu.\nWende 3 [gold]Gift[/gold] an.",
+    "upgrade_description": "Füge 8 Schaden zu.\nWende 4 [gold]Gift[/gold] an.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 146
@@ -7969,6 +7969,52 @@
     "compendium_order": 300
   },
   {
+    "id": "GRAPPLE",
+    "name": "Grapple",
+    "description": "",
+    "description_raw": "",
+    "cost": 1,
+    "is_x_cost": null,
+    "is_x_star_cost": null,
+    "star_cost": null,
+    "type": "Angriff",
+    "rarity": "Ungewöhnlich",
+    "target": "AnyEnemy",
+    "color": "unknown",
+    "damage": 7,
+    "block": null,
+    "hit_count": null,
+    "powers_applied": [
+      {
+        "power": "Grapple",
+        "amount": 5,
+        "power_key": "Grapple"
+      }
+    ],
+    "cards_draw": null,
+    "energy_gain": null,
+    "hp_loss": null,
+    "keywords": null,
+    "tags": null,
+    "spawns_cards": null,
+    "vars": {
+      "Damage": 7,
+      "GrapplePower": 5,
+      "Grapple": 5
+    },
+    "upgrade": {
+      "damage": "+2",
+      "grapplepower": "+2"
+    },
+    "image_url": "/static/images/cards/grapple.webp",
+    "beta_image_url": null,
+    "type_variants": null,
+    "upgrade_description": null,
+    "type_key": "Attack",
+    "rarity_key": "Uncommon",
+    "compendium_order": 576
+  },
+  {
     "id": "CRUELTY",
     "name": "Grausamkeit",
     "description": "[gold]Verwundbare[/gold] Gegner nehmen 25% mehr Schaden.",
@@ -8055,7 +8101,7 @@
     "image_url": "/static/images/cards/fight_me.webp",
     "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
-    "upgrade_description": "Füge zweimal 6 Schaden zu.\nErhalte 3 [gold]Stärke[/gold].\nDer Gegner erhält 1 [gold]Stärke[/gold].",
+    "upgrade_description": "Füge zweimal 6 Schaden zu.\nErhalte 4 [gold]Stärke[/gold].\nDer Gegner erhält 1 [gold]Stärke[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 35
@@ -8594,7 +8640,7 @@
     "image_url": "/static/images/cards/high_five.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]Osty[/gold] fügt ALLEN Gegnern 13 Schaden zu.\nWende auf ALLE Gegner \n2 [gold]Verwundbar[/gold] an.",
+    "upgrade_description": "[gold]Osty[/gold] fügt ALLEN Gegnern 13 Schaden zu.\nWende auf ALLE Gegner \n3 [gold]Verwundbar[/gold] an.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 303
@@ -9161,7 +9207,7 @@
     "image_url": "/static/images/cards/go_for_the_eyes.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Füge 4 Schaden zu.\nFalls der Gegner angreifen möchte, wende 1 [gold]Schwach[/gold] an.",
+    "upgrade_description": "Füge 4 Schaden zu.\nFalls der Gegner angreifen möchte, wende 2 [gold]Schwach[/gold] an.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 389
@@ -9447,7 +9493,7 @@
     "image_url": "/static/images/cards/end_of_days.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Wende auf ALLE Gegner 37 [gold]Verderben[/gold] an.\nTöte Gegner mit mindestens so viel [gold]Verderben[/gold] wie TP.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 290
@@ -10334,7 +10380,7 @@
     "image_url": "/static/images/cards/coordinate.webp",
     "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Gib einem Mitspieler für diesen Zug 8 [gold]Stärke[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 448
@@ -11005,7 +11051,7 @@
     "image_url": "/static/images/cards/prowess.webp",
     "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Erhalte 2 [gold]Stärke[/gold].\nErhalte 2 [gold]Geschicklichkeit[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 481
@@ -12690,7 +12736,7 @@
     "image_url": "/static/images/cards/negative_pulse.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Erhalte 6 [gold]Block[/gold].\nWende auf ALLE Gegner 7 [gold]Verderben[/gold] an.",
+    "upgrade_description": "Erhalte 6 [gold]Block[/gold].\nWende auf ALLE Gegner 11 [gold]Verderben[/gold] an.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 310
@@ -12905,7 +12951,7 @@
     "image_url": "/static/images/cards/neutralize.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Füge 4 Schaden zu.\nWende 1 [gold]Schwach[/gold] an.",
+    "upgrade_description": "Füge 4 Schaden zu.\nWende 2 [gold]Schwach[/gold] an.",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 139
@@ -12996,7 +13042,7 @@
     "image_url": "/static/images/cards/null.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Füge 13 Schaden zu.\nWende 2 [gold]Schwach[/gold] an.\n[gold]Erschaffe[/gold] 1 [gold]Schatten[/gold].",
+    "upgrade_description": "Füge 13 Schaden zu.\nWende 3 [gold]Schwach[/gold] an.\n[gold]Erschaffe[/gold] 1 [gold]Schatten[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 407
@@ -13150,7 +13196,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "upgrade_description": "Heile 13 TP.",
     "type_key": "Skill",
@@ -15495,7 +15541,7 @@
     "image_url": "/static/images/cards/snakebite.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Wende 10 [gold]Gift[/gold] an.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -15783,7 +15829,7 @@
     "image_url": "/static/images/cards/bash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Füge 10 Schaden zu.\nWende 2 [gold]Verwundbar[/gold] an.",
+    "upgrade_description": "Füge 10 Schaden zu.\nWende 3 [gold]Verwundbar[/gold] an.",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 5
@@ -17258,7 +17304,7 @@
   {
     "id": "STACK",
     "name": "Stapel",
-    "description": "Erhalte [gold]Block[/gold] in Höhe der Kartenzahl in deinem [gold]Abwurfstapel[/gold]|}.",
+    "description": "Erhalte [gold]Block[/gold] in Höhe der Kartenzahl in deinem [gold]Abwurfstapel[/gold].",
     "description_raw": "Erhalte [gold]Block[/gold] in Höhe der Kartenzahl in deinem [gold]Abwurfstapel[/gold]{IfUpgraded:show: +{CalculationBase}|}.{InCombat:\n({CalculatedBlock:diff()} [gold]Block[/gold])|}",
     "cost": 1,
     "is_x_cost": null,
@@ -17288,7 +17334,7 @@
     "image_url": "/static/images/cards/stack.webp",
     "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
-    "upgrade_description": "Erhalte [gold]Block[/gold] in Höhe der Kartenzahl in deinem [gold]Abwurfstapel[/gold] +[CalculationBase|].",
+    "upgrade_description": "Erhalte [gold]Block[/gold] in Höhe der Kartenzahl in deinem [gold]Abwurfstapel[/gold] +3.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 544
@@ -17689,7 +17735,7 @@
     "image_url": "/static/images/cards/beam_cell.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Füge 4 Schaden zu.\nWende 1 [gold]Verwundbar[/gold] an.",
+    "upgrade_description": "Füge 4 Schaden zu.\nWende 2 [gold]Verwundbar[/gold] an.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 355
@@ -18690,7 +18736,7 @@
     "image_url": "/static/images/cards/deathbringer.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Wende auf ALLE Gegner 26 [gold]Verderben[/gold] und 1 [gold]Schwach[/gold] an.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 276
@@ -18949,7 +18995,7 @@
     "image_url": "/static/images/cards/bulk_up.webp",
     "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Verliere 1 Orb-Slot.\nErhalte 3 [gold]Stärke[/gold].\nErhalte 3 [gold]Geschicklichkeit[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 360
@@ -19207,7 +19253,7 @@
     "image_url": "/static/images/cards/deadly_poison.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Wende 7 [gold]Gift[/gold] an.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 110
@@ -19497,7 +19543,7 @@
     "image_url": "/static/images/cards/sucker_punch.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Füge 10 Schaden zu.\nWende 1 [gold]Schwach[/gold] an.",
+    "upgrade_description": "Füge 10 Schaden zu.\nWende 2 [gold]Schwach[/gold] an.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 164
@@ -19829,7 +19875,7 @@
     "image_url": "/static/images/cards/suppress.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Füge 17 Schaden zu.\nWende 3 [gold]Schwach[/gold] an.",
+    "upgrade_description": "Füge 17 Schaden zu.\nWende 5 [gold]Schwach[/gold] an.",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "keywords_key": [
@@ -20821,7 +20867,7 @@
     "image_url": "/static/images/cards/taunt.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Erhalte 8 [gold]Block[/gold].\nWende 1 [gold]Verwundbar[/gold] an.",
+    "upgrade_description": "Erhalte 8 [gold]Block[/gold].\nWende 2 [gold]Verwundbar[/gold] an.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -21670,7 +21716,7 @@
     "image_url": "/static/images/cards/setup_strike.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Füge 9 Schaden zu.\nErhalte für diesen Zug 2 [gold]Stärke[/gold].",
+    "upgrade_description": "Füge 9 Schaden zu.\nErhalte für diesen Zug 3 [gold]Stärke[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 65
@@ -22382,7 +22428,7 @@
     "image_url": "/static/images/cards/squash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Füge 12 Schaden zu.\nWende 2 [gold]Verwundbar[/gold] an.",
+    "upgrade_description": "Füge 12 Schaden zu.\nWende 3 [gold]Verwundbar[/gold] an.",
     "type_key": "Attack",
     "rarity_key": "Event",
     "compendium_order": 543
@@ -22813,7 +22859,7 @@
     "image_url": "/static/images/cards/tremble.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Wende 4 [gold]Verwundbar[/gold] an.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -23152,7 +23198,7 @@
   {
     "id": "DUAL_WIELD",
     "name": "Zweiwaffenkampf",
-    "description": "Wähle eine Angriffs- oder Machtkarte. Erhalte  Kopien|eine Kopie} dieser Karte auf deine [gold]Hand[/gold].",
+    "description": "Wähle eine Angriffs- oder Machtkarte. Erhalte eine Kopie dieser Karte auf deine [gold]Hand[/gold].",
     "description_raw": "Wähle eine Angriffs- oder Machtkarte. Erhalte {IfUpgraded:show:{Cards} Kopien|eine Kopie} dieser Karte auf deine [gold]Hand[/gold].",
     "cost": 1,
     "is_x_cost": null,
@@ -23181,7 +23227,7 @@
     "image_url": "/static/images/cards/dual_wield.webp",
     "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
-    "upgrade_description": "Wähle eine Angriffs- oder Machtkarte. Erhalte [Cards Kopien|eine Kopie] dieser Karte auf deine [gold]Hand[/gold].",
+    "upgrade_description": "Wähle eine Angriffs- oder Machtkarte. Erhalte 2 Kopien dieser Karte auf deine [gold]Hand[/gold].",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 528

--- a/data/deu/enchantments.json
+++ b/data/deu/enchantments.json
@@ -33,6 +33,17 @@
     "image_url": "/static/images/enchantments/corrupted.webp"
   },
   {
+    "id": "FAVORED",
+    "name": "Favored",
+    "description": "",
+    "description_raw": null,
+    "extra_card_text": null,
+    "card_type": "Attack",
+    "applicable_to": null,
+    "is_stackable": false,
+    "image_url": "/static/images/enchantments/favored.webp"
+  },
+  {
     "id": "GLAM",
     "name": "Schick",
     "description": "Diese Karte hat einmal pro Kampf [gold]Erneut Spielen[/gold].",

--- a/data/deu/encounters.json
+++ b/data/deu/encounters.json
@@ -1411,6 +1411,25 @@
     "loss_text": "Ein [gold]Diebischer Hüpfer[/gold] raubte {characterObject} aus."
   },
   {
+    "id": "TOADPOLES_NORMAL",
+    "name": "Toadpoles Normal",
+    "room_type": "Monster",
+    "is_weak": false,
+    "act": null,
+    "tags": null,
+    "monsters": [
+      {
+        "id": "CALCIFIED_CULTIST",
+        "name": "Verkalkter Kultist"
+      },
+      {
+        "id": "TOADPOLE",
+        "name": "Krötling"
+      }
+    ],
+    "loss_text": null
+  },
+  {
     "id": "TOADPOLES_WEAK",
     "name": "Krötlinge",
     "room_type": "Monster",

--- a/data/deu/monsters.json
+++ b/data/deu/monsters.json
@@ -481,13 +481,6 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": true
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Grabendes Pärchen",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -728,13 +721,6 @@
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
         "encounter_name": "Schlummergruppe",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Grabendes Pärchen",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -1077,8 +1063,8 @@
         "is_weak": false
       },
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "Unterdocks-Wildtiere",
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "Unterdocks-Fauna",
         "room_type": "Monster",
         "act": "Underdocks",
         "is_weak": false
@@ -1203,7 +1189,7 @@
     "encounters": [
       {
         "encounter_id": "CEREMONIAL_BEAST_BOSS",
-        "encounter_name": "Zeremonientier",
+        "encounter_name": "Zeremonienbiest",
         "room_type": "Boss",
         "act": "Act 1 - Overgrowth",
         "is_weak": false
@@ -1296,6 +1282,13 @@
         "encounter_name": "Ein Paar Automatons",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
+        "is_weak": false
+      },
+      {
+        "encounter_id": "TUNNELER_NORMAL",
+        "encounter_name": "Grabendes Pärchen",
+        "room_type": "Monster",
+        "act": null,
         "is_weak": false
       }
     ],
@@ -2019,6 +2012,99 @@
     },
     "image_url": "/static/images/monsters/devoted_sculptor.webp",
     "beta_image_url": null
+  },
+  {
+    "id": "DOOR",
+    "name": "Tür",
+    "type": "Normal",
+    "min_hp": 155,
+    "max_hp": null,
+    "min_hp_ascension": 165,
+    "max_hp_ascension": null,
+    "moves": [
+      {
+        "id": "DRAMATIC_OPEN",
+        "name": "Dramatic Open",
+        "intent": "Attack",
+        "damage": {
+          "normal": 25,
+          "ascension": 28
+        }
+      },
+      {
+        "id": "ENFORCE",
+        "name": "Enforce",
+        "intent": "Attack + Buff",
+        "powers": [
+          {
+            "power_id": "STRENGTH",
+            "target": "self",
+            "amount": 3
+          }
+        ],
+        "damage": {
+          "normal": 20
+        }
+      },
+      {
+        "id": "DOOR_SLAM",
+        "name": "Door Slam",
+        "intent": "Attack",
+        "damage": {
+          "normal": 15,
+          "ascension": 15,
+          "hit_count": 2
+        }
+      },
+      {
+        "id": "DEAD",
+        "name": "Dead",
+        "intent": "Unknown"
+      }
+    ],
+    "damage_values": {
+      "DramaticOpen": {
+        "normal": 25,
+        "ascension": 28
+      },
+      "DoorSlam": {
+        "normal": 15,
+        "ascension": 15,
+        "hit_count": 2
+      },
+      "Enforce": {
+        "normal": 20
+      }
+    },
+    "block_values": null,
+    "encounters": null,
+    "innate_powers": null,
+    "attack_pattern": {
+      "type": "cycle",
+      "initial_move": null,
+      "states": [
+        {
+          "id": "ENFORCE_MOVE",
+          "type": "move",
+          "move_id": "ENFORCE"
+        },
+        {
+          "id": "DOOR_SLAM_MOVE",
+          "type": "move",
+          "move_id": "DOOR_SLAM",
+          "next": "ENFORCE_MOVE"
+        },
+        {
+          "id": "DEAD_MOVE",
+          "type": "move",
+          "move_id": "DEAD",
+          "next": "DEAD_MOVE"
+        }
+      ],
+      "description": ""
+    },
+    "image_url": "/static/images/monsters/door.webp",
+    "beta_image_url": "/static/images/monsters/beta/door.webp"
   },
   {
     "id": "DOORMAKER",
@@ -5232,7 +5318,7 @@
     "encounters": [
       {
         "encounter_id": "MAWLER_NORMAL",
-        "encounter_name": "Mauler",
+        "encounter_name": "Schlunderer",
         "room_type": "Monster",
         "act": "Act 1 - Overgrowth",
         "is_weak": false
@@ -5450,7 +5536,7 @@
     "encounters": [
       {
         "encounter_id": "MYTES_NORMAL",
-        "encounter_name": "Eine Menge Myten",
+        "encounter_name": "Eine Menge Mylben",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -6766,6 +6852,13 @@
     },
     "block_values": null,
     "encounters": [
+      {
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "Unterdocks-Fauna",
+        "room_type": "Monster",
+        "act": "Underdocks",
+        "is_weak": false
+      },
       {
         "encounter_id": "SEAPUNK_WEAK",
         "encounter_name": "Meerespunk",
@@ -9191,13 +9284,6 @@
     "block_values": null,
     "encounters": [
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "Unterdocks-Wildtiere",
-        "room_type": "Monster",
-        "act": "Underdocks",
-        "is_weak": false
-      },
-      {
         "encounter_id": "TOADPOLES_WEAK",
         "encounter_name": "Krötlinge",
         "room_type": "Monster",
@@ -9564,7 +9650,7 @@
         "encounter_id": "TUNNELER_NORMAL",
         "encounter_name": "Grabendes Pärchen",
         "room_type": "Monster",
-        "act": "Act 2 - Hive",
+        "act": null,
         "is_weak": false
       },
       {

--- a/data/deu/powers.json
+++ b/data/deu/powers.json
@@ -170,6 +170,16 @@
     "image_url": "/static/images/powers/black_hole_power.webp"
   },
   {
+    "id": "BLADE_OF_INK",
+    "name": "BladeOfInkPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/blade_of_ink_power.webp"
+  },
+  {
     "id": "BLOCK_NEXT_TURN",
     "name": "Block im nächsten Zug",
     "description": "Erhalte zu Beginn deines nächsten Zuges [blue]4[/blue] [gold]Block[/gold].",
@@ -610,6 +620,16 @@
     "image_url": "/static/images/powers/doom_power.webp"
   },
   {
+    "id": "DOOR_REVIVAL",
+    "name": "DoorRevivalPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Single",
+    "allow_negative": null,
+    "image_url": null
+  },
+  {
     "id": "DOUBLE_DAMAGE",
     "name": "Doppelter Schaden",
     "description": "Angriffe fügen in diesem Zug doppelten Schaden zu.",
@@ -948,6 +968,16 @@
     "stack_type": "Counter",
     "allow_negative": null,
     "image_url": "/static/images/powers/gigantification_power.webp"
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "GrapplePower",
+    "description": "",
+    "description_raw": null,
+    "type": "Debuff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/grapple_power.webp"
   },
   {
     "id": "GRASP",

--- a/data/eng/cards.json
+++ b/data/eng/cards.json
@@ -609,7 +609,7 @@
     "image_url": "/static/images/cards/anticipate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Gain 3 [gold]Dexterity[/gold] this turn.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 91
@@ -915,7 +915,7 @@
     "image_url": "/static/images/cards/assassinate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Deal 13 damage.\nApply 1 [gold]Vulnerable[/gold].",
+    "upgrade_description": "Deal 13 damage.\nApply 2 [gold]Vulnerable[/gold].",
     "type_key": "Attack",
     "rarity_key": "Rare",
     "keywords_key": [
@@ -1350,7 +1350,7 @@
     "image_url": "/static/images/cards/bash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Deal 10 damage.\nApply 2 [gold]Vulnerable[/gold].",
+    "upgrade_description": "Deal 10 damage.\nApply 3 [gold]Vulnerable[/gold].",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 0
@@ -1468,7 +1468,7 @@
     "image_url": "/static/images/cards/beam_cell.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Deal 4 damage.\nApply 1 [gold]Vulnerable[/gold].",
+    "upgrade_description": "Deal 4 damage.\nApply 2 [gold]Vulnerable[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 357
@@ -2439,7 +2439,7 @@
     "image_url": "/static/images/cards/brand.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Lose 1 HP.\n[gold]Exhaust[/gold] 1 card.\nGain 2 [gold]Strength[/gold].",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 61
@@ -2485,7 +2485,7 @@
     "image_url": "/static/images/cards/break.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Deal 30 damage.\nApply 5 [gold]Vulnerable[/gold].",
+    "upgrade_description": "Deal 30 damage.\nApply 7 [gold]Vulnerable[/gold].",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "compendium_order": 85
@@ -2607,7 +2607,7 @@
     "image_url": "/static/images/cards/bubble_bubble.webp",
     "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "If the enemy has [gold]Poison[/gold], apply 12 [gold]Poison[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 116
@@ -2704,7 +2704,7 @@
     "image_url": "/static/images/cards/bulk_up.webp",
     "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Lose 1 Orb Slot.\nGain 3 [gold]Strength[/gold].\nGain 3 [gold]Dexterity[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 376
@@ -4462,7 +4462,7 @@
     "image_url": "/static/images/cards/coordinate.webp",
     "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Give another player 8 [gold]Strength[/gold] this turn.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 442
@@ -5254,7 +5254,7 @@
     "image_url": "/static/images/cards/deadly_poison.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Apply 7 [gold]Poison[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 97
@@ -5383,7 +5383,7 @@
     "image_url": "/static/images/cards/deathbringer.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Apply 26 [gold]Doom[/gold] and 1 [gold]Weak[/gold] to ALL enemies.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 295
@@ -6768,7 +6768,7 @@
   {
     "id": "DUAL_WIELD",
     "name": "Dual Wield",
-    "description": "Choose an Attack or Power card. Add  copies|a copy} of that card into your [gold]Hand[/gold].",
+    "description": "Choose an Attack or Power card. Add a copy of that card into your [gold]Hand[/gold].",
     "description_raw": "Choose an Attack or Power card. Add {IfUpgraded:show:{Cards} copies|a copy} of that card into your [gold]Hand[/gold].",
     "cost": 1,
     "is_x_cost": null,
@@ -6797,7 +6797,7 @@
     "image_url": "/static/images/cards/dual_wield.webp",
     "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
-    "upgrade_description": "Choose an Attack or Power card. Add [Cards copies|a copy] of that card into your [gold]Hand[/gold].",
+    "upgrade_description": "Choose an Attack or Power card. Add 2 copies of that card into your [gold]Hand[/gold].",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 533
@@ -7037,7 +7037,7 @@
     "image_url": "/static/images/cards/end_of_days.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Apply 37 [gold]Doom[/gold] to ALL enemies.\nKill enemies with at least as much [gold]Doom[/gold] as HP.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 328
@@ -7888,7 +7888,7 @@
     "image_url": "/static/images/cards/fear.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Deal 8 damage.\nApply 1 [gold]Vulnerable[/gold].",
+    "upgrade_description": "Deal 8 damage.\nApply 2 [gold]Vulnerable[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "keywords_key": [
@@ -7979,7 +7979,7 @@
     "image_url": "/static/images/cards/feeding_frenzy.webp",
     "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Gain 7 [gold]Strength[/gold] this turn.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 537
@@ -8191,7 +8191,7 @@
     "image_url": "/static/images/cards/fight_me.webp",
     "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
-    "upgrade_description": "Deal 6 damage twice.\nGain 3 [gold]Strength[/gold].\nThe enemy gains 1 [gold]Strength[/gold].",
+    "upgrade_description": "Deal 6 damage twice.\nGain 4 [gold]Strength[/gold].\nThe enemy gains 1 [gold]Strength[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 36
@@ -8790,7 +8790,7 @@
     "image_url": "/static/images/cards/footwork.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Gain 3 [gold]Dexterity[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 125
@@ -9670,7 +9670,7 @@
     "image_url": "/static/images/cards/go_for_the_eyes.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Deal 4 damage.\nIf the enemy intends to attack, apply 1 [gold]Weak[/gold].",
+    "upgrade_description": "Deal 4 damage.\nIf the enemy intends to attack, apply 2 [gold]Weak[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 365
@@ -9750,6 +9750,52 @@
     "type_key": "Attack",
     "rarity_key": "Rare",
     "compendium_order": 159
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "Grapple",
+    "description": "",
+    "description_raw": "",
+    "cost": 1,
+    "is_x_cost": null,
+    "is_x_star_cost": null,
+    "star_cost": null,
+    "type": "Attack",
+    "rarity": "Uncommon",
+    "target": "AnyEnemy",
+    "color": "unknown",
+    "damage": 7,
+    "block": null,
+    "hit_count": null,
+    "powers_applied": [
+      {
+        "power": "Grapple",
+        "amount": 5,
+        "power_key": "Grapple"
+      }
+    ],
+    "cards_draw": null,
+    "energy_gain": null,
+    "hp_loss": null,
+    "keywords": null,
+    "tags": null,
+    "spawns_cards": null,
+    "vars": {
+      "Damage": 7,
+      "GrapplePower": 5,
+      "Grapple": 5
+    },
+    "upgrade": {
+      "damage": "+2",
+      "grapplepower": "+2"
+    },
+    "image_url": "/static/images/cards/grapple.webp",
+    "beta_image_url": null,
+    "type_variants": null,
+    "upgrade_description": null,
+    "type_key": "Attack",
+    "rarity_key": "Uncommon",
+    "compendium_order": 576
   },
   {
     "id": "GRAVE_WARDEN",
@@ -10301,7 +10347,7 @@
     "image_url": "/static/images/cards/haze.webp",
     "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Apply 6 [gold]Poison[/gold] to ALL enemies.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "keywords_key": [
@@ -10774,7 +10820,7 @@
     "image_url": "/static/images/cards/high_five.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]Osty[/gold] deals 13 damage\nand applies 2 [gold]Vulnerable[/gold]\nto ALL enemies.",
+    "upgrade_description": "[gold]Osty[/gold] deals 13 damage\nand applies 3 [gold]Vulnerable[/gold]\nto ALL enemies.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 306
@@ -12203,7 +12249,7 @@
     "image_url": "/static/images/cards/leg_sweep.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Apply 2 [gold]Weak[/gold].\nGain 14 [gold]Block[/gold].",
+    "upgrade_description": "Apply 3 [gold]Weak[/gold].\nGain 14 [gold]Block[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 130
@@ -13860,7 +13906,7 @@
     "image_url": "/static/images/cards/negative_pulse.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Gain 6 [gold]Block[/gold].\nApply 7 [gold]Doom[/gold] to ALL enemies.",
+    "upgrade_description": "Gain 6 [gold]Block[/gold].\nApply 11 [gold]Doom[/gold] to ALL enemies.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 277
@@ -13996,7 +14042,7 @@
     "image_url": "/static/images/cards/neutralize.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Deal 4 damage.\nApply 1 [gold]Weak[/gold].",
+    "upgrade_description": "Deal 4 damage.\nApply 2 [gold]Weak[/gold].",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 88
@@ -14233,7 +14279,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "upgrade_description": "Heal 13 HP.",
     "type_key": "Skill",
@@ -14321,7 +14367,7 @@
     "image_url": "/static/images/cards/null.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Deal 13 damage.\nApply 2 [gold]Weak[/gold].\n[gold]Channel[/gold] 1 [gold]Dark[/gold].",
+    "upgrade_description": "Deal 13 damage.\nApply 3 [gold]Weak[/gold].\n[gold]Channel[/gold] 1 [gold]Dark[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 393
@@ -14365,7 +14411,7 @@
     "image_url": "/static/images/cards/oblivion.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Whenever you play a card this turn, apply 4 [gold]Doom[/gold] to the enemy.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 335
@@ -15370,7 +15416,7 @@
     "image_url": "/static/images/cards/poisoned_stab.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Deal 8 damage.\nApply 3 [gold]Poison[/gold].",
+    "upgrade_description": "Deal 8 damage.\nApply 4 [gold]Poison[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 104
@@ -15935,7 +15981,7 @@
     "image_url": "/static/images/cards/prowess.webp",
     "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Gain 2 [gold]Strength[/gold].\nGain 2 [gold]Dexterity[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 464
@@ -17380,7 +17426,7 @@
     "image_url": "/static/images/cards/rupture.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Whenever you lose HP on your turn, gain 2 [gold]Strength[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -17540,7 +17586,7 @@
     "image_url": "/static/images/cards/scourge.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Apply 13 [gold]Doom[/gold].\nDraw 2 cards.",
+    "upgrade_description": "Apply 16 [gold]Doom[/gold].\nDraw 2 cards.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 282
@@ -18034,7 +18080,7 @@
     "image_url": "/static/images/cards/setup_strike.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Deal 9 damage.\nGain 2 [gold]Strength[/gold] this turn.",
+    "upgrade_description": "Deal 9 damage.\nGain 3 [gold]Strength[/gold] this turn.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 16
@@ -18969,7 +19015,7 @@
     "image_url": "/static/images/cards/snakebite.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Apply 10 [gold]Poison[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -19752,7 +19798,7 @@
     "image_url": "/static/images/cards/squash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Deal 12 damage.\nApply 2 [gold]Vulnerable[/gold].",
+    "upgrade_description": "Deal 12 damage.\nApply 3 [gold]Vulnerable[/gold].",
     "type_key": "Attack",
     "rarity_key": "Event",
     "compendium_order": 545
@@ -19802,7 +19848,7 @@
   {
     "id": "STACK",
     "name": "Stack",
-    "description": "Gain [gold]Block[/gold] equal to the number of cards in your [gold]Discard Pile[/gold]|}.",
+    "description": "Gain [gold]Block[/gold] equal to the number of cards in your [gold]Discard Pile[/gold].",
     "description_raw": "Gain [gold]Block[/gold] equal to the number of cards in your [gold]Discard Pile[/gold]{IfUpgraded:show: +{CalculationBase}|}.{InCombat:\n(Gain {CalculatedBlock:diff()} [gold]Block[/gold])|}",
     "cost": 1,
     "is_x_cost": null,
@@ -19832,7 +19878,7 @@
     "image_url": "/static/images/cards/stack.webp",
     "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
-    "upgrade_description": "Gain [gold]Block[/gold] equal to the number of cards in your [gold]Discard Pile[/gold] +[CalculationBase|].",
+    "upgrade_description": "Gain [gold]Block[/gold] equal to the number of cards in your [gold]Discard Pile[/gold] +3.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 546
@@ -20460,7 +20506,7 @@
     "image_url": "/static/images/cards/sucker_punch.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Deal 10 damage.\nApply 1 [gold]Weak[/gold].",
+    "upgrade_description": "Deal 10 damage.\nApply 2 [gold]Weak[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 109
@@ -20666,7 +20712,7 @@
     "image_url": "/static/images/cards/suppress.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Deal 17 damage.\nApply 3 [gold]Weak[/gold].",
+    "upgrade_description": "Deal 17 damage.\nApply 5 [gold]Weak[/gold].",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "keywords_key": [
@@ -21154,7 +21200,7 @@
     "image_url": "/static/images/cards/taunt.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Gain 8 [gold]Block[/gold].\nApply 1 [gold]Vulnerable[/gold].",
+    "upgrade_description": "Gain 8 [gold]Block[/gold].\nApply 2 [gold]Vulnerable[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -22066,7 +22112,7 @@
     "image_url": "/static/images/cards/tremble.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Apply 4 [gold]Vulnerable[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [

--- a/data/eng/enchantments.json
+++ b/data/eng/enchantments.json
@@ -33,6 +33,17 @@
     "image_url": "/static/images/enchantments/corrupted.webp"
   },
   {
+    "id": "FAVORED",
+    "name": "Favored",
+    "description": "",
+    "description_raw": null,
+    "extra_card_text": null,
+    "card_type": "Attack",
+    "applicable_to": null,
+    "is_stackable": false,
+    "image_url": "/static/images/enchantments/favored.webp"
+  },
+  {
     "id": "GLAM",
     "name": "Glam",
     "description": "This card has [gold]Replay[/gold] once per combat.",

--- a/data/eng/encounters.json
+++ b/data/eng/encounters.json
@@ -1411,6 +1411,25 @@
     "loss_text": "A [gold]Thieving Hopper[/gold] mugged [b]The Adventurer[/b]."
   },
   {
+    "id": "TOADPOLES_NORMAL",
+    "name": "Toadpoles Normal",
+    "room_type": "Monster",
+    "is_weak": false,
+    "act": null,
+    "tags": null,
+    "monsters": [
+      {
+        "id": "CALCIFIED_CULTIST",
+        "name": "Calcified Cultist"
+      },
+      {
+        "id": "TOADPOLE",
+        "name": "Toadpole"
+      }
+    ],
+    "loss_text": null
+  },
+  {
     "id": "TOADPOLES_WEAK",
     "name": "Toadpoles",
     "room_type": "Monster",

--- a/data/eng/monsters.json
+++ b/data/eng/monsters.json
@@ -481,13 +481,6 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": true
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Tunneling Twosome",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -728,13 +721,6 @@
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
         "encounter_name": "Slumber Party",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Tunneling Twosome",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -1077,7 +1063,7 @@
         "is_weak": false
       },
       {
-        "encounter_id": "TOADPOLES_NORMAL",
+        "encounter_id": "SEAPUNK_NORMAL",
         "encounter_name": "Underdocks Wildlife",
         "room_type": "Monster",
         "act": "Underdocks",
@@ -1296,6 +1282,13 @@
         "encounter_name": "An Automaton Pair",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
+        "is_weak": false
+      },
+      {
+        "encounter_id": "TUNNELER_NORMAL",
+        "encounter_name": "Tunneling Twosome",
+        "room_type": "Monster",
+        "act": null,
         "is_weak": false
       }
     ],
@@ -2019,6 +2012,99 @@
     },
     "image_url": "/static/images/monsters/devoted_sculptor.webp",
     "beta_image_url": null
+  },
+  {
+    "id": "DOOR",
+    "name": "Door",
+    "type": "Normal",
+    "min_hp": 155,
+    "max_hp": null,
+    "min_hp_ascension": 165,
+    "max_hp_ascension": null,
+    "moves": [
+      {
+        "id": "DRAMATIC_OPEN",
+        "name": "Dramatic Open",
+        "intent": "Attack",
+        "damage": {
+          "normal": 25,
+          "ascension": 28
+        }
+      },
+      {
+        "id": "ENFORCE",
+        "name": "Enforce",
+        "intent": "Attack + Buff",
+        "powers": [
+          {
+            "power_id": "STRENGTH",
+            "target": "self",
+            "amount": 3
+          }
+        ],
+        "damage": {
+          "normal": 20
+        }
+      },
+      {
+        "id": "DOOR_SLAM",
+        "name": "Door Slam",
+        "intent": "Attack",
+        "damage": {
+          "normal": 15,
+          "ascension": 15,
+          "hit_count": 2
+        }
+      },
+      {
+        "id": "DEAD",
+        "name": "Dead",
+        "intent": "Unknown"
+      }
+    ],
+    "damage_values": {
+      "DramaticOpen": {
+        "normal": 25,
+        "ascension": 28
+      },
+      "DoorSlam": {
+        "normal": 15,
+        "ascension": 15,
+        "hit_count": 2
+      },
+      "Enforce": {
+        "normal": 20
+      }
+    },
+    "block_values": null,
+    "encounters": null,
+    "innate_powers": null,
+    "attack_pattern": {
+      "type": "cycle",
+      "initial_move": null,
+      "states": [
+        {
+          "id": "ENFORCE_MOVE",
+          "type": "move",
+          "move_id": "ENFORCE"
+        },
+        {
+          "id": "DOOR_SLAM_MOVE",
+          "type": "move",
+          "move_id": "DOOR_SLAM",
+          "next": "ENFORCE_MOVE"
+        },
+        {
+          "id": "DEAD_MOVE",
+          "type": "move",
+          "move_id": "DEAD",
+          "next": "DEAD_MOVE"
+        }
+      ],
+      "description": ""
+    },
+    "image_url": "/static/images/monsters/door.webp",
+    "beta_image_url": "/static/images/monsters/beta/door.webp"
   },
   {
     "id": "DOORMAKER",
@@ -6767,6 +6853,13 @@
     "block_values": null,
     "encounters": [
       {
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "Underdocks Wildlife",
+        "room_type": "Monster",
+        "act": "Underdocks",
+        "is_weak": false
+      },
+      {
         "encounter_id": "SEAPUNK_WEAK",
         "encounter_name": "Seapunk",
         "room_type": "Monster",
@@ -9191,13 +9284,6 @@
     "block_values": null,
     "encounters": [
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "Underdocks Wildlife",
-        "room_type": "Monster",
-        "act": "Underdocks",
-        "is_weak": false
-      },
-      {
         "encounter_id": "TOADPOLES_WEAK",
         "encounter_name": "Toadpoles",
         "room_type": "Monster",
@@ -9564,7 +9650,7 @@
         "encounter_id": "TUNNELER_NORMAL",
         "encounter_name": "Tunneling Twosome",
         "room_type": "Monster",
-        "act": "Act 2 - Hive",
+        "act": null,
         "is_weak": false
       },
       {

--- a/data/eng/powers.json
+++ b/data/eng/powers.json
@@ -170,6 +170,16 @@
     "image_url": "/static/images/powers/black_hole_power.webp"
   },
   {
+    "id": "BLADE_OF_INK",
+    "name": "BladeOfInkPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/blade_of_ink_power.webp"
+  },
+  {
     "id": "BLOCK_NEXT_TURN",
     "name": "Block Next Turn",
     "description": "At the start of your next turn, gain [blue]4[/blue] [gold]Block[/gold].",
@@ -610,6 +620,16 @@
     "image_url": "/static/images/powers/doom_power.webp"
   },
   {
+    "id": "DOOR_REVIVAL",
+    "name": "DoorRevivalPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Single",
+    "allow_negative": null,
+    "image_url": null
+  },
+  {
     "id": "DOUBLE_DAMAGE",
     "name": "Double Damage",
     "description": "This turn, Attacks deal double damage.",
@@ -948,6 +968,16 @@
     "stack_type": "Counter",
     "allow_negative": null,
     "image_url": "/static/images/powers/gigantification_power.webp"
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "GrapplePower",
+    "description": "",
+    "description_raw": null,
+    "type": "Debuff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/grapple_power.webp"
   },
   {
     "id": "GRASP",

--- a/data/esp/cards.json
+++ b/data/esp/cards.json
@@ -478,7 +478,7 @@
   {
     "id": "STACK",
     "name": "Acumulación",
-    "description": "Obtienes [gold]bloqueo[/gold] por un valor equivalente a la cantidad de cartas en la [gold]pila de descarte[/gold]|}.",
+    "description": "Obtienes [gold]bloqueo[/gold] por un valor equivalente a la cantidad de cartas en la [gold]pila de descarte[/gold].",
     "description_raw": "Obtienes [gold]bloqueo[/gold] por un valor equivalente a la cantidad de cartas en la [gold]pila de descarte[/gold]{IfUpgraded:show: +{CalculationBase}|}.{InCombat:\n(Obtienes {CalculatedBlock:diff()} de [gold]bloqueo[/gold])|}",
     "cost": 1,
     "is_x_cost": null,
@@ -508,7 +508,7 @@
     "image_url": "/static/images/cards/stack.webp",
     "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
-    "upgrade_description": "Obtienes [gold]bloqueo[/gold] por un valor equivalente a la cantidad de cartas en la [gold]pila de descarte[/gold] +[CalculationBase|].",
+    "upgrade_description": "Obtienes [gold]bloqueo[/gold] por un valor equivalente a la cantidad de cartas en la [gold]pila de descarte[/gold] +3.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 544
@@ -1123,7 +1123,7 @@
     "image_url": "/static/images/cards/anticipate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Obtienes 3 de [gold]destreza[/gold] durante este turno.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 93
@@ -1211,7 +1211,7 @@
     "image_url": "/static/images/cards/squash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliges 12 de daño.\nAplicas 2 de [gold]vulnerabilidad[/gold].",
+    "upgrade_description": "Infliges 12 de daño.\nAplicas 3 de [gold]vulnerabilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Event",
     "compendium_order": 543
@@ -1503,7 +1503,7 @@
     "image_url": "/static/images/cards/go_for_the_eyes.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliges 4 de daño.\nSi el enemigo planea atacar, aplicas 1 de [gold]debilitamiento[/gold].",
+    "upgrade_description": "Infliges 4 de daño.\nSi el enemigo planea atacar, aplicas 2 de [gold]debilitamiento[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 389
@@ -2002,7 +2002,7 @@
     "image_url": "/static/images/cards/assassinate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliges 13 de daño.\nAplicas 1 de [gold]vulnerabilidad[/gold].",
+    "upgrade_description": "Infliges 13 de daño.\nAplicas 2 de [gold]vulnerabilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Rare",
     "keywords_key": [
@@ -2333,7 +2333,7 @@
     "image_url": "/static/images/cards/sucker_punch.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliges 10 de daño.\nAplicas 1 de [gold]debilitamiento[/gold].",
+    "upgrade_description": "Infliges 10 de daño.\nAplicas 2 de [gold]debilitamiento[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 164
@@ -3574,7 +3574,7 @@
     "image_url": "/static/images/cards/bubble_bubble.webp",
     "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Si tu enemigo ya sufre [gold]veneno[/gold], aplicas 12 de [gold]veneno[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 101
@@ -3620,7 +3620,7 @@
     "image_url": "/static/images/cards/leg_sweep.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Aplicas 2 de [gold]debilitamiento[/gold].\nObtienes 14 de [gold]bloqueo[/gold].",
+    "upgrade_description": "Aplicas 3 de [gold]debilitamiento[/gold].\nObtienes 14 de [gold]bloqueo[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 133
@@ -4251,7 +4251,7 @@
     "image_url": "/static/images/cards/high_five.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]Puro Hueso[/gold] inflige 13 de daño\ny aplica 2 de [gold]vulnerabilidad[/gold]\na TODOS los enemigos.",
+    "upgrade_description": "[gold]Puro Hueso[/gold] inflige 13 de daño\ny aplica 3 de [gold]vulnerabilidad[/gold]\na TODOS los enemigos.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 303
@@ -4903,7 +4903,7 @@
     "image_url": "/static/images/cards/coordinate.webp",
     "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Le das 8 de [gold]fuerza[/gold] a otra persona durante este turno.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 448
@@ -7833,7 +7833,7 @@
   {
     "id": "DUAL_WIELD",
     "name": "Empuñadura doble",
-    "description": "Eliges una carta de ataque o de poder. Agregas  copias|una copia} de esa carta a tu [gold]mano[/gold].",
+    "description": "Eliges una carta de ataque o de poder. Agregas una copia de esa carta a tu [gold]mano[/gold].",
     "description_raw": "Eliges una carta de ataque o de poder. Agregas {IfUpgraded:show:{Cards} copias|una copia} de esa carta a tu [gold]mano[/gold].",
     "cost": 1,
     "is_x_cost": null,
@@ -7862,7 +7862,7 @@
     "image_url": "/static/images/cards/dual_wield.webp",
     "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
-    "upgrade_description": "Eliges una carta de ataque o de poder. Agregas [Cards copias|una copia] de esa carta a tu [gold]mano[/gold].",
+    "upgrade_description": "Eliges una carta de ataque o de poder. Agregas 2 copias de esa carta a tu [gold]mano[/gold].",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 528
@@ -8236,7 +8236,7 @@
     "image_url": "/static/images/cards/neutralize.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliges 4 de daño.\nAplicas 1 de [gold]debilitamiento[/gold].",
+    "upgrade_description": "Infliges 4 de daño.\nAplicas 2 de [gold]debilitamiento[/gold].",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 139
@@ -9620,7 +9620,7 @@
     "image_url": "/static/images/cards/feeding_frenzy.webp",
     "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Obtienes 7 de [gold]fuerza[/gold] en este turno.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 532
@@ -9744,7 +9744,7 @@
     "image_url": "/static/images/cards/end_of_days.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplicas 37 de [gold]condena[/gold] a TODOS los enemigos.\nDerrota a todos los enemigos que posean al menos la misma cantidad de [gold]condena[/gold] que de PV.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 290
@@ -9790,7 +9790,7 @@
     "image_url": "/static/images/cards/scourge.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Aplicas 13 de [gold]condena[/gold].\nRobas 2 cartas.",
+    "upgrade_description": "Aplicas 16 de [gold]condena[/gold].\nRobas 2 cartas.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 328
@@ -11608,7 +11608,7 @@
     "image_url": "/static/images/cards/setup_strike.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliges 9 de daño.\nObtienes 2 de [gold]fuerza[/gold] en este turno.",
+    "upgrade_description": "Infliges 9 de daño.\nObtienes 3 de [gold]fuerza[/gold] en este turno.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 65
@@ -11930,6 +11930,52 @@
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 391
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "Grapple",
+    "description": "",
+    "description_raw": "",
+    "cost": 1,
+    "is_x_cost": null,
+    "is_x_star_cost": null,
+    "star_cost": null,
+    "type": "Ataque",
+    "rarity": "Infrecuente",
+    "target": "AnyEnemy",
+    "color": "unknown",
+    "damage": 7,
+    "block": null,
+    "hit_count": null,
+    "powers_applied": [
+      {
+        "power": "Grapple",
+        "amount": 5,
+        "power_key": "Grapple"
+      }
+    ],
+    "cards_draw": null,
+    "energy_gain": null,
+    "hp_loss": null,
+    "keywords": null,
+    "tags": null,
+    "spawns_cards": null,
+    "vars": {
+      "Damage": 7,
+      "GrapplePower": 5,
+      "Grapple": 5
+    },
+    "upgrade": {
+      "damage": "+2",
+      "grapplepower": "+2"
+    },
+    "image_url": "/static/images/cards/grapple.webp",
+    "beta_image_url": null,
+    "type_variants": null,
+    "upgrade_description": null,
+    "type_key": "Attack",
+    "rarity_key": "Uncommon",
+    "compendium_order": 576
   },
   {
     "id": "DARK_SHACKLES",
@@ -13269,7 +13315,7 @@
     "image_url": "/static/images/cards/footwork.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Obtienes 3 de [gold]destreza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 125
@@ -13595,7 +13641,7 @@
     "image_url": "/static/images/cards/negative_pulse.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Obtienes 6 de [gold]bloqueo[/gold].\nAplicas 7 de [gold]condena[/gold] a TODOS los enemigos.",
+    "upgrade_description": "Obtienes 6 de [gold]bloqueo[/gold].\nAplicas 11 de [gold]condena[/gold] a TODOS los enemigos.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 310
@@ -14618,7 +14664,7 @@
     "image_url": "/static/images/cards/brand.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Pierdes 1 PV.\n[gold]Agotas[/gold] 1 carta.\nObtienes 2 de [gold]fuerza[/gold].",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 11
@@ -14780,7 +14826,7 @@
     "image_url": "/static/images/cards/bash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliges 10 de daño.\nAplicas 2 de [gold]vulnerabilidad[/gold].",
+    "upgrade_description": "Infliges 10 de daño.\nAplicas 3 de [gold]vulnerabilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 5
@@ -15394,7 +15440,7 @@
     "image_url": "/static/images/cards/snakebite.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplicas 10 de [gold]veneno[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -15751,7 +15797,7 @@
     "image_url": "/static/images/cards/haze.webp",
     "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplicas 6 de [gold]veneno[/gold] a TODOS los enemigos.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "keywords_key": [
@@ -15982,7 +16028,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "upgrade_description": null,
     "type_key": "Skill",
@@ -16033,7 +16079,7 @@
     "image_url": "/static/images/cards/null.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliges 13 de daño.\nAplicas 2 de [gold]debilitamiento[/gold].\n[gold]Canalizas[/gold] 1 de [gold]oscuridad[/gold].",
+    "upgrade_description": "Infliges 13 de daño.\nAplicas 3 de [gold]debilitamiento[/gold].\n[gold]Canalizas[/gold] 1 de [gold]oscuridad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 407
@@ -16160,7 +16206,7 @@
     "image_url": "/static/images/cards/oblivion.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Al jugar una carta en este turno, aplicas 4 de [gold]condena[/gold] al enemigo.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 313
@@ -17263,7 +17309,7 @@
     "image_url": "/static/images/cards/deathbringer.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplicas 26 de [gold]condena[/gold] y 1 de [gold]debilitamiento[/gold] a TODOS los enemigos.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 276
@@ -17548,7 +17594,7 @@
     "image_url": "/static/images/cards/prowess.webp",
     "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Obtienes 2 de [gold]fuerza[/gold].\nObtienes 2 de [gold]destreza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 481
@@ -17794,7 +17840,7 @@
     "image_url": "/static/images/cards/taunt.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Obtienes 8 de [gold]bloqueo[/gold].\nAplicas 1 de [gold]vulnerabilidad[/gold].",
+    "upgrade_description": "Obtienes 8 de [gold]bloqueo[/gold].\nAplicas 2 de [gold]vulnerabilidad[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -18039,7 +18085,7 @@
     "image_url": "/static/images/cards/poisoned_stab.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliges 8 de daño.\nAplicas 3 de [gold]veneno[/gold].",
+    "upgrade_description": "Infliges 8 de daño.\nAplicas 4 de [gold]veneno[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 146
@@ -18283,7 +18329,7 @@
     "image_url": "/static/images/cards/break.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliges 30 de daño.\nAplicas 5 de [gold]vulnerabilidad[/gold].",
+    "upgrade_description": "Infliges 30 de daño.\nAplicas 7 de [gold]vulnerabilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "compendium_order": 12
@@ -18490,7 +18536,7 @@
     "image_url": "/static/images/cards/beam_cell.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliges 4 de daño.\nAplicas 1 de [gold]vulnerabilidad[/gold].",
+    "upgrade_description": "Infliges 4 de daño.\nAplicas 2 de [gold]vulnerabilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 355
@@ -19606,7 +19652,7 @@
     "image_url": "/static/images/cards/rupture.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Al perder PV durante tu turno, obtienes 2 de [gold]fuerza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -20946,7 +20992,7 @@
     "image_url": "/static/images/cards/suppress.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliges 17 de daño.\nAplicas 3 de [gold]debilitamiento[/gold].",
+    "upgrade_description": "Infliges 17 de daño.\nAplicas 5 de [gold]debilitamiento[/gold].",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "keywords_key": [
@@ -21266,7 +21312,7 @@
     "image_url": "/static/images/cards/tremble.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplicas 4 de [gold]vulnerabilidad[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -21396,7 +21442,7 @@
     "image_url": "/static/images/cards/fear.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliges 8 de daño.\nAplicas 1 de [gold]vulnerabilidad[/gold].",
+    "upgrade_description": "Infliges 8 de daño.\nAplicas 2 de [gold]vulnerabilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "keywords_key": [
@@ -22597,7 +22643,7 @@
     "image_url": "/static/images/cards/deadly_poison.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplicas 7 de [gold]veneno[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 110
@@ -22965,7 +23011,7 @@
     "image_url": "/static/images/cards/bulk_up.webp",
     "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Pierdes 1 espacio de orbe.\nObtienes 3 de [gold]fuerza[/gold].\nObtienes 3 de [gold]destreza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 360
@@ -23099,7 +23145,7 @@
     "image_url": "/static/images/cards/fight_me.webp",
     "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
-    "upgrade_description": "Infliges 6 de daño dos veces.\nObtienes 3 de [gold]fuerza[/gold].\nEl enemigo obtiene 1 de [gold]fuerza[/gold].",
+    "upgrade_description": "Infliges 6 de daño dos veces.\nObtienes 4 de [gold]fuerza[/gold].\nEl enemigo obtiene 1 de [gold]fuerza[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 35

--- a/data/esp/enchantments.json
+++ b/data/esp/enchantments.json
@@ -33,6 +33,17 @@
     "image_url": "/static/images/enchantments/corrupted.webp"
   },
   {
+    "id": "FAVORED",
+    "name": "Favored",
+    "description": "",
+    "description_raw": null,
+    "extra_card_text": null,
+    "card_type": "Attack",
+    "applicable_to": null,
+    "is_stackable": false,
+    "image_url": "/static/images/enchantments/favored.webp"
+  },
+  {
     "id": "GLAM",
     "name": "Glamur",
     "description": "Esta carta se puede [gold]rejugar[/gold] una vez por combate.",

--- a/data/esp/encounters.json
+++ b/data/esp/encounters.json
@@ -1411,6 +1411,25 @@
     "loss_text": "Un [gold]asaltamontes[/gold] asaltó a [b]The Adventurer[/b]."
   },
   {
+    "id": "TOADPOLES_NORMAL",
+    "name": "Toadpoles Normal",
+    "room_type": "Monster",
+    "is_weak": false,
+    "act": null,
+    "tags": null,
+    "monsters": [
+      {
+        "id": "CALCIFIED_CULTIST",
+        "name": "Sectario calciremojado"
+      },
+      {
+        "id": "TOADPOLE",
+        "name": "Ranacuajo"
+      }
+    ],
+    "loss_text": null
+  },
+  {
     "id": "TOADPOLES_WEAK",
     "name": "ranacuajos",
     "room_type": "Monster",

--- a/data/esp/monsters.json
+++ b/data/esp/monsters.json
@@ -481,13 +481,6 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": true
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "excavante y compañía",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -728,13 +721,6 @@
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
         "encounter_name": "fiesta de escaramorfeos",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "excavante y compañía",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -1077,8 +1063,8 @@
         "is_weak": false
       },
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "fauna de Muelles Funestos",
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "fauna de los Muelles Funestos",
         "room_type": "Monster",
         "act": "Underdocks",
         "is_weak": false
@@ -1296,6 +1282,13 @@
         "encounter_name": "Un par de mordebots",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
+        "is_weak": false
+      },
+      {
+        "encounter_id": "TUNNELER_NORMAL",
+        "encounter_name": "excavante y compañía",
+        "room_type": "Monster",
+        "act": null,
         "is_weak": false
       }
     ],
@@ -2019,6 +2012,99 @@
     },
     "image_url": "/static/images/monsters/devoted_sculptor.webp",
     "beta_image_url": null
+  },
+  {
+    "id": "DOOR",
+    "name": "Portal",
+    "type": "Normal",
+    "min_hp": 155,
+    "max_hp": null,
+    "min_hp_ascension": 165,
+    "max_hp_ascension": null,
+    "moves": [
+      {
+        "id": "DRAMATIC_OPEN",
+        "name": "Dramatic Open",
+        "intent": "Attack",
+        "damage": {
+          "normal": 25,
+          "ascension": 28
+        }
+      },
+      {
+        "id": "ENFORCE",
+        "name": "Enforce",
+        "intent": "Attack + Buff",
+        "powers": [
+          {
+            "power_id": "STRENGTH",
+            "target": "self",
+            "amount": 3
+          }
+        ],
+        "damage": {
+          "normal": 20
+        }
+      },
+      {
+        "id": "DOOR_SLAM",
+        "name": "Door Slam",
+        "intent": "Attack",
+        "damage": {
+          "normal": 15,
+          "ascension": 15,
+          "hit_count": 2
+        }
+      },
+      {
+        "id": "DEAD",
+        "name": "Dead",
+        "intent": "Unknown"
+      }
+    ],
+    "damage_values": {
+      "DramaticOpen": {
+        "normal": 25,
+        "ascension": 28
+      },
+      "DoorSlam": {
+        "normal": 15,
+        "ascension": 15,
+        "hit_count": 2
+      },
+      "Enforce": {
+        "normal": 20
+      }
+    },
+    "block_values": null,
+    "encounters": null,
+    "innate_powers": null,
+    "attack_pattern": {
+      "type": "cycle",
+      "initial_move": null,
+      "states": [
+        {
+          "id": "ENFORCE_MOVE",
+          "type": "move",
+          "move_id": "ENFORCE"
+        },
+        {
+          "id": "DOOR_SLAM_MOVE",
+          "type": "move",
+          "move_id": "DOOR_SLAM",
+          "next": "ENFORCE_MOVE"
+        },
+        {
+          "id": "DEAD_MOVE",
+          "type": "move",
+          "move_id": "DEAD",
+          "next": "DEAD_MOVE"
+        }
+      ],
+      "description": ""
+    },
+    "image_url": "/static/images/monsters/door.webp",
+    "beta_image_url": "/static/images/monsters/beta/door.webp"
   },
   {
     "id": "DOORMAKER",
@@ -6767,6 +6853,13 @@
     "block_values": null,
     "encounters": [
       {
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "fauna de los Muelles Funestos",
+        "room_type": "Monster",
+        "act": "Underdocks",
+        "is_weak": false
+      },
+      {
         "encounter_id": "SEAPUNK_WEAK",
         "encounter_name": "rufián marino",
         "room_type": "Monster",
@@ -9191,13 +9284,6 @@
     "block_values": null,
     "encounters": [
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "fauna de Muelles Funestos",
-        "room_type": "Monster",
-        "act": "Underdocks",
-        "is_weak": false
-      },
-      {
         "encounter_id": "TOADPOLES_WEAK",
         "encounter_name": "ranacuajos",
         "room_type": "Monster",
@@ -9564,7 +9650,7 @@
         "encounter_id": "TUNNELER_NORMAL",
         "encounter_name": "excavante y compañía",
         "room_type": "Monster",
-        "act": "Act 2 - Hive",
+        "act": null,
         "is_weak": false
       },
       {

--- a/data/esp/powers.json
+++ b/data/esp/powers.json
@@ -170,6 +170,16 @@
     "image_url": "/static/images/powers/black_hole_power.webp"
   },
   {
+    "id": "BLADE_OF_INK",
+    "name": "BladeOfInkPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/blade_of_ink_power.webp"
+  },
+  {
     "id": "BLOCK_NEXT_TURN",
     "name": "Bloqueo de próximo turno",
     "description": "Al comienzo del próximo turno, brinda [blue]4[/blue] de [gold]bloqueo[/gold].",
@@ -610,6 +620,16 @@
     "image_url": "/static/images/powers/doom_power.webp"
   },
   {
+    "id": "DOOR_REVIVAL",
+    "name": "DoorRevivalPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Single",
+    "allow_negative": null,
+    "image_url": null
+  },
+  {
     "id": "DOUBLE_DAMAGE",
     "name": "Daño doble",
     "description": "En este turno, los ataques infligen el doble de daño.",
@@ -948,6 +968,16 @@
     "stack_type": "Counter",
     "allow_negative": null,
     "image_url": "/static/images/powers/gigantification_power.webp"
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "GrapplePower",
+    "description": "",
+    "description_raw": null,
+    "type": "Debuff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/grapple_power.webp"
   },
   {
     "id": "GRASP",

--- a/data/fra/cards.json
+++ b/data/fra/cards.json
@@ -592,7 +592,7 @@
   {
     "id": "DUAL_WIELD",
     "name": "Ambidextrie",
-    "description": "Choisissez une carte Attaque ou Pouvoir. Ajoutez  copies|une copie} de cette carte à votre [gold]Main[/gold].",
+    "description": "Choisissez une carte Attaque ou Pouvoir. Ajoutez une copie de cette carte à votre [gold]Main[/gold].",
     "description_raw": "Choisissez une carte Attaque ou Pouvoir. Ajoutez {IfUpgraded:show:{Cards} copies|une copie} de cette carte à votre [gold]Main[/gold].",
     "cost": 1,
     "is_x_cost": null,
@@ -621,7 +621,7 @@
     "image_url": "/static/images/cards/dual_wield.webp",
     "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
-    "upgrade_description": "Choisissez une carte Attaque ou Pouvoir. Ajoutez [Cards copies|une copie] de cette carte à votre [gold]Main[/gold].",
+    "upgrade_description": "Choisissez une carte Attaque ou Pouvoir. Ajoutez 2 copies de cette carte à votre [gold]Main[/gold].",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 528
@@ -807,7 +807,7 @@
     "image_url": "/static/images/cards/negative_pulse.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Gagnez 6 d'[gold]Armure[/gold].\nAppliquez 7 de [gold]Fatalité[/gold] sur TOUS les ennemis.",
+    "upgrade_description": "Gagnez 6 d'[gold]Armure[/gold].\nAppliquez 11 de [gold]Fatalité[/gold] sur TOUS les ennemis.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 325
@@ -851,7 +851,7 @@
     "image_url": "/static/images/cards/anticipate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Gagnez 3 de [gold]Dextérité[/gold] jusqu'à la fin du tour.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 115
@@ -897,7 +897,7 @@
     "image_url": "/static/images/cards/squash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infligez 12 dégâts.\nAppliquez [gold]Vulnérable[/gold] (2).",
+    "upgrade_description": "Infligez 12 dégâts.\nAppliquez [gold]Vulnérable[/gold] (3).",
     "type_key": "Attack",
     "rarity_key": "Event",
     "compendium_order": 543
@@ -1441,7 +1441,7 @@
     "image_url": "/static/images/cards/assassinate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infligez 13 dégâts.\nAppliquez [gold]Vulnérable[/gold] (1).",
+    "upgrade_description": "Infligez 13 dégâts.\nAppliquez [gold]Vulnérable[/gold] (2).",
     "type_key": "Attack",
     "rarity_key": "Rare",
     "keywords_key": [
@@ -1788,7 +1788,7 @@
     "image_url": "/static/images/cards/leg_sweep.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Appliquez [gold]Affaibli[/gold] (2).\nGagnez 14 d'[gold]Armure[/gold].",
+    "upgrade_description": "Appliquez [gold]Affaibli[/gold] (3).\nGagnez 14 d'[gold]Armure[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 145
@@ -2599,7 +2599,7 @@
     "image_url": "/static/images/cards/break.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infligez 30 dégâts.\nAppliquez [gold]Vulnérable[/gold] (5).",
+    "upgrade_description": "Infligez 30 dégâts.\nAppliquez [gold]Vulnérable[/gold] (7).",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "compendium_order": 35
@@ -2645,7 +2645,7 @@
     "image_url": "/static/images/cards/haze.webp",
     "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Appliquez 6 de [gold]Poison[/gold] à TOUS les ennemis.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "keywords_key": [
@@ -4361,7 +4361,7 @@
     "image_url": "/static/images/cards/coordinate.webp",
     "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Donnez à un autre joueur 8 de [gold]Force[/gold] jusqu'à la fin du tour.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 467
@@ -4493,7 +4493,7 @@
     "image_url": "/static/images/cards/sucker_punch.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infligez 10 dégâts.\nAppliquez [gold]Affaibli[/gold] (1).",
+    "upgrade_description": "Infligez 10 dégâts.\nAppliquez [gold]Affaibli[/gold] (2).",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 167
@@ -7943,7 +7943,7 @@
     "image_url": "/static/images/cards/end_of_days.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Appliquez 37 de [gold]Fatalité[/gold] à TOUS les ennemis.\nLes ennemis avec au moins autant de [gold]Fatalité[/gold] que de PV périssent.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 268
@@ -9531,7 +9531,7 @@
     "image_url": "/static/images/cards/setup_strike.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infligez 9 dégâts.\nGagnez 2 de [gold]Force[/gold] jusqu'à la fin du tour.",
+    "upgrade_description": "Infligez 9 dégâts.\nGagnez 3 de [gold]Force[/gold] jusqu'à la fin du tour.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 70
@@ -10166,6 +10166,52 @@
     "compendium_order": 102
   },
   {
+    "id": "GRAPPLE",
+    "name": "Grapple",
+    "description": "",
+    "description_raw": "",
+    "cost": 1,
+    "is_x_cost": null,
+    "is_x_star_cost": null,
+    "star_cost": null,
+    "type": "Attaque",
+    "rarity": "Inhabituel",
+    "target": "AnyEnemy",
+    "color": "unknown",
+    "damage": 7,
+    "block": null,
+    "hit_count": null,
+    "powers_applied": [
+      {
+        "power": "Grapple",
+        "amount": 5,
+        "power_key": "Grapple"
+      }
+    ],
+    "cards_draw": null,
+    "energy_gain": null,
+    "hp_loss": null,
+    "keywords": null,
+    "tags": null,
+    "spawns_cards": null,
+    "vars": {
+      "Damage": 7,
+      "GrapplePower": 5,
+      "Grapple": 5
+    },
+    "upgrade": {
+      "damage": "+2",
+      "grapplepower": "+2"
+    },
+    "image_url": "/static/images/cards/grapple.webp",
+    "beta_image_url": null,
+    "type_variants": null,
+    "upgrade_description": null,
+    "type_key": "Attack",
+    "rarity_key": "Uncommon",
+    "compendium_order": 576
+  },
+  {
     "id": "SCRAWL",
     "name": "Griffonage",
     "description": "Piochez des cartes jusqu'à remplir votre [gold]Main[/gold].",
@@ -10593,7 +10639,7 @@
     "image_url": "/static/images/cards/bash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infligez 10 dégâts.\nAppliquez [gold]Vulnérable[/gold] (2).",
+    "upgrade_description": "Infligez 10 dégâts.\nAppliquez [gold]Vulnérable[/gold] (3).",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 29
@@ -11574,7 +11620,7 @@
     "image_url": "/static/images/cards/tremble.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Appliquez [gold]Vulnérable[/gold] (4).",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -11896,7 +11942,7 @@
     "image_url": "/static/images/cards/footwork.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Gagnez 3 de [gold]Dextérité[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 139
@@ -13486,7 +13532,7 @@
     "image_url": "/static/images/cards/brand.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Perdez 1 PV.\n[gold]Épuisez[/gold] 1 carte.\nGagnez 2 de [gold]Force[/gold].",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 2
@@ -14002,7 +14048,7 @@
     "image_url": "/static/images/cards/snakebite.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Appliquez 10 de [gold]Poison[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -14321,7 +14367,7 @@
     "image_url": "/static/images/cards/neutralize.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infligez 4 dégâts.\nAppliquez [gold]Affaibli[/gold] (1).",
+    "upgrade_description": "Infligez 4 dégâts.\nAppliquez [gold]Affaibli[/gold] (2).",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 148
@@ -14483,7 +14529,7 @@
     "image_url": "/static/images/cards/oblivion.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Lorsque vous jouez une carte ce tour, appliquez 4 de [gold]Fatalité[/gold] sur l'ennemi.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 275
@@ -15253,7 +15299,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "upgrade_description": "Récupérez 13 PV.",
     "type_key": "Skill",
@@ -15531,7 +15577,7 @@
     "image_url": "/static/images/cards/scourge.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Appliquez 13 de [gold]Fatalité[/gold].\nPiochez 2 cartes.",
+    "upgrade_description": "Appliquez 16 de [gold]Fatalité[/gold].\nPiochez 2 cartes.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 338
@@ -15668,7 +15714,7 @@
   {
     "id": "STACK",
     "name": "Pile",
-    "description": "Gagnez un montant d'[gold]Armure[/gold] égal au nombre de cartes dans votre [gold]Défausse[/gold]|}.",
+    "description": "Gagnez un montant d'[gold]Armure[/gold] égal au nombre de cartes dans votre [gold]Défausse[/gold].",
     "description_raw": "Gagnez un montant d'[gold]Armure[/gold] égal au nombre de cartes dans votre [gold]Défausse[/gold]{IfUpgraded:show: +{CalculationBase}|}.{InCombat:\n(Gagnez {CalculatedBlock:diff()} d'[gold]Armure[/gold])|}",
     "cost": 1,
     "is_x_cost": null,
@@ -15698,7 +15744,7 @@
     "image_url": "/static/images/cards/stack.webp",
     "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
-    "upgrade_description": "Gagnez un montant d'[gold]Armure[/gold] égal au nombre de cartes dans votre [gold]Défausse[/gold] +[CalculationBase|].",
+    "upgrade_description": "Gagnez un montant d'[gold]Armure[/gold] égal au nombre de cartes dans votre [gold]Défausse[/gold] +3.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 544
@@ -16331,7 +16377,7 @@
     "image_url": "/static/images/cards/poisoned_stab.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infligez 8 dégâts.\nAppliquez 3 de [gold]Poison[/gold].",
+    "upgrade_description": "Infligez 8 dégâts.\nAppliquez 4 de [gold]Poison[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 154
@@ -16576,7 +16622,7 @@
     "image_url": "/static/images/cards/deadly_poison.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Appliquez 7 de [gold]Poison[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 127
@@ -16669,7 +16715,7 @@
     "image_url": "/static/images/cards/deathbringer.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Appliquez 26 de [gold]Fatalité[/gold] et [gold]Affaibli[/gold] (1) à TOUS les ennemis.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 300
@@ -16799,7 +16845,7 @@
     "image_url": "/static/images/cards/bulk_up.webp",
     "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Perdez 1 Emplacement d'Orbe.\nGagnez 3 de [gold]Force[/gold].\nGagnez 3 de [gold]Dextérité[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 383
@@ -17098,7 +17144,7 @@
     "image_url": "/static/images/cards/prowess.webp",
     "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Gagnez 2 de [gold]Force[/gold].\nGagnez 2 de [gold]Dextérité[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 489
@@ -17144,7 +17190,7 @@
     "image_url": "/static/images/cards/taunt.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Gagnez 8 d'[gold]Armure[/gold].\nAppliquez [gold]Vulnérable[/gold] (1).",
+    "upgrade_description": "Gagnez 8 d'[gold]Armure[/gold].\nAppliquez [gold]Vulnérable[/gold] (2).",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -17765,7 +17811,7 @@
     "image_url": "/static/images/cards/beam_cell.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infligez 4 dégâts.\nAppliquez [gold]Vulnérable[/gold] (1).",
+    "upgrade_description": "Infligez 4 dégâts.\nAppliquez [gold]Vulnérable[/gold] (2).",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 379
@@ -18209,7 +18255,7 @@
     "image_url": "/static/images/cards/feeding_frenzy.webp",
     "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Gagnez 7 de [gold]Force[/gold] jusqu'à la fin du tour.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 532
@@ -18484,7 +18530,7 @@
     "image_url": "/static/images/cards/rupture.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Lorsque vous perdez des PV pendant votre tour, gagnez 2 de [gold]Force[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -18767,7 +18813,7 @@
     "image_url": "/static/images/cards/suppress.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infligez 17 dégâts.\nAppliquez [gold]Affaibli[/gold] (3).",
+    "upgrade_description": "Infligez 17 dégâts.\nAppliquez [gold]Affaibli[/gold] (5).",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "keywords_key": [
@@ -20893,7 +20939,7 @@
     "image_url": "/static/images/cards/fear.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infligez 8 dégâts.\nAppliquez [gold]Vulnérable[/gold] (1).",
+    "upgrade_description": "Infligez 8 dégâts.\nAppliquez [gold]Vulnérable[/gold] (2).",
     "type_key": "Attack",
     "rarity_key": "Common",
     "keywords_key": [
@@ -21031,7 +21077,7 @@
     "image_url": "/static/images/cards/high_five.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]Titos[/gold] inflige 13 dégâts\net applique [gold]Vulnérable[/gold] (2) \nà TOUS les ennemis.",
+    "upgrade_description": "[gold]Titos[/gold] inflige 13 dégâts\net applique [gold]Vulnérable[/gold] (3) \nà TOUS les ennemis.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 320
@@ -21907,7 +21953,7 @@
     "image_url": "/static/images/cards/null.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infligez 13 dégâts.\nAppliquez [gold]Affaibli[/gold] (2).\n[gold]Canalisez[/gold] 1 [gold]Orbe ténébreux[/gold].",
+    "upgrade_description": "Infligez 13 dégâts.\nAppliquez [gold]Affaibli[/gold] (3).\n[gold]Canalisez[/gold] 1 [gold]Orbe ténébreux[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 415
@@ -21988,7 +22034,7 @@
     "image_url": "/static/images/cards/bubble_bubble.webp",
     "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Si l'ennemi est affligé de [gold]Poison[/gold], appliquez 12 de [gold]Poison[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 121
@@ -22196,7 +22242,7 @@
     "image_url": "/static/images/cards/fight_me.webp",
     "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
-    "upgrade_description": "Infligez 6 dégâts 2 fois.\nGagnez 3 de [gold]Force[/gold].\nL'ennemi gagne 1 de [gold]Force[/gold].",
+    "upgrade_description": "Infligez 6 dégâts 2 fois.\nGagnez 4 de [gold]Force[/gold].\nL'ennemi gagne 1 de [gold]Force[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -22279,7 +22325,7 @@
     "image_url": "/static/images/cards/go_for_the_eyes.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infligez 4 dégâts.\nSi l'ennemi s'apprête à attaquer, appliquez [gold]Affaibli[/gold] (1).",
+    "upgrade_description": "Infligez 4 dégâts.\nSi l'ennemi s'apprête à attaquer, appliquez [gold]Affaibli[/gold] (2).",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 405

--- a/data/fra/enchantments.json
+++ b/data/fra/enchantments.json
@@ -33,6 +33,17 @@
     "image_url": "/static/images/enchantments/corrupted.webp"
   },
   {
+    "id": "FAVORED",
+    "name": "Favored",
+    "description": "",
+    "description_raw": null,
+    "extra_card_text": null,
+    "card_type": "Attack",
+    "applicable_to": null,
+    "is_stackable": false,
+    "image_url": "/static/images/enchantments/favored.webp"
+  },
+  {
     "id": "GLAM",
     "name": "Glamour",
     "description": "Cette carte a [gold]Écho[/gold] ([blue]1[/blue]) une fois par combat.",

--- a/data/fra/encounters.json
+++ b/data/fra/encounters.json
@@ -1411,6 +1411,25 @@
     "loss_text": "Une [gold]Mante Chapardeuse[/gold] a braqué [b]The Adventurer[/b]."
   },
   {
+    "id": "TOADPOLES_NORMAL",
+    "name": "Toadpoles Normal",
+    "room_type": "Monster",
+    "is_weak": false,
+    "act": null,
+    "tags": null,
+    "monsters": [
+      {
+        "id": "CALCIFIED_CULTIST",
+        "name": "Adepte calcifié"
+      },
+      {
+        "id": "TOADPOLE",
+        "name": "Crapautard"
+      }
+    ],
+    "loss_text": null
+  },
+  {
     "id": "TOADPOLES_WEAK",
     "name": "Crapautards",
     "room_type": "Monster",

--- a/data/fra/monsters.json
+++ b/data/fra/monsters.json
@@ -481,13 +481,6 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": true
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Tunnelier accompagné",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -728,13 +721,6 @@
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
         "encounter_name": "Veillée",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Tunnelier accompagné",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -1077,8 +1063,8 @@
         "is_weak": false
       },
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "Faune et flore des Bas-Quais",
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "Faune des Bas-Quais",
         "room_type": "Monster",
         "act": "Underdocks",
         "is_weak": false
@@ -1296,6 +1282,13 @@
         "encounter_name": "Jumeaux croquebots",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
+        "is_weak": false
+      },
+      {
+        "encounter_id": "TUNNELER_NORMAL",
+        "encounter_name": "Tunnelier accompagné",
+        "room_type": "Monster",
+        "act": null,
         "is_weak": false
       }
     ],
@@ -2019,6 +2012,99 @@
     },
     "image_url": "/static/images/monsters/devoted_sculptor.webp",
     "beta_image_url": null
+  },
+  {
+    "id": "DOOR",
+    "name": "Porte",
+    "type": "Normal",
+    "min_hp": 155,
+    "max_hp": null,
+    "min_hp_ascension": 165,
+    "max_hp_ascension": null,
+    "moves": [
+      {
+        "id": "DRAMATIC_OPEN",
+        "name": "Dramatic Open",
+        "intent": "Attack",
+        "damage": {
+          "normal": 25,
+          "ascension": 28
+        }
+      },
+      {
+        "id": "ENFORCE",
+        "name": "Enforce",
+        "intent": "Attack + Buff",
+        "powers": [
+          {
+            "power_id": "STRENGTH",
+            "target": "self",
+            "amount": 3
+          }
+        ],
+        "damage": {
+          "normal": 20
+        }
+      },
+      {
+        "id": "DOOR_SLAM",
+        "name": "Door Slam",
+        "intent": "Attack",
+        "damage": {
+          "normal": 15,
+          "ascension": 15,
+          "hit_count": 2
+        }
+      },
+      {
+        "id": "DEAD",
+        "name": "Dead",
+        "intent": "Unknown"
+      }
+    ],
+    "damage_values": {
+      "DramaticOpen": {
+        "normal": 25,
+        "ascension": 28
+      },
+      "DoorSlam": {
+        "normal": 15,
+        "ascension": 15,
+        "hit_count": 2
+      },
+      "Enforce": {
+        "normal": 20
+      }
+    },
+    "block_values": null,
+    "encounters": null,
+    "innate_powers": null,
+    "attack_pattern": {
+      "type": "cycle",
+      "initial_move": null,
+      "states": [
+        {
+          "id": "ENFORCE_MOVE",
+          "type": "move",
+          "move_id": "ENFORCE"
+        },
+        {
+          "id": "DOOR_SLAM_MOVE",
+          "type": "move",
+          "move_id": "DOOR_SLAM",
+          "next": "ENFORCE_MOVE"
+        },
+        {
+          "id": "DEAD_MOVE",
+          "type": "move",
+          "move_id": "DEAD",
+          "next": "DEAD_MOVE"
+        }
+      ],
+      "description": ""
+    },
+    "image_url": "/static/images/monsters/door.webp",
+    "beta_image_url": "/static/images/monsters/beta/door.webp"
   },
   {
     "id": "DOORMAKER",
@@ -2860,7 +2946,7 @@
     "encounters": [
       {
         "encounter_id": "FLYCONID_NORMAL",
-        "encounter_name": "Champi et Limon",
+        "encounter_name": "Mycoptère et Limon",
         "room_type": "Monster",
         "act": "Act 1 - Overgrowth",
         "is_weak": false
@@ -4637,7 +4723,7 @@
     "encounters": [
       {
         "encounter_id": "FLYCONID_NORMAL",
-        "encounter_name": "Champi et Limon",
+        "encounter_name": "Mycoptère et Limon",
         "room_type": "Monster",
         "act": "Act 1 - Overgrowth",
         "is_weak": false
@@ -6766,6 +6852,13 @@
     },
     "block_values": null,
     "encounters": [
+      {
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "Faune des Bas-Quais",
+        "room_type": "Monster",
+        "act": "Underdocks",
+        "is_weak": false
+      },
       {
         "encounter_id": "SEAPUNK_WEAK",
         "encounter_name": "Voyou marin",
@@ -9191,13 +9284,6 @@
     "block_values": null,
     "encounters": [
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "Faune et flore des Bas-Quais",
-        "room_type": "Monster",
-        "act": "Underdocks",
-        "is_weak": false
-      },
-      {
         "encounter_id": "TOADPOLES_WEAK",
         "encounter_name": "Crapautards",
         "room_type": "Monster",
@@ -9564,7 +9650,7 @@
         "encounter_id": "TUNNELER_NORMAL",
         "encounter_name": "Tunnelier accompagné",
         "room_type": "Monster",
-        "act": "Act 2 - Hive",
+        "act": null,
         "is_weak": false
       },
       {
@@ -9732,7 +9818,7 @@
     "encounters": [
       {
         "encounter_id": "FLYCONID_NORMAL",
-        "encounter_name": "Champi et Limon",
+        "encounter_name": "Mycoptère et Limon",
         "room_type": "Monster",
         "act": "Act 1 - Overgrowth",
         "is_weak": false
@@ -10142,7 +10228,7 @@
     "encounters": [
       {
         "encounter_id": "VINE_SHAMBLER_NORMAL",
-        "encounter_name": "Bourbelianes",
+        "encounter_name": "Bourbeliane",
         "room_type": "Monster",
         "act": "Act 1 - Overgrowth",
         "is_weak": false

--- a/data/fra/powers.json
+++ b/data/fra/powers.json
@@ -170,6 +170,16 @@
     "image_url": "/static/images/powers/black_hole_power.webp"
   },
   {
+    "id": "BLADE_OF_INK",
+    "name": "BladeOfInkPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/blade_of_ink_power.webp"
+  },
+  {
     "id": "BLOCK_NEXT_TURN",
     "name": "Armure au prochain tour",
     "description": "Au début de votre prochain tour, gagnez [blue]4[/blue] d'[gold]Armure[/gold].",
@@ -610,6 +620,16 @@
     "image_url": "/static/images/powers/doom_power.webp"
   },
   {
+    "id": "DOOR_REVIVAL",
+    "name": "DoorRevivalPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Single",
+    "allow_negative": null,
+    "image_url": null
+  },
+  {
     "id": "DOUBLE_DAMAGE",
     "name": "Dégâts doublés",
     "description": "Pendant ce tour, les Attaques infligent le double de dégâts.",
@@ -948,6 +968,16 @@
     "stack_type": "Counter",
     "allow_negative": null,
     "image_url": "/static/images/powers/gigantification_power.webp"
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "GrapplePower",
+    "description": "",
+    "description_raw": null,
+    "type": "Debuff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/grapple_power.webp"
   },
   {
     "id": "GRASP",

--- a/data/ita/cards.json
+++ b/data/ita/cards.json
@@ -2,7 +2,7 @@
   {
     "id": "DUAL_WIELD",
     "name": "A Due Mani",
-    "description": "Scegli una carta Attacco o Potere. Aggiungi  copie|una copia} di quella carta alla tua [gold]mano[/gold].",
+    "description": "Scegli una carta Attacco o Potere. Aggiungi una copia di quella carta alla tua [gold]mano[/gold].",
     "description_raw": "Scegli una carta Attacco o Potere. Aggiungi {IfUpgraded:show:{Cards} copie|una copia} di quella carta alla tua [gold]mano[/gold].",
     "cost": 1,
     "is_x_cost": null,
@@ -31,7 +31,7 @@
     "image_url": "/static/images/cards/dual_wield.webp",
     "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
-    "upgrade_description": "Scegli una carta Attacco o Potere. Aggiungi [Cards copie|una copia] di quella carta alla tua [gold]mano[/gold].",
+    "upgrade_description": "Scegli una carta Attacco o Potere. Aggiungi 2 copie di quella carta alla tua [gold]mano[/gold].",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 528
@@ -394,7 +394,7 @@
     "image_url": "/static/images/cards/fight_me.webp",
     "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
-    "upgrade_description": "Infliggi 6 di danno due volte.\nOttieni 3 di [gold]Forza[/gold].\nIl nemico ottiene 1 di [gold]Forza[/gold].",
+    "upgrade_description": "Infliggi 6 di danno due volte.\nOttieni 4 di [gold]Forza[/gold].\nIl nemico ottiene 1 di [gold]Forza[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 35
@@ -557,7 +557,7 @@
     "image_url": "/static/images/cards/go_for_the_eyes.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliggi 4 di danno.\nSe il nemico si appresta ad attaccare, applichi 1 di [gold]Debolezza[/gold].",
+    "upgrade_description": "Infliggi 4 di danno.\nSe il nemico si appresta ad attaccare, applichi 2 di [gold]Debolezza[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 389
@@ -944,7 +944,7 @@
     "image_url": "/static/images/cards/end_of_days.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Applichi 37 di [gold]Condanna[/gold] a TUTTI i nemici.\nUccidi i nemici con tanta [gold]Condanna[/gold] quanti PV.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 290
@@ -1514,7 +1514,7 @@
     "image_url": "/static/images/cards/assassinate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliggi 13 di danno.\nApplichi 1 di [gold]Vulnerabilità[/gold].",
+    "upgrade_description": "Infliggi 13 di danno.\nApplichi 2 di [gold]Vulnerabilità[/gold].",
     "type_key": "Attack",
     "rarity_key": "Rare",
     "keywords_key": [
@@ -2345,7 +2345,7 @@
     "image_url": "/static/images/cards/high_five.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]Osty[/gold] infligge 13 di danno.\ne applica 2 di [gold]Vulnerabilità[/gold]\na TUTTI i nemici.",
+    "upgrade_description": "[gold]Osty[/gold] infligge 13 di danno.\ne applica 3 di [gold]Vulnerabilità[/gold]\na TUTTI i nemici.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 303
@@ -2391,7 +2391,7 @@
     "image_url": "/static/images/cards/negative_pulse.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Ottieni 6 di [gold]Blocco[/gold].\nApplichi 7 di [gold]Condanna[/gold] a TUTTI i nemici.",
+    "upgrade_description": "Ottieni 6 di [gold]Blocco[/gold].\nApplichi 11 di [gold]Condanna[/gold] a TUTTI i nemici.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 310
@@ -4359,7 +4359,7 @@
     "image_url": "/static/images/cards/setup_strike.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliggi 9 di danno.\nOttieni 2 di [gold]Forza[/gold] in questo turno.",
+    "upgrade_description": "Infliggi 9 di danno.\nOttieni 3 di [gold]Forza[/gold] in questo turno.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 65
@@ -5289,7 +5289,7 @@
     "image_url": "/static/images/cards/coordinate.webp",
     "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Dai a un altro giocatore 8 di [gold]Forza[/gold] in questo turno.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 448
@@ -7530,7 +7530,7 @@
     "image_url": "/static/images/cards/feeding_frenzy.webp",
     "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Ottieni 7 di [gold]Forza[/gold] in questo turno.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 532
@@ -8114,7 +8114,7 @@
     "image_url": "/static/images/cards/scourge.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Applichi 13 di [gold]Condanna[/gold].\nPeschi 2 carte.",
+    "upgrade_description": "Applichi 16 di [gold]Condanna[/gold].\nPeschi 2 carte.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 328
@@ -8615,7 +8615,7 @@
     "image_url": "/static/images/cards/haze.webp",
     "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Applichi 6 di [gold]Veleno[/gold] a TUTTI i nemici.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "keywords_key": [
@@ -9525,7 +9525,7 @@
     "image_url": "/static/images/cards/footwork.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Ottieni 3 di [gold]Destrezza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 125
@@ -9684,6 +9684,52 @@
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 391
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "Grapple",
+    "description": "",
+    "description_raw": "",
+    "cost": 1,
+    "is_x_cost": null,
+    "is_x_star_cost": null,
+    "star_cost": null,
+    "type": "Attacco",
+    "rarity": "Non comune",
+    "target": "AnyEnemy",
+    "color": "unknown",
+    "damage": 7,
+    "block": null,
+    "hit_count": null,
+    "powers_applied": [
+      {
+        "power": "Grapple",
+        "amount": 5,
+        "power_key": "Grapple"
+      }
+    ],
+    "cards_draw": null,
+    "energy_gain": null,
+    "hp_loss": null,
+    "keywords": null,
+    "tags": null,
+    "spawns_cards": null,
+    "vars": {
+      "Damage": 7,
+      "GrapplePower": 5,
+      "Grapple": 5
+    },
+    "upgrade": {
+      "damage": "+2",
+      "grapplepower": "+2"
+    },
+    "image_url": "/static/images/cards/grapple.webp",
+    "beta_image_url": null,
+    "type_variants": null,
+    "upgrade_description": null,
+    "type_key": "Attack",
+    "rarity_key": "Uncommon",
+    "compendium_order": 576
   },
   {
     "id": "FORBIDDEN_GRIMOIRE",
@@ -11120,7 +11166,7 @@
     "image_url": "/static/images/cards/bulk_up.webp",
     "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Perdi 1 spazio Globi.\nOttieni 3 di [gold]Forza[/gold].\nOttieni 3 di [gold]Destrezza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 360
@@ -11449,7 +11495,7 @@
     "image_url": "/static/images/cards/poisoned_stab.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliggi 8 di danno.\nApplichi 3 di [gold]Veleno[/gold].",
+    "upgrade_description": "Infliggi 8 di danno.\nApplichi 4 di [gold]Veleno[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 146
@@ -12637,7 +12683,7 @@
     "image_url": "/static/images/cards/brand.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Perdi 1 PV.\n[gold]Esaurisci[/gold] 1 carta.\nOttieni 2 di [gold]Forza[/gold].",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 11
@@ -12886,7 +12932,7 @@
     "image_url": "/static/images/cards/bash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliggi 10 di danno.\nApplichi 2 di [gold]Vulnerabilità[/gold].",
+    "upgrade_description": "Infliggi 10 di danno.\nApplichi 3 di [gold]Vulnerabilità[/gold].",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 5
@@ -13369,7 +13415,7 @@
     "image_url": "/static/images/cards/snakebite.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Applichi 10 di [gold]Veleno[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -13692,7 +13738,7 @@
     "image_url": "/static/images/cards/neutralize.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliggi 4 di danno.\nApplichi 1 di [gold]Debolezza[/gold].",
+    "upgrade_description": "Infliggi 4 di danno.\nApplichi 2 di [gold]Debolezza[/gold].",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 139
@@ -13729,7 +13775,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "upgrade_description": "Recuperi 13 PV.",
     "type_key": "Skill",
@@ -13930,7 +13976,7 @@
     "image_url": "/static/images/cards/oblivion.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Ogni volta che giochi una carta in questo turno, applichi 4 di [gold]Condanna[/gold] al nemico.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 313
@@ -14907,7 +14953,7 @@
     "image_url": "/static/images/cards/squash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliggi 12 di danno.\nApplichi 2 di [gold]Vulnerabilità[/gold].",
+    "upgrade_description": "Infliggi 12 di danno.\nApplichi 3 di [gold]Vulnerabilità[/gold].",
     "type_key": "Attack",
     "rarity_key": "Event",
     "compendium_order": 543
@@ -15385,7 +15431,7 @@
     "image_url": "/static/images/cards/break.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliggi 30 di danno.\nApplichi 5 di [gold]Vulnerabilità[/gold].",
+    "upgrade_description": "Infliggi 30 di danno.\nApplichi 7 di [gold]Vulnerabilità[/gold].",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "compendium_order": 12
@@ -15511,7 +15557,7 @@
     "image_url": "/static/images/cards/deathbringer.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Applichi 26 di [gold]Condanna[/gold] e 1 di [gold]Debolezza[/gold] a TUTTI i nemici.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 276
@@ -15714,7 +15760,7 @@
     "image_url": "/static/images/cards/anticipate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Ottieni 3 di [gold]Destrezza[/gold] in questo turno.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 93
@@ -15766,7 +15812,7 @@
     "image_url": "/static/images/cards/prowess.webp",
     "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Ottieni 2 di [gold]Forza[/gold].\nOttieni 2 di [gold]Destrezza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 481
@@ -16377,7 +16423,7 @@
     "image_url": "/static/images/cards/sucker_punch.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliggi 10 di danno.\nApplichi 1 di [gold]Debolezza[/gold].",
+    "upgrade_description": "Infliggi 10 di danno.\nApplichi 2 di [gold]Debolezza[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 164
@@ -16854,7 +16900,7 @@
     "image_url": "/static/images/cards/beam_cell.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliggi 4 di danno.\nApplichi 1 di [gold]Vulnerabilità[/gold].",
+    "upgrade_description": "Infliggi 4 di danno.\nApplichi 2 di [gold]Vulnerabilità[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 355
@@ -18602,7 +18648,7 @@
     "image_url": "/static/images/cards/taunt.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Ottieni 8 di [gold]Blocco[/gold].\nApplichi 1 di [gold]Vulnerabilità[/gold].",
+    "upgrade_description": "Ottieni 8 di [gold]Blocco[/gold].\nApplichi 2 di [gold]Vulnerabilità[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -19612,7 +19658,7 @@
     "image_url": "/static/images/cards/leg_sweep.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Applichi 2 di [gold]Debolezza[/gold].\nOttieni 14 di [gold]Blocco[/gold].",
+    "upgrade_description": "Applichi 3 di [gold]Debolezza[/gold].\nOttieni 14 di [gold]Blocco[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 133
@@ -20014,7 +20060,7 @@
     "image_url": "/static/images/cards/suppress.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliggi 17 di danno.\nApplichi 3 di [gold]Debolezza[/gold].",
+    "upgrade_description": "Infliggi 17 di danno.\nApplichi 5 di [gold]Debolezza[/gold].",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "keywords_key": [
@@ -20333,7 +20379,7 @@
     "image_url": "/static/images/cards/bubble_bubble.webp",
     "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Se il nemico ha [gold]Veleno[/gold], applichi 12 di [gold]Veleno[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 101
@@ -20578,7 +20624,7 @@
     "image_url": "/static/images/cards/rupture.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Ogni volta che perdi PV durante il tuo turno, ottieni 2 di [gold]Forza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -20626,7 +20672,7 @@
   {
     "id": "STACK",
     "name": "Stack",
-    "description": "Ottieni [gold]Blocco[/gold] pari al numero di carte nella tua [gold]pila degli scarti[/gold]|}.",
+    "description": "Ottieni [gold]Blocco[/gold] pari al numero di carte nella tua [gold]pila degli scarti[/gold].",
     "description_raw": "Ottieni [gold]Blocco[/gold] pari al numero di carte nella tua [gold]pila degli scarti[/gold]{IfUpgraded:show: +{CalculationBase}|}.{InCombat:\n(Ottieni {CalculatedBlock:diff()} di [gold]Blocco[/gold])|}",
     "cost": 1,
     "is_x_cost": null,
@@ -20656,7 +20702,7 @@
     "image_url": "/static/images/cards/stack.webp",
     "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
-    "upgrade_description": "Ottieni [gold]Blocco[/gold] pari al numero di carte nella tua [gold]pila degli scarti[/gold] +[CalculationBase|].",
+    "upgrade_description": "Ottieni [gold]Blocco[/gold] pari al numero di carte nella tua [gold]pila degli scarti[/gold] +3.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 544
@@ -21809,7 +21855,7 @@
     "image_url": "/static/images/cards/fear.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliggi 8 di danno.\nApplichi 1 di [gold]Vulnerabilità[/gold].",
+    "upgrade_description": "Infliggi 8 di danno.\nApplichi 2 di [gold]Vulnerabilità[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "keywords_key": [
@@ -22333,7 +22379,7 @@
     "image_url": "/static/images/cards/tremble.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Applichi 4 di [gold]Vulnerabilità[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -22883,7 +22929,7 @@
     "image_url": "/static/images/cards/null.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliggi 13 di danno.\nApplichi 2 di [gold]Debolezza[/gold].\n[gold]Tetroglobi[/gold] [gold]canalizzati[/gold]: 1.",
+    "upgrade_description": "Infliggi 13 di danno.\nApplichi 3 di [gold]Debolezza[/gold].\n[gold]Tetroglobi[/gold] [gold]canalizzati[/gold]: 1.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 407
@@ -22927,7 +22973,7 @@
     "image_url": "/static/images/cards/deadly_poison.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Applichi 7 di [gold]Veleno[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 110

--- a/data/ita/enchantments.json
+++ b/data/ita/enchantments.json
@@ -33,6 +33,17 @@
     "image_url": "/static/images/enchantments/corrupted.webp"
   },
   {
+    "id": "FAVORED",
+    "name": "Favored",
+    "description": "",
+    "description_raw": null,
+    "extra_card_text": null,
+    "card_type": "Attack",
+    "applicable_to": null,
+    "is_stackable": false,
+    "image_url": "/static/images/enchantments/favored.webp"
+  },
+  {
     "id": "GLAM",
     "name": "Glamour",
     "description": "Questa carta possiede [gold]Riattivazione[/gold] una volta per combattimento.",

--- a/data/ita/encounters.json
+++ b/data/ita/encounters.json
@@ -1411,6 +1411,25 @@
     "loss_text": "Una [gold]Mantide ladra[/gold] ha derubato [b]The Adventurer[/b]."
   },
   {
+    "id": "TOADPOLES_NORMAL",
+    "name": "Toadpoles Normal",
+    "room_type": "Monster",
+    "is_weak": false,
+    "act": null,
+    "tags": null,
+    "monsters": [
+      {
+        "id": "CALCIFIED_CULTIST",
+        "name": "Accolito calcificato"
+      },
+      {
+        "id": "TOADPOLE",
+        "name": "Girino"
+      }
+    ],
+    "loss_text": null
+  },
+  {
     "id": "TOADPOLES_WEAK",
     "name": "Girini",
     "room_type": "Monster",

--- a/data/ita/monsters.json
+++ b/data/ita/monsters.json
@@ -470,7 +470,7 @@
     "encounters": [
       {
         "encounter_id": "BOWLBUGS_NORMAL",
-        "encounter_name": "Sciame di Scaraciotole",
+        "encounter_name": "sciame di Scaraciotole",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -481,13 +481,6 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": true
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "coppia di Scavatori",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -554,7 +547,7 @@
     "encounters": [
       {
         "encounter_id": "BOWLBUGS_NORMAL",
-        "encounter_name": "Sciame di Scaraciotole",
+        "encounter_name": "sciame di Scaraciotole",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -630,7 +623,7 @@
     "encounters": [
       {
         "encounter_id": "BOWLBUGS_NORMAL",
-        "encounter_name": "Sciame di Scaraciotole",
+        "encounter_name": "sciame di Scaraciotole",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -644,7 +637,7 @@
       },
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
-        "encounter_name": "festa di melme",
+        "encounter_name": "festa di scarafaggi",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -720,21 +713,14 @@
     "encounters": [
       {
         "encounter_id": "BOWLBUGS_NORMAL",
-        "encounter_name": "Sciame di Scaraciotole",
+        "encounter_name": "sciame di Scaraciotole",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
       },
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
-        "encounter_name": "festa di melme",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "coppia di Scavatori",
+        "encounter_name": "festa di scarafaggi",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -1077,7 +1063,7 @@
         "is_weak": false
       },
       {
-        "encounter_id": "TOADPOLES_NORMAL",
+        "encounter_id": "SEAPUNK_NORMAL",
         "encounter_name": "fauna dei Moli Funesti",
         "room_type": "Monster",
         "act": "Underdocks",
@@ -1296,6 +1282,13 @@
         "encounter_name": "Una coppia di automi",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
+        "is_weak": false
+      },
+      {
+        "encounter_id": "TUNNELER_NORMAL",
+        "encounter_name": "coppia di Scavatori",
+        "room_type": "Monster",
+        "act": null,
         "is_weak": false
       }
     ],
@@ -2019,6 +2012,99 @@
     },
     "image_url": "/static/images/monsters/devoted_sculptor.webp",
     "beta_image_url": null
+  },
+  {
+    "id": "DOOR",
+    "name": "Porta",
+    "type": "Normal",
+    "min_hp": 155,
+    "max_hp": null,
+    "min_hp_ascension": 165,
+    "max_hp_ascension": null,
+    "moves": [
+      {
+        "id": "DRAMATIC_OPEN",
+        "name": "Dramatic Open",
+        "intent": "Attack",
+        "damage": {
+          "normal": 25,
+          "ascension": 28
+        }
+      },
+      {
+        "id": "ENFORCE",
+        "name": "Enforce",
+        "intent": "Attack + Buff",
+        "powers": [
+          {
+            "power_id": "STRENGTH",
+            "target": "self",
+            "amount": 3
+          }
+        ],
+        "damage": {
+          "normal": 20
+        }
+      },
+      {
+        "id": "DOOR_SLAM",
+        "name": "Door Slam",
+        "intent": "Attack",
+        "damage": {
+          "normal": 15,
+          "ascension": 15,
+          "hit_count": 2
+        }
+      },
+      {
+        "id": "DEAD",
+        "name": "Dead",
+        "intent": "Unknown"
+      }
+    ],
+    "damage_values": {
+      "DramaticOpen": {
+        "normal": 25,
+        "ascension": 28
+      },
+      "DoorSlam": {
+        "normal": 15,
+        "ascension": 15,
+        "hit_count": 2
+      },
+      "Enforce": {
+        "normal": 20
+      }
+    },
+    "block_values": null,
+    "encounters": null,
+    "innate_powers": null,
+    "attack_pattern": {
+      "type": "cycle",
+      "initial_move": null,
+      "states": [
+        {
+          "id": "ENFORCE_MOVE",
+          "type": "move",
+          "move_id": "ENFORCE"
+        },
+        {
+          "id": "DOOR_SLAM_MOVE",
+          "type": "move",
+          "move_id": "DOOR_SLAM",
+          "next": "ENFORCE_MOVE"
+        },
+        {
+          "id": "DEAD_MOVE",
+          "type": "move",
+          "move_id": "DEAD",
+          "next": "DEAD_MOVE"
+        }
+      ],
+      "description": ""
+    },
+    "image_url": "/static/images/monsters/door.webp",
+    "beta_image_url": "/static/images/monsters/beta/door.webp"
   },
   {
     "id": "DOORMAKER",
@@ -3743,7 +3829,7 @@
     "encounters": [
       {
         "encounter_id": "HAUNTED_SHIP_NORMAL",
-        "encounter_name": "Nave Infestata",
+        "encounter_name": "Nave infestata",
         "room_type": "Monster",
         "act": "Underdocks",
         "is_weak": false
@@ -4651,7 +4737,7 @@
       },
       {
         "encounter_id": "SLIMES_WEAK",
-        "encounter_name": "gruppo di melme",
+        "encounter_name": "gruppo di Melme",
         "room_type": "Monster",
         "act": "Act 1 - Overgrowth",
         "is_weak": true
@@ -4728,7 +4814,7 @@
       },
       {
         "encounter_id": "SLIMES_WEAK",
-        "encounter_name": "gruppo di melme",
+        "encounter_name": "gruppo di Melme",
         "room_type": "Monster",
         "act": "Act 1 - Overgrowth",
         "is_weak": true
@@ -6279,7 +6365,7 @@
       },
       {
         "encounter_id": "PUNCH_OFF_EVENT_ENCOUNTER",
-        "encounter_name": "Assemblaggi pugili",
+        "encounter_name": "Assemblaggi Pugili",
         "room_type": "Monster",
         "act": null,
         "is_weak": false
@@ -6767,6 +6853,13 @@
     "block_values": null,
     "encounters": [
       {
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "fauna dei Moli Funesti",
+        "room_type": "Monster",
+        "act": "Underdocks",
+        "is_weak": false
+      },
+      {
         "encounter_id": "SEAPUNK_WEAK",
         "encounter_name": "Teppista marino",
         "room_type": "Monster",
@@ -7038,7 +7131,7 @@
     "encounters": [
       {
         "encounter_id": "SKULKING_COLONY_ELITE",
-        "encounter_name": "colonia furtiva",
+        "encounter_name": "Colonia furtiva",
         "room_type": "Elite",
         "act": "Underdocks",
         "is_weak": false
@@ -7439,7 +7532,7 @@
     "encounters": [
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
-        "encounter_name": "festa di melme",
+        "encounter_name": "festa di scarafaggi",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -7684,7 +7777,7 @@
     "encounters": [
       {
         "encounter_id": "SOUL_FYSH_BOSS",
-        "encounter_name": "Animapesce",
+        "encounter_name": "Pesce anima",
         "room_type": "Boss",
         "act": "Underdocks",
         "is_weak": false
@@ -9191,13 +9284,6 @@
     "block_values": null,
     "encounters": [
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "fauna dei Moli Funesti",
-        "room_type": "Monster",
-        "act": "Underdocks",
-        "is_weak": false
-      },
-      {
         "encounter_id": "TOADPOLES_WEAK",
         "encounter_name": "Girini",
         "room_type": "Monster",
@@ -9564,7 +9650,7 @@
         "encounter_id": "TUNNELER_NORMAL",
         "encounter_name": "coppia di Scavatori",
         "room_type": "Monster",
-        "act": "Act 2 - Hive",
+        "act": null,
         "is_weak": false
       },
       {
@@ -9746,7 +9832,7 @@
       },
       {
         "encounter_id": "SLIMES_WEAK",
-        "encounter_name": "gruppo di melme",
+        "encounter_name": "gruppo di Melme",
         "room_type": "Monster",
         "act": "Act 1 - Overgrowth",
         "is_weak": true
@@ -9828,7 +9914,7 @@
       },
       {
         "encounter_id": "SLIMES_WEAK",
-        "encounter_name": "gruppo di melme",
+        "encounter_name": "gruppo di Melme",
         "room_type": "Monster",
         "act": "Act 1 - Overgrowth",
         "is_weak": true

--- a/data/ita/powers.json
+++ b/data/ita/powers.json
@@ -170,6 +170,16 @@
     "image_url": "/static/images/powers/black_hole_power.webp"
   },
   {
+    "id": "BLADE_OF_INK",
+    "name": "BladeOfInkPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/blade_of_ink_power.webp"
+  },
+  {
     "id": "BLOCK_NEXT_TURN",
     "name": "Blocco Imminente",
     "description": "All'inizio del tuo turno successivo, ottieni [blue]4[/blue] di [gold]Blocco[/gold].",
@@ -610,6 +620,16 @@
     "image_url": "/static/images/powers/doom_power.webp"
   },
   {
+    "id": "DOOR_REVIVAL",
+    "name": "DoorRevivalPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Single",
+    "allow_negative": null,
+    "image_url": null
+  },
+  {
     "id": "DOUBLE_DAMAGE",
     "name": "Danno Doppio",
     "description": "In questo turno, le carte Attacco infliggono danno doppio.",
@@ -948,6 +968,16 @@
     "stack_type": "Counter",
     "allow_negative": null,
     "image_url": "/static/images/powers/gigantification_power.webp"
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "GrapplePower",
+    "description": "",
+    "description_raw": null,
+    "type": "Debuff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/grapple_power.webp"
   },
   {
     "id": "GRASP",

--- a/data/jpn/cards.json
+++ b/data/jpn/cards.json
@@ -40,6 +40,52 @@
     "compendium_order": 384
   },
   {
+    "id": "GRAPPLE",
+    "name": "Grapple",
+    "description": "",
+    "description_raw": "",
+    "cost": 1,
+    "is_x_cost": null,
+    "is_x_star_cost": null,
+    "star_cost": null,
+    "type": "アタック",
+    "rarity": "アンコモン",
+    "target": "AnyEnemy",
+    "color": "unknown",
+    "damage": 7,
+    "block": null,
+    "hit_count": null,
+    "powers_applied": [
+      {
+        "power": "Grapple",
+        "amount": 5,
+        "power_key": "Grapple"
+      }
+    ],
+    "cards_draw": null,
+    "energy_gain": null,
+    "hp_loss": null,
+    "keywords": null,
+    "tags": null,
+    "spawns_cards": null,
+    "vars": {
+      "Damage": 7,
+      "GrapplePower": 5,
+      "Grapple": 5
+    },
+    "upgrade": {
+      "damage": "+2",
+      "grapplepower": "+2"
+    },
+    "image_url": "/static/images/cards/grapple.webp",
+    "beta_image_url": null,
+    "type_variants": null,
+    "upgrade_description": null,
+    "type_key": "Attack",
+    "rarity_key": "Uncommon",
+    "compendium_order": 576
+  },
+  {
     "id": "BELIEVE_IN_YOU",
     "name": "お前を信じる",
     "description": "他のプレイヤーは[energy:2]を得る。",
@@ -1322,7 +1368,7 @@
     "image_url": "/static/images/cards/oblivion.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "このターン、カードをプレイするたび、対象の敵に[gold]破滅[/gold]4を付与する。",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 313
@@ -2684,7 +2730,7 @@
   {
     "id": "STACK",
     "name": "スタック",
-    "description": "[gold]捨て札[/gold]の枚数|}に等しい[gold]ブロック[/gold]を得る。",
+    "description": "[gold]捨て札[/gold]の枚数に等しい[gold]ブロック[/gold]を得る。",
     "description_raw": "[gold]捨て札[/gold]の枚数{IfUpgraded:show: +{CalculationBase}|}に等しい[gold]ブロック[/gold]を得る。{InCombat:\n({CalculatedBlock:diff()}[gold]ブロック[/gold]を得る)|}",
     "cost": 1,
     "is_x_cost": null,
@@ -2714,7 +2760,7 @@
     "image_url": "/static/images/cards/stack.webp",
     "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
-    "upgrade_description": "[gold]捨て札[/gold]の枚数 +[CalculationBase|]に等しい[gold]ブロック[/gold]を得る。",
+    "upgrade_description": "[gold]捨て札[/gold]の枚数 +3に等しい[gold]ブロック[/gold]を得る。",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 544
@@ -3279,7 +3325,7 @@
     "image_url": "/static/images/cards/setup_strike.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "9ダメージを与える。\nターン終了時まで[gold]筋力[/gold]2を得る。",
+    "upgrade_description": "9ダメージを与える。\nターン終了時まで[gold]筋力[/gold]3を得る。",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 65
@@ -3996,7 +4042,7 @@
     "image_url": "/static/images/cards/deathbringer.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "すべての敵に[gold]破滅[/gold]26と[gold]脱力[/gold]1を付与する。",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 276
@@ -4412,7 +4458,7 @@
     "image_url": "/static/images/cards/null.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "13ダメージを与える。\n[gold]脱力[/gold]2を付与する。\n[gold]ダーク[/gold]1を[gold]生成[/gold]する。",
+    "upgrade_description": "13ダメージを与える。\n[gold]脱力[/gold]3を付与する。\n[gold]ダーク[/gold]1を[gold]生成[/gold]する。",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 407
@@ -4626,7 +4672,7 @@
     "image_url": "/static/images/cards/high_five.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]オスティ[/gold]が13ダメージを与え、\nすべての敵に[gold]弱体[/gold]2を\n付与する。",
+    "upgrade_description": "[gold]オスティ[/gold]が13ダメージを与え、\nすべての敵に[gold]弱体[/gold]3を\n付与する。",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 303
@@ -4987,7 +5033,7 @@
     "image_url": "/static/images/cards/bubble_bubble.webp",
     "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "敵が[gold]毒[/gold]に侵されている場合、[gold]毒[/gold]12を付与する。",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 101
@@ -5462,7 +5508,7 @@
     "image_url": "/static/images/cards/beam_cell.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "4ダメージを与える。\n[gold]弱体[/gold]1を付与する。",
+    "upgrade_description": "4ダメージを与える。\n[gold]弱体[/gold]2を付与する。",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 355
@@ -5754,7 +5800,7 @@
     "image_url": "/static/images/cards/footwork.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "[gold]敏捷[/gold]3を得る。",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 125
@@ -5963,7 +6009,7 @@
     "image_url": "/static/images/cards/feeding_frenzy.webp",
     "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "ターン終了時まで[gold]筋力[/gold]7を得る。",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 532
@@ -8118,7 +8164,7 @@
     "image_url": "/static/images/cards/sucker_punch.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "10ダメージを与える。\n[gold]脱力[/gold]1を付与する。",
+    "upgrade_description": "10ダメージを与える。\n[gold]脱力[/gold]2を付与する。",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 164
@@ -8404,7 +8450,7 @@
   {
     "id": "DUAL_WIELD",
     "name": "二刀流",
-    "description": "アタックかパワーを1枚選ぶ。そのコピーを枚|1枚}[gold]手札[/gold]に加える。",
+    "description": "アタックかパワーを1枚選ぶ。そのコピーを1枚[gold]手札[/gold]に加える。",
     "description_raw": "アタックかパワーを1枚選ぶ。そのコピーを{IfUpgraded:show:{Cards}枚|1枚}[gold]手札[/gold]に加える。",
     "cost": 1,
     "is_x_cost": null,
@@ -8433,7 +8479,7 @@
     "image_url": "/static/images/cards/dual_wield.webp",
     "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
-    "upgrade_description": "アタックかパワーを1枚選ぶ。そのコピーを[Cards枚|1枚][gold]手札[/gold]に加える。",
+    "upgrade_description": "アタックかパワーを1枚選ぶ。そのコピーを2枚[gold]手札[/gold]に加える。",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 528
@@ -8769,7 +8815,7 @@
     "image_url": "/static/images/cards/fight_me.webp",
     "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
-    "upgrade_description": "6ダメージを2回与える。\n[gold]筋力[/gold]3を得る。\n敵は[gold]筋力[/gold]1を得る。",
+    "upgrade_description": "6ダメージを2回与える。\n[gold]筋力[/gold]4を得る。\n敵は[gold]筋力[/gold]1を得る。",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 35
@@ -11315,7 +11361,7 @@
     "image_url": "/static/images/cards/scourge.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]破滅[/gold]13を付与する。\nカードを2枚引く。",
+    "upgrade_description": "[gold]破滅[/gold]16を付与する。\nカードを2枚引く。",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 328
@@ -12382,7 +12428,7 @@
     "image_url": "/static/images/cards/bash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "10ダメージを与える。\n[gold]弱体[/gold]2を付与する。",
+    "upgrade_description": "10ダメージを与える。\n[gold]弱体[/gold]3を付与する。",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 5
@@ -13988,7 +14034,7 @@
     "image_url": "/static/images/cards/suppress.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "17ダメージを与える。\n[gold]脱力[/gold]3を付与する。",
+    "upgrade_description": "17ダメージを与える。\n[gold]脱力[/gold]5を付与する。",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "keywords_key": [
@@ -14074,7 +14120,7 @@
     "image_url": "/static/images/cards/taunt.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "8[gold]ブロック[/gold]を得る。\n[gold]弱体[/gold]1を付与する。",
+    "upgrade_description": "8[gold]ブロック[/gold]を得る。\n[gold]弱体[/gold]2を付与する。",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -14672,7 +14718,7 @@
     "image_url": "/static/images/cards/assassinate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "13ダメージを与える。\n[gold]弱体[/gold]1を付与する。",
+    "upgrade_description": "13ダメージを与える。\n[gold]弱体[/gold]2を付与する。",
     "type_key": "Attack",
     "rarity_key": "Rare",
     "keywords_key": [
@@ -14903,7 +14949,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "upgrade_description": "HPを13回復する。",
     "type_key": "Skill",
@@ -15152,7 +15198,7 @@
     "image_url": "/static/images/cards/anticipate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "ターン終了時まで[gold]敏捷[/gold]3を得る。",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 93
@@ -15241,7 +15287,7 @@
     "image_url": "/static/images/cards/prowess.webp",
     "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "[gold]筋力[/gold]2を得る。\n[gold]敏捷[/gold]2を得る。",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 481
@@ -15746,7 +15792,7 @@
     "image_url": "/static/images/cards/poisoned_stab.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "8ダメージを与える。\n[gold]毒[/gold]3を付与する。",
+    "upgrade_description": "8ダメージを与える。\n[gold]毒[/gold]4を付与する。",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 146
@@ -15836,7 +15882,7 @@
     "image_url": "/static/images/cards/haze.webp",
     "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "すべての敵に[gold]毒[/gold]6を付与する。",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "keywords_key": [
@@ -16624,7 +16670,7 @@
     "image_url": "/static/images/cards/neutralize.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "4ダメージを与える。\n[gold]脱力[/gold]1を付与する。",
+    "upgrade_description": "4ダメージを与える。\n[gold]脱力[/gold]2を付与する。",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 139
@@ -16861,7 +16907,7 @@
     "image_url": "/static/images/cards/brand.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "HPを1失う。\nカードを1枚[gold]廃棄[/gold]する。\n[gold]筋力[/gold]2を得る。",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 11
@@ -17468,7 +17514,7 @@
     "image_url": "/static/images/cards/fear.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "8ダメージを与える。\n[gold]弱体[/gold]1を付与する。",
+    "upgrade_description": "8ダメージを与える。\n[gold]弱体[/gold]2を付与する。",
     "type_key": "Attack",
     "rarity_key": "Common",
     "keywords_key": [
@@ -17847,7 +17893,7 @@
     "image_url": "/static/images/cards/go_for_the_eyes.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "4ダメージを与える。\n敵が攻撃を予定している場合、[gold]脱力[/gold]1を付与する。",
+    "upgrade_description": "4ダメージを与える。\n敵が攻撃を予定している場合、[gold]脱力[/gold]2を付与する。",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 389
@@ -17974,7 +18020,7 @@
     "image_url": "/static/images/cards/break.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "30ダメージを与える。\n[gold]弱体[/gold]5を付与する。",
+    "upgrade_description": "30ダメージを与える。\n[gold]弱体[/gold]7を付与する。",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "compendium_order": 12
@@ -18708,7 +18754,7 @@
     "image_url": "/static/images/cards/end_of_days.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "すべての敵に[gold]破滅[/gold]37を付与する。現在のHP以上の[gold]破滅[/gold]が蓄積している敵を即死させる。",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 290
@@ -19197,7 +19243,7 @@
     "image_url": "/static/images/cards/bulk_up.webp",
     "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "オーブスロットを1個失う。\n[gold]筋力[/gold]3を得る。\n[gold]敏捷[/gold]3を得る。",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 360
@@ -19429,7 +19475,7 @@
     "image_url": "/static/images/cards/deadly_poison.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "[gold]毒[/gold]7を付与する。",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 110
@@ -19983,7 +20029,7 @@
     "image_url": "/static/images/cards/snakebite.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "[gold]毒[/gold]10を付与する。",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -20185,7 +20231,7 @@
     "image_url": "/static/images/cards/rupture.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "自身のターンにHPを失うたび、[gold]筋力[/gold]2を得る。",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -20681,7 +20727,7 @@
     "image_url": "/static/images/cards/negative_pulse.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "6[gold]ブロック[/gold]を得る。\nすべての敵に[gold]破滅[/gold]7を付与する。",
+    "upgrade_description": "6[gold]ブロック[/gold]を得る。\nすべての敵に[gold]破滅[/gold]11を付与する。",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 310
@@ -21015,7 +21061,7 @@
     "image_url": "/static/images/cards/leg_sweep.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]脱力[/gold]2を付与する。\n14[gold]ブロック[/gold]を得る。",
+    "upgrade_description": "[gold]脱力[/gold]3を付与する。\n14[gold]ブロック[/gold]を得る。",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 133
@@ -21178,7 +21224,7 @@
     "image_url": "/static/images/cards/squash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "12ダメージを与える。\n[gold]弱体[/gold]2を付与する。",
+    "upgrade_description": "12ダメージを与える。\n[gold]弱体[/gold]3を付与する。",
     "type_key": "Attack",
     "rarity_key": "Event",
     "compendium_order": 543
@@ -21280,7 +21326,7 @@
     "image_url": "/static/images/cards/tremble.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "[gold]弱体[/gold]4を付与する。",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -21591,7 +21637,7 @@
     "image_url": "/static/images/cards/coordinate.webp",
     "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "ターン終了時まで、他のプレイヤー1人に[gold]筋力[/gold]8を付与する。",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 448

--- a/data/jpn/enchantments.json
+++ b/data/jpn/enchantments.json
@@ -33,6 +33,17 @@
     "image_url": "/static/images/enchantments/corrupted.webp"
   },
   {
+    "id": "FAVORED",
+    "name": "Favored",
+    "description": "",
+    "description_raw": null,
+    "extra_card_text": null,
+    "card_type": "Attack",
+    "applicable_to": null,
+    "is_stackable": false,
+    "image_url": "/static/images/enchantments/favored.webp"
+  },
+  {
     "id": "GLAM",
     "name": "魅惑",
     "description": "各戦闘につき1回、[gold]リプレイ[/gold]を得る。",

--- a/data/jpn/encounters.json
+++ b/data/jpn/encounters.json
@@ -1411,6 +1411,25 @@
     "loss_text": "[gold]泥棒バッタ[/gold]は[b]The Adventurer[/b]を強盗した。"
   },
   {
+    "id": "TOADPOLES_NORMAL",
+    "name": "Toadpoles Normal",
+    "room_type": "Monster",
+    "is_weak": false,
+    "act": null,
+    "tags": null,
+    "monsters": [
+      {
+        "id": "CALCIFIED_CULTIST",
+        "name": "石を纏った狂信者"
+      },
+      {
+        "id": "TOADPOLE",
+        "name": "ヒキジャクシ"
+      }
+    ],
+    "loss_text": null
+  },
+  {
     "id": "TOADPOLES_WEAK",
     "name": "ヒキジャクシ",
     "room_type": "Monster",

--- a/data/jpn/monsters.json
+++ b/data/jpn/monsters.json
@@ -481,13 +481,6 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": true
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "トンネリング",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -728,13 +721,6 @@
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
         "encounter_name": "パジャマパーティー",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "トンネリング",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -1077,8 +1063,8 @@
         "is_weak": false
       },
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "地下水路の生物",
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "地下ドックに生きるものたち",
         "room_type": "Monster",
         "act": "Underdocks",
         "is_weak": false
@@ -1296,6 +1282,13 @@
         "encounter_name": "オートマトンのコンビ",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
+        "is_weak": false
+      },
+      {
+        "encounter_id": "TUNNELER_NORMAL",
+        "encounter_name": "トンネリング",
+        "room_type": "Monster",
+        "act": null,
         "is_weak": false
       }
     ],
@@ -2019,6 +2012,99 @@
     },
     "image_url": "/static/images/monsters/devoted_sculptor.webp",
     "beta_image_url": null
+  },
+  {
+    "id": "DOOR",
+    "name": "ドア",
+    "type": "Normal",
+    "min_hp": 155,
+    "max_hp": null,
+    "min_hp_ascension": 165,
+    "max_hp_ascension": null,
+    "moves": [
+      {
+        "id": "DRAMATIC_OPEN",
+        "name": "Dramatic Open",
+        "intent": "Attack",
+        "damage": {
+          "normal": 25,
+          "ascension": 28
+        }
+      },
+      {
+        "id": "ENFORCE",
+        "name": "Enforce",
+        "intent": "Attack + Buff",
+        "powers": [
+          {
+            "power_id": "STRENGTH",
+            "target": "self",
+            "amount": 3
+          }
+        ],
+        "damage": {
+          "normal": 20
+        }
+      },
+      {
+        "id": "DOOR_SLAM",
+        "name": "Door Slam",
+        "intent": "Attack",
+        "damage": {
+          "normal": 15,
+          "ascension": 15,
+          "hit_count": 2
+        }
+      },
+      {
+        "id": "DEAD",
+        "name": "Dead",
+        "intent": "Unknown"
+      }
+    ],
+    "damage_values": {
+      "DramaticOpen": {
+        "normal": 25,
+        "ascension": 28
+      },
+      "DoorSlam": {
+        "normal": 15,
+        "ascension": 15,
+        "hit_count": 2
+      },
+      "Enforce": {
+        "normal": 20
+      }
+    },
+    "block_values": null,
+    "encounters": null,
+    "innate_powers": null,
+    "attack_pattern": {
+      "type": "cycle",
+      "initial_move": null,
+      "states": [
+        {
+          "id": "ENFORCE_MOVE",
+          "type": "move",
+          "move_id": "ENFORCE"
+        },
+        {
+          "id": "DOOR_SLAM_MOVE",
+          "type": "move",
+          "move_id": "DOOR_SLAM",
+          "next": "ENFORCE_MOVE"
+        },
+        {
+          "id": "DEAD_MOVE",
+          "type": "move",
+          "move_id": "DEAD",
+          "next": "DEAD_MOVE"
+        }
+      ],
+      "description": ""
+    },
+    "image_url": "/static/images/monsters/door.webp",
+    "beta_image_url": "/static/images/monsters/beta/door.webp"
   },
   {
     "id": "DOORMAKER",
@@ -6174,7 +6260,7 @@
     "encounters": [
       {
         "encounter_id": "PHROG_PARASITE_ELITE",
-        "encounter_name": "寄生カエル",
+        "encounter_name": "寄生キャエル",
         "room_type": "Elite",
         "act": "Act 1 - Overgrowth",
         "is_weak": false
@@ -6766,6 +6852,13 @@
     },
     "block_values": null,
     "encounters": [
+      {
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "地下ドックに生きるものたち",
+        "room_type": "Monster",
+        "act": "Underdocks",
+        "is_weak": false
+      },
       {
         "encounter_id": "SEAPUNK_WEAK",
         "encounter_name": "シーパンク",
@@ -9191,13 +9284,6 @@
     "block_values": null,
     "encounters": [
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "地下水路の生物",
-        "room_type": "Monster",
-        "act": "Underdocks",
-        "is_weak": false
-      },
-      {
         "encounter_id": "TOADPOLES_WEAK",
         "encounter_name": "ヒキジャクシ",
         "room_type": "Monster",
@@ -9564,7 +9650,7 @@
         "encounter_id": "TUNNELER_NORMAL",
         "encounter_name": "トンネリング",
         "room_type": "Monster",
-        "act": "Act 2 - Hive",
+        "act": null,
         "is_weak": false
       },
       {
@@ -10427,7 +10513,7 @@
       },
       {
         "encounter_id": "PHROG_PARASITE_ELITE",
-        "encounter_name": "寄生カエル",
+        "encounter_name": "寄生キャエル",
         "room_type": "Elite",
         "act": "Act 1 - Overgrowth",
         "is_weak": false

--- a/data/jpn/powers.json
+++ b/data/jpn/powers.json
@@ -170,6 +170,16 @@
     "image_url": "/static/images/powers/black_hole_power.webp"
   },
   {
+    "id": "BLADE_OF_INK",
+    "name": "BladeOfInkPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/blade_of_ink_power.webp"
+  },
+  {
     "id": "BLOCK_NEXT_TURN",
     "name": "次ターンブロック",
     "description": "次のターン開始時、[blue]4[/blue][gold]ブロック[/gold]を得る。",
@@ -610,6 +620,16 @@
     "image_url": "/static/images/powers/doom_power.webp"
   },
   {
+    "id": "DOOR_REVIVAL",
+    "name": "DoorRevivalPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Single",
+    "allow_negative": null,
+    "image_url": null
+  },
+  {
     "id": "DOUBLE_DAMAGE",
     "name": "ダメージ2倍",
     "description": "このターン、アタックは2倍のダメージを与える。",
@@ -948,6 +968,16 @@
     "stack_type": "Counter",
     "allow_negative": null,
     "image_url": "/static/images/powers/gigantification_power.webp"
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "GrapplePower",
+    "description": "",
+    "description_raw": null,
+    "type": "Debuff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/grapple_power.webp"
   },
   {
     "id": "GRASP",

--- a/data/kor/cards.json
+++ b/data/kor/cards.json
@@ -40,6 +40,52 @@
     "compendium_order": 384
   },
   {
+    "id": "GRAPPLE",
+    "name": "Grapple",
+    "description": "",
+    "description_raw": "",
+    "cost": 1,
+    "is_x_cost": null,
+    "is_x_star_cost": null,
+    "star_cost": null,
+    "type": "공격",
+    "rarity": "고급",
+    "target": "AnyEnemy",
+    "color": "unknown",
+    "damage": 7,
+    "block": null,
+    "hit_count": null,
+    "powers_applied": [
+      {
+        "power": "Grapple",
+        "amount": 5,
+        "power_key": "Grapple"
+      }
+    ],
+    "cards_draw": null,
+    "energy_gain": null,
+    "hp_loss": null,
+    "keywords": null,
+    "tags": null,
+    "spawns_cards": null,
+    "vars": {
+      "Damage": 7,
+      "GrapplePower": 5,
+      "Grapple": 5
+    },
+    "upgrade": {
+      "damage": "+2",
+      "grapplepower": "+2"
+    },
+    "image_url": "/static/images/cards/grapple.webp",
+    "beta_image_url": null,
+    "type_variants": null,
+    "upgrade_description": null,
+    "type_key": "Attack",
+    "rarity_key": "Uncommon",
+    "compendium_order": 576
+  },
+  {
     "id": "HELLO_WORLD",
     "name": "Hello World",
     "description": "내 턴 시작 시,\n무작위 일반 카드를 1장\n[gold]손[/gold]으로 가져옵니다.",
@@ -115,7 +161,7 @@
     "image_url": "/static/images/cards/null.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "피해를 13 줍니다.\n[gold]약화[/gold]를 2 부여합니다.\n[gold]암흑[/gold]을 1번 [gold]영창[/gold]합니다.",
+    "upgrade_description": "피해를 13 줍니다.\n[gold]약화[/gold]를 3 부여합니다.\n[gold]암흑[/gold]을 1번 [gold]영창[/gold]합니다.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 407
@@ -563,7 +609,7 @@
     "image_url": "/static/images/cards/bash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "피해를 10 줍니다.\n[gold]취약[/gold]을 2 부여합니다.",
+    "upgrade_description": "피해를 10 줍니다.\n[gold]취약[/gold]을 3 부여합니다.",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 5
@@ -1684,7 +1730,7 @@
     "image_url": "/static/images/cards/feeding_frenzy.webp",
     "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "이번 턴 동안\n[gold]힘[/gold]을 7 얻습니다.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 532
@@ -2966,7 +3012,7 @@
     "image_url": "/static/images/cards/prowess.webp",
     "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "[gold]힘[/gold]을 2 얻습니다.\n[gold]민첩[/gold]을 2 얻습니다.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 481
@@ -3400,7 +3446,7 @@
     "image_url": "/static/images/cards/brand.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "체력을 1 잃습니다.\n카드를 1장 [gold]소멸[/gold]시킵니다.\n[gold]힘[/gold]을 2 얻습니다.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 11
@@ -4003,7 +4049,7 @@
     "image_url": "/static/images/cards/go_for_the_eyes.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "피해를 4 줍니다.\n적이 공격할 의도가 있다면 [gold]약화[/gold]를 1 부여합니다.",
+    "upgrade_description": "피해를 4 줍니다.\n적이 공격할 의도가 있다면 [gold]약화[/gold]를 2 부여합니다.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 389
@@ -4131,7 +4177,7 @@
     "image_url": "/static/images/cards/leg_sweep.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]약화[/gold]를 2 부여합니다.\n[gold]방어도[/gold]를 14 얻습니다.",
+    "upgrade_description": "[gold]약화[/gold]를 3 부여합니다.\n[gold]방어도[/gold]를 14 얻습니다.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 133
@@ -4682,7 +4728,7 @@
     "image_url": "/static/images/cards/fight_me.webp",
     "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
-    "upgrade_description": "피해를 6만큼 2번 줍니다.\n[gold]힘[/gold]을 3 얻습니다.\n대상 적이 [gold]힘[/gold]을 1 얻습니다.",
+    "upgrade_description": "피해를 6만큼 2번 줍니다.\n[gold]힘[/gold]을 4 얻습니다.\n대상 적이 [gold]힘[/gold]을 1 얻습니다.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 35
@@ -4853,7 +4899,7 @@
     "image_url": "/static/images/cards/taunt.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]방어도[/gold]를 8 얻습니다.\n[gold]취약[/gold]을 1 부여합니다.",
+    "upgrade_description": "[gold]방어도[/gold]를 8 얻습니다.\n[gold]취약[/gold]을 2 부여합니다.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -5023,7 +5069,7 @@
     "image_url": "/static/images/cards/poisoned_stab.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "피해를 8 줍니다.\n[gold]중독[/gold]을 3 부여합니다.",
+    "upgrade_description": "피해를 8 줍니다.\n[gold]중독[/gold]을 4 부여합니다.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 146
@@ -5430,7 +5476,7 @@
     "image_url": "/static/images/cards/fear.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "피해를 8 줍니다.\n[gold]취약[/gold]을 1 부여합니다.",
+    "upgrade_description": "피해를 8 줍니다.\n[gold]취약[/gold]을 2 부여합니다.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "keywords_key": [
@@ -5693,7 +5739,7 @@
     "image_url": "/static/images/cards/tremble.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "[gold]취약[/gold]을 4 부여합니다.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -5824,7 +5870,7 @@
     "image_url": "/static/images/cards/beam_cell.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "피해를 4 줍니다.\n[gold]취약[/gold]을 1 부여합니다.",
+    "upgrade_description": "피해를 4 줍니다.\n[gold]취약[/gold]을 2 부여합니다.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 355
@@ -6106,7 +6152,7 @@
     "image_url": "/static/images/cards/oblivion.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "이번 턴에 카드를 사용할\n때마다, 대상 적에게\n[gold]종말[/gold]을 4 부여합니다.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 313
@@ -6337,7 +6383,7 @@
     "image_url": "/static/images/cards/deadly_poison.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "[gold]중독[/gold]을 7 부여합니다.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 110
@@ -6908,7 +6954,7 @@
     "image_url": "/static/images/cards/neutralize.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "피해를 4 줍니다.\n[gold]약화[/gold]를 1 부여합니다.",
+    "upgrade_description": "피해를 4 줍니다.\n[gold]약화[/gold]를 2 부여합니다.",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 139
@@ -7310,7 +7356,7 @@
     "image_url": "/static/images/cards/break.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "피해를 30 줍니다.\n[gold]취약[/gold]을 5 부여합니다.",
+    "upgrade_description": "피해를 30 줍니다.\n[gold]취약[/gold]을 7 부여합니다.",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "compendium_order": 12
@@ -7642,7 +7688,7 @@
     "image_url": "/static/images/cards/footwork.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "[gold]민첩[/gold]을 3 얻습니다.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 125
@@ -8057,7 +8103,7 @@
     "image_url": "/static/images/cards/snakebite.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "[gold]중독[/gold]을 10 부여합니다.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -9148,7 +9194,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "upgrade_description": "체력을 13 회복합니다.",
     "type_key": "Skill",
@@ -9433,7 +9479,7 @@
     "image_url": "/static/images/cards/sucker_punch.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "피해를 10 줍니다.\n[gold]약화[/gold]를 1 부여합니다.",
+    "upgrade_description": "피해를 10 줍니다.\n[gold]약화[/gold]를 2 부여합니다.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 164
@@ -9600,7 +9646,7 @@
     "image_url": "/static/images/cards/negative_pulse.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]방어도[/gold]를 6 얻습니다.\n모든 적에게\n[gold]종말[/gold]을 7 부여합니다.",
+    "upgrade_description": "[gold]방어도[/gold]를 6 얻습니다.\n모든 적에게\n[gold]종말[/gold]을 11 부여합니다.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 310
@@ -10419,7 +10465,7 @@
     "image_url": "/static/images/cards/setup_strike.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "피해를 9 줍니다.\n이번 턴 동안\n[gold]힘[/gold]을 2 얻습니다.",
+    "upgrade_description": "피해를 9 줍니다.\n이번 턴 동안\n[gold]힘[/gold]을 3 얻습니다.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 65
@@ -12051,7 +12097,7 @@
   {
     "id": "STACK",
     "name": "스택",
-    "description": "[gold]버린 카드 더미[/gold]에 있는\n카드의 수|}만큼\n[gold]방어도[/gold]를 얻습니다.",
+    "description": "[gold]버린 카드 더미[/gold]에 있는\n카드의 수만큼\n[gold]방어도[/gold]를 얻습니다.",
     "description_raw": "[gold]버린 카드 더미[/gold]에 있는\n카드의 수{IfUpgraded:show: +{CalculationBase}|}만큼\n[gold]방어도[/gold]를 얻습니다.{InCombat:\n([gold]방어도[/gold]를 {CalculatedBlock:diff()} 얻습니다)|}",
     "cost": 1,
     "is_x_cost": null,
@@ -12081,7 +12127,7 @@
     "image_url": "/static/images/cards/stack.webp",
     "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
-    "upgrade_description": "[gold]버린 카드 더미[/gold]에 있는\n카드의 수 +[CalculationBase|]만큼\n[gold]방어도[/gold]를 얻습니다.",
+    "upgrade_description": "[gold]버린 카드 더미[/gold]에 있는\n카드의 수 +3만큼\n[gold]방어도[/gold]를 얻습니다.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 544
@@ -12547,7 +12593,7 @@
     "image_url": "/static/images/cards/haze.webp",
     "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "모든 적에게\n[gold]중독[/gold]을 6 부여합니다.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "keywords_key": [
@@ -12892,7 +12938,7 @@
     "image_url": "/static/images/cards/assassinate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "피해를 13 줍니다.\n[gold]취약[/gold]을 1 부여합니다.",
+    "upgrade_description": "피해를 13 줍니다.\n[gold]취약[/gold]을 2 부여합니다.",
     "type_key": "Attack",
     "rarity_key": "Rare",
     "keywords_key": [
@@ -14078,7 +14124,7 @@
     "image_url": "/static/images/cards/anticipate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "이번 턴 동안\n[gold]민첩[/gold]을 3 얻습니다.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 93
@@ -15206,7 +15252,7 @@
   {
     "id": "DUAL_WIELD",
     "name": "이도류",
-    "description": "공격이나 파워 카드를\n1장 선택합니다.\n그 카드의 복사본을 장|1장}\n[gold]손[/gold]으로 가져옵니다.",
+    "description": "공격이나 파워 카드를\n1장 선택합니다.\n그 카드의 복사본을 1장\n[gold]손[/gold]으로 가져옵니다.",
     "description_raw": "공격이나 파워 카드를\n1장 선택합니다.\n그 카드의 복사본을 {IfUpgraded:show:{Cards}장|1장}\n[gold]손[/gold]으로 가져옵니다.",
     "cost": 1,
     "is_x_cost": null,
@@ -15235,7 +15281,7 @@
     "image_url": "/static/images/cards/dual_wield.webp",
     "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
-    "upgrade_description": "공격이나 파워 카드를\n1장 선택합니다.\n그 카드의 복사본을 [Cards장|1장]\n[gold]손[/gold]으로 가져옵니다.",
+    "upgrade_description": "공격이나 파워 카드를\n1장 선택합니다.\n그 카드의 복사본을 2장\n[gold]손[/gold]으로 가져옵니다.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 528
@@ -17397,7 +17443,7 @@
     "image_url": "/static/images/cards/end_of_days.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "모든 적에게\n[gold]종말[/gold]을 37 부여합니다.\n체력이 [gold]종말[/gold] 이하인\n적을 처치합니다.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 290
@@ -17570,7 +17616,7 @@
     "image_url": "/static/images/cards/deathbringer.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "모든 적에게 [gold]종말[/gold]을 26,\n[gold]약화[/gold]를 1 부여합니다.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 276
@@ -17954,7 +18000,7 @@
     "image_url": "/static/images/cards/bulk_up.webp",
     "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "구체 슬롯을 1개 잃습니다.\n[gold]힘[/gold]을 3 얻습니다.\n[gold]민첩[/gold]을 3 얻습니다.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 360
@@ -18197,7 +18243,7 @@
     "image_url": "/static/images/cards/suppress.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "피해를 17 줍니다.\n[gold]약화[/gold]를 3 부여합니다.",
+    "upgrade_description": "피해를 17 줍니다.\n[gold]약화[/gold]를 5 부여합니다.",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "keywords_key": [
@@ -18400,7 +18446,7 @@
     "image_url": "/static/images/cards/squash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "피해를 12 줍니다.\n[gold]취약[/gold]을 2 부여합니다.",
+    "upgrade_description": "피해를 12 줍니다.\n[gold]취약[/gold]을 3 부여합니다.",
     "type_key": "Attack",
     "rarity_key": "Event",
     "compendium_order": 543
@@ -18483,7 +18529,7 @@
     "image_url": "/static/images/cards/scourge.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]종말[/gold]을 13 부여합니다.\n카드를 2장 뽑습니다.",
+    "upgrade_description": "[gold]종말[/gold]을 16 부여합니다.\n카드를 2장 뽑습니다.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 328
@@ -18603,7 +18649,7 @@
     "image_url": "/static/images/cards/bubble_bubble.webp",
     "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "대상 적이 [gold]중독[/gold]을\n보유하고 있다면,\n[gold]중독[/gold]을 12 부여합니다.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 101
@@ -20887,7 +20933,7 @@
     "image_url": "/static/images/cards/rupture.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "내 턴 동안 체력을 잃을\n때마다, [gold]힘[/gold]을 2 얻습니다.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -22048,7 +22094,7 @@
     "image_url": "/static/images/cards/high_five.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]골골이[/gold]가 모든 적에게\n피해를 13 주고\n[gold]취약[/gold]을 2 부여합니다.",
+    "upgrade_description": "[gold]골골이[/gold]가 모든 적에게\n피해를 13 주고\n[gold]취약[/gold]을 3 부여합니다.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 303
@@ -22406,7 +22452,7 @@
     "image_url": "/static/images/cards/coordinate.webp",
     "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "이번 턴 동안\n다른 플레이어에게\n[gold]힘[/gold]을 8 줍니다.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 448

--- a/data/kor/enchantments.json
+++ b/data/kor/enchantments.json
@@ -33,6 +33,17 @@
     "image_url": "/static/images/enchantments/corrupted.webp"
   },
   {
+    "id": "FAVORED",
+    "name": "Favored",
+    "description": "",
+    "description_raw": null,
+    "extra_card_text": null,
+    "card_type": "Attack",
+    "applicable_to": null,
+    "is_stackable": false,
+    "image_url": "/static/images/enchantments/favored.webp"
+  },
+  {
     "id": "GLAM",
     "name": "호화",
     "description": "이 카드는 전투당 한 번 [gold]재사용[/gold]을 보유합니다.",

--- a/data/kor/encounters.json
+++ b/data/kor/encounters.json
@@ -1411,6 +1411,25 @@
     "loss_text": "[gold]폴짝이 도적[/gold]은 [b]The Adventurer[/b]를 털어먹었습니다."
   },
   {
+    "id": "TOADPOLES_NORMAL",
+    "name": "Toadpoles Normal",
+    "room_type": "Monster",
+    "is_weak": false,
+    "act": null,
+    "tags": null,
+    "monsters": [
+      {
+        "id": "CALCIFIED_CULTIST",
+        "name": "석회화된 광신자"
+      },
+      {
+        "id": "TOADPOLE",
+        "name": "올챙이"
+      }
+    ],
+    "loss_text": null
+  },
+  {
     "id": "TOADPOLES_WEAK",
     "name": "올챙이들",
     "room_type": "Monster",

--- a/data/kor/monsters.json
+++ b/data/kor/monsters.json
@@ -481,13 +481,6 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": true
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "땅굴 2인조",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -728,13 +721,6 @@
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
         "encounter_name": "잠자리 파티",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "땅굴 2인조",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -1077,7 +1063,7 @@
         "is_weak": false
       },
       {
-        "encounter_id": "TOADPOLES_NORMAL",
+        "encounter_id": "SEAPUNK_NORMAL",
         "encounter_name": "지하 선착장 야생동물",
         "room_type": "Monster",
         "act": "Underdocks",
@@ -1296,6 +1282,13 @@
         "encounter_name": "자동인형 한 쌍",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
+        "is_weak": false
+      },
+      {
+        "encounter_id": "TUNNELER_NORMAL",
+        "encounter_name": "땅굴 2인조",
+        "room_type": "Monster",
+        "act": null,
         "is_weak": false
       }
     ],
@@ -2019,6 +2012,99 @@
     },
     "image_url": "/static/images/monsters/devoted_sculptor.webp",
     "beta_image_url": null
+  },
+  {
+    "id": "DOOR",
+    "name": "문",
+    "type": "Normal",
+    "min_hp": 155,
+    "max_hp": null,
+    "min_hp_ascension": 165,
+    "max_hp_ascension": null,
+    "moves": [
+      {
+        "id": "DRAMATIC_OPEN",
+        "name": "Dramatic Open",
+        "intent": "Attack",
+        "damage": {
+          "normal": 25,
+          "ascension": 28
+        }
+      },
+      {
+        "id": "ENFORCE",
+        "name": "Enforce",
+        "intent": "Attack + Buff",
+        "powers": [
+          {
+            "power_id": "STRENGTH",
+            "target": "self",
+            "amount": 3
+          }
+        ],
+        "damage": {
+          "normal": 20
+        }
+      },
+      {
+        "id": "DOOR_SLAM",
+        "name": "Door Slam",
+        "intent": "Attack",
+        "damage": {
+          "normal": 15,
+          "ascension": 15,
+          "hit_count": 2
+        }
+      },
+      {
+        "id": "DEAD",
+        "name": "Dead",
+        "intent": "Unknown"
+      }
+    ],
+    "damage_values": {
+      "DramaticOpen": {
+        "normal": 25,
+        "ascension": 28
+      },
+      "DoorSlam": {
+        "normal": 15,
+        "ascension": 15,
+        "hit_count": 2
+      },
+      "Enforce": {
+        "normal": 20
+      }
+    },
+    "block_values": null,
+    "encounters": null,
+    "innate_powers": null,
+    "attack_pattern": {
+      "type": "cycle",
+      "initial_move": null,
+      "states": [
+        {
+          "id": "ENFORCE_MOVE",
+          "type": "move",
+          "move_id": "ENFORCE"
+        },
+        {
+          "id": "DOOR_SLAM_MOVE",
+          "type": "move",
+          "move_id": "DOOR_SLAM",
+          "next": "ENFORCE_MOVE"
+        },
+        {
+          "id": "DEAD_MOVE",
+          "type": "move",
+          "move_id": "DEAD",
+          "next": "DEAD_MOVE"
+        }
+      ],
+      "description": ""
+    },
+    "image_url": "/static/images/monsters/door.webp",
+    "beta_image_url": "/static/images/monsters/beta/door.webp"
   },
   {
     "id": "DOORMAKER",
@@ -6767,6 +6853,13 @@
     "block_values": null,
     "encounters": [
       {
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "지하 선착장 야생동물",
+        "room_type": "Monster",
+        "act": "Underdocks",
+        "is_weak": false
+      },
+      {
         "encounter_id": "SEAPUNK_WEAK",
         "encounter_name": "불량 해초",
         "room_type": "Monster",
@@ -9191,13 +9284,6 @@
     "block_values": null,
     "encounters": [
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "지하 선착장 야생동물",
-        "room_type": "Monster",
-        "act": "Underdocks",
-        "is_weak": false
-      },
-      {
         "encounter_id": "TOADPOLES_WEAK",
         "encounter_name": "올챙이들",
         "room_type": "Monster",
@@ -9564,7 +9650,7 @@
         "encounter_id": "TUNNELER_NORMAL",
         "encounter_name": "땅굴 2인조",
         "room_type": "Monster",
-        "act": "Act 2 - Hive",
+        "act": null,
         "is_weak": false
       },
       {

--- a/data/kor/powers.json
+++ b/data/kor/powers.json
@@ -170,6 +170,16 @@
     "image_url": "/static/images/powers/black_hole_power.webp"
   },
   {
+    "id": "BLADE_OF_INK",
+    "name": "BladeOfInkPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/blade_of_ink_power.webp"
+  },
+  {
     "id": "BLOCK_NEXT_TURN",
     "name": "다음 턴 방어도",
     "description": "다음 턴 시작 시, [gold]방어도[/gold]를 [blue]4[/blue] 얻습니다.",
@@ -610,6 +620,16 @@
     "image_url": "/static/images/powers/doom_power.webp"
   },
   {
+    "id": "DOOR_REVIVAL",
+    "name": "DoorRevivalPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Single",
+    "allow_negative": null,
+    "image_url": null
+  },
+  {
     "id": "DOUBLE_DAMAGE",
     "name": "2배의 피해",
     "description": "이번 턴에 가하는 공격의 피해량이 2배가 됩니다.",
@@ -948,6 +968,16 @@
     "stack_type": "Counter",
     "allow_negative": null,
     "image_url": "/static/images/powers/gigantification_power.webp"
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "GrapplePower",
+    "description": "",
+    "description_raw": null,
+    "type": "Debuff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/grapple_power.webp"
   },
   {
     "id": "GRASP",

--- a/data/pol/cards.json
+++ b/data/pol/cards.json
@@ -743,7 +743,7 @@
     "image_url": "/static/images/cards/bubble_bubble.webp",
     "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Jeżeli przeciwnik ma [gold]Truciznę[/gold], nałóż 12 pkt. [gold]Trucizny[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 101
@@ -826,7 +826,7 @@
     "image_url": "/static/images/cards/sucker_punch.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zadaj 10 pkt. obrażeń.\nNałóż 1 pkt. [gold]Słabości[/gold].",
+    "upgrade_description": "Zadaj 10 pkt. obrażeń.\nNałóż 2 pkt. [gold]Słabości[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 164
@@ -1732,7 +1732,7 @@
     "image_url": "/static/images/cards/go_for_the_eyes.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zadaj 4 pkt. obrażeń.\nJeżeli przeciwnik zamierza zaatakować, nałóż 1 pkt. [gold]Słabości[/gold].",
+    "upgrade_description": "Zadaj 4 pkt. obrażeń.\nJeżeli przeciwnik zamierza zaatakować, nałóż 2 pkt. [gold]Słabości[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 389
@@ -1975,7 +1975,7 @@
     "image_url": "/static/images/cards/scourge.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Nałóż 13 pkt. [gold]Zagłady[/gold].\nDobierz 2 karty|kart.",
+    "upgrade_description": "Nałóż 16 pkt. [gold]Zagłady[/gold].\nDobierz 2 karty|kart.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 328
@@ -4220,6 +4220,52 @@
     "compendium_order": 57
   },
   {
+    "id": "GRAPPLE",
+    "name": "Grapple",
+    "description": "",
+    "description_raw": "",
+    "cost": 1,
+    "is_x_cost": null,
+    "is_x_star_cost": null,
+    "star_cost": null,
+    "type": "Atak",
+    "rarity": "Niepospolita",
+    "target": "AnyEnemy",
+    "color": "unknown",
+    "damage": 7,
+    "block": null,
+    "hit_count": null,
+    "powers_applied": [
+      {
+        "power": "Grapple",
+        "amount": 5,
+        "power_key": "Grapple"
+      }
+    ],
+    "cards_draw": null,
+    "energy_gain": null,
+    "hp_loss": null,
+    "keywords": null,
+    "tags": null,
+    "spawns_cards": null,
+    "vars": {
+      "Damage": 7,
+      "GrapplePower": 5,
+      "Grapple": 5
+    },
+    "upgrade": {
+      "damage": "+2",
+      "grapplepower": "+2"
+    },
+    "image_url": "/static/images/cards/grapple.webp",
+    "beta_image_url": null,
+    "type_variants": null,
+    "upgrade_description": null,
+    "type_key": "Attack",
+    "rarity_key": "Uncommon",
+    "compendium_order": 576
+  },
+  {
     "id": "GATHER_LIGHT",
     "name": "Gromadzenie światła",
     "description": "Zyskaj 8 pkt. [gold]Bloku[/gold].\nZyskaj [star:1].",
@@ -4460,7 +4506,7 @@
     "image_url": "/static/images/cards/bash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zadaj 10 pkt. obrażeń.\nNałóż 2 pkt. [gold]Wrażliwości[/gold].",
+    "upgrade_description": "Zadaj 10 pkt. obrażeń.\nNałóż 3 pkt. [gold]Wrażliwości[/gold].",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 5
@@ -5389,7 +5435,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "upgrade_description": "Przywróć 13 PŻ.",
     "type_key": "Skill",
@@ -6243,7 +6289,7 @@
     "image_url": "/static/images/cards/coordinate.webp",
     "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Daj innemu graczowi 8 pkt. [gold]Siły[/gold] w tej turze.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 448
@@ -6449,7 +6495,7 @@
     "image_url": "/static/images/cards/end_of_days.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Nałóż 37 pkt. [gold]Zagłady[/gold] na WSZYSTKICH przeciwników.\nZabij przeciwników, których pkt. [gold]Zagłady[/gold] są równe ich PŻ lub większe.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 290
@@ -7364,7 +7410,7 @@
     "image_url": "/static/images/cards/rupture.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Kiedykolwiek utracisz PŻ podczas swojej tury, zyskaj 2 pkt. [gold]Siły[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -8086,7 +8132,7 @@
     "image_url": "/static/images/cards/fight_me.webp",
     "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
-    "upgrade_description": "Zadaj 6 pkt. obrażeń dwukrotnie.\nZyskaj 3 pkt. [gold]Siły[/gold].\nPrzeciwnik otrzymuje 1 pkt. [gold]Siły[/gold].",
+    "upgrade_description": "Zadaj 6 pkt. obrażeń dwukrotnie.\nZyskaj 4 pkt. [gold]Siły[/gold].\nPrzeciwnik otrzymuje 1 pkt. [gold]Siły[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 35
@@ -8241,7 +8287,7 @@
     "image_url": "/static/images/cards/neutralize.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zadaj 4 pkt. obrażeń.\nNałóż 1 pkt. [gold]Słabości[/gold].",
+    "upgrade_description": "Zadaj 4 pkt. obrażeń.\nNałóż 2 pkt. [gold]Słabości[/gold].",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 139
@@ -8807,7 +8853,7 @@
     "image_url": "/static/images/cards/null.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zadaj 13 pkt. obrażeń.\nNałóż 2 pkt. [gold]Słabości[/gold].\n[gold]Załaduj[/gold] 1 [gold]Sferę Ciemności[/gold].",
+    "upgrade_description": "Zadaj 13 pkt. obrażeń.\nNałóż 3 pkt. [gold]Słabości[/gold].\n[gold]Załaduj[/gold] 1 [gold]Sferę Ciemności[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 407
@@ -9285,7 +9331,7 @@
   {
     "id": "DUAL_WIELD",
     "name": "Oburęczność",
-    "description": "Wybierz Atak lub Moc. Dodaj  kopie|kopię} tej karty do [gold]ręki[/gold].",
+    "description": "Wybierz Atak lub Moc. Dodaj kopię tej karty do [gold]ręki[/gold].",
     "description_raw": "Wybierz Atak lub Moc. Dodaj {IfUpgraded:show:{Cards} kopie|kopię} tej karty do [gold]ręki[/gold].",
     "cost": 1,
     "is_x_cost": null,
@@ -9314,7 +9360,7 @@
     "image_url": "/static/images/cards/dual_wield.webp",
     "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
-    "upgrade_description": "Wybierz Atak lub Moc. Dodaj [Cards kopie|kopię] tej karty do [gold]ręki[/gold].",
+    "upgrade_description": "Wybierz Atak lub Moc. Dodaj 2 kopie tej karty do [gold]ręki[/gold].",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 528
@@ -9962,7 +10008,7 @@
     "image_url": "/static/images/cards/beam_cell.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zadaj 4 pkt. obrażeń.\nNałóż 1 pkt. [gold]Wrażliwości[/gold].",
+    "upgrade_description": "Zadaj 4 pkt. obrażeń.\nNałóż 2 pkt. [gold]Wrażliwości[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 355
@@ -10933,7 +10979,7 @@
     "image_url": "/static/images/cards/setup_strike.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zadaj 9 pkt. obrażeń.\nZyskaj 2 pkt. [gold]Siły[/gold] w tej turze.",
+    "upgrade_description": "Zadaj 9 pkt. obrażeń.\nZyskaj 3 pkt. [gold]Siły[/gold] w tej turze.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 65
@@ -11152,7 +11198,7 @@
     "image_url": "/static/images/cards/high_five.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]Kostek[/gold] zadaje 13 pkt. obrażeń\ni nakłada 2 pkt. [gold]Wrażliwości[/gold]\nna WSZYSTKICH przeciwników.",
+    "upgrade_description": "[gold]Kostek[/gold] zadaje 13 pkt. obrażeń\ni nakłada 3 pkt. [gold]Wrażliwości[/gold]\nna WSZYSTKICH przeciwników.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 303
@@ -11464,7 +11510,7 @@
     "image_url": "/static/images/cards/leg_sweep.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Nałóż 2 pkt. [gold]Słabości[/gold].\nZyskaj 14 pkt. [gold]Bloku[/gold].",
+    "upgrade_description": "Nałóż 3 pkt. [gold]Słabości[/gold].\nZyskaj 14 pkt. [gold]Bloku[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 133
@@ -11940,7 +11986,7 @@
     "image_url": "/static/images/cards/suppress.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zadaj 17 pkt. obrażeń.\nNałóż 3 pkt. [gold]Słabości[/gold].",
+    "upgrade_description": "Zadaj 17 pkt. obrażeń.\nNałóż 5 pkt. [gold]Słabości[/gold].",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "keywords_key": [
@@ -12400,7 +12446,7 @@
     "image_url": "/static/images/cards/footwork.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Zyskaj 3 pkt. [gold]Zręczności[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 125
@@ -12836,7 +12882,7 @@
     "image_url": "/static/images/cards/taunt.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zyskaj 8 pkt. [gold]Bloku[/gold].\nNałóż 1 pkt. [gold]Wrażliwości[/gold].",
+    "upgrade_description": "Zyskaj 8 pkt. [gold]Bloku[/gold].\nNałóż 2 pkt. [gold]Wrażliwości[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -13188,7 +13234,7 @@
     "image_url": "/static/images/cards/tremble.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Nałóż 4 pkt. [gold]Wrażliwości[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -13427,7 +13473,7 @@
     "image_url": "/static/images/cards/anticipate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Zyskaj 3 pkt. [gold]Zręczności[/gold] w tej turze.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 93
@@ -13678,7 +13724,7 @@
     "image_url": "/static/images/cards/bulk_up.webp",
     "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Utrać 1 miejsce na Sferę.\nZyskaj 3 pkt. [gold]Siły[/gold].\nZyskaj 3 pkt. [gold]Zręczności[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 360
@@ -16171,7 +16217,7 @@
     "image_url": "/static/images/cards/prowess.webp",
     "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Zyskaj 2 pkt. [gold]Siły[/gold].\nZyskaj 2 pkt. [gold]Zręczności[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 481
@@ -16256,7 +16302,7 @@
   {
     "id": "STACK",
     "name": "Stos",
-    "description": "Zyskaj [gold]Blok[/gold] równy liczbie kart na [gold]stosie kart odrzuconych[/gold] pkt.|}.",
+    "description": "Zyskaj [gold]Blok[/gold] równy liczbie kart na [gold]stosie kart odrzuconych[/gold].",
     "description_raw": "Zyskaj [gold]Blok[/gold] równy liczbie kart na [gold]stosie kart odrzuconych[/gold]{IfUpgraded:show: +{CalculationBase} pkt.|}.{InCombat:\n(Zyskaj {CalculatedBlock:diff()} pkt. [gold]Bloku[/gold])|}",
     "cost": 1,
     "is_x_cost": null,
@@ -16286,7 +16332,7 @@
     "image_url": "/static/images/cards/stack.webp",
     "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
-    "upgrade_description": "Zyskaj [gold]Blok[/gold] równy liczbie kart na [gold]stosie kart odrzuconych[/gold] +[CalculationBase pkt.|].",
+    "upgrade_description": "Zyskaj [gold]Blok[/gold] równy liczbie kart na [gold]stosie kart odrzuconych[/gold] +3 pkt..",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 544
@@ -16334,7 +16380,7 @@
     "image_url": "/static/images/cards/fear.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zadaj 8 pkt. obrażeń.\nNałóż 1 pkt. [gold]Wrażliwości[/gold].",
+    "upgrade_description": "Zadaj 8 pkt. obrażeń.\nNałóż 2 pkt. [gold]Wrażliwości[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "keywords_key": [
@@ -17511,7 +17557,7 @@
     "image_url": "/static/images/cards/haze.webp",
     "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Nałóż 6 pkt. [gold]Trucizny[/gold] na WSZYSTKICH przeciwników.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "keywords_key": [
@@ -18061,7 +18107,7 @@
     "image_url": "/static/images/cards/feeding_frenzy.webp",
     "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Zyskaj 7 pkt. [gold]Siły[/gold] w tej turze.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 532
@@ -18594,7 +18640,7 @@
     "image_url": "/static/images/cards/negative_pulse.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zyskaj 6 pkt. [gold]Bloku[/gold].\nNałóż 7 pkt. [gold]Zagłady[/gold] na WSZYSTKICH przeciwników.",
+    "upgrade_description": "Zyskaj 6 pkt. [gold]Bloku[/gold].\nNałóż 11 pkt. [gold]Zagłady[/gold] na WSZYSTKICH przeciwników.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 310
@@ -18758,7 +18804,7 @@
     "image_url": "/static/images/cards/snakebite.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Nałóż 10 pkt. [gold]Trucizny[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -20259,7 +20305,7 @@
     "image_url": "/static/images/cards/oblivion.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Kiedykolwiek zagrasz kartę w tej turze, nałóż 4 pkt. [gold]Zagłady[/gold] na przeciwnika.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 313
@@ -20304,7 +20350,7 @@
     "image_url": "/static/images/cards/brand.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Utrać 1 PŻ.\n[gold]Wyczerp[/gold] 1 kartę.\nZyskaj 2 pkt. [gold]Siły[/gold].",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 11
@@ -20626,7 +20672,7 @@
     "image_url": "/static/images/cards/deadly_poison.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Nałóż 7 pkt. [gold]Trucizny[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 110
@@ -20675,7 +20721,7 @@
     "image_url": "/static/images/cards/assassinate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zadaj 13 pkt. obrażeń.\nNałóż 1 pkt. [gold]Wrażliwości[/gold].",
+    "upgrade_description": "Zadaj 13 pkt. obrażeń.\nNałóż 2 pkt. [gold]Wrażliwości[/gold].",
     "type_key": "Attack",
     "rarity_key": "Rare",
     "keywords_key": [
@@ -21156,7 +21202,7 @@
     "image_url": "/static/images/cards/poisoned_stab.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zadaj 8 pkt. obrażeń.\nNałóż 3 pkt. [gold]Trucizny[/gold].",
+    "upgrade_description": "Zadaj 8 pkt. obrażeń.\nNałóż 4 pkt. [gold]Trucizny[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 146
@@ -21508,7 +21554,7 @@
     "image_url": "/static/images/cards/squash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zadaj 12 pkt. obrażeń.\nNałóż 2 pkt. [gold]Wrażliwości[/gold].",
+    "upgrade_description": "Zadaj 12 pkt. obrażeń.\nNałóż 3 pkt. [gold]Wrażliwości[/gold].",
     "type_key": "Attack",
     "rarity_key": "Event",
     "compendium_order": 543
@@ -22122,7 +22168,7 @@
     "image_url": "/static/images/cards/deathbringer.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Nałóż 26 pkt. [gold]Zagłady[/gold] i 1 pkt. [gold]Słabości[/gold] na WSZYSTKICH przeciwników.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 276
@@ -22293,7 +22339,7 @@
     "image_url": "/static/images/cards/break.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zadaj 30 pkt. obrażeń.\nNałóż 5 pkt. [gold]Wrażliwości[/gold].",
+    "upgrade_description": "Zadaj 30 pkt. obrażeń.\nNałóż 7 pkt. [gold]Wrażliwości[/gold].",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "compendium_order": 12

--- a/data/pol/enchantments.json
+++ b/data/pol/enchantments.json
@@ -33,6 +33,17 @@
     "image_url": "/static/images/enchantments/corrupted.webp"
   },
   {
+    "id": "FAVORED",
+    "name": "Favored",
+    "description": "",
+    "description_raw": null,
+    "extra_card_text": null,
+    "card_type": "Attack",
+    "applicable_to": null,
+    "is_stackable": false,
+    "image_url": "/static/images/enchantments/favored.webp"
+  },
+  {
     "id": "GLAM",
     "name": "Dwakroć",
     "description": "Karta otrzymuje [gold]Powtórkę[/gold] raz na walkę.",

--- a/data/pol/encounters.json
+++ b/data/pol/encounters.json
@@ -1411,6 +1411,25 @@
     "loss_text": "[gold]Złodziejski Skoczek[/gold] napadł na {characterObject}."
   },
   {
+    "id": "TOADPOLES_NORMAL",
+    "name": "Toadpoles Normal",
+    "room_type": "Monster",
+    "is_weak": false,
+    "act": null,
+    "tags": null,
+    "monsters": [
+      {
+        "id": "CALCIFIED_CULTIST",
+        "name": "Zwapniały Kultysta"
+      },
+      {
+        "id": "TOADPOLE",
+        "name": "Kijanka"
+      }
+    ],
+    "loss_text": null
+  },
+  {
     "id": "TOADPOLES_WEAK",
     "name": "Kijanki",
     "room_type": "Monster",

--- a/data/pol/monsters.json
+++ b/data/pol/monsters.json
@@ -481,13 +481,6 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": true
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Tunelowy duet",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -728,13 +721,6 @@
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
         "encounter_name": "Pidżama Party",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Tunelowy duet",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -1077,7 +1063,7 @@
         "is_weak": false
       },
       {
-        "encounter_id": "TOADPOLES_NORMAL",
+        "encounter_id": "SEAPUNK_NORMAL",
         "encounter_name": "Kijanki",
         "room_type": "Monster",
         "act": "Underdocks",
@@ -1203,7 +1189,7 @@
     "encounters": [
       {
         "encounter_id": "CEREMONIAL_BEAST_BOSS",
-        "encounter_name": "Leśnym Stróżem",
+        "encounter_name": "Leśny Stróż",
         "room_type": "Boss",
         "act": "Act 1 - Overgrowth",
         "is_weak": false
@@ -1296,6 +1282,13 @@
         "encounter_name": "Para automatonów",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
+        "is_weak": false
+      },
+      {
+        "encounter_id": "TUNNELER_NORMAL",
+        "encounter_name": "Tunelowy duet",
+        "room_type": "Monster",
+        "act": null,
         "is_weak": false
       }
     ],
@@ -1579,7 +1572,7 @@
     "encounters": [
       {
         "encounter_id": "KAISER_CRAB_BOSS",
-        "encounter_name": "Krabem Cesarskim",
+        "encounter_name": "Krab Cesarski",
         "room_type": "Boss",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -2021,6 +2014,99 @@
     "beta_image_url": null
   },
   {
+    "id": "DOOR",
+    "name": "Portal",
+    "type": "Normal",
+    "min_hp": 155,
+    "max_hp": null,
+    "min_hp_ascension": 165,
+    "max_hp_ascension": null,
+    "moves": [
+      {
+        "id": "DRAMATIC_OPEN",
+        "name": "Dramatic Open",
+        "intent": "Attack",
+        "damage": {
+          "normal": 25,
+          "ascension": 28
+        }
+      },
+      {
+        "id": "ENFORCE",
+        "name": "Enforce",
+        "intent": "Attack + Buff",
+        "powers": [
+          {
+            "power_id": "STRENGTH",
+            "target": "self",
+            "amount": 3
+          }
+        ],
+        "damage": {
+          "normal": 20
+        }
+      },
+      {
+        "id": "DOOR_SLAM",
+        "name": "Door Slam",
+        "intent": "Attack",
+        "damage": {
+          "normal": 15,
+          "ascension": 15,
+          "hit_count": 2
+        }
+      },
+      {
+        "id": "DEAD",
+        "name": "Dead",
+        "intent": "Unknown"
+      }
+    ],
+    "damage_values": {
+      "DramaticOpen": {
+        "normal": 25,
+        "ascension": 28
+      },
+      "DoorSlam": {
+        "normal": 15,
+        "ascension": 15,
+        "hit_count": 2
+      },
+      "Enforce": {
+        "normal": 20
+      }
+    },
+    "block_values": null,
+    "encounters": null,
+    "innate_powers": null,
+    "attack_pattern": {
+      "type": "cycle",
+      "initial_move": null,
+      "states": [
+        {
+          "id": "ENFORCE_MOVE",
+          "type": "move",
+          "move_id": "ENFORCE"
+        },
+        {
+          "id": "DOOR_SLAM_MOVE",
+          "type": "move",
+          "move_id": "DOOR_SLAM",
+          "next": "ENFORCE_MOVE"
+        },
+        {
+          "id": "DEAD_MOVE",
+          "type": "move",
+          "move_id": "DEAD",
+          "next": "DEAD_MOVE"
+        }
+      ],
+      "description": ""
+    },
+    "image_url": "/static/images/monsters/door.webp",
+    "beta_image_url": "/static/images/monsters/beta/door.webp"
+  },
+  {
     "id": "DOORMAKER",
     "name": "Tytan Pustki",
     "type": "Boss",
@@ -2089,7 +2175,7 @@
     "encounters": [
       {
         "encounter_id": "DOORMAKER_BOSS",
-        "encounter_name": "Drzwiarzem",
+        "encounter_name": "Tytan Pustki",
         "room_type": "Boss",
         "act": "Act 3 - Glory",
         "is_weak": false
@@ -4193,7 +4279,7 @@
     "encounters": [
       {
         "encounter_id": "THE_KIN_BOSS",
-        "encounter_name": "Kapłanem",
+        "encounter_name": "Kapłan",
         "room_type": "Boss",
         "act": "Act 1 - Overgrowth",
         "is_weak": false
@@ -4311,7 +4397,7 @@
     "encounters": [
       {
         "encounter_id": "THE_KIN_BOSS",
-        "encounter_name": "Kapłanem",
+        "encounter_name": "Kapłan",
         "room_type": "Boss",
         "act": "Act 1 - Overgrowth",
         "is_weak": false
@@ -4422,7 +4508,7 @@
     "encounters": [
       {
         "encounter_id": "KNOWLEDGE_DEMON_BOSS",
-        "encounter_name": "Demonem Wiedzy",
+        "encounter_name": "Demon Wiedzy",
         "room_type": "Boss",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -4552,7 +4638,7 @@
     "encounters": [
       {
         "encounter_id": "LAGAVULIN_MATRIARCH_BOSS",
-        "encounter_name": "Królową Lagavulinów",
+        "encounter_name": "Matka Lagavulinów",
         "room_type": "Boss",
         "act": "Underdocks",
         "is_weak": false
@@ -6410,7 +6496,7 @@
     "encounters": [
       {
         "encounter_id": "QUEEN_BOSS",
-        "encounter_name": "Królową",
+        "encounter_name": "Królowa",
         "room_type": "Boss",
         "act": "Act 3 - Glory",
         "is_weak": false
@@ -6563,7 +6649,7 @@
     "encounters": [
       {
         "encounter_id": "KAISER_CRAB_BOSS",
-        "encounter_name": "Krabem Cesarskim",
+        "encounter_name": "Krab Cesarski",
         "room_type": "Boss",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -6766,6 +6852,13 @@
     },
     "block_values": null,
     "encounters": [
+      {
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "Kijanki",
+        "room_type": "Monster",
+        "act": "Underdocks",
+        "is_weak": false
+      },
       {
         "encounter_id": "SEAPUNK_WEAK",
         "encounter_name": "Gloniarz",
@@ -7684,7 +7777,7 @@
     "encounters": [
       {
         "encounter_id": "SOUL_FYSH_BOSS",
-        "encounter_name": "Duszą Rypki",
+        "encounter_name": "Dusza Rypki",
         "room_type": "Boss",
         "act": "Underdocks",
         "is_weak": false
@@ -8330,7 +8423,7 @@
     "encounters": [
       {
         "encounter_id": "TEST_SUBJECT_BOSS",
-        "encounter_name": "Eksperymentem",
+        "encounter_name": "Eksperyment",
         "room_type": "Boss",
         "act": "Act 3 - Glory",
         "is_weak": false
@@ -8796,7 +8889,7 @@
     "encounters": [
       {
         "encounter_id": "THE_INSATIABLE_BOSS",
-        "encounter_name": "Nienasyconym",
+        "encounter_name": "Nienasycony",
         "room_type": "Boss",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -9191,13 +9284,6 @@
     "block_values": null,
     "encounters": [
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "Kijanki",
-        "room_type": "Monster",
-        "act": "Underdocks",
-        "is_weak": false
-      },
-      {
         "encounter_id": "TOADPOLES_WEAK",
         "encounter_name": "Kijanki",
         "room_type": "Monster",
@@ -9323,7 +9409,7 @@
     "encounters": [
       {
         "encounter_id": "QUEEN_BOSS",
-        "encounter_name": "Królową",
+        "encounter_name": "Królowa",
         "room_type": "Boss",
         "act": "Act 3 - Glory",
         "is_weak": false
@@ -9564,7 +9650,7 @@
         "encounter_id": "TUNNELER_NORMAL",
         "encounter_name": "Tunelowy duet",
         "room_type": "Monster",
-        "act": "Act 2 - Hive",
+        "act": null,
         "is_weak": false
       },
       {
@@ -10037,7 +10123,7 @@
     "encounters": [
       {
         "encounter_id": "VANTOM_BOSS",
-        "encounter_name": "Fantomem",
+        "encounter_name": "Fantom",
         "room_type": "Boss",
         "act": "Act 1 - Overgrowth",
         "is_weak": false
@@ -10308,7 +10394,7 @@
     "encounters": [
       {
         "encounter_id": "WATERFALL_GIANT_BOSS",
-        "encounter_name": "Kaskadowym Olbrzymem",
+        "encounter_name": "Kaskadowy Olbrzym",
         "room_type": "Boss",
         "act": "Underdocks",
         "is_weak": false

--- a/data/pol/powers.json
+++ b/data/pol/powers.json
@@ -170,6 +170,16 @@
     "image_url": "/static/images/powers/black_hole_power.webp"
   },
   {
+    "id": "BLADE_OF_INK",
+    "name": "BladeOfInkPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/blade_of_ink_power.webp"
+  },
+  {
     "id": "BLOCK_NEXT_TURN",
     "name": "Blok w następnej turze",
     "description": "Na początku następnej tury zyskaj [blue]4[/blue] pkt. [gold]Bloku[/gold].",
@@ -610,6 +620,16 @@
     "image_url": "/static/images/powers/doom_power.webp"
   },
   {
+    "id": "DOOR_REVIVAL",
+    "name": "DoorRevivalPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Single",
+    "allow_negative": null,
+    "image_url": null
+  },
+  {
     "id": "DOUBLE_DAMAGE",
     "name": "Podwójne obrażenia",
     "description": "W tej turze Ataki zadają podwójne obrażenia.",
@@ -948,6 +968,16 @@
     "stack_type": "Counter",
     "allow_negative": null,
     "image_url": "/static/images/powers/gigantification_power.webp"
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "GrapplePower",
+    "description": "",
+    "description_raw": null,
+    "type": "Debuff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/grapple_power.webp"
   },
   {
     "id": "GRASP",

--- a/data/ptb/cards.json
+++ b/data/ptb/cards.json
@@ -331,7 +331,7 @@
     "image_url": "/static/images/cards/squash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Cause 12 de dano.\nAplique 2 de [gold]Vulnerável[/gold].",
+    "upgrade_description": "Cause 12 de dano.\nAplique 3 de [gold]Vulnerável[/gold].",
     "type_key": "Attack",
     "rarity_key": "Event",
     "compendium_order": 543
@@ -637,7 +637,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "upgrade_description": "Cure 13 PV.",
     "type_key": "Skill",
@@ -1154,7 +1154,7 @@
     "image_url": "/static/images/cards/anticipate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Receba 3 de [gold]Destreza[/gold] neste turno.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 93
@@ -2027,7 +2027,7 @@
     "image_url": "/static/images/cards/assassinate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Cause 13 de dano.\nAplique 1 de [gold]Vulnerável[/gold].",
+    "upgrade_description": "Cause 13 de dano.\nAplique 2 de [gold]Vulnerável[/gold].",
     "type_key": "Attack",
     "rarity_key": "Rare",
     "keywords_key": [
@@ -2708,7 +2708,7 @@
     "image_url": "/static/images/cards/bubble_bubble.webp",
     "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Se o inimigo estiver [gold]Envenenado[/gold], aplique 12 de [gold]Veneno[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 101
@@ -2874,7 +2874,7 @@
     "image_url": "/static/images/cards/haze.webp",
     "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplique 6 de [gold]Veneno[/gold] a TODOS os inimigos.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "keywords_key": [
@@ -3391,7 +3391,7 @@
     "image_url": "/static/images/cards/deathbringer.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplique 26 de [gold]Ruína[/gold] e 1 de [gold]Fraqueza[/gold] a TODOS os inimigos.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 276
@@ -4704,7 +4704,7 @@
     "image_url": "/static/images/cards/coordinate.webp",
     "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Conceda a outro jogador 8 de [gold]Força[/gold] neste turno.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 448
@@ -6869,7 +6869,7 @@
   {
     "id": "DUAL_WIELD",
     "name": "Dupla Empunhadura",
-    "description": "Escolha uma carta de Ataque ou Poder. Adicione  cópias|uma cópia} desta carta na sua [gold]Mão[/gold].",
+    "description": "Escolha uma carta de Ataque ou Poder. Adicione uma cópia desta carta na sua [gold]Mão[/gold].",
     "description_raw": "Escolha uma carta de Ataque ou Poder. Adicione {IfUpgraded:show:{Cards} cópias|uma cópia} desta carta na sua [gold]Mão[/gold].",
     "cost": 1,
     "is_x_cost": null,
@@ -6898,7 +6898,7 @@
     "image_url": "/static/images/cards/dual_wield.webp",
     "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
-    "upgrade_description": "Escolha uma carta de Ataque ou Poder. Adicione [Cards cópias|uma cópia] desta carta na sua [gold]Mão[/gold].",
+    "upgrade_description": "Escolha uma carta de Ataque ou Poder. Adicione 2 cópias desta carta na sua [gold]Mão[/gold].",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 528
@@ -7105,7 +7105,7 @@
   {
     "id": "STACK",
     "name": "Empilhar",
-    "description": "Receba [gold]Proteção[/gold] equivalente à quantidade de cartas na sua [gold]Pilha de Descarte[/gold]|}.",
+    "description": "Receba [gold]Proteção[/gold] equivalente à quantidade de cartas na sua [gold]Pilha de Descarte[/gold].",
     "description_raw": "Receba [gold]Proteção[/gold] equivalente à quantidade de cartas na sua [gold]Pilha de Descarte[/gold]{IfUpgraded:show: +{CalculationBase}|}.{InCombat:\n(Receba {CalculatedBlock:diff()} de [gold]Proteção[/gold])|}",
     "cost": 1,
     "is_x_cost": null,
@@ -7135,7 +7135,7 @@
     "image_url": "/static/images/cards/stack.webp",
     "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
-    "upgrade_description": "Receba [gold]Proteção[/gold] equivalente à quantidade de cartas na sua [gold]Pilha de Descarte[/gold] +[CalculationBase|].",
+    "upgrade_description": "Receba [gold]Proteção[/gold] equivalente à quantidade de cartas na sua [gold]Pilha de Descarte[/gold] +3.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 544
@@ -7768,7 +7768,7 @@
     "image_url": "/static/images/cards/bash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Cause 10 de dano.\nAplique 2 de [gold]Vulnerável[/gold].",
+    "upgrade_description": "Cause 10 de dano.\nAplique 3 de [gold]Vulnerável[/gold].",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 5
@@ -8245,7 +8245,7 @@
     "image_url": "/static/images/cards/poisoned_stab.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Cause 8 de dano.\nAplique 3 de [gold]Veneno[/gold].",
+    "upgrade_description": "Cause 8 de dano.\nAplique 4 de [gold]Veneno[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 146
@@ -8589,7 +8589,7 @@
     "image_url": "/static/images/cards/tremble.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplique 4 de [gold]Vulnerável[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -9033,7 +9033,7 @@
     "image_url": "/static/images/cards/beam_cell.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Cause 4 de dano.\nAplique 1 de [gold]Vulnerável[/gold].",
+    "upgrade_description": "Cause 4 de dano.\nAplique 2 de [gold]Vulnerável[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 355
@@ -9225,7 +9225,7 @@
     "image_url": "/static/images/cards/end_of_days.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplique 37 de [gold]Ruína[/gold] a TODOS os inimigos.\nFinalize inimigos que tenham pelo menos tanta [gold]Ruína[/gold] quanto PV.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 290
@@ -9310,7 +9310,7 @@
     "image_url": "/static/images/cards/scourge.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Aplique 13 de [gold]Ruína[/gold].\nCompre 2 cartas.",
+    "upgrade_description": "Aplique 16 de [gold]Ruína[/gold].\nCompre 2 cartas.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 328
@@ -9862,7 +9862,7 @@
     "image_url": "/static/images/cards/bulk_up.webp",
     "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Perca 1 Espaço de Orbe.\nReceba 3 de [gold]Força[/gold].\nReceba 3 de [gold]Destreza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 360
@@ -10030,7 +10030,7 @@
     "image_url": "/static/images/cards/feeding_frenzy.webp",
     "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Receba 7 de [gold]Força[/gold] neste turno.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 532
@@ -11384,7 +11384,7 @@
     "image_url": "/static/images/cards/setup_strike.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Cause 9 de dano.\nReceba 2 de [gold]Força[/gold] neste turno.",
+    "upgrade_description": "Cause 9 de dano.\nReceba 3 de [gold]Força[/gold] neste turno.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 65
@@ -11590,6 +11590,52 @@
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 185
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "Grapple",
+    "description": "",
+    "description_raw": "",
+    "cost": 1,
+    "is_x_cost": null,
+    "is_x_star_cost": null,
+    "star_cost": null,
+    "type": "Ataque",
+    "rarity": "Incomum",
+    "target": "AnyEnemy",
+    "color": "unknown",
+    "damage": 7,
+    "block": null,
+    "hit_count": null,
+    "powers_applied": [
+      {
+        "power": "Grapple",
+        "amount": 5,
+        "power_key": "Grapple"
+      }
+    ],
+    "cards_draw": null,
+    "energy_gain": null,
+    "hp_loss": null,
+    "keywords": null,
+    "tags": null,
+    "spawns_cards": null,
+    "vars": {
+      "Damage": 7,
+      "GrapplePower": 5,
+      "Grapple": 5
+    },
+    "upgrade": {
+      "damage": "+2",
+      "grapplepower": "+2"
+    },
+    "image_url": "/static/images/cards/grapple.webp",
+    "beta_image_url": null,
+    "type_variants": null,
+    "upgrade_description": null,
+    "type_key": "Attack",
+    "rarity_key": "Uncommon",
+    "compendium_order": 576
   },
   {
     "id": "DARK_SHACKLES",
@@ -14337,7 +14383,7 @@
     "image_url": "/static/images/cards/brand.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Perca 1 PV.\n[gold]Exaure[/gold] 1 carta.\nReceba 2 de [gold]Força[/gold].",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 11
@@ -14906,7 +14952,7 @@
     "image_url": "/static/images/cards/go_for_the_eyes.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Cause 4 de dano.\nSe o inimigo tem intenção de atacar, aplique 1 de [gold]Fraqueza[/gold].",
+    "upgrade_description": "Cause 4 de dano.\nSe o inimigo tem intenção de atacar, aplique 2 de [gold]Fraqueza[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 389
@@ -15114,7 +15160,7 @@
     "image_url": "/static/images/cards/snakebite.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplique 10 de [gold]Veneno[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -15462,7 +15508,7 @@
     "image_url": "/static/images/cards/neutralize.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Cause 4 de dano.\nAplique 1 de [gold]Fraqueza[/gold].",
+    "upgrade_description": "Cause 4 de dano.\nAplique 2 de [gold]Fraqueza[/gold].",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 139
@@ -15699,7 +15745,7 @@
     "image_url": "/static/images/cards/null.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Cause 13 de dano.\nAplique 2 de [gold]Fraqueza[/gold].\n[gold]Canalize[/gold] 1 [gold]Trevas[/gold].",
+    "upgrade_description": "Cause 13 de dano.\nAplique 3 de [gold]Fraqueza[/gold].\n[gold]Canalize[/gold] 1 [gold]Trevas[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 407
@@ -15818,7 +15864,7 @@
     "image_url": "/static/images/cards/oblivion.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Sempre que você jogar uma carta neste turno, aplique 4 de [gold]Ruína[/gold] ao inimigo.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 313
@@ -17208,7 +17254,7 @@
     "image_url": "/static/images/cards/footwork.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Receba 3 de [gold]Destreza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 125
@@ -17540,7 +17586,7 @@
     "image_url": "/static/images/cards/prowess.webp",
     "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Receba 2 de [gold]Força[/gold].\nReceba 2 de [gold]Destreza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 481
@@ -17747,7 +17793,7 @@
     "image_url": "/static/images/cards/taunt.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Receba 8 de [gold]Proteção[/gold].\nAplique 1 de [gold]Vulnerável[/gold].",
+    "upgrade_description": "Receba 8 de [gold]Proteção[/gold].\nAplique 2 de [gold]Vulnerável[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -17831,7 +17877,7 @@
     "image_url": "/static/images/cards/negative_pulse.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Receba 6 de [gold]Proteção[/gold].\nAplique 7 de [gold]Ruína[/gold] a TODOS os inimigos.",
+    "upgrade_description": "Receba 6 de [gold]Proteção[/gold].\nAplique 11 de [gold]Ruína[/gold] a TODOS os inimigos.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 310
@@ -18280,7 +18326,7 @@
     "image_url": "/static/images/cards/break.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Cause 30 de dano.\nAplique 5 de [gold]Vulnerável[/gold].",
+    "upgrade_description": "Cause 30 de dano.\nAplique 7 de [gold]Vulnerável[/gold].",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "compendium_order": 12
@@ -18710,7 +18756,7 @@
     "image_url": "/static/images/cards/leg_sweep.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Aplique 2 de [gold]Fraqueza[/gold].\nReceba 14 de [gold]Proteção[/gold].",
+    "upgrade_description": "Aplique 3 de [gold]Fraqueza[/gold].\nReceba 14 de [gold]Proteção[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 133
@@ -19471,7 +19517,7 @@
     "image_url": "/static/images/cards/fight_me.webp",
     "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
-    "upgrade_description": "Cause 6 de dano duas vezes.\nReceba 3 de [gold]Força[/gold].\nO inimigo recebe 1 de [gold]Força[/gold].",
+    "upgrade_description": "Cause 6 de dano duas vezes.\nReceba 4 de [gold]Força[/gold].\nO inimigo recebe 1 de [gold]Força[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 35
@@ -19838,7 +19884,7 @@
     "image_url": "/static/images/cards/rupture.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Sempre que você perder PV no seu turno, receba 2 de [gold]Força[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -21023,7 +21069,7 @@
     "image_url": "/static/images/cards/sucker_punch.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Cause 10 de dano.\nAplique 1 de [gold]Fraqueza[/gold].",
+    "upgrade_description": "Cause 10 de dano.\nAplique 2 de [gold]Fraqueza[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 164
@@ -21421,7 +21467,7 @@
     "image_url": "/static/images/cards/suppress.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Cause 17 de dano.\nAplique 3 de [gold]Fraqueza[/gold].",
+    "upgrade_description": "Cause 17 de dano.\nAplique 5 de [gold]Fraqueza[/gold].",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "keywords_key": [
@@ -22056,7 +22102,7 @@
     "image_url": "/static/images/cards/fear.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Cause 8 de dano.\nAplique 1 de [gold]Vulnerável[/gold].",
+    "upgrade_description": "Cause 8 de dano.\nAplique 2 de [gold]Vulnerável[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "keywords_key": [
@@ -22237,7 +22283,7 @@
     "image_url": "/static/images/cards/high_five.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]Ostheo[/gold] causa 13 de dano\ne aplica 2 de [gold]Vulnerável[/gold]\na TODOS os inimigos.",
+    "upgrade_description": "[gold]Ostheo[/gold] causa 13 de dano\ne aplica 3 de [gold]Vulnerável[/gold]\na TODOS os inimigos.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 303
@@ -22885,7 +22931,7 @@
     "image_url": "/static/images/cards/deadly_poison.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplique 7 de [gold]Veneno[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 110

--- a/data/ptb/enchantments.json
+++ b/data/ptb/enchantments.json
@@ -33,6 +33,17 @@
     "image_url": "/static/images/enchantments/corrupted.webp"
   },
   {
+    "id": "FAVORED",
+    "name": "Favored",
+    "description": "",
+    "description_raw": null,
+    "extra_card_text": null,
+    "card_type": "Attack",
+    "applicable_to": null,
+    "is_stackable": false,
+    "image_url": "/static/images/enchantments/favored.webp"
+  },
+  {
     "id": "GLAM",
     "name": "Elegante",
     "description": "Esta carta recebe [gold]Repetir[/gold] uma vez por combate.",

--- a/data/ptb/encounters.json
+++ b/data/ptb/encounters.json
@@ -1411,6 +1411,25 @@
     "loss_text": "Um [gold]Gafanhoto Larápio[/gold] assaltou [b]The Adventurer[/b]."
   },
   {
+    "id": "TOADPOLES_NORMAL",
+    "name": "Toadpoles Normal",
+    "room_type": "Monster",
+    "is_weak": false,
+    "act": null,
+    "tags": null,
+    "monsters": [
+      {
+        "id": "CALCIFIED_CULTIST",
+        "name": "Cultista Calcificado"
+      },
+      {
+        "id": "TOADPOLE",
+        "name": "Girino"
+      }
+    ],
+    "loss_text": null
+  },
+  {
     "id": "TOADPOLES_WEAK",
     "name": "Girinos",
     "room_type": "Monster",

--- a/data/ptb/monsters.json
+++ b/data/ptb/monsters.json
@@ -481,13 +481,6 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": true
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Escavador e seu aliado",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -728,13 +721,6 @@
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
         "encounter_name": "Precioso Descanso",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Escavador e seu aliado",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -1077,8 +1063,8 @@
         "is_weak": false
       },
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "Fauna das Docas Subterrâneas",
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "Vida Selvagem das Docas Subterrâneas",
         "room_type": "Monster",
         "act": "Underdocks",
         "is_weak": false
@@ -1296,6 +1282,13 @@
         "encounter_name": "Par de Autômatos",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
+        "is_weak": false
+      },
+      {
+        "encounter_id": "TUNNELER_NORMAL",
+        "encounter_name": "Escavador e seu aliado",
+        "room_type": "Monster",
+        "act": null,
         "is_weak": false
       }
     ],
@@ -2021,6 +2014,99 @@
     "beta_image_url": null
   },
   {
+    "id": "DOOR",
+    "name": "Porta",
+    "type": "Normal",
+    "min_hp": 155,
+    "max_hp": null,
+    "min_hp_ascension": 165,
+    "max_hp_ascension": null,
+    "moves": [
+      {
+        "id": "DRAMATIC_OPEN",
+        "name": "Dramatic Open",
+        "intent": "Attack",
+        "damage": {
+          "normal": 25,
+          "ascension": 28
+        }
+      },
+      {
+        "id": "ENFORCE",
+        "name": "Enforce",
+        "intent": "Attack + Buff",
+        "powers": [
+          {
+            "power_id": "STRENGTH",
+            "target": "self",
+            "amount": 3
+          }
+        ],
+        "damage": {
+          "normal": 20
+        }
+      },
+      {
+        "id": "DOOR_SLAM",
+        "name": "Door Slam",
+        "intent": "Attack",
+        "damage": {
+          "normal": 15,
+          "ascension": 15,
+          "hit_count": 2
+        }
+      },
+      {
+        "id": "DEAD",
+        "name": "Dead",
+        "intent": "Unknown"
+      }
+    ],
+    "damage_values": {
+      "DramaticOpen": {
+        "normal": 25,
+        "ascension": 28
+      },
+      "DoorSlam": {
+        "normal": 15,
+        "ascension": 15,
+        "hit_count": 2
+      },
+      "Enforce": {
+        "normal": 20
+      }
+    },
+    "block_values": null,
+    "encounters": null,
+    "innate_powers": null,
+    "attack_pattern": {
+      "type": "cycle",
+      "initial_move": null,
+      "states": [
+        {
+          "id": "ENFORCE_MOVE",
+          "type": "move",
+          "move_id": "ENFORCE"
+        },
+        {
+          "id": "DOOR_SLAM_MOVE",
+          "type": "move",
+          "move_id": "DOOR_SLAM",
+          "next": "ENFORCE_MOVE"
+        },
+        {
+          "id": "DEAD_MOVE",
+          "type": "move",
+          "move_id": "DEAD",
+          "next": "DEAD_MOVE"
+        }
+      ],
+      "description": ""
+    },
+    "image_url": "/static/images/monsters/door.webp",
+    "beta_image_url": "/static/images/monsters/beta/door.webp"
+  },
+  {
     "id": "DOORMAKER",
     "name": "Porteiro",
     "type": "Boss",
@@ -2454,7 +2540,7 @@
     "encounters": [
       {
         "encounter_id": "FABRICATOR_NORMAL",
-        "encounter_name": "Operador",
+        "encounter_name": "Engenheiro",
         "room_type": "Monster",
         "act": "Act 3 - Glory",
         "is_weak": false
@@ -6767,6 +6853,13 @@
     "block_values": null,
     "encounters": [
       {
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "Vida Selvagem das Docas Subterrâneas",
+        "room_type": "Monster",
+        "act": "Underdocks",
+        "is_weak": false
+      },
+      {
         "encounter_id": "SEAPUNK_WEAK",
         "encounter_name": "Arruaceiro Marinho",
         "room_type": "Monster",
@@ -9191,13 +9284,6 @@
     "block_values": null,
     "encounters": [
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "Fauna das Docas Subterrâneas",
-        "room_type": "Monster",
-        "act": "Underdocks",
-        "is_weak": false
-      },
-      {
         "encounter_id": "TOADPOLES_WEAK",
         "encounter_name": "Girinos",
         "room_type": "Monster",
@@ -9564,7 +9650,7 @@
         "encounter_id": "TUNNELER_NORMAL",
         "encounter_name": "Escavador e seu aliado",
         "room_type": "Monster",
-        "act": "Act 2 - Hive",
+        "act": null,
         "is_weak": false
       },
       {

--- a/data/ptb/powers.json
+++ b/data/ptb/powers.json
@@ -170,6 +170,16 @@
     "image_url": "/static/images/powers/black_hole_power.webp"
   },
   {
+    "id": "BLADE_OF_INK",
+    "name": "BladeOfInkPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/blade_of_ink_power.webp"
+  },
+  {
     "id": "BLOCK_NEXT_TURN",
     "name": "Proteção Iminente",
     "description": "No início do seu próximo turno, receba [blue]4[/blue] de [gold]Proteção[/gold].",
@@ -610,6 +620,16 @@
     "image_url": "/static/images/powers/doom_power.webp"
   },
   {
+    "id": "DOOR_REVIVAL",
+    "name": "DoorRevivalPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Single",
+    "allow_negative": null,
+    "image_url": null
+  },
+  {
     "id": "DOUBLE_DAMAGE",
     "name": "Dano em Dobro",
     "description": "Neste turno, Ataques causam o dobro de dano.",
@@ -948,6 +968,16 @@
     "stack_type": "Counter",
     "allow_negative": null,
     "image_url": "/static/images/powers/gigantification_power.webp"
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "GrapplePower",
+    "description": "",
+    "description_raw": null,
+    "type": "Debuff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/grapple_power.webp"
   },
   {
     "id": "GRASP",

--- a/data/rus/cards.json
+++ b/data/rus/cards.json
@@ -1,5 +1,51 @@
 [
   {
+    "id": "GRAPPLE",
+    "name": "Grapple",
+    "description": "",
+    "description_raw": "",
+    "cost": 1,
+    "is_x_cost": null,
+    "is_x_star_cost": null,
+    "star_cost": null,
+    "type": "Атака",
+    "rarity": "Необычная",
+    "target": "AnyEnemy",
+    "color": "unknown",
+    "damage": 7,
+    "block": null,
+    "hit_count": null,
+    "powers_applied": [
+      {
+        "power": "Grapple",
+        "amount": 5,
+        "power_key": "Grapple"
+      }
+    ],
+    "cards_draw": null,
+    "energy_gain": null,
+    "hp_loss": null,
+    "keywords": null,
+    "tags": null,
+    "spawns_cards": null,
+    "vars": {
+      "Damage": 7,
+      "GrapplePower": 5,
+      "Grapple": 5
+    },
+    "upgrade": {
+      "damage": "+2",
+      "grapplepower": "+2"
+    },
+    "image_url": "/static/images/cards/grapple.webp",
+    "beta_image_url": null,
+    "type_variants": null,
+    "upgrade_description": null,
+    "type_key": "Attack",
+    "rarity_key": "Uncommon",
+    "compendium_order": 576
+  },
+  {
     "id": "AUTOMATION",
     "name": "Автоматизация",
     "description": "Дает [energy:1] за каждые 10 добираемых карт.",
@@ -1295,7 +1341,7 @@
     "image_url": "/static/images/cards/scourge.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Накладывает 13 [gold]злого рока[/gold].\nВы добираете 2 plural(ru):карту.",
+    "upgrade_description": "Накладывает 16 [gold]злого рока[/gold].\nВы добираете 2 plural(ru):карту.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 328
@@ -2406,7 +2452,7 @@
     "image_url": "/static/images/cards/deathbringer.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Накладывает 26 [gold]злого рока[/gold] и 1 [gold]слабости[/gold] на ВСЕХ врагов.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 276
@@ -2620,7 +2666,7 @@
     "image_url": "/static/images/cards/bash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Наносит 10 урона.\nНакладывает 2 [gold]уязвимости[/gold].",
+    "upgrade_description": "Наносит 10 урона.\nНакладывает 3 [gold]уязвимости[/gold].",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 5
@@ -3214,7 +3260,7 @@
     "image_url": "/static/images/cards/fight_me.webp",
     "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
-    "upgrade_description": "Наносит 6 урона 2 раза.\nДает 3 [gold]силы[/gold].\nВраг получает 1 [gold]силы[/gold].",
+    "upgrade_description": "Наносит 6 урона 2 раза.\nДает 4 [gold]силы[/gold].\nВраг получает 1 [gold]силы[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 35
@@ -3763,7 +3809,7 @@
     "image_url": "/static/images/cards/footwork.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Дает 3 [gold]ловкости[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 125
@@ -4015,7 +4061,7 @@
     "image_url": "/static/images/cards/squash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Наносит 12 урона.\nНакладывает 2 [gold]уязвимости[/gold].",
+    "upgrade_description": "Наносит 12 урона.\nНакладывает 3 [gold]уязвимости[/gold].",
     "type_key": "Attack",
     "rarity_key": "Event",
     "compendium_order": 543
@@ -4064,7 +4110,7 @@
     "image_url": "/static/images/cards/high_five.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]Костя[/gold] наносит 13 урона\nи накладывает 2 [gold]уязвимости[/gold]\nна ВСЕХ врагов.",
+    "upgrade_description": "[gold]Костя[/gold] наносит 13 урона\nи накладывает 3 [gold]уязвимости[/gold]\nна ВСЕХ врагов.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 303
@@ -4927,7 +4973,7 @@
     "image_url": "/static/images/cards/haze.webp",
     "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Накладывает 6 [gold]яда[/gold] на ВСЕХ врагов.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "keywords_key": [
@@ -5168,7 +5214,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "upgrade_description": "Восполняет 13 ОЗ.",
     "type_key": "Skill",
@@ -5607,7 +5653,7 @@
     "image_url": "/static/images/cards/oblivion.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Накладывает на врага 4 [gold]злого рока[/gold], когда вы разыгрываете карту в этом ходу.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 313
@@ -6201,7 +6247,7 @@
     "image_url": "/static/images/cards/sucker_punch.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Наносит 10 урона.\nНакладывает 1 [gold]слабости[/gold].",
+    "upgrade_description": "Наносит 10 урона.\nНакладывает 2 [gold]слабости[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 164
@@ -6596,7 +6642,7 @@
     "image_url": "/static/images/cards/snakebite.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Накладывает 10 [gold]яда[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -7722,7 +7768,7 @@
     "image_url": "/static/images/cards/brand.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Вы теряете 1 ОЗ.\n[gold]Сжигает[/gold] 1 карту.\nДает 2 [gold]силы[/gold].",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 11
@@ -8170,7 +8216,7 @@
     "image_url": "/static/images/cards/end_of_days.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Накладывает 37 [gold]злого рока[/gold] на ВСЕХ врагов.\nУбивает врагов, чей [gold]злой рок[/gold] не ниже их ОЗ.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 290
@@ -9395,7 +9441,7 @@
     "image_url": "/static/images/cards/beam_cell.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Наносит 4 урона.\nНакладывает 1 [gold]уязвимости[/gold].",
+    "upgrade_description": "Наносит 4 урона.\nНакладывает 2 [gold]уязвимости[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 355
@@ -10508,7 +10554,7 @@
     "image_url": "/static/images/cards/rupture.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Дает 2 [gold]силы[/gold], когда вы теряете ОЗ в свой ход.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -10713,7 +10759,7 @@
     "image_url": "/static/images/cards/taunt.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Дает 8 [gold]защиты[/gold].\nНакладывает 1 [gold]уязвимости[/gold].",
+    "upgrade_description": "Дает 8 [gold]защиты[/gold].\nНакладывает 2 [gold]уязвимости[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -11568,7 +11614,7 @@
     "image_url": "/static/images/cards/feeding_frenzy.webp",
     "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Дает 7 [gold]силы[/gold] на этот ход.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 532
@@ -11768,7 +11814,7 @@
     "image_url": "/static/images/cards/null.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Наносит 13 урона.\nНакладывает 2 [gold]слабости[/gold].\n[gold]Заряжает[/gold] 1 [gold]сферу тьмы[/gold].",
+    "upgrade_description": "Наносит 13 урона.\nНакладывает 3 [gold]слабости[/gold].\n[gold]Заряжает[/gold] 1 [gold]сферу тьмы[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 407
@@ -11851,7 +11897,7 @@
     "image_url": "/static/images/cards/neutralize.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Наносит 4 урона.\nНакладывает 1 [gold]слабости[/gold].",
+    "upgrade_description": "Наносит 4 урона.\nНакладывает 2 [gold]слабости[/gold].",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 139
@@ -13345,7 +13391,7 @@
     "image_url": "/static/images/cards/poisoned_stab.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Наносит 8 урона.\nНакладывает 3 [gold]яда[/gold].",
+    "upgrade_description": "Наносит 8 урона.\nНакладывает 4 [gold]яда[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 146
@@ -13468,7 +13514,7 @@
     "image_url": "/static/images/cards/negative_pulse.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Дает 6 [gold]защиты[/gold].\nНакладывает 7 [gold]злого рока[/gold] на ВСЕХ врагов.",
+    "upgrade_description": "Дает 6 [gold]защиты[/gold].\nНакладывает 11 [gold]злого рока[/gold] на ВСЕХ врагов.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 310
@@ -13882,7 +13928,7 @@
   {
     "id": "DUAL_WIELD",
     "name": "Парное оружие",
-    "description": "Добавляет в [gold]руку[/gold]  копии|копию} Атаки или Таланта из [gold]руки[/gold] на выбор.",
+    "description": "Добавляет в [gold]руку[/gold] копию Атаки или Таланта из [gold]руки[/gold] на выбор.",
     "description_raw": "Добавляет в [gold]руку[/gold] {IfUpgraded:show:{Cards} копии|копию} Атаки или Таланта из [gold]руки[/gold] на выбор.",
     "cost": 1,
     "is_x_cost": null,
@@ -13911,7 +13957,7 @@
     "image_url": "/static/images/cards/dual_wield.webp",
     "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
-    "upgrade_description": "Добавляет в [gold]руку[/gold] [Cards копии|копию] Атаки или Таланта из [gold]руки[/gold] на выбор.",
+    "upgrade_description": "Добавляет в [gold]руку[/gold] 2 копии Атаки или Таланта из [gold]руки[/gold] на выбор.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 528
@@ -14845,7 +14891,7 @@
     "image_url": "/static/images/cards/leg_sweep.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Накладывает 2 [gold]слабости[/gold].\nДает 14 [gold]защиты[/gold].",
+    "upgrade_description": "Накладывает 3 [gold]слабости[/gold].\nДает 14 [gold]защиты[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 133
@@ -16231,7 +16277,7 @@
     "image_url": "/static/images/cards/break.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Наносит 30 урона.\nНакладывает 5 [gold]уязвимости[/gold].",
+    "upgrade_description": "Наносит 30 урона.\nНакладывает 7 [gold]уязвимости[/gold].",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "compendium_order": 12
@@ -18593,7 +18639,7 @@
     "image_url": "/static/images/cards/coordinate.webp",
     "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Дает другому игроку 8 [gold]силы[/gold] на этот ход.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 448
@@ -18923,7 +18969,7 @@
     "image_url": "/static/images/cards/deadly_poison.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Накладывает 7 [gold]яда[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 110
@@ -19498,7 +19544,7 @@
   {
     "id": "STACK",
     "name": "Стек",
-    "description": "Дает [gold]защиту[/gold], равную количеству карт в [gold]стопке сброса[/gold]|}.",
+    "description": "Дает [gold]защиту[/gold], равную количеству карт в [gold]стопке сброса[/gold].",
     "description_raw": "Дает [gold]защиту[/gold], равную количеству карт в [gold]стопке сброса[/gold]{IfUpgraded:show: +{CalculationBase}|}.{InCombat:\n(Дает {CalculatedBlock:diff()} [gold]защиты[/gold])|}",
     "cost": 1,
     "is_x_cost": null,
@@ -19528,7 +19574,7 @@
     "image_url": "/static/images/cards/stack.webp",
     "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
-    "upgrade_description": "Дает [gold]защиту[/gold], равную количеству карт в [gold]стопке сброса[/gold] +[CalculationBase|].",
+    "upgrade_description": "Дает [gold]защиту[/gold], равную количеству карт в [gold]стопке сброса[/gold] +3.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 544
@@ -19763,7 +19809,7 @@
     "image_url": "/static/images/cards/fear.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Наносит 8 урона.\nНакладывает 1 [gold]уязвимости[/gold].",
+    "upgrade_description": "Наносит 8 урона.\nНакладывает 2 [gold]уязвимости[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "keywords_key": [
@@ -20682,7 +20728,7 @@
     "image_url": "/static/images/cards/bubble_bubble.webp",
     "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Накладывает 12 [gold]яда[/gold], если на врага уже наложен [gold]яд[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 101
@@ -20803,7 +20849,7 @@
     "image_url": "/static/images/cards/tremble.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Накладывает 4 [gold]уязвимости[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -20977,7 +21023,7 @@
     "image_url": "/static/images/cards/assassinate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Наносит 13 урона.\nНакладывает 1 [gold]уязвимости[/gold].",
+    "upgrade_description": "Наносит 13 урона.\nНакладывает 2 [gold]уязвимости[/gold].",
     "type_key": "Attack",
     "rarity_key": "Rare",
     "keywords_key": [
@@ -21149,7 +21195,7 @@
     "image_url": "/static/images/cards/prowess.webp",
     "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Дает 2 [gold]силы[/gold].\nДает 2 [gold]ловкости[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 481
@@ -21392,7 +21438,7 @@
     "image_url": "/static/images/cards/setup_strike.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Наносит 9 урона.\nДает 2 [gold]силы[/gold] на этот ход.",
+    "upgrade_description": "Наносит 9 урона.\nДает 3 [gold]силы[/gold] на этот ход.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 65
@@ -21572,7 +21618,7 @@
     "image_url": "/static/images/cards/bulk_up.webp",
     "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Вы теряете 1 plural(ru):слот.\nДает 3 [gold]силы[/gold].\nДает 3 [gold]ловкости[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 360
@@ -21828,7 +21874,7 @@
     "image_url": "/static/images/cards/suppress.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Наносит 17 урона.\nНакладывает 3 [gold]слабости[/gold].",
+    "upgrade_description": "Наносит 17 урона.\nНакладывает 5 [gold]слабости[/gold].",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "keywords_key": [
@@ -22420,7 +22466,7 @@
     "image_url": "/static/images/cards/go_for_the_eyes.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Наносит 4 урона.\nНакладывает 1 [gold]слабости[/gold], если враг планирует атаковать.",
+    "upgrade_description": "Наносит 4 урона.\nНакладывает 2 [gold]слабости[/gold], если враг планирует атаковать.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 389
@@ -22772,7 +22818,7 @@
     "image_url": "/static/images/cards/anticipate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Дает 3 [gold]ловкости[/gold] на этот ход.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 93

--- a/data/rus/enchantments.json
+++ b/data/rus/enchantments.json
@@ -33,6 +33,17 @@
     "image_url": "/static/images/enchantments/corrupted.webp"
   },
   {
+    "id": "FAVORED",
+    "name": "Favored",
+    "description": "",
+    "description_raw": null,
+    "extra_card_text": null,
+    "card_type": "Attack",
+    "applicable_to": null,
+    "is_stackable": false,
+    "image_url": "/static/images/enchantments/favored.webp"
+  },
+  {
     "id": "GLAM",
     "name": "Шик",
     "description": "При первом разыгрывании в каждом бою у карты есть [gold]повтор[/gold].",

--- a/data/rus/encounters.json
+++ b/data/rus/encounters.json
@@ -1411,6 +1411,25 @@
     "loss_text": "[gold]Загребущая цикада[/gold] обобрала {characterObject}."
   },
   {
+    "id": "TOADPOLES_NORMAL",
+    "name": "Toadpoles Normal",
+    "room_type": "Monster",
+    "is_weak": false,
+    "act": null,
+    "tags": null,
+    "monsters": [
+      {
+        "id": "CALCIFIED_CULTIST",
+        "name": "Окаменелый культист"
+      },
+      {
+        "id": "TOADPOLE",
+        "name": "Головастик"
+      }
+    ],
+    "loss_text": null
+  },
+  {
     "id": "TOADPOLES_WEAK",
     "name": "Головастики",
     "room_type": "Monster",

--- a/data/rus/monsters.json
+++ b/data/rus/monsters.json
@@ -481,13 +481,6 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": true
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Команда копателей",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -728,13 +721,6 @@
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
         "encounter_name": "Жучиная ночевка",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Команда копателей",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -1077,7 +1063,7 @@
         "is_weak": false
       },
       {
-        "encounter_id": "TOADPOLES_NORMAL",
+        "encounter_id": "SEAPUNK_NORMAL",
         "encounter_name": "Живность Пристани",
         "room_type": "Monster",
         "act": "Underdocks",
@@ -1297,6 +1283,13 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
+      },
+      {
+        "encounter_id": "TUNNELER_NORMAL",
+        "encounter_name": "Команда копателей",
+        "room_type": "Monster",
+        "act": null,
+        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -1374,7 +1367,7 @@
     "encounters": [
       {
         "encounter_id": "CORPSE_SLUGS_NORMAL",
-        "encounter_name": "Много слизней-падальщиков",
+        "encounter_name": "Куча слизней-падальщиков",
         "room_type": "Monster",
         "act": "Underdocks",
         "is_weak": false
@@ -2021,6 +2014,99 @@
     "beta_image_url": null
   },
   {
+    "id": "DOOR",
+    "name": "Дверь",
+    "type": "Normal",
+    "min_hp": 155,
+    "max_hp": null,
+    "min_hp_ascension": 165,
+    "max_hp_ascension": null,
+    "moves": [
+      {
+        "id": "DRAMATIC_OPEN",
+        "name": "Dramatic Open",
+        "intent": "Attack",
+        "damage": {
+          "normal": 25,
+          "ascension": 28
+        }
+      },
+      {
+        "id": "ENFORCE",
+        "name": "Enforce",
+        "intent": "Attack + Buff",
+        "powers": [
+          {
+            "power_id": "STRENGTH",
+            "target": "self",
+            "amount": 3
+          }
+        ],
+        "damage": {
+          "normal": 20
+        }
+      },
+      {
+        "id": "DOOR_SLAM",
+        "name": "Door Slam",
+        "intent": "Attack",
+        "damage": {
+          "normal": 15,
+          "ascension": 15,
+          "hit_count": 2
+        }
+      },
+      {
+        "id": "DEAD",
+        "name": "Dead",
+        "intent": "Unknown"
+      }
+    ],
+    "damage_values": {
+      "DramaticOpen": {
+        "normal": 25,
+        "ascension": 28
+      },
+      "DoorSlam": {
+        "normal": 15,
+        "ascension": 15,
+        "hit_count": 2
+      },
+      "Enforce": {
+        "normal": 20
+      }
+    },
+    "block_values": null,
+    "encounters": null,
+    "innate_powers": null,
+    "attack_pattern": {
+      "type": "cycle",
+      "initial_move": null,
+      "states": [
+        {
+          "id": "ENFORCE_MOVE",
+          "type": "move",
+          "move_id": "ENFORCE"
+        },
+        {
+          "id": "DOOR_SLAM_MOVE",
+          "type": "move",
+          "move_id": "DOOR_SLAM",
+          "next": "ENFORCE_MOVE"
+        },
+        {
+          "id": "DEAD_MOVE",
+          "type": "move",
+          "move_id": "DEAD",
+          "next": "DEAD_MOVE"
+        }
+      ],
+      "description": ""
+    },
+    "image_url": "/static/images/monsters/door.webp",
+    "beta_image_url": "/static/images/monsters/beta/door.webp"
+  },
+  {
     "id": "DOORMAKER",
     "name": "Привратник",
     "type": "Boss",
@@ -2284,7 +2370,7 @@
     "encounters": [
       {
         "encounter_id": "EXOSKELETONS_NORMAL",
-        "encounter_name": "Множество экзоскелетов",
+        "encounter_name": "Группа экзоскелетов",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -3222,7 +3308,7 @@
     "encounters": [
       {
         "encounter_id": "FROG_KNIGHT_NORMAL",
-        "encounter_name": "Сэр лягушка",
+        "encounter_name": "Сэр Лягушка",
         "room_type": "Monster",
         "act": "Act 3 - Glory",
         "is_weak": false
@@ -5881,7 +5967,7 @@
     "encounters": [
       {
         "encounter_id": "OWL_MAGISTRATE_NORMAL",
-        "encounter_name": "Сова юстициарий",
+        "encounter_name": "Сова-юстициарий",
         "room_type": "Monster",
         "act": "Act 3 - Glory",
         "is_weak": false
@@ -6666,7 +6752,7 @@
     "encounters": [
       {
         "encounter_id": "SCROLLS_OF_BITING_NORMAL",
-        "encounter_name": "Много зубастых свитков",
+        "encounter_name": "Группа зубастых свитков",
         "room_type": "Monster",
         "act": "Act 3 - Glory",
         "is_weak": false
@@ -6766,6 +6852,13 @@
     },
     "block_values": null,
     "encounters": [
+      {
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "Живность Пристани",
+        "room_type": "Monster",
+        "act": "Underdocks",
+        "is_weak": false
+      },
       {
         "encounter_id": "SEAPUNK_WEAK",
         "encounter_name": "Зламинария",
@@ -9191,13 +9284,6 @@
     "block_values": null,
     "encounters": [
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "Живность Пристани",
-        "room_type": "Monster",
-        "act": "Underdocks",
-        "is_weak": false
-      },
-      {
         "encounter_id": "TOADPOLES_WEAK",
         "encounter_name": "Головастики",
         "room_type": "Monster",
@@ -9564,7 +9650,7 @@
         "encounter_id": "TUNNELER_NORMAL",
         "encounter_name": "Команда копателей",
         "room_type": "Monster",
-        "act": "Act 2 - Hive",
+        "act": null,
         "is_weak": false
       },
       {

--- a/data/rus/powers.json
+++ b/data/rus/powers.json
@@ -170,6 +170,16 @@
     "image_url": "/static/images/powers/black_hole_power.webp"
   },
   {
+    "id": "BLADE_OF_INK",
+    "name": "BladeOfInkPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/blade_of_ink_power.webp"
+  },
+  {
     "id": "BLOCK_NEXT_TURN",
     "name": "Отложенная защита",
     "description": "Даст [blue]4[/blue] [gold]защиты[/gold] в начале следующего хода.",
@@ -610,6 +620,16 @@
     "image_url": "/static/images/powers/doom_power.webp"
   },
   {
+    "id": "DOOR_REVIVAL",
+    "name": "DoorRevivalPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Single",
+    "allow_negative": null,
+    "image_url": null
+  },
+  {
     "id": "DOUBLE_DAMAGE",
     "name": "Двойной урон",
     "description": "Атаки наносят двойной урон в этом ходу.",
@@ -948,6 +968,16 @@
     "stack_type": "Counter",
     "allow_negative": null,
     "image_url": "/static/images/powers/gigantification_power.webp"
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "GrapplePower",
+    "description": "",
+    "description_raw": null,
+    "type": "Debuff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/grapple_power.webp"
   },
   {
     "id": "GRASP",

--- a/data/spa/cards.json
+++ b/data/spa/cards.json
@@ -1280,7 +1280,7 @@
     "image_url": "/static/images/cards/anticipate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Gana 3 de [gold]Destreza[/gold] este turno.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 93
@@ -1461,7 +1461,7 @@
   {
     "id": "STACK",
     "name": "Apilar",
-    "description": "Gana [gold]Bloqueo[/gold] igual al número de cartas en tu [gold]Pila de descarte[/gold]|}.",
+    "description": "Gana [gold]Bloqueo[/gold] igual al número de cartas en tu [gold]Pila de descarte[/gold].",
     "description_raw": "Gana [gold]Bloqueo[/gold] igual al número de cartas en tu [gold]Pila de descarte[/gold]{IfUpgraded:show: +{CalculationBase}|}.{InCombat:\n(Gana {CalculatedBlock:diff()} de [gold]Bloqueo[/gold])|}",
     "cost": 1,
     "is_x_cost": null,
@@ -1491,7 +1491,7 @@
     "image_url": "/static/images/cards/stack.webp",
     "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
-    "upgrade_description": "Gana [gold]Bloqueo[/gold] igual al número de cartas en tu [gold]Pila de descarte[/gold] +[CalculationBase|].",
+    "upgrade_description": "Gana [gold]Bloqueo[/gold] igual al número de cartas en tu [gold]Pila de descarte[/gold] +3.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 544
@@ -2260,7 +2260,7 @@
     "image_url": "/static/images/cards/assassinate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Inflige 13 de daño.\nAplica 1 de [gold]Vulnerabilidad[/gold].",
+    "upgrade_description": "Inflige 13 de daño.\nAplica 2 de [gold]Vulnerabilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Rare",
     "keywords_key": [
@@ -2966,7 +2966,7 @@
     "image_url": "/static/images/cards/leg_sweep.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Aplica 2 de [gold]Debilidad[/gold].\nGana 14 de [gold]Bloqueo[/gold].",
+    "upgrade_description": "Aplica 3 de [gold]Debilidad[/gold].\nGana 14 de [gold]Bloqueo[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 133
@@ -3883,7 +3883,7 @@
     "image_url": "/static/images/cards/beam_cell.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Inflige 4 de daño.\nAplica 1 de [gold]Vulnerabilidad[/gold].",
+    "upgrade_description": "Inflige 4 de daño.\nAplica 2 de [gold]Vulnerabilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 355
@@ -4126,7 +4126,7 @@
     "image_url": "/static/images/cards/high_five.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]Nudillos[/gold] inflige 13 de daño\ny aplica 2 de [gold]Vulnerabilidad[/gold]\na TODOS los enemigos.",
+    "upgrade_description": "[gold]Nudillos[/gold] inflige 13 de daño\ny aplica 3 de [gold]Vulnerabilidad[/gold]\na TODOS los enemigos.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 303
@@ -5010,7 +5010,7 @@
     "image_url": "/static/images/cards/coordinate.webp",
     "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Otorga a otro jugador 8 de [gold]Fuerza[/gold] durante este turno.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 448
@@ -6055,7 +6055,7 @@
     "image_url": "/static/images/cards/null.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Inflige 13 de daño.\nAplica 2 de [gold]Debilidad[/gold].\n[gold]Invoca[/gold] 1 [gold]Oscuridad[/gold].",
+    "upgrade_description": "Inflige 13 de daño.\nAplica 3 de [gold]Debilidad[/gold].\n[gold]Invoca[/gold] 1 [gold]Oscuridad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 407
@@ -7088,7 +7088,7 @@
   {
     "id": "DUAL_WIELD",
     "name": "Doble empuñadura",
-    "description": "Elige una carta de Ataque o Poder. Añade  copias|una copia} de dicha carta a tu [gold]Mano[/gold].",
+    "description": "Elige una carta de Ataque o Poder. Añade una copia de dicha carta a tu [gold]Mano[/gold].",
     "description_raw": "Elige una carta de Ataque o Poder. Añade {IfUpgraded:show:{Cards} copias|una copia} de dicha carta a tu [gold]Mano[/gold].",
     "cost": 1,
     "is_x_cost": null,
@@ -7117,7 +7117,7 @@
     "image_url": "/static/images/cards/dual_wield.webp",
     "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
-    "upgrade_description": "Elige una carta de Ataque o Poder. Añade [Cards copias|una copia] de dicha carta a tu [gold]Mano[/gold].",
+    "upgrade_description": "Elige una carta de Ataque o Poder. Añade 2 copias de dicha carta a tu [gold]Mano[/gold].",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 528
@@ -7426,7 +7426,7 @@
     "image_url": "/static/images/cards/deathbringer.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplica 26 de [gold]Condena[/gold] y 1 de [gold]Debilidad[/gold] a TODOS los enemigos.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 276
@@ -8100,7 +8100,7 @@
     "image_url": "/static/images/cards/squash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Inflige 12 de daño.\nAplica 2 de [gold]Vulnerabilidad[/gold].",
+    "upgrade_description": "Inflige 12 de daño.\nAplica 3 de [gold]Vulnerabilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Event",
     "compendium_order": 543
@@ -9051,7 +9051,7 @@
     "image_url": "/static/images/cards/scourge.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Aplica 13 de [gold]Condena[/gold].\nRoba 2 cartas.",
+    "upgrade_description": "Aplica 16 de [gold]Condena[/gold].\nRoba 2 cartas.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 328
@@ -9523,7 +9523,7 @@
     "image_url": "/static/images/cards/bulk_up.webp",
     "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Pierde 1 espacio de Orbe.\nGana 3 de [gold]Fuerza[/gold].\nGana 3 de [gold]Destreza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 360
@@ -9649,7 +9649,7 @@
     "image_url": "/static/images/cards/feeding_frenzy.webp",
     "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Gana 7 de [gold]Fuerza[/gold] este turno.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 532
@@ -10796,7 +10796,7 @@
     "image_url": "/static/images/cards/setup_strike.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Inflige 9 de daño.\nGana 2 de [gold]Fuerza[/gold] este turno.",
+    "upgrade_description": "Inflige 9 de daño.\nGana 3 de [gold]Fuerza[/gold] este turno.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 65
@@ -11256,6 +11256,52 @@
     "compendium_order": 391
   },
   {
+    "id": "GRAPPLE",
+    "name": "Grapple",
+    "description": "",
+    "description_raw": "",
+    "cost": 1,
+    "is_x_cost": null,
+    "is_x_star_cost": null,
+    "star_cost": null,
+    "type": "Ataque",
+    "rarity": "Poco común",
+    "target": "AnyEnemy",
+    "color": "unknown",
+    "damage": 7,
+    "block": null,
+    "hit_count": null,
+    "powers_applied": [
+      {
+        "power": "Grapple",
+        "amount": 5,
+        "power_key": "Grapple"
+      }
+    ],
+    "cards_draw": null,
+    "energy_gain": null,
+    "hp_loss": null,
+    "keywords": null,
+    "tags": null,
+    "spawns_cards": null,
+    "vars": {
+      "Damage": 7,
+      "GrapplePower": 5,
+      "Grapple": 5
+    },
+    "upgrade": {
+      "damage": "+2",
+      "grapplepower": "+2"
+    },
+    "image_url": "/static/images/cards/grapple.webp",
+    "beta_image_url": null,
+    "type_variants": null,
+    "upgrade_description": null,
+    "type_key": "Attack",
+    "rarity_key": "Uncommon",
+    "compendium_order": 576
+  },
+  {
     "id": "DARK_SHACKLES",
     "name": "Grilletes oscuros",
     "description": "El enemigo pierde 9 de [gold]Fuerza[/gold] este turno.",
@@ -11618,7 +11664,7 @@
     "image_url": "/static/images/cards/tremble.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplica 4 de [gold]Vulnerabilidad[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -12861,7 +12907,7 @@
     "image_url": "/static/images/cards/go_for_the_eyes.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Inflige 4 de daño.\nSi el enemigo tiene intención de atacar, aplica 1 de [gold]Debilidad[/gold].",
+    "upgrade_description": "Inflige 4 de daño.\nSi el enemigo tiene intención de atacar, aplica 2 de [gold]Debilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 389
@@ -13026,7 +13072,7 @@
     "image_url": "/static/images/cards/footwork.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Gana 3 de [gold]Destreza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 125
@@ -13107,7 +13153,7 @@
     "image_url": "/static/images/cards/end_of_days.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplica 37 de [gold]Condena[/gold] a TODOS los enemigos.\nLos enemigos que tengan al menos tanta [gold]Condena[/gold] como PV mueren.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 290
@@ -14517,7 +14563,7 @@
     "image_url": "/static/images/cards/brand.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Pierde 1 PV.\n[gold]Agota[/gold] 1 carta.\nGana 2 de [gold]Fuerza[/gold].",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 11
@@ -15283,7 +15329,7 @@
     "image_url": "/static/images/cards/snakebite.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplica 10 de [gold]Veneno[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -15609,7 +15655,7 @@
     "image_url": "/static/images/cards/haze.webp",
     "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplica 6 de [gold]Veneno[/gold] a TODOS los enemigos.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "keywords_key": [
@@ -15658,7 +15704,7 @@
     "image_url": "/static/images/cards/neutralize.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Inflige 4 de daño.\nAplica 1 de [gold]Debilidad[/gold].",
+    "upgrade_description": "Inflige 4 de daño.\nAplica 2 de [gold]Debilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 139
@@ -15928,7 +15974,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "upgrade_description": null,
     "type_key": "Skill",
@@ -16095,7 +16141,7 @@
     "image_url": "/static/images/cards/oblivion.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Cuando juegues una carta este turno, aplica 4 de [gold]Condena[/gold] al enemigo.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 313
@@ -17276,7 +17322,7 @@
     "image_url": "/static/images/cards/bubble_bubble.webp",
     "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Si el enemigo está [gold]Envenenado[/gold], le aplicas 12 de [gold]Veneno[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 101
@@ -17322,7 +17368,7 @@
     "image_url": "/static/images/cards/bash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Inflige 10 de daño.\nAplica 2 de [gold]Vulnerabilidad[/gold].",
+    "upgrade_description": "Inflige 10 de daño.\nAplica 3 de [gold]Vulnerabilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 5
@@ -17823,7 +17869,7 @@
     "image_url": "/static/images/cards/taunt.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Gana 8 de [gold]Bloqueo[/gold].\nAplica 1 de [gold]Vulnerabilidad[/gold].",
+    "upgrade_description": "Gana 8 de [gold]Bloqueo[/gold].\nAplica 2 de [gold]Vulnerabilidad[/gold].",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -17987,7 +18033,7 @@
     "image_url": "/static/images/cards/negative_pulse.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Gana 6 de [gold]Bloqueo[/gold].\nAplica 7 de [gold]Condena[/gold] a TODOS los enemigos.",
+    "upgrade_description": "Gana 6 de [gold]Bloqueo[/gold].\nAplica 11 de [gold]Condena[/gold] a TODOS los enemigos.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 310
@@ -18158,7 +18204,7 @@
     "image_url": "/static/images/cards/poisoned_stab.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Inflige 8 de daño.\nAplica 3 de [gold]Veneno[/gold].",
+    "upgrade_description": "Inflige 8 de daño.\nAplica 4 de [gold]Veneno[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 146
@@ -18204,7 +18250,7 @@
     "image_url": "/static/images/cards/sucker_punch.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Inflige 10 de daño.\nAplica 1 de [gold]Debilidad[/gold].",
+    "upgrade_description": "Inflige 10 de daño.\nAplica 2 de [gold]Debilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 164
@@ -18482,7 +18528,7 @@
     "image_url": "/static/images/cards/break.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Inflige 30 de daño.\nAplica 5 de [gold]Vulnerabilidad[/gold].",
+    "upgrade_description": "Inflige 30 de daño.\nAplica 7 de [gold]Vulnerabilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "compendium_order": 12
@@ -19688,7 +19734,7 @@
     "image_url": "/static/images/cards/rupture.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Cuando pierdas PV durante tu turno, gana 2 de [gold]Fuerza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -20588,7 +20634,7 @@
     "image_url": "/static/images/cards/prowess.webp",
     "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Gana 2 de [gold]Fuerza[/gold].\nGana 2 de [gold]Destreza[/gold].",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 481
@@ -20962,7 +21008,7 @@
     "image_url": "/static/images/cards/suppress.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Inflige 17 de daño.\nAplica 3 de [gold]Debilidad[/gold].",
+    "upgrade_description": "Inflige 17 de daño.\nAplica 5 de [gold]Debilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "keywords_key": [
@@ -21362,7 +21408,7 @@
     "image_url": "/static/images/cards/fear.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Inflige 8 de daño.\nAplica 1 de [gold]Vulnerabilidad[/gold].",
+    "upgrade_description": "Inflige 8 de daño.\nAplica 2 de [gold]Vulnerabilidad[/gold].",
     "type_key": "Attack",
     "rarity_key": "Common",
     "keywords_key": [
@@ -22540,7 +22586,7 @@
     "image_url": "/static/images/cards/deadly_poison.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Aplica 7 de [gold]Veneno[/gold].",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 110
@@ -23031,7 +23077,7 @@
     "image_url": "/static/images/cards/fight_me.webp",
     "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
-    "upgrade_description": "Inflige 6 de daño dos veces.\nGana 3 de [gold]Fuerza[/gold].\nEl enemigo gana 1 de [gold]Fuerza[/gold].",
+    "upgrade_description": "Inflige 6 de daño dos veces.\nGana 4 de [gold]Fuerza[/gold].\nEl enemigo gana 1 de [gold]Fuerza[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 35

--- a/data/spa/enchantments.json
+++ b/data/spa/enchantments.json
@@ -33,6 +33,17 @@
     "image_url": "/static/images/enchantments/corrupted.webp"
   },
   {
+    "id": "FAVORED",
+    "name": "Favored",
+    "description": "",
+    "description_raw": null,
+    "extra_card_text": null,
+    "card_type": "Attack",
+    "applicable_to": null,
+    "is_stackable": false,
+    "image_url": "/static/images/enchantments/favored.webp"
+  },
+  {
     "id": "GLAM",
     "name": "Glamour",
     "description": "Esta carta tiene [gold]Repetición[/gold] una vez por combate.",

--- a/data/spa/encounters.json
+++ b/data/spa/encounters.json
@@ -1411,6 +1411,25 @@
     "loss_text": "Un [gold]Asaltamontes[/gold] atracó a [b]The Adventurer[/b]."
   },
   {
+    "id": "TOADPOLES_NORMAL",
+    "name": "Toadpoles Normal",
+    "room_type": "Monster",
+    "is_weak": false,
+    "act": null,
+    "tags": null,
+    "monsters": [
+      {
+        "id": "CALCIFIED_CULTIST",
+        "name": "Sectario calcificado"
+      },
+      {
+        "id": "TOADPOLE",
+        "name": "Ranicuajo"
+      }
+    ],
+    "loss_text": null
+  },
+  {
     "id": "TOADPOLES_WEAK",
     "name": "Ranicuajos",
     "room_type": "Monster",

--- a/data/spa/monsters.json
+++ b/data/spa/monsters.json
@@ -481,13 +481,6 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": true
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Dúo tunelador",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -728,13 +721,6 @@
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
         "encounter_name": "la siesta de unos escarabajos",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Dúo tunelador",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -1077,8 +1063,8 @@
         "is_weak": false
       },
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "criatura de los Muelles Sombríos",
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "fauna de los Muelles Sombríos",
         "room_type": "Monster",
         "act": "Underdocks",
         "is_weak": false
@@ -1296,6 +1282,13 @@
         "encounter_name": "Un par de autómatas",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
+        "is_weak": false
+      },
+      {
+        "encounter_id": "TUNNELER_NORMAL",
+        "encounter_name": "Dúo tunelador",
+        "room_type": "Monster",
+        "act": null,
         "is_weak": false
       }
     ],
@@ -2019,6 +2012,99 @@
     },
     "image_url": "/static/images/monsters/devoted_sculptor.webp",
     "beta_image_url": null
+  },
+  {
+    "id": "DOOR",
+    "name": "Portal",
+    "type": "Normal",
+    "min_hp": 155,
+    "max_hp": null,
+    "min_hp_ascension": 165,
+    "max_hp_ascension": null,
+    "moves": [
+      {
+        "id": "DRAMATIC_OPEN",
+        "name": "Dramatic Open",
+        "intent": "Attack",
+        "damage": {
+          "normal": 25,
+          "ascension": 28
+        }
+      },
+      {
+        "id": "ENFORCE",
+        "name": "Enforce",
+        "intent": "Attack + Buff",
+        "powers": [
+          {
+            "power_id": "STRENGTH",
+            "target": "self",
+            "amount": 3
+          }
+        ],
+        "damage": {
+          "normal": 20
+        }
+      },
+      {
+        "id": "DOOR_SLAM",
+        "name": "Door Slam",
+        "intent": "Attack",
+        "damage": {
+          "normal": 15,
+          "ascension": 15,
+          "hit_count": 2
+        }
+      },
+      {
+        "id": "DEAD",
+        "name": "Dead",
+        "intent": "Unknown"
+      }
+    ],
+    "damage_values": {
+      "DramaticOpen": {
+        "normal": 25,
+        "ascension": 28
+      },
+      "DoorSlam": {
+        "normal": 15,
+        "ascension": 15,
+        "hit_count": 2
+      },
+      "Enforce": {
+        "normal": 20
+      }
+    },
+    "block_values": null,
+    "encounters": null,
+    "innate_powers": null,
+    "attack_pattern": {
+      "type": "cycle",
+      "initial_move": null,
+      "states": [
+        {
+          "id": "ENFORCE_MOVE",
+          "type": "move",
+          "move_id": "ENFORCE"
+        },
+        {
+          "id": "DOOR_SLAM_MOVE",
+          "type": "move",
+          "move_id": "DOOR_SLAM",
+          "next": "ENFORCE_MOVE"
+        },
+        {
+          "id": "DEAD_MOVE",
+          "type": "move",
+          "move_id": "DEAD",
+          "next": "DEAD_MOVE"
+        }
+      ],
+      "description": ""
+    },
+    "image_url": "/static/images/monsters/door.webp",
+    "beta_image_url": "/static/images/monsters/beta/door.webp"
   },
   {
     "id": "DOORMAKER",
@@ -6767,6 +6853,13 @@
     "block_values": null,
     "encounters": [
       {
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "fauna de los Muelles Sombríos",
+        "room_type": "Monster",
+        "act": "Underdocks",
+        "is_weak": false
+      },
+      {
         "encounter_id": "SEAPUNK_WEAK",
         "encounter_name": "Canalla marino",
         "room_type": "Monster",
@@ -9191,13 +9284,6 @@
     "block_values": null,
     "encounters": [
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "criatura de los Muelles Sombríos",
-        "room_type": "Monster",
-        "act": "Underdocks",
-        "is_weak": false
-      },
-      {
         "encounter_id": "TOADPOLES_WEAK",
         "encounter_name": "Ranicuajos",
         "room_type": "Monster",
@@ -9564,7 +9650,7 @@
         "encounter_id": "TUNNELER_NORMAL",
         "encounter_name": "Dúo tunelador",
         "room_type": "Monster",
-        "act": "Act 2 - Hive",
+        "act": null,
         "is_weak": false
       },
       {

--- a/data/spa/powers.json
+++ b/data/spa/powers.json
@@ -170,6 +170,16 @@
     "image_url": "/static/images/powers/black_hole_power.webp"
   },
   {
+    "id": "BLADE_OF_INK",
+    "name": "BladeOfInkPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/blade_of_ink_power.webp"
+  },
+  {
     "id": "BLOCK_NEXT_TURN",
     "name": "Bloqueo inminente",
     "description": "Al comienzo de tu siguiente turno, gana [blue]4[/blue] de [gold]Bloqueo[/gold].",
@@ -610,6 +620,16 @@
     "image_url": "/static/images/powers/doom_power.webp"
   },
   {
+    "id": "DOOR_REVIVAL",
+    "name": "DoorRevivalPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Single",
+    "allow_negative": null,
+    "image_url": null
+  },
+  {
     "id": "DOUBLE_DAMAGE",
     "name": "Daño doble",
     "description": "Este turno, los Ataques infligen el doble de daño.",
@@ -948,6 +968,16 @@
     "stack_type": "Counter",
     "allow_negative": null,
     "image_url": "/static/images/powers/gigantification_power.webp"
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "GrapplePower",
+    "description": "",
+    "description_raw": null,
+    "type": "Debuff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/grapple_power.webp"
   },
   {
     "id": "GRASP",

--- a/data/tha/cards.json
+++ b/data/tha/cards.json
@@ -39,7 +39,7 @@
     "image_url": "/static/images/cards/brand.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "เสีย 1 HP\n[gold]สลาย[/gold]การ์ด 1 ใบ\nได้รับ 2 [gold]ความแข็งแรง[/gold]",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 11
@@ -85,7 +85,7 @@
     "image_url": "/static/images/cards/break.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้างความเสียหาย 30\nสร้าง 5 [gold]จุดอ่อน[/gold]",
+    "upgrade_description": "สร้างความเสียหาย 30\nสร้าง 7 [gold]จุดอ่อน[/gold]",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "compendium_order": 12
@@ -138,7 +138,7 @@
     "image_url": "/static/images/cards/bulk_up.webp",
     "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "เสียช่องเก็บลูกแก้ว 1 ช่อง\nได้รับ 3 [gold]ความแข็งแรง[/gold]\nได้รับ 3 [gold]ความชำนาญ[/gold]",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 360
@@ -1166,7 +1166,7 @@
     "image_url": "/static/images/cards/coordinate.webp",
     "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "ผู้เล่นคนอื่น 1 คนได้รับ 8 [gold]ความแข็งแรง[/gold]ในเทิร์นนี้",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 448
@@ -1497,7 +1497,7 @@
     "image_url": "/static/images/cards/deathbringer.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "สร้าง 26 [gold]อายุขัย[/gold]และ 1 [gold]ความอ่อนแอ[/gold]ใส่ศัตรูทั้งหมด",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 276
@@ -2090,7 +2090,7 @@
     "image_url": "/static/images/cards/end_of_days.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "สร้าง 37 [gold]อายุขัย[/gold]ใส่ศัตรูทั้งหมด\nฆ่าศัตรูทั้งหมดที่เหลือ HP ไม่เกิน[gold]อายุขัย[/gold]",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 290
@@ -2588,7 +2588,7 @@
     "image_url": "/static/images/cards/feeding_frenzy.webp",
     "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "ได้รับ 7 [gold]ความแข็งแรง[/gold]ในเทิร์นนี้",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 532
@@ -3474,6 +3474,52 @@
     "compendium_order": 460
   },
   {
+    "id": "GRAPPLE",
+    "name": "Grapple",
+    "description": "",
+    "description_raw": "",
+    "cost": 1,
+    "is_x_cost": null,
+    "is_x_star_cost": null,
+    "star_cost": null,
+    "type": "โจมตี",
+    "rarity": "ไม่ธรรมดา",
+    "target": "AnyEnemy",
+    "color": "unknown",
+    "damage": 7,
+    "block": null,
+    "hit_count": null,
+    "powers_applied": [
+      {
+        "power": "Grapple",
+        "amount": 5,
+        "power_key": "Grapple"
+      }
+    ],
+    "cards_draw": null,
+    "energy_gain": null,
+    "hp_loss": null,
+    "keywords": null,
+    "tags": null,
+    "spawns_cards": null,
+    "vars": {
+      "Damage": 7,
+      "GrapplePower": 5,
+      "Grapple": 5
+    },
+    "upgrade": {
+      "damage": "+2",
+      "grapplepower": "+2"
+    },
+    "image_url": "/static/images/cards/grapple.webp",
+    "beta_image_url": null,
+    "type_variants": null,
+    "upgrade_description": null,
+    "type_key": "Attack",
+    "rarity_key": "Uncommon",
+    "compendium_order": 576
+  },
+  {
     "id": "GRAVE_WARDEN",
     "name": "GraveWarden",
     "description": "ได้รับ 8 [gold]บล็อก[/gold]\nเพิ่ม[gold]วิญญาณ[/gold] 1 ใบเข้า[gold]กองจั่ว[/gold]",
@@ -4112,7 +4158,7 @@
     "image_url": "/static/images/cards/high_five.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]Osty[/gold]สร้างความเสียหาย 13\nและสร้าง 2 [gold]จุดอ่อน[/gold]\nใส่ศัตรูทั้งหมด",
+    "upgrade_description": "[gold]Osty[/gold]สร้างความเสียหาย 13\nและสร้าง 3 [gold]จุดอ่อน[/gold]\nใส่ศัตรูทั้งหมด",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 303
@@ -5445,7 +5491,7 @@
     "image_url": "/static/images/cards/negative_pulse.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "ได้รับ 6 [gold]บล็อก[/gold]\nสร้าง 7 [gold]อายุขัย[/gold]ใส่ศัตรูทั้งหมด",
+    "upgrade_description": "ได้รับ 6 [gold]บล็อก[/gold]\nสร้าง 11 [gold]อายุขัย[/gold]ใส่ศัตรูทั้งหมด",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 310
@@ -5691,7 +5737,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "upgrade_description": null,
     "type_key": "Skill",
@@ -5742,7 +5788,7 @@
     "image_url": "/static/images/cards/null.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้างความเสียหาย 13\nสร้าง 2 [gold]ความอ่อนแอ[/gold]\n[gold]ปลุกเสก[/gold] 1 [gold]ความมืด[/gold]",
+    "upgrade_description": "สร้างความเสียหาย 13\nสร้าง 3 [gold]ความอ่อนแอ[/gold]\n[gold]ปลุกเสก[/gold] 1 [gold]ความมืด[/gold]",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 407
@@ -5786,7 +5832,7 @@
     "image_url": "/static/images/cards/oblivion.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "ทุกครั้งที่คุณเล่นการ์ดในเทิร์นนี้ สร้าง 4 [gold]อายุขัย[/gold]ใส่ศัตรู",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 313
@@ -6828,7 +6874,7 @@
     "image_url": "/static/images/cards/prowess.webp",
     "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "ได้รับ 2 [gold]ความแข็งแรง[/gold]\nได้รับ 2 [gold]ความชำนาญ[/gold]",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 481
@@ -7798,7 +7844,7 @@
     "image_url": "/static/images/cards/scourge.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้าง 13 [gold]อายุขัย[/gold]\nจั่วการ์ด 2 ใบ",
+    "upgrade_description": "สร้าง 16 [gold]อายุขัย[/gold]\nจั่วการ์ด 2 ใบ",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 328
@@ -8052,7 +8098,7 @@
     "image_url": "/static/images/cards/setup_strike.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้างความเสียหาย 9\nได้รับ 2 [gold]ความแข็งแรง[/gold]ในเทิร์นนี้",
+    "upgrade_description": "สร้างความเสียหาย 9\nได้รับ 3 [gold]ความแข็งแรง[/gold]ในเทิร์นนี้",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 65
@@ -8630,7 +8676,7 @@
     "image_url": "/static/images/cards/snakebite.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "สร้าง 10 [gold]พิษ[/gold]",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -9240,7 +9286,7 @@
     "image_url": "/static/images/cards/squash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้างความเสียหาย 12\nสร้าง 2 [gold]จุดอ่อน[/gold]",
+    "upgrade_description": "สร้างความเสียหาย 12\nสร้าง 3 [gold]จุดอ่อน[/gold]",
     "type_key": "Attack",
     "rarity_key": "Event",
     "compendium_order": 543
@@ -9754,7 +9800,7 @@
     "image_url": "/static/images/cards/suppress.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้างความเสียหาย 17\nสร้าง 3 [gold]ความอ่อนแอ[/gold]",
+    "upgrade_description": "สร้างความเสียหาย 17\nสร้าง 5 [gold]ความอ่อนแอ[/gold]",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "keywords_key": [
@@ -10048,7 +10094,7 @@
     "image_url": "/static/images/cards/taunt.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "ได้รับ 8 [gold]บล็อก[/gold]\nสร้าง 1 [gold]จุดอ่อน[/gold]",
+    "upgrade_description": "ได้รับ 8 [gold]บล็อก[/gold]\nสร้าง 2 [gold]จุดอ่อน[/gold]",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -10647,7 +10693,7 @@
     "image_url": "/static/images/cards/tremble.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "สร้าง 4 [gold]จุดอ่อน[/gold]",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -11790,7 +11836,7 @@
     "image_url": "/static/images/cards/leg_sweep.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้าง 2 [gold]ความอ่อนแอ[/gold]\nได้รับ 14 [gold]บล็อก[/gold]",
+    "upgrade_description": "สร้าง 3 [gold]ความอ่อนแอ[/gold]\nได้รับ 14 [gold]บล็อก[/gold]",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 133
@@ -12009,7 +12055,7 @@
     "image_url": "/static/images/cards/rupture.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "ทุกครั้งที่คุณเสีย HP ในเทิร์นของคุณ ได้รับ 2 [gold]ความแข็งแรง[/gold]",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -12891,7 +12937,7 @@
     "image_url": "/static/images/cards/fear.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้างความเสียหาย 8\nสร้าง 1 [gold]จุดอ่อน[/gold]",
+    "upgrade_description": "สร้างความเสียหาย 8\nสร้าง 2 [gold]จุดอ่อน[/gold]",
     "type_key": "Attack",
     "rarity_key": "Common",
     "keywords_key": [
@@ -14121,7 +14167,7 @@
     "image_url": "/static/images/cards/footwork.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "ได้รับ 3 [gold]ความชำนาญ[/gold]",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 125
@@ -14253,7 +14299,7 @@
   {
     "id": "DUAL_WIELD",
     "name": "จับดาบสองมือ",
-    "description": "เลือกการ์ดโจมตีหรือการ์ดพลัง เพิ่มสำเนาการ์ดนั้น  ใบ|1 ใบ}ใส่[gold]มือ[/gold]",
+    "description": "เลือกการ์ดโจมตีหรือการ์ดพลัง เพิ่มสำเนาการ์ดนั้น 1 ใบใส่[gold]มือ[/gold]",
     "description_raw": "เลือกการ์ดโจมตีหรือการ์ดพลัง เพิ่มสำเนาการ์ดนั้น {IfUpgraded:show:{Cards} ใบ|1 ใบ}ใส่[gold]มือ[/gold]",
     "cost": 1,
     "is_x_cost": null,
@@ -14282,7 +14328,7 @@
     "image_url": "/static/images/cards/dual_wield.webp",
     "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
-    "upgrade_description": "เลือกการ์ดโจมตีหรือการ์ดพลัง เพิ่มสำเนาการ์ดนั้น [Cards ใบ|1 ใบ]ใส่[gold]มือ[/gold]",
+    "upgrade_description": "เลือกการ์ดโจมตีหรือการ์ดพลัง เพิ่มสำเนาการ์ดนั้น 2 ใบใส่[gold]มือ[/gold]",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 528
@@ -15440,7 +15486,7 @@
   {
     "id": "STACK",
     "name": "ทับซ้อน",
-    "description": "ได้รับ[gold]บล็อก[/gold]ตามจำนวนการ์ดใน[gold]กองทิ้ง[/gold]|}",
+    "description": "ได้รับ[gold]บล็อก[/gold]ตามจำนวนการ์ดใน[gold]กองทิ้ง[/gold]",
     "description_raw": "ได้รับ[gold]บล็อก[/gold]ตามจำนวนการ์ดใน[gold]กองทิ้ง[/gold]{IfUpgraded:show: +{CalculationBase}|}{InCombat:\n(ได้รับ {CalculatedBlock:diff()} [gold]บล็อก[/gold])|}",
     "cost": 1,
     "is_x_cost": null,
@@ -15470,7 +15516,7 @@
     "image_url": "/static/images/cards/stack.webp",
     "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
-    "upgrade_description": "ได้รับ[gold]บล็อก[/gold]ตามจำนวนการ์ดใน[gold]กองทิ้ง[/gold] +[CalculationBase|]",
+    "upgrade_description": "ได้รับ[gold]บล็อก[/gold]ตามจำนวนการ์ดใน[gold]กองทิ้ง[/gold] +3",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 544
@@ -15553,7 +15599,7 @@
     "image_url": "/static/images/cards/neutralize.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้างความเสียหาย 4\nสร้าง 1 [gold]ความอ่อนแอ[/gold]",
+    "upgrade_description": "สร้างความเสียหาย 4\nสร้าง 2 [gold]ความอ่อนแอ[/gold]",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 139
@@ -15599,7 +15645,7 @@
     "image_url": "/static/images/cards/bash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้างความเสียหาย 10\nสร้าง 2 [gold]จุดอ่อน[/gold]",
+    "upgrade_description": "สร้างความเสียหาย 10\nสร้าง 3 [gold]จุดอ่อน[/gold]",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 5
@@ -15996,7 +16042,7 @@
     "image_url": "/static/images/cards/bubble_bubble.webp",
     "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "ถ้าศัตรูมี[gold]พิษ[/gold] สร้าง 12 [gold]พิษ[/gold]",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 101
@@ -16154,7 +16200,7 @@
     "image_url": "/static/images/cards/anticipate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "ได้รับ 3 [gold]ความชำนาญ[/gold]ในเทิร์นนี้",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 93
@@ -17277,7 +17323,7 @@
     "image_url": "/static/images/cards/deadly_poison.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "สร้าง 7 [gold]พิษ[/gold]",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 110
@@ -17440,7 +17486,7 @@
     "image_url": "/static/images/cards/go_for_the_eyes.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้างความเสียหาย 4\nถ้าศัตรูตั้งใจจะโจมตี สร้าง 1 [gold]ความอ่อนแอ[/gold]",
+    "upgrade_description": "สร้างความเสียหาย 4\nถ้าศัตรูตั้งใจจะโจมตี สร้าง 2 [gold]ความอ่อนแอ[/gold]",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 389
@@ -17904,7 +17950,7 @@
     "image_url": "/static/images/cards/fight_me.webp",
     "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
-    "upgrade_description": "สร้างความเสียหาย 6 จำนวน 2 ครั้ง\nได้รับ 3 [gold]ความแข็งแรง[/gold]\nศัตรูได้รับ 1 [gold]ความแข็งแรง[/gold]",
+    "upgrade_description": "สร้างความเสียหาย 6 จำนวน 2 ครั้ง\nได้รับ 4 [gold]ความแข็งแรง[/gold]\nศัตรูได้รับ 1 [gold]ความแข็งแรง[/gold]",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 35
@@ -18078,7 +18124,7 @@
     "image_url": "/static/images/cards/poisoned_stab.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้างความเสียหาย 8\nสร้าง 3 [gold]พิษ[/gold]",
+    "upgrade_description": "สร้างความเสียหาย 8\nสร้าง 4 [gold]พิษ[/gold]",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 146
@@ -19209,7 +19255,7 @@
     "image_url": "/static/images/cards/assassinate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้างความเสียหาย 13\nสร้าง 1 [gold]จุดอ่อน[/gold]",
+    "upgrade_description": "สร้างความเสียหาย 13\nสร้าง 2 [gold]จุดอ่อน[/gold]",
     "type_key": "Attack",
     "rarity_key": "Rare",
     "keywords_key": [
@@ -19437,7 +19483,7 @@
     "image_url": "/static/images/cards/beam_cell.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้างความเสียหาย 4\nสร้าง 1 [gold]จุดอ่อน[/gold]",
+    "upgrade_description": "สร้างความเสียหาย 4\nสร้าง 2 [gold]จุดอ่อน[/gold]",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 355
@@ -20512,7 +20558,7 @@
     "image_url": "/static/images/cards/haze.webp",
     "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "สร้าง 6 [gold]พิษ[/gold]ใส่ศัตรูทั้งหมด",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "keywords_key": [
@@ -20561,7 +20607,7 @@
     "image_url": "/static/images/cards/sucker_punch.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "สร้างความเสียหาย 10\nสร้าง 1 [gold]ความอ่อนแอ[/gold]",
+    "upgrade_description": "สร้างความเสียหาย 10\nสร้าง 2 [gold]ความอ่อนแอ[/gold]",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 164

--- a/data/tha/enchantments.json
+++ b/data/tha/enchantments.json
@@ -33,6 +33,17 @@
     "image_url": "/static/images/enchantments/corrupted.webp"
   },
   {
+    "id": "FAVORED",
+    "name": "Favored",
+    "description": "",
+    "description_raw": null,
+    "extra_card_text": null,
+    "card_type": "Attack",
+    "applicable_to": null,
+    "is_stackable": false,
+    "image_url": "/static/images/enchantments/favored.webp"
+  },
+  {
     "id": "GLAM",
     "name": "มนตร์สวยหรู",
     "description": "การ์ดนี้มี[gold]เล่นซ้ำ[/gold] 1 ครั้งต่อการต่อสู้",

--- a/data/tha/encounters.json
+++ b/data/tha/encounters.json
@@ -1411,6 +1411,25 @@
     "loss_text": "[gold]Thieving Hopper Weak[/gold]ปล้น[b]The Adventurer[/b]"
   },
   {
+    "id": "TOADPOLES_NORMAL",
+    "name": "Toadpoles Normal",
+    "room_type": "Monster",
+    "is_weak": false,
+    "act": null,
+    "tags": null,
+    "monsters": [
+      {
+        "id": "CALCIFIED_CULTIST",
+        "name": "Calcified Cultist"
+      },
+      {
+        "id": "TOADPOLE",
+        "name": "Toadpole"
+      }
+    ],
+    "loss_text": null
+  },
+  {
     "id": "TOADPOLES_WEAK",
     "name": "Toadpoles Weak",
     "room_type": "Monster",

--- a/data/tha/monsters.json
+++ b/data/tha/monsters.json
@@ -481,13 +481,6 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": true
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Tunneler Normal",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -728,13 +721,6 @@
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
         "encounter_name": "Slumbering Beetle Normal",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Tunneler Normal",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -1077,8 +1063,8 @@
         "is_weak": false
       },
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "Toadpoles Normal",
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "สิ่งมีชีวิตในท่าเรือเบื้องล่าง",
         "room_type": "Monster",
         "act": "Underdocks",
         "is_weak": false
@@ -1296,6 +1282,13 @@
         "encounter_name": "Chompers Normal",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
+        "is_weak": false
+      },
+      {
+        "encounter_id": "TUNNELER_NORMAL",
+        "encounter_name": "Tunneler Normal",
+        "room_type": "Monster",
+        "act": null,
         "is_weak": false
       }
     ],
@@ -2019,6 +2012,99 @@
     },
     "image_url": "/static/images/monsters/devoted_sculptor.webp",
     "beta_image_url": null
+  },
+  {
+    "id": "DOOR",
+    "name": "Door",
+    "type": "Normal",
+    "min_hp": 155,
+    "max_hp": null,
+    "min_hp_ascension": 165,
+    "max_hp_ascension": null,
+    "moves": [
+      {
+        "id": "DRAMATIC_OPEN",
+        "name": "Dramatic Open",
+        "intent": "Attack",
+        "damage": {
+          "normal": 25,
+          "ascension": 28
+        }
+      },
+      {
+        "id": "ENFORCE",
+        "name": "Enforce",
+        "intent": "Attack + Buff",
+        "powers": [
+          {
+            "power_id": "STRENGTH",
+            "target": "self",
+            "amount": 3
+          }
+        ],
+        "damage": {
+          "normal": 20
+        }
+      },
+      {
+        "id": "DOOR_SLAM",
+        "name": "Door Slam",
+        "intent": "Attack",
+        "damage": {
+          "normal": 15,
+          "ascension": 15,
+          "hit_count": 2
+        }
+      },
+      {
+        "id": "DEAD",
+        "name": "Dead",
+        "intent": "Unknown"
+      }
+    ],
+    "damage_values": {
+      "DramaticOpen": {
+        "normal": 25,
+        "ascension": 28
+      },
+      "DoorSlam": {
+        "normal": 15,
+        "ascension": 15,
+        "hit_count": 2
+      },
+      "Enforce": {
+        "normal": 20
+      }
+    },
+    "block_values": null,
+    "encounters": null,
+    "innate_powers": null,
+    "attack_pattern": {
+      "type": "cycle",
+      "initial_move": null,
+      "states": [
+        {
+          "id": "ENFORCE_MOVE",
+          "type": "move",
+          "move_id": "ENFORCE"
+        },
+        {
+          "id": "DOOR_SLAM_MOVE",
+          "type": "move",
+          "move_id": "DOOR_SLAM",
+          "next": "ENFORCE_MOVE"
+        },
+        {
+          "id": "DEAD_MOVE",
+          "type": "move",
+          "move_id": "DEAD",
+          "next": "DEAD_MOVE"
+        }
+      ],
+      "description": ""
+    },
+    "image_url": "/static/images/monsters/door.webp",
+    "beta_image_url": "/static/images/monsters/beta/door.webp"
   },
   {
     "id": "DOORMAKER",
@@ -6272,14 +6358,14 @@
       },
       {
         "encounter_id": "PUNCH_CONSTRUCT_NORMAL",
-        "encounter_name": "Punch Construct Normal",
+        "encounter_name": "จักรกลชกต่อย",
         "room_type": "Monster",
         "act": "Underdocks",
         "is_weak": false
       },
       {
         "encounter_id": "PUNCH_OFF_EVENT_ENCOUNTER",
-        "encounter_name": "Punch Off Event Encounter",
+        "encounter_name": "พวกจักรกลชกต่อย",
         "room_type": "Monster",
         "act": null,
         "is_weak": false
@@ -6767,8 +6853,15 @@
     "block_values": null,
     "encounters": [
       {
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "สิ่งมีชีวิตในท่าเรือเบื้องล่าง",
+        "room_type": "Monster",
+        "act": "Underdocks",
+        "is_weak": false
+      },
+      {
         "encounter_id": "SEAPUNK_WEAK",
-        "encounter_name": "Seapunk Weak",
+        "encounter_name": "หร่ายเล",
         "room_type": "Monster",
         "act": "Underdocks",
         "is_weak": true
@@ -9191,13 +9284,6 @@
     "block_values": null,
     "encounters": [
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "Toadpoles Normal",
-        "room_type": "Monster",
-        "act": "Underdocks",
-        "is_weak": false
-      },
-      {
         "encounter_id": "TOADPOLES_WEAK",
         "encounter_name": "Toadpoles Weak",
         "room_type": "Monster",
@@ -9564,7 +9650,7 @@
         "encounter_id": "TUNNELER_NORMAL",
         "encounter_name": "Tunneler Normal",
         "room_type": "Monster",
-        "act": "Act 2 - Hive",
+        "act": null,
         "is_weak": false
       },
       {

--- a/data/tha/powers.json
+++ b/data/tha/powers.json
@@ -170,6 +170,16 @@
     "image_url": "/static/images/powers/black_hole_power.webp"
   },
   {
+    "id": "BLADE_OF_INK",
+    "name": "BladeOfInkPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/blade_of_ink_power.webp"
+  },
+  {
     "id": "BLOCK_NEXT_TURN",
     "name": "บล็อกเทิร์นถัดไป",
     "description": "ตอนเริ่มต้นเทิร์นถัดไป ได้รับ [blue]4[/blue] [gold]บล็อก[/gold]",
@@ -610,6 +620,16 @@
     "image_url": "/static/images/powers/doom_power.webp"
   },
   {
+    "id": "DOOR_REVIVAL",
+    "name": "DoorRevivalPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Single",
+    "allow_negative": null,
+    "image_url": null
+  },
+  {
     "id": "DOUBLE_DAMAGE",
     "name": "ความเสียหาย 2 เท่า",
     "description": "ในเทิร์นนี้ การ์ดโจมตีสร้างความเสียหาย 2 เท่า",
@@ -948,6 +968,16 @@
     "stack_type": "Counter",
     "allow_negative": null,
     "image_url": "/static/images/powers/gigantification_power.webp"
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "GrapplePower",
+    "description": "",
+    "description_raw": null,
+    "type": "Debuff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/grapple_power.webp"
   },
   {
     "id": "GRASP",

--- a/data/tur/cards.json
+++ b/data/tur/cards.json
@@ -1135,7 +1135,7 @@
     "image_url": "/static/images/cards/footwork.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "3 [gold]Beceriklilik[/gold] elde et.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 125
@@ -1767,7 +1767,7 @@
     "image_url": "/static/images/cards/bubble_bubble.webp",
     "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Eğer düşman [gold]Zehir[/gold]'den etkilenmişse, 12 [gold]Zehir[/gold] uygula.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 101
@@ -2091,7 +2091,7 @@
     "image_url": "/static/images/cards/scourge.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "13 [gold]Kader[/gold] uygula.\n2 kart çek.",
+    "upgrade_description": "16 [gold]Kader[/gold] uygula.\n2 kart çek.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 328
@@ -2259,7 +2259,7 @@
     "image_url": "/static/images/cards/feeding_frenzy.webp",
     "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Bu tur için 7 [gold]Kuvvet[/gold] elde et.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 532
@@ -3634,7 +3634,7 @@
     "image_url": "/static/images/cards/brand.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "1 CP kaybet.\n1 kart [gold]Tüket[/gold].\n2 [gold]Kuvvet[/gold] elde et.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 11
@@ -4926,7 +4926,7 @@
     "image_url": "/static/images/cards/neutralize.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "4 hasar ver.\n1 [gold]Zayıf[/gold] uygula.",
+    "upgrade_description": "4 hasar ver.\n2 [gold]Zayıf[/gold] uygula.",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 139
@@ -6216,6 +6216,52 @@
     "compendium_order": 489
   },
   {
+    "id": "GRAPPLE",
+    "name": "Grapple",
+    "description": "",
+    "description_raw": "",
+    "cost": 1,
+    "is_x_cost": null,
+    "is_x_star_cost": null,
+    "star_cost": null,
+    "type": "Saldırı",
+    "rarity": "Az Yaygın",
+    "target": "AnyEnemy",
+    "color": "unknown",
+    "damage": 7,
+    "block": null,
+    "hit_count": null,
+    "powers_applied": [
+      {
+        "power": "Grapple",
+        "amount": 5,
+        "power_key": "Grapple"
+      }
+    ],
+    "cards_draw": null,
+    "energy_gain": null,
+    "hp_loss": null,
+    "keywords": null,
+    "tags": null,
+    "spawns_cards": null,
+    "vars": {
+      "Damage": 7,
+      "GrapplePower": 5,
+      "Grapple": 5
+    },
+    "upgrade": {
+      "damage": "+2",
+      "grapplepower": "+2"
+    },
+    "image_url": "/static/images/cards/grapple.webp",
+    "beta_image_url": null,
+    "type_variants": null,
+    "upgrade_description": null,
+    "type_key": "Attack",
+    "rarity_key": "Uncommon",
+    "compendium_order": 576
+  },
+  {
     "id": "BYRD_SWOOP",
     "name": "Guş Dalışı",
     "description": "14 hasar ver.",
@@ -6718,7 +6764,7 @@
     "image_url": "/static/images/cards/go_for_the_eyes.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "4 hasar ver.\nEğer düşman saldırmayı amaçlıyorsa 1 [gold]Zayıf[/gold] uygula.",
+    "upgrade_description": "4 hasar ver.\nEğer düşman saldırmayı amaçlıyorsa 2 [gold]Zayıf[/gold] uygula.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 389
@@ -6764,7 +6810,7 @@
     "image_url": "/static/images/cards/bash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "10 hasar ver.\n2 [gold]Savunmasız[/gold] uygula.",
+    "upgrade_description": "10 hasar ver.\n3 [gold]Savunmasız[/gold] uygula.",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 5
@@ -7852,7 +7898,7 @@
     "image_url": "/static/images/cards/prowess.webp",
     "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "2 [gold]Kuvvet[/gold] elde et.\n2 [gold]Beceriklilik[/gold] elde et.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 481
@@ -8215,7 +8261,7 @@
     "image_url": "/static/images/cards/beam_cell.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "4 hasar ver.\n1 [gold]Savunmasız[/gold] uygula.",
+    "upgrade_description": "4 hasar ver.\n2 [gold]Savunmasız[/gold] uygula.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 355
@@ -9478,7 +9524,7 @@
     "image_url": "/static/images/cards/coordinate.webp",
     "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Başka bir oyuncuya bu tur için 8 [gold]Kuvvet[/gold] ver.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 448
@@ -9606,7 +9652,7 @@
     "image_url": "/static/images/cards/fear.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "8 hasar ver.\n1 [gold]Savunmasız[/gold] uygula.",
+    "upgrade_description": "8 hasar ver.\n2 [gold]Savunmasız[/gold] uygula.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "keywords_key": [
@@ -10652,7 +10698,7 @@
     "image_url": "/static/images/cards/end_of_days.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "TÜM düşmanlara 37 [gold]Kader[/gold] uygula.\nCP'si kadar [gold]Kader[/gold]'e sahip düşmanları öldür.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 290
@@ -10742,7 +10788,7 @@
     "image_url": "/static/images/cards/taunt.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "8 [gold]Blok[/gold] elde et.\n1 [gold]Savunmasız[/gold] uygula.",
+    "upgrade_description": "8 [gold]Blok[/gold] elde et.\n2 [gold]Savunmasız[/gold] uygula.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -11623,7 +11669,7 @@
     "image_url": "/static/images/cards/negative_pulse.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "6 [gold]Blok[/gold] elde et.\nTÜM düşmanlara 7 [gold]Kader[/gold] uygula.",
+    "upgrade_description": "6 [gold]Blok[/gold] elde et.\nTÜM düşmanlara 11 [gold]Kader[/gold] uygula.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 310
@@ -11896,7 +11942,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "upgrade_description": null,
     "type_key": "Skill",
@@ -12712,7 +12758,7 @@
     "image_url": "/static/images/cards/haze.webp",
     "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "TÜM düşmanlara 6 [gold]Zehir[/gold] uygula.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "keywords_key": [
@@ -13902,7 +13948,7 @@
     "image_url": "/static/images/cards/fight_me.webp",
     "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
-    "upgrade_description": "İki kez 6 hasar ver.\n3 [gold]Kuvvet[/gold] elde et.\nDüşman 1 [gold]Kuvvet[/gold] elde eder.",
+    "upgrade_description": "İki kez 6 hasar ver.\n4 [gold]Kuvvet[/gold] elde et.\nDüşman 1 [gold]Kuvvet[/gold] elde eder.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 35
@@ -15630,7 +15676,7 @@
     "image_url": "/static/images/cards/assassinate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "13 hasar ver.\n1 [gold]Savunmasız[/gold] uygula.",
+    "upgrade_description": "13 hasar ver.\n2 [gold]Savunmasız[/gold] uygula.",
     "type_key": "Attack",
     "rarity_key": "Rare",
     "keywords_key": [
@@ -15876,7 +15922,7 @@
     "image_url": "/static/images/cards/sucker_punch.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "10 hasar ver.\n1 [gold]Zayıf[/gold] uygula.",
+    "upgrade_description": "10 hasar ver.\n2 [gold]Zayıf[/gold] uygula.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 164
@@ -15961,7 +16007,7 @@
     "image_url": "/static/images/cards/null.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "13 hasar ver.\n2 [gold]Zayıf[/gold] uygula.\n1 [gold]Karanlık[/gold] [gold]Oluştur[/gold].",
+    "upgrade_description": "13 hasar ver.\n3 [gold]Zayıf[/gold] uygula.\n1 [gold]Karanlık[/gold] [gold]Oluştur[/gold].",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 407
@@ -16930,7 +16976,7 @@
     "image_url": "/static/images/cards/tremble.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "4 [gold]Savunmasız[/gold] uygula.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -17336,7 +17382,7 @@
     "image_url": "/static/images/cards/oblivion.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Bu tur her kart oynadığında düşmana 4 [gold]Kader[/gold] uygula.",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 313
@@ -17856,7 +17902,7 @@
     "image_url": "/static/images/cards/rupture.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Turunda her CP kaybettiğinde 2 [gold]Kuvvet[/gold] elde et.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -19440,7 +19486,7 @@
     "image_url": "/static/images/cards/break.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "30 hasar ver.\n5 [gold]Savunmasız[/gold] uygula.",
+    "upgrade_description": "30 hasar ver.\n7 [gold]Savunmasız[/gold] uygula.",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "compendium_order": 12
@@ -19530,7 +19576,7 @@
     "image_url": "/static/images/cards/snakebite.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "10 [gold]Zehir[/gold] uygula.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -19812,7 +19858,7 @@
   {
     "id": "STACK",
     "name": "Yığın",
-    "description": "[gold]Atık Deste[/gold]'ndeki kart sayısı kadar [gold]Blok[/gold] kazan.  Blok daha ekle|}",
+    "description": "[gold]Atık Deste[/gold]'ndeki kart sayısı kadar [gold]Blok[/gold] kazan.",
     "description_raw": "[gold]Atık Deste[/gold]'ndeki kart sayısı kadar [gold]Blok[/gold] kazan. {IfUpgraded:show: +{CalculationBase} Blok daha ekle|} {InCombat:\n({CalculatedBlock:diff()} [gold]Blok[/gold] elde et)|}",
     "cost": 1,
     "is_x_cost": null,
@@ -19842,7 +19888,7 @@
     "image_url": "/static/images/cards/stack.webp",
     "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
-    "upgrade_description": "[gold]Atık Deste[/gold]'ndeki kart sayısı kadar [gold]Blok[/gold] kazan.  +[CalculationBase Blok daha ekle|]",
+    "upgrade_description": "[gold]Atık Deste[/gold]'ndeki kart sayısı kadar [gold]Blok[/gold] kazan.  +3 Blok daha ekle",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 544
@@ -19934,7 +19980,7 @@
     "image_url": "/static/images/cards/suppress.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "17 hasar ver.\n3 [gold]Zayıf[/gold] uygula.",
+    "upgrade_description": "17 hasar ver.\n5 [gold]Zayıf[/gold] uygula.",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "keywords_key": [
@@ -20148,7 +20194,7 @@
     "image_url": "/static/images/cards/poisoned_stab.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "8 hasar ver.\n3 [gold]Zehir[/gold] uygula.",
+    "upgrade_description": "8 hasar ver.\n4 [gold]Zehir[/gold] uygula.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 146
@@ -20400,7 +20446,7 @@
     "image_url": "/static/images/cards/high_five.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]Osti[/gold] 13 hasar verir\nve TÜM düşmanlara 2 [gold]Savunmasız[/gold] \nuygular.",
+    "upgrade_description": "[gold]Osti[/gold] 13 hasar verir\nve TÜM düşmanlara 3 [gold]Savunmasız[/gold] \nuygular.",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 303
@@ -20890,7 +20936,7 @@
     "image_url": "/static/images/cards/leg_sweep.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "2 [gold]Zayıf[/gold] uygula.\n14 [gold]Blok[/gold] elde et.",
+    "upgrade_description": "3 [gold]Zayıf[/gold] uygula.\n14 [gold]Blok[/gold] elde et.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 133
@@ -20898,7 +20944,7 @@
   {
     "id": "DUAL_WIELD",
     "name": "Çift El",
-    "description": "Bir Saldırı veya Güç kartı seç. Bu kartın  kopyasını|kopyasını} [gold]El[/gold]'ine ekle.",
+    "description": "Bir Saldırı veya Güç kartı seç. Bu kartın kopyasını [gold]El[/gold]'ine ekle.",
     "description_raw": "Bir Saldırı veya Güç kartı seç. Bu kartın {IfUpgraded:show:{Cards} kopyasını|kopyasını} [gold]El[/gold]'ine ekle.",
     "cost": 1,
     "is_x_cost": null,
@@ -20927,7 +20973,7 @@
     "image_url": "/static/images/cards/dual_wield.webp",
     "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
-    "upgrade_description": "Bir Saldırı veya Güç kartı seç. Bu kartın [Cards kopyasını|kopyasını] [gold]El[/gold]'ine ekle.",
+    "upgrade_description": "Bir Saldırı veya Güç kartı seç. Bu kartın 2 kopyasını [gold]El[/gold]'ine ekle.",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 528
@@ -21008,7 +21054,7 @@
     "image_url": "/static/images/cards/squash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "12 hasar ver.\n2 [gold]Savunmasız[/gold] uygula.",
+    "upgrade_description": "12 hasar ver.\n3 [gold]Savunmasız[/gold] uygula.",
     "type_key": "Attack",
     "rarity_key": "Event",
     "compendium_order": 543
@@ -21534,7 +21580,7 @@
     "image_url": "/static/images/cards/deathbringer.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "TÜM düşmanlara 26 [gold]Kader[/gold] ve 1 [gold]Zayıf[/gold] uygula.",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 276
@@ -21692,7 +21738,7 @@
     "image_url": "/static/images/cards/deadly_poison.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "7 [gold]Zehir[/gold] uygula.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 110
@@ -21873,7 +21919,7 @@
     "image_url": "/static/images/cards/setup_strike.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "9 hasar ver.\nBu tur 2 [gold]Kuvvet[/gold] elde et.",
+    "upgrade_description": "9 hasar ver.\nBu tur 3 [gold]Kuvvet[/gold] elde et.",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 65
@@ -21959,7 +22005,7 @@
     "image_url": "/static/images/cards/anticipate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "Bu tur 3 [gold]Beceriklilik[/gold] elde et.",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 93
@@ -22688,7 +22734,7 @@
     "image_url": "/static/images/cards/bulk_up.webp",
     "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "1 Küre Yuvası kaybet.\n3 [gold]Kuvvet[/gold] elde et.\n3 [gold]Beceriklilik[/gold] elde et.",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 360

--- a/data/tur/enchantments.json
+++ b/data/tur/enchantments.json
@@ -33,6 +33,17 @@
     "image_url": "/static/images/enchantments/corrupted.webp"
   },
   {
+    "id": "FAVORED",
+    "name": "Favored",
+    "description": "",
+    "description_raw": null,
+    "extra_card_text": null,
+    "card_type": "Attack",
+    "applicable_to": null,
+    "is_stackable": false,
+    "image_url": "/static/images/enchantments/favored.webp"
+  },
+  {
     "id": "GLAM",
     "name": "Cazibeli",
     "description": "Bu kart, her savaşta tek seferliğine [gold]Yeniden Oyna[/gold]'ya sahip olur.",

--- a/data/tur/encounters.json
+++ b/data/tur/encounters.json
@@ -1411,6 +1411,25 @@
     "loss_text": "[b]The Adventurer[/b], [gold]Hırsız Çekirge[/gold] tarafından gasp edildi."
   },
   {
+    "id": "TOADPOLES_NORMAL",
+    "name": "Toadpoles Normal",
+    "room_type": "Monster",
+    "is_weak": false,
+    "act": null,
+    "tags": null,
+    "monsters": [
+      {
+        "id": "CALCIFIED_CULTIST",
+        "name": "Taşlaşmış Tarikatçı"
+      },
+      {
+        "id": "TOADPOLE",
+        "name": "İribaş"
+      }
+    ],
+    "loss_text": null
+  },
+  {
     "id": "TOADPOLES_WEAK",
     "name": "İribaşlar",
     "room_type": "Monster",

--- a/data/tur/monsters.json
+++ b/data/tur/monsters.json
@@ -481,13 +481,6 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": true
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Tünel Kazan İkili",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -728,13 +721,6 @@
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
         "encounter_name": "Uyku Partisi",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "Tünel Kazan İkili",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -1077,8 +1063,8 @@
         "is_weak": false
       },
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "Dip Rıhtımlar'ın Vahşi Yaşamı",
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "Dip Rıhtımlar'ın Yaban Hayatı",
         "room_type": "Monster",
         "act": "Underdocks",
         "is_weak": false
@@ -1296,6 +1282,13 @@
         "encounter_name": "Bir Otomaton İkilisi",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
+        "is_weak": false
+      },
+      {
+        "encounter_id": "TUNNELER_NORMAL",
+        "encounter_name": "Tünel Kazan İkili",
+        "room_type": "Monster",
+        "act": null,
         "is_weak": false
       }
     ],
@@ -2019,6 +2012,99 @@
     },
     "image_url": "/static/images/monsters/devoted_sculptor.webp",
     "beta_image_url": null
+  },
+  {
+    "id": "DOOR",
+    "name": "Kapı",
+    "type": "Normal",
+    "min_hp": 155,
+    "max_hp": null,
+    "min_hp_ascension": 165,
+    "max_hp_ascension": null,
+    "moves": [
+      {
+        "id": "DRAMATIC_OPEN",
+        "name": "Dramatic Open",
+        "intent": "Attack",
+        "damage": {
+          "normal": 25,
+          "ascension": 28
+        }
+      },
+      {
+        "id": "ENFORCE",
+        "name": "Enforce",
+        "intent": "Attack + Buff",
+        "powers": [
+          {
+            "power_id": "STRENGTH",
+            "target": "self",
+            "amount": 3
+          }
+        ],
+        "damage": {
+          "normal": 20
+        }
+      },
+      {
+        "id": "DOOR_SLAM",
+        "name": "Door Slam",
+        "intent": "Attack",
+        "damage": {
+          "normal": 15,
+          "ascension": 15,
+          "hit_count": 2
+        }
+      },
+      {
+        "id": "DEAD",
+        "name": "Dead",
+        "intent": "Unknown"
+      }
+    ],
+    "damage_values": {
+      "DramaticOpen": {
+        "normal": 25,
+        "ascension": 28
+      },
+      "DoorSlam": {
+        "normal": 15,
+        "ascension": 15,
+        "hit_count": 2
+      },
+      "Enforce": {
+        "normal": 20
+      }
+    },
+    "block_values": null,
+    "encounters": null,
+    "innate_powers": null,
+    "attack_pattern": {
+      "type": "cycle",
+      "initial_move": null,
+      "states": [
+        {
+          "id": "ENFORCE_MOVE",
+          "type": "move",
+          "move_id": "ENFORCE"
+        },
+        {
+          "id": "DOOR_SLAM_MOVE",
+          "type": "move",
+          "move_id": "DOOR_SLAM",
+          "next": "ENFORCE_MOVE"
+        },
+        {
+          "id": "DEAD_MOVE",
+          "type": "move",
+          "move_id": "DEAD",
+          "next": "DEAD_MOVE"
+        }
+      ],
+      "description": ""
+    },
+    "image_url": "/static/images/monsters/door.webp",
+    "beta_image_url": "/static/images/monsters/beta/door.webp"
   },
   {
     "id": "DOORMAKER",
@@ -6767,6 +6853,13 @@
     "block_values": null,
     "encounters": [
       {
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "Dip Rıhtımlar'ın Yaban Hayatı",
+        "room_type": "Monster",
+        "act": "Underdocks",
+        "is_weak": false
+      },
+      {
         "encounter_id": "SEAPUNK_WEAK",
         "encounter_name": "Deniz Haydutu",
         "room_type": "Monster",
@@ -9191,13 +9284,6 @@
     "block_values": null,
     "encounters": [
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "Dip Rıhtımlar'ın Vahşi Yaşamı",
-        "room_type": "Monster",
-        "act": "Underdocks",
-        "is_weak": false
-      },
-      {
         "encounter_id": "TOADPOLES_WEAK",
         "encounter_name": "İribaşlar",
         "room_type": "Monster",
@@ -9564,7 +9650,7 @@
         "encounter_id": "TUNNELER_NORMAL",
         "encounter_name": "Tünel Kazan İkili",
         "room_type": "Monster",
-        "act": "Act 2 - Hive",
+        "act": null,
         "is_weak": false
       },
       {

--- a/data/tur/powers.json
+++ b/data/tur/powers.json
@@ -170,6 +170,16 @@
     "image_url": "/static/images/powers/black_hole_power.webp"
   },
   {
+    "id": "BLADE_OF_INK",
+    "name": "BladeOfInkPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/blade_of_ink_power.webp"
+  },
+  {
     "id": "BLOCK_NEXT_TURN",
     "name": "Sonraki Turda Blokla",
     "description": "Bir sonraki turunun başında [blue]4[/blue] [gold]Blok[/gold] elde et.",
@@ -610,6 +620,16 @@
     "image_url": "/static/images/powers/doom_power.webp"
   },
   {
+    "id": "DOOR_REVIVAL",
+    "name": "DoorRevivalPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Single",
+    "allow_negative": null,
+    "image_url": null
+  },
+  {
     "id": "DOUBLE_DAMAGE",
     "name": "İki Kat Hasar",
     "description": "Saldırılar, bu turda iki kat daha fazla hasar verir.",
@@ -948,6 +968,16 @@
     "stack_type": "Counter",
     "allow_negative": null,
     "image_url": "/static/images/powers/gigantification_power.webp"
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "GrapplePower",
+    "description": "",
+    "description_raw": null,
+    "type": "Debuff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/grapple_power.webp"
   },
   {
     "id": "GRASP",

--- a/data/zhs/cards.json
+++ b/data/zhs/cards.json
@@ -1,5 +1,51 @@
 [
   {
+    "id": "GRAPPLE",
+    "name": "Grapple",
+    "description": "",
+    "description_raw": "",
+    "cost": 1,
+    "is_x_cost": null,
+    "is_x_star_cost": null,
+    "star_cost": null,
+    "type": "攻击",
+    "rarity": "罕见",
+    "target": "AnyEnemy",
+    "color": "unknown",
+    "damage": 7,
+    "block": null,
+    "hit_count": null,
+    "powers_applied": [
+      {
+        "power": "Grapple",
+        "amount": 5,
+        "power_key": "Grapple"
+      }
+    ],
+    "cards_draw": null,
+    "energy_gain": null,
+    "hp_loss": null,
+    "keywords": null,
+    "tags": null,
+    "spawns_cards": null,
+    "vars": {
+      "Damage": 7,
+      "GrapplePower": 5,
+      "Grapple": 5
+    },
+    "upgrade": {
+      "damage": "+2",
+      "grapplepower": "+2"
+    },
+    "image_url": "/static/images/cards/grapple.webp",
+    "beta_image_url": null,
+    "type_variants": null,
+    "upgrade_description": null,
+    "type_key": "Attack",
+    "rarity_key": "Uncommon",
+    "compendium_order": 576
+  },
+  {
     "id": "SEVEN_STARS",
     "name": "七星",
     "description": "对所有敌人造成7点伤害7次。",
@@ -306,7 +352,7 @@
     "image_url": "/static/images/cards/fight_me.webp",
     "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
-    "upgrade_description": "造成6点伤害两次。\n获得3点[gold]力量[/gold]。\n该敌人获得1点[gold]力量[/gold]。",
+    "upgrade_description": "造成6点伤害两次。\n获得4点[gold]力量[/gold]。\n该敌人获得1点[gold]力量[/gold]。",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 35
@@ -352,7 +398,7 @@
     "image_url": "/static/images/cards/neutralize.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "造成4点伤害。\n给予1层[gold]虚弱[/gold]。",
+    "upgrade_description": "造成4点伤害。\n给予2层[gold]虚弱[/gold]。",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 139
@@ -1639,7 +1685,7 @@
     "image_url": "/static/images/cards/beam_cell.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "造成4点伤害。\n给予1层[gold]易伤[/gold]。",
+    "upgrade_description": "造成4点伤害。\n给予2层[gold]易伤[/gold]。",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 355
@@ -2620,7 +2666,7 @@
     "image_url": "/static/images/cards/high_five.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "[gold]奥斯提[/gold]对所有敌人\n造成13点伤害并给予它们\n2层[gold]易伤[/gold]。",
+    "upgrade_description": "[gold]奥斯提[/gold]对所有敌人\n造成13点伤害并给予它们\n3层[gold]易伤[/gold]。",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 303
@@ -3058,7 +3104,7 @@
     "image_url": "/static/images/cards/assassinate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "造成13点伤害。\n给予1层[gold]易伤[/gold]。",
+    "upgrade_description": "造成13点伤害。\n给予2层[gold]易伤[/gold]。",
     "type_key": "Attack",
     "rarity_key": "Rare",
     "keywords_key": [
@@ -3499,7 +3545,7 @@
     "image_url": "/static/images/cards/coordinate.webp",
     "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "在本回合给予其他玩家8点[gold]力量[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 448
@@ -3584,7 +3630,7 @@
     "image_url": "/static/images/cards/suppress.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "造成17点伤害。\n给予3层[gold]虚弱[/gold]。",
+    "upgrade_description": "造成17点伤害。\n给予5层[gold]虚弱[/gold]。",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "keywords_key": [
@@ -3633,7 +3679,7 @@
     "image_url": "/static/images/cards/squash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "造成12点伤害。\n给予2层[gold]易伤[/gold]。",
+    "upgrade_description": "造成12点伤害。\n给予3层[gold]易伤[/gold]。",
     "type_key": "Attack",
     "rarity_key": "Event",
     "compendium_order": 543
@@ -3839,7 +3885,7 @@
   {
     "id": "DUAL_WIELD",
     "name": "双持",
-    "description": "选择一张攻击牌或能力牌。将张此牌的复制品|一张此牌的复制品}加入你的[gold]手牌[/gold]。",
+    "description": "选择一张攻击牌或能力牌。将一张此牌的复制品加入你的[gold]手牌[/gold]。",
     "description_raw": "选择一张攻击牌或能力牌。将{IfUpgraded:show:{Cards}张此牌的复制品|一张此牌的复制品}加入你的[gold]手牌[/gold]。",
     "cost": 1,
     "is_x_cost": null,
@@ -3868,7 +3914,7 @@
     "image_url": "/static/images/cards/dual_wield.webp",
     "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
-    "upgrade_description": "选择一张攻击牌或能力牌。将[Cards张此牌的复制品|一张此牌的复制品]加入你的[gold]手牌[/gold]。",
+    "upgrade_description": "选择一张攻击牌或能力牌。将2张此牌的复制品加入你的[gold]手牌[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 528
@@ -4600,7 +4646,7 @@
     "image_url": "/static/images/cards/bubble_bubble.webp",
     "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "如果敌方拥有[gold]中毒[/gold]，则给予12层[gold]中毒[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 101
@@ -5234,7 +5280,7 @@
   {
     "id": "STACK",
     "name": "堆栈",
-    "description": "获得等量于与你当前[gold]弃牌堆[/gold]中牌数|}的[gold]格挡[/gold]值。",
+    "description": "获得等量于与你当前[gold]弃牌堆[/gold]中牌数的[gold]格挡[/gold]值。",
     "description_raw": "获得等量于与你当前[gold]弃牌堆[/gold]中牌数{IfUpgraded:show:+{CalculationBase}|}的[gold]格挡[/gold]值。{InCombat:\n（获得{CalculatedBlock:diff()}点[gold]格挡[/gold]）|}",
     "cost": 1,
     "is_x_cost": null,
@@ -5264,7 +5310,7 @@
     "image_url": "/static/images/cards/stack.webp",
     "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
-    "upgrade_description": "获得等量于与你当前[gold]弃牌堆[/gold]中牌数+[CalculationBase|]的[gold]格挡[/gold]值。",
+    "upgrade_description": "获得等量于与你当前[gold]弃牌堆[/gold]中牌数+3的[gold]格挡[/gold]值。",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 544
@@ -6901,7 +6947,7 @@
     "image_url": "/static/images/cards/poisoned_stab.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "造成8点伤害。\n给予3层[gold]中毒[/gold]。",
+    "upgrade_description": "造成8点伤害。\n给予4层[gold]中毒[/gold]。",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 146
@@ -8324,7 +8370,7 @@
     "image_url": "/static/images/cards/fear.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "造成8点伤害。\n给予1层[gold]易伤[/gold]。",
+    "upgrade_description": "造成8点伤害。\n给予2层[gold]易伤[/gold]。",
     "type_key": "Attack",
     "rarity_key": "Common",
     "keywords_key": [
@@ -8933,7 +8979,7 @@
     "image_url": "/static/images/cards/tremble.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "给予4层[gold]易伤[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -9566,7 +9612,7 @@
     "image_url": "/static/images/cards/leg_sweep.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "给予2层[gold]虚弱[/gold]。\n获得14点[gold]格挡[/gold]。",
+    "upgrade_description": "给予3层[gold]虚弱[/gold]。\n获得14点[gold]格挡[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 133
@@ -10253,7 +10299,7 @@
     "image_url": "/static/images/cards/taunt.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "获得8点[gold]格挡[/gold]。\n给予1层[gold]易伤[/gold]。",
+    "upgrade_description": "获得8点[gold]格挡[/gold]。\n给予2层[gold]易伤[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -10547,7 +10593,7 @@
     "image_url": "/static/images/cards/rupture.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "每当你在你的回合失去生命值时, 获得2点[gold]力量[/gold]。",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -11293,7 +11339,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "upgrade_description": "回复13点生命。",
     "type_key": "Skill",
@@ -11787,7 +11833,7 @@
     "image_url": "/static/images/cards/bulk_up.webp",
     "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "失去1个充能球栏位。\n获得3点[gold]力量[/gold]。\n获得3点[gold]敏捷[/gold]。",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 360
@@ -12022,7 +12068,7 @@
     "image_url": "/static/images/cards/end_of_days.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "给予所有敌人37层[gold]灾厄[/gold]。\n杀死所有[gold]灾厄[/gold]大于等于当前生命值的敌人。",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 290
@@ -12666,7 +12712,7 @@
     "image_url": "/static/images/cards/deathbringer.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "给予所有敌人26层[gold]灾厄[/gold]和1层[gold]虚弱[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "compendium_order": 276
@@ -13601,7 +13647,7 @@
     "image_url": "/static/images/cards/oblivion.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "打出此牌后，你在本回合内每打出一张牌，就给予该敌人4层[gold]灾厄[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 313
@@ -14012,7 +14058,7 @@
     "image_url": "/static/images/cards/footwork.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "获得3点[gold]敏捷[/gold]。",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 125
@@ -14293,7 +14339,7 @@
     "image_url": "/static/images/cards/brand.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "失去1点生命。\n[gold]消耗[/gold]1张牌。\n获得2点[gold]力量[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Rare",
     "compendium_order": 11
@@ -16030,7 +16076,7 @@
     "image_url": "/static/images/cards/feeding_frenzy.webp",
     "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "在本回合内获得7点[gold]力量[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Event",
     "compendium_order": 532
@@ -16076,7 +16122,7 @@
     "image_url": "/static/images/cards/bash.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "造成10点伤害。\n给予2层[gold]易伤[/gold]。",
+    "upgrade_description": "造成10点伤害。\n给予3层[gold]易伤[/gold]。",
     "type_key": "Attack",
     "rarity_key": "Basic",
     "compendium_order": 5
@@ -16236,7 +16282,7 @@
     "image_url": "/static/images/cards/go_for_the_eyes.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "造成4点伤害。\n如果敌人的意图是攻击，则给予1层[gold]虚弱[/gold]。",
+    "upgrade_description": "造成4点伤害。\n如果敌人的意图是攻击，则给予2层[gold]虚弱[/gold]。",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 389
@@ -16322,7 +16368,7 @@
     "image_url": "/static/images/cards/break.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "造成30点伤害。\n给予5层[gold]易伤[/gold]。",
+    "upgrade_description": "造成30点伤害。\n给予7层[gold]易伤[/gold]。",
     "type_key": "Attack",
     "rarity_key": "Ancient",
     "compendium_order": 12
@@ -16943,7 +16989,7 @@
     "image_url": "/static/images/cards/null.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "造成13点伤害。\n给予2层[gold]虚弱[/gold]。\n[gold]生成[/gold]1个[gold]黑暗[/gold]充能球。",
+    "upgrade_description": "造成13点伤害。\n给予3层[gold]虚弱[/gold]。\n[gold]生成[/gold]1个[gold]黑暗[/gold]充能球。",
     "type_key": "Attack",
     "rarity_key": "Uncommon",
     "compendium_order": 407
@@ -16989,7 +17035,7 @@
     "image_url": "/static/images/cards/sucker_punch.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "造成10点伤害。\n给予1层[gold]虚弱[/gold]。",
+    "upgrade_description": "造成10点伤害。\n给予2层[gold]虚弱[/gold]。",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 164
@@ -18525,7 +18571,7 @@
     "image_url": "/static/images/cards/deadly_poison.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "给予7层[gold]中毒[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 110
@@ -19062,7 +19108,7 @@
     "image_url": "/static/images/cards/snakebite.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "给予10层[gold]中毒[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Common",
     "keywords_key": [
@@ -19740,7 +19786,7 @@
     "image_url": "/static/images/cards/negative_pulse.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "获得6点[gold]格挡[/gold]。\n给予所有敌人7层[gold]灾厄[/gold]。",
+    "upgrade_description": "获得6点[gold]格挡[/gold]。\n给予所有敌人11层[gold]灾厄[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 310
@@ -20670,7 +20716,7 @@
     "image_url": "/static/images/cards/haze.webp",
     "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "给予所有敌人6层[gold]中毒[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Uncommon",
     "keywords_key": [
@@ -22517,7 +22563,7 @@
     "image_url": "/static/images/cards/prowess.webp",
     "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "获得2点[gold]力量[/gold]。\n获得2点[gold]敏捷[/gold]。",
     "type_key": "Power",
     "rarity_key": "Uncommon",
     "compendium_order": 481
@@ -22563,7 +22609,7 @@
     "image_url": "/static/images/cards/scourge.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "给予13层[gold]灾厄[/gold]。\n抽2张牌。",
+    "upgrade_description": "给予16层[gold]灾厄[/gold]。\n抽2张牌。",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 328
@@ -22645,7 +22691,7 @@
     "image_url": "/static/images/cards/anticipate.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": null,
+    "upgrade_description": "在本回合获得3点[gold]敏捷[/gold]。",
     "type_key": "Skill",
     "rarity_key": "Common",
     "compendium_order": 93
@@ -22693,7 +22739,7 @@
     "image_url": "/static/images/cards/setup_strike.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "造成9点伤害。\n在本回合内获得2点[gold]力量[/gold]。",
+    "upgrade_description": "造成9点伤害。\n在本回合内获得3点[gold]力量[/gold]。",
     "type_key": "Attack",
     "rarity_key": "Common",
     "compendium_order": 65

--- a/data/zhs/enchantments.json
+++ b/data/zhs/enchantments.json
@@ -33,6 +33,17 @@
     "image_url": "/static/images/enchantments/corrupted.webp"
   },
   {
+    "id": "FAVORED",
+    "name": "Favored",
+    "description": "",
+    "description_raw": null,
+    "extra_card_text": null,
+    "card_type": "Attack",
+    "applicable_to": null,
+    "is_stackable": false,
+    "image_url": "/static/images/enchantments/favored.webp"
+  },
+  {
     "id": "GLAM",
     "name": "华彩",
     "description": "这张牌每场战斗能够[gold]重放[/gold]一次。",

--- a/data/zhs/encounters.json
+++ b/data/zhs/encounters.json
@@ -1411,6 +1411,25 @@
     "loss_text": "一只[gold]偷窃草蜢[/gold]抢走了[b]The Adventurer[/b]的生命。"
   },
   {
+    "id": "TOADPOLES_NORMAL",
+    "name": "Toadpoles Normal",
+    "room_type": "Monster",
+    "is_weak": false,
+    "act": null,
+    "tags": null,
+    "monsters": [
+      {
+        "id": "CALCIFIED_CULTIST",
+        "name": "钙化邪教徒"
+      },
+      {
+        "id": "TOADPOLE",
+        "name": "蟾蜍蝌蚪"
+      }
+    ],
+    "loss_text": null
+  },
+  {
     "id": "TOADPOLES_WEAK",
     "name": "蟾蜍蝌蚪",
     "room_type": "Monster",

--- a/data/zhs/monsters.json
+++ b/data/zhs/monsters.json
@@ -481,13 +481,6 @@
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": true
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "地道组合",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
       }
     ],
     "innate_powers": null,
@@ -728,13 +721,6 @@
       {
         "encounter_id": "SLUMBERING_BEETLE_NORMAL",
         "encounter_name": "熟睡派对",
-        "room_type": "Monster",
-        "act": "Act 2 - Hive",
-        "is_weak": false
-      },
-      {
-        "encounter_id": "TUNNELER_NORMAL",
-        "encounter_name": "地道组合",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
         "is_weak": false
@@ -1077,7 +1063,7 @@
         "is_weak": false
       },
       {
-        "encounter_id": "TOADPOLES_NORMAL",
+        "encounter_id": "SEAPUNK_NORMAL",
         "encounter_name": "暗港野生动物",
         "room_type": "Monster",
         "act": "Underdocks",
@@ -1296,6 +1282,13 @@
         "encounter_name": "一对自动机械",
         "room_type": "Monster",
         "act": "Act 2 - Hive",
+        "is_weak": false
+      },
+      {
+        "encounter_id": "TUNNELER_NORMAL",
+        "encounter_name": "地道组合",
+        "room_type": "Monster",
+        "act": null,
         "is_weak": false
       }
     ],
@@ -2019,6 +2012,99 @@
     },
     "image_url": "/static/images/monsters/devoted_sculptor.webp",
     "beta_image_url": null
+  },
+  {
+    "id": "DOOR",
+    "name": "门扉",
+    "type": "Normal",
+    "min_hp": 155,
+    "max_hp": null,
+    "min_hp_ascension": 165,
+    "max_hp_ascension": null,
+    "moves": [
+      {
+        "id": "DRAMATIC_OPEN",
+        "name": "Dramatic Open",
+        "intent": "Attack",
+        "damage": {
+          "normal": 25,
+          "ascension": 28
+        }
+      },
+      {
+        "id": "ENFORCE",
+        "name": "Enforce",
+        "intent": "Attack + Buff",
+        "powers": [
+          {
+            "power_id": "STRENGTH",
+            "target": "self",
+            "amount": 3
+          }
+        ],
+        "damage": {
+          "normal": 20
+        }
+      },
+      {
+        "id": "DOOR_SLAM",
+        "name": "Door Slam",
+        "intent": "Attack",
+        "damage": {
+          "normal": 15,
+          "ascension": 15,
+          "hit_count": 2
+        }
+      },
+      {
+        "id": "DEAD",
+        "name": "Dead",
+        "intent": "Unknown"
+      }
+    ],
+    "damage_values": {
+      "DramaticOpen": {
+        "normal": 25,
+        "ascension": 28
+      },
+      "DoorSlam": {
+        "normal": 15,
+        "ascension": 15,
+        "hit_count": 2
+      },
+      "Enforce": {
+        "normal": 20
+      }
+    },
+    "block_values": null,
+    "encounters": null,
+    "innate_powers": null,
+    "attack_pattern": {
+      "type": "cycle",
+      "initial_move": null,
+      "states": [
+        {
+          "id": "ENFORCE_MOVE",
+          "type": "move",
+          "move_id": "ENFORCE"
+        },
+        {
+          "id": "DOOR_SLAM_MOVE",
+          "type": "move",
+          "move_id": "DOOR_SLAM",
+          "next": "ENFORCE_MOVE"
+        },
+        {
+          "id": "DEAD_MOVE",
+          "type": "move",
+          "move_id": "DEAD",
+          "next": "DEAD_MOVE"
+        }
+      ],
+      "description": ""
+    },
+    "image_url": "/static/images/monsters/door.webp",
+    "beta_image_url": "/static/images/monsters/beta/door.webp"
   },
   {
     "id": "DOORMAKER",
@@ -6767,6 +6853,13 @@
     "block_values": null,
     "encounters": [
       {
+        "encounter_id": "SEAPUNK_NORMAL",
+        "encounter_name": "暗港野生动物",
+        "room_type": "Monster",
+        "act": "Underdocks",
+        "is_weak": false
+      },
+      {
         "encounter_id": "SEAPUNK_WEAK",
         "encounter_name": "海洋混混",
         "room_type": "Monster",
@@ -9191,13 +9284,6 @@
     "block_values": null,
     "encounters": [
       {
-        "encounter_id": "TOADPOLES_NORMAL",
-        "encounter_name": "暗港野生动物",
-        "room_type": "Monster",
-        "act": "Underdocks",
-        "is_weak": false
-      },
-      {
         "encounter_id": "TOADPOLES_WEAK",
         "encounter_name": "蟾蜍蝌蚪",
         "room_type": "Monster",
@@ -9564,7 +9650,7 @@
         "encounter_id": "TUNNELER_NORMAL",
         "encounter_name": "地道组合",
         "room_type": "Monster",
-        "act": "Act 2 - Hive",
+        "act": null,
         "is_weak": false
       },
       {

--- a/data/zhs/powers.json
+++ b/data/zhs/powers.json
@@ -170,6 +170,16 @@
     "image_url": "/static/images/powers/black_hole_power.webp"
   },
   {
+    "id": "BLADE_OF_INK",
+    "name": "BladeOfInkPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/blade_of_ink_power.webp"
+  },
+  {
     "id": "BLOCK_NEXT_TURN",
     "name": "下回合格挡",
     "description": "在你的下个回合开始时，获得[blue]4[/blue]点[gold]格挡[/gold]。",
@@ -610,6 +620,16 @@
     "image_url": "/static/images/powers/doom_power.webp"
   },
   {
+    "id": "DOOR_REVIVAL",
+    "name": "DoorRevivalPower",
+    "description": "",
+    "description_raw": null,
+    "type": "Buff",
+    "stack_type": "Single",
+    "allow_negative": null,
+    "image_url": null
+  },
+  {
     "id": "DOUBLE_DAMAGE",
     "name": "双倍伤害",
     "description": "本回合，攻击造成双倍伤害。",
@@ -948,6 +968,16 @@
     "stack_type": "Counter",
     "allow_negative": null,
     "image_url": "/static/images/powers/gigantification_power.webp"
+  },
+  {
+    "id": "GRAPPLE",
+    "name": "GrapplePower",
+    "description": "",
+    "description_raw": null,
+    "type": "Debuff",
+    "stack_type": "Counter",
+    "allow_negative": null,
+    "image_url": "/static/images/powers/grapple_power.webp"
   },
   {
     "id": "GRASP",


### PR DESCRIPTION
## Summary

Two parser bugs reported on production:

1. **`/cards/stack`** rendered "...Discard Pile|}." with a stray `|}` suffix.
2. **Upgraded Sucker Punch / Suppress / Taunt** (and any card that bumps both damage/block AND a debuff value) showed the unupgraded debuff amount in the upgrade preview — "Apply 1 Weak" instead of "2", etc.

## Bug 1 — `IfUpgraded:show:` regex couldn't handle nested braces

`description_resolver.resolve_description` used `re.sub(r"\{IfUpgraded:show:([^}]*)\}", ...)`. That `[^}]*` stops at the first `}` it sees, so on a body like `{IfUpgraded:show: +{CalculationBase}|}` the regex matched only up to the inner `}` after `CalculationBase`, leaving `|}` stranded in the output.

**Fix:** replaced with a manual brace-counting loop that splits the inner body on `|` at depth 0 — same pattern already used in this file for `:plural:` and `:cond:` blocks. Now both branches resolve cleanly:
- upgraded → `Discard Pile +3.`
- unupgraded → `Discard Pile.`

## Bug 2 — upgrade bump only hit one matching var

Power-applying cards register both the bare power name (`Weak`) and the C# class name (`WeakPower`) in their var dict. Descriptions usually reference `{WeakPower:diff()}`, but the upgrade key is the bare lowercase `weak`. The old loop in `card_parser` matched on `vk.lower() == key.lower()` and `break`'d on the first hit, so for SUCKER_PUNCH it bumped `Weak` (1→2) but never `WeakPower` — and the rendered description still showed `Apply {WeakPower}=1 Weak`.

**Fix:** drop the `break`, and accept `vk.lower() == key.lower() + "power"` as a match too. Both vars get bumped whenever the upgrade key is the bare power name.

## Verified

| Card | Before | After |
|---|---|---|
| `STACK` desc | "...Discard Pile**\|}**." | "...Discard Pile." ✅ |
| `STACK` upgraded | "...Discard Pile **+[CalculationBase\|]**." | "...Discard Pile **+3**." ✅ |
| `SUCKER_PUNCH` upgraded | "Apply **1** Weak" | "Apply **2** Weak" ✅ |
| `SUPPRESS` upgraded | "Apply **3** Weak" | "Apply **5** Weak" ✅ |
| `TAUNT` upgraded | "Apply **1** Vulnerable" | "Apply **2** Vulnerable" ✅ |

Tested across all 14 languages — fix propagates everywhere.

## Files

- `backend/app/parsers/description_resolver.py` — `resolve_all_if_upgraded` brace-counting loop
- `backend/app/parsers/card_parser.py` — drop `break`, match `+power` suffix
- 70 regenerated `data/<lang>/*.json` files — bulk is `cards.json` across 14 langs (the actual fix); smaller changes in encounters/monsters/powers/enchantments are unrelated catch-up from prior parser drift surfacing in the same `parse_all.py` run

ruff check + format both clean.
