### PR TITLE
Stop main.focus() from scrolling past the donation banner

### DIFF
--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -140,10 +140,13 @@ export default function Navbar() {
   // Close menu on route change
   useEffect(() => {
     setOpen(false);
-    // Clear nav focus after navigation so focus-within dropdowns close (keyboard support preserved).
+    // Clear nav focus after navigation so focus-within dropdowns close
+    // (keyboard support preserved). preventScroll matters: without it the
+    // browser scrolls <main> into view, which on small screens jumps past
+    // the donation banner that sits above main in the layout.
     const main = document.querySelector("main");
     if (main instanceof HTMLElement) {
-      main.focus();
+      main.focus({ preventScroll: true });
     }
   }, [pathname]);
 


### PR DESCRIPTION
## Summary
- Regression from #142: every route change called `main.focus()` so the mega-menu's `focus-within` state would clear, but the default focus behavior also scrolls the focused element into view
- Since `<main>` sits below both the fixed navbar AND the donation banner, the browser was scrolling past the banner on every navigation — banner only re-appeared if the user manually scrolled up
- Pass `{ preventScroll: true }` so focus moves without affecting the viewport. Keyboard/a11y behavior unchanged.
