### PR TITLE
Fix card pity wording on /mechanics/card-rarity (per roll, not per pick)

### DIFF
--- a/frontend/app/mechanics/[slug]/MechanicContent.tsx
+++ b/frontend/app/mechanics/[slug]/MechanicContent.tsx
@@ -41,7 +41,7 @@ export default function MechanicContent({ slug }: { slug: string }) {
           <div className={`${card} mt-4`}>
             <h3 className={h3}>Rare Card Pity System</h3>
             <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
-              A hidden offset starts at <strong className={bold}>-5%</strong> and increases by <strong className={bold}>+1%</strong> each time you pick a non-rare card (+0.5% on A7+). When a rare is rolled, the offset resets to -5%. Caps at <strong className={bold}>+40%</strong>. This ensures you see rares more often the longer you go without one.
+              A hidden offset starts at <strong className={bold}>-5%</strong> and increases by <strong className={bold}>+1%</strong> for each non-rare card <em>shown</em> in a combat reward (+0.5% on A7+) — including ones you skip. When a rare is rolled, the offset resets to -5%. Caps at <strong className={bold}>+40%</strong>. Each combat reward generates 3 cards up front, so a skipped reward still ticks the counter 3 times. This ensures you see rares more often the longer you go without one.
             </p>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">


### PR DESCRIPTION
## Summary

Fixes a factually wrong line in the Rare Card Pity System blurb on `/mechanics/card-rarity`.

**Before:**

> A hidden offset starts at **-5%** and increases by **+1%** each time you **pick** a non-rare card (+0.5% on A7+). When a rare is rolled, the offset resets to -5%. Caps at **+40%**. This ensures you see rares more often the longer you go without one.

**After:**

> A hidden offset starts at **-5%** and increases by **+1%** for each non-rare card *shown* in a combat reward (+0.5% on A7+) — including ones you skip. When a rare is rolled, the offset resets to -5%. Caps at **+40%**. Each combat reward generates 3 cards up front, so a skipped reward still ticks the counter 3 times. This ensures you see rares more often the longer you go without one.

## Why

The "per pick" wording implies skipping a reward leaves the pity counter unchanged. That's wrong — `CardRarityOdds.Roll()` is called from inside the `for (int i = 0; i < cardCount; i++)` loop in `CardFactory.CreateForReward(player, cardCount, options)`, which runs once when the reward is generated (`CardReward.Populate()`). Skipping or rerolling never re-enters `Roll()`, and picking doesn't tick anything extra.

This was caught by a community player (Xo) who demonstrated rares appearing on the floor-4 combat reward after skipping floors 1–3. Impossible under "per pick" (offset stays at -0.05 → 0% rare chance), expected under "per roll" (3 rolls per skipped reward → offset hits +0.01 by floor 3 → ~20% cumulative rare odds across the 9 rolls).

