### PR TITLE
Wire up merchant pipeline: parser → /api/merchant/config → /merchant page

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -49,6 +49,7 @@ from .routers import (
     versions,
     unlocks,
     news,
+    merchant,
 )
 from .services.data_service import get_stats, load_translation_maps, current_version
 from .dependencies import get_lang, VALID_LANGUAGES, LANGUAGE_NAMES
@@ -354,6 +355,7 @@ app.include_router(guides.router)
 app.include_router(versions.router)
 app.include_router(unlocks.router)
 app.include_router(news.router)
+app.include_router(merchant.router)
 
 
 @app.get("/api/languages", tags=["Languages"])

--- a/backend/app/parsers/merchant_parser.py
+++ b/backend/app/parsers/merchant_parser.py
@@ -1,0 +1,212 @@
+"""Parse merchant pricing constants from decompiled C# entry classes.
+
+Source of truth for the numbers shown on `/merchant`. Today every cost
+on that page is hand-typed (50/75/150 cards, 175/200/225/275 relics,
+75 + 25n removal) — exactly the drift surface that bit us on
+Tri-Boomerang. This parser pulls the constants from the four C# files
+where they actually live:
+
+  - MerchantCardEntry.cs       — card costs (rare/uncommon/common,
+                                  colorless markup, on-sale halving)
+  - MerchantPotionEntry.cs     — potion costs by rarity
+  - MerchantCardRemovalEntry.cs — removal base + per-use increment,
+                                   including Inflation ascension overrides
+  - RelicModel.cs              — `MerchantCost => Rarity switch { ... }`
+
+Output: `data/merchant_config.json` — language-agnostic since it's all
+numbers, served via `/api/merchant/config`. Frontend `/merchant` page
+fetches and renders from this file instead of hardcoding.
+"""
+
+import json
+import re
+
+from parser_paths import BASE, DECOMPILED, DATA_DIR
+
+CARD_ENTRY = (
+    DECOMPILED / "MegaCrit.Sts2.Core.Entities.Merchant" / "MerchantCardEntry.cs"
+)
+POTION_ENTRY = (
+    DECOMPILED / "MegaCrit.Sts2.Core.Entities.Merchant" / "MerchantPotionEntry.cs"
+)
+REMOVAL_ENTRY = (
+    DECOMPILED / "MegaCrit.Sts2.Core.Entities.Merchant" / "MerchantCardRemovalEntry.cs"
+)
+RELIC_MODEL = DECOMPILED / "MegaCrit.Sts2.Core.Models" / "RelicModel.cs"
+
+# Per-card variance multipliers (from MerchantCardEntry.cs::CalcCost +
+# MerchantPotionEntry.cs::CalcCost + MerchantRelicEntry.cs::CalcCost).
+# Different value per category — cards/potions get ±5%, relics get ±15%.
+# Hardcoded rather than parsed because they appear inline in the
+# `_player.PlayerRng.Shops.NextFloat(low, high)` call which is awkward
+# to regex precisely; if Mega Crit ever shifts these, we'll see it
+# show up in player-reported price ranges and re-derive then.
+CARD_VARIANCE = (0.95, 1.05)
+POTION_VARIANCE = (0.95, 1.05)
+RELIC_VARIANCE = (0.85, 1.15)
+COLORLESS_MARKUP = 1.15  # MerchantCardEntry.GetCost: colorless × 1.15
+ON_SALE_DIVISOR = 2  # _cost /= 2 in CalcCost when IsOnSale
+
+# Pattern: `<Rarity> => <int>,` inside a switch — handles both card and
+# potion entries where each line of the switch sets a price for one
+# rarity. Captures the rarity name and the price integer.
+_SWITCH_CASE = re.compile(
+    r"\b(?:CardRarity|PotionRarity|RelicRarity)\.(\w+)\s*=>\s*(\d+)"
+)
+
+# Pattern for removal entry's static getters using AscensionHelper:
+#   private static int BaseCost => AscensionHelper.GetValueIfAscension(AscensionLevel.Inflation, 100, 75);
+#   public static int PriceIncrease => AscensionHelper.GetValueIfAscension(AscensionLevel.Inflation, 50, 25);
+_REMOVAL_ASC = re.compile(
+    r"(?P<name>BaseCost|PriceIncrease)\s*=>\s*"
+    r"AscensionHelper\.GetValueIfAscension\(\s*"
+    r"AscensionLevel\.(?P<level>\w+)\s*,\s*"
+    r"(?P<asc_value>\d+)\s*,\s*"
+    r"(?P<base_value>\d+)\s*\)"
+)
+
+
+def _parse_switch_costs(
+    filepath, expected_prefix: str, default_rarity: str | None = None
+) -> dict[str, int]:
+    """Pull `Rarity.X => N` pairs from a switch expression in one file.
+
+    `expected_prefix` filters which switch we want — `MerchantCardEntry.cs`
+    contains both card-rarity logic and pool checks, so we only keep
+    pairs whose rarity belongs to the right enum. Caller passes
+    "CardRarity", "PotionRarity", or "RelicRarity".
+
+    `default_rarity` (when supplied) names the rarity that the switch's
+    `_ => N` arm represents — the C# card / potion entries only enumerate
+    Rare and Uncommon explicitly, with Common falling through to `_`.
+    Without this we'd silently miss the Common price.
+    """
+    if not filepath.exists():
+        return {}
+    content = filepath.read_text(encoding="utf-8")
+    out: dict[str, int] = {}
+    # Locate the relevant switch by re-searching with the prefix in the
+    # raw match text — avoids an over-broad scan that would mix enums.
+    for match in _SWITCH_CASE.finditer(content):
+        # Grab the surrounding 60 chars to peek at the enum name; cheap
+        # heuristic that works because the enum prefix appears verbatim
+        # right before the rarity name in the C# source.
+        start = max(0, match.start() - 30)
+        snippet = content[start : match.end()]
+        if expected_prefix in snippet:
+            out[match.group(1)] = int(match.group(2))
+    # Capture the switch's default arm (`_ => N`) and attribute it to
+    # `default_rarity` if the caller said which enum value falls through.
+    # Restrict the search to a window starting just after the first
+    # captured pair so we don't pull `_ => N` from unrelated switches
+    # elsewhere in the file.
+    if default_rarity and out:
+        first_match = next(_SWITCH_CASE.finditer(content), None)
+        if first_match:
+            window = content[first_match.start() : first_match.start() + 600]
+            default_match = re.search(r"_\s*=>\s*(\d+)", window)
+            if default_match:
+                out[default_rarity] = int(default_match.group(1))
+    return out
+
+
+def _parse_removal_constants() -> dict:
+    """Card-removal cost rules: base price + per-use increment, with
+    Inflation-ascension overrides."""
+    out: dict = {}
+    if not REMOVAL_ENTRY.exists():
+        return out
+    content = REMOVAL_ENTRY.read_text(encoding="utf-8")
+    for match in _REMOVAL_ASC.finditer(content):
+        out[match.group("name")] = {
+            "base": int(match.group("base_value")),
+            "ascended": int(match.group("asc_value")),
+            "ascension_level": match.group("level"),
+        }
+    return out
+
+
+def parse_merchant_config() -> dict:
+    """Build the full merchant config dict from all four source files."""
+    card_costs = _parse_switch_costs(CARD_ENTRY, "CardRarity", default_rarity="Common")
+    potion_costs = _parse_switch_costs(
+        POTION_ENTRY, "PotionRarity", default_rarity="Common"
+    )
+    relic_costs = _parse_switch_costs(RELIC_MODEL, "RelicRarity")
+    # Drop relic rarities the merchant never sells — Ancient/Starter/Event
+    # use 999999999 as a sentinel and `None` is just the unset default.
+    relic_costs = {
+        k: v for k, v in relic_costs.items() if v < 1_000_000 and k != "None"
+    }
+    removal = _parse_removal_constants()
+
+    def _ranges(base_costs: dict[str, int], variance: tuple[float, float]) -> dict:
+        """Build {rarity: {base, min, max}} from base prices + variance."""
+        out: dict = {}
+        for rarity, base in base_costs.items():
+            out[rarity] = {
+                "base": base,
+                "min": round(base * variance[0]),
+                "max": round(base * variance[1]),
+            }
+        return out
+
+    return {
+        "cards": {
+            "by_rarity": _ranges(card_costs, CARD_VARIANCE),
+            "colorless_markup": COLORLESS_MARKUP,
+            "on_sale_divisor": ON_SALE_DIVISOR,
+            "variance": {"min": CARD_VARIANCE[0], "max": CARD_VARIANCE[1]},
+        },
+        "potions": {
+            "by_rarity": _ranges(potion_costs, POTION_VARIANCE),
+            "variance": {"min": POTION_VARIANCE[0], "max": POTION_VARIANCE[1]},
+        },
+        "relics": {
+            "by_rarity": _ranges(relic_costs, RELIC_VARIANCE),
+            "variance": {"min": RELIC_VARIANCE[0], "max": RELIC_VARIANCE[1]},
+        },
+        "card_removal": {
+            "base_cost": removal.get("BaseCost", {}).get("base"),
+            "price_increase": removal.get("PriceIncrease", {}).get("base"),
+            "inflation_ascension": {
+                "level": removal.get("BaseCost", {}).get("ascension_level"),
+                "base_cost": removal.get("BaseCost", {}).get("ascended"),
+                "price_increase": removal.get("PriceIncrease", {}).get("ascended"),
+            },
+        },
+        "fake_merchant": {
+            # MerchantRelicEntry overrides MerchantCost to a flat 50 for
+            # FakeMerchant inventory. Documented for the page; not
+            # parsed because it lives in a different code path that's
+            # easier to assert than to regex. If this ever changes,
+            # the page will look wrong and we'll fix it here.
+            "relic_cost": 50,
+        },
+    }
+
+
+def write_output(config: dict) -> None:
+    """Persist to `data/merchant_config.json`."""
+    out_file = DATA_DIR / "merchant_config.json"
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_file, "w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2, ensure_ascii=False, sort_keys=True)
+        f.write("\n")
+
+
+def main() -> None:
+    config = parse_merchant_config()
+    write_output(config)
+    cards = len(config["cards"]["by_rarity"])
+    potions = len(config["potions"]["by_rarity"])
+    relics = len(config["relics"]["by_rarity"])
+    print(
+        f"Parsed merchant config: {cards} card / {potions} potion / "
+        f"{relics} relic rarity tiers -> data/merchant_config.json"
+    )
+
+
+if __name__ == "__main__":
+    _ = BASE
+    main()

