### PR TITLE
Add license + hosted API terms

### DIFF
--- a/API_TERMS.md
+++ b/API_TERMS.md
@@ -1,0 +1,46 @@
+# Spire Codex API — Terms of Use
+
+Everything under `https://spire-codex.com/api/*` is free for community use, within the rate limits below. If your project needs more, open a [GitHub issue](https://github.com/ptrlrd/spire-codex/issues) or ping the [Discord](https://discord.gg/xMsTBeh) and we'll work something out.
+
+These terms cover the **hosted API and the tooltip / changelog widgets at spire-codex.com**. They do not replace the software license — source code is covered by [LICENSE.md](LICENSE.md) (PolyForm Noncommercial 1.0.0).
+
+## Rate limits
+
+| Endpoint | Limit |
+|---|---|
+| Data endpoints (`/api/cards`, `/api/relics`, `/api/monsters`, ...) | 60 requests / minute / IP |
+| `/api/runs/shared/{hash}` | 60 requests / minute / IP |
+| Feedback submission (`POST /api/feedback`) | 5 requests / minute / IP |
+| Guide submission (`POST /api/guides`) | 3 requests / minute / IP |
+
+Hit a limit and you'll get `429 Too Many Requests`. Back off and retry.
+
+If you're building a bot, a site, or a large-scale tool and the default limits aren't enough, reach out — higher limits are usually fine, we just want to know about the traffic.
+
+## Attribution (encouraged, not required)
+
+If you ship something useful built on this API or the extracted assets, a link back to `https://spire-codex.com` somewhere visible helps other players find the data and keeps the ecosystem visible.
+
+## No warranty, no SLA
+
+The API is offered as-is:
+
+- No uptime guarantees.
+- No guarantees the data is complete, correct, or up-to-date.
+- No guarantees the response schema won't change between game patches.
+
+Field-level changes between game versions are tracked at `/changelog`, but not every breaking change is backwards-compatible.
+
+## Game data ownership
+
+Card, relic, monster, potion, event, and all other Slay the Spire 2 game data belongs to **Mega Crit Games**. This project serves it as a community reference under fair-use / educational terms. If you build something with it, do not use the data to recompile, repackage, or redistribute the game itself, or in any way that competes with Mega Crit's own commercial interests.
+
+## Abuse
+
+Scraper traffic that bypasses rate limits, attempts to enumerate run hashes, or otherwise degrades service quality for other users will be blocked without notice.
+
+## Contact
+
+- Bugs and higher-limit requests: [GitHub issues](https://github.com/ptrlrd/spire-codex/issues)
+- Community / chat: [Discord](https://discord.gg/xMsTBeh)
+- Media / press: media@spire-codex.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,4 +186,6 @@ docker compose up --build
 
 ## License
 
-This project is for educational purposes. Game data belongs to Mega Crit Games.
+Contributions are accepted under the project's [PolyForm Noncommercial 1.0.0](LICENSE.md) license — by opening a PR you agree your contribution is licensed under the same terms as the rest of the code. Noncommercial use, modification, and redistribution are all permitted; selling the software is not.
+
+Game data (cards, relics, monsters, etc.) belongs to **Mega Crit Games** and is served here as a community reference under fair-use / educational terms. See [API_TERMS.md](API_TERMS.md) for the hosted API's usage policy.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,75 @@
+# PolyForm Noncommercial License 1.0.0
+
+Required Notice: Copyright © 2025-present Peter Lord and Spire Codex contributors.
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose. However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software. Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software. For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else. These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice. Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization. **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise. Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/README.md
+++ b/README.md
@@ -731,6 +731,10 @@ Thanks to **vesper-arch**, **terracubist**, **U77654**, **Purple Aspired Dreamin
 - **Infrastructure**: Docker, GitHub Actions CI (self-hosted K8s runner), SSH deploy
 - **Tools**: Python (update pipeline, changelog diffing, image copying)
 
-## Disclaimer
+## License
 
-This project is for educational purposes. Game data belongs to Mega Crit Games. This should not be used to recompile or redistribute the game.
+- **Source code**: [PolyForm Noncommercial 1.0.0](LICENSE.md) — free to use, modify, and redistribute for noncommercial purposes. Selling the software is not permitted.
+- **Hosted API**: [API_TERMS.md](API_TERMS.md) — free for any use within the published rate limits; reach out on Discord or in an issue if you need more.
+- **Game data** (cards, relics, monsters, etc.): © Mega Crit Games. Served here as a community reference under fair-use / educational terms. Do not use this data to recompile, repackage, or redistribute the game.
+
+Contributions are accepted under the same PolyForm Noncommercial 1.0.0 terms — see [CONTRIBUTING.md](CONTRIBUTING.md#license).


### PR DESCRIPTION
Closes #144. Three surfaces, three docs:

- **`LICENSE.md`** — [PolyForm Noncommercial 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0), verbatim. Governs the source: free for noncommercial use, modification, and redistribution; selling it is not permitted.
- **`API_TERMS.md`** — usage policy for `spire-codex.com/api/*`. Rate limits per endpoint, no-warranty / no-SLA, game-data ownership note (Mega Crit), contact for higher limits. Kept separate from the software license because the hosted API is a service, not software redistribution.
- **`CONTRIBUTING.md`** + **`README.md`** — License sections updated to link both docs and note contributions flow under the same PolyForm NC terms.