### PR TITLE
Fix Nonupeipe banner thank-you link to /thank-you route

### DIFF
--- a/frontend/app/components/DonationBanner.tsx
+++ b/frontend/app/components/DonationBanner.tsx
@@ -155,7 +155,7 @@ function KofiBanner({ onDismiss }: { onDismiss: () => void }) {
             </a>
             . Servants! Fetch tea for{" "}
             <Link
-              href="/about#thank-you"
+              href="/thank-you"
               className="font-medium text-emerald-100 underline hover:text-white transition-colors"
             >
               those who&apos;ve supported us


### PR DESCRIPTION
Banner link still pointed at `/about#thank-you` after the thank-you content was split into a standalone `/thank-you` route. Now points at the live page.