--- a/backend/app/parsers/parse_all.py
+++ b/backend/app/parsers/parse_all.py
@@ -90,4 +90,12 @@ if __name__ == "__main__":
 
     parse_ancient_pools()
 
+    # Merchant pricing config — language-agnostic. Pulls card / potion /
+    # relic / removal cost constants from the C# entry classes so the
+    # frontend `/merchant` page can render from data instead of hardcoded
+    # numbers (which silently desync on every Mega Crit balance pass).
+    from merchant_parser import main as parse_merchant_config
+
+    parse_merchant_config()
+
     print("\n=== Done! ===")

--- a/backend/app/routers/merchant.py
+++ b/backend/app/routers/merchant.py
@@ -1,0 +1,46 @@
+"""Merchant pricing API.
+
+Serves `data/merchant_config.json` produced by `merchant_parser.py`.
+The shape is language-agnostic (just numbers + rarity keys), so this
+router doesn't run translation — but it does honor the version
+ContextVar so beta deployments can ship adjusted pricing without
+touching stable. The frontend `/merchant` page consumes this instead
+of hardcoding card / potion / relic / removal costs.
+"""
+
+import json
+
+from fastapi import APIRouter, HTTPException, Request
+
+from ..services.data_service import DATA_DIR, _resolve_base, _get_version
+
+router = APIRouter(prefix="/api/merchant", tags=["Merchant"])
+
+
+def _load_config() -> dict:
+    """Read `merchant_config.json` from the version-resolved base, then
+    fall back to `DATA_DIR` so an unversioned file at the data root
+    works for both stable and beta layouts."""
+    candidates = [
+        _resolve_base(_get_version()) / "merchant_config.json",
+        DATA_DIR / "merchant_config.json",
+    ]
+    for path in candidates:
+        if path.exists():
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+    return {}
+
+
+@router.get("/config", tags=["Merchant"])
+def get_merchant_config(request: Request) -> dict:
+    """Return the parsed merchant pricing config — card / potion / relic
+    cost tiers with min/max ranges, removal formula, and Fake-Merchant
+    flat price. 404 if the file isn't present (parser hasn't run)."""
+    config = _load_config()
+    if not config:
+        raise HTTPException(
+            status_code=404,
+            detail="merchant_config.json not found — run backend/app/parsers/parse_all.py",
+        )
+    return config

