### PR TITLE
Force /news pages to render at request time

### DIFF
--- a/frontend/app/[lang]/news/[gid]/page.tsx
+++ b/frontend/app/[lang]/news/[gid]/page.tsx
@@ -11,6 +11,7 @@ import { t } from "@/lib/ui-translations";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
+export const dynamic = "force-dynamic";
 export const revalidate = 1800;
 
 async function fetchItem(gid: string): Promise<NewsArticle | null> {

--- a/frontend/app/[lang]/news/page.tsx
+++ b/frontend/app/[lang]/news/page.tsx
@@ -17,6 +17,7 @@ import { t } from "@/lib/ui-translations";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
+export const dynamic = "force-dynamic";
 export const revalidate = 1800;
 
 export async function generateMetadata({

--- a/frontend/app/news/[gid]/page.tsx
+++ b/frontend/app/news/[gid]/page.tsx
@@ -9,6 +9,9 @@ import { sanitizeSteamNews, newsExcerpt, formatNewsDate } from "@/lib/steam-news
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
+// Same reasoning as /news — skip the build-time prerender so we don't
+// bake a "Not Found" page when the backend isn't reachable from CI.
+export const dynamic = "force-dynamic";
 export const revalidate = 1800;
 
 async function fetchItem(gid: string): Promise<NewsArticle | null> {

--- a/frontend/app/news/page.tsx
+++ b/frontend/app/news/page.tsx
@@ -8,7 +8,14 @@ import { newsExcerpt, formatNewsDate } from "@/lib/steam-news";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
-export const revalidate = 1800; // 30 min
+// Render at request time, not build time. The Docker build container
+// can't reach the backend, so a build-time prerender would catch the
+// fetch error and bake an empty list into the image — and ISR's 30-min
+// revalidate window would then serve that empty version for half an
+// hour after every deploy. Same pattern as `/[lang]/showcase` and
+// `/[lang]/leaderboards`.
+export const dynamic = "force-dynamic";
+export const revalidate = 1800;
 
 export const metadata: Metadata = {
   title: `Slay the Spire 2 News - Patch Notes & Announcements | ${SITE_NAME}`,


### PR DESCRIPTION
**Why /news shows "No news available" on prod despite `/api/news` returning 101 articles:**

The CI Docker build runs in GitHub Actions where the backend container isn't reachable. Without `dynamic = "force-dynamic"`, Next.js prerenders ISR pages at build time — `loadNews()`/`fetchItem()` throw, the try/catch returns the empty fallback, and Next bakes that empty render into the image. The 30-min `revalidate` window then serves the empty version for half an hour after every deploy.

Same pattern as `/[lang]/showcase`, `/[lang]/leaderboards`, and other data-fetching server pages in this repo: skip build-time prerender, render fresh per request, keep the 30-min revalidate hint for downstream proxies.

Affects all four news pages (`/news`, `/news/[gid]`, `/[lang]/news`, `/[lang]/news/[gid]`). Type-check clean.