### PR TITLE
Make per-character relic-art variants self-explanatory (Yummy Cookie)

### DIFF
--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -102,20 +102,31 @@ export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | n
               crossOrigin="anonymous"
             />
             {relic.image_variants && Object.keys(relic.image_variants).length > 0 && (
-              <div className="flex gap-1.5 mt-3">
-                {Object.entries(relic.image_variants).map(([char, url]) => (
-                  <button
-                    key={char}
-                    onClick={() => { setSelectedVariant(url); setSelectedChar(char); }}
-                    className={`text-xs px-2 py-1 rounded border transition-colors ${
-                      selectedVariant === url
-                        ? "border-[var(--accent-gold)]/50 text-[var(--accent-gold)] bg-[var(--accent-gold)]/10"
-                        : "border-[var(--border-subtle)] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-                    }`}
-                  >
-                    {char}
-                  </button>
-                ))}
+              <div className="mt-4 text-center">
+                <p className="text-xs text-[var(--text-muted)] mb-2">
+                  {t("This relic has different art for each character. Click to preview.", lang)}
+                </p>
+                <div className="flex gap-1.5 justify-center">
+                  {Object.entries(relic.image_variants).map(([char, url]) => (
+                    <button
+                      key={char}
+                      onClick={() => { setSelectedVariant(url); setSelectedChar(char); }}
+                      title={`${t("Show", lang)} ${char} ${t("variant", lang)}`}
+                      className={`text-xs px-2 py-1 rounded border transition-colors ${
+                        selectedVariant === url
+                          ? "border-[var(--accent-gold)]/50 text-[var(--accent-gold)] bg-[var(--accent-gold)]/10"
+                          : "border-[var(--border-subtle)] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                      }`}
+                    >
+                      {char}
+                    </button>
+                  ))}
+                </div>
+                {selectedChar && (
+                  <p className="text-xs text-[var(--text-muted)] mt-2 italic">
+                    {t("Showing", lang)}: {selectedChar}
+                  </p>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
Player feedback: someone thought the Yummy Cookie image was wrong. Root cause is the per-character variant picker — five unlabeled name buttons under the relic image with no context, so it reads as "broken UI" instead of "click to swap art."

- Adds a short caption above the variant row: *"This relic has different art for each character. Click to preview."*
- Adds an italic "Showing: <character>" line under the active selection so it's clear which variant is currently displayed
- Adds `title=""` tooltips on the buttons themselves
- No data change — just makes the existing mechanism legible

Affects any relic with `image_variants` in the API response (today: just Yummy Cookie, but the change is generic).
