### PR TITLE
Surface both Looming Fruit icons via image_variants

### DIFF
--- a/backend/app/parsers/relic_parser.py
+++ b/backend/app/parsers/relic_parser.py
@@ -185,6 +185,20 @@ def parse_single_relic(
         if variant_file.exists():
             image_variants[char_name] = f"/static/images/relics/{variant_file.name}"
 
+    # Looming Fruit ships two icons (cornucopia + bare fruit) and the
+    # game picks one per save based on `UniqueId % 2 == 0` in
+    # `LoomingFruit.cs::HasCornucopia()`. Half the playerbase sees
+    # each, which leads to "wrong icon" reports — surface both so the
+    # detail page's variant picker shows them as alternates.
+    if class_name == "LoomingFruit":
+        cornucopia_url = f"/static/images/relics/{relic_base}.webp"
+        fruit_file = STATIC_IMAGES / f"{relic_base}_2.webp"
+        if not fruit_file.exists():
+            fruit_file = STATIC_IMAGES / f"{relic_base}_2.png"
+        if fruit_file.exists():
+            image_variants["Cornucopia"] = cornucopia_url
+            image_variants["Fruit"] = f"/static/images/relics/{fruit_file.name}"
+
     # Relic-specific notes extracted from C# source
     notes = None
     if class_name == "ToyBox":

--- a/data/deu/relics.json
+++ b/data/deu/relics.json
@@ -4214,7 +4214,10 @@
     "pool": "shared",
     "merchant_price": null,
     "image_url": "/static/images/relics/looming_fruit.webp",
-    "image_variants": null,
+    "image_variants": {
+      "Cornucopia": "/static/images/relics/looming_fruit.webp",
+      "Fruit": "/static/images/relics/looming_fruit_2.webp"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 241

--- a/data/eng/relics.json
+++ b/data/eng/relics.json
@@ -2197,7 +2197,10 @@
     "pool": "shared",
     "merchant_price": null,
     "image_url": "/static/images/relics/looming_fruit.webp",
-    "image_variants": null,
+    "image_variants": {
+      "Cornucopia": "/static/images/relics/looming_fruit.webp",
+      "Fruit": "/static/images/relics/looming_fruit_2.webp"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 198

--- a/data/esp/relics.json
+++ b/data/esp/relics.json
@@ -1260,7 +1260,10 @@
     "pool": "shared",
     "merchant_price": null,
     "image_url": "/static/images/relics/looming_fruit.webp",
-    "image_variants": null,
+    "image_variants": {
+      "Cornucopia": "/static/images/relics/looming_fruit.webp",
+      "Fruit": "/static/images/relics/looming_fruit_2.webp"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 184

--- a/data/fra/relics.json
+++ b/data/fra/relics.json
@@ -1874,7 +1874,10 @@
     "pool": "shared",
     "merchant_price": null,
     "image_url": "/static/images/relics/looming_fruit.webp",
-    "image_variants": null,
+    "image_variants": {
+      "Cornucopia": "/static/images/relics/looming_fruit.webp",
+      "Fruit": "/static/images/relics/looming_fruit_2.webp"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 200

--- a/data/ita/relics.json
+++ b/data/ita/relics.json
@@ -1824,7 +1824,10 @@
     "pool": "shared",
     "merchant_price": null,
     "image_url": "/static/images/relics/looming_fruit.webp",
-    "image_variants": null,
+    "image_variants": {
+      "Cornucopia": "/static/images/relics/looming_fruit.webp",
+      "Fruit": "/static/images/relics/looming_fruit_2.webp"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 199

--- a/data/jpn/relics.json
+++ b/data/jpn/relics.json
@@ -2884,7 +2884,10 @@
     "pool": "shared",
     "merchant_price": null,
     "image_url": "/static/images/relics/looming_fruit.webp",
-    "image_variants": null,
+    "image_variants": {
+      "Cornucopia": "/static/images/relics/looming_fruit.webp",
+      "Fruit": "/static/images/relics/looming_fruit_2.webp"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 214

--- a/data/kor/relics.json
+++ b/data/kor/relics.json
@@ -346,7 +346,10 @@
     "pool": "shared",
     "merchant_price": null,
     "image_url": "/static/images/relics/looming_fruit.webp",
-    "image_variants": null,
+    "image_variants": {
+      "Cornucopia": "/static/images/relics/looming_fruit.webp",
+      "Fruit": "/static/images/relics/looming_fruit_2.webp"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 165

--- a/data/pol/relics.json
+++ b/data/pol/relics.json
@@ -3394,7 +3394,10 @@
     "pool": "shared",
     "merchant_price": null,
     "image_url": "/static/images/relics/looming_fruit.webp",
-    "image_variants": null,
+    "image_variants": {
+      "Cornucopia": "/static/images/relics/looming_fruit.webp",
+      "Fruit": "/static/images/relics/looming_fruit_2.webp"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 220

--- a/data/ptb/relics.json
+++ b/data/ptb/relics.json
@@ -2271,7 +2271,10 @@
     "pool": "shared",
     "merchant_price": null,
     "image_url": "/static/images/relics/looming_fruit.webp",
-    "image_variants": null,
+    "image_variants": {
+      "Cornucopia": "/static/images/relics/looming_fruit.webp",
+      "Fruit": "/static/images/relics/looming_fruit_2.webp"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 199

--- a/data/rus/relics.json
+++ b/data/rus/relics.json
@@ -4467,7 +4467,10 @@
     "pool": "shared",
     "merchant_price": null,
     "image_url": "/static/images/relics/looming_fruit.webp",
-    "image_variants": null,
+    "image_variants": {
+      "Cornucopia": "/static/images/relics/looming_fruit.webp",
+      "Fruit": "/static/images/relics/looming_fruit_2.webp"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 242

--- a/data/spa/relics.json
+++ b/data/spa/relics.json
@@ -1109,7 +1109,10 @@
     "pool": "shared",
     "merchant_price": null,
     "image_url": "/static/images/relics/looming_fruit.webp",
-    "image_variants": null,
+    "image_variants": {
+      "Cornucopia": "/static/images/relics/looming_fruit.webp",
+      "Fruit": "/static/images/relics/looming_fruit_2.webp"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 181

--- a/data/tha/relics.json
+++ b/data/tha/relics.json
@@ -1887,7 +1887,10 @@
     "pool": "shared",
     "merchant_price": null,
     "image_url": "/static/images/relics/looming_fruit.webp",
-    "image_variants": null,
+    "image_variants": {
+      "Cornucopia": "/static/images/relics/looming_fruit.webp",
+      "Fruit": "/static/images/relics/looming_fruit_2.webp"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 191

--- a/data/tur/relics.json
+++ b/data/tur/relics.json
@@ -1246,7 +1246,10 @@
     "pool": "shared",
     "merchant_price": null,
     "image_url": "/static/images/relics/looming_fruit.webp",
-    "image_variants": null,
+    "image_variants": {
+      "Cornucopia": "/static/images/relics/looming_fruit.webp",
+      "Fruit": "/static/images/relics/looming_fruit_2.webp"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 180

--- a/data/zhs/relics.json
+++ b/data/zhs/relics.json
@@ -1500,7 +1500,10 @@
     "pool": "shared",
     "merchant_price": null,
     "image_url": "/static/images/relics/looming_fruit.webp",
-    "image_variants": null,
+    "image_variants": {
+      "Cornucopia": "/static/images/relics/looming_fruit.webp",
+      "Fruit": "/static/images/relics/looming_fruit_2.webp"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 197


### PR DESCRIPTION
## Summary
`LoomingFruit.cs` picks one of two icons per save based on `SaveManager.Progress.UniqueId % 2 == 0` — half of players see the cornucopia variant, the other half see the bare-fruit variant (`looming_fruit_2.png`). Players who see the variant that doesn't match what we display report the icon as wrong.

- Surfaces both icons via the `image_variants` field labeled **Cornucopia** and **Fruit**
- Piggybacks on the same UI variant picker already used for Yummy Cookie's character art (#164) — no frontend change needed
- Reparses all 14 languages so the field is populated everywhere

After deploy, the Looming Fruit detail page shows both icons with the picker and the explainer caption, so players can swap to whichever matches their save.
