### PR TITLE
Beta badge on home hero: gold → emerald

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -67,7 +67,7 @@ export default async function Home() {
                 CODEX
               </span>
               {IS_BETA && (
-                <span className="ml-3 text-sm font-medium px-2 py-1 rounded bg-[var(--accent-gold)]/20 text-[var(--accent-gold)] align-middle">
+                <span className="ml-3 text-sm font-medium px-2 py-1 rounded bg-emerald-500/20 text-emerald-400 align-middle">
                   BETA
                 </span>
               )}


### PR DESCRIPTION
The little **BETA** tag next to the SPIRE CODEX logo on the beta home hero was still gold (the main-site accent colour). Every other beta indicator on the site (SiteSwitcher pill in #115, navbar tint) is emerald. One-line swap to match.

`bg-[var(--accent-gold)]/20 text-[var(--accent-gold)]` → `bg-emerald-500/20 text-emerald-400`