### PR TITLE
Wire up 1h news refresh, drop news lru_cache so entries land live

### DIFF
--- a/.github/workflows/news-refresh.yml
+++ b/.github/workflows/news-refresh.yml
@@ -1,0 +1,70 @@
+name: News refresh
+
+# Steam's ISteamNews/GetNewsForApp returns a sliding window of the newest
+# ~200 articles, so once a post ages out we can never query it again through
+# that endpoint. This workflow polls every 6h, overwrites changed bodies,
+# appends new gids to `data/news/`, rebuilds `data/news/index.json`, and
+# commits the diff to main when something changed.
+#
+# `news_parser.py` is stdlib-only (no `pip install` needed) and swallows
+# fetch errors with a log line + exit 0, so a Steam outage just produces
+# an empty diff rather than a red workflow.
+
+on:
+  schedule:
+    # Every 6h on the hour. Mega Crit ships announcements roughly weekly
+    # and press picks them up shortly after, so 4× daily is plenty without
+    # spamming the Steam API. Adjust if you want fresher data.
+    - cron: "0 */6 * * *"
+  workflow_dispatch: {}  # allow manual "run now" from the Actions tab
+
+# Don't allow two refreshes to race — if a long run is still committing,
+# skip the next tick rather than collide on `git push`.
+concurrency:
+  group: news-refresh
+  cancel-in-progress: false
+
+permissions:
+  contents: write  # needed to push the data/news/ commit back to main
+
+jobs:
+  refresh:
+    name: Poll Steam + commit changes
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # We need full history so the commit lands on the live branch
+          # rather than a detached HEAD that the push then rejects.
+          ref: main
+          # The workflow's GITHUB_TOKEN doesn't trigger downstream
+          # workflows by default, which is what we want here — the
+          # data-only refresh shouldn't rerun the CI suite for every
+          # poll. The deploy pipeline picks up the new files on the
+          # next real push.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run news parser
+        # Stdlib-only — no `pip install` step needed.
+        run: python3 backend/app/parsers/news_parser.py
+
+      - name: Commit + push if anything changed
+        run: |
+          if git diff --quiet -- data/news/; then
+            echo "No new or updated news entries — nothing to commit."
+            exit 0
+          fi
+          git config user.name  "spire-codex-bot"
+          git config user.email "bot@spire-codex.com"
+          git add data/news/
+          # `[skip ci]` keeps the existing CI workflow (lint/type-check/
+          # secret-scan/Docker build) from firing on every poll. The
+          # backend reads `data/news/` from the mounted volume, so a
+          # Docker rebuild isn't required — the next regular merge will
+          # cycle the image normally.
+          git commit -m "Refresh news archive from Steam [skip ci]"
+          git push origin main

--- a/.github/workflows/news-refresh.yml
+++ b/.github/workflows/news-refresh.yml
@@ -2,7 +2,7 @@ name: News refresh
 
 # Steam's ISteamNews/GetNewsForApp returns a sliding window of the newest
 # ~200 articles, so once a post ages out we can never query it again through
-# that endpoint. This workflow polls every 6h, overwrites changed bodies,
+# that endpoint. This workflow polls hourly, overwrites changed bodies,
 # appends new gids to `data/news/`, rebuilds `data/news/index.json`, and
 # commits the diff to main when something changed.
 #
@@ -12,10 +12,12 @@ name: News refresh
 
 on:
   schedule:
-    # Every 6h on the hour. Mega Crit ships announcements roughly weekly
-    # and press picks them up shortly after, so 4× daily is plenty without
-    # spamming the Steam API. Adjust if you want fresher data.
-    - cron: "0 */6 * * *"
+    # Hourly on the top of the hour. The backend reads the bind-mounted
+    # `data/news/` on every request (no lru_cache), so a new Steam post
+    # is visible within ~1h of publish without a container restart.
+    # The parser is idempotent — polls that find nothing new bail before
+    # committing, so most ticks are free aside from the Steam round-trip.
+    - cron: "0 * * * *"
   workflow_dispatch: {}  # allow manual "run now" from the Actions tab
 
 # Don't allow two refreshes to race — if a long run is still committing,

