### PR TITLE
News refresh: pull new news onto prod without restarting container

### DIFF
--- a/.github/workflows/news-refresh.yml
+++ b/.github/workflows/news-refresh.yml
@@ -55,9 +55,11 @@ jobs:
         run: python3 backend/app/parsers/news_parser.py
 
       - name: Commit + push if anything changed
+        id: commit
         run: |
           if git diff --quiet -- data/news/; then
             echo "No new or updated news entries — nothing to commit."
+            echo "committed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git config user.name  "spire-codex-bot"
@@ -70,3 +72,24 @@ jobs:
           # cycle the image normally.
           git commit -m "Refresh news archive from Steam [skip ci]"
           git push origin main
+          echo "committed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Pull new news onto prod
+        # The container reads `data/news/` from a bind mount on the prod
+        # host (`/var/www/spire-codex/data:/data:ro`), so new gids don't
+        # appear on spire-codex.com until the host's working tree is
+        # up-to-date with main. Normally that happens during the CI
+        # deploy step, but news commits use `[skip ci]` so we have to
+        # ssh in and `git pull` ourselves. No `docker compose down/up`
+        # here — the lru_cache on news loaders is gone, so the running
+        # container picks up the new files on the next request.
+        if: steps.commit.outputs.committed == 'true'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd /var/www/spire-codex
+            git pull --ff-only
+            echo "News pulled at $(date)"


### PR DESCRIPTION
Bot commits to main with `[skip ci]`, so the deploy job (which is what `git pull`s on the prod host) never runs. Result: new news lands in main but never on prod's bind-mounted `data/news/`.

Add an SSH step that fires only when the commit step actually committed something. It runs `cd /var/www/spire-codex && git pull --ff-only` — no `docker compose`. The lru_cache is already off the news loaders, so the running container reads the new files on the next request.