### PR TITLE
Drop stale 'costing 1+' qualifier from Tri-Boomerang pool gate

### DIFF
--- a/data/ancient_pools.json
+++ b/data/ancient_pools.json
@@ -214,7 +214,7 @@
           { "id": "TANXS_WHISTLE", "condition": null },
           { "id": "THROWING_AXE", "condition": null },
           { "id": "WAR_HAMMER", "condition": null },
-          { "id": "TRI_BOOMERANG", "condition": "Deck has 3+ cards that can be enchanted with Instinct (Attacks costing 1+)" }
+          { "id": "TRI_BOOMERANG", "condition": "Deck has 3+ Attack cards (the type filter Instinct enforces)" }
         ]
       }
     ]


### PR DESCRIPTION
Tanx event gate (`Tanx.cs::GenerateInitialOptions`) checks `deck.Count(c => Instinct.CanEnchant(c)) >= 3`. Pre-2026-03-19 Instinct restricted to Attacks costing 1+, but the patch reworked it to `cardType == CardType.Attack` (flat type filter, no cost check). Our `data/ancient_pools.json` still carried the old qualifier on the displayed condition, so `/ancients` showed the precondition as cost-gated. Updates the string to match the current implementation.