--- a/backend/app/services/data_service.py
+++ b/backend/app/services/data_service.py
@@ -136,11 +136,18 @@ def load_ascensions(lang: str = DEFAULT_LANG) -> list[dict]:
     return _load_json(lang, "ascensions")
 
 
-@lru_cache(maxsize=4)
-def _load_news_index(version: str | None) -> list[dict]:
+def load_news_index() -> list[dict]:
     """Load the news/index.json built by news_parser. The index is
-    language-agnostic — Steam news isn't translated."""
-    base = _resolve_base(version)
+    language-agnostic — Steam news isn't translated.
+
+    Intentionally NOT `@lru_cache`'d: the `news-refresh` workflow commits
+    new entries to `data/news/` every 6 hours, and the data dir is
+    bind-mounted into the production container (`./data:/data:ro`), so
+    caching would pin the first-load snapshot and the new articles
+    wouldn't show up until the next deploy. At ~44 KB / ~100 entries
+    the re-read is sub-millisecond — cheaper than the staleness.
+    """
+    base = _resolve_base(_get_version())
     filepath = base / "news" / "index.json"
     if not filepath.exists():
         return []
@@ -148,23 +155,16 @@ def _load_news_index(version: str | None) -> list[dict]:
         return json.load(f)
 
 
-def load_news_index() -> list[dict]:
-    return _load_news_index(_get_version())
-
-
-@lru_cache(maxsize=512)
-def _load_news_item(gid: str, version: str | None) -> dict | None:
-    """Load a single archived Steam news item by Steam `gid`."""
-    base = _resolve_base(version)
+def load_news_item(gid: str) -> dict | None:
+    """Load a single archived Steam news item by Steam `gid`. Not cached
+    for the same reason as `load_news_index` — individual articles are
+    small and new ones land on disk between deploys."""
+    base = _resolve_base(_get_version())
     filepath = base / "news" / f"{gid}.json"
     if not filepath.exists():
         return None
     with open(filepath, "r", encoding="utf-8") as f:
         return json.load(f)
-
-
-def load_news_item(gid: str) -> dict | None:
-    return _load_news_item(gid, _get_version())
 
 
 @lru_cache(maxsize=16)


### PR DESCRIPTION
Closes the gap between "news vertical launched" and "news stays current without me in the loop".

## Problem

The `/news` vertical is live but the archive only grows when I manually run the parser. And if I *did* just run it on a cron, the existing setup has two failure modes:

1. Every commit to `main` fires the full CI pipeline (secret scan → lint → type-check → Docker build+push → SSH deploy). Running that every hour to ship ~20 KB of JSON is wasteful.
2. Even if the deploy *didn't* run, `_load_news_index` / `_load_news_item` are `@lru_cache`'d, so the production container would keep serving the first-load snapshot forever. The bind-mounted file on disk would change, but the process wouldn't see it.

## Fix

**Workflow**: commits `.github/workflows/news-refresh.yml` (previously sitting untracked on my disk). Runs cron `0 * * * *` (top of every hour) on the self-hosted runner + `workflow_dispatch` for a "Run workflow" button. Calls `python3 backend/app/parsers/news_parser.py`, diffs `data/news/`, and if anything changed, commits as the bot user with `[skip ci]` so the main CI doesn't trigger. Concurrency group `news-refresh` so overlapping polls don't race the push. Ticks that find no new gids bail before committing — most runs cost only the Steam round-trip.

**Cache**: `_load_news_index` + `_load_news_item` drop their `@lru_cache` decorators. At ~44 KB / ~100 entries the index re-read is sub-millisecond — the cache was pure overhead once we committed to bind-mounted live-refresh semantics. Docstrings call out *why* they're uncached so a future "obvious" optimization doesn't put the cache back.

## Result

- New Steam announcements land in `/api/news` and `/news` within **~1 hour of Mega Crit / press publishing**, no manual step
- Production container **doesn't restart** on news-only refreshes — CI stays quiet via `[skip ci]`
- Index stays fresh live because nothing's pinning it in memory anymore
- Knowledge Demon's `/news` slash command reads through the same API so it benefits too