--- a/data/merchant_config.json
+++ b/data/merchant_config.json
@@ -1,0 +1,90 @@
+{
+  "card_removal": {
+    "base_cost": 75,
+    "inflation_ascension": {
+      "base_cost": 100,
+      "level": "Inflation",
+      "price_increase": 50
+    },
+    "price_increase": 25
+  },
+  "cards": {
+    "by_rarity": {
+      "Common": {
+        "base": 50,
+        "max": 52,
+        "min": 48
+      },
+      "Rare": {
+        "base": 150,
+        "max": 158,
+        "min": 142
+      },
+      "Uncommon": {
+        "base": 75,
+        "max": 79,
+        "min": 71
+      }
+    },
+    "colorless_markup": 1.15,
+    "on_sale_divisor": 2,
+    "variance": {
+      "max": 1.05,
+      "min": 0.95
+    }
+  },
+  "fake_merchant": {
+    "relic_cost": 50
+  },
+  "potions": {
+    "by_rarity": {
+      "Common": {
+        "base": 50,
+        "max": 52,
+        "min": 48
+      },
+      "Rare": {
+        "base": 100,
+        "max": 105,
+        "min": 95
+      },
+      "Uncommon": {
+        "base": 75,
+        "max": 79,
+        "min": 71
+      }
+    },
+    "variance": {
+      "max": 1.05,
+      "min": 0.95
+    }
+  },
+  "relics": {
+    "by_rarity": {
+      "Common": {
+        "base": 175,
+        "max": 201,
+        "min": 149
+      },
+      "Rare": {
+        "base": 275,
+        "max": 316,
+        "min": 234
+      },
+      "Shop": {
+        "base": 200,
+        "max": 230,
+        "min": 170
+      },
+      "Uncommon": {
+        "base": 225,
+        "max": 259,
+        "min": 191
+      }
+    },
+    "variance": {
+      "max": 1.15,
+      "min": 0.85
+    }
+  }
+}

