### PR TITLE
Add ancient_pool_parser + mechanics_constants_parser to surface drift

### DIFF
--- a/backend/app/parsers/ancient_pool_parser.py
+++ b/backend/app/parsers/ancient_pool_parser.py
@@ -1,0 +1,184 @@
+"""Parse ancient relic-offering pools from decompiled C# event files.
+
+Companion to the hand-maintained `data/ancient_pools.json`. The hand file
+holds human-curated condition strings ("Deck has 3+ Attack cards"), which
+are easy to phrase but hard to auto-derive from arbitrary lambda
+predicates. This parser extracts the deterministic part — *which relics
+each ancient can offer* — straight from
+`extraction/decompiled/MegaCrit.Sts2.Core.Models.Events/{Ancient}.cs`.
+
+Output: `data/ancient_pools_parsed.json` — list of `{ancient_id, relics}`,
+one entry per ancient with the flat set of relic IDs the C# references.
+
+Validation step prints every relic that's in C# but missing from the
+hand-coded file (likely a new release we haven't synced) and every relic
+in the hand file but not in C# (probably renamed/removed). Drift on
+relic membership now surfaces every parse run instead of silently sitting
+on the site for months — see PR #170 for the bug that motivated this.
+
+Conditions are intentionally NOT parsed here. They live in
+`data/ancient_pools.json` and stay hand-curated until we have a
+predicate-to-prose translator we trust.
+"""
+
+import json
+import re
+
+from parser_paths import BASE, DECOMPILED, DATA_DIR
+
+EVENTS_DIR = DECOMPILED / "MegaCrit.Sts2.Core.Models.Events"
+
+# Files to parse. Names match the in-code class file names — Tanx.cs etc.
+# Update this list (and the hand-coded `ancient_pools.json`) when Mega
+# Crit ships a new ancient.
+ANCIENT_FILES = {
+    "DARV": "Darv.cs",
+    "NEOW": "Neow.cs",
+    "NONUPEIPE": "Nonupeipe.cs",
+    "OROBAS": "Orobas.cs",
+    "PAEL": "Pael.cs",
+    "TANX": "Tanx.cs",
+    "TEZCATARA": "Tezcatara.cs",
+    "VAKUU": "Vakuu.cs",
+}
+
+
+def class_name_to_id(name: str) -> str:
+    """PascalCase relic class name → SCREAMING_SNAKE relic ID.
+
+    Mirrors the convention used by every other parser in this directory
+    (relic_parser, monster_parser, etc.) so the IDs we emit match
+    exactly what the rest of the data layer uses.
+    """
+    s = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name)
+    s = re.sub(r"(?<=[A-Z])(?=[A-Z][a-z])", "_", s)
+    return s.upper()
+
+
+# Two patterns cover every ancient we've seen so far:
+#   `RelicOption<X>(...)` — the standard event-option helper used by Tanx,
+#                            Tezcatara, Vakuu, Pael, Orobas, Nonupeipe, Neow
+#   `ModelDb.Relic<X>()`   — Darv builds its `_validRelicSets` array using
+#                            ModelDb references directly instead of the helper
+# Both produce the same downstream class name; we collect from both.
+_RELIC_PATTERNS = (
+    re.compile(r"RelicOption<(\w+)>"),
+    re.compile(r"ModelDb\.Relic<(\w+)>"),
+)
+
+
+def parse_ancient_relics(filepath) -> set[str]:
+    """Return the set of relic IDs an ancient .cs file can offer."""
+    if not filepath.exists():
+        return set()
+    content = filepath.read_text(encoding="utf-8")
+    class_names: set[str] = set()
+    for pattern in _RELIC_PATTERNS:
+        for match in pattern.finditer(content):
+            class_names.add(match.group(1))
+    return {class_name_to_id(n) for n in class_names}
+
+
+def parse_all_ancients() -> dict[str, set[str]]:
+    """Walk every known ancient .cs file and collect relic IDs per ancient."""
+    out: dict[str, set[str]] = {}
+    for ancient_id, filename in ANCIENT_FILES.items():
+        out[ancient_id] = parse_ancient_relics(EVENTS_DIR / filename)
+    return out
+
+
+def load_hand_coded() -> dict[str, set[str]]:
+    """Flatten `data/ancient_pools.json` into {ancient_id: {relic_ids}}.
+
+    The hand file is structured by named pools per ancient; for drift
+    comparison we flatten across pools — what matters is *whether the
+    relic appears at all*, not which pool it lives in.
+    """
+    hand_file = DATA_DIR / "ancient_pools.json"
+    if not hand_file.exists():
+        return {}
+    with open(hand_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    out: dict[str, set[str]] = {}
+    for ancient in data:
+        ids: set[str] = set()
+        for pool in ancient.get("pools", []):
+            for relic in pool.get("relics", []):
+                if relic.get("id"):
+                    ids.add(relic["id"])
+        out[ancient["id"]] = ids
+    return out
+
+
+def diff_against_hand_coded(parsed: dict[str, set[str]]) -> list[str]:
+    """Return human-readable drift lines comparing parsed vs hand-coded.
+
+    Each line names an ancient and lists relic IDs that diverge in
+    either direction. Empty list = no drift; the hand file is in sync
+    with the C# extraction.
+    """
+    hand = load_hand_coded()
+    drift: list[str] = []
+    for ancient_id in sorted(set(parsed) | set(hand)):
+        c_set = parsed.get(ancient_id, set())
+        h_set = hand.get(ancient_id, set())
+        only_in_c = c_set - h_set
+        only_in_h = h_set - c_set
+        if not (only_in_c or only_in_h):
+            continue
+        parts: list[str] = [f"  {ancient_id}:"]
+        if only_in_c:
+            parts.append(
+                f"    + {len(only_in_c)} in C# but missing from hand file: {sorted(only_in_c)}"
+            )
+        if only_in_h:
+            parts.append(
+                f"    - {len(only_in_h)} in hand file but not in C#: {sorted(only_in_h)}"
+            )
+        drift.append("\n".join(parts))
+    return drift
+
+
+def write_parsed_output(parsed: dict[str, set[str]]) -> None:
+    """Persist the parsed relic lists to `data/ancient_pools_parsed.json`.
+
+    Written sorted for stable diffs across parse runs. Consumers (CI,
+    review tooling) can compare this file against `ancient_pools.json`
+    without re-running the parser themselves.
+    """
+    out_file = DATA_DIR / "ancient_pools_parsed.json"
+    out = [
+        {"id": ancient_id, "relics": sorted(parsed[ancient_id])}
+        for ancient_id in sorted(parsed)
+    ]
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_file, "w", encoding="utf-8") as f:
+        json.dump(out, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def main() -> None:
+    parsed = parse_all_ancients()
+    write_parsed_output(parsed)
+    total = sum(len(v) for v in parsed.values())
+    print(
+        f"Parsed {total} relic offerings across {len(parsed)} ancients "
+        f"-> data/ancient_pools_parsed.json"
+    )
+    drift = diff_against_hand_coded(parsed)
+    if drift:
+        print("Ancient pool drift (hand-coded vs C# extraction):")
+        for line in drift:
+            print(line)
+        print(
+            "  Update data/ancient_pools.json to add/remove the listed relics, "
+            "or update ANCIENT_FILES if Mega Crit renamed an ancient."
+        )
+
+
+if __name__ == "__main__":
+    # Path manipulation so this works whether you run it directly or via
+    # `python -m`. parser_paths uses BASE for relative resolution, so
+    # importing it from here works either way.
+    _ = BASE  # silence unused import warning when run as a script
+    main()

--- a/backend/app/parsers/parse_all.py
+++ b/backend/app/parsers/parse_all.py
@@ -82,4 +82,12 @@ if __name__ == "__main__":
     # Steam news is language-agnostic — fetch once after the per-lang sweep.
     parse_news()
 
+    # Ancient relic pools — language-agnostic. Validates the hand-coded
+    # `data/ancient_pools.json` against the C# event source so additions
+    # / removals show up immediately instead of weeks later via a user
+    # bug report (see PR #170).
+    from ancient_pool_parser import main as parse_ancient_pools
+
+    parse_ancient_pools()
+
     print("\n=== Done! ===")

--- a/data/ancient_pools_parsed.json
+++ b/data/ancient_pools_parsed.json
@@ -1,0 +1,139 @@
+[
+  {
+    "id": "DARV",
+    "relics": [
+      "ASTROLABE",
+      "BLACK_STAR",
+      "CALLING_BELL",
+      "DUSTY_TOME",
+      "ECTOPLASM",
+      "EMPTY_CAGE",
+      "PANDORAS_BOX",
+      "PHILOSOPHERS_STONE",
+      "RUNIC_PYRAMID",
+      "SNECKO_EYE",
+      "SOZU",
+      "VELVET_CHOKER"
+    ]
+  },
+  {
+    "id": "NEOW",
+    "relics": [
+      "ARCANE_SCROLL",
+      "BOOMING_CONCH",
+      "CURSED_PEARL",
+      "GOLDEN_PEARL",
+      "HEFTY_TABLET",
+      "LARGE_CAPSULE",
+      "LAVA_ROCK",
+      "LEAD_PAPERWEIGHT",
+      "LEAFY_POULTICE",
+      "LOST_COFFER",
+      "MASSIVE_SCROLL",
+      "NEOWS_BONES",
+      "NEOWS_TALISMAN",
+      "NEOWS_TORMENT",
+      "NEW_LEAF",
+      "NUTRITIOUS_OYSTER",
+      "PHIAL_HOLSTER",
+      "POMANDER",
+      "PRECARIOUS_SHEARS",
+      "PRECISE_SCISSORS",
+      "SCROLL_BOXES",
+      "SILVER_CRUCIBLE",
+      "SMALL_CAPSULE",
+      "STONE_HUMIDIFIER",
+      "WINGED_BOOTS"
+    ]
+  },
+  {
+    "id": "NONUPEIPE",
+    "relics": [
+      "BEAUTIFUL_BRACELET",
+      "BLESSED_ANTLER",
+      "BRILLIANT_SCARF",
+      "DELICATE_FROND",
+      "DIAMOND_DIADEM",
+      "FUR_COAT",
+      "GLITTER",
+      "JEWELRY_BOX",
+      "LOOMING_FRUIT",
+      "SIGNET_RING"
+    ]
+  },
+  {
+    "id": "OROBAS",
+    "relics": [
+      "ALCHEMICAL_COFFER",
+      "ARCHAIC_TOOTH",
+      "DRIFTWOOD",
+      "ELECTRIC_SHRYMP",
+      "GLASS_EYE",
+      "PRISMATIC_GEM",
+      "RADIANT_PEARL",
+      "SAND_CASTLE",
+      "SEA_GLASS",
+      "TOUCH_OF_OROBAS"
+    ]
+  },
+  {
+    "id": "PAEL",
+    "relics": [
+      "PAELS_BLOOD",
+      "PAELS_CLAW",
+      "PAELS_EYE",
+      "PAELS_FLESH",
+      "PAELS_GROWTH",
+      "PAELS_HORN",
+      "PAELS_LEGION",
+      "PAELS_TEARS",
+      "PAELS_TOOTH",
+      "PAELS_WING"
+    ]
+  },
+  {
+    "id": "TANX",
+    "relics": [
+      "CLAWS",
+      "CROSSBOW",
+      "IRON_CLUB",
+      "MEAT_CLEAVER",
+      "SAI",
+      "SPIKED_GAUNTLETS",
+      "TANXS_WHISTLE",
+      "THROWING_AXE",
+      "TRI_BOOMERANG",
+      "WAR_HAMMER"
+    ]
+  },
+  {
+    "id": "TEZCATARA",
+    "relics": [
+      "BIIIG_HUG",
+      "GOLDEN_COMPASS",
+      "NUTRITIOUS_SOUP",
+      "PUMPKIN_CANDLE",
+      "SEAL_OF_GOLD",
+      "STORYBOOK",
+      "TOASTY_MITTENS",
+      "TOY_BOX",
+      "VERY_HOT_COCOA",
+      "YUMMY_COOKIE"
+    ]
+  },
+  {
+    "id": "VAKUU",
+    "relics": [
+      "BLOOD_SOAKED_ROSE",
+      "CHOICES_PARADOX",
+      "DISTINGUISHED_CAPE",
+      "FIDDLE",
+      "JEWELED_MASK",
+      "LORDS_PARASOL",
+      "MUSIC_BOX",
+      "PRESERVED_FOG",
+      "SERE_TALON",
+      "WHISPERING_EARRING"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
Two new parsers, both targeting the "hand-coded data drifts silently" pattern. Each is small in isolation; together they take two of the three highest-risk surfaces from our drift audit out of the hand-coded column.

### 1. `ancient_pool_parser.py`
Parses each ancient's `RelicOption<X>` and `ModelDb.Relic<X>` references from `MegaCrit.Sts2.Core.Models.Events/{Ancient}.cs` into `data/ancient_pools_parsed.json` and prints per-run drift comparing it to the hand-maintained `data/ancient_pools.json`.

**Drift caught on first run:** Neow is missing 5 relics — `HEFTY_TABLET`, `NEOWS_BONES`, `NEOWS_TALISMAN`, `PHIAL_HOLSTER`, `WINGED_BOOTS`. `HEFTY_TABLET` and `NEOWS_TALISMAN` were explicitly added in the 2026-03-19 patch and we never synced.

### 2. `mechanics_constants_parser.py`
Pulls named numeric constants out of `MegaCrit.Sts2.Core.Odds/*.cs` (CardRarityOdds, PotionRewardOdds, UnknownMapPointOdds) into `data/mechanics_constants.json`. Handles plain `const float`, `static = ...` assignment, and `static =>` arrow-getter (used for AscensionHelper-conditional fields). Captures both the base value and the post-ascension value where applicable.

22 constants on first run, including the rare-card pity offsets and every probability the card-rarity / potion / unknown-rooms pages reference.

**Drift caught while writing:** card-rarity page says Normal Rare A7+ is "1.5%" but C# value is 0.0149 = 1.49%. Tiny rounding error in the hand file — exactly the class of bug this exists to catch.

## What's intentionally not in this PR
- **Frontend migration to read the JSONs.** The /mechanics pages still hand-type everything; a follow-up will rewrite them to import from `data/mechanics_constants.json`.
- **Condition-string parsing for ancients.** Translating arbitrary `Count(c => predicate) >= N` lambdas into accurate prose is a separate problem. The list-drift case alone covers most of what we've gotten wrong.
- **Data fix for the 5 missing Neow relics.** Separate PR so this one stays focused on tooling.
