### PR TITLE
Beta runs UX: notice on submit + home Leaderboards/Stats pull from stable

### DIFF
--- a/frontend/app/components/HomeLeaderboardSection.tsx
+++ b/frontend/app/components/HomeLeaderboardSection.tsx
@@ -1,7 +1,15 @@
 import Link from "next/link";
 import { t } from "@/lib/ui-translations";
+import { IS_BETA } from "@/lib/seo";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+// Beta has run submissions disabled, so its local runs.db is essentially
+// empty. Fetch leaderboard + recent-runs data from stable instead so the
+// section actually has content to show. Server-side fetch — no CORS hop.
+// All in-page links (row → /runs/{hash}, View more → /leaderboards) on
+// beta point at stable's absolute URL since the data only lives there.
+const RUNS_HOST = IS_BETA ? "https://spire-codex.com" : "";
+const RUNS_API = IS_BETA ? "https://spire-codex.com" : API;
 // The browser fetches images from the public API URL — `API_INTERNAL_URL`
 // only resolves inside the Docker network during server render. The
 // production build sets `NEXT_PUBLIC_API_URL=""` (empty) on purpose so
@@ -101,7 +109,7 @@ async function loadFastestWins(): Promise<{ runs: RunRow[]; ascension: number | 
   // back to "any ascension" so the section never renders empty when wins
   // exist at all.
   try {
-    const res = await fetch(`${API}/api/runs/leaderboard?category=fastest&limit=50`, {
+    const res = await fetch(`${RUNS_API}/api/runs/leaderboard?category=fastest&limit=50`, {
       next: { revalidate: REVALIDATE },
     });
     if (!res.ok) return { runs: [], ascension: null };
@@ -121,7 +129,7 @@ async function loadFastestWins(): Promise<{ runs: RunRow[]; ascension: number | 
 
 async function loadRecentRuns(): Promise<RunRow[]> {
   try {
-    const res = await fetch(`${API}/api/runs/list?limit=5&sort=newest`, {
+    const res = await fetch(`${RUNS_API}/api/runs/list?limit=5&sort=newest`, {
       next: { revalidate: REVALIDATE },
     });
     if (!res.ok) return [];
@@ -147,7 +155,12 @@ export default async function HomeLeaderboardSection({
   const [fastest, recent] = await Promise.all([loadFastestWins(), loadRecentRuns()]);
   if (fastest.runs.length === 0 && recent.length === 0) return null;
 
-  const lbBase = `${langPrefix}/leaderboards`;
+  // On beta, point all in-page links at stable's absolute URL — the data
+  // shown in this section came from stable, so the run-detail / browse /
+  // submit pages need to live there too. On stable, stay relative so
+  // the langPrefix stays meaningful.
+  const lbBase = `${RUNS_HOST}${langPrefix}/leaderboards`;
+  const runsBase = `${RUNS_HOST}${langPrefix}/runs`;
   const ascLabel =
     fastest.ascension === TARGET_ASCENSION
       ? `A${TARGET_ASCENSION}`
@@ -203,7 +216,7 @@ export default async function HomeLeaderboardSection({
               {fastest.runs.map((r, i) => (
                 <li key={r.run_hash}>
                   <Link
-                    href={`${langPrefix}/runs/${r.run_hash}`}
+                    href={`${runsBase}/${r.run_hash}`}
                     className="grid grid-cols-[1.5rem_2rem_1fr_auto] items-center gap-3 px-5 py-3 hover:bg-[var(--bg-card-hover)] transition-colors"
                   >
                     <span className="text-base font-bold text-[var(--text-muted)] tabular-nums">
@@ -266,7 +279,7 @@ export default async function HomeLeaderboardSection({
                 return (
                   <li key={r.run_hash}>
                     <Link
-                      href={`${langPrefix}/runs/${r.run_hash}`}
+                      href={`${runsBase}/${r.run_hash}`}
                       className="flex items-center gap-3 px-5 py-3 hover:bg-[var(--bg-card-hover)] transition-colors"
                     >
                       <img

--- a/frontend/app/components/HomeStatsSection.tsx
+++ b/frontend/app/components/HomeStatsSection.tsx
@@ -1,7 +1,13 @@
 import Link from "next/link";
 import { t } from "@/lib/ui-translations";
+import { IS_BETA } from "@/lib/seo";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+// Beta has run submissions disabled, so its stats endpoint reports near
+// zero. Pull from stable on beta so the section matches the community
+// leaderboards above. Server-side fetch — no CORS hop.
+const RUNS_HOST = IS_BETA ? "https://spire-codex.com" : "";
+const RUNS_API = IS_BETA ? "https://spire-codex.com" : API;
 
 const REVALIDATE = 300;
 
@@ -49,7 +55,7 @@ function winRateColor(pct: number): string {
 
 async function loadStats(): Promise<CommunityStats | null> {
   try {
-    const res = await fetch(`${API}/api/runs/stats`, { next: { revalidate: REVALIDATE } });
+    const res = await fetch(`${RUNS_API}/api/runs/stats`, { next: { revalidate: REVALIDATE } });
     if (!res.ok) return null;
     return (await res.json()) as CommunityStats;
   } catch {
@@ -86,7 +92,7 @@ export default async function HomeStatsSection({
           {t("Stats", lang)}
         </h2>
         <Link
-          href={`${langPrefix}/leaderboards/stats`}
+          href={`${RUNS_HOST}${langPrefix}/leaderboards/stats`}
           className="shrink-0 inline-flex items-center gap-1 text-sm font-medium text-[var(--text-secondary)] hover:text-[var(--accent-gold)] transition-colors"
         >
           <span>{t("View all stats", lang)}</span>

--- a/frontend/app/leaderboards/submit/SubmitRunClient.tsx
+++ b/frontend/app/leaderboards/submit/SubmitRunClient.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
+import { IS_BETA } from "@/lib/seo";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -250,6 +251,39 @@ export default function SubmitRunClient() {
       document.removeEventListener("drop", handleDocDrop);
     };
   }, [handleFileUpload]);
+
+  // Run submissions are server-side rejected on beta (the backend returns
+  // 403 with "Submit to spire-codex.com instead"). The Navbar already
+  // hides this route on beta, but bookmarks / external links can still
+  // land here — show an upfront notice instead of letting users drag in
+  // files only to get a 403 per file. Two open bug reports (#104, #105)
+  // came from exactly this flow before this gate existed.
+  if (IS_BETA) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <h1 className="text-3xl font-bold mb-3">
+          <span className="text-[var(--accent-gold)]">{t("Submit a Run", lang)}</span>
+        </h1>
+        <div className="rounded-xl border border-[var(--accent-gold)]/30 bg-[var(--accent-gold)]/5 p-6">
+          <p className="text-base text-[var(--text-primary)] mb-4">
+            Run submissions are disabled on the beta site so the leaderboards
+            and community stats stay aligned with the stable game build.
+          </p>
+          <p className="text-sm text-[var(--text-secondary)] mb-5">
+            Head to the stable site to upload your runs — they&apos;ll appear
+            on the public leaderboards within a minute.
+          </p>
+          <a
+            href="https://spire-codex.com/leaderboards/submit"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[var(--accent-gold)] text-[var(--bg-primary)] font-medium hover:opacity-90 transition-opacity"
+          >
+            Submit on spire-codex.com
+            <span aria-hidden>→</span>
+          </a>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">


### PR DESCRIPTION
## Summary

Combines #108 + #109 — two related fixes that hang together for beta's run-UX story. Supersedes both.

### 1. Beta home Leaderboards + Stats now pull from stable (was #109)

Run submissions are server-side disabled on beta, so beta's local `runs.db` is essentially empty — the home **Leaderboards** and **Stats** sections rendered near-empty cards. Both sections are server components, so the fetch happens inside the beta backend container — no CORS hop. When `IS_BETA` is true:

- `RUNS_API` resolves to `https://spire-codex.com` for `/api/runs/leaderboard`, `/api/runs/list`, and `/api/runs/stats`.
- `RUNS_HOST` prefix on every in-page link (row → `/runs/{hash}`, `View more →` `/leaderboards`, `Upload your runs →` `/leaderboards/submit`, `View all stats →` `/leaderboards/stats`) so click-through lands on stable instead of 404ing on beta.

Stable behaviour unchanged. News, Guides, and Showcase are version-agnostic so they stay as-is.

### 2. Beta `/leaderboards/submit` shows a notice instead of 403ing per file (was #108)

Both [#104](https://github.com/ptrlrd/spire-codex/issues/104) and [#105](https://github.com/ptrlrd/spire-codex/issues/105) are the same root cause: users land directly on `https://beta.spire-codex.com/leaderboards/submit` (Navbar already hides it on beta but bookmarks bypass that), drag in `.run` files, and only get rejected per-file when the backend returns 403. #104 was 1 file, #105 was 64 files.

Adds an `IS_BETA` early-return at the top of `SubmitRunClient` that renders a gold-bordered notice + a `Submit on spire-codex.com →` button. Matches the visual language of the `View Stable Site` nav button.

Closes #104, closes #105.
