### PR TITLE
Add POST /api/runs/claim for attaching usernames by hash

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
-from ..services.runs_db import submit_run, get_stats
+from ..services.runs_db import submit_run, get_stats, claim_runs
 from ..metrics import (
     run_submissions,
     run_character,
@@ -110,6 +110,57 @@ async def submit_run_endpoint(request: Request, username: str | None = None):
         run_duration.observe(run_time)
 
     return result
+
+
+MAX_CLAIM_HASHES = 5000
+
+
+@router.post("/claim", tags=["Runs"])
+@limiter.limit("10/minute")
+async def claim_runs_endpoint(request: Request):
+    """Attach a username to previously-submitted runs by hash.
+
+    Body: `{ "username": "name", "hashes": ["abc123...", ...] }`
+
+    Only rows with a NULL/empty username are updated — existing
+    claims are never overwritten. Intended for the Spire Compendium
+    desktop app: after Steam sign-in, the client computes hashes
+    for every local run and claims the ones it already uploaded
+    anonymously.
+    """
+    try:
+        payload = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    raw_username = payload.get("username")
+    if not raw_username or not isinstance(raw_username, str):
+        raise HTTPException(status_code=400, detail="username is required")
+
+    import re
+
+    sanitized = re.sub(r"[^a-zA-Z0-9_\- ]", "", raw_username.strip())[:25].strip()
+    if not sanitized:
+        raise HTTPException(
+            status_code=400, detail="username is empty after sanitization"
+        )
+
+    hashes = payload.get("hashes")
+    if not isinstance(hashes, list):
+        raise HTTPException(status_code=400, detail="hashes must be a list")
+    if len(hashes) > MAX_CLAIM_HASHES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Too many hashes. Max {MAX_CLAIM_HASHES} per request.",
+        )
+
+    clean_hashes = [
+        h for h in hashes if isinstance(h, str) and h.isalnum() and 8 <= len(h) <= 64
+    ]
+    if not clean_hashes:
+        return {"claimed": 0, "already_claimed": 0, "unknown": 0}
+
+    return claim_runs(sanitized, clean_hashes)
 
 
 @router.get("/list", tags=["Runs"])

--- a/backend/app/services/runs_db.py
+++ b/backend/app/services/runs_db.py
@@ -327,6 +327,46 @@ def _submit_player_run(
     return {"success": True, "run_id": run_id, "run_hash": run_hash}
 
 
+def claim_runs(username: str, hashes: list[str]) -> dict:
+    """Attach `username` to any run rows whose hash matches and whose
+    current username is NULL/empty. Rows already claimed by any user
+    (including the same one) are left untouched so this can't overwrite.
+
+    Returns a summary: how many rows were updated, how many hashes
+    matched a row but were skipped (already claimed), and how many
+    hashes didn't match any row at all.
+    """
+    if not hashes:
+        return {"claimed": 0, "already_claimed": 0, "unknown": 0}
+
+    with get_conn() as conn:
+        placeholders = ",".join("?" for _ in hashes)
+        existing = conn.execute(
+            f"SELECT run_hash, username FROM runs WHERE run_hash IN ({placeholders})",
+            hashes,
+        ).fetchall()
+        by_hash = {r["run_hash"]: r["username"] for r in existing}
+
+        unclaimed = [h for h, u in by_hash.items() if not u]
+        already_claimed = len(by_hash) - len(unclaimed)
+        unknown = len(hashes) - len(by_hash)
+
+        if unclaimed:
+            unclaimed_placeholders = ",".join("?" for _ in unclaimed)
+            conn.execute(
+                f"UPDATE runs SET username = ? "
+                f"WHERE run_hash IN ({unclaimed_placeholders}) "
+                f"AND (username IS NULL OR username = '')",
+                [username, *unclaimed],
+            )
+
+    return {
+        "claimed": len(unclaimed),
+        "already_claimed": already_claimed,
+        "unknown": unknown,
+    }
+
+
 def get_stats(
     character: str | None = None,
     win: str | None = None,


### PR DESCRIPTION
## Summary
- New `POST /api/runs/claim` takes `{ username, hashes: [...] }` and attaches the username to any matching rows whose current username is NULL/empty
- Existing claims are never overwritten — prevents takeover by anyone who happens to know a hash
- Capped at 5000 hashes per request, rate-limited to 10/min per IP
- Intended for the Spire Compendium desktop app: after Steam sign-in the client re-derives each local run's `run_hash` (same formula the server uses in `_submit_player_run`) and claims them in one shot instead of re-uploading thousands of files
