### PR TITLE
fix(navbar): close desktop dropdown after navigation

### DIFF
--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -143,9 +143,6 @@ export default function Navbar() {
     // Clear nav focus after navigation so focus-within dropdowns close (keyboard support preserved).
     const main = document.querySelector("main");
     if (main instanceof HTMLElement) {
-      if (!main.hasAttribute("tabindex")) {
-        main.setAttribute("tabindex", "-1");
-      }
       main.focus();
     }
   }, [pathname]);
@@ -194,7 +191,6 @@ export default function Navbar() {
                   <button
                     type="button"
                     aria-haspopup="menu"
-                    // Mouse clicks should not leave focus in the nav
                     onMouseDown={(e) => e.preventDefault()}
                     className={`flex items-center gap-1.5 px-3.5 py-2 text-sm font-medium rounded-md transition-colors ${
                       hasActive
@@ -235,8 +231,7 @@ export default function Navbar() {
                         }`;
                         if (isInternal) {
                           return (
-                            // Mouse clicks should not leave focus in the nav (onMouseDown)
-                            <Link key={link.href} href={fullHref} role="menuitem"  className={className} onMouseDown={(e) => e.preventDefault()}>
+                            <Link key={link.href} href={fullHref} role="menuitem" className={className} onMouseDown={(e) => e.preventDefault()}>
                               {t(link.label, lang)}
                             </Link>
                           );
@@ -247,7 +242,6 @@ export default function Navbar() {
                             href={fullHref}
                             {...(isHttp ? { target: "_blank", rel: "noopener noreferrer" } : {})}
                             role="menuitem"
-                            // Mouse clicks should not leave focus in the nav
                             onMouseDown={(e) => e.preventDefault()}
                             className={className}
                           >

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -140,6 +140,14 @@ export default function Navbar() {
   // Close menu on route change
   useEffect(() => {
     setOpen(false);
+    // Clear nav focus after navigation so focus-within dropdowns close (keyboard support preserved).
+    const main = document.querySelector("main");
+    if (main instanceof HTMLElement) {
+      if (!main.hasAttribute("tabindex")) {
+        main.setAttribute("tabindex", "-1");
+      }
+      main.focus();
+    }
   }, [pathname]);
 
   function toggleGroup(label: string) {
@@ -186,6 +194,8 @@ export default function Navbar() {
                   <button
                     type="button"
                     aria-haspopup="menu"
+                    // Mouse clicks should not leave focus in the nav
+                    onMouseDown={(e) => e.preventDefault()}
                     className={`flex items-center gap-1.5 px-3.5 py-2 text-sm font-medium rounded-md transition-colors ${
                       hasActive
                         ? "text-[var(--accent-gold)]"
@@ -225,7 +235,8 @@ export default function Navbar() {
                         }`;
                         if (isInternal) {
                           return (
-                            <Link key={link.href} href={fullHref} role="menuitem" className={className}>
+                            // Mouse clicks should not leave focus in the nav (onMouseDown)
+                            <Link key={link.href} href={fullHref} role="menuitem"  className={className} onMouseDown={(e) => e.preventDefault()}>
                               {t(link.label, lang)}
                             </Link>
                           );
@@ -236,6 +247,8 @@ export default function Navbar() {
                             href={fullHref}
                             {...(isHttp ? { target: "_blank", rel: "noopener noreferrer" } : {})}
                             role="menuitem"
+                            // Mouse clicks should not leave focus in the nav
+                            onMouseDown={(e) => e.preventDefault()}
                             className={className}
                           >
                             {t(link.label, lang)}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -59,7 +59,7 @@ export default function RootLayout({
               <Navbar />
               <div className="pt-16">
                 <DonationBanner />
-                <main>{children}</main>
+                <main tabIndex={-1}>{children}</main>
               </div>
               <Footer />
               <GlobalSearch />


### PR DESCRIPTION
## Issue
https://github.com/ptrlrd/spire-codex/issues/140

## Summary
Fixes a desktop navbar bug where mega-menu dropdowns could remain open after link activation.

## Root Cause
Dropdown visibility relied on `group-focus-within` in addition to hover.
After activating a link, focus could remain inside the nav, so the dropdown stayed visible.

## Changes
- Kept keyboard accessibility behavior (`group-focus-within`) intact.
- Prevented mouse-down focus persistence on desktop nav trigger and dropdown links (`onMouseDown={(e) => e.preventDefault()}`).
- On route change, moved focus to `main` so nav `group-focus-within` state clears and dropdown closes reliably.