### PR TITLE
Add Looming Fruit notes + collapse variant picker to one hint line

### DIFF
--- a/backend/app/parsers/relic_parser.py
+++ b/backend/app/parsers/relic_parser.py
@@ -207,6 +207,11 @@ def parse_single_relic(
             "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
             "All wax relics melt after 12 total combats, then Toy Box is used up.",
         ]
+    if class_name == "LoomingFruit":
+        notes = [
+            "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+            "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows.",
+        ]
 
     return {
         "id": relic_id,

--- a/data/deu/relics.json
+++ b/data/deu/relics.json
@@ -4218,7 +4218,10 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
-    "notes": null,
+    "notes": [
+      "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+      "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
+    ],
     "rarity_key": "Ancient",
     "compendium_order": 241
   },

--- a/data/eng/relics.json
+++ b/data/eng/relics.json
@@ -2201,7 +2201,10 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
-    "notes": null,
+    "notes": [
+      "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+      "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
+    ],
     "rarity_key": "Ancient",
     "compendium_order": 198
   },

--- a/data/esp/relics.json
+++ b/data/esp/relics.json
@@ -1264,7 +1264,10 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
-    "notes": null,
+    "notes": [
+      "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+      "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
+    ],
     "rarity_key": "Ancient",
     "compendium_order": 184
   },

--- a/data/fra/relics.json
+++ b/data/fra/relics.json
@@ -1878,7 +1878,10 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
-    "notes": null,
+    "notes": [
+      "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+      "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
+    ],
     "rarity_key": "Ancient",
     "compendium_order": 200
   },

--- a/data/ita/relics.json
+++ b/data/ita/relics.json
@@ -1828,7 +1828,10 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
-    "notes": null,
+    "notes": [
+      "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+      "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
+    ],
     "rarity_key": "Ancient",
     "compendium_order": 199
   },

--- a/data/jpn/relics.json
+++ b/data/jpn/relics.json
@@ -2888,7 +2888,10 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
-    "notes": null,
+    "notes": [
+      "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+      "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
+    ],
     "rarity_key": "Ancient",
     "compendium_order": 214
   },

--- a/data/kor/relics.json
+++ b/data/kor/relics.json
@@ -350,7 +350,10 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
-    "notes": null,
+    "notes": [
+      "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+      "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
+    ],
     "rarity_key": "Ancient",
     "compendium_order": 165
   },

--- a/data/pol/relics.json
+++ b/data/pol/relics.json
@@ -3398,7 +3398,10 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
-    "notes": null,
+    "notes": [
+      "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+      "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
+    ],
     "rarity_key": "Ancient",
     "compendium_order": 220
   },

--- a/data/ptb/relics.json
+++ b/data/ptb/relics.json
@@ -2275,7 +2275,10 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
-    "notes": null,
+    "notes": [
+      "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+      "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
+    ],
     "rarity_key": "Ancient",
     "compendium_order": 199
   },

--- a/data/rus/relics.json
+++ b/data/rus/relics.json
@@ -4471,7 +4471,10 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
-    "notes": null,
+    "notes": [
+      "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+      "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
+    ],
     "rarity_key": "Ancient",
     "compendium_order": 242
   },

--- a/data/spa/relics.json
+++ b/data/spa/relics.json
@@ -1113,7 +1113,10 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
-    "notes": null,
+    "notes": [
+      "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+      "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
+    ],
     "rarity_key": "Ancient",
     "compendium_order": 181
   },

--- a/data/tha/relics.json
+++ b/data/tha/relics.json
@@ -1891,7 +1891,10 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
-    "notes": null,
+    "notes": [
+      "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+      "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
+    ],
     "rarity_key": "Ancient",
     "compendium_order": 191
   },

--- a/data/tur/relics.json
+++ b/data/tur/relics.json
@@ -1250,7 +1250,10 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
-    "notes": null,
+    "notes": [
+      "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+      "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
+    ],
     "rarity_key": "Ancient",
     "compendium_order": 180
   },

--- a/data/zhs/relics.json
+++ b/data/zhs/relics.json
@@ -1504,7 +1504,10 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
-    "notes": null,
+    "notes": [
+      "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
+      "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
+    ],
     "rarity_key": "Ancient",
     "compendium_order": 197
   },

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -102,23 +102,19 @@ export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | n
               crossOrigin="anonymous"
             />
             {relic.image_variants && Object.keys(relic.image_variants).length > 0 && (() => {
-              // Detect what KIND of variant this is so the caption fits.
-              // Character-name keys (Ironclad / Silent / etc.) → Yummy Cookie
-              // pattern. Anything else (e.g. Looming Fruit's Cornucopia / Fruit)
-              // is a per-save / per-context variant and gets a generic caption
-              // — relic_parser.py adds a `notes` entry explaining the specific
-              // mechanic for those, which renders below.
+              // Single layout for both variant types: buttons row, then a
+              // single italic hint below. Active button is already
+              // gold-highlighted so an explicit "Showing: X" was redundant.
+              // The full "why" for non-character variants (e.g. Looming
+              // Fruit's per-save coin flip) lives in the relic's `notes`.
               const CHARACTER_KEYS = new Set(["Ironclad", "Silent", "Defect", "Necrobinder", "Regent"]);
               const variantKeys = Object.keys(relic.image_variants);
               const isCharacterVariants = variantKeys.every((k) => CHARACTER_KEYS.has(k));
-              const caption = isCharacterVariants
-                ? t("This relic has different art for each character. Click to preview.", lang)
-                : t("This relic has multiple in-game art variants. Click to preview.", lang);
+              const hint = isCharacterVariants
+                ? t("This relic has different art for each character. Use buttons above.", lang)
+                : t("Multiple in-game art variants, toggle above", lang);
               return (
                 <div className="mt-4 text-center w-full max-w-xs mx-auto">
-                  <p className="text-xs text-[var(--text-muted)] mb-2 px-2">
-                    {caption}
-                  </p>
                   <div className="flex flex-wrap gap-1.5 justify-center">
                     {Object.entries(relic.image_variants).map(([variantKey, url]) => (
                       <button
@@ -135,11 +131,9 @@ export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | n
                       </button>
                     ))}
                   </div>
-                  {selectedChar && (
-                    <p className="text-xs text-[var(--text-muted)] mt-2 italic">
-                      {t("Showing", lang)}: {selectedChar}
-                    </p>
-                  )}
+                  <p className="text-xs text-[var(--text-muted)] mt-2 italic px-2">
+                    {hint}
+                  </p>
                 </div>
               );
             })()}


### PR DESCRIPTION
## Summary
Two related cleanups for the relic variant picker, addressed together since they touch the same UI.

**1. Looming Fruit notes** — answers "why does this relic have two icons?" without forcing players to read decompiled C#. Notes explain the per-save UniqueId parity coin flip and clarify both variants are functionally identical (+31 Max HP). Renders in the existing relic notes block. Reparses all 14 languages.

**2. Variant picker — collapse to one hint line** for both Yummy Cookie and Looming Fruit:
- Drops the verbose top caption that duplicated content with the relic name area
- Drops the redundant "Showing: X" line (active button is already gold-highlighted)
- Single italic line below the buttons — *"This relic has different art for each character. Use buttons above."* for Yummy Cookie, *"Multiple in-game art variants, toggle above"* for Looming Fruit
- `max-w-xs mx-auto` + `flex-wrap` stays so the picker still wraps cleanly on mobile
