### PR TITLE
Fix /leaderboards/stats tables overflowing on mobile

### DIFF
--- a/frontend/app/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/leaderboards/stats/StatsClient.tsx
@@ -957,7 +957,7 @@ function CardTable({
     );
   }
   return (
-    <div className="overflow-visible">
+    <div className="overflow-x-auto md:overflow-visible">
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-[var(--border-subtle)]">
@@ -1084,7 +1084,7 @@ function RelicsTab({
       {rows.length === 0 ? (
         <div className="py-8 text-center text-sm text-[var(--text-muted)]">No relics match.</div>
       ) : (
-        <div className="overflow-visible">
+        <div className="overflow-x-auto md:overflow-visible">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-[var(--border-subtle)]">
@@ -1212,7 +1212,7 @@ function PotionsTab({
       {rows.length === 0 ? (
         <div className="py-8 text-center text-sm text-[var(--text-muted)]">No potions match.</div>
       ) : (
-        <div className="overflow-visible">
+        <div className="overflow-x-auto md:overflow-visible">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-[var(--border-subtle)]">


### PR DESCRIPTION
Closes #141. The three wide stat tables (cards / relics / potions) wrapped their scroll div in `overflow-visible` so hover tooltips could pop outside the table. Fine on desktop, wrecks narrow mobile viewports — tables spill past the edge of the page.

Swap to `overflow-x-auto md:overflow-visible`. Mobile scrolls inside the container, desktop keeps the existing tooltip behaviour. Mobile loses pop-out tooltips but mobile doesn't hover anyway.