--- a/frontend/app/merchant/page.tsx
+++ b/frontend/app/merchant/page.tsx
@@ -1,7 +1,123 @@
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 
-export default function MerchantPage() {
+const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+interface RarityRange {
+  base: number;
+  min: number;
+  max: number;
+}
+
+interface MerchantConfig {
+  cards: {
+    by_rarity: Record<string, RarityRange>;
+    colorless_markup: number;
+    on_sale_divisor: number;
+    variance: { min: number; max: number };
+  };
+  potions: {
+    by_rarity: Record<string, RarityRange>;
+    variance: { min: number; max: number };
+  };
+  relics: {
+    by_rarity: Record<string, RarityRange>;
+    variance: { min: number; max: number };
+  };
+  card_removal: {
+    base_cost: number;
+    price_increase: number;
+    inflation_ascension: {
+      level: string;
+      base_cost: number;
+      price_increase: number;
+    };
+  };
+  fake_merchant: {
+    relic_cost: number;
+  };
+}
+
+// Hardcoded fallback used only when /api/merchant/config is unreachable
+// at build/render time. Values mirror what merchant_parser.py extracts —
+// kept in sync by running parse_all.py before any release. The fallback
+// exists purely so a backend outage doesn't break the page render.
+const FALLBACK_CONFIG: MerchantConfig = {
+  cards: {
+    by_rarity: {
+      Common: { base: 50, min: 48, max: 52 },
+      Uncommon: { base: 75, min: 71, max: 79 },
+      Rare: { base: 150, min: 142, max: 158 },
+    },
+    colorless_markup: 1.15,
+    on_sale_divisor: 2,
+    variance: { min: 0.95, max: 1.05 },
+  },
+  potions: {
+    by_rarity: {
+      Common: { base: 50, min: 48, max: 52 },
+      Uncommon: { base: 75, min: 71, max: 79 },
+      Rare: { base: 100, min: 95, max: 105 },
+    },
+    variance: { min: 0.95, max: 1.05 },
+  },
+  relics: {
+    by_rarity: {
+      Common: { base: 175, min: 149, max: 201 },
+      Uncommon: { base: 225, min: 191, max: 259 },
+      Rare: { base: 275, min: 234, max: 316 },
+      Shop: { base: 200, min: 170, max: 230 },
+    },
+    variance: { min: 0.85, max: 1.15 },
+  },
+  card_removal: {
+    base_cost: 75,
+    price_increase: 25,
+    inflation_ascension: { level: "Inflation", base_cost: 100, price_increase: 50 },
+  },
+  fake_merchant: { relic_cost: 50 },
+};
+
+async function fetchMerchantConfig(): Promise<MerchantConfig> {
+  try {
+    const res = await fetch(`${API_INTERNAL}/api/merchant/config`, {
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) return FALLBACK_CONFIG;
+    return (await res.json()) as MerchantConfig;
+  } catch {
+    return FALLBACK_CONFIG;
+  }
+}
+
+// Display order for the rarity tiers — matches the previous hand-coded
+// page so we don't surprise readers with a different sort. Rarities not
+// in this list fall through alphabetically at the end.
+const CARD_RARITY_ORDER = ["Common", "Uncommon", "Rare"];
+const POTION_RARITY_ORDER = ["Common", "Uncommon", "Rare"];
+const RELIC_RARITY_ORDER = ["Common", "Shop", "Uncommon", "Rare"];
+
+function sortByOrder(rarities: string[], order: string[]): string[] {
+  return [...rarities].sort((a, b) => {
+    const ai = order.indexOf(a);
+    const bi = order.indexOf(b);
+    if (ai === -1 && bi === -1) return a.localeCompare(b);
+    if (ai === -1) return 1;
+    if (bi === -1) return -1;
+    return ai - bi;
+  });
+}
+
+const RARITY_COLOR: Record<string, string> = {
+  Common: "text-gray-300",
+  Shop: "text-emerald-400",
+  Uncommon: "text-blue-400",
+  Rare: "text-[var(--accent-gold)]",
+};
+
+export default async function MerchantPage() {
+  const cfg = await fetchMerchantConfig();
+
   const jsonLd = [
     ...buildDetailPageJsonLd({
       name: "Merchant Guide",
@@ -14,12 +130,27 @@ export default function MerchantPage() {
       ],
     }),
     buildFAQPageJsonLd([
-      { question: "How much do cards cost at the merchant in Slay the Spire 2?", answer: "Common cards cost 48-53 gold, Uncommon 71-79 gold, Rare 143-158 gold. Colorless cards have a 15% markup. One random card is on sale for half price." },
-      { question: "How much do relics cost at the shop in Slay the Spire 2?", answer: "Common relics cost 149-201 gold, Uncommon 191-259 gold, Rare 234-316 gold, and Shop relics 170-230 gold. Major Update #1 (v0.103.2) reduced every relic base price by 25 gold." },
-      { question: "How much does card removal cost in Slay the Spire 2?", answer: "Card removal starts at 75 gold and increases by 25 gold each time you use it. At Ascension 6 and above, the Inflation modifier raises the base to 100 gold and the increment to 50 gold (100, 150, 200, ...)." },
-      { question: "What is the Fake Merchant in Slay the Spire 2?", answer: "The Fake Merchant is an event that sells counterfeit versions of popular relics for only 50 gold each. These fakes have weaker effects than the originals." },
+      {
+        question: "How much do cards cost at the merchant in Slay the Spire 2?",
+        answer: `Common cards cost ${cfg.cards.by_rarity.Common.min}-${cfg.cards.by_rarity.Common.max} gold, Uncommon ${cfg.cards.by_rarity.Uncommon.min}-${cfg.cards.by_rarity.Uncommon.max} gold, Rare ${cfg.cards.by_rarity.Rare.min}-${cfg.cards.by_rarity.Rare.max} gold. Colorless cards have a ${Math.round((cfg.cards.colorless_markup - 1) * 100)}% markup. One random card is on sale for half price.`,
+      },
+      {
+        question: "How much do relics cost at the shop in Slay the Spire 2?",
+        answer: `Common relics cost ${cfg.relics.by_rarity.Common.min}-${cfg.relics.by_rarity.Common.max} gold, Uncommon ${cfg.relics.by_rarity.Uncommon.min}-${cfg.relics.by_rarity.Uncommon.max} gold, Rare ${cfg.relics.by_rarity.Rare.min}-${cfg.relics.by_rarity.Rare.max} gold, and Shop relics ${cfg.relics.by_rarity.Shop.min}-${cfg.relics.by_rarity.Shop.max} gold. Major Update #1 (v0.103.2) reduced every relic base price by 25 gold.`,
+      },
+      {
+        question: "How much does card removal cost in Slay the Spire 2?",
+        answer: `Card removal starts at ${cfg.card_removal.base_cost} gold and increases by ${cfg.card_removal.price_increase} gold each time you use it. At Ascension 6 and above, the Inflation modifier raises the base to ${cfg.card_removal.inflation_ascension.base_cost} gold and the increment to ${cfg.card_removal.inflation_ascension.price_increase} gold (${cfg.card_removal.inflation_ascension.base_cost}, ${cfg.card_removal.inflation_ascension.base_cost + cfg.card_removal.inflation_ascension.price_increase}, ${cfg.card_removal.inflation_ascension.base_cost + 2 * cfg.card_removal.inflation_ascension.price_increase}, ...).`,
+      },
+      {
+        question: "What is the Fake Merchant in Slay the Spire 2?",
+        answer: `The Fake Merchant is an event that sells counterfeit versions of popular relics for only ${cfg.fake_merchant.relic_cost} gold each. These fakes have weaker effects than the originals.`,
+      },
     ]),
   ];
+
+  const variancePct = (v: { min: number; max: number }) =>
+    `±${Math.round(((v.max - v.min) / 2) * 100)}%`;
 
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -48,7 +179,7 @@ export default function MerchantPage() {
             </div>
             <div className="bg-[var(--bg-primary)] rounded-lg p-3">
               <h3 className="font-semibold text-[var(--text-primary)] mb-1">Colorless Cards (2)</h3>
-              <p className="text-[var(--text-muted)]">1 Uncommon, 1 Rare — from the colorless pool. 15% price markup.</p>
+              <p className="text-[var(--text-muted)]">1 Uncommon, 1 Rare — from the colorless pool. {Math.round((cfg.cards.colorless_markup - 1) * 100)}% price markup.</p>
             </div>
             <div className="bg-[var(--bg-primary)] rounded-lg p-3">
               <h3 className="font-semibold text-[var(--text-primary)] mb-1">Relics (3)</h3>
@@ -83,31 +214,26 @@ export default function MerchantPage() {
               </tr>
             </thead>
             <tbody>
-              <tr className="border-b border-[var(--border-subtle)]/50">
-                <td className="p-3 text-gray-300">Common</td>
-                <td className="p-3 text-right text-[var(--text-primary)]">50</td>
-                <td className="p-3 text-right text-[var(--accent-gold)]">48–53</td>
-                <td className="p-3 text-right text-[var(--text-secondary)]">55–60</td>
-                <td className="p-3 text-right text-emerald-400">24–27</td>
-              </tr>
-              <tr className="border-b border-[var(--border-subtle)]/50">
-                <td className="p-3 text-blue-400">Uncommon</td>
-                <td className="p-3 text-right text-[var(--text-primary)]">75</td>
-                <td className="p-3 text-right text-[var(--accent-gold)]">71–79</td>
-                <td className="p-3 text-right text-[var(--text-secondary)]">82–90</td>
-                <td className="p-3 text-right text-emerald-400">36–40</td>
-              </tr>
-              <tr>
-                <td className="p-3 text-[var(--accent-gold)]">Rare</td>
-                <td className="p-3 text-right text-[var(--text-primary)]">150</td>
-                <td className="p-3 text-right text-[var(--accent-gold)]">143–158</td>
-                <td className="p-3 text-right text-[var(--text-secondary)]">164–181</td>
-                <td className="p-3 text-right text-emerald-400">71–79</td>
-              </tr>
+              {sortByOrder(Object.keys(cfg.cards.by_rarity), CARD_RARITY_ORDER).map((rarity, i, arr) => {
+                const r = cfg.cards.by_rarity[rarity];
+                const colorlessMin = Math.round(r.min * cfg.cards.colorless_markup);
+                const colorlessMax = Math.round(r.max * cfg.cards.colorless_markup);
+                const saleMin = Math.round(r.min / cfg.cards.on_sale_divisor);
+                const saleMax = Math.round(r.max / cfg.cards.on_sale_divisor);
+                return (
+                  <tr key={rarity} className={i < arr.length - 1 ? "border-b border-[var(--border-subtle)]/50" : ""}>
+                    <td className={`p-3 ${RARITY_COLOR[rarity] ?? "text-gray-300"}`}>{rarity}</td>
+                    <td className="p-3 text-right text-[var(--text-primary)]">{r.base}</td>
+                    <td className="p-3 text-right text-[var(--accent-gold)]">{r.min}–{r.max}</td>
+                    <td className="p-3 text-right text-[var(--text-secondary)]">{colorlessMin}–{colorlessMax}</td>
+                    <td className="p-3 text-right text-emerald-400">{saleMin}–{saleMax}</td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
           <div className="px-3 py-2 text-xs text-[var(--text-muted)] border-t border-[var(--border-subtle)]/50">
-            Range: base × random(0.95–1.05). Colorless: +15% markup. On sale: 50% off.
+            Range: base × random({cfg.cards.variance.min}–{cfg.cards.variance.max}). Colorless: +{Math.round((cfg.cards.colorless_markup - 1) * 100)}% markup. On sale: {Math.round(100 / cfg.cards.on_sale_divisor)}% off.
           </div>
         </div>
       </section>
@@ -128,34 +254,21 @@ export default function MerchantPage() {
               </tr>
             </thead>
             <tbody>
-              <tr className="border-b border-[var(--border-subtle)]/50">
-                <td className="p-3 text-gray-300">Common</td>
-                <td className="p-3 text-right text-[var(--text-primary)]">175</td>
-                <td className="p-3 text-right text-[var(--accent-gold)]">149–201</td>
-                <td className="p-3 text-right text-[var(--text-muted)]">×0.85–1.15</td>
-              </tr>
-              <tr className="border-b border-[var(--border-subtle)]/50">
-                <td className="p-3 text-emerald-400">Shop</td>
-                <td className="p-3 text-right text-[var(--text-primary)]">200</td>
-                <td className="p-3 text-right text-[var(--accent-gold)]">170–230</td>
-                <td className="p-3 text-right text-[var(--text-muted)]">×0.85–1.15</td>
-              </tr>
-              <tr className="border-b border-[var(--border-subtle)]/50">
-                <td className="p-3 text-blue-400">Uncommon</td>
-                <td className="p-3 text-right text-[var(--text-primary)]">225</td>
-                <td className="p-3 text-right text-[var(--accent-gold)]">191–259</td>
-                <td className="p-3 text-right text-[var(--text-muted)]">×0.85–1.15</td>
-              </tr>
-              <tr>
-                <td className="p-3 text-[var(--accent-gold)]">Rare</td>
-                <td className="p-3 text-right text-[var(--text-primary)]">275</td>
-                <td className="p-3 text-right text-[var(--accent-gold)]">234–316</td>
-                <td className="p-3 text-right text-[var(--text-muted)]">×0.85–1.15</td>
-              </tr>
+              {sortByOrder(Object.keys(cfg.relics.by_rarity), RELIC_RARITY_ORDER).map((rarity, i, arr) => {
+                const r = cfg.relics.by_rarity[rarity];
+                return (
+                  <tr key={rarity} className={i < arr.length - 1 ? "border-b border-[var(--border-subtle)]/50" : ""}>
+                    <td className={`p-3 ${RARITY_COLOR[rarity] ?? "text-gray-300"}`}>{rarity}</td>
+                    <td className="p-3 text-right text-[var(--text-primary)]">{r.base}</td>
+                    <td className="p-3 text-right text-[var(--accent-gold)]">{r.min}–{r.max}</td>
+                    <td className="p-3 text-right text-[var(--text-muted)]">×{cfg.relics.variance.min}–{cfg.relics.variance.max}</td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
           <div className="px-3 py-2 text-xs text-[var(--text-muted)] border-t border-[var(--border-subtle)]/50">
-            Relics have a wider price variance (±15%) than cards (±5%). Major Update #1 (v0.103.2) reduced every relic base by 25 gold. Five relics are blacklisted from the shop pool: The Courier, Old Coin, Lucky Fysh, Bowler Hat, Amethyst Aubergine.
+            Relics have a wider price variance ({variancePct(cfg.relics.variance)}) than cards ({variancePct(cfg.cards.variance)}). Major Update #1 (v0.103.2) reduced every relic base by 25 gold. Five relics are blacklisted from the shop pool: The Courier, Old Coin, Lucky Fysh, Bowler Hat, Amethyst Aubergine.
           </div>
         </div>
       </section>
@@ -175,25 +288,20 @@ export default function MerchantPage() {
               </tr>
             </thead>
             <tbody>
-              <tr className="border-b border-[var(--border-subtle)]/50">
-                <td className="p-3 text-gray-300">Common</td>
-                <td className="p-3 text-right text-[var(--text-primary)]">50</td>
-                <td className="p-3 text-right text-[var(--accent-gold)]">48–53</td>
-              </tr>
-              <tr className="border-b border-[var(--border-subtle)]/50">
-                <td className="p-3 text-blue-400">Uncommon</td>
-                <td className="p-3 text-right text-[var(--text-primary)]">75</td>
-                <td className="p-3 text-right text-[var(--accent-gold)]">71–79</td>
-              </tr>
-              <tr>
-                <td className="p-3 text-[var(--accent-gold)]">Rare</td>
-                <td className="p-3 text-right text-[var(--text-primary)]">100</td>
-                <td className="p-3 text-right text-[var(--accent-gold)]">95–105</td>
-              </tr>
+              {sortByOrder(Object.keys(cfg.potions.by_rarity), POTION_RARITY_ORDER).map((rarity, i, arr) => {
+                const r = cfg.potions.by_rarity[rarity];
+                return (
+                  <tr key={rarity} className={i < arr.length - 1 ? "border-b border-[var(--border-subtle)]/50" : ""}>
+                    <td className={`p-3 ${RARITY_COLOR[rarity] ?? "text-gray-300"}`}>{rarity}</td>
+                    <td className="p-3 text-right text-[var(--text-primary)]">{r.base}</td>
+                    <td className="p-3 text-right text-[var(--accent-gold)]">{r.min}–{r.max}</td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
           <div className="px-3 py-2 text-xs text-[var(--text-muted)] border-t border-[var(--border-subtle)]/50">
-            Range: base × random(0.95–1.05). Same variance as cards.
+            Range: base × random({cfg.potions.variance.min}–{cfg.potions.variance.max}). Same variance as cards.
           </div>
         </div>
       </section>
@@ -217,20 +325,20 @@ export default function MerchantPage() {
                     {i === 0 ? "1st" : i === 1 ? "2nd" : i === 2 ? "3rd" : `${i + 1}th`}
                   </div>
                   <div className="text-lg font-bold text-[var(--accent-gold)]">
-                    {75 + 25 * i}
+                    {cfg.card_removal.base_cost + cfg.card_removal.price_increase * i}
                   </div>
                   <div className="text-xs text-[var(--text-muted)]">gold</div>
                 </div>
               ))}
             </div>
             <p className="text-xs text-[var(--text-muted)] mt-2">
-              Formula: 75 + (25 × removals used).
+              Formula: {cfg.card_removal.base_cost} + ({cfg.card_removal.price_increase} × removals used).
             </p>
           </div>
 
           <div>
             <h3 className="text-sm font-semibold text-[var(--text-primary)] mb-2">
-              Ascension 6+ — <span className="text-[var(--accent-gold)]">Inflation</span>
+              Ascension 6+ — <span className="text-[var(--accent-gold)]">{cfg.card_removal.inflation_ascension.level}</span>
             </h3>
             <div className="flex flex-wrap gap-2">
               {[0, 1, 2, 3, 4, 5].map((i) => (
@@ -239,14 +347,14 @@ export default function MerchantPage() {
                     {i === 0 ? "1st" : i === 1 ? "2nd" : i === 2 ? "3rd" : `${i + 1}th`}
                   </div>
                   <div className="text-lg font-bold text-[var(--accent-gold)]">
-                    {100 + 50 * i}
+                    {cfg.card_removal.inflation_ascension.base_cost + cfg.card_removal.inflation_ascension.price_increase * i}
                   </div>
                   <div className="text-xs text-[var(--text-muted)]">gold</div>
                 </div>
               ))}
             </div>
             <p className="text-xs text-[var(--text-muted)] mt-2">
-              Formula: 100 + (50 × removals used). Major Update #1 reworked Ascension 6 from <span className="line-through">Gloom (less rest sites)</span> to Inflation, raising the base by 25 gold and the per-use increment by 25.
+              Formula: {cfg.card_removal.inflation_ascension.base_cost} + ({cfg.card_removal.inflation_ascension.price_increase} × removals used). Major Update #1 reworked Ascension 6 from <span className="line-through">Gloom (less rest sites)</span> to {cfg.card_removal.inflation_ascension.level}, raising the base by {cfg.card_removal.inflation_ascension.base_cost - cfg.card_removal.base_cost} gold and the per-use increment by {cfg.card_removal.inflation_ascension.price_increase - cfg.card_removal.price_increase}.
             </p>
           </div>
         </div>
@@ -258,7 +366,7 @@ export default function MerchantPage() {
           Fake Merchant
         </h2>
         <p className="text-sm text-[var(--text-secondary)] mb-4">
-          The Fake Merchant is an event that sells counterfeit relics for a flat 50 gold each. These are weaker versions of well-known relics. All fake relics have Event rarity.
+          The Fake Merchant is an event that sells counterfeit relics for a flat {cfg.fake_merchant.relic_cost} gold each. These are weaker versions of well-known relics. All fake relics have Event rarity.
         </p>
         <div className="bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] overflow-hidden">
           <table className="w-full text-sm">
@@ -272,21 +380,21 @@ export default function MerchantPage() {
             </thead>
             <tbody>
               {[
-                { fake: "Fake Anchor", real: "Anchor", price: 50, effect: "Gain 4 Block at the start of combat (real: 10)" },
-                { fake: "Fake Blood Vial", real: "Blood Vial", price: 50, effect: "Heal 1 HP at the start of turn 1 only" },
-                { fake: "Fake Happy Flower", real: "Happy Flower", price: 50, effect: "Gain 1 Energy every 5 turns (real: every 3)" },
-                { fake: "Fake Lee's Waffle", real: "Lee's Waffle", price: 50, effect: "Heal 10% Max HP on pickup (real: raise Max HP)" },
-                { fake: "Fake Mango", real: "Mango", price: 50, effect: "Gain 3 Max HP on pickup (real: 14)" },
-                { fake: "Fake Orichalcum", real: "Orichalcum", price: 50, effect: "Gain 3 Block at end of turn if no Block (real: 6)" },
-                { fake: "Fake Snecko Eye", real: "Snecko Eye", price: 50, effect: "Applies Confused (randomizes card costs) with no draw bonus" },
-                { fake: "Fake Strike Dummy", real: "Strike Dummy", price: 50, effect: "Strike cards deal 1 extra damage (real: 3)" },
-                { fake: "Fake Venerable Tea Set", real: "Venerable Tea Set", price: 50, effect: "Gain 1 Energy next combat after resting (real: 2)" },
-                { fake: "Fake Merchant's Rug", real: "—", price: 50, effect: "No effect. Purely decorative." },
+                { fake: "Fake Anchor", real: "Anchor", effect: "Gain 4 Block at the start of combat (real: 10)" },
+                { fake: "Fake Blood Vial", real: "Blood Vial", effect: "Heal 1 HP at the start of turn 1 only" },
+                { fake: "Fake Happy Flower", real: "Happy Flower", effect: "Gain 1 Energy every 5 turns (real: every 3)" },
+                { fake: "Fake Lee's Waffle", real: "Lee's Waffle", effect: "Heal 10% Max HP on pickup (real: raise Max HP)" },
+                { fake: "Fake Mango", real: "Mango", effect: "Gain 3 Max HP on pickup (real: 14)" },
+                { fake: "Fake Orichalcum", real: "Orichalcum", effect: "Gain 3 Block at end of turn if no Block (real: 6)" },
+                { fake: "Fake Snecko Eye", real: "Snecko Eye", effect: "Applies Confused (randomizes card costs) with no draw bonus" },
+                { fake: "Fake Strike Dummy", real: "Strike Dummy", effect: "Strike cards deal 1 extra damage (real: 3)" },
+                { fake: "Fake Venerable Tea Set", real: "Venerable Tea Set", effect: "Gain 1 Energy next combat after resting (real: 2)" },
+                { fake: "Fake Merchant's Rug", real: "—", effect: "No effect. Purely decorative." },
               ].map((row) => (
                 <tr key={row.fake} className="border-b border-[var(--border-subtle)]/50 last:border-0">
                   <td className="p-3 text-[var(--text-primary)] font-medium">{row.fake}</td>
                   <td className="p-3 text-[var(--text-muted)]">{row.real}</td>
-                  <td className="p-3 text-right text-[var(--accent-gold)]">{row.price}g</td>
+                  <td className="p-3 text-right text-[var(--accent-gold)]">{cfg.fake_merchant.relic_cost}g</td>
                   <td className="p-3 text-[var(--text-secondary)]">{row.effect}</td>
                 </tr>
               ))}
@@ -305,10 +413,10 @@ export default function MerchantPage() {
             All prices use the seeded <code className="text-[var(--accent-gold)] text-xs">PlayerRng.Shops</code> random number generator, meaning prices are deterministic per seed.
           </p>
           <p>
-            Cards use <code className="text-[var(--accent-gold)] text-xs">NextFloat(0.95f, 1.05f)</code> for a ±5% variance. Relics use <code className="text-[var(--accent-gold)] text-xs">NextFloat(0.85f, 1.15f)</code> for a wider ±15% variance. Potions use the same ±5% as cards.
+            Cards use <code className="text-[var(--accent-gold)] text-xs">NextFloat({cfg.cards.variance.min}f, {cfg.cards.variance.max}f)</code> for a {variancePct(cfg.cards.variance)} variance. Relics use <code className="text-[var(--accent-gold)] text-xs">NextFloat({cfg.relics.variance.min}f, {cfg.relics.variance.max}f)</code> for a wider {variancePct(cfg.relics.variance)} variance. Potions use the same {variancePct(cfg.potions.variance)} as cards.
           </p>
           <p>
-            The shop randomly picks one of the 5 character cards to put on sale (50% off). The sale slot is determined by <code className="text-[var(--accent-gold)] text-xs">PlayerRng.Shops.NextInt(5)</code>.
+            The shop randomly picks one of the 5 character cards to put on sale ({Math.round(100 / cfg.cards.on_sale_divisor)}% off). The sale slot is determined by <code className="text-[var(--accent-gold)] text-xs">PlayerRng.Shops.NextInt(5)</code>.
           </p>
           <p>
             When you buy an item, the slot is emptied. Items only restock if you have <strong>The Courier</strong> relic, which refills purchased slots with new random items (excluding duplicates already in the shop).


### PR DESCRIPTION
## Summary
Closes the gap from the drift audit: `/merchant` was hand-typing ~15 numbers (50/75/150 cards, 175/200/225/275 relics, 75 + 25n removal, 50 fake-merchant) that came from C# constants nothing on the site was reading. CLAUDE.md claimed a `merchant_parser` and a `merchant.py` router existed; neither did.

This PR builds all three layers:

### Backend parser
`backend/app/parsers/merchant_parser.py` — reads `MerchantCardEntry.cs`, `MerchantPotionEntry.cs`, `MerchantCardRemovalEntry.cs`, `RelicModel.cs`. Captures:
- Explicit switch arms (`CardRarity.Rare => 150`)
- Default `_ => N` arm (Common falls through in card/potion entries)
- AscensionHelper-conditional getters for Inflation removal overrides

Filters relic sentinel rarities (Ancient/Starter/Event use `999999999` to mean "never appears at merchant"). Output: `data/merchant_config.json` — language-agnostic.

### Backend router
`backend/app/routers/merchant.py` — serves `/api/merchant/config`. Uses the existing version-resolved data dir so beta deploys can ship adjusted pricing.

### Frontend page
`frontend/app/merchant/page.tsx` — server component now fetches the config and renders every table from data instead of hand-typed numbers. Derived values computed in the page (colorless = base × markup, on sale = base ÷ divisor, ascension formulas). Hardcoded fallback kept for backend-outage robustness; values mirror parser output. FAQ JSON-LD strings template the actual values for SEO.

### Wired in
`parse_all.py` runs the parser; `main.py` includes the router.

## What's intentionally not here
`/[lang]/merchant` (the localized variants) still hand-codes the same numbers. CLAUDE.md flagged this surface as "section headings/descriptions/fake relic table still English" — that's a bigger i18n cleanup. Separate PR.
