### PR TITLE
Target "StS2" abbreviation in meta descriptions, FAQ, About intro

### DIFF
--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -73,9 +73,11 @@ export default function AboutPage() {
         {/* Intro */}
         <div className="text-[var(--text-secondary)] leading-relaxed space-y-4">
           <p>
-            Spire Codex is a comprehensive database for Slay the Spire 2, built by reverse-engineering
-            the game files. Every card, relic, monster, potion, event, and power on this site was
-            extracted directly from the game&apos;s source code and localization data.
+            Spire Codex is a comprehensive database for Slay the Spire 2 — commonly abbreviated
+            <strong className="text-[var(--text-primary)]"> StS2</strong> — built by
+            reverse-engineering the game files. Every card, relic, monster, potion, event, and
+            power on this site was extracted directly from the game&apos;s source code and
+            localization data.
           </p>
           <p>
             The project started from curiosity about how StS2 was built, and grew into a full API

--- a/frontend/app/badges/page.tsx
+++ b/frontend/app/badges/page.tsx
@@ -44,7 +44,7 @@ export default async function BadgesPage() {
     buildCollectionPageJsonLd({
       name: "Slay the Spire 2 Badges",
       description:
-        "All run-end badges in Slay the Spire 2 — Bronze, Silver, and Gold tier mini-achievements awarded on the Game Over screen.",
+        "All run-end badges in Slay the Spire 2 (StS2) — Bronze, Silver, and Gold tier mini-achievements awarded on the Game Over screen.",
       path: "/badges",
       items: badges.map((b) => ({
         name: b.name,

--- a/frontend/app/cards/layout.tsx
+++ b/frontend/app/cards/layout.tsx
@@ -11,10 +11,10 @@ export async function generateMetadata(): Promise<Metadata> {
   }
   return {
     title: "Slay the Spire 2 Cards - Complete Card List | Spire Codex",
-    description: `Browse all ${count} Slay the Spire 2 cards. Filter by character (Ironclad, Silent, Defect, Necrobinder, Regent), type, rarity, and keywords. View card art, stats, upgrades, and related cards.`,
+    description: `Browse all ${count} Slay the Spire 2 (StS2) cards. Filter by character (Ironclad, Silent, Defect, Necrobinder, Regent), type, rarity, and keywords. View card art, stats, upgrades, and related cards.`,
     openGraph: {
       title: "Slay the Spire 2 Cards - Complete Card List | Spire Codex",
-      description: `Browse all ${count} Slay the Spire 2 cards. Filter by character, type, rarity, and keywords.`,
+      description: `Browse all ${count} Slay the Spire 2 (StS2) cards. Filter by character, type, rarity, and keywords.`,
     },
     alternates: { canonical: "/cards" },
   };

--- a/frontend/app/compare/page.tsx
+++ b/frontend/app/compare/page.tsx
@@ -49,7 +49,7 @@ export default function ComparePage() {
     buildCollectionPageJsonLd({
       name: "Slay the Spire 2 Character Comparisons",
       description:
-        "Compare all Slay the Spire 2 characters side by side. Stats, card pools, keywords, and starting decks.",
+        "Compare all Slay the Spire 2 (StS2) characters side by side. Stats, card pools, keywords, and starting decks.",
       path: "/compare",
       items: pairs.map((p) => ({
         name: `${p.a.name} vs ${p.b.name}`,

--- a/frontend/app/components/HomeFAQ.tsx
+++ b/frontend/app/components/HomeFAQ.tsx
@@ -17,7 +17,12 @@ function buildFaqs(stats: Stats | null): { question: string; answer: string }[] 
     {
       question: "What is Slay the Spire 2?",
       answer:
-        "Slay the Spire 2 is the sequel to Mega Crit's iconic roguelike deckbuilder, currently in Steam Early Access. You climb the Spire one combat at a time, building a custom deck of cards, collecting powerful relics, and fighting through randomly generated encounters culminating in act bosses.",
+        "Slay the Spire 2 (commonly abbreviated StS2) is the sequel to Mega Crit's iconic roguelike deckbuilder, currently in Steam Early Access. You climb the Spire one combat at a time, building a custom deck of cards, collecting powerful relics, and fighting through randomly generated encounters culminating in act bosses.",
+    },
+    {
+      question: "What does StS2 stand for?",
+      answer:
+        "StS2 is the community shorthand for Slay the Spire 2, following the same convention as StS / StS1 for the original 2017 game. The Spire Codex database tracks every StS2 card, relic, character, monster, potion, event, and power across all 14 languages the game ships with.",
     },
     {
       question: "When does Slay the Spire 2 release?",

--- a/frontend/app/developers/page.tsx
+++ b/frontend/app/developers/page.tsx
@@ -9,11 +9,11 @@ const API_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://spire-codex.com";
 export const metadata: Metadata = {
   title: "Slay the Spire 2 Developer API & Tooltip Widget | Spire Codex",
   description:
-    "Integrate Slay the Spire 2 game data into your projects. Public REST API with 22+ endpoints, embeddable tooltip widget, and multi-language support.",
+    "Integrate Slay the Spire 2 (StS2) game data into your projects. Public REST API with 22+ endpoints, embeddable tooltip widget, and multi-language support.",
   openGraph: {
     title: "Slay the Spire 2 Developer API & Tooltip Widget | Spire Codex",
     description:
-      "Public REST API and embeddable tooltip widget for Slay the Spire 2 game data.",
+      "Public REST API and embeddable tooltip widget for Slay the Spire 2 (StS2) game data.",
   },
   alternates: { canonical: "/developers" },
 };

--- a/frontend/app/encounters/layout.tsx
+++ b/frontend/app/encounters/layout.tsx
@@ -11,10 +11,10 @@ export async function generateMetadata(): Promise<Metadata> {
   }
   return {
     title: "Slay the Spire 2 Encounters - All Combat Encounters | Spire Codex",
-    description: `Slay the Spire 2 encounters — browse all ${count} combat encounters including normal fights, elites, and bosses. View monster compositions, act assignments, and room types.`,
+    description: `Slay the Spire 2 (StS2) encounters — browse all ${count} combat encounters including normal fights, elites, and bosses. View monster compositions, act assignments, and room types.`,
     openGraph: {
       title: "Slay the Spire 2 Encounters - All Combat Encounters | Spire Codex",
-      description: `Slay the Spire 2 encounters — browse all ${count} combat encounters including normal fights, elites, and bosses.`,
+      description: `Slay the Spire 2 (StS2) encounters — browse all ${count} combat encounters including normal fights, elites, and bosses.`,
     },
     alternates: { canonical: "/encounters" },
   };

--- a/frontend/app/events/layout.tsx
+++ b/frontend/app/events/layout.tsx
@@ -11,10 +11,10 @@ export async function generateMetadata(): Promise<Metadata> {
   }
   return {
     title: "Slay the Spire 2 Events - All In-Game Events | Spire Codex",
-    description: `Slay the Spire 2 events — browse all ${count} shrine events, Ancient encounters, and story events. View choices, dialogue, relic offerings, and outcomes for every event.`,
+    description: `Slay the Spire 2 (StS2) events — browse all ${count} shrine events, Ancient encounters, and story events. View choices, dialogue, relic offerings, and outcomes for every event.`,
     openGraph: {
       title: "Slay the Spire 2 Events - All In-Game Events | Spire Codex",
-      description: `Slay the Spire 2 events — browse all ${count} shrine events, Ancient encounters, and story events with choices, dialogue, and outcomes.`,
+      description: `Slay the Spire 2 (StS2) events — browse all ${count} shrine events, Ancient encounters, and story events with choices, dialogue, and outcomes.`,
     },
     alternates: { canonical: "/events" },
   };

--- a/frontend/app/keywords/layout.tsx
+++ b/frontend/app/keywords/layout.tsx
@@ -3,11 +3,11 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Slay the Spire 2 Keywords - All Card Keywords | Spire Codex",
   description:
-    "Browse all card keywords in Slay the Spire 2 — Exhaust, Ethereal, Innate, Retain, Sly, Eternal, and more. See every card with each keyword.",
+    "Browse all card keywords in Slay the Spire 2 (StS2) — Exhaust, Ethereal, Innate, Retain, Sly, Eternal, and more. See every card with each keyword.",
   openGraph: {
     title: "Slay the Spire 2 Keywords - All Card Keywords | Spire Codex",
     description:
-      "Browse all card keywords in Slay the Spire 2 — Exhaust, Ethereal, Innate, Retain, Sly, Eternal, and more.",
+      "Browse all card keywords in Slay the Spire 2 (StS2) — Exhaust, Ethereal, Innate, Retain, Sly, Eternal, and more.",
   },
   alternates: { canonical: "/keywords" },
 };

--- a/frontend/app/leaderboards/page.tsx
+++ b/frontend/app/leaderboards/page.tsx
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 export const metadata: Metadata = {
   title: "Leaderboards - Slay the Spire 2 | Spire Codex",
   description:
-    "Browse community-submitted Slay the Spire 2 runs. Filter by character, ascension level, and outcome. View leaderboards and detailed run breakdowns.",
+    "Browse community-submitted Slay the Spire 2 (StS2) runs. Filter by character, ascension level, and outcome. View leaderboards and detailed run breakdowns.",
 };
 
 export default function ToolsPage() {

--- a/frontend/app/merchant/page.tsx
+++ b/frontend/app/merchant/page.tsx
@@ -5,7 +5,7 @@ export default function MerchantPage() {
   const jsonLd = [
     ...buildDetailPageJsonLd({
       name: "Merchant Guide",
-      description: "Complete Slay the Spire 2 merchant price guide with card, relic, and potion costs, card removal pricing, and Fake Merchant relic details.",
+      description: "Complete Slay the Spire 2 (StS2) merchant price guide with card, relic, and potion costs, card removal pricing, and Fake Merchant relic details.",
       path: "/merchant",
       category: "Guide",
       breadcrumbs: [

--- a/frontend/app/monsters/layout.tsx
+++ b/frontend/app/monsters/layout.tsx
@@ -11,10 +11,10 @@ export async function generateMetadata(): Promise<Metadata> {
   }
   return {
     title: "Slay the Spire 2 Monsters - Complete Monster List | Spire Codex",
-    description: `Slay the Spire 2 monsters — browse all ${count} normals, elites, and bosses. View HP values, moves, damage stats, and ascension scaling.`,
+    description: `Slay the Spire 2 (StS2) monsters — browse all ${count} normals, elites, and bosses. View HP values, moves, damage stats, and ascension scaling.`,
     openGraph: {
       title: "Slay the Spire 2 Monsters - Complete Monster List | Spire Codex",
-      description: `Slay the Spire 2 monsters — browse all ${count} normals, elites, and bosses. View HP, moves, and ascension scaling.`,
+      description: `Slay the Spire 2 (StS2) monsters — browse all ${count} normals, elites, and bosses. View HP, moves, and ascension scaling.`,
     },
     alternates: { canonical: "/monsters" },
   };

--- a/frontend/app/news/page.tsx
+++ b/frontend/app/news/page.tsx
@@ -20,12 +20,12 @@ export const revalidate = 1800;
 export const metadata: Metadata = {
   title: `Slay the Spire 2 News - Patch Notes & Announcements | ${SITE_NAME}`,
   description:
-    "Slay the Spire 2 patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
+    "Slay the Spire 2 (StS2) patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
   alternates: { canonical: `${SITE_URL}/news` },
   openGraph: {
     title: `Slay the Spire 2 News - Patch Notes & Announcements | ${SITE_NAME}`,
     description:
-      "Slay the Spire 2 patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
+      "Slay the Spire 2 (StS2) patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
     url: `${SITE_URL}/news`,
     siteName: SITE_NAME,
     type: "website",

--- a/frontend/app/potions/layout.tsx
+++ b/frontend/app/potions/layout.tsx
@@ -11,10 +11,10 @@ export async function generateMetadata(): Promise<Metadata> {
   }
   return {
     title: "Slay the Spire 2 Potions - Complete Potion List | Spire Codex",
-    description: `Browse all ${count} Slay the Spire 2 potions. Filter by rarity (Common, Uncommon, Rare) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View potion effects and descriptions.`,
+    description: `Browse all ${count} Slay the Spire 2 (StS2) potions. Filter by rarity (Common, Uncommon, Rare) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View potion effects and descriptions.`,
     openGraph: {
       title: "Slay the Spire 2 Potions - Complete Potion List | Spire Codex",
-      description: `Browse all ${count} Slay the Spire 2 potions. Filter by rarity and character pool.`,
+      description: `Browse all ${count} Slay the Spire 2 (StS2) potions. Filter by rarity and character pool.`,
     },
     alternates: { canonical: "/potions" },
   };

--- a/frontend/app/powers/layout.tsx
+++ b/frontend/app/powers/layout.tsx
@@ -11,10 +11,10 @@ export async function generateMetadata(): Promise<Metadata> {
   }
   return {
     title: "Slay the Spire 2 Powers - Complete Power List | Spire Codex",
-    description: `Browse all ${count} Slay the Spire 2 powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior. View descriptions, icons, and details for every power.`,
+    description: `Browse all ${count} Slay the Spire 2 (StS2) powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior. View descriptions, icons, and details for every power.`,
     openGraph: {
       title: "Slay the Spire 2 Powers - Complete Power List | Spire Codex",
-      description: `Browse all ${count} Slay the Spire 2 powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior.`,
+      description: `Browse all ${count} Slay the Spire 2 (StS2) powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior.`,
     },
     alternates: { canonical: "/powers" },
   };

--- a/frontend/app/relics/layout.tsx
+++ b/frontend/app/relics/layout.tsx
@@ -11,10 +11,10 @@ export async function generateMetadata(): Promise<Metadata> {
   }
   return {
     title: "Slay the Spire 2 Relics - Complete Relic List | Spire Codex",
-    description: `Browse all ${count} Slay the Spire 2 relics. Filter by rarity (Common, Uncommon, Rare, Shop, Event, Ancient) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View relic effects, flavor text, and images.`,
+    description: `Browse all ${count} Slay the Spire 2 (StS2) relics. Filter by rarity (Common, Uncommon, Rare, Shop, Event, Ancient) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View relic effects, flavor text, and images.`,
     openGraph: {
       title: "Slay the Spire 2 Relics - Complete Relic List | Spire Codex",
-      description: `Browse all ${count} Slay the Spire 2 relics. Filter by rarity and character pool. View relic effects and images.`,
+      description: `Browse all ${count} Slay the Spire 2 (StS2) relics. Filter by rarity and character pool. View relic effects and images.`,
     },
     alternates: { canonical: "/relics" },
   };


### PR DESCRIPTION
Community shorthand for Slay the Spire 2 is **StS2** — same convention as StS / StS1 for the original. Site never had it in any meta tag, JSON-LD description, or visible page copy, so queries like `StS2 cards` or `StS2 tier list` routed entirely elsewhere.

## Changes

- **24 description fields across 14 page/layout files** now lead with `Slay the Spire 2 (StS2)` instead of bare `Slay the Spire 2`. Both the standard `description` and the OpenGraph `description` get the insertion. **Titles intentionally untouched** — they keep the established `Slay the Spire 2 [Topic] - [Descriptor] | Spire Codex` format so the canonical title pattern stays clean.
- **New FAQ entry on the home page**: "What does StS2 stand for?" — Q&A body explicitly equates the two terms so Google's entity graph can link them.
- Updated the existing "What is Slay the Spire 2?" answer to lead with `Slay the Spire 2 (commonly abbreviated StS2)`.
- **About page intro paragraph** now mentions "commonly abbreviated **StS2**" in the very first line of visible body copy.

## What I did NOT change

Localized variants (`[lang]/page.tsx` for non-English) intentionally left as-is. "StS2" only reads naturally in English; sprinkling it into Japanese / Chinese / Russian descriptions would look out of place.
