### PR TITLE
Suppress visible focus ring on programmatically-focused <main>

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -59,7 +59,13 @@ export default function RootLayout({
               <Navbar />
               <div className="pt-16">
                 <DonationBanner />
-                <main tabIndex={-1}>{children}</main>
+                {/* tabIndex=-1 lets Navbar's main.focus() (PR #142) clear
+                    focus-within from the dropdown after route changes. The
+                    outline-none is required because the programmatic focus
+                    would otherwise paint a visible browser focus ring around
+                    the entire content area, which read as a stray "tab" line
+                    underneath the donation banner on every navigation. */}
+                <main tabIndex={-1} className="outline-none">{children}</main>
               </div>
               <Footer />
               <GlobalSearch />


### PR DESCRIPTION
PR #142's `main.focus()` on route change paints the browser's default focus outline around the content area, which reads as a stray "tab" line under the donation banner. The focus call is purely mechanical (clearing nav `focus-within`), no user-meaningful state to indicate. Adds `outline-none` so focus still moves but the ring is invisible.