### PR TITLE
Fix locale prefix getting dropped on localized list pages

### DIFF
--- a/frontend/app/cards/CardsClient.tsx
+++ b/frontend/app/cards/CardsClient.tsx
@@ -7,6 +7,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import CardGrid from "../components/CardGrid";
 import SearchFilter from "../components/SearchFilter";
 import { useLanguage } from "../contexts/LanguageContext";
+import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -55,6 +56,7 @@ const keywordOptions = [
 ];
 
 export default function CardsClient({ initialCards }: { initialCards: Card[] }) {
+  const lp = useLangPrefix();
   const searchParams = useSearchParams();
   const router = useRouter();
 
@@ -75,8 +77,8 @@ export default function CardsClient({ initialCards }: { initialCards: Card[] }) 
       if (v && v !== "az") params.set(k, v);
     }
     const qs = params.toString();
-    router.replace(`/cards${qs ? `?${qs}` : ""}`, { scroll: false });
-  }, [router]);
+    router.replace(`${lp}/cards${qs ? `?${qs}` : ""}`, { scroll: false });
+  }, [router, lp]);
 
   // Wrap setters to also update URL
   const setFilterAndUrl = useCallback((key: string, value: string, setter: (v: string) => void) => {

--- a/frontend/app/enchantments/EnchantmentsClient.tsx
+++ b/frontend/app/enchantments/EnchantmentsClient.tsx
@@ -40,8 +40,8 @@ export default function EnchantmentsClient({ initialEnchantments }: { initialEnc
       if (v) params.set(k, v);
     }
     const qs = params.toString();
-    router.replace(`/enchantments${qs ? `?${qs}` : ""}`, { scroll: false });
-  }, [router]);
+    router.replace(`${lp}/enchantments${qs ? `?${qs}` : ""}`, { scroll: false });
+  }, [router, lp]);
 
   const setFilterAndUrl = useCallback((key: string, value: string, setter: (v: string) => void) => {
     setter(value);

--- a/frontend/app/encounters/EncountersClient.tsx
+++ b/frontend/app/encounters/EncountersClient.tsx
@@ -39,10 +39,10 @@ const actOptions = [
 ];
 
 export default function EncountersClient({ initialEncounters }: { initialEncounters: Encounter[] }) {
-    const lp = useLangPrefix();
+  const lp = useLangPrefix();
   const searchParams = useSearchParams();
   const router = useRouter();
-const [encounters, setEncounters] = useState<Encounter[]>(initialEncounters);
+  const [encounters, setEncounters] = useState<Encounter[]>(initialEncounters);
   const [search, setSearch] = useState(searchParams.get("search") || "");
   const [roomType, setRoomType] = useState(searchParams.get("roomType") || "");
   const [act, setAct] = useState(searchParams.get("act") || "");
@@ -55,8 +55,8 @@ const [encounters, setEncounters] = useState<Encounter[]>(initialEncounters);
       if (v) params.set(k, v);
     }
     const qs = params.toString();
-    router.replace(`/encounters${qs ? `?${qs}` : ""}`, { scroll: false });
-  }, [router]);
+    router.replace(`${lp}/encounters${qs ? `?${qs}` : ""}`, { scroll: false });
+  }, [router, lp]);
 
   const setFilterAndUrl = useCallback((key: string, value: string, setter: (v: string) => void) => {
     setter(value);

--- a/frontend/app/events/EventsClient.tsx
+++ b/frontend/app/events/EventsClient.tsx
@@ -100,10 +100,10 @@ function PageBlock({
 }
 
 export default function EventsClient({ initialEvents }: { initialEvents: GameEvent[] }) {
-    const lp = useLangPrefix();
+  const lp = useLangPrefix();
   const searchParams = useSearchParams();
   const router = useRouter();
-const [events, setEvents] = useState<GameEvent[]>(initialEvents);
+  const [events, setEvents] = useState<GameEvent[]>(initialEvents);
   const [search, setSearch] = useState(searchParams.get("search") || "");
   const [type, setType] = useState(searchParams.get("type") || "");
   const [act, setAct] = useState(searchParams.get("act") || "");
@@ -126,8 +126,8 @@ const [events, setEvents] = useState<GameEvent[]>(initialEvents);
       if (v) params.set(k, v);
     }
     const qs = params.toString();
-    router.replace(`/events${qs ? `?${qs}` : ""}`, { scroll: false });
-  }, [router]);
+    router.replace(`${lp}/events${qs ? `?${qs}` : ""}`, { scroll: false });
+  }, [router, lp]);
 
   const setFilterAndUrl = useCallback((key: string, value: string, setter: (v: string) => void) => {
     setter(value);
@@ -207,7 +207,7 @@ const [events, setEvents] = useState<GameEvent[]>(initialEvents);
           return (
             <div
               key={event.id}
-              onClick={() => router.push(`/events/${event.id.toLowerCase()}`)}
+              onClick={() => router.push(`${lp}/events/${event.id.toLowerCase()}`)}
               className={`bg-[var(--bg-card)] rounded-lg border ${
                 typeColors[event.type] || "border-[var(--border-subtle)]"
               } p-4 hover:bg-[var(--bg-card-hover)] transition-all cursor-pointer`}

--- a/frontend/app/guides/GuidesClient.tsx
+++ b/frontend/app/guides/GuidesClient.tsx
@@ -6,6 +6,7 @@ import type { GuideSummary } from "@/lib/api";
 import { cachedFetch } from "@/lib/fetch-cache";
 import Link from "next/link";
 import SearchFilter from "../components/SearchFilter";
+import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -41,6 +42,7 @@ const sortOptions = [
 ];
 
 export default function GuidesClient({ initialGuides }: { initialGuides: GuideSummary[] }) {
+  const lp = useLangPrefix();
   const searchParams = useSearchParams();
   const router = useRouter();
   const [guides, setGuides] = useState<GuideSummary[]>(initialGuides);
@@ -61,8 +63,8 @@ export default function GuidesClient({ initialGuides }: { initialGuides: GuideSu
       if (v && v !== "newest") params.set(k, v);
     }
     const qs = params.toString();
-    router.replace(`/guides${qs ? `?${qs}` : ""}`, { scroll: false });
-  }, [router]);
+    router.replace(`${lp}/guides${qs ? `?${qs}` : ""}`, { scroll: false });
+  }, [router, lp]);
 
   const setFilterAndUrl = useCallback((key: string, value: string, setter: (v: string) => void) => {
     setter(value);
@@ -123,7 +125,7 @@ export default function GuidesClient({ initialGuides }: { initialGuides: GuideSu
         {filtered.map((guide) => (
           <Link
             key={guide.slug}
-            href={`/guides/${guide.slug}`}
+            href={`${lp}/guides/${guide.slug}`}
             className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-5 hover:bg-[var(--bg-card-hover)] hover:border-[var(--border-accent)] transition-all block"
           >
             <h3 className="font-semibold text-lg text-[var(--accent-gold)] mb-1">{guide.title}</h3>

--- a/frontend/app/guides/[slug]/GuideDetail.tsx
+++ b/frontend/app/guides/[slug]/GuideDetail.tsx
@@ -7,6 +7,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import Link from "next/link";
+import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -33,6 +34,7 @@ const categoryLabels: Record<string, string> = {
 };
 
 export default function GuideDetail({ slug, initialGuide }: { slug: string; initialGuide: Guide | null }) {
+  const lp = useLangPrefix();
   const router = useRouter();
   const [guide, setGuide] = useState<Guide | null>(initialGuide);
   const [notFound, setNotFound] = useState(false);
@@ -73,7 +75,7 @@ export default function GuideDetail({ slug, initialGuide }: { slug: string; init
       <div className="text-center py-20">
         <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-2">Guide Not Found</h1>
         <p className="text-[var(--text-muted)] mb-4">This guide doesn&apos;t exist.</p>
-        <Link href="/guides" className="text-[var(--accent-gold)] hover:underline">Browse all guides</Link>
+        <Link href={`${lp}/guides`} className="text-[var(--accent-gold)] hover:underline">Browse all guides</Link>
       </div>
     );
   }
@@ -111,7 +113,7 @@ export default function GuideDetail({ slug, initialGuide }: { slug: string; init
             {categoryLabels[guide.category] || guide.category}
           </span>
           {guide.character && (
-            <Link href={`/characters`} className="px-2 py-0.5 rounded bg-[var(--bg-primary)] text-[var(--accent-gold)] border border-[var(--border-subtle)] text-[10px] hover:border-[var(--accent-gold)] transition-colors">
+            <Link href={`${lp}/characters`} className="px-2 py-0.5 rounded bg-[var(--bg-primary)] text-[var(--accent-gold)] border border-[var(--border-subtle)] text-[10px] hover:border-[var(--accent-gold)] transition-colors">
               {guide.character}
             </Link>
           )}

--- a/frontend/app/guides/submit/page.tsx
+++ b/frontend/app/guides/submit/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -31,6 +32,7 @@ const characters = [
 ];
 
 export default function SubmitGuidePage() {
+  const lp = useLangPrefix();
   const [title, setTitle] = useState("");
   const [authorName, setAuthorName] = useState("");
   const [contact, setContact] = useState("");
@@ -103,7 +105,7 @@ export default function SubmitGuidePage() {
           <p className="text-[var(--text-secondary)] mb-6">
             Thanks for your contribution! We&apos;ll review your guide and publish it soon.
           </p>
-          <Link href="/guides" className="text-[var(--accent-gold)] hover:underline">
+          <Link href={`${lp}/guides`} className="text-[var(--accent-gold)] hover:underline">
             Back to Guides
           </Link>
         </div>
@@ -116,7 +118,7 @@ export default function SubmitGuidePage() {
 
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <Link href="/guides" className="text-sm text-[var(--text-muted)] hover:text-[var(--accent-gold)] mb-6 inline-flex items-center gap-1 transition-colors">
+      <Link href={`${lp}/guides`} className="text-sm text-[var(--text-muted)] hover:text-[var(--accent-gold)] mb-6 inline-flex items-center gap-1 transition-colors">
         <span>&larr;</span> Back to Guides
       </Link>
 

--- a/frontend/app/monsters/MonstersClient.tsx
+++ b/frontend/app/monsters/MonstersClient.tsx
@@ -39,10 +39,10 @@ const actOptions = [
 
 export default function MonstersClient({ initialMonsters }: { initialMonsters: Monster[] }) {
   const { lang } = useLanguage();
-    const lp = useLangPrefix();
+  const lp = useLangPrefix();
   const searchParams = useSearchParams();
   const router = useRouter();
-const [monsters, setMonsters] = useState<Monster[]>(initialMonsters);
+  const [monsters, setMonsters] = useState<Monster[]>(initialMonsters);
   const [search, setSearch] = useState(searchParams.get("search") || "");
   const [type, setType] = useState(searchParams.get("type") || "");
   const [act, setAct] = useState(searchParams.get("act") || "");
@@ -54,8 +54,8 @@ const [monsters, setMonsters] = useState<Monster[]>(initialMonsters);
       if (v) params.set(k, v);
     }
     const qs = params.toString();
-    router.replace(`/monsters${qs ? `?${qs}` : ""}`, { scroll: false });
-  }, [router]);
+    router.replace(`${lp}/monsters${qs ? `?${qs}` : ""}`, { scroll: false });
+  }, [router, lp]);
 
   const setFilterAndUrl = useCallback((key: string, value: string, setter: (v: string) => void) => {
     setter(value);

--- a/frontend/app/potions/PotionsClient.tsx
+++ b/frontend/app/potions/PotionsClient.tsx
@@ -42,10 +42,10 @@ const sortOptions = [
 
 export default function PotionsClient({ initialPotions }: { initialPotions: Potion[] }) {
   const { lang } = useLanguage();
-    const lp = useLangPrefix();
+  const lp = useLangPrefix();
   const searchParams = useSearchParams();
   const router = useRouter();
-const [potions, setPotions] = useState<Potion[]>(initialPotions);
+  const [potions, setPotions] = useState<Potion[]>(initialPotions);
   const [search, setSearch] = useState(searchParams.get("search") || "");
   const [rarity, setRarity] = useState(searchParams.get("rarity") || "");
   const [pool, setPool] = useState(searchParams.get("pool") || "");
@@ -59,8 +59,8 @@ const [potions, setPotions] = useState<Potion[]>(initialPotions);
       if (v && v !== "az") params.set(k, v);
     }
     const qs = params.toString();
-    router.replace(`/potions${qs ? `?${qs}` : ""}`, { scroll: false });
-  }, [router]);
+    router.replace(`${lp}/potions${qs ? `?${qs}` : ""}`, { scroll: false });
+  }, [router, lp]);
 
   const setFilterAndUrl = useCallback((key: string, value: string, setter: (v: string) => void) => {
     setter(value);

--- a/frontend/app/relics/RelicsClient.tsx
+++ b/frontend/app/relics/RelicsClient.tsx
@@ -48,10 +48,10 @@ const sortOptions = [
 ];
 
 export default function RelicsClient({ initialRelics }: { initialRelics: Relic[] }) {
-    const lp = useLangPrefix();
+  const lp = useLangPrefix();
   const searchParams = useSearchParams();
   const router = useRouter();
-const [relics, setRelics] = useState<Relic[]>(initialRelics);
+  const [relics, setRelics] = useState<Relic[]>(initialRelics);
   const [search, setSearch] = useState(searchParams.get("search") || "");
   const [rarity, setRarity] = useState(searchParams.get("rarity") || "");
   const [pool, setPool] = useState(searchParams.get("pool") || "");
@@ -65,8 +65,8 @@ const [relics, setRelics] = useState<Relic[]>(initialRelics);
       if (v && v !== "az") params.set(k, v);
     }
     const qs = params.toString();
-    router.replace(`/relics${qs ? `?${qs}` : ""}`, { scroll: false });
-  }, [router]);
+    router.replace(`${lp}/relics${qs ? `?${qs}` : ""}`, { scroll: false });
+  }, [router, lp]);
 
   const setFilterAndUrl = useCallback((key: string, value: string, setter: (v: string) => void) => {
     setter(value);


### PR DESCRIPTION
## Summary

Fix #126
Fix localized list pages so filter/sort/search updates keep the current locale prefix in the URL.
Also fixes event detail navigation from localized event lists.

## What changed

- preserve locale prefix on cards list updates
- preserve locale prefix on relics, potions, monsters, encounters, enchantments, and events list updates
- preserve locale prefix when opening event details from localized event lists
