### PR TITLE
Track default beta traffic as version=latest

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -205,6 +205,10 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         version = request.query_params.get("version")
         if version:
             version_usage.labels(version=version).inc()
+        else:
+            host = request.headers.get("x-forwarded-host") or request.headers.get("host", "")
+            if host.startswith("beta."):
+                version_usage.labels(version="latest").inc()
 
         # Track entity views and searches from API paths
         path = request.url.path

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -206,7 +206,9 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         if version:
             version_usage.labels(version=version).inc()
         else:
-            host = request.headers.get("x-forwarded-host") or request.headers.get("host", "")
+            host = request.headers.get("x-forwarded-host") or request.headers.get(
+                "host", ""
+            )
             if host.startswith("beta."):
                 version_usage.labels(version="latest").inc()
 


### PR DESCRIPTION
## Summary
- `version_usage` only incremented on explicit `?version=` query params, so `beta.spire-codex.com` visits that fell through to the `latest` symlink never registered
- Grafana's beta panel was effectively showing only dropdown picks of old versions — a tiny slice of real beta traffic
- Now emit `version="latest"` when the host starts with `beta.` and no explicit version is set; explicit picks (`v0.103.0`, etc.) keep their granular label
