### PR TITLE
Identify which run field is missing in 400 rejections (issue #151)

### DIFF
--- a/backend/app/services/runs_db.py
+++ b/backend/app/services/runs_db.py
@@ -152,13 +152,24 @@ def clean_id(raw_id: str) -> str:
 
 def submit_run(data: dict, username: str | None = None) -> dict:
     """Parse and store a run. Returns status dict."""
-    # Validate structure
-    if (
-        not data.get("players")
-        or not data.get("map_point_history")
-        or not isinstance(data.get("acts"), list)
-    ):
-        return {"error": "Invalid run data — missing required fields"}
+    # Validate structure. Errors call out the specific field so failed
+    # batch uploads (issue #151) can be triaged without re-running with
+    # a debugger — previously every rejection collapsed to the same
+    # "missing required fields" message regardless of which field was
+    # actually the problem.
+    missing: list[str] = []
+    if not data.get("players"):
+        missing.append("players")
+    if not data.get("map_point_history"):
+        missing.append("map_point_history")
+    if not isinstance(data.get("acts"), list):
+        missing.append("acts")
+    if missing:
+        return {
+            "error": (
+                f"Invalid run data — missing or empty fields: {', '.join(missing)}"
+            )
+        }
 
     was_abandoned = int(data.get("was_abandoned", False))
     total_floors = sum(len(act) for act in data.get("map_point_history", []))


### PR DESCRIPTION
## Summary
Closes #151 (diagnostic step). The bug report shows 31 runs rejected from a single batch, all with the same opaque `"missing required fields"` 400. Without knowing which specific field is the problem, we can't tell if it's schema drift, an empty-array edge case, or something else.

- Splits the structural validation in `submit_run` into per-field checks
- Surfaces the specific missing/empty fields in the 400 response (`"missing or empty fields: players, acts"`)
- No behavior change — same fields are still required

After deploy, the next batch upload that hits this will give us actionable info, and we can decide whether to loosen validation or fix the client.
