### PR TITLE
Docs: refresh README + API reference for new pages and bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ spire-codex/
 | Images | `/images` | Browsable game assets with ZIP download per category |
 | Changelog | `/changelog` | Data diffs between game updates |
 | About | `/about` | Project info, stats, pipeline visualization |
+| Thank You | `/thank-you` | Ko-fi supporters and community contributors (split from About so the page can be linked directly) |
+| Knowledge Demon | `/knowledge-demon` | Info page for the Discord bot — slash commands, moderation features, install CTA |
+| News | `/news` | Mirrored Steam announcements feed; canonical links back to Steam so it's additive, not duplicative |
+| News article | `/news/[gid]` | Single Steam announcement with sanitized BBCode body and `NewsArticle` JSON-LD |
 
 ## API Endpoints
 
@@ -711,13 +715,13 @@ Full docs: [spire-codex.com/developers](https://spire-codex.com/developers)
 - ~~Monster attack patterns~~ ✅ — 112 monsters with cycle/random/conditional/mixed AI from C# state machines
 - ~~Event preconditions~~ ✅ — 25 events with IsAllowed() conditions parsed from C# source
 - ~~Multi-version beta browsing~~ ✅ — Version dropdown, all past betas preserved and browsable with changelogs
-- **Discord bot** — Card lookup, patch alerts
+- ~~Discord bot~~ ✅ — [Knowledge Demon](https://bot.spire-codex.com): slash commands for every entity (`/card`, `/relic`, `/monster`, `/potion`, `/character`, `/event`, `/power`, `/enchantment`, `/lookup`, `/meta`), Steam-news RSS, plus a full moderation toolkit forked from [Kernel](https://github.com/ptrlrd/kernel)
 - **Deck builder** — Interactive deck theorycrafting
 - **Database backend** — Replace JSON loading with SQLite/PostgreSQL
 
 ## Acknowledgments
 
-Thanks to **vesper-arch**, **terracubist**, **U77654**, **Purple Aspired Dreaming**, and **Kobaru** for QA testing, bug reports, and contributions.
+Thanks to **vesper-arch**, **terracubist**, **U77654**, **Purple Aspired Dreaming**, **Kobaru**, and **Severi** for QA testing, bug reports, and contributions. The full supporter list — including Ko-fi donors who keep the lights on — lives at [spire-codex.com/thank-you](https://spire-codex.com/thank-you).
 
 ## Tech Stack
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -183,6 +183,10 @@ spire-codex/
 | 图片 | `/images` | 可浏览的游戏素材，支持按类别下载 ZIP |
 | 更新日志 | `/changelog` | 游戏更新之间的数据差异 |
 | 关于 | `/about` | 项目信息、统计、流水线可视化 |
+| 致谢页 | `/thank-you` | Ko-fi 支持者与社区贡献者（从「关于」页拆分出来，方便单独链接） |
+| Knowledge Demon | `/knowledge-demon` | Discord 机器人介绍页 —— 斜杠命令、版务功能、加入服务器入口 |
+| 新闻 | `/news` | 镜像 Steam 公告流；canonical 链接回 Steam，作为补充而非重复 |
+| 单条新闻 | `/news/[gid]` | 单篇 Steam 公告，BBCode 内容已净化，并附 `NewsArticle` JSON-LD |
 
 ## API 端点
 
@@ -686,13 +690,13 @@ Spire Codex 使用 **`1.X.Y`** 语义化版本规则：
 - ~~怪物出招模式~~ ✅ —— 112 个怪物，基于 C# 状态机解析出的循环 / 随机 / 条件 / 混合型 AI
 - ~~事件前置条件~~ ✅ —— 25 个事件，条件来自 C# 源码中 IsAllowed() 的解析
 - ~~Beta 多版本浏览~~ ✅ —— 版本下拉框，保留所有历史 beta，并支持查看 changelog
-- **Discord 机器人** —— 卡牌查询、补丁提醒
+- ~~Discord 机器人~~ ✅ —— [Knowledge Demon](https://bot.spire-codex.com)：每个实体都有斜杠命令（`/card`、`/relic`、`/monster`、`/potion`、`/character`、`/event`、`/power`、`/enchantment`、`/lookup`、`/meta`），支持 Steam 新闻 RSS，外加从 [Kernel](https://github.com/ptrlrd/kernel) 派生的完整版务工具集
 - **构筑编辑器** —— 可交互式牌组理论构筑
 - **数据库后端** —— 用 SQLite / PostgreSQL 替换 JSON 加载
 
 ## 致谢
 
-感谢 **vesper-arch**、**terracubist**、**U77654**、**Purple Aspired Dreaming** 和 **Kobaru** 在 QA 测试、Bug 报告和贡献方面提供的帮助。
+感谢 **vesper-arch**、**terracubist**、**U77654**、**Purple Aspired Dreaming**、**Kobaru** 和 **Severi** 在 QA 测试、Bug 报告和贡献方面提供的帮助。完整支持者名单（含为本项目持续供电的 Ko-fi 捐赠者）见 [spire-codex.com/thank-you](https://spire-codex.com/thank-you)。
 
 ## 技术栈
 

--- a/contributing/API_REFERENCE.md
+++ b/contributing/API_REFERENCE.md
@@ -78,6 +78,9 @@ All data endpoints accept `?lang=` (default: `eng`). Rate limited to 60 req/min 
 | `GET /api/images/{category}/download` | ZIP download of image category |
 | `GET /api/changelogs` | Changelog summaries |
 | `GET /api/changelogs/{tag}` | Full changelog for a version |
+| `GET /api/news` | Steam announcements + community news (locally archived). Filters: `feed_type`, `feedname`, `tag`, `since`, `search`, `limit`, `offset` |
+| `GET /api/news/{gid}` | Single Steam news article with raw HTML/BBCode body |
+| `GET /api/merchant/config` | Merchant pricing config (auto-extracted from C#: card/potion/relic prices, removal tiers, blacklist) |
 | `GET /api/names/{type}/{id}` | Cross-language name lookup |
 | `GET /api/exports/{lang}` | ZIP download of all entity JSON |
 | `GET /api/history/{type}/{id}` | Per-entity version history (newest first, case-insensitive id match) |


### PR DESCRIPTION
Catches the docs up to recent shipped + in-flight work.

## README.md / README_CN.md

Website Pages table grows by four rows:
- `/thank-you` — Ko-fi supporters and contributors (split out of `/about` so it can be linked directly)
- `/knowledge-demon` — info page for the Discord bot (slash commands + install CTA)
- `/news` — mirrored Steam announcements feed
- `/news/[gid]` — single-article view with sanitized BBCode body and `NewsArticle` JSON-LD

Roadmap: `Discord bot` moves from "to-do" to ✅ with a link to [bot.spire-codex.com](https://bot.spire-codex.com), the slash-command surface, and the [Kernel](https://github.com/ptrlrd/kernel) fork attribution.

Acknowledgments: adds **Severi** alongside the other QA contributors and points readers at [spire-codex.com/thank-you](https://spire-codex.com/thank-you) for the full supporter list (including Ko-fi donors).

## contributing/API_REFERENCE.md

Lists three endpoints that have been live but missing from the table:
- `GET /api/news` — Steam announcements + community news (locally archived, filterable)
- `GET /api/news/{gid}` — single news article body
- `GET /api/merchant/config` — merchant pricing config auto-extracted from the C# source

## Notes

The `/knowledge-demon` row depends on PR #123 landing. If that one's still open when this is reviewed, just merge in either order — the row points at a route, not at a route's *content*.
