### PR TITLE
Restore card-page beta-art toggle

### DIFF
--- a/backend/app/parsers/card_parser.py
+++ b/backend/app/parsers/card_parser.py
@@ -483,21 +483,20 @@ def parse_single_card(
                 else None
             )
         ),
-        # Beta-only art lives in the top-level `backend/static/images/beta/cards/`
-        # tree (established by commit a554dbb). When a beta game version goes
-        # stable, the asset moves out of beta/ into the regular cards/ path —
-        # so this field stays None for any card that's already in stable. Don't
-        # use the legacy nested `cards/beta/` path; it was retired and can
-        # contain stale duplicates of pre-promotion art.
-        "beta_image_url": f"/static/images/beta/cards/{card_id.lower()}.webp"
-        if (
-            STATIC_IMAGES.parent / "beta" / "cards" / f"{card_id.lower()}.webp"
-        ).exists()
+        # Source for the card-page beta-art toggle. Resolves to the
+        # historical archive at `backend/static/images/cards/beta/<id>` —
+        # whatever was the previous stable art before the most recent
+        # game patch (or a duplicate of stable when nothing has changed).
+        # Lets visitors view / download the pre-promotion version of any
+        # re-arted card. Don't switch this to the top-level
+        # `backend/static/images/beta/cards/` tree: that one tracks the
+        # CURRENT beta cycle's art and goes empty between drops, which
+        # silently disables the toggle.
+        "beta_image_url": f"/static/images/cards/beta/{card_id.lower()}.webp"
+        if (STATIC_IMAGES / "beta" / f"{card_id.lower()}.webp").exists()
         else (
-            f"/static/images/beta/cards/{card_id.lower()}.png"
-            if (
-                STATIC_IMAGES.parent / "beta" / "cards" / f"{card_id.lower()}.png"
-            ).exists()
+            f"/static/images/cards/beta/{card_id.lower()}.png"
+            if (STATIC_IMAGES / "beta" / f"{card_id.lower()}.png").exists()
             else None
         ),
         "type_variants": type_variants,

--- a/backend/app/parsers/monster_parser.py
+++ b/backend/app/parsers/monster_parser.py
@@ -1099,43 +1099,25 @@ def parse_single_monster(
         f"/static/images/monsters/{image_file.name}" if image_file.exists() else None
     )
 
-    # Concept-art aliases — a few monsters (Door / Doormaker / Pael's Legion)
-    # ship a placeholder/concept variant under `monsters/beta/` that the beta
-    # site uses while the proper sprite is still being made. This is NOT the
-    # same as v0.X.Y beta-only art (which lives under top-level
-    # `backend/static/images/beta/monsters/`). When that asset graduates to
-    # stable it gets moved into `monsters/` and the alias drops out.
+    # Beta/concept art toggle — checks `monsters/beta/` (the historical
+    # archive that drives the monster-page beta-art toggle, same role as
+    # `cards/beta/` for cards). Three monsters use placeholder names
+    # (Door / Doormaker / Pael's Legion) so they need an alias map; every
+    # other monster falls back to the slug-derived filename.
     BETA_ALIASES = {
         "DOOR": "door",
         "DOORMAKER": "door_maker_placeholder_2",
         "PAELS_LEGION": "paels_legion",
     }
-    beta_name = BETA_ALIASES.get(monster_id)
-    beta_file = None
-    if beta_name:
-        candidate_webp = IMAGES_DIR / "beta" / f"{beta_name}.webp"
-        candidate_png = IMAGES_DIR / "beta" / f"{beta_name}.png"
-        beta_file = (
-            candidate_webp
-            if candidate_webp.exists()
-            else (candidate_png if candidate_png.exists() else None)
-        )
-    # Fall back to the top-level `beta/monsters/` tree for genuine v0.X.Y
-    # beta-only art that hasn't promoted yet. Same path convention the cards
-    # parser uses.
-    if not beta_file:
-        top_beta = IMAGES_DIR.parent / "beta" / "monsters"
-        slug = monster_id.lower()
-        candidate_webp = top_beta / f"{slug}.webp"
-        candidate_png = top_beta / f"{slug}.png"
-        if candidate_webp.exists():
-            beta_image_url = f"/static/images/beta/monsters/{candidate_webp.name}"
-        elif candidate_png.exists():
-            beta_image_url = f"/static/images/beta/monsters/{candidate_png.name}"
-        else:
-            beta_image_url = None
+    beta_name = BETA_ALIASES.get(monster_id, img_name)
+    beta_webp = IMAGES_DIR / "beta" / f"{beta_name}.webp"
+    beta_png = IMAGES_DIR / "beta" / f"{beta_name}.png"
+    if beta_webp.exists():
+        beta_image_url = f"/static/images/monsters/beta/{beta_webp.name}"
+    elif beta_png.exists():
+        beta_image_url = f"/static/images/monsters/beta/{beta_png.name}"
     else:
-        beta_image_url = f"/static/images/monsters/beta/{beta_file.name}"
+        beta_image_url = None
 
     return {
         "id": monster_id,

--- a/data/deu/cards.json
+++ b/data/deu/cards.json
@@ -114,7 +114,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/distraction.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/distraction.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -158,7 +158,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/ricochet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ricochet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 5 Mal einem zufälligen Gegner 3 Schaden zu.",
@@ -277,7 +277,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/adaptive_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/adaptive_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 23 Schaden zu.\nNimm eine 0[energy:1]-Kopie dieser Karte in deinen [gold]Abwurfstapel[/gold].",
@@ -635,7 +635,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/lift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gib einem Mitspieler 16 [gold]Block[/gold].",
@@ -674,7 +674,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/alignment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/alignment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte [energy:3].",
@@ -893,7 +893,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/apparition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/apparition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -982,7 +982,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/arsenal.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/arsenal.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1102,7 +1102,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/astral_pulse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/astral_pulse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge ALLEN Gegnern 18 Schaden zu.",
@@ -1206,7 +1206,7 @@
       "sicempower": "+1"
     },
     "image_url": "/static/images/cards/sic_em.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sic_em.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] fügt 6 Schaden zu.\nImmer wenn [gold]Osty[/gold] diesen Gegner in diesem Zug trifft, [gold]Beschwöre[/gold] 3.",
@@ -1326,7 +1326,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/uproar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/uproar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge zweimal 7 Schaden zu.\nSpiele einen zufälligen Angriff aus deinem [gold]Nachziehstapel[/gold].",
@@ -1438,7 +1438,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/tracking.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tracking.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1476,7 +1476,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/ascenders_bane.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ascenders_bane.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1559,7 +1559,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/up_my_sleeve.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/up_my_sleeve.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 4 [gold]Messer[/gold] auf deine [gold]Hand[/gold].\nSenke die Kosten dieser Karte um 1.",
@@ -1605,7 +1605,7 @@
       "outbreakpower": "+4"
     },
     "image_url": "/static/images/cards/outbreak.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outbreak.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge immer, wenn du 3 Mal [gold]Gift[/gold] anwendest, ALLEN Gegnern 15 Schaden zu.",
@@ -1643,7 +1643,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/foregone_conclusion.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/foregone_conclusion.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Nimm im nächsten Zug 3 Karten aus deinem [gold]Nachziehstapel[/gold] auf deine [gold]Hand[/gold].",
@@ -1720,7 +1720,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/outmaneuver.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outmaneuver.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte im nächsten Zug [energy:3].",
@@ -1763,7 +1763,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/squeeze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/squeeze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] fügt 25 Schaden zu.\nFügt 6 Schaden mehr für ALLE deine anderen [gold]Osty[/gold]-Angriffskarten zu.",
@@ -1999,7 +1999,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/automation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/automation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2037,7 +2037,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/manifest_authority.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/manifest_authority.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 8 [gold]Block[/gold].\nErhalte 1 zufällige [gold]Verbesserte[/gold] Farblose Karte auf deine [gold]Hand[/gold].",
@@ -2152,7 +2152,7 @@
       "extrablock": "+2"
     },
     "image_url": "/static/images/cards/fasten.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fasten.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 7 [gold]Block[/gold] mehr von Verteidigen-Karten.",
@@ -2190,7 +2190,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/bury.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bury.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 63 Schaden zu.",
@@ -2436,7 +2436,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/bodyguard.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bodyguard.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Beschwöre[/gold] 7.",
@@ -2475,7 +2475,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/pale_blue_dot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pale_blue_dot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Falls du 5 oder mehr Karten in einem Zug spielst, ziehe zu Beginn deines nächsten Zuges 2 Karten.",
@@ -2555,7 +2555,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/glimpse_beyond.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glimpse_beyond.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ALLE Spieler erhalten 4 [gold]Seelen[/gold] in ihren [gold]Nachziehstapel[/gold].",
@@ -2686,7 +2686,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/lightning_rod.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lightning_rod.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 7 [gold]Block[/gold].\n[gold]Erschaffe[/gold] zu Beginn deiner nächsten 2 Züge 1 [gold]Blitz[/gold].",
@@ -2731,7 +2731,7 @@
       "poison": "+3"
     },
     "image_url": "/static/images/cards/bubble_bubble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Falls der Gegner [gold]Gift[/gold] hat, wende 12 [gold]Gift[/gold] an.",
@@ -2821,7 +2821,7 @@
       "crimsonmantlepower": "+2"
     },
     "image_url": "/static/images/cards/crimson_mantle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crimson_mantle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Verliere immer zu Beginn deines Zuges 1 TP und erhalte 10 [gold]Block[/gold].",
@@ -2898,7 +2898,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/pagestorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pagestorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3016,7 +3016,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/bulwark.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulwark.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 16 [gold]Block[/gold].\n[gold]Schmiede[/gold] 13.",
@@ -3056,7 +3056,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/bombardment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bombardment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 24 Schaden zu.\nFalls diese Karte zu Beginn deines Zuges in deinem [gold]Erschöpfungsstapel[/gold] ist, spiele sie.",
@@ -3097,7 +3097,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/vicious.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/vicious.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du [gold]Verwundbar[/gold] anwendest, ziehe 2 Karten.",
@@ -3269,7 +3269,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/crash_landing.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crash_landing.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge ALLEN Gegnern 26 Schaden zu.\nFülle deine [gold]Hand[/gold] mit [gold]Schutt[/gold].",
@@ -3430,7 +3430,7 @@
       "dansemacabrepower": "+2"
     },
     "image_url": "/static/images/cards/danse_macabre.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/danse_macabre.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du eine Karte spielst, die [energy:2] oder mehr kostet, erhalte 6 [gold]Block[/gold].",
@@ -3506,7 +3506,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/intercept.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/intercept.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 13 [gold]Block[/gold].\nLeite in diesem Zug alle eingehenden Angriffe, die andere Spieler treffen würden, auf dich um.",
@@ -3628,7 +3628,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/the_sealed_throne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_sealed_throne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3707,7 +3707,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/the_hunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_hunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Füge 15 Schaden zu.\nFalls [gold]Tödlich[/gold], erhalte eine Kartenbelohnung mehr.",
@@ -3752,7 +3752,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/the_scythe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_scythe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 13 Schaden zu.\nErhöhe den Schaden dieser Karte permanent um 4.",
@@ -3797,7 +3797,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/minion_sacrifice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_sacrifice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 12 [gold]Block[/gold].",
@@ -3844,7 +3844,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/minion_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 9 Schaden zu.\nZiehe 1 Karte.",
@@ -4141,7 +4141,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/demesne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demesne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4189,7 +4189,7 @@
       "thunderpower": "+2"
     },
     "image_url": "/static/images/cards/thunder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/thunder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du einen [gold]Blitz Entlädst[/gold], füge dem getroffenen Gegner 8 Schaden zu.",
@@ -4468,7 +4468,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/gunk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gunk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 3 Mal 5 Schaden zu.\nErhalte ein [gold]Verschleimt[/gold] in deinen [gold]Abwurfstapel[/gold].",
@@ -4506,7 +4506,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/believe_in_you.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/believe_in_you.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ein anderer Spieler erhält [energy:3].",
@@ -4668,7 +4668,7 @@
       "poison": "+2"
     },
     "image_url": "/static/images/cards/haze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Wende auf ALLE Gegner 6 [gold]Gift[/gold] an.",
@@ -4791,7 +4791,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/veilpiercer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/veilpiercer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 13 Schaden zu.\nDie nächste [gold]Flüchtige[/gold] Karte, die du spielst, kostet 0 [energy:1].",
@@ -4831,7 +4831,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/fight_through.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_through.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 17 [gold]Block[/gold].\nErhalte 2 [gold]Wunden[/gold] in deinen [gold]Abwurfstapel[/gold].",
@@ -4918,7 +4918,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/demonic_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demonic_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5002,7 +5002,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/eidolon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/eidolon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5119,7 +5119,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/ice_lance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ice_lance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 24 Schaden zu.\n[gold]Erschaffe[/gold] 3 [gold]Frost[/gold].",
@@ -5158,7 +5158,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/misery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/misery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 9 Schaden zu.\nWende jegliche Debuffs auf dem Gegner auf ALLE anderen Gegner an.",
@@ -5237,7 +5237,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/energy_surge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/energy_surge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ALLE Spieler erhalten [energy:3].",
@@ -5373,7 +5373,7 @@
       "debilitatepower": "+1"
     },
     "image_url": "/static/images/cards/debilitate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debilitate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 12 Schaden zu.\n[gold]Verwundbar[/gold] und [gold]Schwach[/gold] sind auf diesem Gegner für die nächsten 4 Züge doppelt so effektiv.",
@@ -5413,7 +5413,7 @@
       "strengthloss": "+3"
     },
     "image_url": "/static/images/cards/enfeebling_touch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enfeebling_touch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Der Gegner verliert für diesen Zug 11 [gold]Stärke[/gold].",
@@ -5497,7 +5497,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/entropy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entropy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5541,7 +5541,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/relax.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/relax.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 17 [gold]Block[/gold].\nZiehe zu Beginn deines nächsten Zuges 3 Karten und erhalte [energy:3].",
@@ -5582,7 +5582,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/hang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 13 Schaden zu.\nVerdopple den Schaden ALLER Erhängen-Karten für diesen Gegner.",
@@ -5663,7 +5663,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/murder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/murder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5701,7 +5701,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/conqueror.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conqueror.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Schmiede[/gold] 5.\n[gold]Hoheitsklinge[/gold] fügt diesem Gegner in diesem Zug doppelten Schaden zu.",
@@ -5748,7 +5748,7 @@
       "stranglepower": "+1"
     },
     "image_url": "/static/images/cards/strangle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/strangle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 10 Schaden zu.\nImmer wenn du in diesem Zug eine Karte spielst, verliert der Gegner 3 TP.",
@@ -5971,7 +5971,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/falling_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/falling_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 12 Schaden zu.\nWende 1 [gold]Schwach[/gold] an.\nWende 1 [gold]Verwundbar[/gold] an.",
@@ -6056,7 +6056,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/sloth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sloth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -6094,7 +6094,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/fisticuffs.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fisticuffs.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 9 Schaden zu.\nErhalte [gold]Block[/gold] in Höhe des zugefügten Schadens.",
@@ -6138,7 +6138,7 @@
       "ostydamage": "+5"
     },
     "image_url": "/static/images/cards/sweeping_gaze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sweeping_gaze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] fügt einem zufälligen Gegner 15 Schaden zu.",
@@ -6300,7 +6300,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/conflagration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conflagration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge ALLEN Gegnern 8 Schaden zu.\nFügt 3 Schaden mehr zu pro anderem Angriff, den du in diesem Zug gespielt hast.",
@@ -6378,7 +6378,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/flak_cannon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/flak_cannon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Erschöpfe[/gold] ALLE deine Statuskarten.\nFüge für jede [gold]Erschöpfte[/gold] Karte einem zufälligen Gegner 11 Schaden zu.",
@@ -6702,7 +6702,7 @@
       "focuspower": "+1"
     },
     "image_url": "/static/images/cards/focused_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/focused_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 11 Schaden zu.\nErhalte für diesen Zug 2 [gold]Fokus[/gold].",
@@ -6747,7 +6747,7 @@
       "strength": "+2"
     },
     "image_url": "/static/images/cards/feeding_frenzy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte für diesen Zug 7 [gold]Stärke[/gold].",
@@ -6971,7 +6971,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/leading_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/leading_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 6 Schaden zu.\nErhalte 2 [gold]Messer[/gold] auf deine [gold]Hand[/gold].",
@@ -7025,7 +7025,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/gamma_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gamma_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 18 Schaden zu.\nWende 2 [gold]Schwach[/gold] an.\nWende 2 [gold]Verwundbar[/gold] an.",
@@ -7109,7 +7109,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/heirloom_hammer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heirloom_hammer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 25 Schaden zu.\nWähle eine Farblose [gold]Handkarte[/gold]. Erhalte eine Kopie dieser Karte auf deine [gold]Hand[/gold].",
@@ -7267,7 +7267,7 @@
       "blockonexhaust": "+1"
     },
     "image_url": "/static/images/cards/spirit_of_ash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spirit_of_ash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du eine [gold]Flüchtige[/gold] Karte spielst, erhalte 5 [gold]Block[/gold].",
@@ -7362,7 +7362,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/mind_rot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mind_rot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -7574,7 +7574,7 @@
       "starsperturn": "+1"
     },
     "image_url": "/static/images/cards/genesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/genesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte immer zu Beginn deines Zuges [star:3].",
@@ -7656,7 +7656,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/scrawl.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/scrawl.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7750,7 +7750,7 @@
       "sneakypower": "+1"
     },
     "image_url": "/static/images/cards/sneaky.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sneaky.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn ein anderer Spieler einen Gegner angreift, erhalte 2 [gold]Block[/gold].",
@@ -7826,7 +7826,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/greed.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/greed.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8113,7 +8113,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/graveblast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/graveblast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 6 Schaden zu.\nNimm eine Karte aus deinem [gold]Abwurfstapel[/gold] auf deine [gold]Hand[/gold].",
@@ -8251,7 +8251,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/fight_me.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge zweimal 6 Schaden zu.\nErhalte 4 [gold]Stärke[/gold].\nDer Gegner erhält 1 [gold]Stärke[/gold].",
@@ -8291,7 +8291,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/pull_from_below.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pull_from_below.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 7 Schaden für jede in diesem Kampf gespielte [gold]Flüchtige[/gold] Karte zu.",
@@ -8365,7 +8365,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/largesse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/largesse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ein Mitspieler erhält 1 zufällige [gold]Verbesserte[/gold] Farblose Karte auf die [gold]Hand[/gold].",
@@ -8441,7 +8441,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/begone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/begone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Wähle eine [gold]Handkarte[/gold], die du zu [gold]Diener-Schlag+[/gold] [gold]Transformierst[/gold].",
@@ -8486,7 +8486,7 @@
       "hailstormpower": "+2"
     },
     "image_url": "/static/images/cards/hailstorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hailstorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge immer am Ende deines Zuges ALLEN Gegnern 8 Schaden zu, falls du [gold]Frost[/gold] hast.",
@@ -8522,7 +8522,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/hello_world.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hello_world.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8558,7 +8558,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/hammer_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hammer_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8633,7 +8633,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/jackpot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/jackpot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 30 Schaden zu.\nErhalte 3 zufällige [gold]Verbesserte[/gold] 0[energy:1]-Karten auf deine [gold]Hand[/gold].",
@@ -8674,7 +8674,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/brightest_flame.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/brightest_flame.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte [energy:3].\nZiehe 3 Karten.\nVerliere 1 max. TP.",
@@ -8714,7 +8714,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/invoke.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/invoke.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Im nächsten Zug [gold]Beschwöre[/gold] 3 und erhalte [energy:3].",
@@ -8754,7 +8754,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/summon_forth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/summon_forth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Schmiede[/gold] 11.\nNimm [gold]Hoheitsklinge[/gold] von irgendwoher auf deine [gold]Hand[/gold].",
@@ -8882,7 +8882,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/heavenly_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heavenly_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge X Mal 10 Schaden zu.\nVerdopple X, falls es 4 oder mehr ist.",
@@ -8918,7 +8918,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/beacon_of_hope.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beacon_of_hope.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8962,7 +8962,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sovereign_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sovereign_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9056,7 +9056,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/hotfix.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hotfix.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9218,7 +9218,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/i_am_invincible.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/i_am_invincible.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 13 [gold]Block[/gold].\nFalls diese Karte am Ende deines Zuges oben auf deinem [gold]Nachziehstapel[/gold] liegt, spiele sie.",
@@ -9258,7 +9258,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/wrought_in_war.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wrought_in_war.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 9 Schaden zu.\n[gold]Schmiede[/gold] 9.",
@@ -9338,7 +9338,7 @@
       "calculationextra": "+2"
     },
     "image_url": "/static/images/cards/beat_into_shape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_into_shape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 7 Schaden zu.\n[gold]Schmiede[/gold] X.\n[gold]Schmiedet[/gold] 7 mehr für jeden vorherigen Treffer auf diesen Gegner in diesem Zug.",
@@ -9423,7 +9423,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/infection.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/infection.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9511,7 +9511,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/wisp.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wisp.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9559,7 +9559,7 @@
       "iterationpower": "+1"
     },
     "image_url": "/static/images/cards/iteration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/iteration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du den ersten Status in einem Zug ziehst, ziehe 3 Karten.",
@@ -9633,7 +9633,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/juggling.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/juggling.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9717,7 +9717,7 @@
       "damage": "+8"
     },
     "image_url": "/static/images/cards/knockout_blow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockout_blow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 38 Schaden zu.\nFalls der Gegner dadurch stirbt, erhalte [star:5].",
@@ -9837,7 +9837,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/spoils_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Schmiede[/gold] 8.\nZiehe 2 Karten.",
@@ -9911,7 +9911,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/cascade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cascade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Spiele die obersten X+1 Karten deines [gold]Nachziehstapels[/gold].",
@@ -9949,7 +9949,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/catastrophe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/catastrophe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Spiele 3 zufällige Karten aus deinem [gold]Nachziehstapel[/gold].",
@@ -10043,7 +10043,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/know_thy_place.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/know_thy_place.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10124,7 +10124,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/refine_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refine_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Schmiede[/gold] 13.\nErhalte im nächsten Zug [energy:1].",
@@ -10254,7 +10254,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/bone_shards.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bone_shards.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Falls [gold]Osty[/gold] lebt, fügt er ALLEN Gegnern 12 Schaden zu und du erhältst 12 [gold]Block[/gold].\n[gold]Osty[/gold] stirbt.",
@@ -10332,7 +10332,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/collision_course.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/collision_course.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 15 Schaden zu.\nErhalte einen [gold]Schutt[/gold] auf deine [gold]Hand[/gold].",
@@ -10371,7 +10371,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/colossus.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/colossus.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 8 [gold]Block[/gold].\nDu nimmst in diesem Zug 50% weniger Schaden von [gold]Verwundbaren[/gold] Gegnern.",
@@ -10425,7 +10425,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/comet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/comet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 44 Schaden zu.\nWende 3 [gold]Schwach[/gold] an.\nWende 3 [gold]Verwundbar[/gold] an.",
@@ -10542,7 +10542,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/convergence.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/convergence.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte im nächsten Zug [energy:1] und [star:2].\n[gold]Behalte[/gold] deine [gold]Hand[/gold] in diesem Zug.",
@@ -10587,7 +10587,7 @@
       "strength": "+3"
     },
     "image_url": "/static/images/cards/coordinate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gib einem Mitspieler für diesen Zug 8 [gold]Stärke[/gold].",
@@ -10663,7 +10663,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/cosmic_indifference.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cosmic_indifference.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 9 [gold]Block[/gold].\nLege eine Karte aus deinem [gold]Abwurfstapel[/gold] auf deinen [gold]Nachziehstapel[/gold].",
@@ -10777,7 +10777,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/frantic_escape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/frantic_escape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -10860,7 +10860,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/spinner.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spinner.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Erschaffe[/gold] 1 [gold]Glas[/gold].\n[gold]Erschaffe[/gold] zu Beginn jedes Zuges 1 [gold]Glas[/gold].",
@@ -10906,7 +10906,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/drum_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/drum_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ziehe 3 Karten.\n[gold]Erschöpfe[/gold] immer zu Beginn deines Zuges die oberste Karte deines [gold]Nachziehstapels[/gold].",
@@ -10989,7 +10989,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/caltrops.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/caltrops.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du angegriffen wirst, füge dem Angreifer 5 Schaden zu.",
@@ -11065,7 +11065,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/volley.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/volley.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge X Mal einem zufälligen Gegner 14 Schaden zu.",
@@ -11184,7 +11184,7 @@
       "increase": "+2"
     },
     "image_url": "/static/images/cards/kingly_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/kingly_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 10 Schaden zu.\nImmer wenn du diese Karte ziehst, erhöhe ihren Schaden für diesen Kampf um 6.",
@@ -11275,7 +11275,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/prowess.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 2 [gold]Stärke[/gold].\nErhalte 2 [gold]Geschicklichkeit[/gold].",
@@ -11396,7 +11396,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/lantern_key.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lantern_key.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11446,7 +11446,7 @@
       "devourlifepower": "+1"
     },
     "image_url": "/static/images/cards/devour_life.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devour_life.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du eine [gold]Seele[/gold] spielst, [gold]Beschwöre[/gold] 2.",
@@ -11536,7 +11536,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/void_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/void_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11579,7 +11579,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/legion_of_bone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/legion_of_bone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ALLE Spieler [gold]Beschwören[/gold] 8.",
@@ -11627,7 +11627,7 @@
       "sleightoffleshpower": "+4"
     },
     "image_url": "/static/images/cards/sleight_of_flesh.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sleight_of_flesh.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du einen Debuff auf einen Gegner anwendest, nimmt er 13 Schaden.",
@@ -11665,7 +11665,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/shroud.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shroud.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du [gold]Verderben[/gold] anwendest, erhalte 3 [gold]Block[/gold].",
@@ -11747,7 +11747,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/guiding_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/guiding_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 13 Schaden zu.\nZiehe 3 Karten.",
@@ -11869,7 +11869,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/glow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte [star:2].\nZiehe 1 Karte.\nZiehe im nächsten Zug 1 Karte.",
@@ -11910,7 +11910,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/luminesce.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/luminesce.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte [energy:3].",
@@ -11953,7 +11953,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/gather_light.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gather_light.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 11 [gold]Block[/gold].\nErhalte [star:1].",
@@ -11992,7 +11992,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/refract.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refract.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge zweimal 12 Schaden zu.\n[gold]Erschaffe[/gold] 2 [gold]Glas[/gold].",
@@ -12028,7 +12028,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/beckon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beckon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12105,7 +12105,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/make_it_so.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/make_it_so.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 9 Schaden zu.\nNimm diese Karte nach je 3 in einem Zug gespielten Fertigkeiten auf deine [gold]Hand[/gold].",
@@ -12188,7 +12188,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sculpting_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sculpting_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 12 Schaden zu.\nGib einer deiner [gold]Handkarten[/gold] [gold]Flüchtig[/gold].",
@@ -12356,7 +12356,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/knife_trap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knife_trap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Verbessere[/gold] und spiele jedes [gold]Messer[/gold] in deinem [gold]Erschöpfungsstapel[/gold] auf diesen Gegner.",
@@ -12622,7 +12622,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/modded.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/modded.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 1 Orb-Slot.\nZiehe 2 Karten. Erhöhe die Kosten dieser Karte um 1.",
@@ -12707,7 +12707,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/lunar_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lunar_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 5 Schaden für jede in diesem Zug bereits gespielte Fertigkeit zu.",
@@ -12786,7 +12786,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/monologue.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/monologue.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12863,7 +12863,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/mimic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mimic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12951,7 +12951,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/afterlife.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/afterlife.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Beschwöre[/gold] 9.",
@@ -13039,7 +13039,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/necro_mastery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/necro_mastery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Beschwöre[/gold] 8.\nImmer wenn [gold]Osty[/gold] TP verliert, verlieren ALLE Gegner ebenso viele TP.",
@@ -13131,7 +13131,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/neurosurge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neurosurge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte [energy:4].\nZiehe 2 Karten.\nWende immer zu Beginn deines Zuges 3 [gold]Verderben[/gold] auf dich selbst an.",
@@ -13267,7 +13267,7 @@
       "platingpower": "+3"
     },
     "image_url": "/static/images/cards/neutron_aegis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neutron_aegis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 11 [gold]Panzerung[/gold].",
@@ -13352,7 +13352,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/beat_down.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_down.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Spiele 4 zufällige Angriffe aus deinem [gold]Abwurfstapel[/gold].",
@@ -13392,7 +13392,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/reap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 33 Schaden zu.",
@@ -13474,7 +13474,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Heile 13 TP.",
@@ -13555,7 +13555,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/nostalgia.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/nostalgia.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13593,7 +13593,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/omnislice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/omnislice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 11 Schaden zu.\nFüge ALLEN anderen Gegnern ebenso viel Schaden zu.",
@@ -13757,7 +13757,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/bundle_of_joy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bundle_of_joy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 4 zufällige Farblose Karten auf deine [gold]Hand[/gold].",
@@ -13851,7 +13851,7 @@
       "parrypower": "+4"
     },
     "image_url": "/static/images/cards/parry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/parry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du [gold]Hoheitsklinge[/gold] spielst, erhalte 14 [gold]Block[/gold].",
@@ -13973,7 +13973,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/whistle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/whistle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 44 Schaden zu.\n[gold]Betäube[/gold] den Gegner.",
@@ -14023,7 +14023,7 @@
       "phantombladespower": "+3"
     },
     "image_url": "/static/images/cards/phantom_blades.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/phantom_blades.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gib [gold]Messern[/gold] [gold]Behalten[/gold].\nDas erste [gold]Messer[/gold], das du jeden Zug spielst, fügt 12 Schaden mehr zu.",
@@ -14064,7 +14064,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/photon_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/photon_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 13 Schaden zu.\nZiehe 2 Karten.\nLege 1 [gold]Handkarte[/gold] auf deinen [gold]Nachziehstapel[/gold].",
@@ -14259,7 +14259,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/pillage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 9 Schaden zu.\nZiehe Karten, bis du eine Karte außer Angriffen ziehst.",
@@ -14306,7 +14306,7 @@
       "vigorpower": "+1"
     },
     "image_url": "/static/images/cards/patter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/patter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 11 [gold]Block[/gold].\nErhalte 3 [gold]Elan[/gold].",
@@ -14346,7 +14346,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/production.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/production.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte [energy:3].",
@@ -14427,7 +14427,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/precise_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/precise_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14510,7 +14510,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/quadcast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quadcast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14552,7 +14552,7 @@
       "cards": "+2"
     },
     "image_url": "/static/images/cards/decisions_decisions.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/decisions_decisions.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ziehe 5 Karten.\nWähle eine Fertigkeit aus deiner [gold]Hand[/gold] und spiele sie 3 Mal.",
@@ -14593,7 +14593,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/quasar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quasar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Wähle 1 aus 3 zufälligen [gold]verbesserten[/gold] Farblosen Karten, die du auf deine [gold]Hand[/gold] erhältst.",
@@ -14633,7 +14633,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/rocket_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rocket_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 14 Schaden zu.\nZiehe 2 Karten.\nImmer wenn du einen Status erzeugst, senke die Kosten dieser Karte auf 0 [energy:1], bis du sie spielst.",
@@ -14756,7 +14756,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/right_hand_hand.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/right_hand_hand.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] fügt 6 Schaden zu.\nImmer wenn du eine Karte spielst, die [energy:2] oder mehr kostet, nimm diese Karte vom [gold]Abwurfstapel[/gold] auf deine [gold]Hand[/gold].",
@@ -14795,7 +14795,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/reflect.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reflect.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 21 [gold]Block[/gold].\nGeblockter Angriffsschaden wird in diesem Zug auf deinen Angreifer zurückgeworfen.",
@@ -14970,7 +14970,7 @@
       "strengthpower": "+1"
     },
     "image_url": "/static/images/cards/resonance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/resonance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 2 [gold]Stärke[/gold]. ALLE Gegner verlieren 1 [gold]Stärke[/gold].",
@@ -15047,7 +15047,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/giant_rock.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/giant_rock.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 20 Schaden zu.",
@@ -15093,7 +15093,7 @@
       "rollingboulderpower": "+5"
     },
     "image_url": "/static/images/cards/rolling_boulder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rolling_boulder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge immer zu Beginn deines Zuges ALLEN Gegnern 10 Schaden zu und erhöhe diesen Schaden um 5.",
@@ -15134,7 +15134,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/royal_gamble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royal_gamble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15175,7 +15175,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/call_of_the_void.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/call_of_the_void.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15229,7 +15229,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/abrasive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/abrasive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 1 [gold]Geschicklichkeit[/gold].\nErhalte 6 [gold]Stacheln[/gold].",
@@ -15268,7 +15268,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/soot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -15309,7 +15309,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/rebound.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rebound.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 12 Schaden zu.\nLege die nächste Karte, die du in diesem Zug spielst, auf deinen [gold]Nachziehstapel[/gold].",
@@ -15386,7 +15386,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/salvo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/salvo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 16 Schaden zu.\n[gold]Behalte[/gold] in diesem Zug deine [gold]Hand[/gold].",
@@ -15473,7 +15473,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/consuming_shadow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/consuming_shadow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Erschaffe[/gold] 3 [gold]Schatten[/gold].\n[gold]Entlade[/gold] immer am Ende deines Zuges deinen hintersten Orb.",
@@ -15511,7 +15511,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/shadow_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shadow_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 15 [gold]Block[/gold].\n[gold]Erschaffe[/gold] 1 [gold]Schatten[/gold].",
@@ -15587,7 +15587,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/spoils_map.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_map.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15923,7 +15923,7 @@
       "serpentformpower": "+2"
     },
     "image_url": "/static/images/cards/serpent_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/serpent_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du eine Karte spielst, füge einem zufälligen Gegner 6 Schaden zu.",
@@ -15960,7 +15960,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/poor_sleep.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/poor_sleep.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16047,7 +16047,7 @@
       "smokestackpower": "+2"
     },
     "image_url": "/static/images/cards/smokestack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/smokestack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du einen Status erzeugst, füge ALLEN Gegnern 7 Schaden zu.",
@@ -16085,7 +16085,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/furnace.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/furnace.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer zu Beginn deines Zuges [gold]Schmiede[/gold] 6.",
@@ -16211,7 +16211,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/snap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/snap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] fügt 10 Schaden zu.\nGib einer deiner [gold]Handkarten[/gold] [gold]Behalten[/gold].",
@@ -16249,7 +16249,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/seeking_edge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeking_edge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Schmiede[/gold] 11.\n[gold]Hoheitsklinge[/gold] fügt jetzt ALLEN Gegnern Schaden zu.",
@@ -16294,7 +16294,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/speedster.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/speedster.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16368,7 +16368,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/reaper_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reaper_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16408,7 +16408,7 @@
       "power": "+2"
     },
     "image_url": "/static/images/cards/shockwave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shockwave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Wende auf ALLE Gegner 5 [gold]Schwach[/gold] und [gold]Verwundbar[/gold] an.",
@@ -16450,7 +16450,7 @@
       "cost": 7
     },
     "image_url": "/static/images/cards/banshees_cry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/banshees_cry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16529,7 +16529,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/trash_to_treasure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/trash_to_treasure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16647,7 +16647,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/debris.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debris.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16695,7 +16695,7 @@
       "blackholepower": "+1"
     },
     "image_url": "/static/images/cards/black_hole.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/black_hole.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du [star:1] ausgibst oder erhältst, füge ALLEN Gegnern 4 Schaden zu.",
@@ -16734,7 +16734,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/deaths_door.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/deaths_door.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 7 [gold]Block[/gold].\nFalls du in diesem Zug [gold]Verderben[/gold] angewandt hast, erhalte 2 weitere Male [gold]Block[/gold].",
@@ -16781,7 +16781,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sword_sage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sword_sage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16861,7 +16861,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/defile.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/defile.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 17 Schaden zu.",
@@ -16907,7 +16907,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/rattle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rattle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] fügt 9 Schaden zu.\nTrifft ein weiteres Mal für jeden seiner Angriffe in diesem Zug.",
@@ -16947,7 +16947,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/soul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ziehe 3 Karten.",
@@ -17032,7 +17032,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/severance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/severance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 18 Schaden zu.\nErhalte eine [gold]Seele[/gold] in deinen [gold]Nachziehstapel[/gold], [gold]Abwurfstapel[/gold] und auf deine [gold]Hand[/gold].",
@@ -17074,7 +17074,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/soul_storm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul_storm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 9 Schaden zu.\nFügt 3 Schaden mehr zu pro [gold]Seele[/gold] in deinem [gold]Erschöpfungsstapel[/gold].",
@@ -17114,7 +17114,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/seven_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seven_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17244,7 +17244,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/spectrum_shift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spectrum_shift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17284,7 +17284,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/barrage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/barrage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 7 Schaden für jeden [gold]Erschaffenen[/gold] Orb zu.",
@@ -17324,7 +17324,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/helix_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/helix_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 5 Schaden zu pro [energy:1], die du vorher in diesem Zug ausgegeben hast.",
@@ -17360,7 +17360,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/spore_mind.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spore_mind.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17483,7 +17483,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/splash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/splash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Wähle 1 aus 3 zufälligen [gold]Verbesserten[/gold] Angriffen eines anderen Charakters, den du auf deine [gold]Hand[/gold] erhältst. Er ist in diesem Zug kostenlos spielbar.",
@@ -17561,7 +17561,7 @@
       "hploss": "+2"
     },
     "image_url": "/static/images/cards/haunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du eine [gold]Seele[/gold] spielst, verliert ein zufälliger Gegner 8 TP.",
@@ -17674,7 +17674,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/unmovable.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/unmovable.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17713,7 +17713,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/stack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte [gold]Block[/gold] in Höhe der Kartenzahl in deinem [gold]Abwurfstapel[/gold] +3.",
@@ -17751,7 +17751,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/venerate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/venerate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte [star:3].",
@@ -17839,7 +17839,7 @@
       "strengthloss": "+2"
     },
     "image_url": "/static/images/cards/dying_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dying_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge ALLEN Gegnern 11 Schaden zu. ALLE Gegner verlieren für diesen Zug 11 [gold]Stärke[/gold].",
@@ -17880,7 +17880,7 @@
       "blockforstars": "+1"
     },
     "image_url": "/static/images/cards/child_of_the_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/child_of_the_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du [star:1] ausgibst, erhalte 3 [gold]Block[/gold] für jeden ausgegebenen [star:1].",
@@ -17995,7 +17995,7 @@
       "gold": "+5"
     },
     "image_url": "/static/images/cards/royalties.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royalties.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Erhalte am Ende des Kampfes 35 [gold]Gold[/gold].",
@@ -18077,7 +18077,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/shining_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shining_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 11 Schaden zu.\nErhalte [star:2].\nLege diese Karte auf deinen [gold]Nachziehstapel[/gold].",
@@ -18160,7 +18160,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/stratagem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stratagem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18241,7 +18241,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/subroutine.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/subroutine.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18282,7 +18282,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/seeker_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeker_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 12 Schaden zu.\nWähle 1 von 3 Karten aus deinem [gold]Nachziehstapel[/gold], die du auf deine [gold]Hand[/gold] nimmst.",
@@ -18365,7 +18365,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/supermassive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/supermassive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 5 Schaden zu.\nFügt 4 Schaden mehr zu pro Karte, die du in diesem Kampf erzeugt hast.",
@@ -18444,7 +18444,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/synchronize.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synchronize.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18485,7 +18485,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/synthesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synthesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 18 Schaden zu.\nDie nächste Macht, die du spielst, kostet 0 [energy:1].",
@@ -18570,7 +18570,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge ALLEN Gegnern 11 Schaden zu.",
@@ -18611,7 +18611,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/pillar_of_creation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillar_of_creation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du eine Karte erzeugst, erhalte 4 [gold]Block[/gold].",
@@ -18653,7 +18653,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/seance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18696,7 +18696,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/turbo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/turbo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte [energy:3].\nErhalte eine [gold]Leere[/gold] in deinen [gold]Abwurfstapel[/gold].",
@@ -18775,7 +18775,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/tank.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tank.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18897,7 +18897,7 @@
       "vigorpower": "+2"
     },
     "image_url": "/static/images/cards/terraforming.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/terraforming.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 8 [gold]Elan[/gold].",
@@ -18935,7 +18935,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/tesla_coil.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tesla_coil.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 6 Schaden zu.\nLöse alle [gold]Blitze[/gold] gegen diesen Gegner aus.",
@@ -19059,7 +19059,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/blade_of_ink.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/blade_of_ink.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 3 [purple]Tintenbeschmierte[/purple] [gold]Messer[/gold] auf deine [gold]Hand[/gold].",
@@ -19275,7 +19275,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/toric_toughness.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/toric_toughness.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 7 [gold]Block[/gold].\nErhalte 7 [gold]Block[/gold] zu Beginn der nächsten 2 Züge.",
@@ -19317,7 +19317,7 @@
       "summon": "+1"
     },
     "image_url": "/static/images/cards/dirge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dirge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Beschwöre[/gold] 4 X Mal.\nErhalte X [gold]Seelen+[/gold] in deinen [gold]Nachziehstapel[/gold].",
@@ -19415,7 +19415,7 @@
       "dexterity": "+1"
     },
     "image_url": "/static/images/cards/bulk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Verliere 1 Orb-Slot.\nErhalte 3 [gold]Stärke[/gold].\nErhalte 3 [gold]Geschicklichkeit[/gold].",
@@ -19456,7 +19456,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/fuel.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fuel.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte [energy:1].\nZiehe 2 Karten.",
@@ -19631,7 +19631,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/tyranny.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tyranny.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19726,7 +19726,7 @@
       "lethalitypower": "+25"
     },
     "image_url": "/static/images/cards/lethality.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lethality.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Der erste Angriff in jedem Zug fügt 75% mehr Schaden zu.",
@@ -19768,7 +19768,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/spite.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spite.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 5 Schaden zu.\nTrifft 3 Mal, falls du in diesem Zug TP verloren hast.",
@@ -19808,7 +19808,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/ultimate_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 20 Schaden zu.",
@@ -19848,7 +19848,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/ultimate_defend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_defend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 15 [gold]Block[/gold].",
@@ -20143,7 +20143,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/feral.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feral.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20182,7 +20182,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/bad_luck.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bad_luck.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20222,7 +20222,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/calamity.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/calamity.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20357,7 +20357,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/undeath.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/undeath.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 9 [gold]Block[/gold].\nErhalte eine Kopie dieser Karte in deinen [gold]Abwurfstapel[/gold].",
@@ -20441,7 +20441,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/big_bang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/big_bang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20520,7 +20520,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/forbidden_grimoire.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/forbidden_grimoire.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20642,7 +20642,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/compact.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/compact.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 7 [gold]Block[/gold].\n[gold]Transformiere[/gold] alle Status-Karten auf deiner [gold]Hand[/gold] zu [gold]Treibstoff+[/gold].",
@@ -20764,7 +20764,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/glasswork.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glasswork.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 8 [gold]Block[/gold].\n[gold]Erschaffe[/gold] 1 [gold]Glas[/gold].",
@@ -20852,7 +20852,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/waste_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/waste_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -20930,7 +20930,7 @@
       "damage": "+10"
     },
     "image_url": "/static/images/cards/devastate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devastate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 40 Schaden zu.",
@@ -21123,7 +21123,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/rally.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rally.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ALLE Spieler erhalten 17 [gold]Block[/gold].",
@@ -21159,7 +21159,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/entrench.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entrench.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21372,7 +21372,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/hidden_daggers.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_daggers.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Wirf 2 Karten ab.\nErhalte 2 [gold]Messer+[/gold] auf deine [gold]Hand[/gold].",
@@ -21418,7 +21418,7 @@
       "starnextturnpower": "+1"
     },
     "image_url": "/static/images/cards/hidden_cache.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_cache.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte [star:1].\nErhalte im nächsten Zug [star:4].",
@@ -21456,7 +21456,7 @@
       "replay": "+1"
     },
     "image_url": "/static/images/cards/hidden_gem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_gem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Gib einer zufälligen Karte ohne [gold]Erneut Spielen[/gold] aus deinem [gold]Nachziehstapel[/gold] [gold]Erneut Spielen[/gold] 3.",
@@ -21736,7 +21736,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/transfigure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/transfigure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21948,7 +21948,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/delay.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/delay.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 13 [gold]Block[/gold].\nErhalte im nächsten Zug [energy:2].",
@@ -21984,7 +21984,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/enthralled.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enthralled.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22068,7 +22068,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/voltaic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/voltaic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22246,7 +22246,7 @@
       "preptimepower": "+2"
     },
     "image_url": "/static/images/cards/prep_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prep_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte immer zu Beginn deines Zuges 6 [gold]Elan[/gold].",
@@ -22286,7 +22286,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/hegemony.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hegemony.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 18 Schaden zu.\nErhalte im nächsten Zug [energy:3].",
@@ -22447,7 +22447,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/boost_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/boost_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Erhalte 9 [gold]Block[/gold].\nErhalte ein [gold]Benommen[/gold] in deinen [gold]Abwurfstapel[/gold].",
@@ -22974,7 +22974,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/disintegration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/disintegration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -23052,7 +23052,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/maul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/maul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge zweimal 6 Schaden zu.\nErhöhe den Schaden ALLER Zerfleischen-Karten für diesen Kampf um 2.",
@@ -23130,7 +23130,7 @@
       "strengthloss": "+1"
     },
     "image_url": "/static/images/cards/crush_under.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crush_under.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge ALLEN Gegnern 8 Schaden zu.\nAlle Gegner verlieren für diesen Zug 2 [gold]Stärke[/gold].",
@@ -23171,7 +23171,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/rend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 15 Schaden zu.\nFügt 8 Schaden mehr zu pro unterschiedlichem Debuff auf dem Gegner.",
@@ -23288,7 +23288,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/shatter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shatter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge ALLEN Gegnern 15 Schaden zu.\n[gold]Entlade[/gold] alle deine Orbs.",
@@ -23461,7 +23461,7 @@
       "knockdownpower": "+1"
     },
     "image_url": "/static/images/cards/knockdown.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockdown.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 14 Schaden zu.\nDieser Gegner nimmt in diesem Zug dreifachen Schaden von Mitspielern.",
@@ -23540,7 +23540,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/dredge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dredge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23583,7 +23583,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/huddle_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/huddle_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ALLE Spieler ziehen 3 Karten.",
@@ -23626,7 +23626,7 @@
       "extradamage": "+2"
     },
     "image_url": "/static/images/cards/gang_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gang_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Füge 5 Schaden zu.\nFügt 7 Schaden mehr zu für jedes Mal, dass ein anderer Spieler diesen Gegner in diesem Zug angegriffen hat.",
@@ -23664,7 +23664,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/clash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/clash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Nur spielbar, wenn jede deiner [gold]Handkarten[/gold] ein Angriff ist.\nFüge 18 Schaden zu.",
@@ -23750,7 +23750,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/dual_wield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Wähle eine Angriffs- oder Machtkarte. Erhalte 2 Kopien dieser Karte auf deine [gold]Hand[/gold].",
@@ -23788,7 +23788,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/ignition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ignition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23829,7 +23829,7 @@
       "corrosivewave": "+1"
     },
     "image_url": "/static/images/cards/corrosive_wave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/corrosive_wave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Immer wenn du in diesem Zug eine Karte ziehst, wende auf ALLE Gegner 3 [gold]Gift[/gold] an.",

--- a/data/eng/cards.json
+++ b/data/eng/cards.json
@@ -45,7 +45,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/abrasive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/abrasive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 1 [gold]Dexterity[/gold].\nGain 6 [gold]Thorns[/gold].",
@@ -211,7 +211,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/adaptive_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/adaptive_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 23 damage.\nAdd a 0[energy:1] copy of this card into your [gold]Discard Pile[/gold].",
@@ -340,7 +340,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/afterlife.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/afterlife.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Summon[/gold] 9.",
@@ -459,7 +459,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/alignment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/alignment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain [energy:3].",
@@ -712,7 +712,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/apparition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/apparition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -799,7 +799,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/arsenal.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/arsenal.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -837,7 +837,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/ascenders_bane.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ascenders_bane.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -977,7 +977,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/astral_pulse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/astral_pulse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 18 damage to ALL enemies.",
@@ -1015,7 +1015,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/automation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/automation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1053,7 +1053,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/begone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/begone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Choose a card in your [gold]Hand[/gold] to [gold]Transform[/gold] into [gold]Minion Strike+[/gold].",
@@ -1176,7 +1176,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/bad_luck.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bad_luck.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1257,7 +1257,7 @@
       "cost": 7
     },
     "image_url": "/static/images/cards/banshees_cry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/banshees_cry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1297,7 +1297,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/barrage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/barrage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 7 damage for each [gold]Channeled[/gold] Orb.",
@@ -1454,7 +1454,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/beacon_of_hope.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beacon_of_hope.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1539,7 +1539,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/beat_down.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_down.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Play 4 random Attacks from your [gold]Discard Pile[/gold].",
@@ -1581,7 +1581,7 @@
       "calculationextra": "+2"
     },
     "image_url": "/static/images/cards/beat_into_shape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_into_shape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 7 damage.\n[gold]Forge[/gold] X.\n[gold]Forges[/gold] an additional 7 for every other time you've hit the enemy this turn.",
@@ -1617,7 +1617,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/beckon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beckon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1655,7 +1655,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/believe_in_you.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/believe_in_you.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Another player gains [energy:3].",
@@ -1750,7 +1750,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/big_bang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/big_bang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1798,7 +1798,7 @@
       "blackholepower": "+1"
     },
     "image_url": "/static/images/cards/black_hole.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/black_hole.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you spend or gain [star:1], deal 4 damage to ALL enemies.",
@@ -1883,7 +1883,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/blade_of_ink.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/blade_of_ink.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Add 3 [purple]Inky[/purple] [gold]Shivs[/gold] into your [gold]Hand[/gold].",
@@ -2156,7 +2156,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/bodyguard.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bodyguard.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Summon[/gold] 7.",
@@ -2234,7 +2234,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/bombardment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bombardment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 24 damage.\nAt the start of your turn, if this is in your [gold]Exhaust Pile[/gold], play it.",
@@ -2280,7 +2280,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/bone_shards.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bone_shards.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "If [gold]Osty[/gold] is alive, he deals 12 damage to ALL enemies and you gain 12 [gold]Block[/gold].\n[gold]Osty[/gold] dies.",
@@ -2320,7 +2320,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/boost_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/boost_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 9 [gold]Block[/gold].\nAdd a [gold]Dazed[/gold] into your [gold]Discard Pile[/gold].",
@@ -2623,7 +2623,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/brightest_flame.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/brightest_flame.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain [energy:3].\nDraw 3 cards.\nLose 1 Max HP.",
@@ -2668,7 +2668,7 @@
       "poison": "+3"
     },
     "image_url": "/static/images/cards/bubble_bubble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "If the enemy has [gold]Poison[/gold], apply 12 [gold]Poison[/gold].",
@@ -2767,7 +2767,7 @@
       "dexterity": "+1"
     },
     "image_url": "/static/images/cards/bulk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lose 1 Orb Slot.\nGain 3 [gold]Strength[/gold].\nGain 3 [gold]Dexterity[/gold].",
@@ -2883,7 +2883,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/bulwark.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulwark.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 16 [gold]Block[/gold].\n[gold]Forge[/gold] 13.",
@@ -2923,7 +2923,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/bundle_of_joy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bundle_of_joy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Add 4 random Colorless cards into your [gold]Hand[/gold].",
@@ -3081,7 +3081,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/bury.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bury.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 63 damage.",
@@ -3234,7 +3234,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/calamity.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/calamity.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3358,7 +3358,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/call_of_the_void.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/call_of_the_void.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3403,7 +3403,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/caltrops.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/caltrops.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you are attacked, deal 5 damage back.",
@@ -3519,7 +3519,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/cascade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cascade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Play the top X+1 cards of your [gold]Draw Pile[/gold].",
@@ -3557,7 +3557,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/catastrophe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/catastrophe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Play 3 random cards from your [gold]Draw Pile[/gold].",
@@ -3711,7 +3711,7 @@
       "blockforstars": "+1"
     },
     "image_url": "/static/images/cards/child_of_the_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/child_of_the_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you spend [star:1], gain 3 [gold]Block[/gold] for each [star:1] spent.",
@@ -3828,7 +3828,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/clash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/clash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Can only be played if every card in your [gold]Hand[/gold] is an Attack.\nDeal 18 damage.",
@@ -4105,7 +4105,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/collision_course.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/collision_course.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 15 damage.\nAdd a [gold]Debris[/gold] into your [gold]Hand[/gold].",
@@ -4144,7 +4144,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/colossus.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/colossus.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 8 [gold]Block[/gold].\nYou receive 50% less damage from [gold]Vulnerable[/gold] enemies this turn.",
@@ -4198,7 +4198,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/comet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/comet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 44 damage.\nApply 3 [gold]Weak[/gold].\nApply 3 [gold]Vulnerable[/gold].",
@@ -4238,7 +4238,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/compact.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/compact.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 7 [gold]Block[/gold].\n[gold]Transform[/gold] all Status cards in your [gold]Hand[/gold] into [gold]Fuel+[/gold].",
@@ -4319,7 +4319,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/conflagration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conflagration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 8 damage to ALL enemies.\nDeals 3 additional damage for each other Attack you've played this turn.",
@@ -4357,7 +4357,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/conqueror.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conqueror.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forge[/gold] 5.\n[gold]Sovereign Blade[/gold] deals double damage to the enemy this turn.",
@@ -4403,7 +4403,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/consuming_shadow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/consuming_shadow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Channel[/gold] 3 [gold]Dark[/gold].\nAt the end of your turn, [gold]Evoke[/gold] your leftmost Orb.",
@@ -4442,7 +4442,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/convergence.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/convergence.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Next turn,\ngain [energy:1] and [star:2].\n[gold]Retain[/gold] your [gold]Hand[/gold] this turn.",
@@ -4570,7 +4570,7 @@
       "strength": "+3"
     },
     "image_url": "/static/images/cards/coordinate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Give another player 8 [gold]Strength[/gold] this turn.",
@@ -4608,7 +4608,7 @@
       "corrosivewave": "+1"
     },
     "image_url": "/static/images/cards/corrosive_wave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/corrosive_wave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you draw a card this turn, apply 3 [gold]Poison[/gold] to ALL enemies.",
@@ -4684,7 +4684,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/cosmic_indifference.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cosmic_indifference.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 9 [gold]Block[/gold].\nPut a card from your [gold]Discard Pile[/gold] on top of your [gold]Draw Pile[/gold].",
@@ -4769,7 +4769,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/crash_landing.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crash_landing.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 26 damage to ALL enemies.\nFill your [gold]Hand[/gold] with [gold]Debris[/gold].",
@@ -4893,7 +4893,7 @@
       "crimsonmantlepower": "+2"
     },
     "image_url": "/static/images/cards/crimson_mantle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crimson_mantle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "At the start of your turn, lose 1 HP and gain 10 [gold]Block[/gold].",
@@ -4978,7 +4978,7 @@
       "strengthloss": "+1"
     },
     "image_url": "/static/images/cards/crush_under.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crush_under.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 8 damage to ALL enemies. All enemies lose 2 [gold]Strength[/gold] this turn.",
@@ -5141,7 +5141,7 @@
       "dansemacabrepower": "+2"
     },
     "image_url": "/static/images/cards/danse_macabre.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/danse_macabre.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you play a card that costs [energy:2] or more, gain 6 [gold]Block[/gold].",
@@ -5462,7 +5462,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/deaths_door.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/deaths_door.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 7 [gold]Block[/gold].\nIf you applied [gold]Doom[/gold] this turn, gain [gold]Block[/gold] 2 additional times.",
@@ -5561,7 +5561,7 @@
       "debilitatepower": "+1"
     },
     "image_url": "/static/images/cards/debilitate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debilitate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 12 damage.\n[gold]Vulnerable[/gold] and [gold]Weak[/gold] are twice as effective against the enemy for the next 4 turns.",
@@ -5597,7 +5597,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/debris.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debris.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5724,7 +5724,7 @@
       "cards": "+2"
     },
     "image_url": "/static/images/cards/decisions_decisions.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/decisions_decisions.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Draw 5 cards.\nChoose a Skill in your [gold]Hand[/gold] and play it 3 times.",
@@ -5967,7 +5967,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/defile.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/defile.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 17 damage.",
@@ -6144,7 +6144,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/delay.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/delay.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 13 [gold]Block[/gold].\nNext turn,\ngain [energy:2].",
@@ -6185,7 +6185,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/demesne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demesne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6275,7 +6275,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/demonic_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demonic_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6317,7 +6317,7 @@
       "damage": "+10"
     },
     "image_url": "/static/images/cards/devastate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devastate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 40 damage.",
@@ -6364,7 +6364,7 @@
       "devourlifepower": "+1"
     },
     "image_url": "/static/images/cards/devour_life.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devour_life.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you play a [gold]Soul[/gold], [gold]Summon[/gold] 2.",
@@ -6406,7 +6406,7 @@
       "summon": "+1"
     },
     "image_url": "/static/images/cards/dirge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dirge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Summon[/gold] 4 X times.\nAdd X [gold]Souls+[/gold] into your [gold]Draw Pile[/gold].",
@@ -6493,7 +6493,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/disintegration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/disintegration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -6569,7 +6569,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/distraction.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/distraction.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6875,7 +6875,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/dredge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dredge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6924,7 +6924,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/drum_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/drum_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Draw 3 cards.\nAt the start of your turn, [gold]Exhaust[/gold] the top card of your [gold]Draw Pile[/gold].",
@@ -6962,7 +6962,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/dual_wield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Choose an Attack or Power card. Add 2 copies of that card into your [gold]Hand[/gold].",
@@ -7041,7 +7041,7 @@
       "strengthloss": "+2"
     },
     "image_url": "/static/images/cards/dying_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dying_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 11 damage to ALL enemies. ALL enemies lose 11 [gold]Strength[/gold] this turn.",
@@ -7163,7 +7163,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/eidolon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/eidolon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7248,7 +7248,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/energy_surge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/energy_surge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ALL players gain [energy:3].",
@@ -7291,7 +7291,7 @@
       "strengthloss": "+3"
     },
     "image_url": "/static/images/cards/enfeebling_touch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enfeebling_touch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Enemy loses 11 [gold]Strength[/gold] this turn.",
@@ -7371,7 +7371,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/enthralled.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enthralled.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7410,7 +7410,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/entrench.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entrench.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7448,7 +7448,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/entropy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entropy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7951,7 +7951,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/falling_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/falling_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 12 damage.\nApply 1 [gold]Weak[/gold].\nApply 1 [gold]Vulnerable[/gold].",
@@ -8031,7 +8031,7 @@
       "extrablock": "+2"
     },
     "image_url": "/static/images/cards/fasten.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fasten.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain an additional 7 [gold]Block[/gold] from Defend cards.",
@@ -8173,7 +8173,7 @@
       "strength": "+2"
     },
     "image_url": "/static/images/cards/feeding_frenzy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 7 [gold]Strength[/gold] this turn.",
@@ -8256,7 +8256,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/feral.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feral.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8390,7 +8390,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/fight_me.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 6 damage twice.\nGain 4 [gold]Strength[/gold].\nThe enemy gains 1 [gold]Strength[/gold].",
@@ -8430,7 +8430,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/fight_through.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_through.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 17 [gold]Block[/gold].\nAdd 2 [gold]Wounds[/gold] into your [gold]Discard Pile[/gold].",
@@ -8547,7 +8547,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/fisticuffs.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fisticuffs.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 9 damage.\nGain [gold]Block[/gold] equal to damage dealt.",
@@ -8587,7 +8587,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/flak_cannon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/flak_cannon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Exhaust[/gold] ALL your Status cards.\nDeal 11 damage to a random enemy for each card [gold]Exhausted[/gold].",
@@ -8875,7 +8875,7 @@
       "focuspower": "+1"
     },
     "image_url": "/static/images/cards/focused_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/focused_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 11 damage.\nGain 2 [gold]Focus[/gold] this turn.",
@@ -9042,7 +9042,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/forbidden_grimoire.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/forbidden_grimoire.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9083,7 +9083,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/foregone_conclusion.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/foregone_conclusion.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Next turn, put 3 cards from your [gold]Draw Pile[/gold] into your [gold]Hand[/gold].",
@@ -9160,7 +9160,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/frantic_escape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/frantic_escape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -9247,7 +9247,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/fuel.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fuel.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain [energy:1].\nDraw 2 cards.",
@@ -9288,7 +9288,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/furnace.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/furnace.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "At the start of your turn, [gold]Forge[/gold] 6.",
@@ -9421,7 +9421,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/gamma_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gamma_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 18 damage.\nApply 2 [gold]Weak[/gold].\nApply 2 [gold]Vulnerable[/gold].",
@@ -9461,7 +9461,7 @@
       "extradamage": "+2"
     },
     "image_url": "/static/images/cards/gang_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gang_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 5 damage.\nDeals 7 additional damage for each time another player has attacked the enemy this turn.",
@@ -9500,7 +9500,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/gather_light.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gather_light.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 11 [gold]Block[/gold].\nGain [star:1].",
@@ -9538,7 +9538,7 @@
       "starsperturn": "+1"
     },
     "image_url": "/static/images/cards/genesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/genesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "At the start of your turn, gain [star:3].",
@@ -9620,7 +9620,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/giant_rock.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/giant_rock.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 20 damage.",
@@ -9696,7 +9696,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/glasswork.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glasswork.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 8 [gold]Block[/gold].\n[gold]Channel[/gold] 1 [gold]Glass[/gold].",
@@ -9777,7 +9777,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/glimpse_beyond.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glimpse_beyond.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ALL players add 4 [gold]Souls[/gold] into their [gold]Draw Pile[/gold].",
@@ -9859,7 +9859,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/glow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain [star:2].\nDraw 1 card.\nNext turn, draw 1 card.",
@@ -10066,7 +10066,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/graveblast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/graveblast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 6 damage.\nPut a card from your [gold]Discard Pile[/gold] into your [gold]Hand[/gold].",
@@ -10106,7 +10106,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/greed.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/greed.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10151,7 +10151,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/guiding_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/guiding_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 13 damage.\nDraw 3 cards.",
@@ -10233,7 +10233,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/gunk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gunk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 5 damage 3 times.\nAdd a [gold]Slimed[/gold] into your [gold]Discard Pile[/gold].",
@@ -10278,7 +10278,7 @@
       "hailstormpower": "+2"
     },
     "image_url": "/static/images/cards/hailstorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hailstorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "At the end of your turn, if you have [gold]Frost[/gold], deal 8 damage to ALL enemies.",
@@ -10314,7 +10314,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/hammer_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hammer_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10430,7 +10430,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/hang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 13 damage.\nDouble the damage ALL Hang cards deal to this enemy.",
@@ -10470,7 +10470,7 @@
       "hploss": "+2"
     },
     "image_url": "/static/images/cards/haunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you play a [gold]Soul[/gold], a random enemy loses 8 HP.",
@@ -10553,7 +10553,7 @@
       "poison": "+2"
     },
     "image_url": "/static/images/cards/haze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Apply 6 [gold]Poison[/gold] to ALL enemies.",
@@ -10633,7 +10633,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/heavenly_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heavenly_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 10 damage X times.\nDouble X if it's 4 or more.",
@@ -10673,7 +10673,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/hegemony.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hegemony.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 18 damage.\nNext turn, gain [energy:3].",
@@ -10712,7 +10712,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/heirloom_hammer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heirloom_hammer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 25 damage.\nChoose a Colorless card in your [gold]Hand[/gold]. Add a copy of that card into your [gold]Hand[/gold].",
@@ -10752,7 +10752,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/helix_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/helix_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 5 damage for each [energy:1] previously spent this turn.",
@@ -10788,7 +10788,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/hello_world.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hello_world.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10909,7 +10909,7 @@
       "starnextturnpower": "+1"
     },
     "image_url": "/static/images/cards/hidden_cache.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_cache.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain [star:1].\nNext turn, gain [star:4].",
@@ -10950,7 +10950,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/hidden_daggers.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_daggers.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Discard 2 cards.\nAdd 2 [gold]Shivs+[/gold] into your [gold]Hand[/gold].",
@@ -10988,7 +10988,7 @@
       "replay": "+1"
     },
     "image_url": "/static/images/cards/hidden_gem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_gem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "A random card without [gold]Replay[/gold] in your [gold]Draw Pile[/gold] gains [gold]Replay[/gold] 3.",
@@ -11129,7 +11129,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/hotfix.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hotfix.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11210,7 +11210,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/huddle_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/huddle_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ALL players draw 3 cards.",
@@ -11297,7 +11297,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/i_am_invincible.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/i_am_invincible.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 13 [gold]Block[/gold].\nAt the end of your turn, if this is on top of your [gold]Draw Pile[/gold], play it.",
@@ -11336,7 +11336,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/ice_lance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ice_lance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 24 damage.\n[gold]Channel[/gold] 3 [gold]Frost[/gold].",
@@ -11374,7 +11374,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/ignition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ignition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11496,7 +11496,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/infection.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/infection.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11745,7 +11745,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/intercept.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/intercept.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 13 [gold]Block[/gold].\nRedirect all incoming attacks that would be dealt to another player this turn to you.",
@@ -11785,7 +11785,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/invoke.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/invoke.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Next turn, [gold]Summon[/gold] 3 and gain [energy:3].",
@@ -11870,7 +11870,7 @@
       "iterationpower": "+1"
     },
     "image_url": "/static/images/cards/iteration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/iteration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "The first time you draw a Status each turn, draw 3 cards.",
@@ -11952,7 +11952,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/jackpot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/jackpot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 30 damage.\nAdd 3 random [gold]Upgraded[/gold] 0[energy:1] cards into your [gold]Hand[/gold].",
@@ -12033,7 +12033,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/juggling.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/juggling.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12111,7 +12111,7 @@
       "increase": "+2"
     },
     "image_url": "/static/images/cards/kingly_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/kingly_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 10 damage.\nWhenever you draw this card, increase its damage by 6 this combat.",
@@ -12154,7 +12154,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/knife_trap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knife_trap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Upgrade[/gold] and play every [gold]Shiv[/gold] in your [gold]Exhaust Pile[/gold] on the enemy.",
@@ -12201,7 +12201,7 @@
       "knockdownpower": "+1"
     },
     "image_url": "/static/images/cards/knockdown.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockdown.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 14 damage.\nThe enemy takes triple damage from other players this turn.",
@@ -12240,7 +12240,7 @@
       "damage": "+8"
     },
     "image_url": "/static/images/cards/knockout_blow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockout_blow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 38 damage.\nIf this kills an enemy, gain [star:5].",
@@ -12294,7 +12294,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/know_thy_place.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/know_thy_place.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12335,7 +12335,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/lantern_key.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lantern_key.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12374,7 +12374,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/largesse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/largesse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Another player adds 1 random [gold]Upgraded[/gold] Colorless card to their [gold]Hand[/gold].",
@@ -12417,7 +12417,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/leading_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/leading_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 6 damage.\nAdd 2 [gold]Shivs[/gold] into your [gold]Hand[/gold].",
@@ -12542,7 +12542,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/legion_of_bone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/legion_of_bone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ALL players [gold]Summon[/gold] 8.",
@@ -12592,7 +12592,7 @@
       "lethalitypower": "+25"
     },
     "image_url": "/static/images/cards/lethality.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lethality.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "The first Attack each turn deals 75% additional damage.",
@@ -12633,7 +12633,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/lift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Give another player 16 [gold]Block[/gold].",
@@ -12679,7 +12679,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/lightning_rod.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lightning_rod.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 7 [gold]Block[/gold].\nAt the start of the next 2 turns, [gold]Channel[/gold] 1 [gold]Lightning[/gold].",
@@ -12758,7 +12758,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/luminesce.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/luminesce.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain [energy:3].",
@@ -12802,7 +12802,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/lunar_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lunar_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 5 damage for each Skill already played this turn.",
@@ -12996,7 +12996,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/make_it_so.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/make_it_so.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 9 damage.\nEvery 3 Skills you play in a turn, put this into your [gold]Hand[/gold].",
@@ -13115,7 +13115,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/manifest_authority.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/manifest_authority.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 8 [gold]Block[/gold].\nAdd 1 random [gold]Upgraded[/gold] Colorless card into your [gold]Hand[/gold].",
@@ -13234,7 +13234,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/maul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/maul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 6 damage twice.\nIncrease the damage of ALL Maul cards by 2 this combat.",
@@ -13528,7 +13528,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/mimic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mimic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13619,7 +13619,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/mind_rot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mind_rot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -13706,7 +13706,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/minion_sacrifice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_sacrifice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 12 [gold]Block[/gold].",
@@ -13753,7 +13753,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/minion_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 9 damage.\nDraw 1 card.",
@@ -13839,7 +13839,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/misery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/misery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 9 damage.\nApply any debuffs on the enemy to ALL other enemies.",
@@ -13878,7 +13878,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/modded.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/modded.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 1 Orb Slot.\nDraw 2 cards. Increase this card's cost by 1.",
@@ -14037,7 +14037,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/monologue.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/monologue.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14113,7 +14113,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/murder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/murder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14151,7 +14151,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/necro_mastery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/necro_mastery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Summon[/gold] 8.\nWhenever [gold]Osty[/gold] loses HP,\nALL enemies lose that much HP as well.",
@@ -14290,7 +14290,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/neurosurge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neurosurge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain [energy:4].\nDraw 2 cards.\nAt the start of your turn, apply 3 [gold]Doom[/gold] to yourself.",
@@ -14383,7 +14383,7 @@
       "platingpower": "+3"
     },
     "image_url": "/static/images/cards/neutron_aegis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neutron_aegis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 11 [gold]Plating[/gold].",
@@ -14542,7 +14542,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/nostalgia.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/nostalgia.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14582,7 +14582,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Heal 13 HP.",
@@ -14798,7 +14798,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/omnislice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/omnislice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 11 damage.\nDamage ALL other enemies equal to the damage dealt.",
@@ -14920,7 +14920,7 @@
       "outbreakpower": "+4"
     },
     "image_url": "/static/images/cards/outbreak.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outbreak.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Every 3 times you apply [gold]Poison[/gold], deal 15 damage to ALL enemies.",
@@ -14958,7 +14958,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/outmaneuver.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outmaneuver.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Next turn, gain [energy:3].",
@@ -15075,7 +15075,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/pagestorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pagestorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15114,7 +15114,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/pale_blue_dot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pale_blue_dot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "If you play 5 or more cards in a turn, draw 2 cards at the start of your next turn.",
@@ -15243,7 +15243,7 @@
       "parrypower": "+4"
     },
     "image_url": "/static/images/cards/parry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/parry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you play [gold]Sovereign Blade[/gold], gain 14 [gold]Block[/gold].",
@@ -15372,7 +15372,7 @@
       "vigorpower": "+1"
     },
     "image_url": "/static/images/cards/patter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/patter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 11 [gold]Block[/gold].\nGain 3 [gold]Vigor[/gold].",
@@ -15500,7 +15500,7 @@
       "phantombladespower": "+3"
     },
     "image_url": "/static/images/cards/phantom_blades.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/phantom_blades.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Shivs[/gold] gain [gold]Retain[/gold].\nThe first [gold]Shiv[/gold] you play each turn deals 12 additional damage.",
@@ -15541,7 +15541,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/photon_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/photon_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 13 damage.\nDraw 2 cards.\nPut 1 card from your [gold]Hand[/gold] on top of your [gold]Draw Pile[/gold].",
@@ -15622,7 +15622,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/pillage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 9 damage.\nDraw cards until you draw a non-Attack card.",
@@ -15660,7 +15660,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/pillar_of_creation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillar_of_creation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you create a card, gain 4 [gold]Block[/gold].",
@@ -15865,7 +15865,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/poor_sleep.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/poor_sleep.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15947,7 +15947,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/precise_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/precise_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16030,7 +16030,7 @@
       "preptimepower": "+2"
     },
     "image_url": "/static/images/cards/prep_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prep_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "At the start of your turn, gain 6 [gold]Vigor[/gold].",
@@ -16146,7 +16146,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/production.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/production.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain [energy:3].",
@@ -16324,7 +16324,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/prowess.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 2 [gold]Strength[/gold].\nGain 2 [gold]Dexterity[/gold].",
@@ -16404,7 +16404,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/pull_from_below.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pull_from_below.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 7 damage for each [gold]Ethereal[/gold] card played this combat.",
@@ -16568,7 +16568,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/quadcast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quadcast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16606,7 +16606,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/quasar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quasar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Choose 1 of 3 random [gold]Upgraded[/gold] Colorless cards to add into your [gold]Hand[/gold].",
@@ -16764,7 +16764,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/rally.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rally.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ALL players gain 17 [gold]Block[/gold].",
@@ -16846,7 +16846,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/rattle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rattle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] deals 9 damage.\nHits an additional time for each other time he has attacked this turn.",
@@ -16929,7 +16929,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/reap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 33 damage.",
@@ -16968,7 +16968,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/reaper_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reaper_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17090,7 +17090,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/rebound.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rebound.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 12 damage.\nPut the next card you play this turn on top of your [gold]Draw Pile[/gold].",
@@ -17129,7 +17129,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/refine_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refine_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forge[/gold] 13.\nNext turn, gain [energy:1].",
@@ -17168,7 +17168,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/reflect.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reflect.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 21 [gold]Block[/gold].\nBlocked attack damage is reflected to your attacker this turn.",
@@ -17250,7 +17250,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/refract.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refract.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 12 damage twice.\n[gold]Channel[/gold] 2 [gold]Glass[/gold].",
@@ -17333,7 +17333,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/relax.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/relax.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 17 [gold]Block[/gold].\nNext turn, draw 3 cards and gain [energy:3].",
@@ -17377,7 +17377,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/rend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 15 damage.\nDeals 8 additional damage for each unique debuff on the enemy.",
@@ -17423,7 +17423,7 @@
       "strengthpower": "+1"
     },
     "image_url": "/static/images/cards/resonance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/resonance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 2 [gold]Strength[/gold]. ALL enemies lose 1 [gold]Strength[/gold].",
@@ -17509,7 +17509,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/ricochet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ricochet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 3 damage to a random enemy 5 times.",
@@ -17554,7 +17554,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/right_hand_hand.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/right_hand_hand.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] deals 6 damage.\nWhenever you play a card that costs [energy:2] or more, return this to your [gold]Hand[/gold] from the [gold]Discard Pile[/gold].",
@@ -17632,7 +17632,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/rocket_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rocket_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 14 damage.\nDraw 2 cards.\nWhenever you create a Status, reduce this card's cost to 0 [energy:1] until played.",
@@ -17678,7 +17678,7 @@
       "rollingboulderpower": "+5"
     },
     "image_url": "/static/images/cards/rolling_boulder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rolling_boulder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "At the start of your turn, deal 10 damage to ALL enemies and increase this damage by 5.",
@@ -17719,7 +17719,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/royal_gamble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royal_gamble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17760,7 +17760,7 @@
       "gold": "+5"
     },
     "image_url": "/static/images/cards/royalties.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royalties.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "At the end of combat, gain 35 [gold]Gold[/gold].",
@@ -17884,7 +17884,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/salvo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/salvo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 16 damage.\n[gold]Retain[/gold] your [gold]Hand[/gold] this turn.",
@@ -18047,7 +18047,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/scrawl.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/scrawl.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18090,7 +18090,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sculpting_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sculpting_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 12 damage.\nAdd [gold]Ethereal[/gold] to a card in your [gold]Hand[/gold].",
@@ -18132,7 +18132,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/seance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18296,7 +18296,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/seeker_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeker_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 12 damage.\nChoose 1 of 3 cards in your [gold]Draw Pile[/gold] to add into your [gold]Hand[/gold].",
@@ -18334,7 +18334,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/seeking_edge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeking_edge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forge[/gold] 11.\n[gold]Sovereign Blade[/gold] now deals damage to ALL enemies.",
@@ -18426,7 +18426,7 @@
       "serpentformpower": "+2"
     },
     "image_url": "/static/images/cards/serpent_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/serpent_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you play a card, deal 6 damage to a random enemy.",
@@ -18515,7 +18515,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/seven_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seven_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18555,7 +18555,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/severance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/severance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 18 damage.\nAdd a [gold]Soul[/gold] into your [gold]Draw Pile[/gold], [gold]Hand[/gold], and [gold]Discard Pile[/gold].",
@@ -18593,7 +18593,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/shadow_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shadow_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 15 [gold]Block[/gold].\n[gold]Channel[/gold] 1 [gold]Dark[/gold].",
@@ -18792,7 +18792,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/shatter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shatter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 15 damage to ALL enemies.\n[gold]Evoke[/gold] all of your Orbs.",
@@ -18833,7 +18833,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/shining_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shining_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 11 damage.\nGain [star:2].\nPut this card on top of your [gold]Draw Pile[/gold].",
@@ -18918,7 +18918,7 @@
       "power": "+2"
     },
     "image_url": "/static/images/cards/shockwave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shockwave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Apply 5 [gold]Weak[/gold] and [gold]Vulnerable[/gold] to ALL enemies.",
@@ -18959,7 +18959,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/shroud.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shroud.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you apply [gold]Doom[/gold], gain 3 [gold]Block[/gold].",
@@ -19048,7 +19048,7 @@
       "sicempower": "+1"
     },
     "image_url": "/static/images/cards/sic_em.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sic_em.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] deals 6 damage.\nWhenever [gold]Osty[/gold] hits this enemy this turn, [gold]Summon[/gold] 3.",
@@ -19219,7 +19219,7 @@
       "sleightoffleshpower": "+4"
     },
     "image_url": "/static/images/cards/sleight_of_flesh.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sleight_of_flesh.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you apply a debuff to an enemy, they take 13 damage.",
@@ -19341,7 +19341,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/sloth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sloth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -19386,7 +19386,7 @@
       "smokestackpower": "+2"
     },
     "image_url": "/static/images/cards/smokestack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/smokestack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you create a Status, deal 7 damage to ALL enemies.",
@@ -19477,7 +19477,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/snap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/snap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] deals 10 damage.\nAdd [gold]Retain[/gold] to a card in your [gold]Hand[/gold].",
@@ -19524,7 +19524,7 @@
       "sneakypower": "+1"
     },
     "image_url": "/static/images/cards/sneaky.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sneaky.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever another player attacks an enemy, gain 2 [gold]Block[/gold].",
@@ -19605,7 +19605,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/soot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -19648,7 +19648,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/soul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Draw 3 cards.",
@@ -19693,7 +19693,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/soul_storm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul_storm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 9 damage.\nDeals 3 additional damage for each [gold]Soul[/gold] in your [gold]Exhaust Pile[/gold].",
@@ -19737,7 +19737,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sovereign_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sovereign_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19780,7 +19780,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 11 damage to ALL enemies.",
@@ -19821,7 +19821,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/spectrum_shift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spectrum_shift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19866,7 +19866,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/speedster.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/speedster.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19911,7 +19911,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/spinner.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spinner.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Channel[/gold] 1 [gold]Glass[/gold].\nAt the start of your turn, [gold]Channel[/gold] 1 [gold]Glass[/gold].",
@@ -19949,7 +19949,7 @@
       "blockonexhaust": "+1"
     },
     "image_url": "/static/images/cards/spirit_of_ash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spirit_of_ash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you play an [gold]Ethereal[/gold] card, gain 5 [gold]Block[/gold].",
@@ -19988,7 +19988,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/spite.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spite.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 5 damage.\nIf you lost HP this turn,\nhits 3 times.",
@@ -20024,7 +20024,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/splash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/splash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Choose 1 of 3 random [gold]Upgraded[/gold] Attacks from another character to add into your [gold]Hand[/gold]. It's free to play this turn.",
@@ -20062,7 +20062,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/spoils_map.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_map.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20104,7 +20104,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/spoils_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forge[/gold] 8.\nDraw 2 cards.",
@@ -20140,7 +20140,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/spore_mind.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spore_mind.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20278,7 +20278,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/squeeze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/squeeze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] deals 25 damage.\nDeals 6 additional damage for ALL your other [gold]Osty[/gold] Attacks.",
@@ -20317,7 +20317,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/stack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain [gold]Block[/gold] equal to the number of cards in your [gold]Discard Pile[/gold] +3.",
@@ -20642,7 +20642,7 @@
       "stranglepower": "+1"
     },
     "image_url": "/static/images/cards/strangle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/strangle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 10 damage.\nWhenever you play a card this turn, the enemy loses 3 HP.",
@@ -20678,7 +20678,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/stratagem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stratagem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20914,7 +20914,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/subroutine.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/subroutine.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21001,7 +21001,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/summon_forth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/summon_forth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forge[/gold] 11.\nPut [gold]Sovereign Blade[/gold] into your [gold]Hand[/gold] from anywhere.",
@@ -21123,7 +21123,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/supermassive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/supermassive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 5 damage.\nDeals 4 additional damage for each card you created this combat.",
@@ -21296,7 +21296,7 @@
       "ostydamage": "+5"
     },
     "image_url": "/static/images/cards/sweeping_gaze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sweeping_gaze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] deals 15 damage to a random enemy.",
@@ -21386,7 +21386,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sword_sage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sword_sage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21427,7 +21427,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/synchronize.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synchronize.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21468,7 +21468,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/synthesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synthesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 18 damage.\nThe next Power you play costs 0 [energy:1].",
@@ -21508,7 +21508,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/turbo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/turbo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain [energy:3].\nAdd a [gold]Void[/gold] into your [gold]Discard Pile[/gold].",
@@ -21625,7 +21625,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/tank.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tank.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21794,7 +21794,7 @@
       "vigorpower": "+2"
     },
     "image_url": "/static/images/cards/terraforming.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/terraforming.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 8 [gold]Vigor[/gold].",
@@ -21832,7 +21832,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/tesla_coil.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tesla_coil.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 6 damage.\nTrigger all [gold]Lightning[/gold] against the enemy.",
@@ -21949,7 +21949,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/the_hunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_hunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Deal 15 damage.\nIf [gold]Fatal[/gold], gain an additional card reward.",
@@ -21994,7 +21994,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/the_scythe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_scythe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 13 damage.\nPermanently increase this card's damage by 4.",
@@ -22035,7 +22035,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/the_sealed_throne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_sealed_throne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22238,7 +22238,7 @@
       "thunderpower": "+2"
     },
     "image_url": "/static/images/cards/thunder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/thunder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you [gold]Evoke Lightning[/gold], deal 8 damage to each enemy hit.",
@@ -22404,7 +22404,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/toric_toughness.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/toric_toughness.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 7 [gold]Block[/gold].\nGain 7 [gold]Block[/gold] at the start of the next 2 turns.",
@@ -22481,7 +22481,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/tracking.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tracking.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22521,7 +22521,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/transfigure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/transfigure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22560,7 +22560,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/trash_to_treasure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/trash_to_treasure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22726,7 +22726,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/tyranny.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tyranny.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22769,7 +22769,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/ultimate_defend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_defend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 15 [gold]Block[/gold].",
@@ -22809,7 +22809,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/ultimate_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 20 damage.",
@@ -22847,7 +22847,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/undeath.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/undeath.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain 9 [gold]Block[/gold].\nAdd a copy of this card into your [gold]Discard Pile[/gold].",
@@ -22925,7 +22925,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/unmovable.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/unmovable.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23046,7 +23046,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/up_my_sleeve.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/up_my_sleeve.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Add 4 [gold]Shivs[/gold] into your [gold]Hand[/gold].\nReduce this card's cost by 1.",
@@ -23123,7 +23123,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/uproar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/uproar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 7 damage twice.\nPlay a random Attack from your [gold]Draw Pile[/gold].",
@@ -23161,7 +23161,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/veilpiercer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/veilpiercer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 13 damage.\nThe next [gold]Ethereal[/gold] card you play costs 0 [energy:1].",
@@ -23199,7 +23199,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/venerate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/venerate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gain [star:3].",
@@ -23237,7 +23237,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/vicious.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/vicious.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Whenever you apply [gold]Vulnerable[/gold], draw 2 cards.",
@@ -23327,7 +23327,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/void_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/void_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23368,7 +23368,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/volley.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/volley.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 14 damage to a random enemy X times.",
@@ -23409,7 +23409,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/voltaic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/voltaic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23455,7 +23455,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/waste_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/waste_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -23571,7 +23571,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/whistle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/whistle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 44 damage.\n[gold]Stun[/gold] the enemy.",
@@ -23696,7 +23696,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/wisp.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wisp.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23871,7 +23871,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/wrought_in_war.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wrought_in_war.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Deal 9 damage.\n[gold]Forge[/gold] 9.",

--- a/data/esp/cards.json
+++ b/data/esp/cards.json
@@ -29,7 +29,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/fisticuffs.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fisticuffs.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 9 de daño.\nObtienes [gold]bloqueo[/gold] por un valor equivalente al daño sin bloquear infligido.",
@@ -65,7 +65,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/hammer_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hammer_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -242,7 +242,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/abrasive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/abrasive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 1 de [gold]destreza[/gold].\nObtienes 6 de [gold]espinas[/gold].",
@@ -365,7 +365,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/caltrops.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/caltrops.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al recibir daño, infliges 5 de daño.",
@@ -518,7 +518,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/stack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes [gold]bloqueo[/gold] por un valor equivalente a la cantidad de cartas en la [gold]pila de descarte[/gold] +3.",
@@ -643,7 +643,7 @@
       "blackholepower": "+1"
     },
     "image_url": "/static/images/cards/black_hole.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/black_hole.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al gastar u obtener [star:1], infliges 4 de daño a TODOS los enemigos.",
@@ -683,7 +683,7 @@
       "extrablock": "+2"
     },
     "image_url": "/static/images/cards/fasten.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fasten.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 7 de [gold]bloqueo[/gold] adicionales al usar cartas «Defensa».",
@@ -722,7 +722,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/deaths_door.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/deaths_door.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 7 de [gold]bloqueo[/gold].\nSi aplicaste [gold]condena[/gold] en este turno, obtienes [gold]bloqueo[/gold] 2 veces más.",
@@ -848,7 +848,7 @@
       "starnextturnpower": "+1"
     },
     "image_url": "/static/images/cards/hidden_cache.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_cache.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes [star:1].\nEn el próximo turno, obtienes [star:4].",
@@ -887,7 +887,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/alignment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/alignment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes [energy:3].",
@@ -927,7 +927,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/soul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Robas 3 cartas.",
@@ -1007,7 +1007,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/cascade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cascade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Juegas las siguientes X+1 cartas del [gold]mazo de robo[/gold].",
@@ -1319,7 +1319,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/lift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Le das 16 de [gold]bloqueo[/gold] a otra persona.",
@@ -1405,7 +1405,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/squeeze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/squeeze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Puro Hueso[/gold] inflige 25 de daño.\nInflige 6 de daño adicional por TODOS tus demás ataques de [gold]Puro Hueso[/gold].",
@@ -1487,7 +1487,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/royal_gamble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royal_gamble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1785,7 +1785,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/ignition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ignition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1912,7 +1912,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/arsenal.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/arsenal.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1950,7 +1950,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/ascenders_bane.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ascenders_bane.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1995,7 +1995,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/bombardment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bombardment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 24 de daño.\nSi al inicio de tu turno esta carta está en tu [gold]pila de agotamiento[/gold], puedes jugarla.",
@@ -2092,7 +2092,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/murder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/murder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2131,7 +2131,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/toric_toughness.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/toric_toughness.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 7 de [gold]bloqueo[/gold].\nObtienes 7 de [gold]bloqueo[/gold] al comienzo de los próximos 2 turnos.",
@@ -2171,7 +2171,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/adaptive_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/adaptive_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 23 de daño.\nAgregas una copia de esta carta de costo 0 [energy:1] a la [gold]pila de descarte[/gold].",
@@ -2212,7 +2212,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/ricochet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ricochet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 3 de daño a un enemigo al azar 5 veces.",
@@ -2340,7 +2340,7 @@
       "focuspower": "+1"
     },
     "image_url": "/static/images/cards/focused_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/focused_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 11 de daño.\nObtienes 2 de [gold]concentración[/gold] en este turno.",
@@ -2427,7 +2427,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/crash_landing.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crash_landing.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 26 de daño a TODOS los enemigos.\nLlenas tu [gold]mano[/gold] con [gold]Escombros[/gold].",
@@ -2467,7 +2467,7 @@
       "hploss": "+2"
     },
     "image_url": "/static/images/cards/haunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al jugar una carta de [gold]Alma[/gold], un enemigo al azar pierde 8 de PV.",
@@ -2503,7 +2503,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/entrench.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entrench.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2546,7 +2546,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/waste_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/waste_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -2702,7 +2702,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/automation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/automation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2739,7 +2739,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/greed.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/greed.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2851,7 +2851,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/nostalgia.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/nostalgia.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2932,7 +2932,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/up_my_sleeve.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/up_my_sleeve.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Agregas 4 [gold]cartas de Navaja[/gold] a tu [gold]mano[/gold].\nSe reduce el costo de esta carta en 1.",
@@ -3008,7 +3008,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/bulwark.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulwark.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 16 de [gold]bloqueo[/gold].\nAplicas [gold]forja[/gold] 13.",
@@ -3090,7 +3090,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/big_bang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/big_bang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3131,7 +3131,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/tesla_coil.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tesla_coil.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 6 de daño.\nActivas todos los orbes de [gold]electricidad[/gold] contra el enemigo.",
@@ -3254,7 +3254,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/barrage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/barrage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 7 de daño por cada orbe [gold]canalizado[/gold].",
@@ -3378,7 +3378,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/spoils_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplicas [gold]forja[/gold] 8.\nRobas 2 cartas.",
@@ -3539,7 +3539,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/glow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes [star:2].\nRobas 1 carta.\nEn el siguiente turno, robas 1 carta.",
@@ -3660,7 +3660,7 @@
       "poison": "+3"
     },
     "image_url": "/static/images/cards/bubble_bubble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Si tu enemigo ya sufre [gold]veneno[/gold], aplicas 12 de [gold]veneno[/gold].",
@@ -3864,7 +3864,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/calamity.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/calamity.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4104,7 +4104,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/catastrophe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/catastrophe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Juegas 3 cartas al azar del [gold]mazo de robo[/gold].",
@@ -4144,7 +4144,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/flak_cannon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/flak_cannon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Agotas[/gold] TODAS tus cartas de estado.\nInfliges 11 de daño a un enemigo al azar por cada carta [gold]agotada[/gold].",
@@ -4182,7 +4182,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/salvo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/salvo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 16 de daño.\n[gold]Retienes[/gold] tu [gold]mano[/gold] en este turno.",
@@ -4218,7 +4218,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/splash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/splash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Eliges 1 de 3 cartas de ataque [gold]mejoradas[/gold] al azar de otro personaje para agregar a tu [gold]mano[/gold]. Puedes jugarla sin costo en este turno.",
@@ -4259,7 +4259,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/snap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/snap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Puro Hueso[/gold] inflige 10 de daño.\nAplicas [gold]retención[/gold] a una carta de tu [gold]mano[/gold].",
@@ -4304,7 +4304,7 @@
       "smokestackpower": "+2"
     },
     "image_url": "/static/images/cards/smokestack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/smokestack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al crear una carta de estado, infliges 7 de daño a TODOS los enemigos.",
@@ -4510,7 +4510,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/colossus.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/colossus.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 8 de [gold]bloqueo[/gold].\nRecibes 50 % menos de daño de enemigos con [gold]vulnerabilidad[/gold] en este turno.",
@@ -4602,7 +4602,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/comet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/comet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 44 de daño.\nAplicas 3 de [gold]debilitamiento[/gold].\nAplicas 3 de [gold]vulnerabilidad[/gold].",
@@ -4642,7 +4642,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/compact.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/compact.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 7 de [gold]bloqueo[/gold].\n[gold]Transformas[/gold] todas las cartas de estado en tu [gold]mano[/gold] en [gold]Gasolina+[/gold].",
@@ -4761,7 +4761,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/conflagration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conflagration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 8 de daño a TODOS los enemigos.\nInfliges 3 de daño adicional por cada carta de ataque que hayas jugado en este turno.",
@@ -4815,7 +4815,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/know_thy_place.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/know_thy_place.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4856,7 +4856,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/conqueror.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conqueror.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplicas [gold]forja[/gold] 5.\n[gold]Espada del soberano[/gold] inflige el doble de daño a los enemigos durante este turno.",
@@ -4895,7 +4895,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/convergence.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/convergence.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Retienes[/gold] tu [gold]mano[/gold] durante este turno.\nEn el próximo turno,\nobtienes [energy:1] y [star:2].",
@@ -4935,7 +4935,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/invoke.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/invoke.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "En el próximo turno, aplicas [gold]invocación[/gold] 3 y obtienes [energy:3].",
@@ -4975,7 +4975,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/summon_forth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/summon_forth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplicas [gold]forja[/gold] 11.\nColocas [gold]Espada del soberano[/gold] en tu [gold]mano[/gold] desde cualquier lugar.",
@@ -5020,7 +5020,7 @@
       "strength": "+3"
     },
     "image_url": "/static/images/cards/coordinate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Le das 8 de [gold]fuerza[/gold] a otra persona durante este turno.",
@@ -5099,7 +5099,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/photon_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/photon_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 13 de daño.\nRobas 2 cartas.\nColocas 1 carta de tu [gold]mano[/gold] en la parte superior del [gold]mazo de robo[/gold].",
@@ -5139,7 +5139,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/precise_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/precise_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5217,7 +5217,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/reap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 33 de daño.",
@@ -5258,7 +5258,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/believe_in_you.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/believe_in_you.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Otra persona obtiene [energy:3].",
@@ -5343,7 +5343,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/blade_of_ink.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/blade_of_ink.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Agregas 3 [gold]cartas de Navaja[/gold] con [purple]entintado[/purple] a la [gold]mano[/gold].",
@@ -5390,7 +5390,7 @@
       "phantombladespower": "+3"
     },
     "image_url": "/static/images/cards/phantom_blades.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/phantom_blades.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Las [gold]cartas de Navaja[/gold] obtienen [gold]retención[/gold].\nLa primera [gold]Navaja[/gold] que juegas en cada turno inflige 12 de daño adicional.",
@@ -5466,7 +5466,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/hang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 13 de daño.\nDuplicas el daño de TODAS las cartas [gold]Cuelgue[/gold].",
@@ -5592,7 +5592,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/collision_course.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/collision_course.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 15 de daño.\nAgregas una carta de [gold]Escombros[/gold] a tu [gold]mano[/gold].",
@@ -5630,7 +5630,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/quasar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quasar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Eliges 1 de 3 cartas incoloras [gold]mejoradas[/gold] al azar para agregar a tu [gold]mano[/gold].",
@@ -5709,7 +5709,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/hidden_daggers.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_daggers.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Descartas 2 cartas.\nAgregas 2 [gold]carta de Navaja+[/gold] a tu [gold]mano[/gold].",
@@ -5800,7 +5800,7 @@
       "dansemacabrepower": "+2"
     },
     "image_url": "/static/images/cards/danse_macabre.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/danse_macabre.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al jugar una carta de costo [energy:2] o más, obtienes 6 de [gold]bloqueo[/gold].",
@@ -5876,7 +5876,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/trash_to_treasure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/trash_to_treasure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5918,7 +5918,7 @@
       "cards": "+2"
     },
     "image_url": "/static/images/cards/decisions_decisions.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/decisions_decisions.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Robas 5 cartas.\nEliges una carta de habilidad de tu [gold]mano[/gold] y la juegas 3 veces.",
@@ -6161,7 +6161,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/ultimate_defend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_defend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 15 de [gold]bloqueo[/gold].",
@@ -6201,7 +6201,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/delay.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/delay.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 13 de [gold]bloqueo[/gold].\nEn el próximo turno,\nobtienes [energy:2].",
@@ -6248,7 +6248,7 @@
       "debilitatepower": "+1"
     },
     "image_url": "/static/images/cards/debilitate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debilitate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 12 de daño.\n[gold]Vulnerabilidad[/gold] y [gold]debilitamiento[/gold] poseen una efectividad doble contra el enemigo durante 4 los próximos turnos.",
@@ -6617,7 +6617,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/rend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 15 de daño.\nInfliges 8 de daño adicional por cada desmejora única que tenga el enemigo.",
@@ -6655,7 +6655,7 @@
       "corrosivewave": "+1"
     },
     "image_url": "/static/images/cards/corrosive_wave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/corrosive_wave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al robar una carta durante este turno, aplicas 3 de [gold]veneno[/gold] a TODOS los enemigos.",
@@ -6698,7 +6698,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/disintegration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/disintegration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -6817,7 +6817,7 @@
       "strengthloss": "+1"
     },
     "image_url": "/static/images/cards/crush_under.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crush_under.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 8 de daño a TODOS los enemigos. Los enemigos pierden 2 de [gold]fuerza[/gold] en este turno.",
@@ -6896,7 +6896,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/vicious.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/vicious.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al aplicar [gold]vulnerabilidad[/gold], robas 2 cartas.",
@@ -7053,7 +7053,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/shatter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shatter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 15 de daño a TODOS los enemigos.\n[gold]Descargas[/gold] todos tus orbes.",
@@ -7138,7 +7138,7 @@
       "parrypower": "+4"
     },
     "image_url": "/static/images/cards/parry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/parry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al jugar [gold]Espada del soberano[/gold], obtén 14 de [gold]bloqueo[/gold].",
@@ -7297,7 +7297,7 @@
       "damage": "+10"
     },
     "image_url": "/static/images/cards/devastate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devastate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 40 de daño.",
@@ -7337,7 +7337,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/maul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/maul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 6 de daño dos veces.\nAumenta el daño de TODAS las cartas [gold]Devorar[/gold] en 2 durante este combate.",
@@ -7384,7 +7384,7 @@
       "devourlifepower": "+1"
     },
     "image_url": "/static/images/cards/devour_life.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devour_life.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al jugar [gold]Alma[/gold], obtienes [gold]invocación[/gold] 2.",
@@ -7422,7 +7422,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/distraction.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/distraction.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7640,7 +7640,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/dredge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dredge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7769,7 +7769,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/clash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/clash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Solo puedes jugar esta carta si todas las cartas de tu [gold]mano[/gold] son de ataque.\nInfliges 18 de daño.",
@@ -7807,7 +7807,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/eidolon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/eidolon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7967,7 +7967,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/hotfix.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hotfix.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8053,7 +8053,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/dual_wield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Eliges una carta de ataque o de poder. Agregas 2 copias de esa carta a tu [gold]mano[/gold].",
@@ -8221,7 +8221,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/gunk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gunk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 5 de daño 3 veces.\nAgregas [gold]Babeado[/gold] a la [gold]pila de descarte[/gold].",
@@ -8304,7 +8304,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/entropy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entropy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8350,7 +8350,7 @@
       "outbreakpower": "+4"
     },
     "image_url": "/static/images/cards/outbreak.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outbreak.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cada 3 veces que aplicas [gold]veneno[/gold], infliges 15 de daño a TODOS los enemigos.",
@@ -8517,7 +8517,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/spectrum_shift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spectrum_shift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8551,7 +8551,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/frantic_escape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/frantic_escape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -8625,7 +8625,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/debris.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debris.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8666,7 +8666,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/shadow_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shadow_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 15 de [gold]bloqueo[/gold].\n[gold]Canalizas[/gold] 1 de [gold]oscuridad[/gold].",
@@ -8708,7 +8708,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/demonic_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demonic_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8794,7 +8794,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sovereign_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sovereign_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8877,7 +8877,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/refine_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refine_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplicas [gold]forja[/gold] 13.\nEn el próximo turno, obtienes [energy:1].",
@@ -8924,7 +8924,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sword_sage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sword_sage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8972,7 +8972,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/apparition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/apparition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9063,7 +9063,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/seance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9104,7 +9104,7 @@
       "blockonexhaust": "+1"
     },
     "image_url": "/static/images/cards/spirit_of_ash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spirit_of_ash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al jugar una carta con [gold]evanescencia[/gold], obtienes 5 de [gold]bloqueo[/gold].",
@@ -9183,7 +9183,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/graveblast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/graveblast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 6 de daño.\nColocas una carta de la [gold]pila de descarte[/gold] en tu [gold]mano[/gold].",
@@ -9307,7 +9307,7 @@
       "stranglepower": "+1"
     },
     "image_url": "/static/images/cards/strangle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/strangle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 10 de daño.\nAl jugar una carta en este turno, el enemigo pierde 3 PV.",
@@ -9343,7 +9343,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/stratagem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stratagem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9440,7 +9440,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/falling_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/falling_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 12 de daño.\nAplicas 1 de [gold]debilitamiento[/gold].\nAplicas 1 de [gold]vulnerabilidad[/gold].",
@@ -9481,7 +9481,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/guiding_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/guiding_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 13 de daño.\nRobas 3 cartas.",
@@ -9524,7 +9524,7 @@
       "strengthloss": "+2"
     },
     "image_url": "/static/images/cards/dying_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dying_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 11 de daño a TODOS los enemigos, los cuales pierden 11 de [gold]fuerza[/gold] en este turno.",
@@ -9567,7 +9567,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/lunar_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lunar_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 5 de daño por cada carta de habilidad que hayas jugado en este turno.",
@@ -9686,7 +9686,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/poor_sleep.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/poor_sleep.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9726,7 +9726,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/beacon_of_hope.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beacon_of_hope.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9762,7 +9762,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/enthralled.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enthralled.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9854,7 +9854,7 @@
       "strength": "+2"
     },
     "image_url": "/static/images/cards/feeding_frenzy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 7 de [gold]fuerza[/gold] en este turno.",
@@ -9895,7 +9895,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/demesne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demesne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9936,7 +9936,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/seeking_edge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeking_edge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplicas [gold]forja[/gold] 11.\n[gold]Espada del soberano[/gold] ahora inflige daño a TODOS los enemigos.",
@@ -10104,7 +10104,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/wrought_in_war.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wrought_in_war.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 9 de daño.\nAplicas [gold]forja[/gold] 9.",
@@ -10146,7 +10146,7 @@
       "calculationextra": "+2"
     },
     "image_url": "/static/images/cards/beat_into_shape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_into_shape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 7 de daño.\nAplicas [gold]forja[/gold] X.\n[gold]Forjas[/gold] 7 más por cada golpe al enemigo en este turno.",
@@ -10322,7 +10322,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/reaper_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reaper_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10369,7 +10369,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/void_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/void_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10417,7 +10417,7 @@
       "serpentformpower": "+2"
     },
     "image_url": "/static/images/cards/serpent_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/serpent_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al jugar una carta, infliges 6 de daño a un enemigo al azar.",
@@ -10460,7 +10460,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/bone_shards.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bone_shards.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Si [gold]Puro Hueso[/gold] está vivo, infliges 12 de daño a TODOS los enemigos y tú obtienes 12 de [gold]bloqueo[/gold].\n[gold]Puro Hueso[/gold] muere.",
@@ -10498,7 +10498,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/furnace.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/furnace.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al inicio de tu turno, aplicas [gold]forja[/gold] 6.",
@@ -10581,7 +10581,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/wisp.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wisp.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10708,7 +10708,7 @@
       "knockdownpower": "+1"
     },
     "image_url": "/static/images/cards/knockdown.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockdown.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 14 de daño.\nEl enemigo recibe el triple de daño de otras personas durante este turno.",
@@ -10838,7 +10838,7 @@
       "sneakypower": "+1"
     },
     "image_url": "/static/images/cards/sneaky.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sneaky.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando tu camarada ataca a un enemigo, obtienes 2 de [gold]bloqueo[/gold].",
@@ -11030,7 +11030,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/scrawl.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/scrawl.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11152,7 +11152,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/fuel.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fuel.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes [energy:1].\nRobas 2 cartas.",
@@ -11193,7 +11193,7 @@
       "replay": "+1"
     },
     "image_url": "/static/images/cards/hidden_gem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_gem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Una carta al azar del [gold]mazo de robo[/gold] que no tenga [gold]rejugada[/gold] recibe [gold]rejugada[/gold] 3.",
@@ -11557,7 +11557,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/minion_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 9 de daño.\nRobas 1 carta.",
@@ -11600,7 +11600,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/ultimate_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 20 de daño.",
@@ -11760,7 +11760,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sculpting_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sculpting_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 12 de daño.\nLe aplicas [gold]evanescencia[/gold] a una carta en tu [gold]mano[/gold].",
@@ -11932,7 +11932,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/seeker_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeker_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 12 de daño.\nEliges 1 de 3 cartas del [gold]mazo de robo[/gold] para agregar a tu [gold]mano[/gold].",
@@ -11973,7 +11973,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/shining_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shining_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 11 de daño.\nObtienes [star:2].\nColocas esta carta en la parte superior del [gold]mazo de robo[/gold].",
@@ -12172,7 +12172,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/uproar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/uproar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 7 de daño dos veces.\nJuegas una carta de ataque al azar del [gold]mazo de robo[/gold].",
@@ -12217,7 +12217,7 @@
       "hailstormpower": "+2"
     },
     "image_url": "/static/images/cards/hailstorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hailstorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al finalizar tu turno, si tienes [gold]escarcha[/gold], infliges 8 de daño a TODOS los enemigos.",
@@ -12298,7 +12298,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/forbidden_grimoire.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/forbidden_grimoire.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12340,7 +12340,7 @@
       "cost": 7
     },
     "image_url": "/static/images/cards/banshees_cry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/banshees_cry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12421,7 +12421,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/bodyguard.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bodyguard.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplicas [gold]invocación[/gold] 7.",
@@ -12537,7 +12537,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/quadcast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quadcast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12613,7 +12613,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/hegemony.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hegemony.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 18 de daño.\nEn el próximo turno, obtienes [energy:3].",
@@ -12770,7 +12770,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/soot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -12862,7 +12862,7 @@
       "preptimepower": "+2"
     },
     "image_url": "/static/images/cards/prep_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prep_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al comienzo de tu turno, obtienes 6 de [gold]vigor[/gold].",
@@ -13135,7 +13135,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/unmovable.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/unmovable.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13258,7 +13258,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/cosmic_indifference.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cosmic_indifference.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 9 de [gold]bloqueo[/gold].\nColocas una carta de la [gold]pila de descarte[/gold] en la parte superior del [gold]mazo de robo[/gold].",
@@ -13334,7 +13334,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/infection.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/infection.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13420,7 +13420,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/intercept.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/intercept.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 13 de [gold]bloqueo[/gold].\nDesvías hacia ti todos los ataques que hubieran herido a tu camarada en este turno.",
@@ -13549,7 +13549,7 @@
       "iterationpower": "+1"
     },
     "image_url": "/static/images/cards/iteration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/iteration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cada turno, la primera vez que robes una carta de estado, robas 3 cartas.",
@@ -13673,7 +13673,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/the_hunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_hunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Infliges 15 de daño.\nSi el golpe es [gold]fatal[/gold], obtienes una carta recompensa adicional.",
@@ -13718,7 +13718,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/the_scythe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_scythe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 13 de daño.\nAumenta el daño de esta carta en 4 de forma permanente.",
@@ -13802,7 +13802,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/ice_lance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ice_lance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 24 de daño.\n[gold]Canalizas[/gold] 3 de [gold]escarcha[/gold].",
@@ -13968,7 +13968,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/legion_of_bone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/legion_of_bone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Todas las personas aplican [gold]invocación[/gold] 8.",
@@ -14057,7 +14057,7 @@
       "lethalitypower": "+25"
     },
     "image_url": "/static/images/cards/lethality.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lethality.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "El primer ataque de cada turno inflige 75% de daño adicional.",
@@ -14147,7 +14147,7 @@
       "sleightoffleshpower": "+4"
     },
     "image_url": "/static/images/cards/sleight_of_flesh.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sleight_of_flesh.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al aplicar una desmejora en un enemigo, recibirá 13 de daño.",
@@ -14228,7 +14228,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/brightest_flame.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/brightest_flame.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes [energy:3].\nRobas 3 cartas.\nPierdes 1 de PV máx.",
@@ -14266,7 +14266,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/call_of_the_void.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/call_of_the_void.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14304,7 +14304,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/lantern_key.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lantern_key.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14446,7 +14446,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/fight_through.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_through.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 17 de [gold]bloqueo[/gold].\nAgregas 2 cartas de [gold]Herida[/gold] a tu [gold]pila de descarte[/gold].",
@@ -14487,7 +14487,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/luminesce.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/luminesce.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes [energy:3].",
@@ -14527,7 +14527,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/largesse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/largesse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Otra persona agrega 1 carta incolora [gold]mejorada[/gold] al azar a su [gold]mano[/gold].",
@@ -14604,7 +14604,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/bad_luck.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bad_luck.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14644,7 +14644,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/juggling.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/juggling.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14723,7 +14723,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/manifest_authority.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/manifest_authority.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 8 de [gold]bloqueo[/gold].\nAgregas 1 carta incolora [gold]mejorada[/gold] a tu [gold]mano[/gold].",
@@ -14805,7 +14805,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/right_hand_hand.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/right_hand_hand.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Puro Hueso[/gold] inflige 6 de daño.\nCuando juegas una carta con costo [energy:2] o más, esta carta regresa desde la [gold]pila de descarte[/gold] a tu [gold]mano[/gold].",
@@ -14850,7 +14850,7 @@
       "crimsonmantlepower": "+2"
     },
     "image_url": "/static/images/cards/crimson_mantle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crimson_mantle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al inicio de tu turno, pierdes 1 PV y obtienes 10 de [gold]bloqueo[/gold].",
@@ -14927,7 +14927,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/spoils_map.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_map.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15056,7 +15056,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/heirloom_hammer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heirloom_hammer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 25 de daño.\nEliges una carta incolora de la [gold]mano[/gold] y agregas una copia de esa carta a tu [gold]mano[/gold].",
@@ -15258,7 +15258,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/spore_mind.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spore_mind.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15345,7 +15345,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/mimic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mimic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15392,7 +15392,7 @@
       "ostydamage": "+5"
     },
     "image_url": "/static/images/cards/sweeping_gaze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sweeping_gaze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Puro Hueso[/gold] inflige 15 de daño a un enemigo al azar.",
@@ -15473,7 +15473,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/misery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/misery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 9 de daño.\nAplicas cualquier desmejora que tenga un enemigo a TODOS los enemigos.",
@@ -15555,7 +15555,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/rally.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rally.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TODAS las personas obtienen 17 de [gold]bloqueo[/gold].",
@@ -15594,7 +15594,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/modded.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/modded.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 1 espacio de orbe.\nRobas 2 cartas. Aumenta el costo de esta carta en 1.",
@@ -15724,7 +15724,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/monologue.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/monologue.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16137,7 +16137,7 @@
       "poison": "+2"
     },
     "image_url": "/static/images/cards/haze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplicas 6 de [gold]veneno[/gold] a TODOS los enemigos.",
@@ -16178,7 +16178,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/necro_mastery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/necro_mastery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplicas [gold]invocación[/gold] 8.\nSi [gold]Puro Hueso[/gold] pierde PV,\nTODOS los enemigos pierden la misma cantidad de PV.",
@@ -16255,7 +16255,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/undeath.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/undeath.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 9 de [gold]bloqueo[/gold].\nAgregas una copia de esta carta a la [gold]pila de descarte[/gold].",
@@ -16294,7 +16294,7 @@
       "damage": "+8"
     },
     "image_url": "/static/images/cards/knockout_blow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockout_blow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 38 de daño.\nSi matas a un enemigo, obtienes [star:5].",
@@ -16376,7 +16376,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -16594,7 +16594,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/omnislice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/omnislice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 11 de daño.\nInfliges la misma cantidad de daño a TODOS los otros enemigos.",
@@ -16634,7 +16634,7 @@
       "power": "+2"
     },
     "image_url": "/static/images/cards/shockwave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shockwave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplicas 5 de [gold]debilitamiento[/gold] y de [gold]vulnerabilidad[/gold] a TODOS los enemigos.",
@@ -16752,7 +16752,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/beat_down.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_down.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Juegas 4 cartas de ataque de la [gold]pila de descarte[/gold] al azar.",
@@ -16792,7 +16792,7 @@
       "extradamage": "+2"
     },
     "image_url": "/static/images/cards/gang_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gang_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 5 de daño.\nInfliges 7 de daño adicional por cada vez que otra persona ataque al enemigo durante este turno.",
@@ -16838,7 +16838,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/lightning_rod.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lightning_rod.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 7 de [gold]bloqueo[/gold].\nAl inicio de los próximos 2 turnos, [gold]canalizas[/gold] 1 de [gold]electricidad[/gold].",
@@ -17009,7 +17009,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/sloth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sloth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -17047,7 +17047,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/veilpiercer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/veilpiercer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 13 de daño.\nLa próxima carta con [gold]evanescencia[/gold] que juegues costará 0 [energy:1].",
@@ -17121,7 +17121,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/tracking.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tracking.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17286,7 +17286,7 @@
       "rollingboulderpower": "+5"
     },
     "image_url": "/static/images/cards/rolling_boulder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rolling_boulder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al comienzo de tu turno, infliges 10 de daño a TODOS los enemigos y aumenta este daño en 5.",
@@ -17324,7 +17324,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/pillar_of_creation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillar_of_creation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando creas una carta, obtienes 4 de [gold]bloqueo[/gold].",
@@ -17559,7 +17559,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/mind_rot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mind_rot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -17764,7 +17764,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/jackpot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/jackpot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 30 de daño.\nAgregas 3 cartas [gold]mejorada(s)[/gold] de costo 0 [energy:1] al azar a tu [gold]mano[/gold].",
@@ -17845,7 +17845,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/leading_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/leading_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 6 de daño.\nAgregas 2 [gold]cartas de Navaja[/gold] a la [gold]mano[/gold].",
@@ -17883,7 +17883,7 @@
       "starsperturn": "+1"
     },
     "image_url": "/static/images/cards/genesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/genesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al inicio de tu turno, obtienes [star:3].",
@@ -17923,7 +17923,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/production.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/production.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes [energy:3].",
@@ -17979,7 +17979,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/prowess.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 2 de [gold]fuerza[/gold].\nObtienes 2 de [gold]destreza[/gold].",
@@ -18019,7 +18019,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/defile.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/defile.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 17 de daño.",
@@ -18141,7 +18141,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/boost_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/boost_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 9 de [gold]bloqueo[/gold].\nAgregas [gold]Deslumbre[/gold] a tu [gold]pila de descarte[/gold].",
@@ -18270,7 +18270,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/astral_pulse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/astral_pulse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 18 de daño a TODOS los enemigos.",
@@ -18309,7 +18309,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/pale_blue_dot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pale_blue_dot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Si juegas 5 o más cartas en un turno, robas 2 cartas al comienzo de tu próximo turno.",
@@ -18522,7 +18522,7 @@
       "increase": "+2"
     },
     "image_url": "/static/images/cards/kingly_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/kingly_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 10 de daño.\nAl robar esta carta, aumenta su daño en 6 durante este combate.",
@@ -18562,7 +18562,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/rocket_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rocket_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 14 de daño.\nRobas 2 cartas.\nAl crear una carta de estado, se reduce el costo de esta carta a 0 [energy:1] hasta que se juegue.",
@@ -18685,7 +18685,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/make_it_so.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/make_it_so.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 9 de daño.\nCada vez que juegas 3 cartas de habilidad en este turno, colocas esta carta en tu [gold]mano[/gold].",
@@ -18998,7 +18998,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/gamma_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gamma_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 18 de daño.\nAplicas 2 de [gold]debilitamiento[/gold].\nAplicas 2 de [gold]vulnerabilidad[/gold].",
@@ -19117,7 +19117,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/rebound.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rebound.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 12 de daño.\nColocas la próxima carta que juegues en este turno en la parte superior del [gold]mazo de robo[/gold].",
@@ -19195,7 +19195,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/gather_light.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gather_light.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 11 de [gold]bloqueo[/gold].\nObtienes [star:1].",
@@ -19234,7 +19234,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/reflect.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reflect.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 21 de [gold]bloqueo[/gold].\nDurante este turno, el ataque bloqueado se refleja en tu atacante.",
@@ -19360,7 +19360,7 @@
       "gold": "+5"
     },
     "image_url": "/static/images/cards/royalties.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royalties.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Al final del combate, obtienes 35 de [gold]oro[/gold].",
@@ -19447,7 +19447,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/relax.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/relax.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 17 de [gold]bloqueo[/gold].\nRobas 3 cartas y obtienes [energy:3] al comienzo de tu próximo turno.",
@@ -19567,7 +19567,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/spite.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spite.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 5 de daño.\nSi perdiste PV en este turno,\ngolpeas 3 veces.",
@@ -19614,7 +19614,7 @@
       "vigorpower": "+1"
     },
     "image_url": "/static/images/cards/patter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/patter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 11 de [gold]bloqueo[/gold].\nObtén 3 de [gold]vigor[/gold].",
@@ -19660,7 +19660,7 @@
       "strengthpower": "+1"
     },
     "image_url": "/static/images/cards/resonance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/resonance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 2 de [gold]fuerza[/gold]. TODOS los enemigos pierden 1 de [gold]fuerza[/gold].",
@@ -19698,7 +19698,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/foregone_conclusion.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/foregone_conclusion.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "En el próximo turno, colocas 3 cartas de la [gold]pila de descarte[/gold] en tu [gold]mano[/gold].",
@@ -19789,7 +19789,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/bundle_of_joy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bundle_of_joy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Agregas 4 cartas incoloras al azar a tu [gold]mano[/gold].",
@@ -19878,7 +19878,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/huddle_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/huddle_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TODOS los jugadores roban 3 cartas.",
@@ -19920,7 +19920,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/refract.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refract.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 12 de daño dos veces.\n[gold]Canalizas[/gold] 2 de [gold]vidrio[/gold].",
@@ -20001,7 +20001,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/giant_rock.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/giant_rock.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 20 de daño.",
@@ -20125,7 +20125,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/volley.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/volley.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 14 de daño a un enemigo al azar X vez/veces.",
@@ -20205,7 +20205,7 @@
       "summon": "+1"
     },
     "image_url": "/static/images/cards/dirge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dirge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplicas [gold]invocación[/gold] 4 X vez/veces.\nAgregas X carta(s) de [gold]Alma+[/gold] al [gold]mazo de robo[/gold].",
@@ -20336,7 +20336,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/minion_sacrifice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_sacrifice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 12 de [gold]bloqueo[/gold].",
@@ -20422,7 +20422,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/feral.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feral.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20499,7 +20499,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/pillage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 9 de daño.\nRobas cartas hasta que robes una que no sea de ataque.",
@@ -20629,7 +20629,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/severance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/severance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 18 de daño.\nAgregas [gold]Alma[/gold] al [gold]mazo de robo[/gold], a tu [gold]mano[/gold] y a la [gold]pila de descarte[/gold].",
@@ -20667,7 +20667,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/bury.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bury.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 63 de daño.",
@@ -20748,7 +20748,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 11 de daño a TODOS los enemigos.",
@@ -20827,7 +20827,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/seven_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seven_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20867,7 +20867,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/whistle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/whistle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 44 de daño.\n[gold]Aturdes[/gold] al enemigo.",
@@ -20951,7 +20951,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/synchronize.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synchronize.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21034,7 +21034,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/energy_surge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/energy_surge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TODAS las personas obtienen [energy:3].",
@@ -21084,7 +21084,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/neurosurge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neurosurge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes [energy:4].\nRobas 2 cartas.\nAl inicio de tu turno, aplicas 3 de [gold]condena[/gold].",
@@ -21168,7 +21168,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/consuming_shadow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/consuming_shadow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Canalizas[/gold] 3 de [gold]oscuridad[/gold].\nAl final de tu turno, [gold]descargas[/gold] tu orbe del extremo izquierdo.",
@@ -21206,7 +21206,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/i_am_invincible.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/i_am_invincible.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 13 de [gold]bloqueo[/gold].\nSi al final de tu turno esta carta está en la parte superior del [gold]mazo de robo[/gold], la juegas.",
@@ -21251,7 +21251,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/spinner.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spinner.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Canalizas[/gold] 1 de [gold]vidrio[/gold].\nAl comienzo de tu turno, [gold]canalizas[/gold] 1 de [gold]vidrio[/gold].",
@@ -21287,7 +21287,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/subroutine.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/subroutine.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21368,7 +21368,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/supermassive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/supermassive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 5 de daño.\nInfliges 4 de daño adicional por cada carta creada en este combate.",
@@ -21540,7 +21540,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/synthesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synthesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 18 de daño.\nEl próximo poder que juegues costará 0 [energy:1].",
@@ -21580,7 +21580,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/turbo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/turbo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes [energy:3].\nAgregas [gold]Vacío[/gold] a la [gold]pila de descarte[/gold].",
@@ -21619,7 +21619,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/heavenly_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heavenly_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 10 de daño X vez/veces.\nDuplicas X vez/veces si usas 4 o más.",
@@ -21659,7 +21659,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/helix_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/helix_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 5 de daño por cada [energy:1] que gastes en este turno.",
@@ -21705,7 +21705,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/drum_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/drum_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Robas 3 cartas.\nAl inicio de tu turno, [gold]agotas[/gold] la carta en la parte superior del [gold]mazo de robo[/gold].",
@@ -21741,7 +21741,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/tank.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tank.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21872,7 +21872,7 @@
       "vigorpower": "+2"
     },
     "image_url": "/static/images/cards/terraforming.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/terraforming.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 8 de [gold]vigor[/gold].",
@@ -22073,7 +22073,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/tyranny.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tyranny.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22116,7 +22116,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/pull_from_below.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pull_from_below.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 7 de daño por cada carta con [gold]evanescencia[/gold] que juegues en este combate.",
@@ -22241,7 +22241,7 @@
       "strengthloss": "+3"
     },
     "image_url": "/static/images/cards/enfeebling_touch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enfeebling_touch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "El enemigo pierde 11 de [gold]fuerza[/gold] en este turno.",
@@ -22372,7 +22372,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/soul_storm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul_storm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 9 de daño.\nInfliges 3 de daño adicional por cada [gold]Alma[/gold] en la [gold]pila de agotamiento[/gold].",
@@ -22448,7 +22448,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/pagestorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pagestorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22573,7 +22573,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/knife_trap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knife_trap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Mejoras[/gold] y juegas todas las [gold]carta de Navaja[/gold] de la [gold]pila de agotamiento[/gold] contra el enemigo.",
@@ -22651,7 +22651,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/transfigure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/transfigure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22697,7 +22697,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/rattle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rattle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Puro Hueso[/gold] inflige 9 de daño.\nGolpea una vez más por cada vez que haya atacado en este turno.",
@@ -22735,7 +22735,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/the_sealed_throne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_sealed_throne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22818,7 +22818,7 @@
       "thunderpower": "+2"
     },
     "image_url": "/static/images/cards/thunder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/thunder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al [gold]descargar electricidad[/gold], infliges 8 de daño a cada enemigo que golpee.",
@@ -22899,7 +22899,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/afterlife.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/afterlife.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplicas [gold]invocación[/gold] 9.",
@@ -23062,7 +23062,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/shroud.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shroud.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al aplicar [gold]condena[/gold], obtienes 3 de [gold]bloqueo[/gold].",
@@ -23107,7 +23107,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/speedster.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/speedster.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23190,7 +23190,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/venerate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/venerate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes [star:3].",
@@ -23228,7 +23228,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/outmaneuver.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outmaneuver.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "En el próximo turno, obtienes [energy:3].",
@@ -23270,7 +23270,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/glimpse_beyond.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glimpse_beyond.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Todas las personas agregan 4 [gold]cartas de Alma[/gold] a sus [gold]mazos de robo[/gold].",
@@ -23352,7 +23352,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/glasswork.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glasswork.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 8 de [gold]bloqueo[/gold].\n[gold]Canalizas[/gold] 1 de [gold]vidrio[/gold].",
@@ -23388,7 +23388,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/beckon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beckon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23429,7 +23429,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/voltaic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/voltaic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23529,7 +23529,7 @@
       "dexterity": "+1"
     },
     "image_url": "/static/images/cards/bulk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Pierdes 1 espacio de orbe.\nObtienes 3 de [gold]fuerza[/gold].\nObtienes 3 de [gold]destreza[/gold].",
@@ -23567,7 +23567,7 @@
       "blockforstars": "+1"
     },
     "image_url": "/static/images/cards/child_of_the_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/child_of_the_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al gastar [star:1], obtienes 3 de [gold]bloqueo[/gold] por cada [star:1] gastada.",
@@ -23617,7 +23617,7 @@
       "sicempower": "+1"
     },
     "image_url": "/static/images/cards/sic_em.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sic_em.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Puro Hueso[/gold] inflige 6 de daño.\nCuando [gold]Puro Hueso[/gold] golpea a un enemigo en este turno, aplica [gold]invocación[/gold] 3.",
@@ -23666,7 +23666,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/fight_me.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliges 6 de daño dos veces.\nObtienes 4 de [gold]fuerza[/gold].\nEl enemigo obtiene 1 de [gold]fuerza[/gold].",
@@ -23702,7 +23702,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/hello_world.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hello_world.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23740,7 +23740,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/begone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/begone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Eliges una carta de tu [gold]mano[/gold] para [gold]transformarla[/gold] en [gold]Golpe de esbirro+[/gold].",
@@ -23869,7 +23869,7 @@
       "platingpower": "+3"
     },
     "image_url": "/static/images/cards/neutron_aegis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neutron_aegis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Obtienes 11 de [gold]revestimiento[/gold].",

--- a/data/fra/cards.json
+++ b/data/fra/cards.json
@@ -45,7 +45,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/abrasive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/abrasive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 1 de [gold]Dextérité[/gold].\nGagnez 6 [gold]Épines[/gold].",
@@ -272,7 +272,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/quadcast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quadcast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -312,7 +312,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/invoke.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/invoke.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Au prochain tour, [gold]Invoquez[/gold] pour 3 et gagnez [energy:3].",
@@ -431,7 +431,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/make_it_so.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/make_it_so.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 9 dégâts.\nToutes les 3 Compétences jouées par tour, placez cette carte dans votre [gold]Main[/gold].",
@@ -555,7 +555,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/alignment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/alignment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez [energy:3].",
@@ -593,7 +593,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/ignition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ignition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -634,7 +634,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/dual_wield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Choisissez une carte Attaque ou Pouvoir. Ajoutez 2 copies de cette carte à votre [gold]Main[/gold].",
@@ -727,7 +727,7 @@
       "debilitatepower": "+1"
     },
     "image_url": "/static/images/cards/debilitate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debilitate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 12 dégâts.\nL'efficacité de [gold]Vulnérable[/gold] et [gold]Affaibli[/gold] sur l'ennemi est doublée pendant les 4 prochains tours.",
@@ -1007,7 +1007,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/apparition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/apparition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1047,7 +1047,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/beckon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beckon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1085,7 +1085,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/call_of_the_void.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/call_of_the_void.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1385,7 +1385,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/arsenal.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/arsenal.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1423,7 +1423,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/volley.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/volley.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 14 dégâts à un ennemi aléatoire X fois.",
@@ -1515,7 +1515,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/lift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Octroyez 16 d'[gold]Armure[/gold] à un autre joueur.",
@@ -1551,7 +1551,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/enthralled.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enthralled.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1592,7 +1592,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/outmaneuver.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outmaneuver.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Au prochain tour, gagnez [energy:3].",
@@ -1632,7 +1632,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/crash_landing.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crash_landing.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 26 dégâts à TOUS les ennemis.\nRemplissez votre [gold]Main[/gold] de [gold]Débris[/gold].",
@@ -1706,7 +1706,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/automation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/automation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1744,7 +1744,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/manifest_authority.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/manifest_authority.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 8 d'[gold]Armure[/gold].\nAjoutez 1 carte Incolore aléatoire [gold]Améliorée[/gold] à votre [gold]Main[/gold].",
@@ -1782,7 +1782,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/fisticuffs.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fisticuffs.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 9 dégâts.\nGagnez un montant d'[gold]Armure[/gold] égal aux dégâts infligés.",
@@ -1873,7 +1873,7 @@
       "ostydamage": "+5"
     },
     "image_url": "/static/images/cards/sweeping_gaze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sweeping_gaze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Titos[/gold] inflige 15 dégâts à un ennemi aléatoire.",
@@ -1913,7 +1913,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/beacon_of_hope.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beacon_of_hope.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1953,7 +1953,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/barrage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/barrage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 7 dégâts pour chaque Orbe [gold]Canalisé[/gold].",
@@ -2121,7 +2121,7 @@
       "extrablock": "+2"
     },
     "image_url": "/static/images/cards/fasten.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fasten.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Vos cartes Défense confèrent 7 d'[gold]Armure[/gold] supplémentaire.",
@@ -2164,7 +2164,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/big_bang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/big_bang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2244,7 +2244,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/tesla_coil.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tesla_coil.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 6 dégâts.\nDéclenchez la capacité passive de tous vos [gold]Orbes kérauniques[/gold] sur l'ennemi.",
@@ -2322,7 +2322,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/bombardment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bombardment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 24 dégâts.\nAu début de votre tour, si cette carte est dans votre pile de cartes [gold]Épuisées[/gold], jouez-la.",
@@ -2403,7 +2403,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/boost_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/boost_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 9 d'[gold]Armure[/gold].\nAjoutez [gold]Hébété[/gold] à votre [gold]Défausse[/gold].",
@@ -2483,7 +2483,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/demonic_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demonic_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2524,7 +2524,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/shadow_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shadow_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 15 d'[gold]Armure[/gold].\n[gold]Canalisez[/gold] 1 [gold]Orbe ténébreux[/gold].",
@@ -2707,7 +2707,7 @@
       "poison": "+2"
     },
     "image_url": "/static/images/cards/haze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Appliquez 6 de [gold]Poison[/gold] à TOUS les ennemis.",
@@ -2750,7 +2750,7 @@
       "strengthloss": "+1"
     },
     "image_url": "/static/images/cards/crush_under.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crush_under.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 8 dégâts à TOUS les ennemis. Tous les ennemis perdent 2 de [gold]Force[/gold] jusqu'à la fin du tour.",
@@ -2907,7 +2907,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/spoils_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forgez[/gold] pour 8.\nPiochez 2 cartes.",
@@ -3031,7 +3031,7 @@
       "starnextturnpower": "+1"
     },
     "image_url": "/static/images/cards/hidden_cache.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_cache.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez [star:1].\nAu prochain tour, gagnez [star:4].",
@@ -3071,7 +3071,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/bundle_of_joy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bundle_of_joy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ajoutez 4 cartes Incolores aléatoires à votre [gold]Main[/gold].",
@@ -3110,7 +3110,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/calamity.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/calamity.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3233,7 +3233,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/flak_cannon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/flak_cannon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Épuisez[/gold] TOUTES vos cartes Statut.\nInfligez 11 dégâts à un ennemi aléatoire pour chaque carte [gold]Épuisée[/gold].",
@@ -3354,7 +3354,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/spoils_map.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_map.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3393,7 +3393,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/cascade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cascade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Jouez les X+1 cartes du dessus de votre [gold]Pioche[/gold].",
@@ -3431,7 +3431,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/catastrophe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/catastrophe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Jouez 3 cartes aléatoires depuis votre [gold]Pioche[/gold].",
@@ -3555,7 +3555,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/caltrops.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/caltrops.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 5 dégâts à l'attaquant chaque fois que vous êtes la cible d'une attaque.",
@@ -3600,7 +3600,7 @@
       "smokestackpower": "+2"
     },
     "image_url": "/static/images/cards/smokestack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/smokestack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous créez un Statut, infligez 7 dégâts à TOUS les ennemis.",
@@ -3695,7 +3695,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/falling_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/falling_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 12 dégâts.\nAppliquez [gold]Affaibli[/gold] (1).\nAppliquez [gold]Vulnérable[/gold] (1).",
@@ -3737,7 +3737,7 @@
       "calculationextra": "+2"
     },
     "image_url": "/static/images/cards/beat_into_shape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_into_shape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 7 dégâts.\n[gold]Forgez[/gold] pour X.\n[gold]Forgez[/gold] pour 7 supplémentaires pour chaque fois que vous avez touché l'ennemi pendant ce tour.",
@@ -3773,7 +3773,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/splash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/splash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Choisissez 1 Attaque [gold]Améliorée[/gold] parmi 3 aléatoires d'un autre personnage à ajouter à votre [gold]Main[/gold]. Elle coûte [blue]0[/blue] ce tour.",
@@ -3814,7 +3814,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/snap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/snap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Titos[/gold] inflige 10 dégâts.\nAjoutez [gold]Retenue[/gold] à une carte dans votre [gold]Main[/gold].",
@@ -3857,7 +3857,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/rattle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rattle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Titos[/gold] inflige 9 dégâts.\nSe déclenche un nombre de fois supplémentaires égal au nombre de fois qu'il a déjà attaqué ce tour.",
@@ -3933,7 +3933,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/lantern_key.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lantern_key.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3975,7 +3975,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/colossus.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/colossus.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 8 d'[gold]Armure[/gold].\nVous subissez 50% de dégâts en moins des ennemis [gold]Vulnérables[/gold] pendant ce tour.",
@@ -4054,7 +4054,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/fuel.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fuel.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez [energy:1].\nPiochez 2 cartes.",
@@ -4097,7 +4097,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/compact.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/compact.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 7 d'[gold]Armure[/gold].\n[gold]Transformez[/gold] toutes les cartes Statut de votre [gold]Main[/gold] en [gold]Combustible+[/gold].",
@@ -4191,7 +4191,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/comet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/comet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 44 dégâts.\nAppliquez [gold]Affaibli[/gold] (3).\nAppliquez [gold]Vulnérable[/gold] (3).",
@@ -4267,7 +4267,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/believe_in_you.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/believe_in_you.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Un autre joueur gagne [energy:3].",
@@ -4305,7 +4305,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/clash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/clash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ne peut être joué que si toutes les cartes dans votre [gold]Main[/gold] sont des Attaques.\nInfligez 18 dégâts.",
@@ -4343,7 +4343,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/conqueror.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conqueror.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forgez[/gold] pour 5.\n[gold]Lame souveraine[/gold] inflige le double de dégâts à l'ennemi pendant ce tour.",
@@ -4379,7 +4379,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/spore_mind.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spore_mind.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4421,7 +4421,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/convergence.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/convergence.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Au prochain tour,\ngagnez [energy:1] et [star:2].\n[gold]Retenez[/gold] votre [gold]Main[/gold] jusqu'au tour suivant.",
@@ -4466,7 +4466,7 @@
       "strength": "+3"
     },
     "image_url": "/static/images/cards/coordinate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Donnez à un autre joueur 8 de [gold]Force[/gold] jusqu'à la fin du tour.",
@@ -4513,7 +4513,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/hotfix.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hotfix.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4760,7 +4760,7 @@
       "increase": "+2"
     },
     "image_url": "/static/images/cards/kingly_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/kingly_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 10 dégâts.\nLorsque vous piochez cette carte, augmentez les dégâts qu'elle inflige de 6 jusqu'à la fin du combat.",
@@ -5048,7 +5048,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/foregone_conclusion.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/foregone_conclusion.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Au prochain tour, placez 3 cartes de votre [gold]Pioche[/gold] dans votre [gold]Main[/gold].",
@@ -5087,7 +5087,7 @@
       "cost": 7
     },
     "image_url": "/static/images/cards/banshees_cry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/banshees_cry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5251,7 +5251,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/greed.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/greed.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5295,7 +5295,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/severance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/severance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 18 dégâts.\nAjoutez une [gold]Âme[/gold] à votre [gold]Pioche[/gold], à votre [gold]Main[/gold] et à votre [gold]Défausse[/gold].",
@@ -5341,7 +5341,7 @@
       "dansemacabrepower": "+2"
     },
     "image_url": "/static/images/cards/danse_macabre.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/danse_macabre.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous jouez une carte qui coûte [energy:2] ou plus, gagnez 6 d'[gold]Armure[/gold].",
@@ -5509,7 +5509,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/distraction.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/distraction.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5553,7 +5553,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/demesne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demesne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5775,7 +5775,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/right_hand_hand.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/right_hand_hand.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Titos[/gold] inflige 6 dégâts.\nLorsque vous jouez une carte qui coûte [energy:2] ou plus, cette carte retourne dans votre [gold]Main[/gold] depuis la [gold]Défausse[/gold].",
@@ -5811,7 +5811,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/debris.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debris.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6266,7 +6266,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/ultimate_defend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_defend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 15 d'[gold]Armure[/gold].",
@@ -6409,7 +6409,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/gamma_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gamma_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 18 dégâts.\nAppliquez [gold]Affaibli[/gold] (2).\nAppliquez [gold]Vulnérable[/gold] (2).",
@@ -6449,7 +6449,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/lunar_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lunar_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 5 dégâts pour chaque Compétence déjà jouée pendant ce tour.",
@@ -6535,7 +6535,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/graveblast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/graveblast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 6 dégâts.\nPlacez une carte de votre [gold]Défausse[/gold] dans votre [gold]Main[/gold].",
@@ -6626,7 +6626,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/mind_rot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mind_rot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -6666,7 +6666,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/delay.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/delay.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 13 d'[gold]Armure[/gold].\nAu prochain tour,\ngagnez [energy:2].",
@@ -6747,7 +6747,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/waste_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/waste_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -6828,7 +6828,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/disintegration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/disintegration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -6868,7 +6868,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/dredge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dredge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6909,7 +6909,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/shatter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shatter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 15 dégâts à TOUS les ennemis.\n[gold]Activez[/gold] tous vos Orbes.",
@@ -6952,7 +6952,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/bone_shards.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bone_shards.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Si [gold]Titos[/gold] est en vie, il inflige 12 dégâts à TOUS les ennemis, et vous gagnez 12 d'[gold]Armure[/gold].\n[gold]Titos[/gold] périt.",
@@ -6991,7 +6991,7 @@
       "damage": "+10"
     },
     "image_url": "/static/images/cards/devastate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devastate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 40 dégâts.",
@@ -7076,7 +7076,7 @@
       "devourlifepower": "+1"
     },
     "image_url": "/static/images/cards/devour_life.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devour_life.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous jouez une [gold]Âme[/gold], [gold]Invoquez[/gold] pour 2.",
@@ -7114,7 +7114,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/eidolon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/eidolon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7270,7 +7270,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/gunk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gunk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 5 dégâts 3 fois.\nAjoutez [gold]Englué[/gold] à votre [gold]Défausse[/gold].",
@@ -7308,7 +7308,7 @@
       "blockforstars": "+1"
     },
     "image_url": "/static/images/cards/child_of_the_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/child_of_the_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous dépensez [star:1], gagnez 3 d'[gold]Armure[/gold] pour chaque [star:1] dépensée.",
@@ -7434,7 +7434,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/precise_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/precise_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7475,7 +7475,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/photon_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/photon_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 13 dégâts.\nPiochez 2 cartes.\nChoisissez 1 carte de votre [gold]Main[/gold] à placer sur le dessus de votre [gold]Pioche[/gold].",
@@ -7513,7 +7513,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/bury.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bury.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 63 dégâts.",
@@ -7594,7 +7594,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/entropy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entropy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7722,7 +7722,7 @@
       "blockonexhaust": "+1"
     },
     "image_url": "/static/images/cards/spirit_of_ash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spirit_of_ash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous jouez une carte [gold]Éthérée[/gold], gagnez 5 d'[gold]Armure[/gold].",
@@ -7848,7 +7848,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/speedster.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/speedster.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8088,7 +8088,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/wisp.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wisp.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8301,7 +8301,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/brightest_flame.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/brightest_flame.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez [energy:3].\nPiochez 3 cartes.\nPerdez 1 PV Max.",
@@ -8341,7 +8341,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/energy_surge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/energy_surge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TOUS les joueurs gagnent [energy:3].",
@@ -8382,7 +8382,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/ascenders_bane.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ascenders_bane.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8504,7 +8504,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/heavenly_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heavenly_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 10 dégâts X fois.\nX est doublé si sa valeur est de 4 ou plus.",
@@ -8544,7 +8544,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/wrought_in_war.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wrought_in_war.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 9 dégâts.\n[gold]Forgez[/gold] pour 9.",
@@ -8580,7 +8580,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/reaper_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reaper_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8627,7 +8627,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/void_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/void_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8675,7 +8675,7 @@
       "serpentformpower": "+2"
     },
     "image_url": "/static/images/cards/serpent_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/serpent_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous jouez une carte, infligez 6 dégâts à un ennemi aléatoire.",
@@ -8851,7 +8851,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/entrench.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entrench.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8968,7 +8968,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/furnace.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/furnace.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Au début de votre tour, [gold]Forgez[/gold] pour 6.",
@@ -9208,7 +9208,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/adaptive_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/adaptive_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 23 dégâts.\nAjoutez une copie de cette carte coûtant 0 [energy:1] à votre [gold]Défausse[/gold].",
@@ -9291,7 +9291,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/seeker_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeker_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 12 dégâts.\nChoisissez 1 carte parmi 3 de votre [gold]Pioche[/gold] à ajouter dans votre [gold]Main[/gold].",
@@ -9335,7 +9335,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/minion_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 9 dégâts.\nPiochez 1 carte.",
@@ -9460,7 +9460,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sculpting_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sculpting_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 12 dégâts.\nAjoutez [gold]Éthéré[/gold] à une carte dans votre [gold]Main[/gold].",
@@ -9549,7 +9549,7 @@
       "focuspower": "+1"
     },
     "image_url": "/static/images/cards/focused_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/focused_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 11 dégâts.\nGagnez 2 de [gold]Focalisation[/gold] jusqu'à la fin du tour.",
@@ -9592,7 +9592,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/leading_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/leading_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 6 dégâts.\nAjoutez 2 [gold]Surins[/gold] à votre [gold]Main[/gold].",
@@ -9804,7 +9804,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/shining_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shining_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 11 dégâts.\nGagnez [star:2].\nPlacez cette carte sur le dessus de votre [gold]Pioche[/gold].",
@@ -9886,7 +9886,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/ultimate_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 20 dégâts.",
@@ -10057,7 +10057,7 @@
       "sneakypower": "+1"
     },
     "image_url": "/static/images/cards/sneaky.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sneaky.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsqu'un autre joueur attaque un ennemi, gagnez 2 d'[gold]Armure[/gold].",
@@ -10177,7 +10177,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/bodyguard.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bodyguard.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Invoquez[/gold] pour 7.",
@@ -10215,7 +10215,7 @@
       "starsperturn": "+1"
     },
     "image_url": "/static/images/cards/genesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/genesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Au début de votre tour, gagnez [star:3].",
@@ -10369,7 +10369,7 @@
       "cards": "+2"
     },
     "image_url": "/static/images/cards/decisions_decisions.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/decisions_decisions.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Piochez 5 cartes.\nSélectionnez une Compétence dans votre [gold]Main[/gold] et jouez-la 3 fois.",
@@ -10446,7 +10446,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/scrawl.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/scrawl.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10527,7 +10527,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/forbidden_grimoire.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/forbidden_grimoire.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10570,7 +10570,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/huddle_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/huddle_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TOUS les joueurs piochent 3 cartes.",
@@ -10611,7 +10611,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/begone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/begone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Choisissez une carte dans votre [gold]Main[/gold] à [gold]Transformer[/gold] en [gold]Frappe de sbire+[/gold].",
@@ -10729,7 +10729,7 @@
       "hploss": "+2"
     },
     "image_url": "/static/images/cards/haunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous jouez une [gold]Âme[/gold], un ennemi aléatoire perd 8 PV.",
@@ -10805,7 +10805,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/hello_world.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hello_world.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10906,7 +10906,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/know_thy_place.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/know_thy_place.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11033,7 +11033,7 @@
       "damage": "+8"
     },
     "image_url": "/static/images/cards/knockout_blow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockout_blow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 38 dégâts.\nSi vous tuez un ennemi ainsi, gagnez [star:5].",
@@ -11202,7 +11202,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/hegemony.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hegemony.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 18 dégâts.\nAu prochain tour, gagnez [energy:3].",
@@ -11444,7 +11444,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/mimic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mimic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11526,7 +11526,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/conflagration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conflagration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 8 dégâts à TOUS les ennemis.\nInflige 3 dégâts supplémentaires pour chaque autre Attaque que vous avez jouée ce tour.",
@@ -11564,7 +11564,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/cosmic_indifference.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cosmic_indifference.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 9 d'[gold]Armure[/gold].\nPlacez une carte de votre [gold]Défausse[/gold] sur le dessus de votre [gold]Pioche[/gold].",
@@ -11602,7 +11602,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/infection.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/infection.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11641,7 +11641,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/unmovable.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/unmovable.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11688,7 +11688,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/neurosurge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neurosurge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez [energy:4].\nPiochez 2 cartes.\nAu début de votre tour, appliquez 3 de [gold]Fatalité[/gold] à vous-même.",
@@ -11768,7 +11768,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/poor_sleep.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/poor_sleep.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11810,7 +11810,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/intercept.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/intercept.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 13 d'[gold]Armure[/gold].\nInterceptez toutes les attaques qui ciblent un autre joueur.",
@@ -11988,7 +11988,7 @@
       "iterationpower": "+1"
     },
     "image_url": "/static/images/cards/iteration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/iteration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "La première fois de chaque tour que vous piochez une carte Statut, piochez 3 cartes.",
@@ -12065,7 +12065,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/jackpot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/jackpot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 30 dégâts.\nAjoutez 3 cartes aléatoires [gold]Améliorées[/gold] coûtant 0 [energy:1] à votre [gold]Main[/gold].",
@@ -12104,7 +12104,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/ice_lance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ice_lance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 24 dégâts.\n[gold]Canalisez[/gold] 3 [gold]Orbes glaciaires[/gold].",
@@ -12142,7 +12142,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/i_am_invincible.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/i_am_invincible.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 13 d'[gold]Armure[/gold].\nÀ la fin de votre tour, si cette carte est sur le dessus de votre [gold]Pioche[/gold], jouez-la.",
@@ -12223,7 +12223,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/juggling.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/juggling.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12266,7 +12266,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/squeeze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/squeeze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Titos[/gold] inflige 25 dégâts.\nInflige 6 dégâts supplémentaires pour CHACUNE de vos autres Attaques de [gold]Titos[/gold].",
@@ -12304,7 +12304,7 @@
       "replay": "+1"
     },
     "image_url": "/static/images/cards/hidden_gem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_gem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Une carte aléatoire sans [gold]Écho[/gold] de votre [gold]Pioche[/gold] gagne [gold]Écho[/gold] 3.",
@@ -12385,7 +12385,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/hammer_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hammer_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12470,7 +12470,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/summon_forth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/summon_forth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forgez[/gold] pour 11.\nPlacez [gold]Lame souveraine[/gold] dans votre [gold]Main[/gold] depuis n'importe où.",
@@ -12551,7 +12551,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/the_scythe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_scythe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 13 dégâts.\nAugmentez les dégâts de cette carte de 4 de façon permanente.",
@@ -12632,7 +12632,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/the_hunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_hunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Infligez 15 dégâts.\n[gold]Coup de grâce[/gold] : obtenez une récompense de carte supplémentaire.",
@@ -12711,7 +12711,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/seeking_edge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeking_edge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forgez[/gold] pour 11.\n[gold]Lame souveraine[/gold] inflige désormais ses dégâts à TOUS les ennemis.",
@@ -12751,7 +12751,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/blade_of_ink.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/blade_of_ink.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ajoutez 3 [gold]Surins[/gold] [purple]Encrés[/purple] à votre [gold]Main[/gold].",
@@ -12831,7 +12831,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/refine_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refine_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forgez[/gold] pour 13.\nAu prochain tour, gagnez [energy:1].",
@@ -12875,7 +12875,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sovereign_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sovereign_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12925,7 +12925,7 @@
       "phantombladespower": "+3"
     },
     "image_url": "/static/images/cards/phantom_blades.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/phantom_blades.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Vos [gold]Surins[/gold] gagnent [gold]Retenue[/gold].\nLe premier [gold]Surin[/gold] que vous jouez chaque tour inflige 12 dégâts supplémentaires.",
@@ -13037,7 +13037,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/largesse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/largesse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Un autre joueur ajoute 1 carte Incolore [gold]Améliorée[/gold] à sa [gold]Main[/gold].",
@@ -13114,7 +13114,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/the_sealed_throne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_sealed_throne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13230,7 +13230,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/glow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez [star:2].\nPiochez 1 carte.\nAu prochain tour, piochez 1 carte.",
@@ -13269,7 +13269,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/gather_light.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gather_light.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 11 d'[gold]Armure[/gold].\nGagnez [star:1].",
@@ -13309,7 +13309,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/fight_through.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_through.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 17 d'[gold]Armure[/gold].\nAjoutez 2 [gold]Plaies[/gold] à votre [gold]Défausse[/gold].",
@@ -13349,7 +13349,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/legion_of_bone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/legion_of_bone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TOUS les joueurs [gold]Invoquent[/gold] pour 8.",
@@ -13399,7 +13399,7 @@
       "lethalitypower": "+25"
     },
     "image_url": "/static/images/cards/lethality.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lethality.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "La première Attaque jouée chaque tour inflige 75% de dégâts supplémentaires.",
@@ -13601,7 +13601,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/bad_luck.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bad_luck.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13730,7 +13730,7 @@
       "crimsonmantlepower": "+2"
     },
     "image_url": "/static/images/cards/crimson_mantle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crimson_mantle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Au début de votre tour, perdez 1 PV et gagnez 10 d'[gold]Armure[/gold].",
@@ -13856,7 +13856,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/heirloom_hammer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heirloom_hammer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 25 dégâts.\nSélectionnez une carte Incolore dans votre [gold]Main[/gold]. Ajoutez une copie de cette carte à votre [gold]Main[/gold].",
@@ -13975,7 +13975,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/necro_mastery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/necro_mastery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Invoquez[/gold] pour 8.\nLorsque [gold]Titos[/gold] perd des PV,\nTOUS les ennemis en perdent le même montant.",
@@ -14056,7 +14056,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/murder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/murder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14096,7 +14096,7 @@
       "extradamage": "+2"
     },
     "image_url": "/static/images/cards/gang_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gang_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 5 dégâts.\nInflige 7 dégâts supplémentaires pour chaque fois qu'un autre joueur a attaqué l'ennemi durant ce tour.",
@@ -14179,7 +14179,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/misery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/misery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 9 dégâts.\nAppliquez tous les effets néfastes présent sur l'ennemi à TOUS les autres ennemis.",
@@ -14218,7 +14218,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/modded.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/modded.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 1 Emplacement d'Orbe.\nPiochez 2 cartes. Augmentez le coût de cette carte de 1.",
@@ -14258,7 +14258,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/reap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 33 dégâts.",
@@ -14299,7 +14299,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/monologue.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/monologue.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14387,7 +14387,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/undeath.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/undeath.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 9 d'[gold]Armure[/gold].\nAjoutez une copie de cette carte à votre [gold]Défausse[/gold].",
@@ -14505,7 +14505,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/maul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/maul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 6 dégâts 2 fois.\nAugmentez les dégâts de TOUTES les cartes Mutilation de 2 jusqu'à la fin du combat.",
@@ -14751,7 +14751,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/nostalgia.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/nostalgia.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14930,7 +14930,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/consuming_shadow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/consuming_shadow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Canalisez[/gold] 3 [gold]Orbes ténébreux[/gold].\nÀ la fin de votre tour, [gold]Activez[/gold] votre Orbe le plus à gauche.",
@@ -14968,7 +14968,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/omnislice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/omnislice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 11 dégâts.\nInfligez le même montant de dégâts à TOUS les autres ennemis.",
@@ -15008,7 +15008,7 @@
       "power": "+2"
     },
     "image_url": "/static/images/cards/shockwave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shockwave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Appliquez [gold]Affaibli[/gold] (5) et [gold]Vulnérable[/gold] (5) à TOUS les ennemis.",
@@ -15098,7 +15098,7 @@
       "summon": "+1"
     },
     "image_url": "/static/images/cards/dirge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dirge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Invoquez[/gold] pour 4 X fois.\nAjoutez X [gold]Âmes+[/gold] à votre [gold]Pioche[/gold].",
@@ -15341,7 +15341,7 @@
       "parrypower": "+4"
     },
     "image_url": "/static/images/cards/parry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/parry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous jouez [gold]Lame souveraine[/gold], gagnez 14 d'[gold]Armure[/gold].",
@@ -15387,7 +15387,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/lightning_rod.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lightning_rod.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 7 d'[gold]Armure[/gold].\nAu début de vos 2 prochains tours, [gold]Canalisez[/gold] 1 [gold]Orbe kéraunique[/gold].",
@@ -15468,7 +15468,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/sloth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sloth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -15509,7 +15509,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/royal_gamble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royal_gamble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15630,7 +15630,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Récupérez 13 PV.",
@@ -15671,7 +15671,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/beat_down.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_down.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Jouez 4 Attaques aléatoires depuis votre [gold]Défausse[/gold].",
@@ -15711,7 +15711,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/up_my_sleeve.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/up_my_sleeve.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ajoutez 4 [gold]Surins[/gold] à votre [gold]Main[/gold].\nRéduisez le coût de cette carte de 1.",
@@ -15749,7 +15749,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/hang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 13 dégâts.\nDouble les dégâts de TOUTES les cartes Pendaison que vous jouez sur cet ennemi.",
@@ -15787,7 +15787,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/veilpiercer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/veilpiercer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 13 dégâts.\nLa prochaine carte [gold]Éthérée[/gold] que vous jouez coûte 0 [energy:1].",
@@ -15827,7 +15827,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/helix_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/helix_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 5 dégâts pour chaque [energy:1] déjà dépensé pendant ce tour.",
@@ -15960,7 +15960,7 @@
       "vigorpower": "+1"
     },
     "image_url": "/static/images/cards/patter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/patter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 11 d'[gold]Armure[/gold].\nGagnez 3 de [gold]Vigueur[/gold].",
@@ -16045,7 +16045,7 @@
       "rollingboulderpower": "+5"
     },
     "image_url": "/static/images/cards/rolling_boulder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rolling_boulder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Au début de votre tour, infligez 10 dégâts à TOUS les ennemis et augmentez le montant de ces dégâts de 5.",
@@ -16084,7 +16084,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/stack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez un montant d'[gold]Armure[/gold] égal au nombre de cartes dans votre [gold]Défausse[/gold] +3.",
@@ -16161,7 +16161,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/pillar_of_creation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillar_of_creation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous créez une carte, gagnez 4 d'[gold]Armure[/gold].",
@@ -16199,7 +16199,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/pillage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 9 dégâts.\nPiochez des cartes jusqu'à piocher une carte qui n'est pas une Attaque.",
@@ -16273,7 +16273,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/tracking.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tracking.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16316,7 +16316,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/knife_trap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knife_trap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Améliorez[/gold] et jouez chaque [gold]Surin[/gold] depuis votre pile de cartes [gold]Épuisées[/gold] sur l'ennemi.",
@@ -16554,7 +16554,7 @@
       "hailstormpower": "+2"
     },
     "image_url": "/static/images/cards/hailstorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hailstorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "À la fin de votre tour, si vous avez un [gold]Orbe glaciaire[/gold], infligez 8 dégâts à TOUS les ennemis.",
@@ -16646,7 +16646,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/pagestorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pagestorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16686,7 +16686,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/seven_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seven_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16774,7 +16774,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/hidden_daggers.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_daggers.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Défaussez 2 cartes.\nAjoutez 2 [gold]Surins+[/gold] à votre [gold]Main[/gold].",
@@ -16857,7 +16857,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/rocket_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rocket_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 14 dégâts.\nPiochez 2 cartes.\nLorsque vous créez une carte Statut, réduisez le coût de cette carte à 0 [energy:1] jusqu'à ce qu'elle soit jouée.",
@@ -16896,7 +16896,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/pale_blue_dot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pale_blue_dot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Si vous jouez 5 cartes ou plus en un tour, piochez 2 cartes au début du tour suivant.",
@@ -17120,7 +17120,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/rend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 15 dégâts.\nInflige 8 dégâts supplémentaires pour chaque effet néfaste unique présent sur l'ennemi.",
@@ -17212,7 +17212,7 @@
       "dexterity": "+1"
     },
     "image_url": "/static/images/cards/bulk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Perdez 1 Emplacement d'Orbe.\nGagnez 3 de [gold]Force[/gold].\nGagnez 3 de [gold]Dextérité[/gold].",
@@ -17252,7 +17252,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/production.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/production.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez [energy:3].",
@@ -17295,7 +17295,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/defile.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/defile.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 17 dégâts.",
@@ -17518,7 +17518,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/prowess.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 2 de [gold]Force[/gold].\nGagnez 2 de [gold]Dextérité[/gold].",
@@ -17844,7 +17844,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/astral_pulse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/astral_pulse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 18 dégâts à TOUS les ennemis.",
@@ -17963,7 +17963,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/quasar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quasar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Choisissez 1 carte Incolore [gold]Améliorée[/gold] parmi 3 aléatoires à ajouter à votre [gold]Main[/gold].",
@@ -18039,7 +18039,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/rally.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rally.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TOUS les joueurs gagnent 17 d'[gold]Armure[/gold].",
@@ -18078,7 +18078,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/spite.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spite.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 5 dégâts.\nSi vous avez perdu des PV pendant ce tour, cette attaque touche l'ennemi 3 fois.",
@@ -18281,7 +18281,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/rebound.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rebound.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 12 dégâts.\nLa prochaine carte que vous jouez ce tour est placée sur le dessus de votre [gold]Pioche[/gold].",
@@ -18363,7 +18363,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/reflect.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reflect.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 21 d'[gold]Armure[/gold].\nLes dégâts d'attaque bloqués par l'[gold]Armure[/gold] sont renvoyés à l'attaquant pendant ce tour.",
@@ -18522,7 +18522,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/relax.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/relax.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 17 d'[gold]Armure[/gold].\nAu prochain tour, piochez 3 cartes et gagnez [energy:3].",
@@ -18565,7 +18565,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/bulwark.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulwark.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 16 d'[gold]Armure[/gold].\n[gold]Forgez[/gold] pour 13.",
@@ -18612,7 +18612,7 @@
       "knockdownpower": "+1"
     },
     "image_url": "/static/images/cards/knockdown.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockdown.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 14 dégâts.\nL'ennemi subit le triple des dégâts infligés par les autres joueurs jusqu'à la fin du tour.",
@@ -18657,7 +18657,7 @@
       "strength": "+2"
     },
     "image_url": "/static/images/cards/feeding_frenzy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 7 de [gold]Force[/gold] jusqu'à la fin du tour.",
@@ -18693,7 +18693,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/trash_to_treasure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/trash_to_treasure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18734,7 +18734,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/ricochet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ricochet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 3 dégâts à un ennemi aléatoire 5 fois.",
@@ -18818,7 +18818,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/giant_rock.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/giant_rock.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 20 dégâts.",
@@ -18856,7 +18856,7 @@
       "gold": "+5"
     },
     "image_url": "/static/images/cards/royalties.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royalties.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "À la fin du combat, gagnez 35 [gold]Pièces d'or[/gold].",
@@ -19180,7 +19180,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/refract.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refract.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 12 dégâts 2 fois.\n[gold]Canalisez[/gold] 2 [gold]Orbes vitreux[/gold].",
@@ -19278,7 +19278,7 @@
       "strengthpower": "+1"
     },
     "image_url": "/static/images/cards/resonance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/resonance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 2 de [gold]Force[/gold]. TOUS les ennemis perdent 1 de [gold]Force[/gold].",
@@ -19446,7 +19446,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sword_sage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sword_sage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19562,7 +19562,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/salvo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/salvo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 16 dégâts.\n[gold]Retenez[/gold] votre [gold]Main[/gold] jusqu'au prochain tour.",
@@ -19690,7 +19690,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/feral.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feral.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19813,7 +19813,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/minion_sacrifice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_sacrifice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 12 d'[gold]Armure[/gold].",
@@ -20088,7 +20088,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 11 dégâts à TOUS les ennemis.",
@@ -20178,7 +20178,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/whistle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/whistle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 44 dégâts.\n[gold]Étourdissez[/gold] l'ennemi.",
@@ -20221,7 +20221,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/pull_from_below.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pull_from_below.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 7 dégâts pour chaque carte [gold]Éthérée[/gold] jouée pendant ce combat.",
@@ -20370,7 +20370,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/subroutine.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/subroutine.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20408,7 +20408,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/spectrum_shift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spectrum_shift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20500,7 +20500,7 @@
       "stranglepower": "+1"
     },
     "image_url": "/static/images/cards/strangle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/strangle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 10 dégâts.\nLorsque vous jouez une carte pendant ce tour, l'ennemi perd 3 PV.",
@@ -20536,7 +20536,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/stratagem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stratagem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20572,7 +20572,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/soot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -20658,7 +20658,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/supermassive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/supermassive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 5 dégâts.\nInflige 4 dégâts supplémentaires pour chaque carte que vous avez créée pendant ce combat.",
@@ -20859,7 +20859,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/synchronize.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synchronize.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20900,7 +20900,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/synthesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synthesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 18 dégâts.\nLe prochain Pouvoir que vous jouez coûte 0 [energy:1].",
@@ -20942,7 +20942,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/seance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20985,7 +20985,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/turbo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/turbo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez [energy:3].\nAjoutez un [gold]Néant[/gold] à votre [gold]Défausse[/gold].",
@@ -21074,7 +21074,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/drum_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/drum_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Piochez 3 cartes.\nAu début de votre tour, [gold]Épuisez[/gold] la carte du dessus de votre [gold]Pioche[/gold].",
@@ -21155,7 +21155,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/tank.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tank.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21312,7 +21312,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/soul_storm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul_storm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 9 dégâts.\nInflige 3 dégâts supplémentaires pour chaque [gold]Âme[/gold] dans votre pile de cartes [gold]Épuisées[/gold].",
@@ -21357,7 +21357,7 @@
       "vigorpower": "+2"
     },
     "image_url": "/static/images/cards/terraforming.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/terraforming.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 8 de [gold]Vigueur[/gold].",
@@ -21497,7 +21497,7 @@
       "thunderpower": "+2"
     },
     "image_url": "/static/images/cards/thunder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/thunder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous [gold]Activez[/gold] vos [gold]Orbes kérauniques[/gold], infligez 8 dégâts à chaque ennemi touché.",
@@ -21587,7 +21587,7 @@
       "strengthloss": "+3"
     },
     "image_url": "/static/images/cards/enfeebling_touch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enfeebling_touch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "L'ennemi perd 11 de [gold]Force[/gold] jusqu'à la fin du tour.",
@@ -21635,7 +21635,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/spinner.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spinner.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Canalisez[/gold] 1 [gold]Orbe vitreux[/gold].\nAu début de votre tour, [gold]Canalisez[/gold] 1 [gold]Orbe vitreux[/gold].",
@@ -21680,7 +21680,7 @@
       "sleightoffleshpower": "+4"
     },
     "image_url": "/static/images/cards/sleight_of_flesh.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sleight_of_flesh.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous appliquez un effet néfaste sur un ennemi, celui-ci subit 13 dégâts.",
@@ -21837,7 +21837,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/collision_course.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/collision_course.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 15 dégâts.\nAjoutez un [gold]Débris[/gold] à votre [gold]Main[/gold].",
@@ -21915,7 +21915,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/transfigure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/transfigure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21963,7 +21963,7 @@
       "blackholepower": "+1"
     },
     "image_url": "/static/images/cards/black_hole.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/black_hole.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous gagnez ou dépensez des [star:1], infligez 4 dégâts à TOUS les ennemis.",
@@ -22039,7 +22039,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/uproar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/uproar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 7 dégâts 2 fois.\nJouez une Attaque aléatoire depuis votre [gold]Pioche[/gold].",
@@ -22077,7 +22077,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/tyranny.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tyranny.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22119,7 +22119,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/toric_toughness.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/toric_toughness.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 7 d'[gold]Armure[/gold].\nGagnez 7 d'[gold]Armure[/gold] au début des 2 prochains tours.",
@@ -22320,7 +22320,7 @@
       "corrosivewave": "+1"
     },
     "image_url": "/static/images/cards/corrosive_wave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/corrosive_wave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous piochez une carte ce tour, appliquez 3 de [gold]Poison[/gold] à TOUS les ennemis.",
@@ -22528,7 +22528,7 @@
       "poison": "+3"
     },
     "image_url": "/static/images/cards/bubble_bubble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Si l'ennemi est affligé de [gold]Poison[/gold], appliquez 12 de [gold]Poison[/gold].",
@@ -22611,7 +22611,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/glasswork.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glasswork.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 8 d'[gold]Armure[/gold].\n[gold]Canalisez[/gold] 1 [gold]Orbe vitreux[/gold].",
@@ -22649,7 +22649,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/vicious.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/vicious.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous appliquez [gold]Vulnérable[/gold], piochez 2 cartes.",
@@ -22689,7 +22689,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/afterlife.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/afterlife.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Invoquez[/gold] pour 9.",
@@ -22741,7 +22741,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/fight_me.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 6 dégâts 2 fois.\nGagnez 4 de [gold]Force[/gold].\nL'ennemi gagne 1 de [gold]Force[/gold].",
@@ -22868,7 +22868,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/glimpse_beyond.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glimpse_beyond.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TOUS les joueurs ajoutent 4 [gold]Âmes[/gold] à leur [gold]Pioche[/gold].",
@@ -22948,7 +22948,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/shroud.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shroud.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Lorsque vous appliquez de la [gold]Fatalité[/gold], gagnez 3 d'[gold]Armure[/gold].",
@@ -22989,7 +22989,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/voltaic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/voltaic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23030,7 +23030,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/venerate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/venerate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez [star:3].",
@@ -23110,7 +23110,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/deaths_door.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/deaths_door.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 7 d'[gold]Armure[/gold].\nSi vous avez appliqué de la [gold]Fatalité[/gold] pendant ce tour, gagnez l'[gold]Armure[/gold] 2 fois supplémentaires.",
@@ -23160,7 +23160,7 @@
       "sicempower": "+1"
     },
     "image_url": "/static/images/cards/sic_em.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sic_em.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Titos[/gold] inflige 6 dégâts.\nLorsque [gold]Titos[/gold] touche cet ennemi pendant ce tour, [gold]Invoquez[/gold] pour 3.",
@@ -23200,7 +23200,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/soul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Piochez 3 cartes.",
@@ -23248,7 +23248,7 @@
       "preptimepower": "+2"
     },
     "image_url": "/static/images/cards/prep_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prep_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Au début de votre tour, gagnez 6 de [gold]Vigueur[/gold].",
@@ -23364,7 +23364,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/luminesce.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/luminesce.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez [energy:3].",
@@ -23414,7 +23414,7 @@
       "platingpower": "+3"
     },
     "image_url": "/static/images/cards/neutron_aegis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neutron_aegis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gagnez 11 de [gold]Blindage[/gold].",
@@ -23501,7 +23501,7 @@
       "outbreakpower": "+4"
     },
     "image_url": "/static/images/cards/outbreak.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outbreak.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Toutes les 3 fois que vous appliquez du [gold]Poison[/gold], infligez 15 dégâts à TOUS les ennemis.",
@@ -23748,7 +23748,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/guiding_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/guiding_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 13 dégâts.\nPiochez 3 cartes.",
@@ -23791,7 +23791,7 @@
       "strengthloss": "+2"
     },
     "image_url": "/static/images/cards/dying_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dying_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infligez 11 dégâts à TOUS les ennemis. TOUS les ennemis perdent 11 de [gold]Force[/gold] jusqu'à la fin du tour.",
@@ -23828,7 +23828,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/frantic_escape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/frantic_escape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,

--- a/data/ita/cards.json
+++ b/data/ita/cards.json
@@ -29,7 +29,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/dual_wield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Scegli una carta Attacco o Potere. Aggiungi 2 copie di quella carta alla tua [gold]mano[/gold].",
@@ -116,7 +116,7 @@
       "knockdownpower": "+1"
     },
     "image_url": "/static/images/cards/knockdown.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockdown.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 14 di danno.\nIl nemico subisce danno triplo da altri giocatori in questo turno.",
@@ -228,7 +228,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/ignition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ignition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -352,7 +352,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/refine_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refine_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Applichi 13 di [gold]Forgiatura[/gold] \nIl turno successivo ottieni [energy:1].",
@@ -401,7 +401,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/fight_me.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 6 di danno due volte.\nOttieni 4 di [gold]Forza[/gold].\nIl nemico ottiene 1 di [gold]Forza[/gold].",
@@ -703,7 +703,7 @@
       "sicempower": "+1"
     },
     "image_url": "/static/images/cards/sic_em.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sic_em.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] infligge 6 di danno.\nOgni volta che [gold]Osty[/gold] colpisce questo nemico in questo turno, applichi 3 di [gold]Invocazione[/gold].",
@@ -742,7 +742,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/alignment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/alignment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni [energy:3].",
@@ -871,7 +871,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/soul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Peschi 3 carte.",
@@ -1342,7 +1342,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/arsenal.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/arsenal.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1592,7 +1592,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/up_my_sleeve.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/up_my_sleeve.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aggiungi 4 [gold]carte Pugnale[/gold] alla tua [gold]mano[/gold].\nRiduci il costo di questa carta di 1.",
@@ -1755,7 +1755,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/crash_landing.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crash_landing.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 26 di danno a TUTTI i nemici.\nRiempi la tua [gold]mano[/gold] di carte [gold]Rottami[/gold].",
@@ -1831,7 +1831,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/automation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/automation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1869,7 +1869,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/manifest_authority.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/manifest_authority.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 8 di [gold]Blocco[/gold].\nAggiungi 1 carta incolore casuale [gold]potenziata[/gold] alla tua [gold]mano[/gold].",
@@ -1945,7 +1945,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/greed.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/greed.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1992,7 +1992,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/waste_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/waste_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -2271,7 +2271,7 @@
       "vigorpower": "+1"
     },
     "image_url": "/static/images/cards/patter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/patter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 11 di [gold]Blocco[/gold].\nOttieni 3 di [gold]Vigore[/gold].",
@@ -2311,7 +2311,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/bulwark.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulwark.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 16 di [gold]Blocco[/gold].\nApplichi 13 di [gold]Forgiatura[/gold].",
@@ -2581,7 +2581,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/big_bang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/big_bang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2622,7 +2622,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/tesla_coil.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tesla_coil.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 6 di danno.\nAttivi ogni [gold]Elettroglobo[/gold] contro il nemico.",
@@ -2700,7 +2700,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/bombardment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bombardment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 24 di danno.\nSe all'inizio del tuo turno questa carta si trova nella tua [gold]pila delle carte esaurite[/gold], giocala.",
@@ -2742,7 +2742,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/spoils_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Applichi 8 di [gold]Forgiatura[/gold].\nPeschi 2 carte.",
@@ -2866,7 +2866,7 @@
       "blackholepower": "+1"
     },
     "image_url": "/static/images/cards/black_hole.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/black_hole.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che consumi od ottieni [star:1], infliggi 4 di danno a TUTTI i nemici.",
@@ -2987,7 +2987,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/hello_world.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hello_world.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3023,7 +3023,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/calamity.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/calamity.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3187,7 +3187,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/flak_cannon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/flak_cannon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Esaurisci[/gold] TUTTE le tue carte Stato.\nInfliggi 11 di danno a un nemico casuale per ogni carta [gold]esaurita[/gold].",
@@ -3352,7 +3352,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/fuel.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fuel.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni [energy:1].\nPeschi 2 carte.",
@@ -3391,7 +3391,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/cascade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cascade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Giochi le prime X+1 carte del tuo [gold]mazzo di pesca[/gold].",
@@ -3429,7 +3429,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/catastrophe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/catastrophe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Giochi 3 carte casuali dal tuo [gold]mazzo di pesca[/gold].",
@@ -3510,7 +3510,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/call_of_the_void.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/call_of_the_void.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3548,7 +3548,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/lantern_key.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lantern_key.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3634,7 +3634,7 @@
       "smokestackpower": "+2"
     },
     "image_url": "/static/images/cards/smokestack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/smokestack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che crei una carta Stato, infliggi 7 di danno a TUTTI i nemici.",
@@ -3674,7 +3674,7 @@
       "extradamage": "+2"
     },
     "image_url": "/static/images/cards/gang_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gang_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 5 di danno.\nInfliggi 7 dii danno extra per ogni altro giocatore che ha attaccato il nemico in questo turno.",
@@ -4080,7 +4080,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/ultimate_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 20 di danno.",
@@ -4129,7 +4129,7 @@
       "focuspower": "+1"
     },
     "image_url": "/static/images/cards/focused_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/focused_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 11 di danno.\nOttieni 2 di [gold]Focus[/gold] in questo turno.",
@@ -4252,7 +4252,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/leading_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/leading_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 6 di danno.\nAggiungi 2 [gold]carte Pugnale[/gold] alla tua [gold]mano[/gold].",
@@ -4293,7 +4293,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/seeker_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeker_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 12 di danno.\nScegli 1 tra 3 carte nel tuo [gold]mazzo di pesca[/gold] da aggiungere alla tua [gold]mano[/gold].",
@@ -4333,7 +4333,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sculpting_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sculpting_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 12 di danno.\nApplichi [gold]Evanescenza[/gold] a una carta nella tua [gold]mano[/gold].",
@@ -4505,7 +4505,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/shining_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shining_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 11 di danno.\nOttieni [star:2].\nMetti questa carta in cima al tuo [gold]mazzo di pesca[/gold].",
@@ -4627,7 +4627,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/adaptive_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/adaptive_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 23 di danno.\nAggiungi una copia con costo 0[energy:1] di questa carta alla tua [gold]pila degli scarti[/gold].",
@@ -4713,7 +4713,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/minion_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 9 di danno.\nPeschi 1 carta.",
@@ -4848,7 +4848,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/comet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/comet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 44 di danno.\nApplichi 3 di [gold]Debolezza[/gold].\nApplichi 3 di [gold]Vulnerabilità[/gold].",
@@ -4926,7 +4926,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/compact.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/compact.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 7 di [gold]Blocco[/gold].\n[gold]Trasformi[/gold] tutte le carte Stato nella tua [gold]mano[/gold] nella carta [gold]Carburante+[/gold].",
@@ -4964,7 +4964,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/foregone_conclusion.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/foregone_conclusion.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Il turno successivo, metti 3 carte dal tuo [gold]mazzo di pesca[/gold] alla tua [gold]mano[/gold].",
@@ -5043,7 +5043,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/conflagration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conflagration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 8 di danno a TUTTI i nemici.\nInfliggi 3 di danno extra per ogni altra carta Attacco che hai giocato in questo turno.",
@@ -5081,7 +5081,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/clash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/clash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Può essere giocata solo se ogni carta nella tua [gold]mano[/gold] è una carta Attacco.\nInfliggi 18 di danno.",
@@ -5119,7 +5119,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/conqueror.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conqueror.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Applichi 5 di [gold]Forgiatura[/gold].\nLa carta [gold]Spada Sovrana[/gold] infligge danno doppio al nemico in questo turno.",
@@ -5252,7 +5252,7 @@
       "parrypower": "+4"
     },
     "image_url": "/static/images/cards/parry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/parry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che giochi la carta [gold]Spada Sovrana[/gold], ottieni 14 di [gold]Blocco[/gold].",
@@ -5291,7 +5291,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/convergence.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/convergence.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Il turno successivo,\nottieni [energy:1] e [star:2].\n[gold]Conservi[/gold] la tua [gold]mano[/gold] in questo turno.",
@@ -5331,7 +5331,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/summon_forth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/summon_forth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Applichi 11 di [gold]Forgiatura[/gold]\nMetti la carta [gold]Spada Sovrana[/gold] nella tua [gold]mano[/gold] dovunque essa si trovi.",
@@ -5417,7 +5417,7 @@
       "strength": "+3"
     },
     "image_url": "/static/images/cards/coordinate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Dai a un altro giocatore 8 di [gold]Forza[/gold] in questo turno.",
@@ -5464,7 +5464,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/hotfix.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hotfix.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5544,7 +5544,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/make_it_so.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/make_it_so.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 9 di danno.\nOgni volta che giochi 3 carte Abilità in questo turno, metti questa carta nella tua [gold]mano[/gold].",
@@ -5582,7 +5582,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/believe_in_you.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/believe_in_you.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Un altro giocatore ottiene [energy:3].",
@@ -5625,7 +5625,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/rattle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rattle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] infligge 9 di danno.\nColpisce una volta in più per ogni altra volta che ha attaccato in questo turno.",
@@ -5663,7 +5663,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/ascenders_bane.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ascenders_bane.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5753,7 +5753,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/bundle_of_joy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bundle_of_joy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aggiungi 4 carte incolori casuali alla tua [gold]mano[/gold].",
@@ -5845,7 +5845,7 @@
       "dansemacabrepower": "+2"
     },
     "image_url": "/static/images/cards/danse_macabre.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/danse_macabre.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che giochi una carta che ha un costo pari o superiore a [energy:2], ottieni 6 di [gold]Blocco[/gold].",
@@ -5968,7 +5968,7 @@
       "cards": "+2"
     },
     "image_url": "/static/images/cards/decisions_decisions.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/decisions_decisions.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Peschi 5 carte.\nScegli una carta Abilità nella tua [gold]mano[/gold] e giocala 3 volte.",
@@ -6104,7 +6104,7 @@
       "debilitatepower": "+1"
     },
     "image_url": "/static/images/cards/debilitate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debilitate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 12 di danno.\n[gold]Vulnerabilità[/gold] e [gold]Debolezza[/gold] sono il doppio più efficaci contro il nemico per i 4 prossimi turni.",
@@ -6184,7 +6184,7 @@
       "damage": "+10"
     },
     "image_url": "/static/images/cards/devastate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devastate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 40 di danno.",
@@ -6220,7 +6220,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/hammer_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hammer_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6460,7 +6460,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/ultimate_defend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_defend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 15 di [gold]Blocco[/gold].",
@@ -6581,7 +6581,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/rend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 15 di danno.\nInfligge 8 di danno extra per ogni debuff unico sul nemico.",
@@ -6624,7 +6624,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/disintegration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/disintegration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -6703,7 +6703,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/distraction.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/distraction.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6794,7 +6794,7 @@
       "devourlifepower": "+1"
     },
     "image_url": "/static/images/cards/devour_life.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devour_life.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che giochi una carta [gold]Anima[/gold], applichi 2 di [gold]Invocazione[/gold].",
@@ -6835,7 +6835,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/demesne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demesne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7045,7 +7045,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/hegemony.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hegemony.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 18 di danno.\nIl turno successivo ottieni [energy:3].",
@@ -7091,7 +7091,7 @@
       "platingpower": "+3"
     },
     "image_url": "/static/images/cards/neutron_aegis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neutron_aegis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 11 di [gold]Placcattura[/gold].",
@@ -7129,7 +7129,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/eidolon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/eidolon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7292,7 +7292,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/entropy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entropy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7338,7 +7338,7 @@
       "outbreakpower": "+4"
     },
     "image_url": "/static/images/cards/outbreak.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outbreak.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni 3 volta che applichi [gold]Veleno[/gold], infliggi 15 di danno a TUTTI i nemici.",
@@ -7431,7 +7431,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/gamma_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gamma_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 18 di danno.\nApplichi 2 di [gold]Debolezza[/gold].\nApplichi 2 di [gold]Vulnerabilità[/gold].",
@@ -7471,7 +7471,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/lunar_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lunar_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 5 di danno per ogni carta Abilità già giocata in questo turno.",
@@ -7512,7 +7512,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/graveblast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/graveblast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 6 di danno.\nMetti una carta dalla tua [gold]pila degli scarti[/gold] alla tua [gold]mano[/gold].",
@@ -7668,7 +7668,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/quadcast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quadcast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7713,7 +7713,7 @@
       "strength": "+2"
     },
     "image_url": "/static/images/cards/feeding_frenzy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 7 di [gold]Forza[/gold] in questo turno.",
@@ -7789,7 +7789,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/beacon_of_hope.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beacon_of_hope.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7825,7 +7825,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/enthralled.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enthralled.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7996,7 +7996,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/feral.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feral.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8073,7 +8073,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/brightest_flame.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/brightest_flame.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni [energy:3].\nPeschi 3 carte.\nI tuoi PV massimi diminuiscono di 1.",
@@ -8147,7 +8147,7 @@
       "blockforstars": "+1"
     },
     "image_url": "/static/images/cards/child_of_the_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/child_of_the_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che consumi [star:1], ottieni 3 di [gold]Blocco[/gold] per ogni [star:1] che consumi.",
@@ -8265,7 +8265,7 @@
       "extrablock": "+2"
     },
     "image_url": "/static/images/cards/fasten.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fasten.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Le carte Difendi offrono 7 di [gold]Blocco[/gold] extra.",
@@ -8392,7 +8392,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/wrought_in_war.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wrought_in_war.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 9 di danno.\nApplichi 9 di [gold]Forgiatura[/gold].",
@@ -8473,7 +8473,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/reaper_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reaper_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8561,7 +8561,7 @@
       "serpentformpower": "+2"
     },
     "image_url": "/static/images/cards/serpent_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/serpent_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che giochi una carta, infliggi 6 di danno a un nemico casuale.",
@@ -8660,7 +8660,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/void_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/void_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8701,7 +8701,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/furnace.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/furnace.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "All'inizio del tuo turno, applichi 6 di [gold]Forgiatura[/gold].",
@@ -8825,7 +8825,7 @@
       "poison": "+2"
     },
     "image_url": "/static/images/cards/haze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Applichi 6 di [gold]Veleno[/gold] a TUTTI i nemici.",
@@ -8871,7 +8871,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/bone_shards.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bone_shards.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Se [gold]Osty[/gold] è vivo, infligge 12 di danno a TUTTI i nemici e ottieni 12 di [gold]Blocco[/gold].\n[gold]Osty[/gold] muore.",
@@ -8909,7 +8909,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/shatter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shatter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 15 di danno a TUTTI i nemici.\n[gold]Evochi[/gold] tutti i tuoi Globi.",
@@ -8943,7 +8943,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/frantic_escape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/frantic_escape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -8979,7 +8979,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/soot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -9103,7 +9103,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/wisp.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wisp.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9146,7 +9146,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/barrage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/barrage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 7 di danno per ogni Globo [gold]canalizzato[/gold].",
@@ -9277,7 +9277,7 @@
       "sneakypower": "+1"
     },
     "image_url": "/static/images/cards/sneaky.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sneaky.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che un altro giocatore attacca un nemico, ottieni 2 di [gold]Blocco[/gold].",
@@ -9480,7 +9480,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/voltaic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/voltaic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9521,7 +9521,7 @@
       "replay": "+1"
     },
     "image_url": "/static/images/cards/hidden_gem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_gem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Una carta casuale nel tuo [gold]mazzo di pesca[/gold] senza [gold]Riattivazione[/gold] ottiene 3 di [gold]Riattivazione[/gold].",
@@ -9557,7 +9557,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/largesse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/largesse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Un altro giocatore aggiunge 1 carta incolore casuale [gold]potenziata[/gold] alla sua [gold]mano[/gold].",
@@ -9595,7 +9595,7 @@
       "starsperturn": "+1"
     },
     "image_url": "/static/images/cards/genesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/genesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "All'inizio del tuo turno, ottieni [star:3].",
@@ -9671,7 +9671,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/scrawl.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/scrawl.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9713,7 +9713,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/colossus.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/colossus.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 8 di [gold]Blocco[/gold].\nSubisci il 50% di danno in meno dai nemici con [gold]Vulnerabilità[/gold] in questo turno.",
@@ -9794,7 +9794,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/juggling.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/juggling.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9917,7 +9917,7 @@
       "hailstormpower": "+2"
     },
     "image_url": "/static/images/cards/hailstorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hailstorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al termine del tuo turno, se hai un [gold]Crioglobo[/gold], infliggi 8 di danno a TUTTI i nemici.",
@@ -9955,7 +9955,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/forbidden_grimoire.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/forbidden_grimoire.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10034,7 +10034,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/bodyguard.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bodyguard.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Applichi 7 di [gold]Invocazione[/gold].",
@@ -10111,7 +10111,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/tank.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tank.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10308,7 +10308,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/mimic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mimic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10516,7 +10516,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/hang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 13 di danno.\nRaddoppi il danno che TUTTE le carte Impiccagione infliggono a questo nemico.",
@@ -10554,7 +10554,7 @@
       "gold": "+5"
     },
     "image_url": "/static/images/cards/royalties.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royalties.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Al termine del combattimento, ottieni 35 unità d'[gold]oro[/gold].",
@@ -10593,7 +10593,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/astral_pulse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/astral_pulse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 18 di danno a TUTTI i nemici.",
@@ -10668,7 +10668,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/entrench.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entrench.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10704,7 +10704,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/unmovable.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/unmovable.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10864,7 +10864,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/cosmic_indifference.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cosmic_indifference.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 9 di [gold]Blocco[/gold].\nMetti una carta dalla tua [gold]pila degli scarti[/gold] in cima al tuo [gold]mazzo di pesca[/gold].",
@@ -10985,7 +10985,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/infection.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/infection.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11026,7 +11026,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/intercept.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/intercept.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 13 di [gold]Blocco[/gold].\nIn questo turno subisci tutti gli attacchi che avevano come bersaglio un altro giocatore.",
@@ -11109,7 +11109,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/invoke.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/invoke.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Nel turno successivo applichi 3 di [gold]Invocazione[/gold] e ottieni [energy:3].",
@@ -11336,7 +11336,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/abrasive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/abrasive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 1 di [gold]Destrezza[/gold].\nOttieni 6 di [gold]Spinascudo[/gold].",
@@ -11393,7 +11393,7 @@
       "dexterity": "+1"
     },
     "image_url": "/static/images/cards/bulk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Perdi 1 spazio Globi.\nOttieni 3 di [gold]Forza[/gold].\nOttieni 3 di [gold]Destrezza[/gold].",
@@ -11474,7 +11474,7 @@
       "iterationpower": "+1"
     },
     "image_url": "/static/images/cards/iteration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/iteration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "La prima volta che peschi una carta Stato in ogni turno, peschi 3 carte.",
@@ -11556,7 +11556,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/jackpot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/jackpot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 30 di danno.\nAggiungi 3 carte casuali [gold]con potenziamento[/gold] di costo 0 [energy:1] alla tua [gold]mano[/gold].",
@@ -11635,7 +11635,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/the_hunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_hunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Infliggi 15 di danno.\nSe è [gold]letale[/gold], ottieni una ricompensa di carte extra.",
@@ -11680,7 +11680,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/the_scythe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_scythe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 13 di danno.\nAumenti permanentemente il danno di questa carta di 4.",
@@ -11811,7 +11811,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/blade_of_ink.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/blade_of_ink.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aggiungi 3 [gold]carte Pugnale[/gold] con l'incantesimo [purple]Tintura[/purple] alla tua [gold]mano[/gold].",
@@ -11903,7 +11903,7 @@
       "phantombladespower": "+3"
     },
     "image_url": "/static/images/cards/phantom_blades.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/phantom_blades.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Le carte [gold]Pugnale[/gold] ottengono [gold]Conservazione[/gold].\nLa prima carta [gold]Pugnale[/gold] che giochi in ogni turno infligge 12 di danno extra.",
@@ -12062,7 +12062,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/ice_lance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ice_lance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 24 di danno.\n[gold]Crioglobi[/gold] [gold]canalizzati[/gold]: 3.",
@@ -12182,7 +12182,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/legion_of_bone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/legion_of_bone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Tutti i giocatori applicano 8 di[gold]Invocazione[/gold].",
@@ -12271,7 +12271,7 @@
       "lethalitypower": "+25"
     },
     "image_url": "/static/images/cards/lethality.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lethality.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Il primo attacco di ogni turno infligge un 75% di danno extra.",
@@ -12315,7 +12315,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/luminesce.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/luminesce.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni [energy:3].",
@@ -12400,7 +12400,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/giant_rock.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/giant_rock.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 20 di danno.",
@@ -12447,7 +12447,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sword_sage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sword_sage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12607,7 +12607,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/poor_sleep.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/poor_sleep.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12656,7 +12656,7 @@
       "sleightoffleshpower": "+4"
     },
     "image_url": "/static/images/cards/sleight_of_flesh.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sleight_of_flesh.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che applichi un debuff su un nemico, questo subisce 13 di danno.",
@@ -12698,7 +12698,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/right_hand_hand.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/right_hand_hand.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] infligge 6 di danno.\nOgni volta che giochi una carta con costo pari o superiore a [energy:2], rimetti questa carta nella tua [gold]mano[/gold] dalla [gold]pila degli scarti[/gold].",
@@ -12776,7 +12776,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/outmaneuver.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outmaneuver.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Il prossimo turno, ottieni [energy:3].",
@@ -12821,7 +12821,7 @@
       "crimsonmantlepower": "+2"
     },
     "image_url": "/static/images/cards/crimson_mantle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crimson_mantle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "All'inizio del tuo turno, perdi 1 PV e ottieni 10 di [gold]Blocco[/gold].",
@@ -12898,7 +12898,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/spoils_map.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_map.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13031,7 +13031,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/mind_rot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mind_rot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -13070,7 +13070,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/heirloom_hammer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heirloom_hammer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 25 di danno.\nScegli una carta incolore nella tua [gold]mano[/gold]. Aggiungi una copia di quella carta alla tua [gold]mano[/gold].",
@@ -13155,7 +13155,7 @@
       "rollingboulderpower": "+5"
     },
     "image_url": "/static/images/cards/rolling_boulder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rolling_boulder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "All'inizio del tuo turno, infliggi 10 di danno a TUTTI i nemici e aumenti questo danno di 5.",
@@ -13244,7 +13244,7 @@
       "summon": "+1"
     },
     "image_url": "/static/images/cards/dirge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dirge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Applichi 4 di [gold]Invocazione[/gold] X volte.\nAggiungi X carte [gold]Anima+[/gold] al tuo [gold]mazzo di pesca[/gold].",
@@ -13573,7 +13573,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/modded.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/modded.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 1 spazio Globi.\nPeschi 2 carte. Aumenti il costo di questa carta di 1.",
@@ -13611,7 +13611,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/monologue.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/monologue.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13896,7 +13896,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/necro_mastery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/necro_mastery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Applichi 8 di [gold]Invocazione[/gold].\nOgni volta che [gold]Osty[/gold] perde i PV,\nAnche TUTTI i nemici perdono altrettanti PV.",
@@ -13981,7 +13981,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/neurosurge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neurosurge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni [energy:4].\nPeschi 2 carte.\nAll'inizio del tuo turno, applichi 3 di [gold]Condanna[/gold] su di te..",
@@ -14068,7 +14068,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Recuperi 13 PV.",
@@ -14109,7 +14109,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/undeath.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/undeath.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 9 di [gold]Blocco[/gold].\nAggiungi una copia di questa carta alla tua [gold]pila degli scarti[/gold].",
@@ -14187,7 +14187,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/nostalgia.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/nostalgia.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14394,7 +14394,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/afterlife.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/afterlife.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Applichi 9 di [gold]Invocazione[/gold].",
@@ -14443,7 +14443,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/consuming_shadow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/consuming_shadow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Tetroglobi[/gold] [gold]canalizzati[/gold]: 3.\nAl termine del tuo turno, [gold]evochi[/gold] il tuo primo Globo a sinistra.",
@@ -14483,7 +14483,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/murder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/murder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14521,7 +14521,7 @@
       "corrosivewave": "+1"
     },
     "image_url": "/static/images/cards/corrosive_wave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/corrosive_wave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che peschi una carta in questo turno, applichi 3 di [gold]Veleno[/gold] a TUTTI i nemici.",
@@ -14599,7 +14599,7 @@
       "power": "+2"
     },
     "image_url": "/static/images/cards/shockwave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shockwave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Applichi 5 di [gold]Debolezza[/gold] e [gold]Vulnerabilità[/gold] a TUTTI i nemici.",
@@ -14795,7 +14795,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/gunk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gunk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 5 di danno 3 volte.\nAggiungi la carta [gold]Inzaccherato[/gold] alla tua [gold]pila degli scarti[/gold].",
@@ -14834,7 +14834,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/pale_blue_dot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pale_blue_dot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Se giochi 5 o più carte in un turno, peschi 2 carte all'inizio del tuo turno successivo.",
@@ -14880,7 +14880,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/lightning_rod.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lightning_rod.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 7 di [gold]Blocco[/gold].\n[gold]Elettroglobi[/gold] [gold]canalizzati[/gold] all'inizio dei prossimi 2 turni: 1.",
@@ -15070,7 +15070,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/veilpiercer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/veilpiercer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 13 di danno.\nLa prossima carta con [gold]Evanescenza[/gold] che giochi ha un costo pari a 0 [energy:1].",
@@ -15110,7 +15110,7 @@
       "hploss": "+2"
     },
     "image_url": "/static/images/cards/haunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che giochi una carta [gold]Anima[/gold], un nemico casuale perde 8 PV.",
@@ -15189,7 +15189,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/fight_through.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_through.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 17 di [gold]Blocco[/gold].\nAggiungi 2 carte [gold]Ferita[/gold] alla tua [gold]pila degli scarti[/gold].",
@@ -15227,7 +15227,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/beat_down.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_down.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Giochi 4 carte Attacco casuali dalla tua [gold]pila degli scarti[/gold].",
@@ -15431,7 +15431,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/sloth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sloth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -15469,7 +15469,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/pillar_of_creation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillar_of_creation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che crei una carta, ottieni 4 di [gold]Blocco[/gold].",
@@ -15599,7 +15599,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/pagestorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pagestorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15679,7 +15679,7 @@
       "calculationextra": "+2"
     },
     "image_url": "/static/images/cards/beat_into_shape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_into_shape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 7 di danno.\nApplichi X di [gold]Forgiatura[/gold].\nApplichi 7 di [gold]Forgiatura[/gold] extra per ogni volta che hai colpito il nemico in questo turno.",
@@ -15803,7 +15803,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/deaths_door.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/deaths_door.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 7 di [gold]Blocco[/gold].\nSe hai applicato [gold]Condanna[/gold] in questo turno, ottieni [gold]Blocco[/gold] 2 volte extra.",
@@ -16056,7 +16056,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/pull_from_below.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pull_from_below.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 7 di danno per ogni carta con [gold]Evanescenza[/gold] giocata in questo combattimento.",
@@ -16154,7 +16154,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/prowess.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 2 di [gold]Forza[/gold].\nOttieni 2 di [gold]Destrezza[/gold].",
@@ -16194,7 +16194,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/production.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/production.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni [energy:3].",
@@ -16237,7 +16237,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/defile.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/defile.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 17 di danno.",
@@ -16359,7 +16359,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/boost_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/boost_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 9 di [gold]Blocco[/gold].\nAggiungi una carta [gold]Disorientato[/gold] alla tua [gold]pila degli scarti[/gold].",
@@ -16530,7 +16530,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/hidden_daggers.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_daggers.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Scarti 2 carte.\nAggiungi 2 [gold]carte Pugnale+[/gold] alla tua [gold]mano[/gold].",
@@ -16569,7 +16569,7 @@
       "damage": "+8"
     },
     "image_url": "/static/images/cards/knockout_blow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockout_blow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 38 di danno.\nSe questa carta uccide un nemico, ottieni [star:5].",
@@ -16693,7 +16693,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/rocket_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rocket_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 14 di danno.\nPeschi 2 carte.\nOgni volta che crei una carta Stato, riduci il costo di questa carta a 0 [energy:1] finché non viene giocata.",
@@ -16733,7 +16733,7 @@
       "increase": "+2"
     },
     "image_url": "/static/images/cards/kingly_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/kingly_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 10 di danno.\nQuando peschi questa carta, aumenti il suo danno di 6 durante questo combattimento.",
@@ -16945,7 +16945,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/uproar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/uproar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 7 di danno due volte.\nGioca una carta Attacco casuale dal tuo [gold]mazzo di pesca[/gold].",
@@ -17026,7 +17026,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/quasar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quasar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Scegli 1 tra 3 carte incolori casuali  [gold]potenziate[/gold] da aggiungere alla tua [gold]mano[/gold].",
@@ -17104,7 +17104,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/reap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 33 di danno.",
@@ -17146,7 +17146,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/gather_light.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gather_light.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 11 di [gold]Blocco[/gold].\nOttieni [star:1].",
@@ -17184,7 +17184,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/rally.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rally.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TUTTI i giocatori ottengono 17 di [gold]Blocco[/gold].",
@@ -17222,7 +17222,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/volley.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/volley.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 14 di danno a un nemico casuale X volte.",
@@ -17309,7 +17309,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/huddle_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/huddle_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TUTTI i giocatori pescano 3 carte.",
@@ -17388,7 +17388,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/rebound.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rebound.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 12 di danno.\nMetti la carta successiva che giochi in questo turno in cima al tuo [gold]mazzo di pesca[/gold].",
@@ -17477,7 +17477,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/relax.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/relax.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 17 di [gold]Blocco[/gold].\nIl prossimo turno, peschi 3 carte e ottieni [energy:3].",
@@ -17519,7 +17519,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/toric_toughness.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/toric_toughness.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 7 di [gold]Blocco[/gold].\nOttieni 7 di [gold]Blocco[/gold] all'inizio dei 2 turni successivi.",
@@ -17641,7 +17641,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/beckon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beckon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17733,7 +17733,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/know_thy_place.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/know_thy_place.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17776,7 +17776,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/dredge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dredge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17861,7 +17861,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/reflect.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reflect.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 21 di [gold]Blocco[/gold].\nIl danno bloccato viene rispedito a chi ha sferrato l'attacco in questo turno.",
@@ -17900,7 +17900,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/refract.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refract.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 12 di danno due volte.\n[gold]Vitreoglobi[/gold] [gold]canalizzati:[/gold] 2.",
@@ -17941,7 +17941,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/ricochet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ricochet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 3 di danno a un nemico casuale 5 volte.",
@@ -18022,7 +18022,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/spite.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spite.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 5 di danno.\nSe perdi PV in questo turno,\ncolpisce 3 volte.",
@@ -18147,7 +18147,7 @@
       "strengthpower": "+1"
     },
     "image_url": "/static/images/cards/resonance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/resonance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 2 di [gold]Forza[/gold]. TUTTI i nemici perdono 1 di [gold]Forza[/gold].",
@@ -18187,7 +18187,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/delay.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/delay.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 13 di [gold]Blocco[/gold].\nIl turno successivo\nottieni [energy:2].",
@@ -18272,7 +18272,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/seance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18361,7 +18361,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/collision_course.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/collision_course.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 15 di danno.\nAggiungi la carta [gold]Rottami[/gold] alla tua [gold]mano[/gold].",
@@ -18397,7 +18397,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/debris.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debris.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18527,7 +18527,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/spinner.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spinner.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Vitreoglobi[/gold] [gold]canalizzati[/gold]: 1.\n[gold]Vitreoglobi[/gold] [gold]canalizzati[/gold] all'inizio del tuo turno: 1.",
@@ -18565,7 +18565,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/begone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/begone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Scegli una carta nella tua [gold]mano[/gold] da [gold]trasformare[/gold] nella carta [gold]Colpo del Seguace+[/gold].",
@@ -18603,7 +18603,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/pillage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 9 di danno.\nPeschi carte finché non ottieni una carta non Attacco.",
@@ -18731,7 +18731,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/minion_sacrifice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_sacrifice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 12 di [gold]Blocco[/gold].",
@@ -18854,7 +18854,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/salvo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/salvo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 16 di danno.\n[gold]Conservi[/gold] la tua [gold]mano[/gold] in questo turno.",
@@ -18892,7 +18892,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/spectrum_shift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spectrum_shift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18932,7 +18932,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/energy_surge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/energy_surge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TUTTI i giocatori ottengono [energy:3].",
@@ -19013,7 +19013,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/fisticuffs.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fisticuffs.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 9 di danno.\nOttieni [gold]Blocco[/gold] pari al danno che hai inflitto.",
@@ -19100,7 +19100,7 @@
       "strengthloss": "+1"
     },
     "image_url": "/static/images/cards/crush_under.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crush_under.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 8 di danno a TUTTI i nemici. Tutti i nemici perdono 2 di [gold]Forza[/gold] per questo turno.",
@@ -19141,7 +19141,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/snap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/snap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] infligge 10 di danno.\nApplichi [gold]Conservazione[/gold] a una carta nella tua [gold]mano[/gold].",
@@ -19215,7 +19215,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/splash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/splash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Scegli 1 tra 3 carte Attacco casuali [gold]potenziate[/gold] di un altro personaggio da aggiungere alla tua [gold]mano[/gold]. Questo turno puoi giocarla senza nessun costo.",
@@ -19371,7 +19371,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/glow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni [star:2].\nPeschi 1 carta.\nNel turno successivo, peschi 1 carta.",
@@ -19411,7 +19411,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/severance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/severance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 18 di danno.\nAggiungi una carta [gold]Anima[/gold] al tuo [gold]mazzo di pesca[/gold], alla tua [gold]mano[/gold] e alla tua [gold]pila degli scarti[/gold].",
@@ -19452,7 +19452,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/royal_gamble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royal_gamble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19657,7 +19657,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/demonic_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demonic_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19746,7 +19746,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/tracking.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tracking.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19826,7 +19826,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 11 di danno a TUTTI i nemici.",
@@ -19867,7 +19867,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/bury.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bury.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 63 di danno.",
@@ -19952,7 +19952,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/seven_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seven_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20042,7 +20042,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/bad_luck.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bad_luck.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20137,7 +20137,7 @@
       "ostydamage": "+5"
     },
     "image_url": "/static/images/cards/sweeping_gaze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sweeping_gaze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] infligge 15 di danno a un nemico casuale.",
@@ -20219,7 +20219,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/whistle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/whistle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 44 di danno.\nProvochi [gold]Stordimento[/gold] sul nemico.",
@@ -20263,7 +20263,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/synchronize.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synchronize.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20304,7 +20304,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/synthesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synthesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 18 di danno.\nIl costo della carta Potere successiva che giochi è pari a 0 [energy:1].",
@@ -20418,7 +20418,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/lift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Dona a un altro giocatore 16 di [gold]Blocco[/gold].",
@@ -20456,7 +20456,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/i_am_invincible.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/i_am_invincible.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 13 di [gold]Blocco[/gold].\nAl termine del tuo turno, se questa carta è in cima al [gold]mazzo di pesca[/gold], giocala.",
@@ -20544,7 +20544,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/subroutine.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/subroutine.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20661,7 +20661,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/seeking_edge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeking_edge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Applichi 11 di [gold]Forgiatura[/gold].\nLa carta [gold]Spada Sovrana[/gold] ora infligge danno a TUTTI i nemici.",
@@ -20705,7 +20705,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sovereign_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sovereign_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20832,7 +20832,7 @@
       "poison": "+3"
     },
     "image_url": "/static/images/cards/bubble_bubble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Se il nemico ha [gold]Veleno[/gold], applichi 12 di [gold]Veleno[/gold].",
@@ -20880,7 +20880,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/apparition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/apparition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20922,7 +20922,7 @@
       "blockonexhaust": "+1"
     },
     "image_url": "/static/images/cards/spirit_of_ash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spirit_of_ash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che giochi una carta con [gold]Evanescenza[/gold], ottieni 5 di [gold]Blocco[/gold].",
@@ -20958,7 +20958,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/spore_mind.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spore_mind.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21000,7 +21000,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/misery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/misery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 9 di danno.\nApplichi tutti i debuff che ha il nemico su TUTTI gli altri nemici.",
@@ -21038,7 +21038,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/omnislice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/omnislice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 11 di danno.\nInfliggi danno a TUTTI gli altri nemici pari al danno inflitto.",
@@ -21124,7 +21124,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/photon_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/photon_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 13 di danno.\nPeschi 2 carte.\nMetti 1 carta della tua [gold]mano[/gold] in cima al tuo [gold]mazzo di pesca[/gold].",
@@ -21163,7 +21163,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/stack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni [gold]Blocco[/gold] pari al numero di carte nella tua [gold]pila degli scarti[/gold] +3.",
@@ -21260,7 +21260,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/falling_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/falling_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 12 di danno.\nApplichi 1 di [gold]Debolezza[/gold].\nApplichi 1 di [gold]Vulnerabilità[/gold].",
@@ -21301,7 +21301,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/guiding_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/guiding_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 13 di danno.\nPeschi 3 carte.",
@@ -21344,7 +21344,7 @@
       "strengthloss": "+2"
     },
     "image_url": "/static/images/cards/dying_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dying_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 11 di danno a TUTTI i nemici. Tutti i nemici perdono 11 di [gold]Forza[/gold] in questo turno.",
@@ -21432,7 +21432,7 @@
       "stranglepower": "+1"
     },
     "image_url": "/static/images/cards/strangle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/strangle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 10 di danno.\nOgni volta che giochi una carta in questo turno, il nemico perde 3 PV.",
@@ -21468,7 +21468,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/stratagem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stratagem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21551,7 +21551,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/maul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/maul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 6 di danno due volte.\nAumenti il danno di tutte le carte Strazio di 2 in questo combattimento.",
@@ -21594,7 +21594,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/squeeze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/squeeze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold] infligge 25 di danno.\nInfligge 6 di danno extra per TUTTE le tue carte Attacco di [gold]Osty[/gold].",
@@ -21634,7 +21634,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/supermassive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/supermassive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 5 di danno.\nInfliggi 4 di danno extra per ogni carta creata in questo combattimento.",
@@ -21763,7 +21763,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/turbo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/turbo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni [energy:3].\nAggiungi una carta [gold]Vuoto[/gold] alla tua [gold]pila degli scarti[/gold].",
@@ -21879,7 +21879,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/precise_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/precise_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21925,7 +21925,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/drum_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/drum_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Peschi 3 carte.\nAll'inizio del tuo turno, [gold]esaurisci[/gold] la carta in cima al tuo [gold]mazzo di pesca[/gold].",
@@ -22175,7 +22175,7 @@
       "preptimepower": "+2"
     },
     "image_url": "/static/images/cards/prep_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prep_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "All'inizio del tuo turno, ottieni 6 di [gold]Vigore[/gold].",
@@ -22295,7 +22295,7 @@
       "vigorpower": "+2"
     },
     "image_url": "/static/images/cards/terraforming.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/terraforming.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 8 di [gold]Vigore[/gold].",
@@ -22393,7 +22393,7 @@
       "starnextturnpower": "+1"
     },
     "image_url": "/static/images/cards/hidden_cache.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_cache.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni [star:1].\nIl turno successivo ottieni [star:4].",
@@ -22469,7 +22469,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/shadow_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shadow_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 15 di [gold]Blocco[/gold].\n[gold]Tetroglobi[/gold] [gold]canalizzati[/gold]: 1.",
@@ -22507,7 +22507,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/tyranny.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tyranny.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22588,7 +22588,7 @@
       "strengthloss": "+3"
     },
     "image_url": "/static/images/cards/enfeebling_touch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enfeebling_touch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ill nemico perde 11 di [gold]Forza[/gold] in questo turno.",
@@ -22633,7 +22633,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/soul_storm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul_storm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 9 di danno.\nInfliggi 3 di danno extra per ogni carta [gold]Anima[/gold] nella tua [gold]pila delle carte esaurite[/gold].",
@@ -22755,7 +22755,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/knife_trap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knife_trap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Potenzia[/gold] e gioca tutte le carte [gold]Pugnale[/gold] della tua [gold]pila delle carte esaurite[/gold] contro il nemico.",
@@ -22795,7 +22795,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/transfigure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/transfigure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22834,7 +22834,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/trash_to_treasure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/trash_to_treasure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22929,7 +22929,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/caltrops.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/caltrops.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che subisci un attacco, infliggi 5 di danno come contrattacco.",
@@ -22968,7 +22968,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/heavenly_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heavenly_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 10 di danno X volte.\nRaddoppi per X se il suo valore è pari o superiore a 4.",
@@ -23008,7 +23008,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/helix_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/helix_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Infliggi 5 di danno per ogni [energy:1] che hai precedentemente consumato in questo turno.",
@@ -23046,7 +23046,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/the_sealed_throne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_sealed_throne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23165,7 +23165,7 @@
       "thunderpower": "+2"
     },
     "image_url": "/static/images/cards/thunder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/thunder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che [gold]evochi un Elettroglobo[/gold], infliggi 8 di danno a ogni nemico colpito.",
@@ -23357,7 +23357,7 @@
       "cost": 7
     },
     "image_url": "/static/images/cards/banshees_cry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/banshees_cry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23619,7 +23619,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/shroud.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shroud.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che applichi [gold]Condanna[/gold], ottieni 3 di [gold]Blocco[/gold].",
@@ -23664,7 +23664,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/speedster.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/speedster.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23702,7 +23702,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/venerate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/venerate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni [star:3].",
@@ -23781,7 +23781,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/vicious.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/vicious.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ogni volta che applichi [gold]Vulnerabilità[/gold], peschi 2 carte.",
@@ -23823,7 +23823,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/glimpse_beyond.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glimpse_beyond.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TUTTI i giocatori aggiungono 4 [gold]carte Anima[/gold] nel loro [gold]mazzo di pesca[/gold].",
@@ -23864,7 +23864,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/glasswork.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glasswork.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Ottieni 8 di [gold]Blocco[/gold].\n[gold]Vitreoglobi[/gold] [gold]canalizzati[/gold]: 1.",

--- a/data/jpn/cards.json
+++ b/data/jpn/cards.json
@@ -70,7 +70,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/believe_in_you.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/believe_in_you.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "他のプレイヤーは[energy:3]を得る。",
@@ -184,7 +184,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/soot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -347,7 +347,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/pillage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9ダメージを与える。\nアタック以外のカードを引くまで、カードを引く。",
@@ -433,7 +433,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/caltrops.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/caltrops.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "アタックされるたび、反撃して5ダメージを与える。",
@@ -475,7 +475,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/right_hand_hand.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/right_hand_hand.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]オスティ[/gold]が6ダメージを与える。コストが[energy:2]以上のカードをプレイするたび、これを[gold]捨て札[/gold]から[gold]手札[/gold]に戻す。",
@@ -557,7 +557,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/mimic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mimic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -610,7 +610,7 @@
       "sicempower": "+1"
     },
     "image_url": "/static/images/cards/sic_em.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sic_em.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]オスティ[/gold]が6ダメージを与える。このターン、[gold]オスティ[/gold]がこの敵を攻撃するたび、[gold]召喚[/gold]3。",
@@ -689,7 +689,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/ice_lance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ice_lance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "24ダメージを与える。\n[gold]フロスト[/gold]3を[gold]生成[/gold]する。",
@@ -765,7 +765,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/ascenders_bane.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ascenders_bane.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -810,7 +810,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/adaptive_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/adaptive_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "23ダメージを与える。\nこのカードの0[energy:1]のコピーを1枚[gold]捨て札[/gold]に加える。",
@@ -1014,7 +1014,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/ignition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ignition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1055,7 +1055,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/intercept.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/intercept.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13[gold]ブロック[/gold]を得る。\nこのターン、他のプレイヤーが受けるすべての攻撃を自分が代わりに受ける。",
@@ -1178,7 +1178,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/wisp.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wisp.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1226,7 +1226,7 @@
       "preptimepower": "+2"
     },
     "image_url": "/static/images/cards/prep_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prep_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ターン開始時、[gold]活力[/gold]6を得る。",
@@ -1266,7 +1266,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/energy_surge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/energy_surge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "すべてのプレイヤーは[energy:3]を得る。",
@@ -1307,7 +1307,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/entropy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entropy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1390,7 +1390,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/automation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/automation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1587,7 +1587,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/cascade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cascade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]山札[/gold]の上からX+1枚のカードをプレイする。",
@@ -1623,7 +1623,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/calamity.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/calamity.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1666,7 +1666,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/rattle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rattle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]オスティ[/gold]が9ダメージを与える。\nこのターン中に[gold]オスティ[/gold]が攻撃した回数分、追加で繰り返す。",
@@ -1704,7 +1704,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/glasswork.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glasswork.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "8[gold]ブロック[/gold]を得る。\n[gold]グラス[/gold]1を[gold]生成[/gold]する。",
@@ -1758,7 +1758,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/gamma_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gamma_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "18ダメージを与える。\n[gold]脱力[/gold]2を付与する。\n[gold]弱体[/gold]2を付与する。",
@@ -1796,7 +1796,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/quadcast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quadcast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1834,7 +1834,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/quasar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quasar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ランダムな[gold]アップグレード[/gold]済みの無色カード3枚の中から1枚選び、[gold]手札[/gold]に加える。",
@@ -1872,7 +1872,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/clash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/clash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]手札[/gold]のカードがすべてアタックの場合にのみプレイできる。\n18ダメージを与える。",
@@ -2100,7 +2100,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/subroutine.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/subroutine.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2145,7 +2145,7 @@
       "thunderpower": "+2"
     },
     "image_url": "/static/images/cards/thunder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/thunder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]ライトニングを解放[/gold]するたび、命中した各敵に8ダメージを与える。",
@@ -2268,7 +2268,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/shining_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shining_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "11ダメージを与える。\n[star:2]を得る。\nこのカードを[gold]山札[/gold]の一番上に置く。",
@@ -2306,7 +2306,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/shadow_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shadow_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "15[gold]ブロック[/gold]を得る。\n[gold]ダーク[/gold]1を[gold]生成[/gold]する。",
@@ -2382,7 +2382,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/synthesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synthesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "18ダメージを与える。\n次にプレイするパワーのコストが0[energy:1]。",
@@ -2423,7 +2423,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/seeker_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeker_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "12ダメージを与える。\n[gold]山札[/gold]のランダムなカード3枚から1枚選び、[gold]手札[/gold]に加える。",
@@ -2543,7 +2543,7 @@
       "starsperturn": "+1"
     },
     "image_url": "/static/images/cards/genesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/genesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ターン開始時、[star:3]を得る。",
@@ -2624,7 +2624,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/juggling.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/juggling.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2663,7 +2663,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/jackpot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/jackpot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "30ダメージを与える。\nランダムな[gold]アップグレード[/gold]済みのコスト0[energy:1]のカードを3枚[gold]手札[/gold]に加える。",
@@ -2780,7 +2780,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/stack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]捨て札[/gold]の枚数 +3に等しい[gold]ブロック[/gold]を得る。",
@@ -3115,7 +3115,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/spinner.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spinner.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]グラス[/gold]1を[gold]生成[/gold]する。\nターン開始時、[gold]グラス[/gold]1を[gold]生成[/gold]する。",
@@ -3160,7 +3160,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/speedster.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/speedster.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3196,7 +3196,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/splash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/splash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "他のキャラクターのランダムな[gold]アップグレード[/gold]済みのアタックを3枚見て1枚を選び、[gold]手札[/gold]に加える。このターン、それはコストを支払わずにプレイできる。",
@@ -3234,7 +3234,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/spectrum_shift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spectrum_shift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3399,7 +3399,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/seven_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seven_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3439,7 +3439,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/soul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "カードを3枚引く。",
@@ -3484,7 +3484,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/soul_storm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul_storm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9ダメージを与える。\n[gold]廃棄札[/gold]にある[gold]ソウル[/gold]1枚につき、追加で3ダメージを与える。",
@@ -3528,7 +3528,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sovereign_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sovereign_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3686,7 +3686,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/tank.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tank.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3883,7 +3883,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/tesla_coil.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tesla_coil.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "6ダメージを与える。\n敵に対し、すべての[gold]ライトニング[/gold]の自動効果を発動する。",
@@ -3928,7 +3928,7 @@
       "vigorpower": "+2"
     },
     "image_url": "/static/images/cards/terraforming.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/terraforming.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]活力[/gold]8を得る。",
@@ -4042,7 +4042,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/delay.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/delay.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13[gold]ブロック[/gold]を得る。\n次のターン、\n[energy:2]を得る。",
@@ -4175,7 +4175,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/debris.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debris.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4340,7 +4340,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/knife_trap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knife_trap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]廃棄札[/gold]にあるすべての[gold]ナイフ[/gold]を[gold]アップグレード[/gold]してプレイする。",
@@ -4426,7 +4426,7 @@
       "platingpower": "+3"
     },
     "image_url": "/static/images/cards/neutron_aegis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neutron_aegis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]プレート[/gold]11を得る。",
@@ -4473,7 +4473,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/neurosurge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neurosurge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:4]を得る。\nカードを2枚引く。\nターン開始時、自身に[gold]破滅[/gold]3を付与する。",
@@ -4603,7 +4603,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/necro_mastery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/necro_mastery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]召喚[/gold]8。\n[gold]オスティ[/gold]がHPを失うたび、すべての敵が同じ値のHPを失う。",
@@ -4642,7 +4642,7 @@
       "damage": "+8"
     },
     "image_url": "/static/images/cards/knockout_blow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockout_blow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "38ダメージを与える。\nこのカードでとどめを刺した時、[star:5]を得る。",
@@ -4689,7 +4689,7 @@
       "knockdownpower": "+1"
     },
     "image_url": "/static/images/cards/knockdown.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockdown.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "14ダメージを与える。\nこのターン、敵は他のプレイヤーから3倍のダメージを受ける。",
@@ -4821,7 +4821,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/hello_world.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hello_world.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4857,7 +4857,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/hammer_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hammer_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5109,7 +5109,7 @@
       "poison": "+3"
     },
     "image_url": "/static/images/cards/bubble_bubble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "敵が[gold]毒[/gold]に侵されている場合、[gold]毒[/gold]12を付与する。",
@@ -5220,7 +5220,7 @@
       "cost": 7
     },
     "image_url": "/static/images/cards/banshees_cry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/banshees_cry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5299,7 +5299,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/snap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/snap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]オスティ[/gold]が10ダメージを与える。\n[gold]手札[/gold]のカード1枚が[gold]保留[/gold]を得る。",
@@ -5346,7 +5346,7 @@
       "parrypower": "+4"
     },
     "image_url": "/static/images/cards/parry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/parry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]ソヴリン・ブレード[/gold]をプレイするたび、14[gold]ブロック[/gold]を得る。",
@@ -5431,7 +5431,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/big_bang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/big_bang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5549,7 +5549,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/beat_down.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_down.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]捨て札[/gold]からランダムなアタックを4枚プレイする。",
@@ -5720,7 +5720,7 @@
       "phantombladespower": "+3"
     },
     "image_url": "/static/images/cards/phantom_blades.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/phantom_blades.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]ナイフ[/gold]が[gold]保留[/gold]を得る。\n毎ターン、最初にプレイする[gold]ナイフ[/gold]が追加で12ダメージを与える。",
@@ -5801,7 +5801,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/photon_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/photon_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13ダメージを与える。\nカードを2枚引く。\n[gold]手札[/gold]からカードを1枚選び、[gold]山札[/gold]の一番上に置く。",
@@ -5850,7 +5850,7 @@
       "focuspower": "+1"
     },
     "image_url": "/static/images/cards/focused_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/focused_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "11ダメージを与える。\nターン終了時まで[gold]集中力[/gold]2を得る。",
@@ -5935,7 +5935,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/flak_cannon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/flak_cannon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "すべての状態異常を[gold]廃棄[/gold]する。[gold]廃棄[/gold]したカード1枚につき、ランダムな敵に11ダメージを与える。",
@@ -6109,7 +6109,7 @@
       "strength": "+2"
     },
     "image_url": "/static/images/cards/feeding_frenzy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ターン終了時まで[gold]筋力[/gold]7を得る。",
@@ -6154,7 +6154,7 @@
       "blackholepower": "+1"
     },
     "image_url": "/static/images/cards/black_hole.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/black_hole.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[star:1]を使用するか得るたび、すべての敵に4ダメージを与える。",
@@ -6321,7 +6321,7 @@
       "hailstormpower": "+2"
     },
     "image_url": "/static/images/cards/hailstorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hailstorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ターン終了時、[gold]フロスト[/gold]を生成中の場合、すべての敵に8ダメージを与える。",
@@ -6400,7 +6400,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/gunk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gunk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "5ダメージを3回与える。\n[gold]粘液[/gold]を1枚[gold]捨て札[/gold]に加える。",
@@ -6514,7 +6514,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/heavenly_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heavenly_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "10ダメージをX回与える。\nXが4以上なら、Xを2倍にする。",
@@ -6552,7 +6552,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/veilpiercer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/veilpiercer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13ダメージを与える。\n次にプレイする[gold]エセリアル[/gold]のコストは0[energy:1]。",
@@ -6591,7 +6591,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/pale_blue_dot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pale_blue_dot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "1ターンの間にカードを5枚以上プレイした場合、次のターン開始時、カードを2枚引く。",
@@ -6631,7 +6631,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/whistle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/whistle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "44ダメージを与える。\nこの敵を[gold]スタン[/gold]させる。",
@@ -6681,7 +6681,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/hotfix.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hotfix.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6807,7 +6807,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/bodyguard.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bodyguard.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]召喚[/gold]7。",
@@ -7202,7 +7202,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/misery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/misery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9ダメージを与える。\n対象の敵に付与しているすべてのデバフを、他のすべての敵にも付与する。",
@@ -7289,7 +7289,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/minion_sacrifice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_sacrifice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "12[gold]ブロック[/gold]を得る。",
@@ -7336,7 +7336,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/minion_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9ダメージを与える。\nカードを1枚引く。",
@@ -7458,7 +7458,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/monologue.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/monologue.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7536,7 +7536,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/lantern_key.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lantern_key.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7616,7 +7616,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/rebound.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rebound.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "12ダメージを与える。\nこのターン、次にプレイするカードを[gold]山札[/gold]の一番上に置く。",
@@ -7660,7 +7660,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/relax.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/relax.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "17[gold]ブロック[/gold]を得る。\n次のターン、カードを3枚引き、[energy:3]を得る。",
@@ -7706,7 +7706,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/leading_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/leading_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "6ダメージを与える。\n[gold]ナイフ[/gold]を2枚[gold]手札[/gold]に加える。",
@@ -7823,7 +7823,7 @@
       "gold": "+5"
     },
     "image_url": "/static/images/cards/royalties.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royalties.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "戦闘終了時、35[gold]ゴールド[/gold]を獲得する。",
@@ -7864,7 +7864,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/royal_gamble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royal_gamble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7907,7 +7907,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/rocket_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rocket_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "14ダメージを与える。\nカードを2枚引く。\n状態異常を作成するたび、プレイするまでこのカードのコストは0[energy:1]。",
@@ -7983,7 +7983,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/salvo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/salvo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "16ダメージを与える。\nこのターン、[gold]手札[/gold]をすべて[gold]保留[/gold]する。",
@@ -8356,7 +8356,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/crash_landing.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crash_landing.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "すべての敵に26ダメージを与える。\n[gold]手札[/gold]を[gold]デブリ[/gold]で満たす。",
@@ -8394,7 +8394,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/undeath.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/undeath.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9[gold]ブロック[/gold]を得る。\nこのカードのコピーを1枚[gold]捨て札[/gold]に加える。",
@@ -8478,7 +8478,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/bad_luck.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bad_luck.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8639,7 +8639,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/dual_wield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "アタックかパワーを1枚選ぶ。そのコピーを2枚[gold]手札[/gold]に加える。",
@@ -8715,7 +8715,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/eidolon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/eidolon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8798,7 +8798,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/huddle_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/huddle_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "全プレイヤーはカードを3枚引く。",
@@ -8983,7 +8983,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/fight_me.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "6ダメージを2回与える。\n[gold]筋力[/gold]4を得る。\n敵は[gold]筋力[/gold]1を得る。",
@@ -9060,7 +9060,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/outmaneuver.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outmaneuver.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "次のターン、[energy:3]を得る。",
@@ -9099,7 +9099,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/gather_light.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gather_light.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "11[gold]ブロック[/gold]を得る。\n[star:1]を得る。",
@@ -9186,7 +9186,7 @@
       "strengthpower": "+1"
     },
     "image_url": "/static/images/cards/resonance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/resonance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]筋力[/gold]2を得る。すべての敵は[gold]筋力[/gold]1を失う。",
@@ -9263,7 +9263,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/toric_toughness.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/toric_toughness.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "7[gold]ブロック[/gold]を得る。\n次のターン開始時、7[gold]ブロック[/gold]を得る。",
@@ -9346,7 +9346,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/defile.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/defile.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "17ダメージを与える。",
@@ -9552,7 +9552,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/wrought_in_war.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wrought_in_war.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9ダメージを与える。\n[gold]鍛造[/gold]9。",
@@ -9592,7 +9592,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/severance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/severance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "18ダメージを与える。\n[gold]ソウル[/gold]を1枚、[gold]山札[/gold]、[gold]手札[/gold]、[gold]捨て札[/gold]にそれぞれ加える。",
@@ -9711,7 +9711,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/reap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "33ダメージを与える。",
@@ -9768,7 +9768,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/abrasive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/abrasive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]敏捷[/gold]1を得る。\n[gold]トゲ[/gold]6を得る。",
@@ -9855,7 +9855,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/refine_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refine_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]鍛造[/gold]13。\n次のターン、[energy:1]を得る。",
@@ -9947,7 +9947,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sword_sage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sword_sage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9985,7 +9985,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/pillar_of_creation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillar_of_creation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "カードを1枚作成するたび、4[gold]ブロック[/gold]を得る。",
@@ -10110,7 +10110,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/turbo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/turbo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3]を得る。\n[gold]虚無[/gold]を1枚[gold]捨て札[/gold]に加える。",
@@ -10148,7 +10148,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/distraction.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/distraction.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10271,7 +10271,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/reflect.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reflect.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "21[gold]ブロック[/gold]を得る。\nこのターン、ブロックしたアタックによるダメージを、攻撃してきた敵に跳ね返す。",
@@ -10359,7 +10359,7 @@
       "iterationpower": "+1"
     },
     "image_url": "/static/images/cards/iteration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/iteration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "毎ターン、最初に状態異常を引いた時、カードを3枚引く。",
@@ -10572,7 +10572,7 @@
       "calculationextra": "+2"
     },
     "image_url": "/static/images/cards/beat_into_shape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_into_shape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "7ダメージを与える。\n[gold]鍛造[/gold]X。\nこのターンに対象の敵へ攻撃していた回数（これを除く）1回につき、追加で[gold]鍛造[/gold]7。",
@@ -10613,7 +10613,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/synchronize.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synchronize.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10699,7 +10699,7 @@
       "sleightoffleshpower": "+4"
     },
     "image_url": "/static/images/cards/sleight_of_flesh.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sleight_of_flesh.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "敵にデバフを付与するたび、その敵は13ダメージを受ける。",
@@ -10814,7 +10814,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/omnislice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/omnislice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "11ダメージを与える。\n与えたダメージと同じダメージを、他のすべての敵に与える。",
@@ -10854,7 +10854,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/compact.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/compact.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "7[gold]ブロック[/gold]を得る。\n[gold]手札[/gold]にあるすべての状態異常を[gold]燃料+[/gold]に[gold]変化[/gold]させる。",
@@ -10894,7 +10894,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/pull_from_below.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pull_from_below.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "この戦闘中にプレイした[gold]エセリアル[/gold]1枚につき、7ダメージを与える。",
@@ -10971,7 +10971,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/bury.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bury.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "63ダメージを与える。",
@@ -11011,7 +11011,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/bulwark.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulwark.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "16[gold]ブロック[/gold]を得る。\n[gold]鍛造[/gold]13。",
@@ -11085,7 +11085,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/entrench.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entrench.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11126,7 +11126,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/graveblast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/graveblast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "6ダメージを与える。\n[gold]捨て札[/gold]からカードを1枚[gold]手札[/gold]に加える。",
@@ -11210,7 +11210,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/blade_of_ink.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/blade_of_ink.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[purple]墨塗り[/purple]の[gold]ナイフ[/gold]を3枚、[gold]手札[/gold]に加える。",
@@ -11250,7 +11250,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/transfigure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/transfigure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11340,7 +11340,7 @@
       "rollingboulderpower": "+5"
     },
     "image_url": "/static/images/cards/rolling_boulder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rolling_boulder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ターン開始時、すべての敵に10ダメージを与え、このダメージを5増加させる。",
@@ -11385,7 +11385,7 @@
       "serpentformpower": "+2"
     },
     "image_url": "/static/images/cards/serpent_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/serpent_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "カードをプレイするたび、ランダムな敵に6ダメージを与える。",
@@ -11427,7 +11427,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/the_scythe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_scythe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13ダメージを与える。\nこのカードのダメージが永続的に4増加する。",
@@ -11468,7 +11468,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/uproar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/uproar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "7ダメージを2回与える。\n[gold]山札[/gold]からランダムなアタックを1枚プレイする。",
@@ -11545,7 +11545,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/catastrophe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/catastrophe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]山札[/gold]にあるカードをランダムに3枚プレイする。",
@@ -11630,7 +11630,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/begone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/begone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]手札[/gold]のカードを1枚選び、[gold]ミニオンストライク+[/gold]に[gold]変化[/gold]させる。",
@@ -11709,7 +11709,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/up_my_sleeve.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/up_my_sleeve.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]ナイフ[/gold]を4枚[gold]手札[/gold]に加える。\nこのカードのコストが1減少する。",
@@ -11836,7 +11836,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/cosmic_indifference.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cosmic_indifference.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9[gold]ブロック[/gold]を得る。\n[gold]捨て札[/gold]のカードを1枚[gold]山札[/gold]の一番上に置く。",
@@ -11911,7 +11911,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/make_it_so.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/make_it_so.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9ダメージを与える。\n1ターンの間に、スキルを3枚プレイするたび、これを[gold]手札[/gold]に戻す。",
@@ -11950,7 +11950,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/heirloom_hammer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heirloom_hammer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "25ダメージを与える。\n[gold]手札[/gold]にある無色カードを1枚選び、そのコピーを1枚[gold]手札[/gold]に加える。",
@@ -12065,7 +12065,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/largesse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/largesse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "他のプレイヤー1人は、ランダムな[gold]アップグレード[/gold]済みの無色カードを1枚[gold]手札[/gold]に加える。",
@@ -12102,7 +12102,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/poor_sleep.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/poor_sleep.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12144,7 +12144,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/the_sealed_throne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_sealed_throne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12182,7 +12182,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/tyranny.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tyranny.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12226,7 +12226,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/guiding_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/guiding_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13ダメージを与える。\nカードを3枚引く。",
@@ -12273,7 +12273,7 @@
       "vigorpower": "+1"
     },
     "image_url": "/static/images/cards/patter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/patter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "11[gold]ブロック[/gold]を得る。\n[gold]活力[/gold]3を得る。",
@@ -12312,7 +12312,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/refract.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refract.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "12ダメージを2回与える。\n[gold]グラス[/gold]2を[gold]生成[/gold]する。",
@@ -12355,7 +12355,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/disintegration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/disintegration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -12394,7 +12394,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/colossus.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/colossus.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "8[gold]ブロック[/gold]を得る。\nこのターン、[gold]弱体[/gold]中の敵から受けるダメージが50%減少する。",
@@ -12432,7 +12432,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/giant_rock.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/giant_rock.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "20ダメージを与える。",
@@ -12468,7 +12468,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/beacon_of_hope.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beacon_of_hope.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12516,7 +12516,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/apparition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/apparition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12639,7 +12639,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/maul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/maul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "6ダメージを2回与える。\nこの戦闘中、すべての引き裂きのダメージが2増加する。",
@@ -12723,7 +12723,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/greed.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/greed.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12807,7 +12807,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/fight_through.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_through.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "17[gold]ブロック[/gold]を得る。\n[gold]負傷[/gold]を2枚[gold]捨て札[/gold]に加える。",
@@ -12861,7 +12861,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/comet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/comet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "44ダメージを与える。\n[gold]脱力[/gold]3を付与する。\n[gold]弱体[/gold]3を付与する。",
@@ -12901,7 +12901,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sculpting_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sculpting_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "12ダメージを与える。\n[gold]手札[/gold]のカード1枚が[gold]エセリアル[/gold]を得る。",
@@ -12977,7 +12977,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/shroud.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shroud.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]破滅[/gold]を付与するたび、3[gold]ブロック[/gold]を得る。",
@@ -13057,7 +13057,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/glimpse_beyond.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glimpse_beyond.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "すべてのプレイヤーは[gold]ソウル[/gold]を4枚[gold]山札[/gold]に加える。",
@@ -13098,7 +13098,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/conqueror.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conqueror.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]鍛造[/gold]5。\nこのターン、[gold]ソヴリン・ブレード[/gold]は対象の敵に2倍のダメージを与える。",
@@ -13212,7 +13212,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/enthralled.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enthralled.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13336,7 +13336,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/bundle_of_joy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bundle_of_joy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ランダムな無色カードを4枚[gold]手札[/gold]に加える。",
@@ -13382,7 +13382,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/sloth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sloth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -13501,7 +13501,7 @@
       "cards": "+2"
     },
     "image_url": "/static/images/cards/decisions_decisions.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/decisions_decisions.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "カードを5枚引く。\n[gold]手札[/gold]にあるスキルを1枚選び、それを3回プレイする。",
@@ -13584,7 +13584,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/spite.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spite.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "5ダメージを与える。\nこのターン、HPを失っていた場合、\n3回攻撃する。",
@@ -13626,7 +13626,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/demonic_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demonic_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13757,7 +13757,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/infection.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/infection.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13806,7 +13806,7 @@
       "outbreakpower": "+4"
     },
     "image_url": "/static/images/cards/outbreak.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outbreak.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]毒[/gold]を3回付与するたび、すべての敵に15ダメージを与える。",
@@ -13885,7 +13885,7 @@
       "hploss": "+2"
     },
     "image_url": "/static/images/cards/haunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]ソウル[/gold]をプレイするたび、ランダムな敵がHPを8失う。",
@@ -13923,7 +13923,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/i_am_invincible.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/i_am_invincible.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13[gold]ブロック[/gold]を得る。\nターン終了時、これが[gold]山札[/gold]の一番上にある場合、自動的にプレイする。",
@@ -13969,7 +13969,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/drum_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/drum_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "カードを3枚引く。\nターン開始時、[gold]山札[/gold]の一番上のカードを[gold]廃棄[/gold]する。",
@@ -14048,7 +14048,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/spoils_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]鍛造[/gold]8。\nカードを2枚引く。",
@@ -14086,7 +14086,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/spoils_map.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_map.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14170,7 +14170,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/lift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "他のプレイヤー1人が16[gold]ブロック[/gold]を得る。",
@@ -14244,7 +14244,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/beckon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beckon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14373,7 +14373,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/fisticuffs.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fisticuffs.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9ダメージを与える。\n与えたダメージに等しい[gold]ブロック[/gold]を得る。",
@@ -14541,7 +14541,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/dredge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dredge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14587,7 +14587,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/squeeze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/squeeze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]オスティ[/gold]が25ダメージを与える。他のすべての[gold]オスティ[/gold]のアタック1枚につき、追加で6ダメージを与える。",
@@ -14626,7 +14626,7 @@
       "damage": "+10"
     },
     "image_url": "/static/images/cards/devastate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devastate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "40ダメージを与える。",
@@ -14665,7 +14665,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/modded.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/modded.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "オーブスロットを1個得る。\nカードを2枚引く。このカードのコストが1増加する。",
@@ -14780,7 +14780,7 @@
       "blockforstars": "+1"
     },
     "image_url": "/static/images/cards/child_of_the_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/child_of_the_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[star:1]を消費するたび、消費した[star:1]1つにつき3[gold]ブロック[/gold]を得る。",
@@ -14819,7 +14819,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/alignment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/alignment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3]を得る。",
@@ -14862,7 +14862,7 @@
       "strengthloss": "+2"
     },
     "image_url": "/static/images/cards/dying_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dying_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "すべての敵に11ダメージを与える。ターン終了時まですべての敵は[gold]筋力[/gold]11を失う。",
@@ -14942,7 +14942,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/astral_pulse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/astral_pulse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "すべての敵に18ダメージを与える。",
@@ -14983,7 +14983,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/hidden_daggers.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_daggers.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "カードを2枚捨てる。\n[gold]ナイフ+[/gold]を2枚[gold]手札[/gold]に加える。",
@@ -15194,7 +15194,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/lunar_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lunar_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "このターンにプレイしたスキル1枚につき、5ダメージを与える。",
@@ -15272,7 +15272,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "HPを13回復する。",
@@ -15315,7 +15315,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/afterlife.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/afterlife.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]召喚[/gold]9。",
@@ -15442,7 +15442,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/brightest_flame.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/brightest_flame.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3]を得る。\nカードを3枚引く。\n最大HPを1失う。",
@@ -15480,7 +15480,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/manifest_authority.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/manifest_authority.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "8[gold]ブロック[/gold]を得る。\nランダムな[gold]アップグレード[/gold]済みの無色カードを1枚[gold]手札[/gold]に加える。",
@@ -15616,7 +15616,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/prowess.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]筋力[/gold]2を得る。\n[gold]敏捷[/gold]2を得る。",
@@ -15661,7 +15661,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/arsenal.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/arsenal.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15745,7 +15745,7 @@
       "dansemacabrepower": "+2"
     },
     "image_url": "/static/images/cards/danse_macabre.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/danse_macabre.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "コストが[energy:2]以上のカードをプレイするたび、6[gold]ブロック[/gold]を得る。",
@@ -15825,7 +15825,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/deaths_door.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/deaths_door.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "7[gold]ブロック[/gold]を得る。\nこのターンに[gold]破滅[/gold]を付与していた場合、追加で2回[gold]ブロック[/gold]を得る。",
@@ -15861,7 +15861,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/reaper_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reaper_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15996,7 +15996,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/vicious.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/vicious.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]弱体[/gold]を付与するたび、カードを2枚引く。",
@@ -16036,7 +16036,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/murder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/murder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16083,7 +16083,7 @@
       "lethalitypower": "+25"
     },
     "image_url": "/static/images/cards/lethality.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lethality.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "毎ターン、最初のアタックは追加で75%のダメージを与える。",
@@ -16225,7 +16225,7 @@
       "poison": "+2"
     },
     "image_url": "/static/images/cards/haze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "すべての敵に[gold]毒[/gold]6を付与する。",
@@ -16341,7 +16341,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/frantic_escape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/frantic_escape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -16478,7 +16478,7 @@
       "crimsonmantlepower": "+2"
     },
     "image_url": "/static/images/cards/crimson_mantle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crimson_mantle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ターン開始時、HPを1失い、10[gold]ブロック[/gold]を得る。",
@@ -16635,7 +16635,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/furnace.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/furnace.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ターン開始時、[gold]鍛造[/gold]6。",
@@ -16874,7 +16874,7 @@
       "blockonexhaust": "+1"
     },
     "image_url": "/static/images/cards/spirit_of_ash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spirit_of_ash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]エセリアル[/gold]をプレイするたび、5[gold]ブロック[/gold]を得る。",
@@ -16910,7 +16910,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/trash_to_treasure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/trash_to_treasure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17361,7 +17361,7 @@
       "smokestackpower": "+2"
     },
     "image_url": "/static/images/cards/smokestack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/smokestack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "状態異常を作成するたび、すべての敵に7ダメージを与える。",
@@ -17402,7 +17402,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/fuel.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fuel.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:1]を得る。\nカードを2枚引く。",
@@ -17484,7 +17484,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/bombardment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bombardment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "24ダメージを与える。\nターン開始時、これが[gold]廃棄札[/gold]にある場合、それをプレイする。",
@@ -17605,7 +17605,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/the_hunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_hunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "15ダメージを与える。\n[gold]リーサル[/gold]時、追加のカード報酬を獲得する。",
@@ -17649,7 +17649,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/conflagration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conflagration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "すべての敵に8ダメージを与える。このターンにプレイしたアタック1枚につき、追加で3ダメージを与える。",
@@ -17727,7 +17727,7 @@
       "increase": "+2"
     },
     "image_url": "/static/images/cards/kingly_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/kingly_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "10ダメージを与える。\nこのカードを引くたび、戦闘終了までダメージが6増加する。",
@@ -17767,7 +17767,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/production.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/production.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3]を得る。",
@@ -17939,7 +17939,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/venerate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/venerate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[star:3]を得る。",
@@ -18066,7 +18066,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/luminesce.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/luminesce.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3]を得る。",
@@ -18239,7 +18239,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/unmovable.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/unmovable.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18369,7 +18369,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/precise_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/precise_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18454,7 +18454,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/foregone_conclusion.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/foregone_conclusion.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "次のターン、[gold]山札[/gold]からカードを3枚[gold]手札[/gold]に加える。",
@@ -18494,7 +18494,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/invoke.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/invoke.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "次のターン、[gold]召喚[/gold]3を行い、[energy:3]を得る。",
@@ -18620,7 +18620,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/forbidden_grimoire.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/forbidden_grimoire.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18663,7 +18663,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "すべての敵に11ダメージを与える。",
@@ -18706,7 +18706,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/ultimate_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "20ダメージを与える。",
@@ -18746,7 +18746,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/ultimate_defend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_defend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "15[gold]ブロック[/gold]を得る。",
@@ -18867,7 +18867,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/shatter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shatter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "すべての敵に15ダメージを与える。\nすべてのオーブを[gold]解放[/gold]する。",
@@ -19037,7 +19037,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/mind_rot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mind_rot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -19075,7 +19075,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/pagestorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pagestorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19119,7 +19119,7 @@
       "ostydamage": "+5"
     },
     "image_url": "/static/images/cards/sweeping_gaze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sweeping_gaze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]オスティ[/gold]が、ランダムな敵に15ダメージを与える。",
@@ -19206,7 +19206,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/rally.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rally.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "すべてのプレイヤーは17[gold]ブロック[/gold]を得る。",
@@ -19253,7 +19253,7 @@
       "stranglepower": "+1"
     },
     "image_url": "/static/images/cards/strangle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/strangle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "10ダメージを与える。\nこのターン、カードをプレイするたび、敵はHPを3失う。",
@@ -19291,7 +19291,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/hang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13ダメージを与える。\nこの敵に与えるすべての絞首のダメージが2倍になる。",
@@ -19331,7 +19331,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/boost_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/boost_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9[gold]ブロック[/gold]を得る。\n[gold]めまい[/gold]を1枚[gold]捨て札[/gold]に加える。",
@@ -19371,7 +19371,7 @@
       "extradamage": "+2"
     },
     "image_url": "/static/images/cards/gang_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gang_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "5ダメージを与える。\nこのターン、味方がアタックした回数1回につき、追加で7ダメージを与える。",
@@ -19411,7 +19411,7 @@
       "extrablock": "+2"
     },
     "image_url": "/static/images/cards/fasten.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fasten.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "防御カードから追加で7[gold]ブロック[/gold]を得る。",
@@ -19669,7 +19669,7 @@
       "dexterity": "+1"
     },
     "image_url": "/static/images/cards/bulk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "オーブスロットを1個失う。\n[gold]筋力[/gold]3を得る。\n[gold]敏捷[/gold]3を得る。",
@@ -19862,7 +19862,7 @@
       "corrosivewave": "+1"
     },
     "image_url": "/static/images/cards/corrosive_wave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/corrosive_wave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "このターン、カードを1枚引くたび、すべての敵に[gold]毒[/gold]3を付与する。",
@@ -20065,7 +20065,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/spore_mind.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spore_mind.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20122,7 +20122,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/falling_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/falling_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "12ダメージを与える。\n[gold]脱力[/gold]1を付与する。\n[gold]弱体[/gold]1を付与する。",
@@ -20164,7 +20164,7 @@
       "summon": "+1"
     },
     "image_url": "/static/images/cards/dirge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dirge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]召喚[/gold]4をX回行う。\n[gold]ソウル+[/gold]をX枚[gold]山札[/gold]に加える。",
@@ -20300,7 +20300,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/void_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/void_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20341,7 +20341,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/call_of_the_void.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/call_of_the_void.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20384,7 +20384,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/waste_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/waste_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -20424,7 +20424,7 @@
       "strengthloss": "+3"
     },
     "image_url": "/static/images/cards/enfeebling_touch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enfeebling_touch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ターン終了時まで敵は[gold]筋力[/gold]11を失う。",
@@ -20597,7 +20597,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/helix_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/helix_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "このターン中に支払った[energy:1]1つにつき、5ダメージを与える。",
@@ -20760,7 +20760,7 @@
       "power": "+2"
     },
     "image_url": "/static/images/cards/shockwave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shockwave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "すべての敵に[gold]脱力[/gold]5と[gold]弱体[/gold]5を付与する。",
@@ -20803,7 +20803,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/collision_course.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/collision_course.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "15ダメージを与える。\n[gold]デブリ[/gold]を1枚[gold]手札[/gold]に加える。",
@@ -20850,7 +20850,7 @@
       "debilitatepower": "+1"
     },
     "image_url": "/static/images/cards/debilitate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debilitate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "12ダメージを与える。\n次の4ターンの間、この敵に対する[gold]弱体[/gold]と[gold]脱力[/gold]の効果が2倍になる。",
@@ -20891,7 +20891,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/rend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "15ダメージを与える。\n対象の敵に付与しているデバフ1種類につき、追加で8ダメージを与える。",
@@ -20931,7 +20931,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/hegemony.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hegemony.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "18ダメージを与える。\n次のターン、[energy:3]を得る。",
@@ -21090,7 +21090,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/stratagem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stratagem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21315,7 +21315,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/consuming_shadow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/consuming_shadow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]ダーク[/gold]3を[gold]生成[/gold]する。\nターン終了時、左端のオーブを[gold]解放[/gold]する。",
@@ -21353,7 +21353,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/scrawl.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/scrawl.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21441,7 +21441,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/supermassive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/supermassive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "5ダメージを与える。\nこの戦闘で作成したカード1枚につき、追加で4ダメージを与える。",
@@ -21572,7 +21572,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/ricochet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ricochet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ランダムな敵に3ダメージを5回与える。",
@@ -21752,7 +21752,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/know_thy_place.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/know_thy_place.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21844,7 +21844,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/glow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[star:2]を得る。\nカードを1枚引く。\n次のターン、カードを1枚引く。",
@@ -21923,7 +21923,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/seeking_edge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeking_edge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]鍛造[/gold]11。\n[gold]ソヴリン・ブレード[/gold]がすべての敵にダメージを与えるようになる。",
@@ -21998,7 +21998,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/tracking.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tracking.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22076,7 +22076,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/volley.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/volley.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ランダムな敵に14ダメージをX回与える。",
@@ -22121,7 +22121,7 @@
       "strength": "+3"
     },
     "image_url": "/static/images/cards/coordinate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ターン終了時まで、他のプレイヤー1人に[gold]筋力[/gold]8を付与する。",
@@ -22255,7 +22255,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/lightning_rod.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lightning_rod.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "7[gold]ブロック[/gold]を得る。\n次の2ターンの間、ターン開始時に[gold]ライトニング[/gold]1を[gold]生成[/gold]する。",
@@ -22291,7 +22291,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/nostalgia.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/nostalgia.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22331,7 +22331,7 @@
       "strengthloss": "+1"
     },
     "image_url": "/static/images/cards/crush_under.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crush_under.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "すべての敵に8ダメージを与える。ターン終了時まですべての敵は[gold]筋力[/gold]2を失う。",
@@ -22376,7 +22376,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/feral.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feral.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22975,7 +22975,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/seance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23016,7 +23016,7 @@
       "replay": "+1"
     },
     "image_url": "/static/images/cards/hidden_gem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_gem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "[gold]山札[/gold]にある[gold]リプレイ[/gold]を持たないランダムなカード1枚が、[gold]リプレイ[/gold]3を得る。",
@@ -23062,7 +23062,7 @@
       "starnextturnpower": "+1"
     },
     "image_url": "/static/images/cards/hidden_cache.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_cache.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[star:1]を得る。\n次のターン、[star:4]を得る。",
@@ -23109,7 +23109,7 @@
       "sneakypower": "+1"
     },
     "image_url": "/static/images/cards/sneaky.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sneaky.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "他のプレイヤーが敵を攻撃するたび、2[gold]ブロック[/gold]を得る。",
@@ -23152,7 +23152,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/barrage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/barrage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]生成[/gold]されたオーブ1つにつき、7ダメージを与える。",
@@ -23191,7 +23191,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/convergence.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/convergence.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "次のターン、\n[energy:1]と[star:2]を得る。\nこのターン、[gold]手札[/gold]をすべて[gold]保留[/gold]する。",
@@ -23232,7 +23232,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/voltaic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/voltaic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23403,7 +23403,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/demesne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demesne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23446,7 +23446,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/summon_forth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/summon_forth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]鍛造[/gold]11。\nあらゆる場所から[gold]ソヴリン・ブレード[/gold]を[gold]手札[/gold]に加える。",
@@ -23650,7 +23650,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/bone_shards.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bone_shards.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]オスティ[/gold]が生存中の場合、すべての敵に12ダメージを与え、12[gold]ブロック[/gold]を得る。\n[gold]オスティ[/gold]は死亡する。",
@@ -23690,7 +23690,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/legion_of_bone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/legion_of_bone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "すべてのプレイヤーは、[gold]召喚[/gold]8。",
@@ -23869,7 +23869,7 @@
       "devourlifepower": "+1"
     },
     "image_url": "/static/images/cards/devour_life.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devour_life.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]ソウル[/gold]をプレイするたび、[gold]召喚[/gold] 2。",

--- a/data/kor/cards.json
+++ b/data/kor/cards.json
@@ -68,7 +68,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/hello_world.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hello_world.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -153,7 +153,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/intercept.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/intercept.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 13 얻습니다.\n이번 턴 동안\n다른 플레이어가 받아야 하는\n모든 공격의 목표를\n자신으로 변경합니다.",
@@ -193,7 +193,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/boost_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/boost_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 9 얻습니다.\n[gold]버린 카드 더미[/gold]에\n[gold]어지러움[/gold]을 1장\n추가합니다.",
@@ -272,7 +272,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/pillage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 9 줍니다.\n공격이 아닌 카드를 뽑을\n때까지 카드를 뽑습니다.",
@@ -326,7 +326,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/gamma_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gamma_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 18 줍니다.\n[gold]약화[/gold]를 2 부여합니다.\n[gold]취약[/gold]을 2 부여합니다.",
@@ -364,7 +364,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/infection.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/infection.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -405,7 +405,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/necro_mastery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/necro_mastery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]소환[/gold] 8.\n[gold]골골이[/gold]가\n체력을 잃을 때마다,\n모든 적이 동일한 만큼의\n체력을 잃습니다.",
@@ -447,7 +447,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/seance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -655,7 +655,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/fight_through.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_through.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 17 얻습니다.\n[gold]버린 카드 더미[/gold]에\n[gold]부상[/gold]을 2장 추가합니다.",
@@ -693,7 +693,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/giant_rock.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/giant_rock.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 20 줍니다.",
@@ -732,7 +732,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/colossus.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/colossus.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 8 얻습니다.\n이번 턴에 [gold]취약[/gold] 상태의\n적에게서 받는 피해량이\n50% 감소합니다.",
@@ -809,7 +809,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/refine_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refine_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]단조[/gold] 13.\n다음 턴에, [energy:1]를 얻습니다.",
@@ -901,7 +901,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sword_sage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sword_sage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -977,7 +977,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/clash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/clash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]손[/gold]에 있는 모든 카드가\n공격 카드일 때만\n사용할 수 있습니다.\n피해를 18 줍니다.",
@@ -1064,7 +1064,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/glimpse_beyond.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glimpse_beyond.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 플레이어의\n[gold]뽑을 카드 더미[/gold]에\n[gold]영혼[/gold]을 4장 추가합니다.",
@@ -1273,7 +1273,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/toric_toughness.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/toric_toughness.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 7 얻습니다.\n다음 2턴 동안, 턴 시작 시\n[gold]방어도[/gold]를 7 얻습니다.",
@@ -1313,7 +1313,7 @@
       "extrablock": "+2"
     },
     "image_url": "/static/images/cards/fasten.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fasten.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "수비 카드를 통해 얻는\n[gold]방어도[/gold]가 7 증가합니다.",
@@ -1349,7 +1349,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/trash_to_treasure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/trash_to_treasure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1508,7 +1508,7 @@
       "strengthpower": "+1"
     },
     "image_url": "/static/images/cards/resonance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/resonance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]힘[/gold]을 2 얻습니다.\n모든 적이\n[gold]힘[/gold]을 1 잃습니다.",
@@ -1589,7 +1589,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/call_of_the_void.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/call_of_the_void.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1636,7 +1636,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/void_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/void_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1723,7 +1723,7 @@
       "strength": "+2"
     },
     "image_url": "/static/images/cards/feeding_frenzy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "이번 턴 동안\n[gold]힘[/gold]을 7 얻습니다.",
@@ -1803,7 +1803,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/photon_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/photon_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 13 줍니다.\n카드를 2장 뽑습니다.\n[gold]손[/gold]에 있는 카드 1장을\n[gold]뽑을 카드 더미[/gold]\n맨 위에 놓습니다.",
@@ -1842,7 +1842,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/glow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[star:2]을 얻습니다.\n카드를 1장 뽑습니다.\n다음 턴에,\n카드를 1장 뽑습니다.",
@@ -2042,7 +2042,7 @@
       "serpentformpower": "+2"
     },
     "image_url": "/static/images/cards/serpent_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/serpent_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "카드를 사용할 때마다,\n무작위 적에게\n피해를 6 줍니다.",
@@ -2162,7 +2162,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sovereign_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sovereign_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2210,7 +2210,7 @@
       "smokestackpower": "+2"
     },
     "image_url": "/static/images/cards/smokestack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/smokestack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "상태이상 카드를 생성할\n때마다, 모든 적에게\n피해를 7 줍니다.",
@@ -2256,7 +2256,7 @@
       "rollingboulderpower": "+5"
     },
     "image_url": "/static/images/cards/rolling_boulder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rolling_boulder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "내 턴 시작 시, 모든\n적에게 피해를 10 주고\n이 효과의 피해량이\n5 증가합니다.",
@@ -2295,7 +2295,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/refract.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refract.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 12만큼 2번 줍니다.\n[gold]유리[/gold]를 2번 [gold]영창[/gold]합니다.",
@@ -2335,7 +2335,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/ultimate_defend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_defend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 15 얻습니다.",
@@ -2375,7 +2375,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/ultimate_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 20 줍니다.",
@@ -2416,7 +2416,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/demesne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demesne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2457,7 +2457,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/manifest_authority.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/manifest_authority.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 8 얻습니다.\n무작위 [gold]강화[/gold]된 무색 카드를\n1장 [gold]손[/gold]으로 가져옵니다.",
@@ -2619,7 +2619,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/make_it_so.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/make_it_so.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 9 줍니다.\n한 턴에 스킬 카드를 3장\n사용할 때마다, 이 카드를\n[gold]손[/gold]으로 가져옵니다.",
@@ -2695,7 +2695,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/shadow_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shadow_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 15 얻습니다.\n[gold]암흑[/gold]을 1번 [gold]영창[/gold]합니다.",
@@ -2741,7 +2741,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/consuming_shadow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/consuming_shadow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]암흑[/gold]을 3번 [gold]영창[/gold]합니다.\n내 턴 종료 시, 가장 왼쪽의 구체를 [gold]발현[/gold]합니다.",
@@ -2815,7 +2815,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/soot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -2941,7 +2941,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/forbidden_grimoire.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/forbidden_grimoire.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3035,7 +3035,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/prowess.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]힘[/gold]을 2 얻습니다.\n[gold]민첩[/gold]을 2 얻습니다.",
@@ -3115,7 +3115,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/bundle_of_joy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bundle_of_joy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "무작위 무색 카드를 4장\n[gold]손[/gold]으로 가져옵니다.",
@@ -3197,7 +3197,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/guiding_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/guiding_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 13 줍니다.\n카드를 3장 뽑습니다.",
@@ -3313,7 +3313,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/pull_from_below.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pull_from_below.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "이번 전투 동안 사용한\n[gold]휘발성[/gold] 카드 1장당\n피해를 7 줍니다.",
@@ -3351,7 +3351,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/i_am_invincible.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/i_am_invincible.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 13 얻습니다.\n내 턴 종료 시 이 카드가\n[gold]뽑을 카드 더미[/gold] 맨 위에\n있다면, 사용합니다.",
@@ -3391,7 +3391,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/helix_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/helix_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "이번 턴 동안 소모한 [energy:1]당 피해를 5 줍니다.",
@@ -3434,7 +3434,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/sloth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sloth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -3558,7 +3558,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/uproar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/uproar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 7만큼 2번 줍니다.\n[gold]뽑을 카드 더미[/gold]에서\n무작위 공격 카드를\n1장 사용합니다.",
@@ -3596,7 +3596,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/volley.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/volley.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "무작위 적에게 피해를\n14만큼 X번 줍니다.",
@@ -3672,7 +3672,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/seeking_edge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeking_edge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]단조[/gold] 11.\n[gold]군주의 칼날[/gold]이 이제\n모든 적을 대상으로 합니다.",
@@ -3750,7 +3750,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/afterlife.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/afterlife.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]소환[/gold] 9.",
@@ -3874,7 +3874,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/believe_in_you.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/believe_in_you.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "다른 플레이어가 [energy:3]를 얻습니다.",
@@ -3915,7 +3915,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/snap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/snap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]골골이[/gold]가 피해를 10 줍니다.\n[gold]손[/gold]에 있는 카드 1장에\n[gold]보존[/gold]을 추가합니다.",
@@ -3969,7 +3969,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/know_thy_place.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/know_thy_place.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4422,7 +4422,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/rally.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rally.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 플레이어가\n[gold]방어도[/gold]를 17 얻습니다.",
@@ -4507,7 +4507,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/lunar_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lunar_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "이번 턴에 사용한\n스킬 카드 1장당\n피해를 5 줍니다.",
@@ -4547,7 +4547,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/flak_cannon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/flak_cannon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 상태이상 카드를\n[gold]소멸[/gold]시킵니다.\n[gold]소멸[/gold]시킨 카드 1장당\n무작위 적에게\n피해를 11 줍니다.",
@@ -4625,7 +4625,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/summon_forth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/summon_forth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]단조[/gold] 11.\n어디에 있든 [gold]군주의 칼날[/gold]을 [gold]손[/gold]으로 가져옵니다.",
@@ -4702,7 +4702,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/conflagration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conflagration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 적에게\n피해를 8 줍니다.\n이번 턴에 사용한 다른\n공격 카드 1장당\n피해량이 3 증가합니다.",
@@ -4745,7 +4745,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/rattle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rattle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]골골이[/gold]가 피해를 9 줍니다.\n이번 턴 동안 골골이가\n공격한 횟수만큼\n반복합니다.",
@@ -4794,7 +4794,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/fight_me.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 6만큼 2번 줍니다.\n[gold]힘[/gold]을 4 얻습니다.\n대상 적이 [gold]힘[/gold]을 1 얻습니다.",
@@ -4844,7 +4844,7 @@
       "sicempower": "+1"
     },
     "image_url": "/static/images/cards/sic_em.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sic_em.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]골골이[/gold]가 피해를 6 줍니다.\n이번 턴에 [gold]골골이[/gold]가\n이 적을 공격할 때마다,\n[gold]소환[/gold] 3.",
@@ -5048,7 +5048,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/ricochet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ricochet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "무작위 적에게\n피해를 3만큼 5번 줍니다.",
@@ -5181,7 +5181,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/monologue.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/monologue.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5219,7 +5219,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/tyranny.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tyranny.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5388,7 +5388,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/synchronize.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synchronize.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5432,7 +5432,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/voltaic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/voltaic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5473,7 +5473,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/rebound.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rebound.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 12 줍니다.\n이번 턴에 다음으로\n사용하는 카드를\n[gold]뽑을 카드 더미[/gold]\n맨 위에 놓습니다.",
@@ -5511,7 +5511,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/beat_down.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_down.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]버린 카드 더미[/gold]에서\n무작위 공격 카드를\n4장 사용합니다.",
@@ -5644,7 +5644,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/ascenders_bane.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ascenders_bane.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5782,7 +5782,7 @@
       "knockdownpower": "+1"
     },
     "image_url": "/static/images/cards/knockdown.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockdown.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 14 줍니다.\n대상 적이 이번 턴에\n다른 플레이어에게서 받는\n피해량이 3배가 됩니다.",
@@ -5872,7 +5872,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/huddle_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/huddle_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 플레이어가\n카드를 3장 뽑습니다.",
@@ -5913,7 +5913,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/lantern_key.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lantern_key.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6001,7 +6001,7 @@
       "gold": "+5"
     },
     "image_url": "/static/images/cards/royalties.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royalties.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "전투 종료 시,\n[gold]골드[/gold]를 35 얻습니다.",
@@ -6041,7 +6041,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/rocket_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rocket_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 14 줍니다.\n카드를 2장 뽑습니다.\n상태이상 카드를 생성 시,\n이 카드의 비용이 사용하기\n전까지 0 [energy:1]으로 감소합니다.",
@@ -6086,7 +6086,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/caltrops.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/caltrops.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "공격을 받을 때마다,\n공격한 적에게\n피해를 5 줍니다.",
@@ -6207,7 +6207,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/omnislice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/omnislice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 11 줍니다.\n가한 피해량만큼 다른 모든 적에게 피해를 줍니다.",
@@ -6288,7 +6288,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/hammer_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hammer_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6367,7 +6367,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/hang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 13 줍니다.\n모든 매달기 카드가\n이 적에게 가하는 피해량이\n2배로 증가합니다.",
@@ -6403,7 +6403,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/enthralled.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enthralled.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6444,7 +6444,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/bury.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bury.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 63 줍니다.",
@@ -6651,7 +6651,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/defile.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/defile.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 17 줍니다.",
@@ -6693,7 +6693,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/modded.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/modded.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "구체 슬롯을 1개 얻습니다.\n카드를 2장 뽑습니다.\n이 카드의 비용이\n1 증가합니다.",
@@ -6740,7 +6740,7 @@
       "stranglepower": "+1"
     },
     "image_url": "/static/images/cards/strangle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/strangle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 10 줍니다.\n이번 턴에 카드를\n사용할 때마다, 대상 적이\n체력을 3 잃습니다.",
@@ -6942,7 +6942,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/arsenal.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/arsenal.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6983,7 +6983,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/graveblast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/graveblast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 6 줍니다.\n[gold]버린 카드 더미[/gold]에서 카드를 1장 [gold]손[/gold]으로 가져옵니다.",
@@ -7272,7 +7272,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/begone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/begone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]손[/gold]에 있는 카드를 1장\n선택해 [gold]하수인 타격+[/gold]으로\n[gold]변화[/gold]시킵니다.",
@@ -7364,7 +7364,7 @@
       "focuspower": "+1"
     },
     "image_url": "/static/images/cards/focused_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/focused_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 11 줍니다.\n이번 턴에\n[gold]밀집[/gold]을 2 얻습니다.",
@@ -7601,7 +7601,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/reflect.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reflect.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 21 얻습니다.\n이번 턴에 막은 공격 피해는\n공격한 적에게 반사됩니다.",
@@ -7777,7 +7777,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/luminesce.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/luminesce.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3]를 얻습니다.",
@@ -7872,7 +7872,7 @@
       "outbreakpower": "+4"
     },
     "image_url": "/static/images/cards/outbreak.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outbreak.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]중독[/gold]을 부여할 때마다, 모든 적에게\n피해를 15 줍니다.",
@@ -8037,7 +8037,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/distraction.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/distraction.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8204,7 +8204,7 @@
       "cost": 7
     },
     "image_url": "/static/images/cards/banshees_cry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/banshees_cry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8425,7 +8425,7 @@
       "thunderpower": "+2"
     },
     "image_url": "/static/images/cards/thunder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/thunder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]전기[/gold]를 [gold]발현[/gold]할 때마다,\n적중한 적에게\n피해를 8 줍니다.",
@@ -8465,7 +8465,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/transfigure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/transfigure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8522,7 +8522,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/falling_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/falling_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 12 줍니다.\n[gold]약화[/gold]를 1 부여합니다.\n[gold]취약[/gold]을 1 부여합니다.",
@@ -8569,7 +8569,7 @@
       "vigorpower": "+1"
     },
     "image_url": "/static/images/cards/patter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/patter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 11 얻습니다.\n[gold]활력[/gold]을 3 얻습니다.",
@@ -8646,7 +8646,7 @@
       "blockforstars": "+1"
     },
     "image_url": "/static/images/cards/child_of_the_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/child_of_the_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[star:1]을 소모할 때마다,\n소모한 [star:1]당\n[gold]방어도[/gold]를 3 얻습니다.",
@@ -8685,7 +8685,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/astral_pulse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/astral_pulse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 적에게\n피해를 18 줍니다.",
@@ -8725,7 +8725,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/bulwark.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulwark.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 16 얻습니다.\n[gold]단조[/gold] 13.",
@@ -8763,7 +8763,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/spoils_map.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_map.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8804,7 +8804,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/the_sealed_throne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_sealed_throne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8844,7 +8844,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/invoke.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/invoke.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "다음 턴에, [gold]소환[/gold] 3 후 [energy:3]를 얻습니다.",
@@ -9003,7 +9003,7 @@
       "corrosivewave": "+1"
     },
     "image_url": "/static/images/cards/corrosive_wave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/corrosive_wave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "이번 턴에 카드를 뽑을\n때마다, 모든 적에게\n[gold]중독[/gold]을 3 부여합니다.",
@@ -9041,7 +9041,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/lift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "다른 플레이어에게\n[gold]방어도[/gold]를 16 줍니다.",
@@ -9205,7 +9205,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/severance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/severance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 18 줍니다.\n[gold]뽑을 카드 더미[/gold], [gold]손[/gold],\n[gold]버린 카드 더미[/gold]에 [gold]영혼[/gold]을\n1장 추가합니다.",
@@ -9291,7 +9291,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/disintegration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/disintegration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -9331,7 +9331,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/collision_course.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/collision_course.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 15 줍니다.\n[gold]잔해[/gold]를 1장\n[gold]손[/gold]으로 가져옵니다.",
@@ -9371,7 +9371,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "체력을 13 회복합니다.",
@@ -9493,7 +9493,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/undeath.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/undeath.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 9 얻습니다.\n이 카드의 복사본을 1장\n[gold]버린 카드 더미[/gold]에\n추가합니다.",
@@ -9533,7 +9533,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/crash_landing.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crash_landing.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 적에게\n피해를 26 줍니다.\n[gold]손[/gold]을 [gold]잔해[/gold]로 가득 채웁니다.",
@@ -9572,7 +9572,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/bad_luck.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bad_luck.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9785,7 +9785,7 @@
       "blackholepower": "+1"
     },
     "image_url": "/static/images/cards/black_hole.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/black_hole.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[star:1]을 소모하거나 얻을\n때마다, 모든 적에게\n피해를 4 줍니다.",
@@ -9960,7 +9960,7 @@
       "starnextturnpower": "+1"
     },
     "image_url": "/static/images/cards/hidden_cache.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_cache.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[star:1]을 얻습니다.\n다음 턴에,\n[star:4]을 얻습니다.",
@@ -10090,7 +10090,7 @@
       "sneakypower": "+1"
     },
     "image_url": "/static/images/cards/sneaky.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sneaky.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "다른 플레이어가\n적을 공격할 때마다,\n[gold]방어도[/gold]를 2 얻습니다.",
@@ -10132,7 +10132,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/misery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/misery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 9 줍니다.\n대상 적에게 부여된 모든\n해로운 효과를 다른\n모든 적에게 부여합니다.",
@@ -10172,7 +10172,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/up_my_sleeve.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/up_my_sleeve.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]단도[/gold]를 4장\n[gold]손[/gold]으로 가져옵니다.\n이 카드의 비용이\n1 감소합니다.",
@@ -10215,7 +10215,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/big_bang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/big_bang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10336,7 +10336,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/gather_light.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gather_light.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 11 얻습니다.\n[star:1]을 얻습니다.",
@@ -10377,7 +10377,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/shining_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shining_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 11 줍니다.\n[star:2]을 얻습니다.\n이 카드를 [gold]뽑을 카드 더미[/gold]\n맨 위에 놓습니다.",
@@ -10460,7 +10460,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/bone_shards.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bone_shards.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]골골이[/gold]가 살아있다면,\n[gold]골골이[/gold]가 모든 적에게\n피해를 12 주고\n내가 방어도를 12 얻습니다.\n[gold]골골이[/gold]가 죽습니다.",
@@ -10500,7 +10500,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/the_hunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_hunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "피해를 15 줍니다.\n[gold]치명타[/gold]라면, 카드 보상을\n추가로 얻습니다.",
@@ -10583,7 +10583,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/the_scythe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_scythe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 13 줍니다.\n이 카드의 피해량이\n영구적으로 4 증가합니다.",
@@ -10622,7 +10622,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/reaper_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reaper_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10709,7 +10709,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/quadcast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quadcast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10786,7 +10786,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/shatter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shatter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 적에게\n피해를 15 줍니다.\n모든 구체를 [gold]발현[/gold]합니다.",
@@ -10831,7 +10831,7 @@
       "sleightoffleshpower": "+4"
     },
     "image_url": "/static/images/cards/sleight_of_flesh.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sleight_of_flesh.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "적에게 해로운 효과를\n부여할 때마다, 대상 적이\n피해를 13 받습니다.",
@@ -10871,7 +10871,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/murder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/murder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10957,7 +10957,7 @@
       "devourlifepower": "+1"
     },
     "image_url": "/static/images/cards/devour_life.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devour_life.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]영혼[/gold]을 사용할 때마다,\n[gold]소환[/gold] 2.",
@@ -10997,7 +10997,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/production.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/production.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3]를 얻습니다.",
@@ -11153,7 +11153,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/pagestorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pagestorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11189,7 +11189,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/subroutine.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/subroutine.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11318,7 +11318,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/leading_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/leading_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 6 줍니다.\n[gold]단도[/gold]를 2장\n[gold]손[/gold]으로 가져옵니다.",
@@ -11357,7 +11357,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/heirloom_hammer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heirloom_hammer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 25 줍니다.\n[gold]손[/gold]에 있는 무색 카드를\n1장 선택합니다.\n그 카드의 복사본을 1장\n[gold]손[/gold]으로 가져옵니다.",
@@ -11472,7 +11472,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/royal_gamble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royal_gamble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11679,7 +11679,7 @@
       "debilitatepower": "+1"
     },
     "image_url": "/static/images/cards/debilitate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debilitate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 12 줍니다.\n다음 4턴 동안\n이 적을 대상으로 하는\n[gold]취약[/gold]과 [gold]약화[/gold]의 효과가\n2배가 됩니다.",
@@ -11719,7 +11719,7 @@
       "strengthloss": "+3"
     },
     "image_url": "/static/images/cards/enfeebling_touch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enfeebling_touch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "이번 턴 동안 적이\n[gold]힘[/gold]을 11 잃습니다.",
@@ -11765,7 +11765,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/waste_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/waste_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -11804,7 +11804,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/convergence.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/convergence.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "다음 턴에, [energy:1]와\n[star:2]을 얻습니다.\n이번 턴에 [gold]손[/gold]에 있는\n카드를 [gold]보존[/gold]합니다.",
@@ -11841,7 +11841,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/poor_sleep.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/poor_sleep.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12083,7 +12083,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/shroud.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shroud.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]종말[/gold]을 부여할 때마다,\n[gold]방어도[/gold]를 3 얻습니다.",
@@ -12164,7 +12164,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/reap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 33 줍니다.",
@@ -12257,7 +12257,7 @@
       "iterationpower": "+1"
     },
     "image_url": "/static/images/cards/iteration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/iteration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "매 턴마다 처음으로\n상태이상 카드를 뽑을 시,\n카드를 3장 뽑습니다.",
@@ -12298,7 +12298,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/hidden_daggers.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_daggers.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "카드를 2장 버립니다.\n[gold]단도+[/gold]를 2장\n[gold]손[/gold]으로 가져옵니다.",
@@ -12336,7 +12336,7 @@
       "replay": "+1"
     },
     "image_url": "/static/images/cards/hidden_gem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_gem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "[gold]뽑을 카드 더미[/gold]에 있는\n[gold]재사용[/gold]이 없는\n무작위 카드 1장이\n[gold]재사용[/gold]을 3 얻습니다.",
@@ -12375,7 +12375,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/stack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]버린 카드 더미[/gold]에 있는\n카드의 수 +3만큼\n[gold]방어도[/gold]를 얻습니다.",
@@ -12413,7 +12413,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/spectrum_shift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spectrum_shift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12458,7 +12458,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/spinner.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spinner.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]유리[/gold]를 1번 [gold]영창[/gold]합니다.\n내 턴 시작 시,\n[gold]유리[/gold]를 1번 [gold]영창[/gold]합니다.",
@@ -12503,7 +12503,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/speedster.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/speedster.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12852,7 +12852,7 @@
       "poison": "+2"
     },
     "image_url": "/static/images/cards/haze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 적에게\n[gold]중독[/gold]을 6 부여합니다.",
@@ -12980,7 +12980,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/demonic_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demonic_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13108,7 +13108,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/spite.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spite.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 5 줍니다.\n이번 턴 동안 체력을\n잃었다면, 3번 적중합니다.",
@@ -13152,7 +13152,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/relax.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/relax.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 17 얻습니다.\n다음 턴에,\n카드를 3장 뽑고\n[energy:3]를 얻습니다.",
@@ -13247,7 +13247,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/outmaneuver.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outmaneuver.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "다음 턴에,\n[energy:3]를 얻습니다.",
@@ -13287,7 +13287,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/compact.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/compact.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 7 얻습니다.\n[gold]손[/gold]에 있는\n모든 상태이상 카드를\n[gold]연료+[/gold]로 [gold]변화[/gold]시킵니다.",
@@ -13332,7 +13332,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/feral.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feral.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13489,7 +13489,7 @@
       "cards": "+2"
     },
     "image_url": "/static/images/cards/decisions_decisions.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/decisions_decisions.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "카드를 5장 뽑습니다.\n[gold]손[/gold]에 있는 스킬 카드를\n1장 선택해 3번\n사용합니다.",
@@ -13656,7 +13656,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/ice_lance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ice_lance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 24 줍니다.\n[gold]냉기[/gold]를 3번 [gold]영창[/gold]합니다.",
@@ -13737,7 +13737,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/energy_surge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/energy_surge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 플레이어가\n[energy:3]를 얻습니다.",
@@ -13778,7 +13778,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/entropy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entropy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13900,7 +13900,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/fuel.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fuel.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:1]를 얻습니다.\n카드를 2장 뽑습니다.",
@@ -13957,7 +13957,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/abrasive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/abrasive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]민첩[/gold]을 1 얻습니다.\n[gold]가시[/gold]를 6 얻습니다.",
@@ -14035,7 +14035,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/cascade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cascade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]뽑을 카드 더미[/gold] 맨 위의\n무작위 카드를 X+1장\n사용합니다.",
@@ -14210,7 +14210,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/apparition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/apparition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14254,7 +14254,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/soul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "카드를 3장 뽑습니다.",
@@ -14299,7 +14299,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/soul_storm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul_storm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 9 줍니다.\n[gold]소멸된 카드 더미[/gold]에 있는\n[gold]영혼[/gold] 1장당 피해량이\n3 증가합니다.",
@@ -14660,7 +14660,7 @@
       "increase": "+2"
     },
     "image_url": "/static/images/cards/kingly_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/kingly_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 10 줍니다.\n이 카드를 뽑을 때마다,\n이번 전투 동안 이 카드의\n피해량이 6 증가합니다.",
@@ -14696,7 +14696,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/unmovable.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/unmovable.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14734,7 +14734,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/furnace.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/furnace.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "내 턴 시작 시, [gold]단조[/gold] 6.",
@@ -14779,7 +14779,7 @@
       "hailstormpower": "+2"
     },
     "image_url": "/static/images/cards/hailstorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hailstorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "내 턴 종료 시 [gold]냉기[/gold]를\n보유하고 있다면, 모든\n적에게 피해를 8 줍니다.",
@@ -14901,7 +14901,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/cosmic_indifference.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cosmic_indifference.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 9 얻습니다.\n[gold]버린 카드 더미[/gold]의 카드\n1장을 [gold]뽑을 카드 더미[/gold]\n맨 위에 놓습니다.",
@@ -15100,7 +15100,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/wisp.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wisp.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15310,7 +15310,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/glasswork.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glasswork.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 8 얻습니다.\n[gold]유리[/gold]를 1번 [gold]영창[/gold]합니다.",
@@ -15440,7 +15440,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/beckon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beckon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15606,7 +15606,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/dual_wield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "공격이나 파워 카드를\n1장 선택합니다.\n그 카드의 복사본을 2장\n[gold]손[/gold]으로 가져옵니다.",
@@ -15774,7 +15774,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/seven_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seven_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15814,7 +15814,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/barrage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/barrage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]영창[/gold]된 구체 1개당\n피해를 7 줍니다.",
@@ -15977,7 +15977,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/blade_of_ink.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/blade_of_ink.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[purple]잉크투성이[/purple] [gold]단도[/gold]를 3장\n[gold]손[/gold]으로 가져옵니다.",
@@ -16058,7 +16058,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/automation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/automation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16175,7 +16175,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/debris.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debris.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16216,7 +16216,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/veilpiercer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/veilpiercer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 13 줍니다.\n다음에 사용하는\n[gold]휘발성[/gold] 카드의 비용이\n0 [energy:1]이 됩니다.",
@@ -16258,7 +16258,7 @@
       "summon": "+1"
     },
     "image_url": "/static/images/cards/dirge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dirge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "X번 [gold]소환[/gold] 4.\n[gold]뽑을 카드 더미[/gold]에 [gold]영혼+[/gold]을\nX장 추가합니다.",
@@ -16299,7 +16299,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/catastrophe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/catastrophe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]뽑을 카드 더미[/gold]에서\n무작위 카드를\n3장 사용합니다.",
@@ -16341,7 +16341,7 @@
       "calculationextra": "+2"
     },
     "image_url": "/static/images/cards/beat_into_shape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_into_shape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 7 줍니다.\n[gold]단조[/gold] X.\n이번 턴에 대상 적을\n공격한 다른 횟수마다\n추가로 [gold]단조[/gold] 7.",
@@ -16377,7 +16377,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/calamity.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/calamity.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16459,7 +16459,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/jackpot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/jackpot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 30 줍니다.\n비용이 0[energy:1]인\n무작위 [gold]강화[/gold]된 카드를\n3장 [gold]손[/gold]으로 가져옵니다.",
@@ -16577,7 +16577,7 @@
       "blockonexhaust": "+1"
     },
     "image_url": "/static/images/cards/spirit_of_ash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spirit_of_ash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]휘발성[/gold] 카드를\n사용할 때마다,\n[gold]방어도[/gold]를 5 얻습니다.",
@@ -16613,7 +16613,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/juggling.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/juggling.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16691,7 +16691,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/adaptive_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/adaptive_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 23 줍니다.\n[gold]버린 카드 더미[/gold]에 이 카드의\n비용이 0[energy:1]인 복사본을\n1장 추가합니다.",
@@ -16855,7 +16855,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/wrought_in_war.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wrought_in_war.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 9 줍니다.\n[gold]단조[/gold] 9.",
@@ -16939,7 +16939,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/drum_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/drum_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "카드를 3장 뽑습니다.\n내 턴 시작 시,\n[gold]뽑을 카드 더미[/gold] 맨 위의\n카드를 [gold]소멸[/gold]시킵니다.",
@@ -16978,7 +16978,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/spoils_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]단조[/gold] 8.\n카드를 2장 뽑습니다.",
@@ -17140,7 +17140,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/ignition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ignition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17182,7 +17182,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/alignment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/alignment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3]를 얻습니다.",
@@ -17346,7 +17346,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/precise_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/precise_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17384,7 +17384,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/conqueror.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conqueror.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]단조[/gold] 5.\n이번 턴 동안 대상 적이\n[gold]군주의 칼날[/gold]로 받는\n피해량이 2배가 됩니다.",
@@ -17472,7 +17472,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/mind_rot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mind_rot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -17519,7 +17519,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/neurosurge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neurosurge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:4]를 얻습니다.\n카드를 2장 뽑습니다.\n내 턴 시작 시, 자신에게\n[gold]종말[/gold]을 3 부여합니다.",
@@ -17693,7 +17693,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sculpting_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sculpting_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 12 줍니다.\n[gold]손[/gold]에 있는 카드 1장에\n[gold]휘발성[/gold]을 추가합니다.",
@@ -17901,7 +17901,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/fisticuffs.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fisticuffs.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 9 줍니다.\n가한 피해량만큼\n[gold]방어도[/gold]를 얻습니다.",
@@ -17944,7 +17944,7 @@
       "strengthloss": "+2"
     },
     "image_url": "/static/images/cards/dying_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dying_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 적에게\n피해를 11 줍니다.\n이번 턴 동안 모든 적이\n[gold]힘[/gold]을 11 잃습니다.",
@@ -18045,7 +18045,7 @@
       "dansemacabrepower": "+2"
     },
     "image_url": "/static/images/cards/danse_macabre.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/danse_macabre.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "비용이 [energy:2] 이상인\n카드를 사용할 때마다,\n[gold]방어도[/gold]를 6 얻습니다.",
@@ -18084,7 +18084,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/deaths_door.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/deaths_door.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 7 얻습니다.\n이번 턴에 [gold]종말[/gold]을\n부여했다면, [gold]방어도[/gold]를\n2번 추가로 얻습니다.",
@@ -18170,7 +18170,7 @@
       "preptimepower": "+2"
     },
     "image_url": "/static/images/cards/prep_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prep_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "내 턴 시작 시,\n[gold]활력[/gold]을 6 얻습니다.",
@@ -18208,7 +18208,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/quasar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quasar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "무작위 [gold]강화[/gold]된 무색 카드\n3장 중 1장을 선택해\n[gold]손[/gold]으로 가져옵니다.",
@@ -18254,7 +18254,7 @@
       "platingpower": "+3"
     },
     "image_url": "/static/images/cards/neutron_aegis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neutron_aegis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]판금[/gold]을 11 얻습니다.",
@@ -18295,7 +18295,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/rend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 15 줍니다.\n적이 보유한\n해로운 효과의 종류 하나당\n피해량이 8 증가합니다.",
@@ -18338,7 +18338,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/squeeze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/squeeze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]골골이[/gold]가 피해를 25 줍니다.\n다른 모든 [gold]골골이[/gold]\n공격 카드 1장당\n피해량이 6 증가합니다.",
@@ -18392,7 +18392,7 @@
       "dexterity": "+1"
     },
     "image_url": "/static/images/cards/bulk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "구체 슬롯을 1개 잃습니다.\n[gold]힘[/gold]을 3 얻습니다.\n[gold]민첩[/gold]을 3 얻습니다.",
@@ -18432,7 +18432,7 @@
       "strengthloss": "+1"
     },
     "image_url": "/static/images/cards/crush_under.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crush_under.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 적에게\n피해를 8 줍니다.\n모든 적이 이번 턴 동안\n[gold]힘[/gold]을 2 잃습니다.",
@@ -18472,7 +18472,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/delay.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/delay.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 13 얻습니다.\n다음 턴에,\n[energy:2]를 얻습니다.",
@@ -18724,7 +18724,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/right_hand_hand.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/right_hand_hand.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]골골이[/gold]가 피해를 6 줍니다.\n비용이 [energy:2] 이상인\n카드를 사용할 때마다,\n이 카드를 [gold]버린 카드 더미[/gold]에서\n다시 [gold]손[/gold]으로 가져옵니다.",
@@ -18764,7 +18764,7 @@
       "extradamage": "+2"
     },
     "image_url": "/static/images/cards/gang_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gang_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 5 줍니다.\n이번 턴에 다른 플레이어가\n대상 적을 공격한 횟수당\n피해량이 7 증가합니다.",
@@ -18802,7 +18802,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/salvo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/salvo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 16 줍니다.\n이번 턴에 [gold]손[/gold]에 있는\n카드를 [gold]보존[/gold]합니다.",
@@ -19057,7 +19057,7 @@
       "poison": "+3"
     },
     "image_url": "/static/images/cards/bubble_bubble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "대상 적이 [gold]중독[/gold]을\n보유하고 있다면,\n[gold]중독[/gold]을 12 부여합니다.",
@@ -19093,7 +19093,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/splash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/splash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "다른 캐릭터의 무작위\n[gold]강화[/gold]된 공격 카드 3장 중 1장을\n선택해 [gold]손[/gold]으로 가져옵니다.\n이번 턴 동안 그 카드를\n비용 없이 사용할 수 있습니다.",
@@ -19134,7 +19134,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/brightest_flame.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/brightest_flame.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3]를 얻습니다.\n카드를 3장 뽑습니다.\n최대 체력을 1 잃습니다.",
@@ -19170,7 +19170,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/entrench.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entrench.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19209,7 +19209,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/pale_blue_dot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pale_blue_dot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "한 턴에 카드를 5장 이상\n사용했다면, 다음 턴\n시작 시 카드를 추가로\n2장 뽑습니다.",
@@ -19247,7 +19247,7 @@
       "starsperturn": "+1"
     },
     "image_url": "/static/images/cards/genesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/genesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "내 턴 시작 시,\n[star:3]을 얻습니다.",
@@ -19323,7 +19323,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/pillar_of_creation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillar_of_creation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "카드를 생성할 때마다,\n[gold]방어도[/gold]를 4 얻습니다.",
@@ -19359,7 +19359,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/stratagem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stratagem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19526,7 +19526,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/heavenly_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heavenly_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 10만큼 X번 줍니다.\nX가 4 이상이라면\nX가 2배가 됩니다.",
@@ -19651,7 +19651,7 @@
       "parrypower": "+4"
     },
     "image_url": "/static/images/cards/parry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/parry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]군주의 칼날[/gold]을\n사용할 때마다,\n[gold]방어도[/gold]를 14 얻습니다.",
@@ -19777,7 +19777,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/supermassive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/supermassive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 5 줍니다.\n이번 전투 동안 생성한\n카드 1장당 피해량이\n4 증가합니다.",
@@ -19816,7 +19816,7 @@
       "damage": "+10"
     },
     "image_url": "/static/images/cards/devastate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devastate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 40 줍니다.",
@@ -19892,7 +19892,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/venerate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/venerate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[star:3]을 얻습니다.",
@@ -19928,7 +19928,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/tracking.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tracking.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20008,7 +20008,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/dredge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dredge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20089,7 +20089,7 @@
       "hploss": "+2"
     },
     "image_url": "/static/images/cards/haunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]영혼[/gold]을 사용할 때마다,\n무작위 적이\n체력을 8 잃습니다.",
@@ -20129,7 +20129,7 @@
       "power": "+2"
     },
     "image_url": "/static/images/cards/shockwave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shockwave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 적에게 [gold]약화[/gold]와 [gold]취약[/gold]을\n5 부여합니다.",
@@ -20215,7 +20215,7 @@
       "lethalitypower": "+25"
     },
     "image_url": "/static/images/cards/lethality.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lethality.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "매 턴마다 처음으로\n사용하는 공격 카드의\n피해량이 75% 증가합니다.",
@@ -20346,7 +20346,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/knife_trap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knife_trap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]소멸된 카드 더미[/gold]에 있는\n모든 [gold]단도[/gold]를 대상 적에게\n [gold]강화[/gold]한 뒤 사용합니다.",
@@ -20830,7 +20830,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/seeker_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeker_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 12 줍니다.\n[gold]뽑을 카드 더미[/gold]의\n카드 3장 중 1장을 선택해\n[gold]손[/gold]으로 가져옵니다.",
@@ -20867,7 +20867,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/greed.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/greed.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21027,7 +21027,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/tank.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tank.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21067,7 +21067,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/turbo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/turbo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3]를 얻습니다.\n[gold]버린 카드 더미[/gold]에\n[gold]공허[/gold]를 1장 추가합니다.",
@@ -21112,7 +21112,7 @@
       "vigorpower": "+2"
     },
     "image_url": "/static/images/cards/terraforming.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/terraforming.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]활력[/gold]을 8 얻습니다.",
@@ -21150,7 +21150,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/tesla_coil.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tesla_coil.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 6 줍니다.\n대상 적을 상대로\n모든 [gold]전기[/gold]를 발동시킵니다.",
@@ -21229,7 +21229,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/gunk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gunk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 5만큼 3번 줍니다.\n[gold]버린 카드 더미[/gold]에\n[gold]점액투성이[/gold]를\n1장 추가합니다.",
@@ -21439,7 +21439,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 적에게\n피해를 11 줍니다.",
@@ -21561,7 +21561,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/hegemony.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hegemony.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 18 줍니다.\n다음 턴에,\n[energy:3]를 얻습니다.",
@@ -21640,7 +21640,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/bombardment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bombardment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 24 줍니다.\n내 턴 시작 시, 이 카드가\n[gold]소멸된 카드 더미[/gold]에 있다면,\n사용합니다.",
@@ -21764,7 +21764,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/vicious.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/vicious.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]취약[/gold]을 부여할 때마다,\n카드를 2장 뽑습니다.",
@@ -21800,7 +21800,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/spore_mind.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spore_mind.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22133,7 +22133,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/lightning_rod.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lightning_rod.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 7 얻습니다.\n다음 턴 시작 시, [gold]전기[/gold]를 1번 [gold]영창[/gold]합니다.",
@@ -22211,7 +22211,7 @@
       "damage": "+8"
     },
     "image_url": "/static/images/cards/knockout_blow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockout_blow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 38 줍니다.\n이 카드가 적을 처치 시, [star:5]을 얻습니다.",
@@ -22245,7 +22245,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/frantic_escape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/frantic_escape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -22283,7 +22283,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/foregone_conclusion.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/foregone_conclusion.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "다음 턴에,\n[gold]뽑을 카드 더미[/gold]에서\n카드를 3장\n[gold]손[/gold]으로 가져옵니다.",
@@ -22328,7 +22328,7 @@
       "crimsonmantlepower": "+2"
     },
     "image_url": "/static/images/cards/crimson_mantle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crimson_mantle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "내 턴 시작 시,\n체력을 1 잃고\n[gold]방어도[/gold]를 10 얻습니다.",
@@ -22402,7 +22402,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/largesse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/largesse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "다른 플레이어가 무작위\n[gold]강화[/gold]된 무색 카드를 1장\n[gold]손[/gold]으로 가져옵니다.",
@@ -22446,7 +22446,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/minion_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 9 줍니다.\n카드를 1장 뽑습니다.",
@@ -22536,7 +22536,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/minion_sacrifice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_sacrifice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]방어도[/gold]를 12 얻습니다.",
@@ -22629,7 +22629,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/maul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/maul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 6만큼 2번 줍니다.\n이번 전투 동안\n모든 할퀴기 카드의\n피해량이 2 증가합니다.",
@@ -22667,7 +22667,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/synthesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synthesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 18 줍니다.\n다음에 사용하는\n파워 카드의 비용이\n0 [energy:1]이 됩니다.",
@@ -22714,7 +22714,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/hotfix.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hotfix.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22757,7 +22757,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/legion_of_bone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/legion_of_bone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "모든 플레이어가 [gold]소환[/gold] 8.",
@@ -22834,7 +22834,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/nostalgia.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/nostalgia.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22872,7 +22872,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/eidolon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/eidolon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22956,7 +22956,7 @@
       "strength": "+3"
     },
     "image_url": "/static/images/cards/coordinate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "이번 턴 동안\n다른 플레이어에게\n[gold]힘[/gold]을 8 줍니다.",
@@ -23050,7 +23050,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/comet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/comet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 44 줍니다.\n[gold]약화[/gold]를 3 부여합니다.\n[gold]취약[/gold]을 3 부여합니다.",
@@ -23090,7 +23090,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/whistle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/whistle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "피해를 44 줍니다.\n적을 [gold]기절[/gold]시킵니다.",
@@ -23131,7 +23131,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/bodyguard.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bodyguard.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]소환[/gold] 7.",
@@ -23419,7 +23419,7 @@
       "phantombladespower": "+3"
     },
     "image_url": "/static/images/cards/phantom_blades.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/phantom_blades.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]단도[/gold]가 [gold]보존[/gold]을 얻습니다.\n매 턴마다 처음으로\n사용하는 [gold]단도[/gold]의\n피해량이 12 증가합니다.",
@@ -23624,7 +23624,7 @@
       "ostydamage": "+5"
     },
     "image_url": "/static/images/cards/sweeping_gaze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sweeping_gaze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]골골이[/gold]가 무작위 적에게\n피해를 15 줍니다.",
@@ -23666,7 +23666,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/scrawl.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/scrawl.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23710,7 +23710,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/mimic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mimic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23827,7 +23827,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/beacon_of_hope.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beacon_of_hope.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,

--- a/data/pol/cards.json
+++ b/data/pol/cards.json
@@ -69,7 +69,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/adaptive_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/adaptive_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 23 pkt. obrażeń.\nDodaj do [gold]stosu kart odrzuconych[/gold] kopię tej karty. Zredukuj jej koszt do 0[energy:1].",
@@ -310,7 +310,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/shroud.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shroud.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek nałożysz [gold]Zagładę[/gold], zyskaj 3 pkt. [gold]Bloku[/gold].",
@@ -440,7 +440,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/arsenal.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/arsenal.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -480,7 +480,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/up_my_sleeve.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/up_my_sleeve.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Dodaj 4 [gold]Noże|Noży[/gold] do [gold]ręki[/gold].\nZredukuj koszt tej karty o 1.",
@@ -519,7 +519,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/astral_pulse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/astral_pulse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 18 pkt. obrażeń WSZYSTKIM przeciwnikom.",
@@ -557,7 +557,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/automation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/automation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -673,7 +673,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/bulwark.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulwark.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 16 pkt. [gold]Bloku[/gold].\n[gold]Wykuj[/gold] 13.",
@@ -711,7 +711,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/scrawl.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/scrawl.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -759,7 +759,7 @@
       "poison": "+3"
     },
     "image_url": "/static/images/cards/bubble_bubble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Jeżeli przeciwnik ma [gold]Truciznę[/gold], nałóż 12 pkt. [gold]Trucizny[/gold].",
@@ -961,7 +961,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/vicious.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/vicious.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek nałożysz [gold]Wrażliwość[/gold], dobierz 2 karty|kart.",
@@ -1052,7 +1052,7 @@
       "sicempower": "+1"
     },
     "image_url": "/static/images/cards/sic_em.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sic_em.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Kostek[/gold] zadaje 6 pkt. obrażeń.\nKiedykolwiek [gold]Kostek[/gold] uderzy tego przeciwnika w tej turze, [gold]Przywołaj[/gold] 3.",
@@ -1091,7 +1091,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/pale_blue_dot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pale_blue_dot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Po zagraniu co najmniej 5 kart w jednej turze dobierz dodatkowo 2 karty|kart na początku następnej tury.",
@@ -1130,7 +1130,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/glow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj [star:2].\nDobierz 1 kartę.\nW następnej turze dobierz 1 kartę.",
@@ -1247,7 +1247,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/bombardment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bombardment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 24 pkt. obrażeń.\nNa początku tury zagraj tę kartę, jeżeli znajduje się na [gold]stosie kart wyczerpanych[/gold].",
@@ -1382,7 +1382,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/soul_storm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul_storm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 9 pkt. obrażeń.\nZadaje dodatkowo 3 pkt. obrażeń za każdą [gold]Duszę[/gold] na [gold]stosie kart wyczerpanych[/gold].",
@@ -1427,7 +1427,7 @@
       "hailstormpower": "+2"
     },
     "image_url": "/static/images/cards/hailstorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hailstorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Jeżeli masz [gold]Załadowaną[/gold] co najmniej [blue]1[/blue] [gold]Sferę Mrozu[/gold] pod koniec tury, zadaj 8 pkt. obrażeń WSZYSTKIM przeciwnikom.",
@@ -1547,7 +1547,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/drum_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/drum_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Dobierz 3 karty.\nNa początku tury [gold]Wyczerp[/gold] kartę ze szczytu [gold]stosu rozgrywającego[/gold].",
@@ -1847,7 +1847,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/greed.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/greed.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1891,7 +1891,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/pull_from_below.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pull_from_below.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 7 pkt. obrażeń za każdą [gold]Eteryczną[/gold] kartę zagraną w tej walce.razy)",
@@ -2266,7 +2266,7 @@
       "sneakypower": "+1"
     },
     "image_url": "/static/images/cards/sneaky.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sneaky.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek inny gracz zaatakuje przeciwnika, zyskaj 2 pkt. [gold]Bloku[/gold].",
@@ -2314,7 +2314,7 @@
       "blackholepower": "+1"
     },
     "image_url": "/static/images/cards/black_hole.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/black_hole.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek wydasz lub zyskasz [star:1], zadaj 4 pkt. obrażeń WSZYSTKIM przeciwnikom.",
@@ -2359,7 +2359,7 @@
       "preptimepower": "+2"
     },
     "image_url": "/static/images/cards/prep_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prep_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Na początku tury zyskaj 6 pkt. [gold]Wigoru[/gold].",
@@ -2442,7 +2442,7 @@
       "gold": "+5"
     },
     "image_url": "/static/images/cards/royalties.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royalties.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Zyskaj 35 szt. [gold]Złota[/gold] pod koniec walki.",
@@ -2483,7 +2483,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/mimic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mimic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2528,7 +2528,7 @@
       "cards": "+2"
     },
     "image_url": "/static/images/cards/decisions_decisions.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/decisions_decisions.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Dobierz 5 karty|kart.\nWybierz Umiejętność w [gold]ręce[/gold] i zagraj ją 3 razy.",
@@ -2663,7 +2663,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/demonic_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demonic_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2802,7 +2802,7 @@
       "damage": "+10"
     },
     "image_url": "/static/images/cards/devastate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devastate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 40 pkt. obrażeń.",
@@ -2845,7 +2845,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/disintegration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/disintegration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -2885,7 +2885,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/huddle_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/huddle_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "WSZYSCY gracze dobierają 3 karty.",
@@ -2978,7 +2978,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/refine_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refine_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Wykuj[/gold] 13.\nW następnej turze zyskaj [energy:1].",
@@ -3104,7 +3104,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/apparition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/apparition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3148,7 +3148,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/soul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Dobierz 3 karty|kart.",
@@ -3189,7 +3189,7 @@
       "blockonexhaust": "+1"
     },
     "image_url": "/static/images/cards/spirit_of_ash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spirit_of_ash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek zagrasz [gold]Eteryczną[/gold] kartę, zyskaj 5 pkt. [gold]Bloku[/gold].",
@@ -3227,7 +3227,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/giant_rock.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/giant_rock.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 20 pkt. obrażeń.",
@@ -3267,7 +3267,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/flak_cannon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/flak_cannon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Wyczerp[/gold] WSZYSTKIE karty Stanu.\nZadaj 11 pkt. obrażeń losowemu przeciwnikowi za każdą [gold]Wyczerpaną[/gold] kartę.razy)",
@@ -3306,7 +3306,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/heirloom_hammer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heirloom_hammer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 25 pkt. obrażeń.\nWybierz bezbarwną kartę w [gold]ręce[/gold]. Dodaj kopię tej karty do [gold]ręki[/gold].",
@@ -3428,7 +3428,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/feral.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feral.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3635,7 +3635,7 @@
       "platingpower": "+3"
     },
     "image_url": "/static/images/cards/neutron_aegis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neutron_aegis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 11 pkt. [gold]Opancerzenia[/gold].",
@@ -3711,7 +3711,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/entropy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entropy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3749,7 +3749,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/glasswork.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glasswork.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 8 pkt. [gold]Bloku[/gold].\n[gold]Załaduj[/gold] 1 [gold]Sferę Szkła[/gold].",
@@ -3787,7 +3787,7 @@
       "corrosivewave": "+1"
     },
     "image_url": "/static/images/cards/corrosive_wave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/corrosive_wave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek dobierzesz kartę w tej turze, nałóż 3 pkt. [gold]Trucizny[/gold] na WSZYSTKICH przeciwników.",
@@ -3827,7 +3827,7 @@
       "power": "+2"
     },
     "image_url": "/static/images/cards/shockwave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shockwave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Nałóż 5 pkt. [gold]Słabości[/gold] i 5 pkt. [gold]Wrażliwości[/gold] na WSZYSTKICH przeciwników.",
@@ -3866,7 +3866,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/enthralled.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enthralled.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3951,7 +3951,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/pillar_of_creation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillar_of_creation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek stworzysz kartę, zyskaj 4 pkt. [gold]Bloku[/gold].",
@@ -4031,7 +4031,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/photon_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/photon_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 13 pkt. obrażeń.\nDobierz 2 karty|kart.\nPrzenieś 1 kartę z [gold]ręki[/gold] na szczyt [gold]stosu rozgrywającego[/gold].",
@@ -4072,7 +4072,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/voltaic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/voltaic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4315,7 +4315,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/pillage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 9 pkt. obrażeń.\nDobierz kartę. Jeżeli jest Atakiem, dobieraj dalej.",
@@ -4354,7 +4354,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/gather_light.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gather_light.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 11 pkt. [gold]Bloku[/gold].\nZyskaj [star:1].",
@@ -4390,7 +4390,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/debris.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debris.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4436,7 +4436,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/rattle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rattle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Kostek[/gold] zadaje 9 pkt. obrażeń.\nUderza dodatkowy raz za każdy inny raz, kiedy zaatakował w tej turze.razy)",
@@ -4608,7 +4608,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/guiding_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/guiding_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 13 pkt. obrażeń.\nDobierz 3 karty|kart.",
@@ -4647,7 +4647,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/heavenly_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heavenly_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 10 pkt. obrażeń X razy.\nPodwój X, jeżeli równa się co najmniej 4.",
@@ -4688,7 +4688,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/shining_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shining_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 11 pkt. obrażeń.\nZyskaj [star:2].\nUmieść tę kartę na szczycie [gold]stosu rozgrywającego[/gold].",
@@ -4726,7 +4726,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/the_sealed_throne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_sealed_throne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4765,7 +4765,7 @@
       "damage": "+8"
     },
     "image_url": "/static/images/cards/knockout_blow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockout_blow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 38 pkt. obrażeń.\nJeżeli to zabije przeciwnika, zyskaj [star:5].",
@@ -4882,7 +4882,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/whistle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/whistle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 44 pkt. obrażeń.\n[gold]Ogłusz[/gold] przeciwnika.",
@@ -4970,7 +4970,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/hegemony.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hegemony.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 18 pkt. obrażeń.\nW następnej turze zyskaj [energy:3].",
@@ -5006,7 +5006,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/hello_world.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hello_world.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5127,7 +5127,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/largesse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/largesse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inny gracz dodaje losową  [gold]Ulepszoną[/gold] bezbarwną kartę do [gold]ręki[/gold].",
@@ -5209,7 +5209,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/venerate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/venerate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj [star:3].",
@@ -5285,7 +5285,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/infection.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/infection.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5328,7 +5328,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/invoke.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/invoke.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "W następnej turze [gold]Przywołaj[/gold] 3 i zyskaj [energy:3].",
@@ -5364,7 +5364,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/tank.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tank.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5444,7 +5444,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/brightest_flame.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/brightest_flame.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj [energy:3].\nDobierz 3 karty|kart.\nUtrać 1 maks. PŻ.",
@@ -5482,7 +5482,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/i_am_invincible.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/i_am_invincible.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 13 pkt. [gold]Bloku[/gold].\nPod koniec tury zagraj tę kartę, jeżeli znajduje się na szczycie [gold]stosu rozgrywającego[/gold].",
@@ -5522,7 +5522,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Przywróć 13 PŻ.",
@@ -5565,7 +5565,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/supermassive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/supermassive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 5 pkt. obrażeń.\nZadaje dodatkowo 4 pkt. obrażeń za każdą kartę dodaną do talii w tej walce.",
@@ -5655,7 +5655,7 @@
       "crimsonmantlepower": "+2"
     },
     "image_url": "/static/images/cards/crimson_mantle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crimson_mantle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Na początku tury utrać 1 PŻ i zyskaj 10 pkt. [gold]Bloku[/gold].",
@@ -5691,7 +5691,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/cascade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cascade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zagraj kartę ze szczytu [gold]stosu rozgrywającego[/gold] X+1 razy.",
@@ -5729,7 +5729,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/catastrophe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/catastrophe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zagraj 3 losowe karty|losowych kart ze [gold]stosu rozgrywającego[/gold].",
@@ -5766,7 +5766,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/poor_sleep.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/poor_sleep.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5808,7 +5808,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/lantern_key.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lantern_key.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5888,7 +5888,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/calamity.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/calamity.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5933,7 +5933,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/caltrops.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/caltrops.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek przeciwnik cię zaatakuje, zadaj mu 5 pkt. obrażeń.",
@@ -5972,7 +5972,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/spite.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spite.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 5 pkt. obrażeń.\nJeżeli utracono PŻ w tej turze,\nuderza 3 razy.",
@@ -6011,7 +6011,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/colossus.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/colossus.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 8 pkt. [gold]Bloku[/gold].\nW tej turze otrzymujesz 50% mniej obrażeń od [gold]Wrażliwych[/gold] przeciwników.",
@@ -6065,7 +6065,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/comet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/comet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 44 pkt. obrażeń.\nNałóż 3 pkt. [gold]Słabości[/gold].\nNałóż 3 pkt. [gold]Wrażliwości[/gold].",
@@ -6110,7 +6110,7 @@
       "smokestackpower": "+2"
     },
     "image_url": "/static/images/cards/smokestack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/smokestack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek stworzysz kartę Stanu, zadaj 7 pkt. obrażeń WSZYSTKIM przeciwnikom.",
@@ -6272,7 +6272,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/alignment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/alignment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj [energy:3].",
@@ -6350,7 +6350,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/convergence.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/convergence.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "W następnej turze,\nzyskaj [energy:1] i [star:2].\n[gold]Zachowaj[/gold] swoją [gold]rękę[/gold] w tej turze.",
@@ -6395,7 +6395,7 @@
       "strength": "+3"
     },
     "image_url": "/static/images/cards/coordinate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Daj innemu graczowi 8 pkt. [gold]Siły[/gold] w tej turze.",
@@ -6478,7 +6478,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/the_scythe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_scythe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 13 pkt. obrażeń.\nNa stałe zwiększ obrażenia zadawane przez tę kartę o 4 pkt.",
@@ -6760,7 +6760,7 @@
       "increase": "+2"
     },
     "image_url": "/static/images/cards/kingly_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/kingly_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 10 pkt. obrażeń.\nKiedykolwiek dobierzesz tę kartę, zwiększ jej obrażenia w tej walce o 6 pkt.",
@@ -6801,7 +6801,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/royal_gamble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royal_gamble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6888,7 +6888,7 @@
       "rollingboulderpower": "+5"
     },
     "image_url": "/static/images/cards/rolling_boulder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rolling_boulder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Na początku tury zadaj 10 pkt. obrażeń WSZYSTKIM przeciwnikom, następnie zwiększ te obrażenia o 5 pkt.",
@@ -6928,7 +6928,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/collision_course.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/collision_course.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 15 pkt. obrażeń.\nDodaj [gold]Gruz[/gold] do [gold]ręki[/gold].",
@@ -6966,7 +6966,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/furnace.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/furnace.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Na początku tury [gold]Wykuj[/gold] 6.",
@@ -7004,7 +7004,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/quasar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quasar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Wybierz 1 z 3 losowych [gold]Ulepszonych[/gold] kart i dodaj ją do [gold]ręki[/gold].",
@@ -7043,7 +7043,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/ice_lance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ice_lance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 24 pkt. obrażeń.\n[gold]Załaduj[/gold] 3 [gold]Sfery Mrozu[/gold].",
@@ -7083,7 +7083,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/legion_of_bone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/legion_of_bone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "WSZYSCY gracze [gold]Przywołują[/gold] 8.",
@@ -7129,7 +7129,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/sloth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sloth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -7206,7 +7206,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/jackpot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/jackpot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 30 pkt. obrażeń.\nDodaj 3 losowe [gold]Ulepszone[/gold] karty kosztujące 0[energy:1]|losowych [gold]Ulepszonych[/gold] kart kosztujących 0[energy:1] do [gold]ręki[/gold].",
@@ -7247,7 +7247,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/luminesce.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/luminesce.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj [energy:3].",
@@ -7289,7 +7289,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/manifest_authority.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/manifest_authority.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 8 pkt. [gold]Bloku[/gold].\nDodaj 1 [gold]Ulepszoną[/gold] bezbarwną kartę do [gold]ręki[/gold].",
@@ -7330,7 +7330,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/demesne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demesne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7371,7 +7371,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/spoils_map.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_map.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7458,7 +7458,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/waste_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/waste_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -7791,7 +7791,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sword_sage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sword_sage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7908,7 +7908,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/necro_mastery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/necro_mastery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7947,7 +7947,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/modded.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/modded.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 1 miejscę na Sferę.\nDobierz 2 karty|kart. Zwiększ koszt tej karty o 1.",
@@ -7985,7 +7985,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/monologue.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/monologue.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8025,7 +8025,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/murder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/murder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8235,7 +8235,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/neurosurge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neurosurge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj [energy:4].\nDobierz 2 karty|kart.\nNa początku tury nałóż na siebie 3 pkt. [gold]Zagłady[/gold].",
@@ -8284,7 +8284,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/fight_me.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 6 pkt. obrażeń dwukrotnie.\nZyskaj 4 pkt. [gold]Siły[/gold].\nPrzeciwnik otrzymuje 1 pkt. [gold]Siły[/gold].",
@@ -8396,7 +8396,7 @@
       "hploss": "+2"
     },
     "image_url": "/static/images/cards/haunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek zagrasz [gold]Duszę[/gold], losowy przeciwnik traci 8 PŻ.",
@@ -8479,7 +8479,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/unmovable.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/unmovable.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8562,7 +8562,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sovereign_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sovereign_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8727,7 +8727,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/undeath.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/undeath.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 9 pkt. [gold]Bloku[/gold].\nDodaj kopię tej karty do [gold]stosu kart odrzuconych[/gold].",
@@ -8853,7 +8853,7 @@
       "knockdownpower": "+1"
     },
     "image_url": "/static/images/cards/knockdown.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockdown.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 14 pkt. obrażeń.\nW tej turze przeciwnik otrzymuje potrójne obrażenia od innych graczy.",
@@ -8931,7 +8931,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/nostalgia.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/nostalgia.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8976,7 +8976,7 @@
       "iterationpower": "+1"
     },
     "image_url": "/static/images/cards/iteration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/iteration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gdy dobierzesz kartę Stanu po raz pierwszy w tej turze, dobierz 3 karty|kart.",
@@ -9107,7 +9107,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/misery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/misery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 9 pkt. obrażeń.\nNałóż osłabienia przeciwnika na WSZYSTKICH pozostałych przeciwników.",
@@ -9224,7 +9224,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/cosmic_indifference.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cosmic_indifference.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 9 pkt. [gold]Bloku[/gold].\nPrzenieś kartę ze [gold]stosu kart odrzuconych[/gold] na szczyt [gold]stosu rozgrywającego[/gold].",
@@ -9505,7 +9505,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/uproar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/uproar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 7 pkt. obrażeń dwukrotnie.\nZagraj losowy Atak ze [gold]stosu rozgrywającego[/gold].",
@@ -9543,7 +9543,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/dual_wield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Wybierz Atak lub Moc. Dodaj 2 kopie tej karty do [gold]ręki[/gold].",
@@ -9619,7 +9619,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/bodyguard.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bodyguard.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Przywołaj[/gold] 7.",
@@ -9695,7 +9695,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/rebound.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rebound.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 12 pkt. obrażeń.\nUmieść następną kartę zagraną w tej turze na szczycie [gold]stosu rozgrywającego[/gold].",
@@ -9857,7 +9857,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/distraction.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/distraction.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9941,7 +9941,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/bone_shards.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bone_shards.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Jeżeli [gold]Kostek[/gold] żyje, zadaje 12 pkt. obrażeń WSZYSTKIM przeciwnikom i zyskujesz 12 pkt. [gold]Bloku[/gold].\n[gold]Kostek[/gold] umiera.",
@@ -10030,7 +10030,7 @@
       "ostydamage": "+5"
     },
     "image_url": "/static/images/cards/sweeping_gaze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sweeping_gaze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Kostek[/gold] zadaje 15 pkt. obrażeń losowemu przeciwnikowi.",
@@ -10074,7 +10074,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/barrage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/barrage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 7 pkt. obrażeń za każdą [gold]Załadowaną[/gold] Sferę.razy)",
@@ -10114,7 +10114,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/wisp.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wisp.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10291,7 +10291,7 @@
       "cost": 7
     },
     "image_url": "/static/images/cards/banshees_cry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/banshees_cry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10331,7 +10331,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/compact.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/compact.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 7 pkt. [gold]Bloku[/gold].\n[gold]Zmień[/gold] wszystkie karty Stanu w [gold]ręce[/gold] w [gold]Paliwo+[/gold].",
@@ -10371,7 +10371,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/delay.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/delay.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 13 pkt. [gold]Bloku[/gold].\nW następnej turze\nzyskaj [energy:2].",
@@ -10449,7 +10449,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/wrought_in_war.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wrought_in_war.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 9 pkt. obrażeń.\n[gold]Wykuj[/gold] diff).",
@@ -10572,7 +10572,7 @@
       "phantombladespower": "+3"
     },
     "image_url": "/static/images/cards/phantom_blades.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/phantom_blades.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Noże[/gold] otrzymują [gold]Zachowanie[/gold].\nW każdej turze pierwszy zagrany [gold]Nóż[/gold] zadaje dodatkowo 12 pkt. obrażeń.",
@@ -10612,7 +10612,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/blade_of_ink.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/blade_of_ink.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Dodaj 3 [gold]Noże|Noży[/gold] z [purple]Atramentem[/purple] do [gold]ręki[/gold].",
@@ -10699,7 +10699,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/consuming_shadow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/consuming_shadow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Załaduj[/gold] 3 [gold]Sfery Ciemności[/gold].\nPod koniec tury [gold]Wyładuj[/gold] ostatnią Sferę.",
@@ -10778,7 +10778,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/begone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/begone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Wybierz kartę w [gold]ręce[/gold] i [gold]Zmień[/gold] ją w [gold]Uderzenie służby+[/gold].",
@@ -10819,7 +10819,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/fuel.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fuel.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj [energy:1].\nDobierz 2 karty|kart.",
@@ -10868,7 +10868,7 @@
       "outbreakpower": "+4"
     },
     "image_url": "/static/images/cards/outbreak.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outbreak.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 15 pkt. obrażeń WSZYSTKIM przeciwnikom po nałożeniu [gold]Trucizny[/gold] 3 razy|3 razy.",
@@ -10902,7 +10902,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/frantic_escape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/frantic_escape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -10985,7 +10985,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/bad_luck.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bad_luck.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11244,7 +11244,7 @@
       "summon": "+1"
     },
     "image_url": "/static/images/cards/dirge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dirge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Przywołaj[/gold] 4 X razy.\nDodaj [gold]Duszę+[/gold] do [gold]stosu rozgrywającego[/gold] X razy.",
@@ -11330,7 +11330,7 @@
       "thunderpower": "+2"
     },
     "image_url": "/static/images/cards/thunder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/thunder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek [gold]Wyładujesz Sferę Gromu[/gold], zadaj 8 pkt. obrażeń każdemu trafionemu przeciwnikowi.",
@@ -11376,7 +11376,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/lightning_rod.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lightning_rod.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 7 pkt. [gold]Bloku[/gold].\nNa początku 2 następnych tur|2 następnych tur [gold]Załaduj[/gold] 1 [gold]Sferę Gromu[/gold].",
@@ -11500,7 +11500,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/splash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/splash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Wybierz 1 z 3 losowych [gold]Ulepszonych[/gold] Ataków od innej postaci i dodaj go do [gold]ręki[/gold]. W tej turze kosztuje 0.",
@@ -11540,7 +11540,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/bundle_of_joy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bundle_of_joy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Dodaj 4 losowe bezbarwne karty|losowych bezbarwnych kart do [gold]ręki[/gold].",
@@ -11622,7 +11622,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/quadcast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quadcast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11660,7 +11660,7 @@
       "starsperturn": "+1"
     },
     "image_url": "/static/images/cards/genesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/genesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Na początku tury zyskaj [star:3].",
@@ -11782,7 +11782,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/subroutine.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/subroutine.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11818,7 +11818,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/stratagem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stratagem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11973,7 +11973,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/bury.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bury.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 63 pkt. obrażeń.",
@@ -12013,7 +12013,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/dredge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dredge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12056,7 +12056,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/the_hunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_hunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Zadaj 15 pkt. obrażeń.\nPo [gold]Uśmierceniu[/gold] przeciwnika, zyskaj dodatkową kartę w łupach.",
@@ -12099,7 +12099,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/fight_through.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_through.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 17 pkt. [gold]Bloku[/gold].\nDodaj 2 [gold]Rany[/gold] do [gold]stosu kart odrzuconych[/gold].",
@@ -12182,7 +12182,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/glimpse_beyond.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glimpse_beyond.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "WSZYSCY gracze dodają 4 [gold]Dusze|Dusz[/gold] do swojego [gold]stosu rozgrywającego[/gold].",
@@ -12275,7 +12275,7 @@
       "blockforstars": "+1"
     },
     "image_url": "/static/images/cards/child_of_the_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/child_of_the_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek wydasz [star:1], zyskaj 3 pkt. [gold]Bloku[/gold] za każdą wydaną [star:1].",
@@ -12358,7 +12358,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/hang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 13 pkt. obrażeń.\nPodwój obrażenia zadawane temu przeciwnikowi przez WSZYSTKIE Powieszenia.",
@@ -12441,7 +12441,7 @@
       "debilitatepower": "+1"
     },
     "image_url": "/static/images/cards/debilitate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debilitate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 12 pkt. obrażeń.\nEfekty [gold]Wrażliwości[/gold] i [gold]Słabości[/gold] na tym przeciwniku są podwojone przez 4 tury|tury.",
@@ -12524,7 +12524,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/minion_sacrifice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_sacrifice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 12 pkt. [gold]Bloku[/gold].",
@@ -12619,7 +12619,7 @@
       "devourlifepower": "+1"
     },
     "image_url": "/static/images/cards/devour_life.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devour_life.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek zagrasz [gold]Duszę[/gold], [gold]Przywołaj[/gold] 2.",
@@ -12660,7 +12660,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/conflagration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conflagration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 8 pkt. obrażeń WSZYSTKIM przeciwnikom.\nZadaje dodatkowo 3 pkt. obrażeń za każdy inny Atak zagrany w tej turze.",
@@ -12747,7 +12747,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/right_hand_hand.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/right_hand_hand.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Kostek[/gold] zadaje 6 pkt. obrażeń.\nKiedykolwiek zagrasz kartę kosztującą co najmniej [energy:2], przełóż tę kartę ze [gold]stosu kart odrzuconych[/gold] do [gold]ręki[/gold].",
@@ -12863,7 +12863,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/precise_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/precise_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12903,7 +12903,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/production.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/production.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj [energy:3].",
@@ -12946,7 +12946,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/defile.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/defile.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 17 pkt. obrażeń.",
@@ -12989,7 +12989,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/lunar_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lunar_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 5 pkt. obrażeń za każdą Umiejętność zagraną w tej turze.razy)",
@@ -13105,7 +13105,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/beacon_of_hope.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beacon_of_hope.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13228,7 +13228,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/outmaneuver.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outmaneuver.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "W następnej turze zyskaj [energy:3].",
@@ -13425,7 +13425,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/transfigure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/transfigure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13466,7 +13466,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/veilpiercer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/veilpiercer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 13 pkt. obrażeń.\nNastępna [gold]Eteryczna[/gold] karta kosztuje 0 [energy:1].",
@@ -13554,7 +13554,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/spectrum_shift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spectrum_shift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13635,7 +13635,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/foregone_conclusion.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/foregone_conclusion.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "W następnej turze przełóż 3 karty ze [gold]stosu rozgrywającego[/gold] do [gold]ręki[/gold].",
@@ -13713,7 +13713,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/seeking_edge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeking_edge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Wykuj[/gold] 11.\nOd teraz [gold]Niebańskie Ostrze[/gold] zadaje obrażenia WSZYSTKIM przeciwnikom.",
@@ -14015,7 +14015,7 @@
       "dexterity": "+1"
     },
     "image_url": "/static/images/cards/bulk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Utrać 1 miejsce na Sferę.\nZyskaj 3 pkt. [gold]Siły[/gold].\nZyskaj 3 pkt. [gold]Zręczności[/gold].",
@@ -14055,7 +14055,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/energy_surge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/energy_surge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "WSZYSCY gracze otrzymują [energy:3].",
@@ -14178,7 +14178,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/snap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/snap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Kostek[/gold] zadaje 10 pkt. obrażeń.\nDodaj [gold]Zachowanie[/gold] do karty w [gold]ręce[/gold].",
@@ -14225,7 +14225,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/void_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/void_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14509,7 +14509,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/rocket_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rocket_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 14 pkt. obrażeń.\nDobierz 2 karty|kart.\nKiedykolwiek stworzysz kartę Stanu, zredukuj koszt tej karty do 0 [energy:1] aż do zagrania.",
@@ -14673,7 +14673,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/refract.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refract.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 12 pkt. obrażeń dwukrotnie.\n[gold]Załaduj[/gold] 2 [gold]Sfery Szkła[/gold].",
@@ -14717,7 +14717,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/relax.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/relax.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 17 pkt. [gold]Bloku[/gold].\nW następnej turze dobierz 3 karty|kart i zyskaj [energy:3].",
@@ -14809,7 +14809,7 @@
       "strengthpower": "+1"
     },
     "image_url": "/static/images/cards/resonance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/resonance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 2 pkt. [gold]Siły[/gold]. WSZYSCY przeciwnicy tracą 1 pkt. [gold]Siły[/gold]",
@@ -14856,7 +14856,7 @@
       "parrypower": "+4"
     },
     "image_url": "/static/images/cards/parry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/parry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Niebiańskie Ostrze[/gold] zyskuje 14 pkt. [gold]Bloku[/gold].",
@@ -14896,7 +14896,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sculpting_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sculpting_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 12 pkt. obrażeń.\nDodaj [gold]Eteryczna[/gold] do karty w [gold]ręce[/gold].",
@@ -15059,7 +15059,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/rend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 15 pkt. obrażeń.\nZadaje dodatkowo 8 pkt. obrażeń za każde unikalne osłabienie na przeciwniku.",
@@ -15137,7 +15137,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/severance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/severance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 18 pkt. obrażeń.\nDodaj [gold]Duszę[/gold] do [gold]stosu rozgrywającego[/gold], do [gold]ręki[/gold] i do [gold]stosu kart odrzuconych[/gold].",
@@ -15217,7 +15217,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/make_it_so.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/make_it_so.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 9 pkt. obrażeń.\nPo zagraniu 3 Umiejętności, umieść tę kartę w [gold]ręce[/gold].",
@@ -15373,7 +15373,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/shatter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shatter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 15 pkt. obrażeń WSZYSTKIM przeciwnikom.\n[gold]Wyładuj[/gold] wszystkie swoje Sfery.",
@@ -15413,7 +15413,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/maul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/maul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 6 pkt. obrażeń dwukrotnie.\nZwiększ obrażenia zadawane przez WSZYSTKIE Rozwalenia w tej walce o 2 pkt.",
@@ -15528,7 +15528,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/ricochet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ricochet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 3 pkt. obrażeń losowemu przeciwnikowi 5 razy.",
@@ -15727,7 +15727,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/fisticuffs.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fisticuffs.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 9 pkt. obrażeń.\nZyskaj [gold]Blok[/gold] równy zadanym obrażeniom.",
@@ -15846,7 +15846,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/soot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -15926,7 +15926,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/salvo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/salvo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 16 pkt. obrażeń.\n[gold]Zachowaj[/gold] swoją [gold]rękę[/gold] w tej turze.",
@@ -16002,7 +16002,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/intercept.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/intercept.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 13 pkt. [gold]Bloku[/gold].\nW tej turze zablokuj wszystkie ataki skierowane na innego gracza.",
@@ -16044,7 +16044,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/seance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16170,7 +16170,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/seven_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seven_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16297,7 +16297,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/trash_to_treasure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/trash_to_treasure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16335,7 +16335,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/beat_down.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_down.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zagraj 4 losowe Ataki ze [gold]stosu kart odrzuconych[/gold].",
@@ -16384,7 +16384,7 @@
       "focuspower": "+1"
     },
     "image_url": "/static/images/cards/focused_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/focused_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 11 pkt. obrażeń.\nZyskaj 2 pkt. [gold]Skupienia[/gold] w tej turze.",
@@ -16477,7 +16477,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/falling_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/falling_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 12 pkt. obrażeń.\nNałóż 1 pkt. [gold]Słabości[/gold].\nNałóż 1 pkt. [gold]Wrażliwości[/gold].",
@@ -16517,7 +16517,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/helix_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/helix_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 5 pkt. obrażeń za każdy [energy:1] wydany w tej turze.razy)",
@@ -16570,7 +16570,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/prowess.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 2 pkt. [gold]Siły[/gold].\nZyskaj 2 pkt. [gold]Zręczności[/gold].",
@@ -16688,7 +16688,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/stack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj [gold]Blok[/gold] równy liczbie kart na [gold]stosie kart odrzuconych[/gold] +3 pkt..",
@@ -16828,7 +16828,7 @@
       "vigorpower": "+1"
     },
     "image_url": "/static/images/cards/patter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/patter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 11 pkt. [gold]Bloku[/gold].\nZyskaj 3 pkt. [gold]Wigoru[/gold].",
@@ -16869,7 +16869,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/synchronize.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synchronize.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16910,7 +16910,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/synthesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synthesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 18 pkt. obrażeń.\nNastępna Moc kosztuje 0 [energy:1].",
@@ -17115,7 +17115,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/knife_trap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knife_trap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Ulepsz[/gold] i zagraj wszystkie [gold]Noże[/gold] ze [gold]stosu kart wyczerpanych[/gold] na przeciwnika.Noży[/gold])",
@@ -17160,7 +17160,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/spinner.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spinner.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Załaduj[/gold] 1 [gold]Sferę Szkła[/gold].\nNa początku tury [gold]Załaduj[/gold] 1 [gold]Sferę Szkła[/gold].",
@@ -17321,7 +17321,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/speedster.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/speedster.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17403,7 +17403,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/turbo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/turbo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj [energy:3].\nDodaj a [gold]Pustkę[/gold] do [gold]stosu kart odrzuconych[/gold].",
@@ -17531,7 +17531,7 @@
       "starnextturnpower": "+1"
     },
     "image_url": "/static/images/cards/hidden_cache.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_cache.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj [star:1].\nW następnej turze zyskaj [star:4].",
@@ -17665,7 +17665,7 @@
       "dansemacabrepower": "+2"
     },
     "image_url": "/static/images/cards/danse_macabre.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/danse_macabre.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek zagrasz kartę kosztującą co najmniej [energy:2], zyskaj 6 pkt. [gold]Bloku[/gold].",
@@ -17703,7 +17703,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/shadow_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shadow_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 15 pkt. [gold]Bloku[/gold].\n[gold]Załaduj[/gold] 1 [gold]Sferę Ciemności[/gold].",
@@ -17741,7 +17741,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/pagestorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pagestorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17858,7 +17858,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/tesla_coil.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tesla_coil.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 6 pkt. obrażeń.\nAktywuj wszystkie [gold]Sfery Gromu[/gold] na przeciwniku.",
@@ -17894,7 +17894,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/tracking.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tracking.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17941,7 +17941,7 @@
       "poison": "+2"
     },
     "image_url": "/static/images/cards/haze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Nałóż 6 pkt. [gold]Trucizny[/gold] na WSZYSTKICH przeciwników.",
@@ -18058,7 +18058,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/lift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Daj innemu graczowi 16 pkt. [gold]Bloku[/gold].",
@@ -18136,7 +18136,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/crash_landing.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crash_landing.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 26 pkt. obrażeń WSZYSTKIM przeciwnikom.\nZapełnij swoją [gold]rękę[/gold] [gold]Gruzem[/gold].",
@@ -18175,7 +18175,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/toric_toughness.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/toric_toughness.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 7 pkt. [gold]Bloku[/gold].\nZyskaj 7 pkt. [gold]Bloku[/gold] na początku 2 następnych tur|2 następnych tur.",
@@ -18220,7 +18220,7 @@
       "vigorpower": "+2"
     },
     "image_url": "/static/images/cards/terraforming.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/terraforming.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 8 pkt. [gold]Wigoru[/gold].",
@@ -18258,7 +18258,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/tyranny.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tyranny.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18380,7 +18380,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/deaths_door.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/deaths_door.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 7 pkt. [gold]Bloku[/gold].\nJeżeli w tej turze nałożono [gold]Zagładę[/gold], zyskaj dodatkowo tyle samo [gold]Bloku[/gold] 2 razy|razy.",
@@ -18505,7 +18505,7 @@
       "strength": "+2"
     },
     "image_url": "/static/images/cards/feeding_frenzy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 7 pkt. [gold]Siły[/gold] w tej turze.",
@@ -18828,7 +18828,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/seeker_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeker_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 12 pkt. obrażeń.\nWybierz 1 z 3 kart ze [gold]stosu rozgrywającego[/gold] i dodaj ją do [gold]ręki[/gold].",
@@ -18872,7 +18872,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/minion_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 9 pkt. obrażeń.\nDobierz 1 kartę.",
@@ -19004,7 +19004,7 @@
       "stranglepower": "+1"
     },
     "image_url": "/static/images/cards/strangle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/strangle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 10 pkt. obrażeń.\nKiedykolwiek zagrasz kartę w tej turze, przeciwnik traci 3 PŻ.",
@@ -19092,7 +19092,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/hidden_daggers.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_daggers.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Odrzuć 2 karty|kart.\nDodaj 2 [gold]Noże+|Noży+[/gold] do [gold]ręki[/gold].",
@@ -19130,7 +19130,7 @@
       "replay": "+1"
     },
     "image_url": "/static/images/cards/hidden_gem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_gem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Dodaj 3 [gold]Powtórki[/gold] do karty bez [gold]Powtórek[/gold] ze [gold]stosu rozgrywającego[/gold].",
@@ -19172,7 +19172,7 @@
       "calculationextra": "+2"
     },
     "image_url": "/static/images/cards/beat_into_shape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_into_shape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 7 pkt. obrażeń.\n[gold]Wykuj[/gold] X.\n[gold]Wykuj[/gold] dodatkowe 7 za każdy inny raz, gdy uderzono przeciwnika w tej turze.",
@@ -19262,7 +19262,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/ultimate_defend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_defend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 15 pkt. [gold]Bloku[/gold].",
@@ -19302,7 +19302,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/ultimate_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 20 pkt. obrażeń.",
@@ -19345,7 +19345,7 @@
       "strengthloss": "+2"
     },
     "image_url": "/static/images/cards/dying_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dying_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 11 pkt. obrażeń WSZYSTKIM przeciwnikom. W tej turze WSZYSCY przeciwnicy tracą 11 pkt. [gold]Siły[/gold].",
@@ -19384,7 +19384,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/entrench.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entrench.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19422,7 +19422,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/eidolon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/eidolon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19540,7 +19540,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/gunk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gunk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 5 pkt. obrażeń 3 razy|razy.\nDodaj [gold]Śluz[/gold] do [gold]stosu kart odrzuconych[/gold].",
@@ -19621,7 +19621,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/squeeze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/squeeze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Kostek[/gold] zadaje 25 pkt. obrażeń.\nZadaje dodatkowo 6 pkt. obrażeń za WSZYSTKIE inne Ataki [gold]Kostka[/gold].",
@@ -19702,7 +19702,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/graveblast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/graveblast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 6 pkt. obrażeń.\nPrzenieś kartę ze [gold]stosu kart odrzuconych[/gold] do [gold]ręki[/gold].",
@@ -19882,7 +19882,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/summon_forth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/summon_forth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Wykuj[/gold] 11.\nPrzenieś [gold]Niebiańskie Ostrze[/gold] z dowolnego miejsca do [gold]ręki[/gold].",
@@ -20022,7 +20022,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/big_bang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/big_bang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20101,7 +20101,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/believe_in_you.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/believe_in_you.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inny gracz zyskuje [energy:3].",
@@ -20144,7 +20144,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/leading_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/leading_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 6 pkt. obrażeń.\nDodaj 2 [gold]Noże|Noży[/gold] do [gold]ręki[/gold].",
@@ -20182,7 +20182,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/volley.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/volley.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 14 pkt. obrażeń losowemu przeciwnikowi X razy.",
@@ -20256,7 +20256,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/hammer_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hammer_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20379,7 +20379,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/omnislice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/omnislice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 11 pkt. obrażeń.\nZadaj równowartość tych obrażeń WSZYSTKIM przeciwnikom.",
@@ -20509,7 +20509,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/gamma_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gamma_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 18 pkt. obrażeń.\nNałóż 2 pkt. [gold]Słabości[/gold].\nNałóż 2 pkt. [gold]Wrażliwości[/gold].",
@@ -20594,7 +20594,7 @@
       "strengthloss": "+3"
     },
     "image_url": "/static/images/cards/enfeebling_touch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enfeebling_touch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "W tej turze przeciwnik traci [blue]11[/blue] pkt. [gold]Siły[/gold].",
@@ -20843,7 +20843,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/boost_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/boost_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 9 pkt. [gold]Bloku[/gold].\nDodaj [gold]Oszołomienie[/gold] do [gold]stosu kart odrzuconych[/gold].",
@@ -21088,7 +21088,7 @@
       "extrablock": "+2"
     },
     "image_url": "/static/images/cards/fasten.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fasten.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskujesz dodatkowo 7 pkt. [gold]Bloku[/gold] od kart Obrony.",
@@ -21351,7 +21351,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/forbidden_grimoire.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/forbidden_grimoire.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21408,7 +21408,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/know_thy_place.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/know_thy_place.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21543,7 +21543,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/ignition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ignition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21582,7 +21582,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/spore_mind.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spore_mind.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21625,7 +21625,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 11 pkt. obrażeń WSZYSTKIM przeciwnikom.",
@@ -21794,7 +21794,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/rally.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rally.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "WSZYSCY gracze otrzymują 17 pkt. [gold]Bloku[/gold].",
@@ -21832,7 +21832,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/conqueror.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conqueror.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Wykuj[/gold] 5.\nW tej turze [gold]Niebiańskie Ostrze[/gold] zadaje danemu przeciwnikowi podwójne obrażenia.",
@@ -21989,7 +21989,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/call_of_the_void.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/call_of_the_void.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22076,7 +22076,7 @@
       "strengthloss": "+1"
     },
     "image_url": "/static/images/cards/crush_under.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crush_under.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 8 pkt. obrażeń WSZYSTKIM przeciwnikom. W tej turze wszyscy przeciwnicy tracą 2 pkt. [gold]Siły[/gold].",
@@ -22162,7 +22162,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/mind_rot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mind_rot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -22198,7 +22198,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/beckon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beckon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22238,7 +22238,7 @@
       "extradamage": "+2"
     },
     "image_url": "/static/images/cards/gang_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gang_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 5 pkt. obrażeń.\nZadaje dodatkowo 7 pkt. obrażeń za każdy raz, gdy inny gracz zaatakował przeciwnika w tej turze.",
@@ -22359,7 +22359,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/ascenders_bane.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ascenders_bane.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22575,7 +22575,7 @@
       "sleightoffleshpower": "+4"
     },
     "image_url": "/static/images/cards/sleight_of_flesh.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sleight_of_flesh.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek nałożysz osłabienie na przeciwnika, otrzymuje dodatkowo 13 pkt. obrażeń.",
@@ -22613,7 +22613,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/clash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/clash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Można zagrać, jeśli pozostałe karty w [gold]ręce[/gold] są Atakami.\nZadaj 18 pkt. obrażeń.",
@@ -22704,7 +22704,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/reflect.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reflect.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 21 pkt. [gold]Bloku[/gold].\nW tej turze zablokowane obrażenia od ataków są odbijane na atakującego.",
@@ -23125,7 +23125,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/hotfix.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hotfix.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23243,7 +23243,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/spoils_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Wykuj[/gold] 8.\nDobierz 2 karty|kart.",
@@ -23413,7 +23413,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/abrasive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/abrasive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zyskaj 1 pkt. [gold]Zręczności[/gold].\nZyskaj 6 pkt [gold]Cierni[/gold].",
@@ -23504,7 +23504,7 @@
       "lethalitypower": "+25"
     },
     "image_url": "/static/images/cards/lethality.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lethality.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Twój pierwszy atak w każdej turze zadaje 75% więcej obrażeń.",
@@ -23669,7 +23669,7 @@
       "serpentformpower": "+2"
     },
     "image_url": "/static/images/cards/serpent_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/serpent_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Kiedykolwiek zagrasz kartę, zadaj 6 pkt. obrażeń losowemu przeciwnikowi.",
@@ -23709,7 +23709,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/reap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Zadaj 33 pkt. obrażeń.",
@@ -23748,7 +23748,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/reaper_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reaper_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23784,7 +23784,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/juggling.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/juggling.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23863,7 +23863,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/afterlife.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/afterlife.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Przywołaj[/gold] 9.",

--- a/data/ptb/cards.json
+++ b/data/ptb/cards.json
@@ -70,7 +70,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/the_hunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_hunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Cause 15 de dano.\nSe for [gold]Letal[/gold], receba uma recompensa de carta adicional.",
@@ -115,7 +115,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/the_scythe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_scythe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 13 de dano.\nAumente permanentemente o dano desta carta em 4.",
@@ -212,7 +212,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/abrasive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/abrasive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 1 de [gold]Destreza[/gold].\nReceba 6 de [gold]Espinhos[/gold].",
@@ -413,7 +413,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/gather_light.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gather_light.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 11 de [gold]Proteção[/gold].\nReceba [star:1].",
@@ -454,7 +454,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/hidden_daggers.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_daggers.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Descarte 2 cartas.\nAdicione 2 [gold]Lâminas+[/gold] na sua [gold]Mão[/gold].",
@@ -652,7 +652,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Cure 13 PV.",
@@ -702,7 +702,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/hotfix.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hotfix.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -788,7 +788,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/alignment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/alignment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba [energy:3].",
@@ -828,7 +828,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/soul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Compre 3 cartas.",
@@ -950,7 +950,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/uproar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/uproar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 7 de dano duas vezes.\nJogue um Ataque aleatório da sua [gold]Pilha de Compra[/gold].",
@@ -1226,7 +1226,7 @@
       "parrypower": "+4"
     },
     "image_url": "/static/images/cards/parry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/parry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você jogar [gold]Espada Soberana[/gold], receba 14 de [gold]Proteção[/gold].",
@@ -1264,7 +1264,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/eidolon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/eidolon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1312,7 +1312,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/apparition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/apparition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1356,7 +1356,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/whistle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/whistle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 44 de dano.\n[gold]Atordoe[/gold] o inimigo.",
@@ -1402,7 +1402,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/mind_rot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mind_rot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -1440,7 +1440,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/rally.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rally.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TODOS os jogadores recebem 17 de [gold]Proteção[/gold].",
@@ -1522,7 +1522,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/royal_gamble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royal_gamble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1693,7 +1693,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/knife_trap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knife_trap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Aprimore[/gold] e jogue cada [gold]Lâmina[/gold] na sua pilha de [gold]Cartas Exauridas[/gold] contra o inimigo.",
@@ -1983,7 +1983,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/arsenal.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/arsenal.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2023,7 +2023,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/flak_cannon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/flak_cannon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Exaure[/gold] TODAS as suas cartas de Condição.\nCause 11 de dano a um inimigo aleatório por cada carta [gold]Exaurida[/gold].",
@@ -2117,7 +2117,7 @@
       "hploss": "+2"
     },
     "image_url": "/static/images/cards/haunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você jogar uma [gold]Alma[/gold], um inimigo aleatório perde 8 PV.",
@@ -2193,7 +2193,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/automation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/automation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2243,7 +2243,7 @@
       "sicempower": "+1"
     },
     "image_url": "/static/images/cards/sic_em.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sic_em.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Ostheo[/gold] causa 6 de dano.\nSempre que [gold]Ostheo[/gold] golpear um inimigo neste turno, [gold]Vincule[/gold] 3.",
@@ -2357,7 +2357,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/bad_luck.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bad_luck.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2401,7 +2401,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/bulwark.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulwark.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 16 de [gold]Proteção[/gold].\n[gold]Forje[/gold] 13.",
@@ -2559,7 +2559,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/big_bang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/big_bang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2600,7 +2600,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/tesla_coil.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tesla_coil.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 6 de dano.\nAtive todos os [gold]Relâmpagos[/gold] contra o inimigo.",
@@ -2678,7 +2678,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/bombardment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bombardment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 24 de dano.\nNo início do seu turno, esta carta é jogada se estiver na sua pilha de [gold]Cartas Exauridas[/gold].",
@@ -2771,7 +2771,7 @@
       "poison": "+3"
     },
     "image_url": "/static/images/cards/bubble_bubble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Se o inimigo estiver [gold]Envenenado[/gold], aplique 12 de [gold]Veneno[/gold].",
@@ -2854,7 +2854,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/glow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba [star:2].\nCompre 1 carta.\nNo próximo turno, compre 1 carta.",
@@ -2894,7 +2894,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/helix_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/helix_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 5 de dano por cada [energy:1] gasta anteriormente neste turno.",
@@ -2941,7 +2941,7 @@
       "poison": "+2"
     },
     "image_url": "/static/images/cards/haze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplique 6 de [gold]Veneno[/gold] a TODOS os inimigos.",
@@ -2982,7 +2982,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/vicious.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/vicious.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você aplicar [gold]Vulnerável[/gold], compre 2 cartas.",
@@ -3027,7 +3027,7 @@
       "blackholepower": "+1"
     },
     "image_url": "/static/images/cards/black_hole.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/black_hole.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você gastar ou receber [star:1], cause 4 de dano a TODOS os inimigos.",
@@ -3143,7 +3143,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/calamity.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/calamity.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3381,7 +3381,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/cascade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cascade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Jogue as X+1 cartas do topo da sua [gold]Pilha de Compra[/gold].",
@@ -3419,7 +3419,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/catastrophe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/catastrophe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Jogue 3 cartas aleatórias da sua [gold]Pilha de Compra[/gold].",
@@ -3511,7 +3511,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/reap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 33 de dano.",
@@ -3555,7 +3555,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/brightest_flame.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/brightest_flame.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba [energy:3].\nCompre 3 cartas.\nPerca 1 PV Máximo.",
@@ -3593,7 +3593,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/call_of_the_void.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/call_of_the_void.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3678,7 +3678,7 @@
       "smokestackpower": "+2"
     },
     "image_url": "/static/images/cards/smokestack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/smokestack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você criar uma carta de Condição, cause 7 de dano a TODOS os inimigos.",
@@ -3716,7 +3716,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/lantern_key.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lantern_key.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3802,7 +3802,7 @@
       "hailstormpower": "+2"
     },
     "image_url": "/static/images/cards/hailstorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hailstorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "No final do seu turno, se você possuir [gold]Gelo[/gold], cause 8 de dano a TODOS os inimigos.",
@@ -4179,7 +4179,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/colossus.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/colossus.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 8 de [gold]Proteção[/gold].\nVocê sofre 50% menos dano de inimigos [gold]Vulneráveis[/gold] neste turno.",
@@ -4220,7 +4220,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/fuel.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fuel.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba [energy:1].\nCompre 2 cartas.",
@@ -4277,7 +4277,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/comet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/comet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 44 de dano.\nAplique 3 de [gold]Fraqueza[/gold].\nAplique 3 de [gold]Vulnerável[/gold].",
@@ -4357,7 +4357,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/compact.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/compact.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 7 de [gold]Proteção[/gold].\n[gold]Transforme[/gold] todas as cartas de Condição na sua [gold]Mão[/gold] em [gold]Combustível+[/gold].",
@@ -4395,7 +4395,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/foregone_conclusion.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/foregone_conclusion.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "No próximo turno, coloque 3 cartas da sua [gold]Pilha de Compra[/gold] na sua [gold]Mão[/gold].",
@@ -4433,7 +4433,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/believe_in_you.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/believe_in_you.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Outro jogador recebe [energy:3].",
@@ -4474,7 +4474,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/conflagration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conflagration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 8 de dano a TODOS os inimigos.\nCausa 3 de dano adicional por cada outro Ataque que você jogou neste turno.",
@@ -4512,7 +4512,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/conqueror.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conqueror.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forje[/gold] 5.\n[gold]Espada Soberana[/gold] causa o dobro de dano ao inimigo neste turno.",
@@ -4645,7 +4645,7 @@
       "devourlifepower": "+1"
     },
     "image_url": "/static/images/cards/devour_life.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devour_life.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você jogar uma [gold]Alma[/gold], [gold]Vincule[/gold] 2.",
@@ -4729,7 +4729,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/convergence.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/convergence.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "No próximo turno,\nreceba [energy:1] e [star:2].\n[gold]Mantenha[/gold] a sua [gold]Mão[/gold] neste turno.",
@@ -4769,7 +4769,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/summon_forth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/summon_forth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forje[/gold] 11.\nColoque [gold]Espada Soberana[/gold] na sua [gold]Mão[/gold].",
@@ -4814,7 +4814,7 @@
       "strength": "+3"
     },
     "image_url": "/static/images/cards/coordinate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Conceda a outro jogador 8 de [gold]Força[/gold] neste turno.",
@@ -4930,7 +4930,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/precise_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/precise_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4971,7 +4971,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/photon_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/photon_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 13 de dano.\nCompre 2 cartas.\nColoque 1 carta da sua [gold]Mão[/gold] no topo da sua [gold]Pilha de Compra[/gold].",
@@ -5047,7 +5047,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/glasswork.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glasswork.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 8 de [gold]Proteção[/gold].\n[gold]Canalize[/gold] 1 [gold]Vidro[/gold].",
@@ -5220,7 +5220,7 @@
       "dansemacabrepower": "+2"
     },
     "image_url": "/static/images/cards/danse_macabre.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/danse_macabre.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você jogar uma carta que custe [energy:2] ou mais, receba 6 de [gold]Proteção[/gold].",
@@ -5352,7 +5352,7 @@
       "debilitatepower": "+1"
     },
     "image_url": "/static/images/cards/debilitate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debilitate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 12 de dano.\n[gold]Vulnerável[/gold] e [gold]Fraqueza[/gold] possuem o dobro de efetividade contra inimigos pelos próximos 4 turnos.",
@@ -5394,7 +5394,7 @@
       "cards": "+2"
     },
     "image_url": "/static/images/cards/decisions_decisions.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/decisions_decisions.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Compre 5 cartas.\nEscolha uma Técnica na sua [gold]Mão[/gold] e a jogue 3 vezes.",
@@ -5637,7 +5637,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/ultimate_defend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_defend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 15 de [gold]Proteção[/gold].",
@@ -5680,7 +5680,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/waste_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/waste_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -5765,7 +5765,7 @@
       "knockdownpower": "+1"
     },
     "image_url": "/static/images/cards/knockdown.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockdown.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 14 de dano.\nO inimigo sofre o triplo de dano de outros jogadores neste turno.",
@@ -6106,7 +6106,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/disintegration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/disintegration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -6386,7 +6386,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/severance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/severance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 18 de dano.\nAdicione uma [gold]Alma[/gold] na sua [gold]Pilha de Compra[/gold], na sua [gold]Mão[/gold] e na sua [gold]Pilha de Descarte[/gold].",
@@ -6424,7 +6424,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/spectrum_shift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spectrum_shift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6504,7 +6504,7 @@
       "damage": "+10"
     },
     "image_url": "/static/images/cards/devastate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devastate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 40 de dano.",
@@ -6544,7 +6544,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/maul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/maul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 6 de dano duas vezes.\nAumenta o dano de TODAS as cartas de Dilacerar 2 neste combate.",
@@ -6582,7 +6582,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/pagestorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pagestorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6676,7 +6676,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/gamma_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gamma_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 18 de dano.\nAplique 2 de [gold]Fraqueza[/gold].\nAplique 2 de [gold]Vulnerável[/gold].",
@@ -6716,7 +6716,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/lunar_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lunar_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 5 de dano por cada Técnica jogada neste turno.",
@@ -6802,7 +6802,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/graveblast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/graveblast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 6 de dano.\nColoque uma carta da sua [gold]Pilha de Descarte[/gold] na sua [gold]Mão[/gold].",
@@ -6843,7 +6843,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/distraction.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/distraction.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6938,7 +6938,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/demesne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demesne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6981,7 +6981,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/dredge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dredge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7062,7 +7062,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/dual_wield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Escolha uma carta de Ataque ou Poder. Adicione 2 cópias desta carta na sua [gold]Mão[/gold].",
@@ -7266,7 +7266,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/clash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/clash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Pode ser jogada apenas se todas as cartas na sua [gold]Mão[/gold] forem Ataques.\nCause 18 de dano.",
@@ -7305,7 +7305,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/stack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba [gold]Proteção[/gold] equivalente à quantidade de cartas na sua [gold]Pilha de Descarte[/gold] +3.",
@@ -7343,7 +7343,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/hang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 13 de dano.\nDobre o dano que TODAS as cartas de Enforcar causam neste inimigo.",
@@ -7381,7 +7381,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/bury.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bury.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Causa 63 de dano.",
@@ -7462,7 +7462,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/entrench.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entrench.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7500,7 +7500,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/entropy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entropy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7583,7 +7583,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/volley.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/volley.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 14 de dano a um inimigo aleatório X vezes.",
@@ -7629,7 +7629,7 @@
       "outbreakpower": "+4"
     },
     "image_url": "/static/images/cards/outbreak.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outbreak.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cada 3 vezes que você aplicar [gold]Veneno[/gold], cause 15 de dano a TODOS os inimigos.",
@@ -7747,7 +7747,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/debris.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debris.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7792,7 +7792,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/demonic_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demonic_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7833,7 +7833,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/shadow_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shadow_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 15 de [gold]Proteção[/gold].\n[gold]Canalize[/gold] 1 [gold]Trevas[/gold].",
@@ -8037,7 +8037,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sovereign_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sovereign_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8159,7 +8159,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/squeeze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/squeeze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Ostheo[/gold] causa 25 de dano.\nCausa 6 de dano adicional por TODOS os seus outros Ataques do [gold]Ostheo[/gold].",
@@ -8197,7 +8197,7 @@
       "blockonexhaust": "+1"
     },
     "image_url": "/static/images/cards/spirit_of_ash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spirit_of_ash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você jogar uma carta [gold]Etérea[/gold], receba 5 de [gold]Proteção[/gold].",
@@ -8236,7 +8236,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/spoils_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forje[/gold] 8.\nCompre 2 cartas.",
@@ -8358,7 +8358,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/snap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/snap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Ostheo[/gold] causa 10 de dano.\nAdicione [gold]Manter[/gold] a uma carta na sua [gold]Mão[/gold].",
@@ -8396,7 +8396,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/shatter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shatter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 15 de dano a TODOS os inimigos.\n[gold]Evoque[/gold] todas as suas Orbes.",
@@ -8528,7 +8528,7 @@
       "stranglepower": "+1"
     },
     "image_url": "/static/images/cards/strangle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/strangle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 10 de dano.\nSempre que você jogar uma carta neste turno, o inimigo perde 3 PV.",
@@ -8564,7 +8564,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/stratagem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stratagem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8661,7 +8661,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/falling_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/falling_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 12 de dano.\nAplique 1 de [gold]Fraqueza[/gold].\nAplique 1 de [gold]Vulnerável[/gold].",
@@ -8702,7 +8702,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/guiding_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/guiding_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 13 de dano.\nCompre 3 cartas.",
@@ -8745,7 +8745,7 @@
       "strengthloss": "+2"
     },
     "image_url": "/static/images/cards/dying_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dying_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 11 de dano a TODOS os inimigos. TODOS os inimigos perdem 11 de [gold]Força[/gold] neste turno.",
@@ -8843,7 +8843,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/caltrops.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/caltrops.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você for atacado, cause 5 de dano em retaliação.",
@@ -8972,7 +8972,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/quadcast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quadcast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9126,7 +9126,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/beacon_of_hope.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beacon_of_hope.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9162,7 +9162,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/enthralled.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enthralled.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9402,7 +9402,7 @@
       "blockforstars": "+1"
     },
     "image_url": "/static/images/cards/child_of_the_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/child_of_the_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você gastar [star:1], receba 3 [gold]Proteção[/gold] por cada [star:1] gasta.",
@@ -9487,7 +9487,7 @@
       "extrablock": "+2"
     },
     "image_url": "/static/images/cards/fasten.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fasten.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 7 de [gold]Proteção[/gold] adicional das cartas de Defesa.",
@@ -9693,7 +9693,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/wisp.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wisp.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9736,7 +9736,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/wrought_in_war.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wrought_in_war.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 9 de dano.\n[gold]Forje[/gold] 9.",
@@ -9772,7 +9772,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/reaper_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reaper_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9957,7 +9957,7 @@
       "serpentformpower": "+2"
     },
     "image_url": "/static/images/cards/serpent_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/serpent_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você jogar uma carta, cause 6 de dano a um inimigo aleatório.",
@@ -10004,7 +10004,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/void_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/void_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10045,7 +10045,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/furnace.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/furnace.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "No início do seu turno, [gold]Forje[/gold] 6.",
@@ -10099,7 +10099,7 @@
       "dexterity": "+1"
     },
     "image_url": "/static/images/cards/bulk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Perca 1 Espaço de Orbe.\nReceba 3 de [gold]Força[/gold].\nReceba 3 de [gold]Destreza[/gold].",
@@ -10180,7 +10180,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/bone_shards.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bone_shards.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Se [gold]Ostheo[/gold] estiver vivo, ele causa 12 de dano a TODOS os inimigos e você recebe 12 de [gold]Proteção[/gold].\n[gold]Ostheo[/gold] é sacrificado.",
@@ -10271,7 +10271,7 @@
       "strength": "+2"
     },
     "image_url": "/static/images/cards/feeding_frenzy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 7 de [gold]Força[/gold] neste turno.",
@@ -10305,7 +10305,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/frantic_escape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/frantic_escape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -10341,7 +10341,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/soot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -10391,7 +10391,7 @@
       "sneakypower": "+1"
     },
     "image_url": "/static/images/cards/sneaky.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sneaky.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que outro jogador atacar um inimigo, receba 2 de [gold]Proteção[/gold].",
@@ -10638,7 +10638,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/greed.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/greed.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10794,7 +10794,7 @@
       "replay": "+1"
     },
     "image_url": "/static/images/cards/hidden_gem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_gem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Uma carta aleatória que não possua [gold]Repetir[/gold] na sua [gold]Pilha de Compra[/gold] recebe [gold]Repetir[/gold] 3.",
@@ -10830,7 +10830,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/largesse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/largesse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Outro jogador adiciona 1 carta Incolor aleatória  [gold]Aprimorada[/gold] na própria [gold]Mão[/gold].",
@@ -11070,7 +11070,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/adaptive_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/adaptive_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 23 de dano.\nAdicione uma cópia de custo 0[energy:1] desta carta na sua [gold]Pilha de Descarte[/gold].",
@@ -11193,7 +11193,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/shining_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shining_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 11 de dano.\nReceba [star:2].\nColoque esta carta no topo da sua [gold]Pilha de Compra[/gold].",
@@ -11315,7 +11315,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sculpting_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sculpting_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 12 de dano.\nAdicione [gold]Etérea[/gold] a uma carta na sua [gold]Mão[/gold].",
@@ -11364,7 +11364,7 @@
       "focuspower": "+1"
     },
     "image_url": "/static/images/cards/focused_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/focused_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 11 de dano.\nReceba 2 de [gold]Foco[/gold] neste turno.",
@@ -11447,7 +11447,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/leading_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/leading_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 6 de dano.\nAdicione 2 [gold]Lâminas[/gold] na sua [gold]Mão[/gold].",
@@ -11528,7 +11528,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/seeker_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeker_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 12 de dano.\nEscolha 1 entre 3 cartas da sua [gold]Pilha de Compra[/gold] para adicionar na sua [gold]Mão[/gold].",
@@ -11610,7 +11610,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/ultimate_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 20 de dano.",
@@ -11745,7 +11745,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/minion_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 9 de dano.\nCompre 1 carta.",
@@ -11947,7 +11947,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/forbidden_grimoire.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/forbidden_grimoire.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11989,7 +11989,7 @@
       "cost": 7
     },
     "image_url": "/static/images/cards/banshees_cry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/banshees_cry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12027,7 +12027,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/bodyguard.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bodyguard.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Vincule[/gold] 7.",
@@ -12106,7 +12106,7 @@
       "starsperturn": "+1"
     },
     "image_url": "/static/images/cards/genesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/genesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "No início do seu turno, receba [star:3].",
@@ -12187,7 +12187,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/hegemony.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hegemony.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 18 de dano.\nNo próximo turno, receba [energy:3].",
@@ -12356,7 +12356,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/murder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/murder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12432,7 +12432,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/ignition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ignition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12562,7 +12562,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/mimic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mimic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12722,7 +12722,7 @@
       "gold": "+5"
     },
     "image_url": "/static/images/cards/royalties.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royalties.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "No final do combate, receba 35 de [gold]Ouro[/gold].",
@@ -12762,7 +12762,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/boost_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/boost_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 9 de [gold]Proteção[/gold].\nAdicione uma [gold]Desorientação[/gold] na sua [gold]Pilha de Descarte[/gold].",
@@ -12798,7 +12798,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/unmovable.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/unmovable.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12836,7 +12836,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/cosmic_indifference.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cosmic_indifference.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 9 de [gold]Proteção[/gold].\nColoque uma carta da sua [gold]Pilha de Descarte[/gold] no topo da sua [gold]Pilha de Compra[/gold].",
@@ -12960,7 +12960,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/infection.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/infection.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13125,7 +13125,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/beckon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beckon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13162,7 +13162,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/poor_sleep.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/poor_sleep.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13204,7 +13204,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/intercept.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/intercept.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 13 de [gold]Proteção[/gold].\nRedirecione para você todos os ataques que tenham outro jogador como alvo neste turno.",
@@ -13327,7 +13327,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/invoke.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/invoke.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "No próximo turno, [gold]Vincule[/gold] 3 e receba [energy:3].",
@@ -13493,7 +13493,7 @@
       "iterationpower": "+1"
     },
     "image_url": "/static/images/cards/iteration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/iteration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Na primeira vez que você comprar uma carta de Condição a cada turno, compre 3 cartas.",
@@ -13693,7 +13693,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/ice_lance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ice_lance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 24 de dano.\n[gold]Canalize[/gold] 3 [gold]Gelo[/gold].",
@@ -13733,7 +13733,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/legion_of_bone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/legion_of_bone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TODOS os jogadores [gold]Vinculam[/gold] 8.",
@@ -13862,7 +13862,7 @@
       "lethalitypower": "+25"
     },
     "image_url": "/static/images/cards/lethality.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lethality.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "O primeiro Ataque de cada turno causa 75% de dano adicional.",
@@ -13903,7 +13903,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/lift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Conceda 16 de [gold]Proteção[/gold] a outro jogador.",
@@ -13942,7 +13942,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/deaths_door.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/deaths_door.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 7 de [gold]Proteção[/gold].\nSe você aplicou [gold]Ruína[/gold] neste turno, receba [gold]Proteção[/gold] 2 vezes adicionais.",
@@ -13983,7 +13983,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/luminesce.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/luminesce.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba [energy:3].",
@@ -14113,7 +14113,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/blade_of_ink.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/blade_of_ink.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Adicione 3 [gold]Lâminas[/gold] com [purple]Nanquim[/purple] na sua [gold]Mão[/gold].",
@@ -14151,7 +14151,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/seeking_edge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeking_edge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forje[/gold] 11.\n[gold]Espada Soberana[/gold] agora causa dano a TODOS os inimigos.",
@@ -14198,7 +14198,7 @@
       "phantombladespower": "+3"
     },
     "image_url": "/static/images/cards/phantom_blades.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/phantom_blades.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Lâminas[/gold] recebem [gold]Manter[/gold].\nA primeira [gold]Lâmina[/gold] que você jogar a cada turno causa 12 de dano adicional.",
@@ -14350,7 +14350,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/juggling.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/juggling.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14429,7 +14429,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/manifest_authority.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/manifest_authority.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 8 de [gold]Proteção[/gold].\nAdicione 1 carta Incolor [gold]Aprimorada[/gold] aleatória na sua [gold]Mão[/gold].",
@@ -14474,7 +14474,7 @@
       "sleightoffleshpower": "+4"
     },
     "image_url": "/static/images/cards/sleight_of_flesh.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sleight_of_flesh.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você aplicar um efeito negativo a um inimigo, cause 13 de dano.",
@@ -14519,7 +14519,7 @@
       "crimsonmantlepower": "+2"
     },
     "image_url": "/static/images/cards/crimson_mantle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crimson_mantle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "No início do seu turno, perca 1 PV e receba 10 de [gold]Proteção[/gold].",
@@ -14637,7 +14637,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/spoils_map.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_map.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14766,7 +14766,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/heirloom_hammer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heirloom_hammer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 25 de dano.\nEscolha uma carta Incolor na sua [gold]Mão[/gold]. Adicione uma cópia desta carta na sua [gold]Mão[/gold].",
@@ -14847,7 +14847,7 @@
       "summon": "+1"
     },
     "image_url": "/static/images/cards/dirge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dirge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Vincule[/gold] 4 X vezes.\nAdicione X [gold]Almas+[/gold] na sua [gold]Pilha de Compra[/gold].",
@@ -15004,7 +15004,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/spore_mind.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spore_mind.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15092,7 +15092,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sword_sage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sword_sage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15308,7 +15308,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/modded.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/modded.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 1 Espaço de Orbe.\nCompre 2 cartas. Aumente o custo desta carta em 1.",
@@ -15397,7 +15397,7 @@
       "calculationextra": "+2"
     },
     "image_url": "/static/images/cards/beat_into_shape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_into_shape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 7 de dano.\n[gold]Forje[/gold] X.\n[gold]Forje[/gold] mais 7 por cada outra vez que você golpeou o inimigo neste turno.",
@@ -15435,7 +15435,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/monologue.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/monologue.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15523,7 +15523,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/shroud.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shroud.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você aplicar [gold]Ruína[/gold], receba 3 de [gold]Proteção[/gold].",
@@ -15561,7 +15561,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/undeath.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/undeath.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 9 de [gold]Proteção[/gold].\nAdicione uma cópia desta carta na sua [gold]Pilha de Descarte[/gold].",
@@ -15678,7 +15678,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/right_hand_hand.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/right_hand_hand.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Ostheo[/gold] causa 6 de dano.\nSempre que você jogar uma carta de custo [energy:2] ou mais, retorne esta carta da sua [gold]Pilha de Descarte[/gold] para a sua [gold]Mão[/gold].",
@@ -15754,7 +15754,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/hammer_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hammer_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15792,7 +15792,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/necro_mastery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/necro_mastery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Vincule[/gold] 8.\nSempre que [gold]Ostheo[/gold] perder PV,\nTODOS os inimigos perdem a mesma quantidade de PV.",
@@ -15961,7 +15961,7 @@
       "damage": "+8"
     },
     "image_url": "/static/images/cards/knockout_blow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockout_blow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 38 de dano.\nSe esta carta derrotar um inimigo, receba [star:5].",
@@ -15997,7 +15997,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/nostalgia.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/nostalgia.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16159,7 +16159,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/the_sealed_throne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_sealed_throne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16283,7 +16283,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/gunk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gunk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Causa 5 de dano 3 vezes.\nAdicione uma [gold]Gosma[/gold] na sua [gold]Pilha de Descarte[/gold].",
@@ -16440,7 +16440,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/hello_world.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hello_world.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16478,7 +16478,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/omnislice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/omnislice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 11 de dano.\nCausa dano equivalente a TODOS os inimigos.",
@@ -16516,7 +16516,7 @@
       "corrosivewave": "+1"
     },
     "image_url": "/static/images/cards/corrosive_wave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/corrosive_wave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você comprar uma carta neste turno, aplique 3 de [gold]Veneno[/gold] a TODOS os inimigos.",
@@ -16596,7 +16596,7 @@
       "power": "+2"
     },
     "image_url": "/static/images/cards/shockwave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shockwave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplique 5 de [gold]Fraqueza[/gold] e [gold]Vulnerável[/gold] a TODOS os inimigos.",
@@ -16829,7 +16829,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/fisticuffs.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fisticuffs.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 9 de dano.\nReceba [gold]Proteção[/gold] equivalente ao dano causado.",
@@ -16875,7 +16875,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/lightning_rod.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lightning_rod.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 7 de [gold]Proteção[/gold].\nNo início dos seus próximos 2 turnos, [gold]Canalize[/gold] 1 [gold]Relâmpago[/gold].",
@@ -17035,7 +17035,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/bundle_of_joy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bundle_of_joy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Adicione 4 cartas Incolores aleatórias na sua [gold]Mão[/gold].",
@@ -17076,7 +17076,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/veilpiercer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/veilpiercer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 13 de dano.\nA próxima carta [gold]Etérea[/gold] que você jogar custa 0 [energy:1].",
@@ -17115,7 +17115,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/heavenly_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heavenly_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 10 de dano X vezes.\nSe X for 4 ou mais, dobre X.",
@@ -17155,7 +17155,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/fight_through.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_through.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 17 de [gold]Proteção[/gold].\nAdicione 2 [gold]Ferimentos[/gold] na sua [gold]Pilha de Descarte[/gold].",
@@ -17272,7 +17272,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/pillar_of_creation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillar_of_creation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você criar uma carta, receba 4 de [gold]Proteção[/gold].",
@@ -17585,7 +17585,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/delay.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/delay.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 13 de [gold]Proteção[/gold].\nNo próximo turno,\nreceba [energy:2].",
@@ -17670,7 +17670,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/crash_landing.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crash_landing.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 26 de dano a TODOS os inimigos.\nPreencha sua [gold]Mão[/gold] com [gold]Escombros[/gold].",
@@ -17751,7 +17751,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/sloth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sloth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -17796,7 +17796,7 @@
       "preptimepower": "+2"
     },
     "image_url": "/static/images/cards/prep_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prep_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "No início do seu turno, receba 6 de [gold]Vigor[/gold].",
@@ -17914,7 +17914,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/production.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/production.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba [energy:3].",
@@ -17970,7 +17970,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/prowess.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 2 de [gold]Força[/gold].\nReceba 2 de [gold]Destreza[/gold].",
@@ -18010,7 +18010,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/defile.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/defile.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 17 de dano.",
@@ -18221,7 +18221,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/astral_pulse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/astral_pulse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 18 de dano a TODOS os inimigos.",
@@ -18522,7 +18522,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/pull_from_below.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pull_from_below.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 7 de dano por cada carta [gold]Etérea[/gold] jogada neste combate.",
@@ -18561,7 +18561,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/pale_blue_dot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pale_blue_dot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Se você jogar 5 ou mais cartas em um turno, compre 2 cartas no início do seu próximo turno.",
@@ -18601,7 +18601,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/afterlife.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/afterlife.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Vincule[/gold] 9.",
@@ -18642,7 +18642,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/quasar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quasar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Escolha 1 entre 3 cartas Incolores [gold]Aprimoradas[/gold] para adicionar na sua [gold]Mão[/gold].",
@@ -18681,7 +18681,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/make_it_so.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/make_it_so.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 9 de dano.\nA cada 3 Técnicas que você jogar em um turno, coloque esta carta na sua [gold]Mão[/gold].",
@@ -18807,7 +18807,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/begone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/begone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Escolha uma carta na sua [gold]Mão[/gold] para [gold]Transformá-la[/gold] em [gold]Golpe de Lacaio+[/gold].",
@@ -18845,7 +18845,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/scrawl.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/scrawl.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18888,7 +18888,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/barrage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/barrage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 7 de dano por cada Orbe [gold]Canalizada[/gold].",
@@ -18965,7 +18965,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/spite.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spite.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 5 de dano.\nSe você perdeu PV neste turno,\ngolpeie 3 vezes.",
@@ -19044,7 +19044,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/rend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 15 de dano.\nCausa 8 de dano adicional por cada tipo de efeito negativo no inimigo.",
@@ -19205,7 +19205,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/tracking.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tracking.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19286,7 +19286,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/rebound.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rebound.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 12 de dano.\nColoque a próxima carta que você jogar neste turno no topo da sua [gold]Pilha de Compra[/gold].",
@@ -19401,7 +19401,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/refine_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refine_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forje[/gold] 13.\nNo próximo turno, receba [energy:1].",
@@ -19440,7 +19440,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/reflect.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reflect.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 21 de [gold]Proteção[/gold].\nO dano bloqueado de ataques é refletido ao seu atacante neste turno.",
@@ -19522,7 +19522,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/refract.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refract.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 12 de dano duas vezes.\n[gold]Canalize[/gold] 2 [gold]Vidro[/gold].",
@@ -19650,7 +19650,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/relax.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/relax.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 17 de [gold]Proteção[/gold].\nNo próximo turno, compre 3 cartas e receba [energy:3].",
@@ -19775,7 +19775,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/toric_toughness.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/toric_toughness.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 7 de [gold]Proteção[/gold].\nReceba 7 de [gold]Proteção[/gold] no início dos próximos 2 turnos.",
@@ -19811,7 +19811,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/splash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/splash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Escolha 1 entre 3 Ataques aleatórios [gold]Aprimorados[/gold] de outro personagem para adicionar na sua [gold]Mão[/gold]. Ele não tem custo neste turno.",
@@ -19857,7 +19857,7 @@
       "strengthpower": "+1"
     },
     "image_url": "/static/images/cards/resonance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/resonance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 2 de [gold]Força[/gold]. TODOS os inimigos perdem 1 de [gold]Força[/gold].",
@@ -19897,7 +19897,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/huddle_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/huddle_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TODOS os jogadores compram 3 cartas.",
@@ -19949,7 +19949,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/fight_me.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 6 de dano duas vezes.\nReceba 4 de [gold]Força[/gold].\nO inimigo recebe 1 de [gold]Força[/gold].",
@@ -19990,7 +19990,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/ricochet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ricochet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 3 de dano a um inimigo aleatório 5 vezes.",
@@ -20035,7 +20035,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/seance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20119,7 +20119,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/giant_rock.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/giant_rock.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 20 de dano.",
@@ -20165,7 +20165,7 @@
       "rollingboulderpower": "+5"
     },
     "image_url": "/static/images/cards/rolling_boulder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rolling_boulder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "No início do seu turno, cause 10 de dano a TODOS os inimigos e aumente este dano em 5.",
@@ -20280,7 +20280,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/collision_course.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/collision_course.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 15 de dano.\nAdicione um [gold]Escombros[/gold] na sua [gold]Mão[/gold].",
@@ -20413,7 +20413,7 @@
       "vigorpower": "+1"
     },
     "image_url": "/static/images/cards/patter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/patter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 11 de [gold]Proteção[/gold].\nReceba 3 de [gold]Vigor[/gold].",
@@ -20451,7 +20451,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/ascenders_bane.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ascenders_bane.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20539,7 +20539,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/minion_sacrifice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_sacrifice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 12 de [gold]Proteção[/gold].",
@@ -20585,7 +20585,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/rattle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rattle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Ostheo[/gold] causa 9 de dano.\nGolpeia uma vez adicional para cada outra vez que ele atacou neste turno.",
@@ -20639,7 +20639,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/know_thy_place.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/know_thy_place.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20877,7 +20877,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/pillage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 9 de dano.\nCompre cartas até você comprar uma carta que não seja um Ataque.",
@@ -20956,7 +20956,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/salvo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/salvo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 16 de dano.\n[gold]Mantenha[/gold] sua [gold]Mão[/gold] neste turno.",
@@ -21001,7 +21001,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/feral.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feral.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21081,7 +21081,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 11 de dano a TODOS os inimigos.",
@@ -21208,7 +21208,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/seven_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seven_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21249,7 +21249,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/synchronize.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synchronize.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21337,7 +21337,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/neurosurge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neurosurge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba [energy:4].\nCompre 2 cartas.\nNo início do seu turno, aplique 3 de [gold]Ruína[/gold] a você.",
@@ -21492,7 +21492,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/rocket_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rocket_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 14 de dano.\nCompre 2 cartas.\nQuando você criar uma carta de Condição, reduza o custo desta carta para 0 [energy:1] até que seja jogada.",
@@ -21579,7 +21579,7 @@
       "increase": "+2"
     },
     "image_url": "/static/images/cards/kingly_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/kingly_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 10 de dano.\nSempre que você comprar estar carta, aumente seu dano em 6 neste combate.",
@@ -21618,7 +21618,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/misery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/misery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 9 de dano.\nAplique qualquer efeito negativo de um inimigo a TODOS os outros inimigos.",
@@ -21664,7 +21664,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/consuming_shadow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/consuming_shadow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Canalize[/gold] 3 [gold]Trevas[/gold].\nNo final do seu turno, [gold]Evoque[/gold] sua Orbe mais à esquerda.",
@@ -21703,7 +21703,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/jackpot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/jackpot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 30 de dano.\nAdicione 3 cartas aleatórias [gold]Aprimoradas[/gold] de custo 0[energy:1] na sua [gold]Mão[/gold].",
@@ -21741,7 +21741,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/i_am_invincible.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/i_am_invincible.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 13 de [gold]Proteção[/gold].\nNo final do seu turno, se esta carta estiver no topo da sua [gold]Pilha de Compra[/gold], jogue-a.",
@@ -21777,7 +21777,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/subroutine.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/subroutine.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21817,7 +21817,7 @@
       "strengthloss": "+1"
     },
     "image_url": "/static/images/cards/crush_under.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crush_under.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 8 de dano a TODOS os inimigos. Todos os inimigos perdem 2 de [gold]Força[/gold] neste turno.",
@@ -21898,7 +21898,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/supermassive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/supermassive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 5 de dano.\nCausa 4 de dano adicional por cada carta que você criou neste combate.",
@@ -21988,7 +21988,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/beat_down.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_down.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Jogue 4 Ataques aleatórios da sua [gold]Pilha de Descarte[/gold].",
@@ -22066,7 +22066,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/energy_surge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/energy_surge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TODOS os jogadores recebem [energy:3].",
@@ -22146,7 +22146,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/synthesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synthesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 18 de dano.\nO próximo Poder que você jogar custa 0 [energy:1].",
@@ -22186,7 +22186,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/turbo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/turbo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba [energy:3].\nAdicione um [gold]Vácuo[/gold] na sua [gold]Pilha de Descarte[/gold].",
@@ -22232,7 +22232,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/drum_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/drum_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Compre 3 cartas.\nNo início do seu turno, [gold]Exaure[/gold] a carta no topo da sua [gold]Pilha de Compra[/gold].",
@@ -22268,7 +22268,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/tank.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tank.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22346,7 +22346,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/soul_storm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul_storm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 9 de dano.\nCausa 3 de dano adicional por cada [gold]Alma[/gold] na sua pilha de [gold]Cartas Exauridas[/gold].",
@@ -22549,7 +22549,7 @@
       "vigorpower": "+2"
     },
     "image_url": "/static/images/cards/terraforming.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/terraforming.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 8 de [gold]Vigor[/gold].",
@@ -22647,7 +22647,7 @@
       "starnextturnpower": "+1"
     },
     "image_url": "/static/images/cards/hidden_cache.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_cache.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba [star:1].\nNo próximo turno, receba [star:4].",
@@ -22685,7 +22685,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/tyranny.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tyranny.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22861,7 +22861,7 @@
       "strengthloss": "+3"
     },
     "image_url": "/static/images/cards/enfeebling_touch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enfeebling_touch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "O inimigo perde 11 de [gold]Força[/gold] neste turno.",
@@ -23031,7 +23031,7 @@
       "extradamage": "+2"
     },
     "image_url": "/static/images/cards/gang_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gang_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cause 5 de dano.\nCausa 7 de dano adicional por cada vez que outro jogador atacou o inimigo neste turno.",
@@ -23071,7 +23071,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/transfigure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/transfigure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23110,7 +23110,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/trash_to_treasure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/trash_to_treasure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23155,7 +23155,7 @@
       "thunderpower": "+2"
     },
     "image_url": "/static/images/cards/thunder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/thunder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sempre que você [gold]Evocar Relâmpago[/gold], cause 8 de dano a cada inimigo golpeado.",
@@ -23233,7 +23233,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/up_my_sleeve.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/up_my_sleeve.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Adicione 4 [gold]Lâminas[/gold] na sua [gold]Mão[/gold].\nReduza o custo desta carta em 1.",
@@ -23309,7 +23309,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/outmaneuver.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outmaneuver.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "No próximo turno, receba [energy:3].",
@@ -23353,7 +23353,7 @@
       "ostydamage": "+5"
     },
     "image_url": "/static/images/cards/sweeping_gaze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sweeping_gaze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Ostheo[/gold] causa 15 de dano a um inimigo aleatório.",
@@ -23402,7 +23402,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/speedster.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/speedster.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23485,7 +23485,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/venerate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/venerate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba [star:3].",
@@ -23611,7 +23611,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/glimpse_beyond.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glimpse_beyond.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TODOS os jogadores adicionam 4 [gold]Almas[/gold] nas suas [gold]Pilhas de Descarte[/gold].",
@@ -23659,7 +23659,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/spinner.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spinner.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Canalize[/gold] 1 [gold]Vidro[/gold].\nNo início do seu turno, [gold]Canalize[/gold] 1 [gold]Vidro[/gold].",
@@ -23700,7 +23700,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/voltaic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/voltaic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23831,7 +23831,7 @@
       "platingpower": "+3"
     },
     "image_url": "/static/images/cards/neutron_aegis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neutron_aegis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Receba 11 de [gold]Blindagem[/gold].",

--- a/data/rus/cards.json
+++ b/data/rus/cards.json
@@ -29,7 +29,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/automation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/automation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -105,7 +105,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/adaptive_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/adaptive_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 23 урона.\nДобавляет копию стоимостью 0 [energy:1] в [gold]стопку сброса[/gold].",
@@ -355,7 +355,7 @@
       "crimsonmantlepower": "+2"
     },
     "image_url": "/static/images/cards/crimson_mantle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crimson_mantle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Вы теряете 1 ОЗ и получаете 10 [gold]защиты[/gold] в начале хода.",
@@ -391,7 +391,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/trash_to_treasure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/trash_to_treasure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -469,7 +469,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/greed.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/greed.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -595,7 +595,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/heavenly_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heavenly_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 10 урона X раз.\nX удваивается, если он не ниже 4.",
@@ -722,7 +722,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/arsenal.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/arsenal.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -761,7 +761,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/astral_pulse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/astral_pulse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 18 урона ВСЕМ врагам.",
@@ -808,7 +808,7 @@
       "stranglepower": "+1"
     },
     "image_url": "/static/images/cards/strangle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/strangle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 10 урона.\nОтнимает у врага 3 ОЗ, когда вы разыгрываете карту в этом ходу.",
@@ -884,7 +884,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/bulwark.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulwark.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 16 [gold]защиты[/gold].\n[gold]Закаляет[/gold] 13.",
@@ -965,7 +965,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/vicious.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/vicious.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Вы добираете 2 plural(ru):карту, когда накладываете [gold]уязвимость[/gold].",
@@ -1272,7 +1272,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/poor_sleep.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/poor_sleep.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1442,7 +1442,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/wisp.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wisp.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1485,7 +1485,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/wrought_in_war.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wrought_in_war.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 9 урона.\n[gold]Закаляет[/gold] 9.",
@@ -1523,7 +1523,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/rally.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rally.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 17 [gold]защиты[/gold] ВСЕМ игрокам.",
@@ -1680,7 +1680,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/big_bang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/big_bang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1762,7 +1762,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/bombardment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bombardment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 24 урона.\nРазыгрывается в начале хода, если находится в [gold]стопке пепла[/gold].",
@@ -1803,7 +1803,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/manifest_authority.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/manifest_authority.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 8 [gold]защиты[/gold].\nДобавляет в [gold]руку[/gold] 1 случайную [gold] улучшенную[/gold] бесцветную карту.",
@@ -1841,7 +1841,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/ascenders_bane.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ascenders_bane.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1926,7 +1926,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/giant_rock.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/giant_rock.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 20 урона.",
@@ -2045,7 +2045,7 @@
       "starsperturn": "+1"
     },
     "image_url": "/static/images/cards/genesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/genesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает [star:3] в начале хода.",
@@ -2210,7 +2210,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/leading_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/leading_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 6 урона.\nДобавляет в [gold]руку[/gold] 2 [gold]plural(ru):«Заточку»[/gold].",
@@ -2290,7 +2290,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/the_hunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_hunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Наносит 15 урона.\nЕсли [gold]казнит[/gold] врага, вы получите дополнительный наградной набор.",
@@ -2329,7 +2329,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/largesse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/largesse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Добавляет в [gold]руку[/gold] другому игроку случайную [gold]улучшенную[/gold] бесцветную карту.",
@@ -2410,7 +2410,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/believe_in_you.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/believe_in_you.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает [energy:3] другому игроку.",
@@ -2546,7 +2546,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/uproar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/uproar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 7 урона 2 раза.\nВы разыгрываете случайную Атаку из [gold]стопки добора[/gold].",
@@ -2596,7 +2596,7 @@
       "sicempower": "+1"
     },
     "image_url": "/static/images/cards/sic_em.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sic_em.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Костя[/gold] наносит 6 урона.\n[gold]Призывает[/gold] 3, когда [gold]Костя[/gold] атакует этого врага в этом ходу.",
@@ -2758,7 +2758,7 @@
       "cost": 7
     },
     "image_url": "/static/images/cards/banshees_cry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/banshees_cry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3006,7 +3006,7 @@
       "ostydamage": "+5"
     },
     "image_url": "/static/images/cards/sweeping_gaze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sweeping_gaze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Костя[/gold] наносит 15 урона случайному врагу.",
@@ -3048,7 +3048,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/omnislice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/omnislice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 11 урона.\nНаносит остальным врагам столько же урона.",
@@ -3088,7 +3088,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/energy_surge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/energy_surge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает [energy:3] ВСЕМ игрокам.",
@@ -3129,7 +3129,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/shatter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shatter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 15 урона ВСЕМ врагам.\n[gold]Разряжает[/gold] все сферы.",
@@ -3165,7 +3165,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/subroutine.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/subroutine.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3290,7 +3290,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/fight_me.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 6 урона 2 раза.\nДает 4 [gold]силы[/gold].\nВраг получает 1 [gold]силы[/gold].",
@@ -3330,7 +3330,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sculpting_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sculpting_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 12 урона.\nВыбранная в [gold]руке[/gold] карта становится [gold]эфирной[/gold].",
@@ -3368,7 +3368,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/necro_mastery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/necro_mastery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Призывает[/gold] 8.\nКогда [gold]Костя[/gold] теряет ОЗ,\nвсе враги теряют столько же.",
@@ -3422,7 +3422,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/gamma_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gamma_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 18 урона.\nНакладывает 2 [gold]слабости[/gold].\nНакладывает 2 [gold]уязвимости[/gold].",
@@ -3462,7 +3462,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/hegemony.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hegemony.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 18 урона.\nДаст [energy:3] в начале следующего хода.",
@@ -3762,7 +3762,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/speedster.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/speedster.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3807,7 +3807,7 @@
       "hailstormpower": "+2"
     },
     "image_url": "/static/images/cards/hailstorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hailstorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 8 урона ВСЕМ врагам, если у вас есть заряженная [gold]сфера льда[/gold] в конце хода.",
@@ -3897,7 +3897,7 @@
       "thunderpower": "+2"
     },
     "image_url": "/static/images/cards/thunder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/thunder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 8 урона каждому врагу, по которому попадает [gold]разряженная молния[/gold].",
@@ -3943,7 +3943,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/lightning_rod.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lightning_rod.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 7 [gold]защиты[/gold].\nplural(ru):[gold]Зарядит[/gold] 1 [gold]сферу молнии[/gold] в начале plural(ru):следующего хода.",
@@ -3986,7 +3986,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/rattle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rattle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Костя[/gold] наносит 9 урона.\nНаносит урон еще раз за каждую предыдущую атаку [gold]Кости[/gold] в этом ходу.",
@@ -4025,7 +4025,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/make_it_so.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/make_it_so.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 9 урона.\nВозвращается в [gold]руку[/gold], когда вы разыгрываете 3 plural(ru):Навык за ход.",
@@ -4198,7 +4198,7 @@
       "gold": "+5"
     },
     "image_url": "/static/images/cards/royalties.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royalties.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Дает 35 [gold]золота[/gold] в конце боя.",
@@ -4317,7 +4317,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/quadcast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quadcast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4395,7 +4395,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/demonic_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demonic_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4440,7 +4440,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/right_hand_hand.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/right_hand_hand.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Костя[/gold] наносит 6 урона.\nВы берете эту карту из [gold]стопки сброса[/gold], когда разыгрываете карту стоимостью [energy:2] или более.",
@@ -4524,7 +4524,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/jackpot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/jackpot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 30 урона.\nДобавляет в [gold]руку[/gold] 3 plural(ru):случайную [gold]улучшенную[/gold] карту стоимостью 0 [energy:1].",
@@ -4578,7 +4578,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/abrasive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/abrasive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 1 [gold]ловкости[/gold].\nДает 6 [gold]шипов[/gold].",
@@ -4626,7 +4626,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/feral.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feral.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4664,7 +4664,7 @@
       "blockforstars": "+1"
     },
     "image_url": "/static/images/cards/child_of_the_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/child_of_the_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 3 [gold]защиты[/gold] за каждую потраченную [star:1], когда вы тратите [star:1].",
@@ -4954,7 +4954,7 @@
       "blockonexhaust": "+1"
     },
     "image_url": "/static/images/cards/spirit_of_ash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spirit_of_ash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 5 [gold]защиты[/gold], когда вы разыгрываете [gold]эфирную[/gold] карту.",
@@ -4994,7 +4994,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/soul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Вы добираете 3 plural(ru):карту.",
@@ -5044,7 +5044,7 @@
       "poison": "+2"
     },
     "image_url": "/static/images/cards/haze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Накладывает 6 [gold]яда[/gold] на ВСЕХ врагов.",
@@ -5092,7 +5092,7 @@
       "smokestackpower": "+2"
     },
     "image_url": "/static/images/cards/smokestack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/smokestack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 7 урона ВСЕМ врагам, когда вы создаете Статус.",
@@ -5131,7 +5131,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/convergence.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/convergence.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Даст [energy:1] и [star:2]\nв следующем ходу.\nВ этом ходу вы [gold]оставляете[/gold] карты в [gold]руке[/gold].",
@@ -5214,7 +5214,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/caltrops.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/caltrops.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 5 урона в ответ на каждую атаку.",
@@ -5293,7 +5293,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Восполняет 13 ОЗ.",
@@ -5334,7 +5334,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/seeking_edge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeking_edge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Закаляет[/gold] 11.\n[gold]Клинок монарха[/gold] наносит урон ВСЕМ врагам.",
@@ -5374,7 +5374,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/reap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 33 урона.",
@@ -5537,7 +5537,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/crash_landing.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crash_landing.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 26 урона ВСЕМ врагам.\nЗаполняет [gold]руку[/gold] [gold]«Обломками»[/gold].",
@@ -5660,7 +5660,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/undeath.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/undeath.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 9 [gold]защиты[/gold].\nДобавляет копию в [gold]стопку сброса[/gold].",
@@ -5696,7 +5696,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/juggling.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/juggling.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5822,7 +5822,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/conqueror.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conqueror.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Закаляет[/gold] 5.\nВ этом ходу [gold]Клинок монарха[/gold] наносит врагу двойной урон.",
@@ -5865,7 +5865,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/mind_rot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mind_rot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -5905,7 +5905,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/afterlife.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/afterlife.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Призывает[/gold] 9.",
@@ -5948,7 +5948,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/pull_from_below.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pull_from_below.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит по 7 урона за каждую разыгранную за бой [gold]эфирную[/gold] карту.",
@@ -5989,7 +5989,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/gunk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gunk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 5 урона 3 plural(ru):раз.\nДобавляет [gold]«Слизь»[/gold] в [gold]стопку сброса[/gold].",
@@ -6029,7 +6029,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/delay.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/delay.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 13 [gold]защиты[/gold].\nДаст [energy:2]\nв следующем ходу.",
@@ -6067,7 +6067,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/ignition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ignition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6110,7 +6110,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/invoke.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/invoke.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Даст [energy:3] и [gold]призовет[/gold] 3 в начале следующего хода.",
@@ -6148,7 +6148,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/salvo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/salvo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 16 урона.\nВ этом ходу вы [gold]оставляете[/gold] карты в [gold]руке[/gold].",
@@ -6262,7 +6262,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/the_sealed_throne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_sealed_throne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6300,7 +6300,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/forbidden_grimoire.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/forbidden_grimoire.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6435,7 +6435,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/up_my_sleeve.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/up_my_sleeve.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Добавляет в [gold]руку[/gold] 4 [gold]plural(ru):«Заточку»[/gold].\nСтоимость понижается на 1.",
@@ -6630,7 +6630,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/pale_blue_dot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pale_blue_dot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Вы добираете еще 2 plural(ru):карту в начале следующего хода, если разыгрываете не менее 5 plural(ru):карты в текущем.",
@@ -6670,7 +6670,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/flak_cannon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/flak_cannon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Сжигает[/gold] ВСЕ Статусы.\nНаносит по 11 урона случайному врагу за каждый.",
@@ -6812,7 +6812,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/know_thy_place.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/know_thy_place.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6889,7 +6889,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/call_of_the_void.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/call_of_the_void.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7043,7 +7043,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/beat_down.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_down.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Вы разыгрываете 4 plural(ru):случайную Атаку из [gold]стопки сброса[/gold].",
@@ -7171,7 +7171,7 @@
       "debilitatepower": "+1"
     },
     "image_url": "/static/images/cards/debilitate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debilitate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 12 урона.\n[gold]Уязвимость[/gold] и [gold]слабость[/gold] в 2 раза эффективнее против врага на 4 plural(ru):ход.",
@@ -7293,7 +7293,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/infection.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/infection.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7374,7 +7374,7 @@
       "strengthloss": "+3"
     },
     "image_url": "/static/images/cards/enfeebling_touch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enfeebling_touch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Отнимает у врага 11 [gold]силы[/gold] на этот ход.",
@@ -7552,7 +7552,7 @@
       "rollingboulderpower": "+5"
     },
     "image_url": "/static/images/cards/rolling_boulder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rolling_boulder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 10 урона ВСЕМ врагам в начале хода, затем урон повышается на 5.",
@@ -7595,7 +7595,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/knife_trap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knife_trap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Все [gold]сожженные[/gold] [gold]«Заточки»[/gold] [gold]улучшаются[/gold] и разыгрываются против врага.",
@@ -7631,7 +7631,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/splash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/splash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Добавляет в [gold]руку[/gold] 1 из 3 случайных [gold]улучшенных[/gold] Атак другого персонажа на выбор. В этом ходу она бесплатная.",
@@ -7669,7 +7669,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/spoils_map.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_map.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7708,7 +7708,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/cascade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cascade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Вы разыгрываете X+1 карт с верха [gold]стопки добора[/gold].",
@@ -7784,7 +7784,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/catastrophe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/catastrophe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Вы разыгрываете 3 plural(ru):случайную карту из [gold]стопки добора[/gold].",
@@ -7822,7 +7822,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/quasar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quasar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Добавляет в [gold]руку[/gold] 1 из 3 случайных [gold]улучшенных[/gold] бесцветных карт на выбор.",
@@ -7863,7 +7863,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/photon_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/photon_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 13 урона.\nВы добираете 2 plural(ru):карту.\nВы кладете 1 выбранную карту из [gold]руки[/gold] на верх [gold]стопки добора[/gold].",
@@ -7953,7 +7953,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sovereign_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sovereign_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8033,7 +8033,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/lantern_key.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lantern_key.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8115,7 +8115,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/colossus.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/colossus.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 8 [gold]защиты[/gold].\nВ этом ходу вы получаете на 50% меньше урона от [gold]уязвимых[/gold] врагов.",
@@ -8245,7 +8245,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/comet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/comet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 44 урона.\nНакладывает 3 [gold]слабости[/gold].\nНакладывает 3 [gold]уязвимости[/gold].",
@@ -8407,7 +8407,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/gather_light.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gather_light.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 11 [gold]защиты[/gold].\nДает [star:1].",
@@ -8448,7 +8448,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/royal_gamble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royal_gamble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8491,7 +8491,7 @@
       "increase": "+2"
     },
     "image_url": "/static/images/cards/kingly_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/kingly_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 10 урона.\nКогда вы добираете эту карту, ее урон повышается на 6 до конца боя.",
@@ -8605,7 +8605,7 @@
       "corrosivewave": "+1"
     },
     "image_url": "/static/images/cards/corrosive_wave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/corrosive_wave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Накладывает 3 [gold]яда[/gold] на ВСЕХ врагов за каждую добираемую в этом ходу карту.",
@@ -8647,7 +8647,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/the_scythe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_scythe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 13 урона.\nУрон повышается на 4 до конца вылазки.",
@@ -8766,7 +8766,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/legion_of_bone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/legion_of_bone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ВСЕ игроки [gold]призывают[/gold] 8.",
@@ -8812,7 +8812,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/bone_shards.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bone_shards.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Если [gold]Костя[/gold] призван, он наносит 12 урона ВСЕМ врагам, вы получаете 12 [gold]защиты[/gold],\nзатем [gold]Костя[/gold] погибает.",
@@ -9056,7 +9056,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/hammer_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hammer_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9177,7 +9177,7 @@
       "extradamage": "+2"
     },
     "image_url": "/static/images/cards/gang_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gang_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 5 урона.\nНаносит еще 7 урона за каждую атаку другого игрока по врагу.",
@@ -9254,7 +9254,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/ice_lance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ice_lance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 24 урона.\n[gold]Заряжает[/gold] 3 [gold]plural(ru):сферу льда[/gold].",
@@ -9297,7 +9297,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/sloth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sloth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -9377,7 +9377,7 @@
       "summon": "+1"
     },
     "image_url": "/static/images/cards/dirge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dirge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Призывает[/gold] 4 X раз.\nДобавляет X [gold]«Душ+»[/gold] в [gold]стопку добора[/gold].",
@@ -9500,7 +9500,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/lunar_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lunar_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит по 5 урона за каждый разыгранный в этом ходу Навык.",
@@ -9577,7 +9577,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/beacon_of_hope.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beacon_of_hope.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9705,7 +9705,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/bundle_of_joy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bundle_of_joy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Добавляет в [gold]руку[/gold] 4 plural(ru):случайную бесцветную карту.",
@@ -9755,7 +9755,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sword_sage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sword_sage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10352,7 +10352,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/graveblast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/graveblast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 6 урона.\nВы берете выбранную карту из [gold]стопки сброса[/gold].",
@@ -10394,7 +10394,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/modded.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/modded.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 1 plural(ru):слот.\nВы добираете 2 plural(ru):карту. Стоимость повышается на 1.",
@@ -10441,7 +10441,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/neurosurge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neurosurge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает [energy:4].\nВы добираете 2 plural(ru):карту.\nВы получаете 3 [gold]злого рока[/gold] в начале хода.",
@@ -10483,7 +10483,7 @@
       "calculationextra": "+2"
     },
     "image_url": "/static/images/cards/beat_into_shape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_into_shape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 7 урона.\n[gold]Закаляет[/gold] X.\n[gold]Закаляет[/gold] на 7 больше за каждый второй ваш удар по врагу в этом ходу.",
@@ -10521,7 +10521,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/monologue.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/monologue.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10679,7 +10679,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/lift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает другому игроку 16 [gold]защиты[/gold].",
@@ -10719,7 +10719,7 @@
       "strengthloss": "+1"
     },
     "image_url": "/static/images/cards/crush_under.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crush_under.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 8 урона ВСЕМ врагам. Отнимает у ВСЕХ врагов 2 [gold]силы[/gold] на этот ход.",
@@ -10804,7 +10804,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/murder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/murder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10889,7 +10889,7 @@
       "knockdownpower": "+1"
     },
     "image_url": "/static/images/cards/knockdown.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockdown.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 14 урона.\nВ этом ходу враг получает тройной урон от других игроков.",
@@ -11173,7 +11173,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/waste_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/waste_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -11297,7 +11297,7 @@
       "platingpower": "+3"
     },
     "image_url": "/static/images/cards/neutron_aegis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neutron_aegis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 11 [gold]панциря[/gold].",
@@ -11343,7 +11343,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/consuming_shadow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/consuming_shadow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Заряжает[/gold] 3 [gold]сферы тьмы[/gold].\n[gold]Разряжает[/gold] левую сферу в конце хода.",
@@ -11379,7 +11379,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/unmovable.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/unmovable.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11850,7 +11850,7 @@
       "strength": "+2"
     },
     "image_url": "/static/images/cards/feeding_frenzy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 7 [gold]силы[/gold] на этот ход.",
@@ -11888,7 +11888,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/i_am_invincible.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/i_am_invincible.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 13 [gold]защиты[/gold].\nРазыгрывается, если находится на верху [gold]стопки добора[/gold] в конце хода.",
@@ -11972,7 +11972,7 @@
       "damage": "+8"
     },
     "image_url": "/static/images/cards/knockout_blow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockout_blow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 38 урона.\nДает [star:5], если убивает врага.",
@@ -12008,7 +12008,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/nostalgia.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/nostalgia.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12181,7 +12181,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/demesne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demesne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12231,7 +12231,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/void_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/void_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12315,7 +12315,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/reaper_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reaper_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12360,7 +12360,7 @@
       "serpentformpower": "+2"
     },
     "image_url": "/static/images/cards/serpent_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/serpent_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 6 урона случайному врагу, когда вы разыгрываете карту.",
@@ -12491,7 +12491,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/debris.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debris.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12541,7 +12541,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/hotfix.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hotfix.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12831,7 +12831,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/seance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12874,7 +12874,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/barrage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/barrage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит по 7 урона за каждую [gold]заряженную[/gold] сферу.",
@@ -13068,7 +13068,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/volley.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/volley.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 14 урона случайному врагу X раз.",
@@ -13227,7 +13227,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/entrench.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entrench.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13462,7 +13462,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/pillar_of_creation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillar_of_creation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 4 [gold]защиты[/gold], когда создается карта.",
@@ -13579,7 +13579,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/rebound.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rebound.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 12 урона.\nСледующая разыгранная в этом ходу карта кладется на верх [gold]стопки добора[/gold].",
@@ -13710,7 +13710,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/reflect.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reflect.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 21 [gold]защиты[/gold].\nНаносит полученный по [gold]защите[/gold] урон в ответ до следующего хода.",
@@ -13750,7 +13750,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/severance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/severance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 18 урона.\nДобавляет [gold]«Душу»[/gold] в [gold]стопку добора[/gold], [gold]руку[/gold] и [gold]стопку сброса[/gold].",
@@ -13837,7 +13837,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/boost_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/boost_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 9 [gold]защиты[/gold].\nДобавляет [gold]«Головокружение»[/gold] в [gold]стопку сброса[/gold].",
@@ -13876,7 +13876,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/refine_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refine_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Закаляет[/gold] 13.\nДаст [energy:1] в начале следующего хода.",
@@ -13952,7 +13952,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/frantic_escape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/frantic_escape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -14073,7 +14073,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/begone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/begone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Преобразует[/gold] выбранную в [gold]руке[/gold] карту в [gold]«Удар слуги+»[/gold].",
@@ -14127,7 +14127,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/falling_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/falling_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 12 урона.\nНакладывает 1 [gold]слабости[/gold].\nНакладывает 1 [gold]уязвимости[/gold].",
@@ -14166,7 +14166,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/alignment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/alignment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает [energy:3].",
@@ -14213,7 +14213,7 @@
       "parrypower": "+4"
     },
     "image_url": "/static/images/cards/parry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/parry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 14 [gold]защиты[/gold], когда вы разыгрываете [gold]Клинок монарха[/gold].",
@@ -14251,7 +14251,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/dual_wield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Добавляет в [gold]руку[/gold] 2 копии Атаки или Таланта из [gold]руки[/gold] на выбор.",
@@ -14415,7 +14415,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/relax.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/relax.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 17 [gold]защиты[/gold].\nВы доберете еще 3 plural(ru):карту и получите [energy:3] в начале следующего хода.",
@@ -14499,7 +14499,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/pagestorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pagestorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14584,7 +14584,7 @@
       "vigorpower": "+1"
     },
     "image_url": "/static/images/cards/patter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/patter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 11 [gold]защиты[/gold].\nДает 3 [gold]бодрости[/gold].",
@@ -14622,7 +14622,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/intercept.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/intercept.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 13 [gold]защиты[/gold].\nПеренаправляет все атаки в этом ходу с другого игрока на вас.",
@@ -14660,7 +14660,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/furnace.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/furnace.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Закаляет[/gold] 6 в начале хода.",
@@ -14698,7 +14698,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/scrawl.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/scrawl.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14826,7 +14826,7 @@
       "dansemacabrepower": "+2"
     },
     "image_url": "/static/images/cards/danse_macabre.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/danse_macabre.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 6 [gold]защиты[/gold], когда вы разыгрываете карту стоимостью не ниже [energy:2].",
@@ -14866,7 +14866,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/summon_forth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/summon_forth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Закаляет[/gold] 11.\nВы берете [gold]Клинок монарха[/gold].",
@@ -14906,7 +14906,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/maul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/maul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 6 урона 2 раза.\nПовышает урон ВСЕХ «Побоев» на 2 до конца боя.",
@@ -14944,7 +14944,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/hang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 13 урона.\nУдваивает урон ВСЕХ «Повешений» против врага.",
@@ -14982,7 +14982,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/bury.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bury.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 63 урона.",
@@ -15027,7 +15027,7 @@
       "sleightoffleshpower": "+4"
     },
     "image_url": "/static/images/cards/sleight_of_flesh.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sleight_of_flesh.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит врагу 13 урона, когда вы накладываете на него отрицательный эффект.",
@@ -15072,7 +15072,7 @@
       "preptimepower": "+2"
     },
     "image_url": "/static/images/cards/prep_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prep_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 6 [gold]бодрости[/gold] в начале хода.",
@@ -15158,7 +15158,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/mimic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mimic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15249,7 +15249,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/conflagration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conflagration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 8 урона ВСЕМ врагам.\nНаносит на 3 урона больше за каждую вторую Атаку, разыгранную в этом ходу.",
@@ -15341,7 +15341,7 @@
       "devourlifepower": "+1"
     },
     "image_url": "/static/images/cards/devour_life.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devour_life.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Призывает[/gold] 2, когда вы разыгрываете [gold]«Душу»[/gold].",
@@ -15377,7 +15377,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/enthralled.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enthralled.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15419,7 +15419,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/deaths_door.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/deaths_door.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 7 [gold]защиты[/gold].\nДает еще 7 [gold]защиты[/gold] 2 plural(ru):раз, если вы накладывали [gold]злой рок[/gold] в этом ходу.",
@@ -15497,7 +15497,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 11 урона ВСЕМ врагам.",
@@ -15538,7 +15538,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/fisticuffs.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fisticuffs.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 9 урона.\nДает [gold]защиту[/gold], равную нанесенному урону.",
@@ -15700,7 +15700,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/fight_through.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_through.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 17 [gold]защиты[/gold].\nДобавляет 2 [gold]«Раны»[/gold] в [gold]стопку сброса[/gold].",
@@ -15740,7 +15740,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/ultimate_defend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_defend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 15 [gold]защиты[/gold].",
@@ -15780,7 +15780,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/ultimate_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 20 урона.",
@@ -15871,7 +15871,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/transfigure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/transfigure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15966,7 +15966,7 @@
       "extrablock": "+2"
     },
     "image_url": "/static/images/cards/fasten.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fasten.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Повышает [gold]защиту[/gold] от «Оборон» на 7.",
@@ -16004,7 +16004,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/foregone_conclusion.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/foregone_conclusion.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Вы возьмете 3 plural(ru):карту из [gold]стопки добора[/gold] в начале следующего хода.",
@@ -16043,7 +16043,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/spite.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spite.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 5 урона.\nНаносит урон 3 plural(ru):раз, если вы теряли ОЗ в этом ходу.",
@@ -16081,7 +16081,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/venerate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/venerate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает [star:3].",
@@ -16120,7 +16120,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/refract.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refract.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 12 урона 2 раза.\n[gold]Заряжает[/gold] 2 [gold]plural(ru):сферу стекла[/gold].",
@@ -16156,7 +16156,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/hello_world.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hello_world.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16204,7 +16204,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/apparition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/apparition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16244,7 +16244,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/beckon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beckon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16291,7 +16291,7 @@
       "phantombladespower": "+3"
     },
     "image_url": "/static/images/cards/phantom_blades.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/phantom_blades.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]«Заточки»[/gold] [gold]оставляются[/gold].\nПервая [gold]«Заточка»[/gold] за ход наносит на 12 урона больше.",
@@ -16374,7 +16374,7 @@
       "iterationpower": "+1"
     },
     "image_url": "/static/images/cards/iteration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/iteration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Вы добираете 3 plural(ru):карту, когда добираете Статус первый раз за ход.",
@@ -16415,7 +16415,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/voltaic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/voltaic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16499,7 +16499,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/production.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/production.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает [energy:3].",
@@ -16907,7 +16907,7 @@
       "damage": "+10"
     },
     "image_url": "/static/images/cards/devastate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devastate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 40 урона.",
@@ -16948,7 +16948,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/guiding_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/guiding_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 13 урона.\nВы добираете 3 plural(ru):карту.",
@@ -17066,7 +17066,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/pillage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 9 урона.\nВы добираете карты до тех пор, пока не возьмете что-то кроме Атаки.",
@@ -17224,7 +17224,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/veilpiercer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/veilpiercer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 13 урона.\nСледующая [gold]эфирная[/gold] карта стоит 0 [energy:1].",
@@ -17340,7 +17340,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/rocket_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rocket_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 14 урона.\nВы добираете 2 plural(ru):карту.\nСтоимость понижается до 0 [energy:1] на одно разыгрывание, когда вы создаете Статус.",
@@ -17509,7 +17509,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/rend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 15 урона.\nНаносит еще 8 больше за каждый отрицательный эффект врага.",
@@ -17631,7 +17631,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/disintegration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/disintegration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -17720,7 +17720,7 @@
       "strengthpower": "+1"
     },
     "image_url": "/static/images/cards/resonance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/resonance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 2 [gold]силы[/gold]. Отнимает у ВСЕХ врагов 1 [gold]силы[/gold].",
@@ -17804,7 +17804,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/ricochet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ricochet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 3 урона случайному врагу 5 plural(ru):раз.",
@@ -17853,7 +17853,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/drum_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/drum_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Вы добираете 3 plural(ru):карту.\n[gold]Сжигает[/gold] карту на верху [gold]стопки добора[/gold] в начале хода.",
@@ -18012,7 +18012,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/soot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -18137,7 +18137,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/supermassive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/supermassive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 5 урона.\nНаносит еще 4 урона за каждую созданную за бой карту.",
@@ -18217,7 +18217,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/luminesce.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/luminesce.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает [energy:3].",
@@ -18261,7 +18261,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/whistle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/whistle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 44 урона.\n[gold]Оглушает[/gold] врага.",
@@ -18418,7 +18418,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/seven_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seven_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18458,7 +18458,7 @@
       "power": "+2"
     },
     "image_url": "/static/images/cards/shockwave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shockwave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Накладывает 5 [gold]слабости[/gold] и [gold]уязвимости[/gold] на ВСЕХ врагов.",
@@ -18538,7 +18538,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/synthesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synthesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 18 урона.\nСледующий Талант стоит 0 [energy:1].",
@@ -18579,7 +18579,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/synchronize.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synchronize.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18621,7 +18621,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/glow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает [star:2].\nВы добираете 1 plural(ru):карту.\nВы доберете 1 plural(ru):карту в начале следующего хода.",
@@ -18662,7 +18662,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/shining_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shining_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 11 урона.\nДает [star:2].\nКладется на верх [gold]стопки добора[/gold].",
@@ -18702,7 +18702,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/precise_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/precise_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18788,7 +18788,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/defile.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/defile.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 17 урона.",
@@ -18870,7 +18870,7 @@
       "replay": "+1"
     },
     "image_url": "/static/images/cards/hidden_gem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_gem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Случайная карта без [gold]повтора[/gold] в [gold]стопке добора[/gold] получает [gold]повтор[/gold] 3.",
@@ -18917,7 +18917,7 @@
       "sneakypower": "+1"
     },
     "image_url": "/static/images/cards/sneaky.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sneaky.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 2 [gold]защиты[/gold], когда другой игрок атакует врага.",
@@ -18961,7 +18961,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/hidden_daggers.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_daggers.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Вы сбрасываете 2 plural(ru):карту.\nДобавляет в [gold]руку[/gold] 2 [gold]plural(ru):«Заточку+»[/gold].",
@@ -19049,7 +19049,7 @@
       "strength": "+3"
     },
     "image_url": "/static/images/cards/coordinate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает другому игроку 8 [gold]силы[/gold] на этот ход.",
@@ -19130,7 +19130,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/tracking.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tracking.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19249,7 +19249,7 @@
       "cards": "+2"
     },
     "image_url": "/static/images/cards/decisions_decisions.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/decisions_decisions.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Вы добираете 5 plural(ru):карта.\nВы разыгрываете выбранный в [gold]руке[/gold] Навык 3 plural(ru):раз.",
@@ -19339,7 +19339,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/minion_sacrifice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_sacrifice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 12 [gold]защиты[/gold].",
@@ -19434,7 +19434,7 @@
       "lethalitypower": "+25"
     },
     "image_url": "/static/images/cards/lethality.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lethality.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Первая Атака за ход наносит на 75% больше урона.",
@@ -19473,7 +19473,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/calamity.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/calamity.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19717,7 +19717,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/spectrum_shift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spectrum_shift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19762,7 +19762,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/spinner.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spinner.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Заряжает[/gold] 1 [gold]сферу стекла[/gold].\n[gold]Заряжает[/gold] 1 [gold]сферу стекла[/gold] в начале хода.",
@@ -19802,7 +19802,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/helix_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/helix_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит по 5 урона за каждую [energy:1], потраченную в этом ходу.",
@@ -19886,7 +19886,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/huddle_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/huddle_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ВСЕ игроки добирают по 3 plural(ru):карте.",
@@ -19925,7 +19925,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/spore_mind.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spore_mind.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20007,7 +20007,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/stack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает [gold]защиту[/gold], равную количеству карт в [gold]стопке сброса[/gold] +3.",
@@ -20045,7 +20045,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/glasswork.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glasswork.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 8 [gold]защиты[/gold].\n[gold]Заряжает[/gold] 1 [gold]сферу стекла[/gold].",
@@ -20124,7 +20124,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/collision_course.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/collision_course.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 15 урона.\nДобавляет в [gold]руку[/gold] [gold]«Обломок»[/gold].",
@@ -20163,7 +20163,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/misery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/misery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 9 урона.\nНакладывает отрицательные эффекты врага на ВСЕХ врагов.",
@@ -20199,7 +20199,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/stratagem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stratagem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20368,7 +20368,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/clash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/clash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Можно разыграть, если в [gold]руке[/gold] есть только Атаки.\nНаносит 18 урона.",
@@ -20406,7 +20406,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/shroud.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shroud.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 3 [gold]защиты[/gold], когда вы накладываете [gold]злой рок[/gold].",
@@ -20446,7 +20446,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/turbo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/turbo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает [energy:3].\nДобавляет [gold]«Бездну»[/gold] в [gold]стопку сброса[/gold].",
@@ -20533,7 +20533,7 @@
       "starnextturnpower": "+1"
     },
     "image_url": "/static/images/cards/hidden_cache.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_cache.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает [star:1].\nДаст [star:4] в начале следующего хода.",
@@ -20698,7 +20698,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/tank.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tank.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20774,7 +20774,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/bodyguard.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bodyguard.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Призывает[/gold] 7.",
@@ -20812,7 +20812,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/shadow_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shadow_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 15 [gold]защиты[/gold].\n[gold]Заряжает[/gold] 1 [gold]сферу тьмы[/gold].",
@@ -20852,7 +20852,7 @@
       "hploss": "+2"
     },
     "image_url": "/static/images/cards/haunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Отнимает 8 ОЗ у случайного врага, когда вы разыгрываете [gold]«Душу»[/gold].",
@@ -20897,7 +20897,7 @@
       "vigorpower": "+2"
     },
     "image_url": "/static/images/cards/terraforming.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/terraforming.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 8 [gold]бодрости[/gold].",
@@ -20935,7 +20935,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/tyranny.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tyranny.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20981,7 +20981,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/squeeze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/squeeze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Костя[/gold] наносит 25 урона.\nНаносит еще 6 урона за КАЖДУЮ вашу Атаку [gold]Кости[/gold], кроме этой.",
@@ -21103,7 +21103,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/fuel.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fuel.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает [energy:1].\nВы добираете 2 plural(ru):карту.",
@@ -21145,7 +21145,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/toric_toughness.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/toric_toughness.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 7 [gold]защиты[/gold].\nДаст 7 [gold]защиты[/gold] в начале plural(ru):следующего хода.",
@@ -21190,7 +21190,7 @@
       "poison": "+3"
     },
     "image_url": "/static/images/cards/bubble_bubble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Накладывает 12 [gold]яда[/gold], если на врага уже наложен [gold]яд[/gold].",
@@ -21267,7 +21267,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/tesla_coil.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tesla_coil.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 6 урона.\nАктивирует пассивный эффект всех [gold]сфер молнии[/gold] против врага.",
@@ -21356,7 +21356,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/spoils_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Закаляет[/gold] 8.\nВы добираете 2 plural(ru):карту.",
@@ -21668,7 +21668,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/prowess.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 2 [gold]силы[/gold].\nДает 2 [gold]ловкости[/gold].",
@@ -21958,7 +21958,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/seeker_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeker_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 12 урона.\nВы берете 1 из 3 карт из [gold]стопки добора[/gold] на выбор.",
@@ -22002,7 +22002,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/minion_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 9 урона.\nВы добираете 1 plural(ru):карту.",
@@ -22101,7 +22101,7 @@
       "dexterity": "+1"
     },
     "image_url": "/static/images/cards/bulk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Вы теряете 1 plural(ru):слот.\nДает 3 [gold]силы[/gold].\nДает 3 [gold]ловкости[/gold].",
@@ -22177,7 +22177,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/distraction.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/distraction.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22223,7 +22223,7 @@
       "strengthloss": "+2"
     },
     "image_url": "/static/images/cards/dying_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dying_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 11 урона ВСЕМ врагам. Отнимает у ВСЕХ врагов 11 [gold]силы[/gold] на этот ход.",
@@ -22406,7 +22406,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/compact.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/compact.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 7 [gold]защиты[/gold].\n[gold]Преобразует[/gold] каждый Статус в [gold]руке[/gold] в [gold]«Топливо+»[/gold].",
@@ -22445,7 +22445,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/heirloom_hammer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heirloom_hammer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 25 урона.\nДобавляет в [gold]руку[/gold] копию выбранной в [gold]руке[/gold] бесцветной карты.",
@@ -22483,7 +22483,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/eidolon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/eidolon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22532,7 +22532,7 @@
       "focuspower": "+1"
     },
     "image_url": "/static/images/cards/focused_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/focused_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 11 урона.\nДает 2 [gold]фокуса[/gold] на этот ход.",
@@ -22727,7 +22727,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/outmaneuver.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outmaneuver.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Даст [energy:3] в начале следующего хода.",
@@ -22844,7 +22844,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/cosmic_indifference.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cosmic_indifference.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает 9 [gold]защиты[/gold].\nВы перекладываете выбранную из [gold]стопки сброса[/gold] карту на верх [gold]стопки добора[/gold].",
@@ -23089,7 +23089,7 @@
       "blackholepower": "+1"
     },
     "image_url": "/static/images/cards/black_hole.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/black_hole.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 4 урона ВСЕМ врагам, когда вы получаете или тратите [star:1].",
@@ -23128,7 +23128,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/bad_luck.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bad_luck.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23172,7 +23172,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/blade_of_ink.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/blade_of_ink.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Добавляет в [gold]руку[/gold] 3 [purple]чернильных[/purple] [gold]plural(ru):«Заточку»[/gold].",
@@ -23373,7 +23373,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/soul_storm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul_storm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 9 урона.\nНаносит еще 3 урона за каждую [gold]«Душу»[/gold] в [gold]стопке пепла[/gold].",
@@ -23533,7 +23533,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/snap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/snap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Костя[/gold] наносит 10 урона.\nВыбранная в [gold]руке[/gold] карта [gold]оставляется[/gold].",
@@ -23612,7 +23612,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/dredge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dredge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23653,7 +23653,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/entropy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entropy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23699,7 +23699,7 @@
       "outbreakpower": "+4"
     },
     "image_url": "/static/images/cards/outbreak.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outbreak.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Наносит 15 урона ВСЕМ врагам plural(ru):каждый раз, когда вы накладываете [gold]яд[/gold].",
@@ -23862,7 +23862,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/brightest_flame.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/brightest_flame.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Дает [energy:3].\nВы добираете 3 plural(ru):карту.\nВы теряете 1 максимальных ОЗ.",
@@ -23904,7 +23904,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/glimpse_beyond.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glimpse_beyond.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Добавляет ВСЕМ игрокам 4 [gold]plural(ru):«Душу»[/gold] в [gold]стопку добора[/gold].",

--- a/data/spa/cards.json
+++ b/data/spa/cards.json
@@ -31,7 +31,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/turbo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/turbo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana [energy:3].\nAñade un [gold]Vacío[/gold] a tu [gold]Pila de descarte[/gold].",
@@ -67,7 +67,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/hammer_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hammer_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -105,7 +105,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/fisticuffs.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fisticuffs.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 9 de daño.\nGana [gold]Bloqueo[/gold] igual al daño infligido.",
@@ -237,7 +237,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/abrasive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/abrasive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 1 de [gold]Destreza[/gold].\nGana 6 [gold]Espinas[/gold].",
@@ -321,7 +321,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/caltrops.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/caltrops.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando te ataquen, inflige 5 de daño al atacante.",
@@ -398,7 +398,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/gather_light.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gather_light.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 11 de [gold]Bloqueo[/gold].\nGana [star:1].",
@@ -476,7 +476,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/huddle_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/huddle_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TODOS los jugadores roban 3 cartas.",
@@ -601,7 +601,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/pull_from_below.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pull_from_below.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 7 de daño por cada carta [gold]Etérea[/gold] jugada durante este combate.",
@@ -718,7 +718,7 @@
       "blackholepower": "+1"
     },
     "image_url": "/static/images/cards/black_hole.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/black_hole.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Siempre que gastes u obtengas [star:1], inflige 4 de daño a TODOS los enemigos.",
@@ -756,7 +756,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/uproar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/uproar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 7 de daño dos veces.\nJuega un Ataque aleatorio de tu [gold]Pila de robo[/gold].",
@@ -884,7 +884,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/alignment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/alignment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana [energy:3].",
@@ -965,7 +965,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/soul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Roba 3 cartas.",
@@ -1087,7 +1087,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/volley.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/volley.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 14 de daño a un enemigo aleatorio X veces.",
@@ -1127,7 +1127,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/energy_surge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/energy_surge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TODOS los jugadores ganan [energy:3].",
@@ -1347,7 +1347,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/beat_down.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_down.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Juega 4 Ataques aleatorios de tu [gold]Pila de descarte[/gold].",
@@ -1387,7 +1387,7 @@
       "hploss": "+2"
     },
     "image_url": "/static/images/cards/haunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando juegues un [gold]Alma[/gold], un enemigo aleatorio pierde 8 PV.",
@@ -1435,7 +1435,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/apparition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/apparition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1486,7 +1486,7 @@
       "devourlifepower": "+1"
     },
     "image_url": "/static/images/cards/devour_life.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devour_life.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando juegues un [gold]Alma[/gold], [gold]Vincula[/gold] 2.",
@@ -1525,7 +1525,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/stack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana [gold]Bloqueo[/gold] igual al número de cartas en tu [gold]Pila de descarte[/gold] +3.",
@@ -1565,7 +1565,7 @@
       "strengthloss": "+1"
     },
     "image_url": "/static/images/cards/crush_under.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crush_under.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 8 de daño a TODOS los enemigos. Pierden 2 de [gold]Fuerza[/gold] este turno.",
@@ -1689,7 +1689,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/squeeze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/squeeze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Nudillos[/gold] inflige 25 de daño.\nInflige 6 de daño adicional por CADA UNO de tus otros Ataques de [gold]Nudillos[/gold].",
@@ -1771,7 +1771,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/royal_gamble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royal_gamble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2107,7 +2107,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/arsenal.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/arsenal.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2147,7 +2147,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/flak_cannon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/flak_cannon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Agota[/gold] TODAS tus cartas de Estado.\nInflige 11 de daño a un enemigo aleatorio por cada carta [gold]Agotada[/gold].",
@@ -2225,7 +2225,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/up_my_sleeve.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/up_my_sleeve.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Añade 4 [gold]Navajas[/gold] a tu [gold]Mano[/gold].\nReduce el coste de esta carta en 1.",
@@ -2357,7 +2357,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/murder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/murder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2397,7 +2397,7 @@
       "extrablock": "+2"
     },
     "image_url": "/static/images/cards/fasten.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fasten.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Las cartas de Defender otorgan 7 de [gold]Bloqueo[/gold] adicional.",
@@ -2437,7 +2437,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/crash_landing.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crash_landing.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 26 de daño a TODOS los enemigos.\nLlena tu [gold]Mano[/gold] de [gold]Escombros[/gold].",
@@ -2479,7 +2479,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/glimpse_beyond.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glimpse_beyond.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TODOS los jugadores añaden 4 [gold]Almas[/gold] a su [gold]Pila de robo[/gold].",
@@ -2518,7 +2518,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/entrench.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entrench.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2594,7 +2594,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/automation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/automation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2632,7 +2632,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/manifest_authority.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/manifest_authority.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 8 de [gold]Bloqueo[/gold].\nAñade una carta incolora [gold]Mejorada[/gold] aleatoria a tu [gold]Mano[/gold].",
@@ -2709,7 +2709,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/outmaneuver.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outmaneuver.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al siguiente turno, gana [energy:3].",
@@ -2837,7 +2837,7 @@
       "vigorpower": "+1"
     },
     "image_url": "/static/images/cards/patter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/patter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 11 de [gold]Bloqueo[/gold].\nGana 3 de [gold]Vigor[/gold].",
@@ -2915,7 +2915,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/shadow_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shadow_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 15 de [gold]Bloqueo[/gold].\n[gold]Invoca[/gold] 1 [gold]Oscuridad[/gold].",
@@ -3081,7 +3081,7 @@
       "ostydamage": "+5"
     },
     "image_url": "/static/images/cards/sweeping_gaze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sweeping_gaze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Nudillos[/gold] inflige 15 de daño a un enemigo aleatorio.",
@@ -3123,7 +3123,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/tesla_coil.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tesla_coil.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 6 de daño.\nActiva todos los [gold]Relámpagos[/gold] contra el enemigo.",
@@ -3239,7 +3239,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/bombardment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bombardment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 24 de daño.\nSi esta carta se encuentra en tu [gold]Pila de agotamiento[/gold] al comienzo de tu turno, se juega.",
@@ -3282,7 +3282,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/barrage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/barrage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 7 de daño por cada Orbe [gold]Invocado[/gold].",
@@ -3366,7 +3366,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/spoils_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forja[/gold] 8.\nRoba 2 cartas.",
@@ -3449,7 +3449,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/glow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana [star:2].\nRoba 1 carta.\nAl siguiente turno, roba 1 carta.",
@@ -3489,7 +3489,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/helix_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/helix_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 5 de daño por cada [energy:1] que hayas gastado este turno.",
@@ -3535,7 +3535,7 @@
       "outbreakpower": "+4"
     },
     "image_url": "/static/images/cards/outbreak.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outbreak.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cada 3 veces que apliques [gold]Veneno[/gold], inflige 15 de daño a TODOS los enemigos.",
@@ -3683,7 +3683,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/calamity.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/calamity.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3766,7 +3766,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/spectrum_shift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spectrum_shift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3812,7 +3812,7 @@
       "rollingboulderpower": "+5"
     },
     "image_url": "/static/images/cards/rolling_boulder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rolling_boulder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al comienzo de tu turno, inflige 10 de daño a TODOS los enemigos y aumenta este daño en 5.",
@@ -4052,7 +4052,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/cascade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cascade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Juega las X+1 primeras cartas de tu [gold]Pila de robo[/gold].",
@@ -4090,7 +4090,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/catastrophe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/catastrophe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Juega 3 cartas aleatorias de tu [gold]Pila de robo[/gold].",
@@ -4131,7 +4131,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/snap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/snap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Nudillos[/gold] inflige 10 de daño.\nAplica [gold]Retención[/gold] a una carta de tu [gold]Mano[/gold].",
@@ -4176,7 +4176,7 @@
       "smokestackpower": "+2"
     },
     "image_url": "/static/images/cards/smokestack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/smokestack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando crees una carta de Estado, inflige 7 de daño a TODOS los enemigos.",
@@ -4264,7 +4264,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/clash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/clash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Solo se puede jugar si todas las cartas de tu [gold]Mano[/gold] son Ataques.\nInflige 18 daño.",
@@ -4418,7 +4418,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/greed.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/greed.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4460,7 +4460,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/hang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 13 de daño.\nDuplica el daño que el enemigo recibe de TODAS las cartas de Colgar.",
@@ -4499,7 +4499,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/colossus.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/colossus.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 8 de [gold]Bloqueo[/gold].\nRecibes un 50 % menos de daño de enemigos [gold]Vulnerables[/gold] durante este turno.",
@@ -4585,7 +4585,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/fuel.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fuel.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana [energy:1].\nRoba 2 cartas.",
@@ -4642,7 +4642,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/comet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/comet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 44 de daño.\nAplica 3 de [gold]Debilidad[/gold].\nAplica 3 de [gold]Vulnerabilidad[/gold].",
@@ -4722,7 +4722,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/compact.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/compact.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 7 de [gold]Bloqueo[/gold].\n[gold]Transforma[/gold] todas las cartas de Estado de tu [gold]Mano[/gold] en [gold]Combustible+[/gold].",
@@ -4760,7 +4760,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/foregone_conclusion.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/foregone_conclusion.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al siguiente turno, coloca 3 cartas de tu [gold]Pila de robo[/gold] en tu [gold]Mano[/gold].",
@@ -4839,7 +4839,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/conflagration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conflagration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 8 de daño a TODOS los enemigos.\nInflige 3 de daño adicional por cada otro Ataque que hayas jugado este turno.",
@@ -4913,7 +4913,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/believe_in_you.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/believe_in_you.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Otro jugador gana [energy:3].",
@@ -5003,7 +5003,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/conqueror.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conqueror.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forja[/gold] 5.\n[gold]Espada del soberano[/gold] inflige el doble de daño al enemigo este turno.",
@@ -5046,7 +5046,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/waste_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/waste_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -5085,7 +5085,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/convergence.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/convergence.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al siguiente turno,\ngana [energy:1] y [star:2].\n[gold]Retén[/gold] tu [gold]Mano[/gold] este turno.",
@@ -5130,7 +5130,7 @@
       "strength": "+3"
     },
     "image_url": "/static/images/cards/coordinate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Otorga a otro jugador 8 de [gold]Fuerza[/gold] durante este turno.",
@@ -5248,7 +5248,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/precise_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/precise_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5324,7 +5324,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/glasswork.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glasswork.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 8 de [gold]Bloqueo[/gold].\n[gold]Invoca[/gold] 1 [gold]Cristal[/gold].",
@@ -5412,7 +5412,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/rattle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rattle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Nudillos[/gold] inflige 9 de daño.\nGolpea una vez más por cada otra vez que haya atacado este turno.",
@@ -5574,7 +5574,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/quasar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quasar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Elige 1 de entre 3 cartas incoloras [gold]Mejoradas[/gold] y añádelas a tu [gold]Mano[/gold].",
@@ -5615,7 +5615,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/hidden_daggers.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_daggers.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Descarta 2 cartas.\nAñade 2 [gold]Navajas+[/gold] a tu [gold]Mano[/gold].",
@@ -5706,7 +5706,7 @@
       "dansemacabrepower": "+2"
     },
     "image_url": "/static/images/cards/danse_macabre.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/danse_macabre.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando juegues una carta que cueste [energy:2] o más, gana 6 de [gold]Bloqueo[/gold].",
@@ -5793,7 +5793,7 @@
       "debilitatepower": "+1"
     },
     "image_url": "/static/images/cards/debilitate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debilitate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 12 de daño.\n[gold]Vulnerabilidad[/gold] y [gold]Debilidad[/gold] son el doble de efectivos en enemigos durante los siguientes 4 turnos.",
@@ -6114,7 +6114,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/ultimate_defend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_defend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 15 de [gold]Bloqueo[/gold].",
@@ -6154,7 +6154,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/delay.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/delay.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 13 de [gold]Bloqueo[/gold].\nAl siguiente turno,\ngana [energy:2].",
@@ -6328,7 +6328,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/quadcast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quadcast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6575,7 +6575,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/disintegration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/disintegration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -6732,7 +6732,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/vicious.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/vicious.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando apliques [gold]Vulnerabilidad[/gold], roba 2 cartas.",
@@ -7013,7 +7013,7 @@
       "damage": "+10"
     },
     "image_url": "/static/images/cards/devastate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devastate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 40 de daño.",
@@ -7051,7 +7051,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/venerate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/venerate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana [star:3].",
@@ -7089,7 +7089,7 @@
       "gold": "+5"
     },
     "image_url": "/static/images/cards/royalties.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royalties.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Al final del combate, gana 35 de [gold]Oro[/gold].",
@@ -7170,7 +7170,7 @@
       "cards": "+2"
     },
     "image_url": "/static/images/cards/decisions_decisions.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/decisions_decisions.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Roba 5 cartas.\nElige una Habilidad de tu [gold]Mano[/gold] y juégala 3 veces.",
@@ -7249,7 +7249,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/distraction.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/distraction.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7290,7 +7290,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/dual_wield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Elige una carta de Ataque o Poder. Añade 2 copias de dicha carta a tu [gold]Mano[/gold].",
@@ -7382,7 +7382,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/demesne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demesne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7425,7 +7425,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/dredge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dredge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7554,7 +7554,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/eidolon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/eidolon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7644,7 +7644,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/the_sealed_throne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_sealed_throne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7759,7 +7759,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/enthralled.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enthralled.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7965,7 +7965,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/entropy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entropy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8126,7 +8126,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/frantic_escape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/frantic_escape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -8166,7 +8166,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/severance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/severance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 18 de daño.\nAñade un [gold]Alma[/gold] a tu [gold]Pila de robo[/gold], a tu [gold]Mano[/gold] y a tu [gold]Pila de descarte[/gold].",
@@ -8202,7 +8202,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/debris.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debris.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8247,7 +8247,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/demonic_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demonic_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8380,7 +8380,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sovereign_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sovereign_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8504,7 +8504,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/spore_mind.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spore_mind.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8587,7 +8587,7 @@
       "blockonexhaust": "+1"
     },
     "image_url": "/static/images/cards/spirit_of_ash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spirit_of_ash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando juegues una carta [gold]Etérea[/gold], gana 5 de [gold]Bloqueo[/gold].",
@@ -8666,7 +8666,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/graveblast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/graveblast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 6 de daño.\nColoca una carta de tu [gold]Pila de descarte[/gold] en tu [gold]Mano[/gold].",
@@ -8792,7 +8792,7 @@
       "stranglepower": "+1"
     },
     "image_url": "/static/images/cards/strangle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/strangle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 10 de daño.\nCuando juegues una carta este turno, el enemigo pierde 3 PV.",
@@ -8828,7 +8828,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/stratagem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stratagem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8925,7 +8925,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/falling_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/falling_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 12 de daño.\nAplica 1 de [gold]Debilidad[/gold].\nAplica 1 de [gold]Vulnerabilidad[/gold].",
@@ -8966,7 +8966,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/guiding_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/guiding_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 13 de daño.\nRoba 3 cartas.",
@@ -9020,7 +9020,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/gamma_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gamma_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 18 de daño\nAplica 2 de [gold]Debilidad[/gold].\nAplica 2 de [gold]Vulnerabilidad[/gold].",
@@ -9185,7 +9185,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/seeking_edge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeking_edge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forja[/gold] 11.\nAhora [gold]Espada del soberano[/gold] inflige daño a TODOS los enemigos.",
@@ -9389,7 +9389,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/sloth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sloth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -9429,7 +9429,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/wrought_in_war.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wrought_in_war.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 9 de daño.\n[gold]Forja[/gold] 9.",
@@ -9465,7 +9465,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/reaper_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reaper_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9512,7 +9512,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/void_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/void_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9657,7 +9657,7 @@
       "serpentformpower": "+2"
     },
     "image_url": "/static/images/cards/serpent_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/serpent_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando juegues una carta, inflige 6 de daño a un enemigo aleatorio.",
@@ -9754,7 +9754,7 @@
       "dexterity": "+1"
     },
     "image_url": "/static/images/cards/bulk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Pierde 1 espacio de Orbe.\nGana 3 de [gold]Fuerza[/gold].\nGana 3 de [gold]Destreza[/gold].",
@@ -9792,7 +9792,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/furnace.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/furnace.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al comienzo de tu turno, [gold]Forja[/gold] 6.",
@@ -9883,7 +9883,7 @@
       "strength": "+2"
     },
     "image_url": "/static/images/cards/feeding_frenzy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 7 de [gold]Fuerza[/gold] este turno.",
@@ -10004,7 +10004,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/wisp.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wisp.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10324,7 +10324,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/scrawl.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/scrawl.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10403,7 +10403,7 @@
       "replay": "+1"
     },
     "image_url": "/static/images/cards/hidden_gem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_gem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Una carta aleatoria que no tenga [gold]Repetición[/gold] de tu [gold]Pila de robo[/gold] gana [gold]Repetición[/gold] 3.",
@@ -10439,7 +10439,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/largesse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/largesse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Otro jugador añade 1 carta incolora [gold]Mejorada[/gold] a su [gold]Mano[/gold].",
@@ -10717,7 +10717,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/adaptive_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/adaptive_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 23 de daño.\nAñade una copia de esta carta con coste 0 [energy:1] a tu [gold]Pila de descarte[/gold].",
@@ -10758,7 +10758,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/seeker_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeker_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 12 de daño.\nElige 1 de entre 3 cartas de tu [gold]Pila de robo[/gold] y añádela a tu [gold]Mano[/gold].",
@@ -10799,7 +10799,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/shining_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shining_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 11 de daño.\nGana [star:2].\nColoca esta carta en la parte superior de tu [gold]Pila de robo[/gold].",
@@ -10881,7 +10881,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sculpting_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sculpting_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 12 de daño.\nAplica [gold]Etérea[/gold] a una carta de tu [gold]Mano[/gold].",
@@ -10967,7 +10967,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/minion_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 9 de daño.\nRoba 1 carta.",
@@ -11099,7 +11099,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/ultimate_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 20 de daño.",
@@ -11222,7 +11222,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/leading_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/leading_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 6 de daño.\nAñade 2 [gold]Navajas[/gold] a tu [gold]Mano[/gold].",
@@ -11353,7 +11353,7 @@
       "focuspower": "+1"
     },
     "image_url": "/static/images/cards/focused_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/focused_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 11 de daño.\nGana 2 de [gold]Concentración[/gold] este turno.",
@@ -11438,7 +11438,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/big_bang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/big_bang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11524,7 +11524,7 @@
       "hailstormpower": "+2"
     },
     "image_url": "/static/images/cards/hailstorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hailstorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al final de tu turno, si tienes [gold]Escarcha[/gold], inflige 8 de daño a TODOS los enemigos.",
@@ -11605,7 +11605,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/forbidden_grimoire.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/forbidden_grimoire.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11648,7 +11648,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/reap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 33 de daño.",
@@ -11689,7 +11689,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/bodyguard.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bodyguard.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Vincula[/gold] 7.",
@@ -11768,7 +11768,7 @@
       "starsperturn": "+1"
     },
     "image_url": "/static/images/cards/genesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/genesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al comienzo de tu turno, gana [star:3].",
@@ -11854,7 +11854,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/rend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 15 de daño.\nInflige 8 de daño adicional por cada efecto negativo único en el enemigo.",
@@ -11984,7 +11984,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/hegemony.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hegemony.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 18 de daño.\nAl siguiente turno, gana [energy:3].",
@@ -12148,7 +12148,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/blade_of_ink.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/blade_of_ink.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Añade 3 [gold]Navajas[/gold] con [purple]Tinta[/purple] a tu [gold]Mano[/gold].",
@@ -12195,7 +12195,7 @@
       "phantombladespower": "+3"
     },
     "image_url": "/static/images/cards/phantom_blades.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/phantom_blades.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Las [gold]Navajas[/gold] ganan [gold]Retención[/gold].\nLa primera [gold]Navaja[/gold] que juegues cada turno inflige 12 de daño adicional.",
@@ -12231,7 +12231,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/hello_world.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hello_world.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12267,7 +12267,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/soot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -12429,7 +12429,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/ignition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ignition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12716,7 +12716,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/boost_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/boost_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 9 de [gold]Bloqueo[/gold].\nAñade 1 [gold]Desorientación[/gold] a tu [gold]Pila de descarte[/gold].",
@@ -12752,7 +12752,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/unmovable.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/unmovable.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12835,7 +12835,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/cosmic_indifference.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cosmic_indifference.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 9 de [gold]Bloqueo[/gold].\nColoca una carta de tu [gold]Pila de descarte[/gold] en la parte superior de tu [gold]Pila de robo[/gold].",
@@ -12873,7 +12873,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/infection.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/infection.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13003,7 +13003,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/poor_sleep.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/poor_sleep.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13045,7 +13045,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/intercept.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/intercept.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 13 de [gold]Bloqueo[/gold].\nRedirige todos los ataques que otro jugador fuera a recibir este turno hacia ti.",
@@ -13128,7 +13128,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/invoke.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/invoke.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al siguiente turno, [gold]Vincula[/gold] 3 y gana [energy:3].",
@@ -13299,7 +13299,7 @@
       "iterationpower": "+1"
     },
     "image_url": "/static/images/cards/iteration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/iteration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "La primera vez que robes una carta de Estado durante tu turno, roba 3 cartas.",
@@ -13467,7 +13467,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/the_hunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_hunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Inflige 15 de daño.\nSi el daño es [gold]Letal[/gold], obtén una recompensa de cartas adicional.",
@@ -13512,7 +13512,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/the_scythe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_scythe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 13 de daño.\nAumenta permanentemente el daño de esta carta en 4.",
@@ -13629,7 +13629,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/ice_lance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ice_lance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 24 de daño.\n[gold]Invoca[/gold] 3 [gold]Escarcha[/gold].",
@@ -13786,7 +13786,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/legion_of_bone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/legion_of_bone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TODOS los jugadores [gold]Vinculan[/gold] 8.",
@@ -13875,7 +13875,7 @@
       "lethalitypower": "+25"
     },
     "image_url": "/static/images/cards/lethality.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lethality.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "El primer Ataque de cada turno inflige un 75 % de daño adicional.",
@@ -13916,7 +13916,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/lift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Otorga 16 de [gold]Bloqueo[/gold] a otro jugador.",
@@ -13997,7 +13997,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/brightest_flame.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/brightest_flame.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana [energy:3].\nRoba 3 cartas.\nPierde 1 PV máx.",
@@ -14033,7 +14033,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/beckon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beckon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14071,7 +14071,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/call_of_the_void.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/call_of_the_void.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14110,7 +14110,7 @@
       "cost": 7
     },
     "image_url": "/static/images/cards/banshees_cry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/banshees_cry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14191,7 +14191,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/lantern_key.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lantern_key.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14327,7 +14327,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/luminesce.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/luminesce.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana [energy:3].",
@@ -14421,7 +14421,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sword_sage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sword_sage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14459,7 +14459,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/necro_mastery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/necro_mastery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Vincula[/gold] 8.\nCuando [gold]Nudillos[/gold] pierda PV,\nTODOS los enemigos pierden los mismos PV.",
@@ -14498,7 +14498,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/bad_luck.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bad_luck.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14538,7 +14538,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/juggling.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/juggling.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14740,7 +14740,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/right_hand_hand.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/right_hand_hand.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Nudillos[/gold] inflige 6 de daño.\nCuando juegues una carta que cueste [energy:2] o más, devuelve esta carta a tu [gold]Mano[/gold] desde la [gold]Pila de descarte[/gold].",
@@ -14785,7 +14785,7 @@
       "crimsonmantlepower": "+2"
     },
     "image_url": "/static/images/cards/crimson_mantle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crimson_mantle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al comienzo de tu turno, pierde 1 PV y gana 10 de [gold]Bloqueo[/gold].",
@@ -14823,7 +14823,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/spoils_map.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_map.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14912,7 +14912,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/summon_forth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/summon_forth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forja[/gold] 11.\nColoca [gold]Espada del soberano[/gold] en tu [gold]Mano[/gold].",
@@ -14992,7 +14992,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/heirloom_hammer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heirloom_hammer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 25 de daño.\nElige una carta incolora de tu [gold]Mano[/gold]. Añade una copia de esa carta a tu [gold]Mano[/gold].",
@@ -15078,7 +15078,7 @@
       "knockdownpower": "+1"
     },
     "image_url": "/static/images/cards/knockdown.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockdown.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 14 de daño.\nEl enemigo recibe el triple de daño de otros jugadores este turno.",
@@ -15237,7 +15237,7 @@
       "summon": "+1"
     },
     "image_url": "/static/images/cards/dirge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dirge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Vincula[/gold] 4 X veces.\nAñade X [gold]Almas+[/gold] a tu [gold]Pila de robo[/gold].",
@@ -15405,7 +15405,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/bone_shards.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bone_shards.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Si [gold]Nudillos[/gold] está vivo, inflige 12 de daño a TODOS los enemigos y ganas 12 de [gold]Bloqueo[/gold].\n[gold]Nudillos[/gold] muere.",
@@ -15482,7 +15482,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/misery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/misery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 9 de daño.\nAplica cualquier efecto negativo del enemigo a TODOS los demás enemigos.",
@@ -15521,7 +15521,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/modded.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/modded.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 1 Espacio de Orbe.\nRoba 2 cartas. Aumenta el coste de esta carta en 1.",
@@ -15610,7 +15610,7 @@
       "calculationextra": "+2"
     },
     "image_url": "/static/images/cards/beat_into_shape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_into_shape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 7 de daño.\n[gold]Forja[/gold] X.\n[gold]Forja[/gold] 7 más por cada otra vez que hayas golpeado al enemigo este turno.",
@@ -15698,7 +15698,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/shroud.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shroud.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando apliques [gold]Condena[/gold], gana 3 de [gold]Bloqueo[/gold].",
@@ -15853,7 +15853,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/mimic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mimic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15991,7 +15991,7 @@
       "poison": "+2"
     },
     "image_url": "/static/images/cards/haze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplica 6 de [gold]Veneno[/gold] a TODOS los enemigos.",
@@ -16087,7 +16087,7 @@
       "platingpower": "+3"
     },
     "image_url": "/static/images/cards/neutron_aegis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neutron_aegis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 11 de [gold]Blindaje[/gold].",
@@ -16163,7 +16163,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/undeath.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/undeath.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 9 de [gold]Bloqueo[/gold].\nAñade una copia de esta carta a tu [gold]Pila de descarte[/gold].",
@@ -16202,7 +16202,7 @@
       "damage": "+8"
     },
     "image_url": "/static/images/cards/knockout_blow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockout_blow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 38 de daño.\nSi esto mata a un enemigo, gana [star:5].",
@@ -16280,7 +16280,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/nostalgia.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/nostalgia.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16320,7 +16320,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -16444,7 +16444,7 @@
       "corrosivewave": "+1"
     },
     "image_url": "/static/images/cards/corrosive_wave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/corrosive_wave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando robes una carta este turno, aplica 3 de [gold]Veneno[/gold] a TODOS los enemigos.",
@@ -16527,7 +16527,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/omnislice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/omnislice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 11 de daño.\nInflige el mismo daño a TODOS los enemigos.",
@@ -16567,7 +16567,7 @@
       "power": "+2"
     },
     "image_url": "/static/images/cards/shockwave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shockwave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Aplica 5 de [gold]Debilidad[/gold] y [gold]Vulnerabilidad[/gold] a TODOS los enemigos.",
@@ -16800,7 +16800,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/pagestorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pagestorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16847,7 +16847,7 @@
       "parrypower": "+4"
     },
     "image_url": "/static/images/cards/parry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/parry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando juegues [gold]Espada del soberano[/gold], gana 14 de [gold]Bloqueo[/gold].",
@@ -16893,7 +16893,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/lightning_rod.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lightning_rod.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 7 de [gold]Bloqueo[/gold].\nAl comienzo de tus siguientes 2 turnos, [gold]Invoca[/gold] 1 [gold]Relámpago[/gold].",
@@ -16940,7 +16940,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/hotfix.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hotfix.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17100,7 +17100,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/bundle_of_joy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bundle_of_joy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Añade 4 cartas incoloras aleatorias a tu [gold]Mano[/gold].",
@@ -17141,7 +17141,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/ascenders_bane.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ascenders_bane.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17185,7 +17185,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/heavenly_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heavenly_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 10 de daño X veces.\nSi X es 4 o más, duplica X.",
@@ -17223,7 +17223,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/veilpiercer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/veilpiercer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 13 de daño.\nLa siguiente carta [gold]Etérea[/gold] que juegues cuesta 0 [energy:1].",
@@ -17306,7 +17306,7 @@
       "sleightoffleshpower": "+4"
     },
     "image_url": "/static/images/cards/sleight_of_flesh.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sleight_of_flesh.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando apliques un efecto negativo a un enemigo, este recibe 13 de daño.",
@@ -17424,7 +17424,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/pillar_of_creation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillar_of_creation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando crees una carta, gana 4 de [gold]Bloqueo[/gold].",
@@ -17617,7 +17617,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/mind_rot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mind_rot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -17700,7 +17700,7 @@
       "poison": "+3"
     },
     "image_url": "/static/images/cards/bubble_bubble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Si el enemigo está [gold]Envenenado[/gold], le aplicas 12 de [gold]Veneno[/gold].",
@@ -17922,7 +17922,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/jackpot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/jackpot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 30 de daño.\nAñade 3 cartas aleatorias [gold]Mejoradas[/gold] de coste 0 [energy:1] a tu [gold]Mano[/gold].",
@@ -18005,7 +18005,7 @@
       "preptimepower": "+2"
     },
     "image_url": "/static/images/cards/prep_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prep_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Al comienzo de tu siguiente turno, gana 6 de [gold]Vigor[/gold].",
@@ -18045,7 +18045,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/production.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/production.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana [energy:3].",
@@ -18088,7 +18088,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/defile.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/defile.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 17 de daño.",
@@ -18342,7 +18342,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/deaths_door.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/deaths_door.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 7 de [gold]Bloqueo[/gold].\nSi has aplicado [gold]Condena[/gold] este turno, gana [gold]Bloqueo[/gold] 2 veces más.",
@@ -18381,7 +18381,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/astral_pulse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/astral_pulse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 18 de daño a TODOS los enemigos.",
@@ -18690,7 +18690,7 @@
       "increase": "+2"
     },
     "image_url": "/static/images/cards/kingly_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/kingly_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 10 de daño.\nCuando robes esta carta, aumenta su daño en 6 durante este combate.",
@@ -18811,7 +18811,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/rocket_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rocket_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 14 de daño.\nRoba 2 cartas.\nCuando crees una carta de Estado, reduce el coste de esta carta a 0 [energy:1] hasta que se juegue.",
@@ -18850,7 +18850,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/make_it_so.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/make_it_so.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 9 de daño.\nCada vez que juegues 3 Habilidades durante tu turno, coloca esta carta en tu [gold]Mano[/gold].",
@@ -18888,7 +18888,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/shatter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shatter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 15 de daño a TODOS los enemigos.\n[gold]Descarga[/gold] todos tus Orbes.",
@@ -19050,7 +19050,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/tracking.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tracking.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19090,7 +19090,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/lunar_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lunar_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 5 de daño por cada Habilidad jugada este turno.",
@@ -19209,7 +19209,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/rebound.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rebound.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 12 de daño.\nColoca la siguiente carta que juegues este turno en la parte superior de tu [gold]Pila de robo[/gold].",
@@ -19301,7 +19301,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/know_thy_place.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/know_thy_place.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19343,7 +19343,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/reflect.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reflect.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 21 de [gold]Bloqueo[/gold].\nEl daño de ataque bloqueado durante este turno se devuelve al atacante.",
@@ -19425,7 +19425,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/refract.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refract.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 12 de daño dos veces.\n[gold]Invoca[/gold] 2 [gold]Cristal[/gold].",
@@ -19557,7 +19557,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/relax.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/relax.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 17 de [gold]Bloqueo[/gold].\nRoba 3 cartas y gana [energy:3] al comienzo de tu siguiente turno.",
@@ -19678,7 +19678,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/spite.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spite.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 5 de daño.\nSi has perdido PV este turno,\ngolpea 3 veces.",
@@ -19716,7 +19716,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/rally.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rally.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TODOS los jugadores ganan 17 de [gold]Bloqueo[/gold].",
@@ -19755,7 +19755,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/toric_toughness.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/toric_toughness.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 7 de [gold]Bloqueo[/gold].\nGana 7 de [gold]Bloqueo[/gold] al comienzo de tus siguientes 2 turnos.",
@@ -19801,7 +19801,7 @@
       "strengthpower": "+1"
     },
     "image_url": "/static/images/cards/resonance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/resonance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 2 de [gold]Fuerza[/gold]. TODOS los enemigos pierden 1 de [gold]Fuerza[/gold].",
@@ -19878,7 +19878,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/trash_to_treasure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/trash_to_treasure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19962,7 +19962,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/seance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20046,7 +20046,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/giant_rock.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/giant_rock.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 20 de daño.",
@@ -20250,7 +20250,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/photon_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/photon_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 13 de daño.\nRoba 2 cartas.\nColoca 1 carta de tu [gold]Mano[/gold] en la parte superior de tu [gold]Pila de robo[/gold].",
@@ -20333,7 +20333,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/minion_sacrifice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_sacrifice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 12 de [gold]Bloqueo[/gold].",
@@ -20372,7 +20372,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/splash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/splash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Elige 1 de entre 3 Ataques aleatorios [gold]Mejorados[/gold] de otro personaje y añádelo a tu [gold]Mano[/gold]. Puedes jugarlo gratis este turno.",
@@ -20491,7 +20491,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/salvo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/salvo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 16 de daño.\n[gold]Retén[/gold] tu [gold]Mano[/gold] este turno.",
@@ -20536,7 +20536,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/feral.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feral.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20574,7 +20574,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/pillage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 9 de daño.\nRoba cartas hasta que robes una que no sea un Ataque.",
@@ -20659,7 +20659,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 11 de daño a TODOS los enemigos.",
@@ -20738,7 +20738,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/bury.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bury.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 63 de daño.",
@@ -20778,7 +20778,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/seven_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seven_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20825,7 +20825,7 @@
       "sneakypower": "+1"
     },
     "image_url": "/static/images/cards/sneaky.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sneaky.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando otro jugador ataque a un enemigo, ganas 2 de [gold]Bloqueo[/gold].",
@@ -20868,7 +20868,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/whistle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/whistle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 44 de daño.\n[gold]Aturde[/gold] al enemigo.",
@@ -20952,7 +20952,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/synchronize.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synchronize.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21002,7 +21002,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/neurosurge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neurosurge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana [energy:4].\nRoba 2 cartas.\nAl comienzo de tu turno, te aplicas 3 de [gold]Condena[/gold].",
@@ -21040,7 +21040,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/monologue.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/monologue.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21093,7 +21093,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/prowess.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 2 de [gold]Fuerza[/gold].\nGana 2 de [gold]Destreza[/gold].",
@@ -21139,7 +21139,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/consuming_shadow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/consuming_shadow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Invoca[/gold] 3 [gold]Oscuridad[/gold].\nAl final de tu turno, [gold]Descarga[/gold] el Orbe situado más a la izquierda.",
@@ -21179,7 +21179,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/fight_through.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_through.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 17 de [gold]Bloqueo[/gold].\nAñade 2 [gold]Heridas[/gold] a tu [gold]Pila de descarte[/gold].",
@@ -21224,7 +21224,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/spinner.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spinner.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Invoca[/gold] 1 [gold]Cristal[/gold].\nAl comienzo de tu turno, [gold]Invoca[/gold] 1 [gold]Cristal[/gold].",
@@ -21260,7 +21260,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/subroutine.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/subroutine.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21343,7 +21343,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/supermassive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/supermassive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 5 de daño.\nInflige 4 de daño adicional por cada carta que hayas creado este combate.",
@@ -21386,7 +21386,7 @@
       "strengthloss": "+2"
     },
     "image_url": "/static/images/cards/dying_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dying_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 11 de daño a TODOS los enemigos. TODOS los enemigos pierden 11 de [gold]Fuerza[/gold] este turno.",
@@ -21556,7 +21556,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/synthesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synthesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 18 de daño.\nEl siguiente Poder que juegues cuesta 0 [energy:1].",
@@ -21681,7 +21681,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/drum_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/drum_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Roba 3 cartas.\nAl comienzo de tu turno, [gold]Agota[/gold] la primera carta de tu [gold]Pila de robo[/gold].",
@@ -21717,7 +21717,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/tank.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tank.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21792,7 +21792,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/refine_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refine_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Forja[/gold] 13.\nAl siguiente turno, gana [energy:1].",
@@ -21837,7 +21837,7 @@
       "vigorpower": "+2"
     },
     "image_url": "/static/images/cards/terraforming.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/terraforming.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 8 de [gold]Vigor[/gold].",
@@ -21935,7 +21935,7 @@
       "starnextturnpower": "+1"
     },
     "image_url": "/static/images/cards/hidden_cache.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_cache.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana [star:1].\nAl siguiente turno, gana [star:4].",
@@ -22048,7 +22048,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/tyranny.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tyranny.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22129,7 +22129,7 @@
       "strengthloss": "+3"
     },
     "image_url": "/static/images/cards/enfeebling_touch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enfeebling_touch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "El enemigo pierde 11 de [gold]Fuerza[/gold] este turno.",
@@ -22295,7 +22295,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/soul_storm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul_storm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 9 de daño.\nInflige 3 de daño adicional por cada [gold]Alma[/gold] en tu [gold]Pila de agotamiento[/gold].",
@@ -22417,7 +22417,7 @@
       "extradamage": "+2"
     },
     "image_url": "/static/images/cards/gang_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gang_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 5 de daño.\nInflige 7 de daño adicional por cada vez que otro jugador haya atacado al enemigo este turno.",
@@ -22460,7 +22460,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/knife_trap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knife_trap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Mejora[/gold] y juega todas las [gold]Navajas[/gold] de tu [gold]Pila de agotamiento[/gold] contra el enemigo.",
@@ -22538,7 +22538,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/transfigure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/transfigure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22581,7 +22581,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/collision_course.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/collision_course.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 15 de daño.\nAñade 1 [gold]Escombros[/gold] a tu [gold]Mano[/gold].",
@@ -22672,7 +22672,7 @@
       "thunderpower": "+2"
     },
     "image_url": "/static/images/cards/thunder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/thunder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Cuando [gold]Descargues Relámpago[/gold], inflige 8 de daño a cada enemigo golpeado.",
@@ -22753,7 +22753,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/afterlife.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/afterlife.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Vincula[/gold] 9.",
@@ -22838,7 +22838,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/pale_blue_dot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pale_blue_dot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Si juegas 5 cartas o más en un turno, roba 2 cartas al comienzo de tu siguiente turno.",
@@ -22962,7 +22962,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/maul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/maul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 6 de daño dos veces.\nAumenta el daño de TODAS las cartas de Vapulear en 2 durante este combate.",
@@ -23048,7 +23048,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/speedster.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/speedster.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23213,7 +23213,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/gunk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gunk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 5 de daño 3 veces.\nAñade 1 [gold]Viscoso[/gold] a tu [gold]Pila de descarte[/gold].",
@@ -23295,7 +23295,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/voltaic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/voltaic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23375,7 +23375,7 @@
       "blockforstars": "+1"
     },
     "image_url": "/static/images/cards/child_of_the_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/child_of_the_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Siempre que gastes [star:1], gana 3 de [gold]Bloqueo[/gold] por cada [star:1] gastado.",
@@ -23454,7 +23454,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/ricochet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ricochet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 3 de daño a un enemigo aleatorio 5 veces.",
@@ -23547,7 +23547,7 @@
       "sicempower": "+1"
     },
     "image_url": "/static/images/cards/sic_em.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sic_em.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Nudillos[/gold] inflige 6 de daño.\nCuando [gold]Nudillos[/gold] ataque al enemigo este turno, [gold]Vincula[/gold] 3.",
@@ -23596,7 +23596,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/fight_me.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Inflige 6 de daño dos veces.\nGana 4 de [gold]Fuerza[/gold].\nEl enemigo gana 1 de [gold]Fuerza[/gold].",
@@ -23634,7 +23634,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/begone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/begone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Elige una carta de tu [gold]Mano[/gold] y [gold]Transfórmala[/gold] en [gold]Golpe de esbirro+[/gold].",
@@ -23672,7 +23672,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/i_am_invincible.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/i_am_invincible.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 13 de [gold]Bloqueo[/gold].\nAl final de tu turno, si esta carta se encuentra en la parte superior de tu [gold]Pila de robo[/gold], juégala.",
@@ -23797,7 +23797,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/bulwark.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulwark.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Gana 16 de [gold]Bloqueo[/gold].\n[gold]Forja[/gold] 13.",
@@ -23833,7 +23833,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/beacon_of_hope.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beacon_of_hope.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,

--- a/data/tha/cards.json
+++ b/data/tha/cards.json
@@ -138,7 +138,7 @@
       "dexterity": "+1"
     },
     "image_url": "/static/images/cards/bulk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "เสียช่องเก็บลูกแก้ว 1 ช่อง\nได้รับ 3 [gold]ความแข็งแรง[/gold]\nได้รับ 3 [gold]ความชำนาญ[/gold]",
@@ -218,7 +218,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/bulwark.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulwark.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 16 [gold]บล็อก[/gold]\n[gold]หลอมสร้าง[/gold] 13",
@@ -258,7 +258,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/bundle_of_joy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bundle_of_joy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "เพิ่มการ์ดไม่มีสี 4 ใบแบบสุ่มใส่[gold]มือ[/gold]",
@@ -299,7 +299,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/bury.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bury.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 63",
@@ -412,7 +412,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/calamity.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/calamity.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -495,7 +495,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/call_of_the_void.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/call_of_the_void.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -573,7 +573,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/cascade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cascade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "เล่นการ์ดใบบนสุด X+1 ใบของ[gold]กองจั่ว[/gold]",
@@ -611,7 +611,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/catastrophe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/catastrophe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "เล่นการ์ด 3 ใบแบบสุ่มจาก[gold]กองจั่ว[/gold]",
@@ -688,7 +688,7 @@
       "blockforstars": "+1"
     },
     "image_url": "/static/images/cards/child_of_the_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/child_of_the_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณจ่าย [star:1] ได้รับ 3 [gold]บล็อก[/gold]ตามจำนวน [star:1] ที่จ่ายไป",
@@ -805,7 +805,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/collision_course.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/collision_course.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 15\nเพิ่ม[gold]Debris[/gold] 1 ใบใส่[gold]มือ[/gold]",
@@ -844,7 +844,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/colossus.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/colossus.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 8 [gold]บล็อก[/gold]\nในเทิร์นนี้ คุณจะได้รับความเสียหายน้อยลง 50% จากศัตรูที่มี[gold]จุดอ่อน[/gold]",
@@ -898,7 +898,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/comet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/comet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 44\nสร้าง 3 [gold]ความอ่อนแอ[/gold]\nสร้าง 3 [gold]จุดอ่อน[/gold]",
@@ -938,7 +938,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/compact.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/compact.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 7 [gold]บล็อก[/gold]\n[gold]แปรสภาพ[/gold]การ์ดสถานะทั้งหมดใน[gold]มือ[/gold]เป็น[gold]เชื้อเพลิง+[/gold]",
@@ -979,7 +979,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/conflagration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conflagration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 8 ใส่ศัตรูทั้งหมด\nสร้างความเสียหายเพิ่ม 3 ตามจำนวนการ์ดโจมตีใบอื่นที่คุณเล่นในเทิร์นนี้",
@@ -1017,7 +1017,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/conqueror.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conqueror.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]หลอมสร้าง[/gold] 5\nและในเทิร์นนี้ [gold]พระแสงอาญาสิทธิ์[/gold]สร้างความเสียหายใส่ศัตรูเป็น 2 เท่า",
@@ -1063,7 +1063,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/consuming_shadow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/consuming_shadow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]ปลุกเสก[/gold] 3 [gold]ความมืด[/gold]\nตอนจบเทิร์น [gold]ปล่อยพลัง[/gold]ลูกแก้วลูกซ้ายสุด",
@@ -1102,7 +1102,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/convergence.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/convergence.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]คงสภาพ[/gold]ทั้ง[gold]มือ[/gold]ในเทิร์นนี้\nเทิร์นถัดไป\nได้รับ [energy:1] และ [star:2]",
@@ -1192,7 +1192,7 @@
       "strength": "+3"
     },
     "image_url": "/static/images/cards/coordinate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ผู้เล่นคนอื่น 1 คนได้รับ 8 [gold]ความแข็งแรง[/gold]ในเทิร์นนี้",
@@ -1230,7 +1230,7 @@
       "corrosivewave": "+1"
     },
     "image_url": "/static/images/cards/corrosive_wave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/corrosive_wave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณจั่วการ์ดในเทิร์นนี้ สร้าง 3 [gold]พิษ[/gold]ใส่ศัตรูทั้งหมด",
@@ -1268,7 +1268,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/cosmic_indifference.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cosmic_indifference.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 9 [gold]บล็อก[/gold]\nนำการ์ด 1 ใบจาก[gold]กองทิ้ง[/gold]ไปวางไว้บนสุดของ[gold]กองจั่ว[/gold]",
@@ -1308,7 +1308,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/crash_landing.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crash_landing.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 26 ใส่ศัตรูทั้งหมด\nเติมทั้ง[gold]มือ[/gold]ด้วย[gold]Debris[/gold]",
@@ -1353,7 +1353,7 @@
       "crimsonmantlepower": "+2"
     },
     "image_url": "/static/images/cards/crimson_mantle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crimson_mantle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ตอนเริ่มต้นเทิร์น เสีย 1 HP และได้รับ 10 [gold]บล็อก[/gold]",
@@ -1438,7 +1438,7 @@
       "strengthloss": "+1"
     },
     "image_url": "/static/images/cards/crush_under.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crush_under.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 8 ใส่ศัตรูทั้งหมด ศัตรูทั้งหมดเสีย 2 [gold]ความแข็งแรง[/gold]ในเทิร์นนี้",
@@ -1578,7 +1578,7 @@
       "debilitatepower": "+1"
     },
     "image_url": "/static/images/cards/debilitate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debilitate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 12\n[gold]จุดอ่อน[/gold]และ[gold]ความอ่อนแอ[/gold]มีผลกับศัตรูเป็น 2 เท่า เป็นเวลา 4 เทิร์น",
@@ -1618,7 +1618,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/defile.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/defile.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 17",
@@ -1662,7 +1662,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/demesne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demesne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1707,7 +1707,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/demonic_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demonic_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1749,7 +1749,7 @@
       "damage": "+10"
     },
     "image_url": "/static/images/cards/devastate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devastate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 40",
@@ -1791,7 +1791,7 @@
       "summon": "+1"
     },
     "image_url": "/static/images/cards/dirge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dirge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]อัญเชิญ[/gold] 4 จำนวน X ครั้ง\nเพิ่ม[gold]วิญญาณ+[/gold] X  ใบเข้า[gold]กองจั่ว[/gold]",
@@ -1837,7 +1837,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/disintegration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/disintegration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -2006,7 +2006,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/dredge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dredge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2052,7 +2052,7 @@
       "strengthloss": "+2"
     },
     "image_url": "/static/images/cards/dying_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dying_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 11 ใส่ศัตรูทั้งหมด ศัตรูทั้งหมดเสีย 11 [gold]ความแข็งแรง[/gold]ในเทิร์นนี้",
@@ -2093,7 +2093,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/eidolon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/eidolon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2178,7 +2178,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/energy_surge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/energy_surge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ผู้เล่นทั้งหมดได้รับ [energy:3]",
@@ -2221,7 +2221,7 @@
       "strengthloss": "+3"
     },
     "image_url": "/static/images/cards/enfeebling_touch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enfeebling_touch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ศัตรูเสีย 11 [gold]ความแข็งแรง[/gold]ในเทิร์นนี้",
@@ -2260,7 +2260,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/enthralled.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enthralled.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2301,7 +2301,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/entropy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entropy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2603,7 +2603,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/falling_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/falling_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 12\nสร้าง 1 [gold]ความอ่อนแอ[/gold]\nสร้าง 1 [gold]จุดอ่อน[/gold]",
@@ -2648,7 +2648,7 @@
       "strength": "+2"
     },
     "image_url": "/static/images/cards/feeding_frenzy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 7 [gold]ความแข็งแรง[/gold]ในเทิร์นนี้",
@@ -2693,7 +2693,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/feral.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feral.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2775,7 +2775,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/fight_through.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_through.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 17 [gold]บล็อก[/gold]\nเพิ่ม[gold]Wounds[/gold] 2 ใบเข้า[gold]กองทิ้ง[/gold]",
@@ -2813,7 +2813,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/fisticuffs.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fisticuffs.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 9\nได้รับ[gold]บล็อก[/gold]ตามความเสียหายที่ไม่ถูกบล็อกที่ทำได้",
@@ -2853,7 +2853,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/flak_cannon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/flak_cannon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]สลาย[/gold]การ์ด[gold]สถานะ[/gold]ทั้งหมดของคุณ\nสร้างความเสียหาย 11 ใส่ศัตรู 1 ตัวแบบสุ่ม ตามจำนวนการ์ดที่ถูก[gold]สลาย[/gold]",
@@ -3020,7 +3020,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/forbidden_grimoire.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/forbidden_grimoire.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3061,7 +3061,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/foregone_conclusion.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/foregone_conclusion.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "เทิร์นถัดไป นำการ์ด 3 ใบจาก[gold]กองจั่ว[/gold]ขึ้น[gold]มือ[/gold]",
@@ -3138,7 +3138,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/frantic_escape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/frantic_escape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -3192,7 +3192,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/gamma_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gamma_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 18\nสร้าง 2 [gold]ความอ่อนแอ[/gold]\nสร้าง 2 [gold]จุดอ่อน[/gold]",
@@ -3232,7 +3232,7 @@
       "extradamage": "+2"
     },
     "image_url": "/static/images/cards/gang_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gang_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 5\nสร้างความเสียหายเพิ่ม 7 ตามจำนวนครั้งที่พันธมิตรเคยโจมตีศัตรูในเทิร์นนี้",
@@ -3271,7 +3271,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/gather_light.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gather_light.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 11 [gold]บล็อก[/gold]\nได้รับ [star:1]",
@@ -3309,7 +3309,7 @@
       "starsperturn": "+1"
     },
     "image_url": "/static/images/cards/genesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/genesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ตอนเริ่มต้นเทิร์น ได้รับ [star:3]",
@@ -3347,7 +3347,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/giant_rock.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/giant_rock.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 20",
@@ -3428,7 +3428,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/glimpse_beyond.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glimpse_beyond.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ผู้เล่นทั้งหมดเพิ่ม[gold]วิญญาณ[/gold] 4 ใบเข้า[gold]กองจั่ว[/gold]",
@@ -3510,7 +3510,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/glow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ [star:2]\nจั่วการ์ด 1 ใบ",
@@ -3632,7 +3632,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/graveblast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/graveblast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 6\nนำการ์ด 1 ใบจาก[gold]กองทิ้ง[/gold]ขึ้น[gold]มือ[/gold]",
@@ -3719,7 +3719,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/guiding_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/guiding_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 13\nเทิร์นถัดไป จั่วการ์ด 3 ใบ",
@@ -3801,7 +3801,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/gunk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gunk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 5 จำนวน 3 ครั้ง\nเพิ่ม[gold]Slimed[/gold] 1 ใบเข้า[gold]กองทิ้ง[/gold]",
@@ -3837,7 +3837,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/hammer_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hammer_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3877,7 +3877,7 @@
       "hploss": "+2"
     },
     "image_url": "/static/images/cards/haunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณเล่น[gold]วิญญาณ[/gold] ศัตรู 1 ตัวแบบสุ่มเสีย 8 HP",
@@ -3916,7 +3916,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/heavenly_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heavenly_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 10 จำนวน X ครั้ง\nถ้า X มีค่า 4 ขึ้นไป จะเกิดผล 2 เท่า",
@@ -3956,7 +3956,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/hegemony.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hegemony.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 18\nเทิร์นถัดไป ได้รับ [energy:3]",
@@ -3995,7 +3995,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/heirloom_hammer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heirloom_hammer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 25\nเลือกการ์ดไม่มีสี 1 ใบใน[gold]มือ[/gold] เพิ่มสำเนาของการ์ดนั้น 1 ใบใส่[gold]มือ[/gold]",
@@ -4035,7 +4035,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/helix_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/helix_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 5 ตามจำนวน [energy:1] ที่เคยจ่ายในเทิร์นนี้",
@@ -4081,7 +4081,7 @@
       "starnextturnpower": "+1"
     },
     "image_url": "/static/images/cards/hidden_cache.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_cache.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ [star:1]\nเทิร์นถัดไป ได้รับ [star:4]",
@@ -4122,7 +4122,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/hidden_daggers.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_daggers.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทิ้งการ์ด 2 ใบ\nเพิ่ม[gold]มีดสั้น+[/gold] 2 ใบใส่[gold]มือ[/gold]",
@@ -4160,7 +4160,7 @@
       "replay": "+1"
     },
     "image_url": "/static/images/cards/hidden_gem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_gem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "การ์ดใน[gold]กองจั่ว[/gold] 1 ใบแบบสุ่มได้รับ [gold]เล่นซ้ำ[/gold] 3",
@@ -4248,7 +4248,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/i_am_invincible.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/i_am_invincible.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 13 [gold]บล็อก[/gold]\nตอนจบเทิร์น ถ้าการ์ดนี้อยู่ใบบนสุดของ[gold]กองจั่ว[/gold] จะเล่นมัน",
@@ -4288,7 +4288,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/invoke.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/invoke.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "เทิร์นถัดไป [gold]อัญเชิญ[/gold] 3 และได้รับ [energy:3]",
@@ -4333,7 +4333,7 @@
       "iterationpower": "+1"
     },
     "image_url": "/static/images/cards/iteration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/iteration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ครั้งแรกที่คุณเล่นการ์ดสถานะในแต่ละเทิร์น จั่วการ์ด 3 ใบ",
@@ -4369,7 +4369,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/juggling.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/juggling.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4447,7 +4447,7 @@
       "increase": "+2"
     },
     "image_url": "/static/images/cards/kingly_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/kingly_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 10\nทุกครั้งที่คุณจั่วได้การ์ดนี้ เพิ่มความเสียหายของมัน 6 จนจบการต่อสู้",
@@ -4494,7 +4494,7 @@
       "knockdownpower": "+1"
     },
     "image_url": "/static/images/cards/knockdown.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockdown.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 14\nในเทิร์นนี้ ศัตรูจะได้รับความเสียหายจากผู้เล่นคนอื่นเป็น 3 เท่า",
@@ -4533,7 +4533,7 @@
       "damage": "+8"
     },
     "image_url": "/static/images/cards/knockout_blow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockout_blow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 38\nถ้าฆ่าศัตรูได้ ได้รับ [star:5]",
@@ -4587,7 +4587,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/know_thy_place.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/know_thy_place.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4628,7 +4628,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/lantern_key.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lantern_key.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4667,7 +4667,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/largesse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/largesse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ผู้เล่นคนอื่น 1 คนเพิ่มการ์ดไร้สี [gold]แบบพัฒนาแล้ว[/gold] 1 ใบแบบสุ่มใส่[gold]มือ[/gold]",
@@ -4710,7 +4710,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/leading_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/leading_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 6\nเพิ่ม[gold]มีดสั้น[/gold] 2 ใบใส่[gold]มือ[/gold]",
@@ -4750,7 +4750,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/legion_of_bone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/legion_of_bone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ผู้เล่นทั้งหมด[gold]อัญเชิญ[/gold] 8",
@@ -4800,7 +4800,7 @@
       "lethalitypower": "+25"
     },
     "image_url": "/static/images/cards/lethality.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lethality.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "การโจมตีแรกในแต่ละเทิร์น สร้างความเสียหายเพิ่ม 75%",
@@ -4841,7 +4841,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/lift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ให้ 16 [gold]บล็อก[/gold]แก่ผู้เล่นคนอื่น 1 คน",
@@ -4882,7 +4882,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/luminesce.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/luminesce.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ [energy:3]",
@@ -4926,7 +4926,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/lunar_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lunar_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 5 ตามจำนวนการ์ดทักษะที่เคยเล่นในเทิร์นนี้",
@@ -5013,7 +5013,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/make_it_so.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/make_it_so.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 9\nการ์ดทักษะทุก 3 ใบที่คุณเล่นในเทิร์นเดียวกัน นำการ์ดนี้ขึ้น[gold]มือ[/gold]",
@@ -5091,7 +5091,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/manifest_authority.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/manifest_authority.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 8 [gold]บล็อก[/gold]\nเพิ่มการ์ดไร้สี [gold]แบบพัฒนาแล้ว[/gold] 1 ใบแบบสุ่มใส่[gold]มือ[/gold]",
@@ -5131,7 +5131,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/maul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/maul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาน 6 จำนวน 2 ครั้ง\nการ์ด Maul ทั้งหมดสร้างความเสียหายเพิ่ม 2 ในการต่อสู้นี้",
@@ -5254,7 +5254,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/mind_rot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mind_rot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -5293,7 +5293,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/misery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/misery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 9\nสร้างผลผิดปกติใส่ศัตรูตัวอื่นทั้งหมด ตามผลผิดปกติทั้งหมดบนศัตรูตัวนี้",
@@ -5332,7 +5332,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/modded.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/modded.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับช่องเก็บลูกแก้ว 1 ช่อง\nจั่วการ์ด 2 ใบ เพิ่มค่าร่ายของการ์ดนี้ 1",
@@ -5451,7 +5451,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/monologue.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/monologue.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5491,7 +5491,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/murder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/murder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5529,7 +5529,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/necro_mastery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/necro_mastery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]อัญเชิญ[/gold] 8\nทุกครั้งที่[gold]Osty[/gold]เสีย HP\nศัตรูทั้งหมดเสีย HP ตามจำนวนนั้นด้วย",
@@ -5668,7 +5668,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/neurosurge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neurosurge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ [energy:4]\nจั่วการ์ด 2 ใบ\nตอนเริ่มต้นเทิร์น สร้าง 3 [gold]อายุขัย[/gold]ใส่ตัวคุณ",
@@ -5714,7 +5714,7 @@
       "platingpower": "+3"
     },
     "image_url": "/static/images/cards/neutron_aegis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neutron_aegis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 11 [gold]เกราะโลหะ[/gold]",
@@ -5790,7 +5790,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/nostalgia.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/nostalgia.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5830,7 +5830,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -5963,7 +5963,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/omnislice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/omnislice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 11\nศัตรูตัวอื่นทั้งหมดได้รับความเสียหายตามความเสียหายที่ทำได้",
@@ -6085,7 +6085,7 @@
       "outbreakpower": "+4"
     },
     "image_url": "/static/images/cards/outbreak.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outbreak.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณสร้าง[gold]พิษ[/gold] สร้างความเสียหาย 15 ใส่ศัตรูทั้งหมด",
@@ -6162,7 +6162,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/pagestorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pagestorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6201,7 +6201,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/pale_blue_dot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pale_blue_dot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ถ้าคุณเล่นการ์ด 5 ใบขึ้นไปในเทิร์นเดียว ตอนเริ่มเทิร์นถัดไป จั่วการ์ด 2 ใบ",
@@ -6248,7 +6248,7 @@
       "parrypower": "+4"
     },
     "image_url": "/static/images/cards/parry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/parry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณเล่น[gold]พระแสงอาญาสิทธิ์[/gold] ได้รับ 14 [gold]บล็อก[/gold]",
@@ -6377,7 +6377,7 @@
       "vigorpower": "+1"
     },
     "image_url": "/static/images/cards/patter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/patter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 11 [gold]บล็อก[/gold]\nได้รับ 3 [gold]ความกำยำ[/gold]",
@@ -6463,7 +6463,7 @@
       "phantombladespower": "+3"
     },
     "image_url": "/static/images/cards/phantom_blades.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/phantom_blades.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]มีดสั้น[/gold]ได้รับ[gold]คงสภาพ[/gold]\n[gold]มีดสั้น[/gold]ใบแรกที่คุณเล่นในแต่ละเทิร์นสร้างความเสียหายเพิ่ม 12",
@@ -6504,7 +6504,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/photon_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/photon_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 13\nจั่วการ์ด 2 ใบ\nนำการ์ด 1 ใบจาก[gold]มือ[/gold]ไปวางไว้บนสุดของ[gold]กองจั่ว[/gold]",
@@ -6542,7 +6542,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/pillage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 9\nจั่วการ์ดจนกว่าจะจั่วได้การ์ดที่ไม่ใช่การ์ดโจมตี",
@@ -6580,7 +6580,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/pillar_of_creation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillar_of_creation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณสร้างการ์ด ได้รับ 4 [gold]บล็อก[/gold]",
@@ -6737,7 +6737,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/precise_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/precise_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6815,7 +6815,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/production.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/production.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ [energy:3]",
@@ -6993,7 +6993,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/prowess.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 2 [gold]ความแข็งแรง[/gold]\nได้รับ 2 [gold]ความชำนาญ[/gold]",
@@ -7073,7 +7073,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/pull_from_below.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pull_from_below.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 7 ตามจำนวนการ์ด[gold]กึ่งสลาย[/gold]ที่เล่นในการต่อสู้นี้",
@@ -7192,7 +7192,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/quasar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quasar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "เลือกการ์ดไร้สีแบบพัฒนาแล้ว 1 จากที่สุ่มมา 3 ใบเพื่อเพิ่มใส่[gold]มือ[/gold]",
@@ -7271,7 +7271,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/rally.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rally.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ผู้เล่นทั้งหมดได้รับ 17 [gold]บล็อก[/gold]",
@@ -7314,7 +7314,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/rattle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rattle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold]สร้างความเสียหาย 9\nโจมตีเพิ่มอีกครั้งต่อทุก 2 ครั้งที่เขาโจมตีในเทิร์นนี้",
@@ -7397,7 +7397,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/reap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 33",
@@ -7480,7 +7480,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/reflect.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reflect.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 21 [gold]บล็อก[/gold]\nสะท้อนความเสียหายจากการโจมตีที่บล็อกได้กลับไปหาผู้โจมตีในเทิร์นนี้",
@@ -7519,7 +7519,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/refract.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refract.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 12 จำนวน 2 ครั้ง\n[gold]ปลุกเสก[/gold] 2 [gold]แก้ว[/gold]",
@@ -7563,7 +7563,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/relax.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/relax.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 17 [gold]บล็อก[/gold]\nเทิร์นถัดไป จั่วการ์ด 3 ใบและได้รับ [energy:3]",
@@ -7607,7 +7607,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/rend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 15\nสร้างความเสียหายเพิ่ม 8 ตามจำนวนผลผิดปกติที่ไม่ซ้ำกันบนตัวศัตรูตัวนั้น",
@@ -7693,7 +7693,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/ricochet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ricochet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 3 ใส่ศัตรู 1 ตัวแบบสุ่ม จำนวน 5 ครั้ง",
@@ -7736,7 +7736,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/rocket_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rocket_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7782,7 +7782,7 @@
       "rollingboulderpower": "+5"
     },
     "image_url": "/static/images/cards/rolling_boulder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rolling_boulder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ตอนต้นเทิร์น สร้างความเสียหาย 10 ใส่ศัตรูทั้งหมด และเพิ่มความเสียหายนี้อีก 5",
@@ -7823,7 +7823,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/royal_gamble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royal_gamble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7864,7 +7864,7 @@
       "gold": "+5"
     },
     "image_url": "/static/images/cards/royalties.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royalties.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "ตอนจบการต่อสู้ ได้รับ 35 [gold]ทอง[/gold]",
@@ -7902,7 +7902,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/salvo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/salvo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 16\n[gold]คงสภาพ[/gold]ทั้ง[gold]มือ[/gold]ในเทิร์นนี้",
@@ -8027,7 +8027,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sculpting_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sculpting_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 12\nเพิ่ม[gold]กึ่งสลาย[/gold]ให้การ์ด 1 ใบใน[gold]มือ[/gold]",
@@ -8069,7 +8069,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/seance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8113,7 +8113,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/seeker_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeker_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 12\nเลือกการ์ด 1 จาก 3 ใบใน[gold]กองจั่ว[/gold]เพื่อนำขึ้น[gold]มือ[/gold]",
@@ -8151,7 +8151,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/seeking_edge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeking_edge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]หลอมสร้าง[/gold] 11\nต่อไปนี้[gold]พระแสงอาญาสิทธิ์[/gold]จะสร้างความเสียหายใส่ศัตรูทั้งหมด",
@@ -8287,7 +8287,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/seven_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seven_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8327,7 +8327,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/severance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/severance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 18\nเพิ่ม[gold]วิญญาณ[/gold]เข้า[gold]กองการ์ด[/gold], [gold]มือ[/gold], และ[gold]กองทิ้ง[/gold] อย่างละ 1 ใบ",
@@ -8365,7 +8365,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/shadow_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shadow_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 15 [gold]บล็อก[/gold]\n[gold]ปลุกเสก[/gold] 1 [gold]ความมืด[/gold]",
@@ -8523,7 +8523,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/shatter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shatter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 15 ใส่ศัตรูทั้งหมด\n[gold]ปล่อยพลัง[/gold]ลูกแก้วทั้งหมดของคุณ",
@@ -8564,7 +8564,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/shining_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shining_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 11\nได้รับ [star:2]\nนำการ์ดนี้ไปไว้บนสุดของ[gold]กองจั่ว[/gold]",
@@ -8602,7 +8602,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/shroud.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shroud.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณสร้าง[gold]อายุขัย[/gold] ได้รับ 3 [gold]บล็อก[/gold]",
@@ -8652,7 +8652,7 @@
       "sicempower": "+1"
     },
     "image_url": "/static/images/cards/sic_em.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sic_em.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold]สร้างความเสียหาย 6\nทุกครั้งที่[gold]Osty[/gold]โจมตีศัตรูตัวนี้ในเทิร์นนี้ [gold]อัญเชิญ[/gold] 3",
@@ -8747,7 +8747,7 @@
       "sleightoffleshpower": "+4"
     },
     "image_url": "/static/images/cards/sleight_of_flesh.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sleight_of_flesh.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณสร้างผลผิดปกติใส่ศัตรู มันจะได้รับความเสียหาย 13",
@@ -8792,7 +8792,7 @@
       "smokestackpower": "+2"
     },
     "image_url": "/static/images/cards/smokestack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/smokestack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณสร้างการ์ดสถานะ สร้างความเสียหาย 7 ใส่ศัตรูทั้งหมด",
@@ -8883,7 +8883,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/snap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/snap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold]สร้างความเสียหาย 10\nเพิ่ม[gold]คงสภาพ[/gold]ให้การ์ด 1 ใบใน[gold]มือ[/gold]",
@@ -8930,7 +8930,7 @@
       "sneakypower": "+1"
     },
     "image_url": "/static/images/cards/sneaky.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sneaky.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่พันธมิตรโจมตีศัตรู ได้รับ 2 [gold]บล็อก[/gold]",
@@ -9011,7 +9011,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/soot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -9054,7 +9054,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 11 ใส่ศัตรูทั้งหมด",
@@ -9095,7 +9095,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/spectrum_shift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spectrum_shift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9140,7 +9140,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/spinner.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spinner.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]ปลุกเสก[/gold] 1 [gold]แก้ว[/gold]\nตอนเริ่มต้นเทิร์น [gold]ปลุกเสก[/gold] 1 [gold]แก้ว[/gold]",
@@ -9178,7 +9178,7 @@
       "blockonexhaust": "+1"
     },
     "image_url": "/static/images/cards/spirit_of_ash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spirit_of_ash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณเล่นการ์ด[gold]กึ่งสลาย[/gold] ได้รับ 5 [gold]บล็อก[/gold]",
@@ -9217,7 +9217,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/spite.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spite.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9253,7 +9253,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/splash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/splash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "เลือกการ์ดโจมตี [gold]แบบพัฒนาแล้ว[/gold] 1 จาก 3 ใบแบบสุ่มจากตัวละครอื่นเพื่อเพิ่มใส่[gold]มือ[/gold] มันเล่นฟรีในเทิร์นนี้",
@@ -9291,7 +9291,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/spoils_map.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_map.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9333,7 +9333,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/spoils_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9369,7 +9369,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/spore_mind.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spore_mind.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9507,7 +9507,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/squeeze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/squeeze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold]สร้างความเสียหาย 25\nสร้างความเสียหายเพิ่ม 6 ตามจำนวนการโจมตีครั้งอื่นของ[gold]Osty[/gold]",
@@ -9747,7 +9747,7 @@
       "stranglepower": "+1"
     },
     "image_url": "/static/images/cards/strangle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/strangle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 10\nทุกครั้งที่คุณเล่นการ์ดในเทิร์นนี้ ศัตรูเสีย 3 HP",
@@ -9783,7 +9783,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/stratagem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stratagem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9819,7 +9819,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/subroutine.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/subroutine.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9859,7 +9859,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/summon_forth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/summon_forth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]หลอมสร้าง[/gold] 11\nนำ[gold]พระแสงอาญาสิทธิ์[/gold]จากที่ไหนก็ได้ขึ้น[gold]มือ[/gold]",
@@ -9942,7 +9942,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/supermassive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/supermassive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 5\nสร้างความเสียหายเพิ่ม 4 ตามจำนวนการ์ดที่คุณสร้างในการต่อสู้นี้",
@@ -10038,7 +10038,7 @@
       "ostydamage": "+5"
     },
     "image_url": "/static/images/cards/sweeping_gaze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sweeping_gaze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold]สร้างความเสียหาย 15 ใส่ศัตรู 1 ตัวแบบสุ่ม",
@@ -10089,7 +10089,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sword_sage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sword_sage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10130,7 +10130,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/synchronize.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synchronize.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10171,7 +10171,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/synthesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synthesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 18\nการ์ดพลังใบถัดไปมีค่าร่าย 0 [energy:1]",
@@ -10245,7 +10245,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/tank.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tank.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10378,7 +10378,7 @@
       "vigorpower": "+2"
     },
     "image_url": "/static/images/cards/terraforming.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/terraforming.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 8 [gold]ความกำยำ[/gold]",
@@ -10418,7 +10418,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/the_hunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_hunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "สร้างความเสียหาย 15\nถ้า[gold]สังหาร[/gold] ได้รับรางวัลการ์ดเพิ่ม 1 รางวัล",
@@ -10463,7 +10463,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/the_scythe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_scythe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 13\nเพิ่มความเสียหายให้การ์ดนี้ 4 แบบถาวร",
@@ -10504,7 +10504,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/the_sealed_throne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_sealed_throne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10703,7 +10703,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/toric_toughness.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/toric_toughness.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 7 [gold]บล็อก[/gold]\nได้รับ 7 [gold]บล็อก[/gold]ตอนเริ่มต้นเทิร์น เป็นเวลา 2 เทิร์น",
@@ -10780,7 +10780,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/tracking.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tracking.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10820,7 +10820,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/transfigure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/transfigure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10859,7 +10859,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/trash_to_treasure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/trash_to_treasure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10947,7 +10947,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/tyranny.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tyranny.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10990,7 +10990,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/ultimate_defend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_defend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 15 [gold]บล็อก[/gold]",
@@ -11030,7 +11030,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/ultimate_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 20",
@@ -11068,7 +11068,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/undeath.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/undeath.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 9 [gold]บล็อก[/gold]\nเพิ่มสำเนา 1 ใบของการ์ดนี้เข้า[gold]กองทิ้ง[/gold]",
@@ -11146,7 +11146,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/unmovable.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/unmovable.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11267,7 +11267,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/up_my_sleeve.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/up_my_sleeve.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "เพิ่ม[gold]มีดสั้น[/gold] 4 ใบใส่[gold]มือ[/gold]\nลดค่าร่ายของการ์ดนี้ลง 1",
@@ -11305,7 +11305,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/uproar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/uproar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 7 จำนวน 2 ครั้ง\nเล่นการ์ดโจมตี 1 ใบแบบสุ่มจาก[gold]กองจั่ว[/gold]",
@@ -11343,7 +11343,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/veilpiercer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/veilpiercer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 13\nการ์ด[gold]กึ่งสลาย[/gold]ใบถัดไปมีค่าร่าย 0 [energy:1]",
@@ -11381,7 +11381,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/venerate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/venerate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ [star:3]",
@@ -11419,7 +11419,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/vicious.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/vicious.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณสร้าง[gold]จุดอ่อน[/gold] จั่วการ์ด 2 ใบ",
@@ -11457,7 +11457,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/volley.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/volley.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 14 ใส่ศัตรู 1 ตัวแบบสุ่ม จำนวน X ครั้ง",
@@ -11498,7 +11498,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/voltaic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/voltaic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11544,7 +11544,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/waste_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/waste_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -11584,7 +11584,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/whistle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/whistle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 44\n[gold]สตัน[/gold]ศัตรูตัวนั้น",
@@ -11627,7 +11627,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/wrought_in_war.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wrought_in_war.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 9\n[gold]หลอมสร้าง[/gold] 9",
@@ -11993,7 +11993,7 @@
       "devourlifepower": "+1"
     },
     "image_url": "/static/images/cards/devour_life.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devour_life.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณเล่น[gold]วิญญาณ[/gold] [gold]อัญเชิญ[/gold] 2",
@@ -12031,7 +12031,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/automation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/automation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12205,7 +12205,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/knife_trap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knife_trap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]พัฒนา[/gold]และเล่น[gold]มีดสั้น[/gold]ทั้งหมดใน[gold]กองสลาย[/gold]ใส่ศัตรู",
@@ -12253,7 +12253,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/apparition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/apparition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12381,7 +12381,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/ignition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ignition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12623,7 +12623,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/tesla_coil.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tesla_coil.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 6\nผลต่อเนื่องของ[gold]สายฟ้า[/gold]ทั้งหมดทำงานใส่ศัตรูตัวนี้",
@@ -12668,7 +12668,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/caltrops.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/caltrops.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณถูกโจมตี สร้างความเสียหาย 5 กลับไป",
@@ -12796,7 +12796,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/refine_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refine_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]หลอมสร้าง[/gold] 13\nเทิร์นถัดไป ได้รับ [energy:1]",
@@ -12832,7 +12832,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/entrench.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entrench.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12994,7 +12994,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/arsenal.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/arsenal.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13034,7 +13034,7 @@
       "power": "+2"
     },
     "image_url": "/static/images/cards/shockwave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shockwave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้าง 5 [gold]ความอ่อนแอ[/gold]และ[gold]จุดอ่อน[/gold]ใส่ศัตรูทั้งหมด",
@@ -13116,7 +13116,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/astral_pulse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/astral_pulse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 18 ใส่ศัตรูทั้งหมด",
@@ -13647,7 +13647,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/sloth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sloth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -13971,7 +13971,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/greed.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/greed.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14212,7 +14212,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/ascenders_bane.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ascenders_bane.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14302,7 +14302,7 @@
       "cards": "+2"
     },
     "image_url": "/static/images/cards/decisions_decisions.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/decisions_decisions.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "จั่วการ์ด 5 ใบ\nเลือกการ์ดทักษะ 1 ใบใน[gold]มือ[/gold]แล้วเล่น 3 ครั้ง",
@@ -14343,7 +14343,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/glasswork.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glasswork.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 8 [gold]บล็อก[/gold]\n[gold]ปลุกเสก[/gold] 1 [gold]แก้ว[/gold]",
@@ -14551,7 +14551,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/alignment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/alignment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ [energy:3]",
@@ -14591,7 +14591,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/huddle_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/huddle_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "พันธมิตรทั้งหมดจั่วการ์ด 3 ใบ",
@@ -14632,7 +14632,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/dual_wield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "เลือกการ์ดโจมตีหรือการ์ดพลัง เพิ่มสำเนาการ์ดนั้น 2 ใบใส่[gold]มือ[/gold]",
@@ -15126,7 +15126,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/adaptive_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/adaptive_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 23\nทำสำเนาของการ์ดนี้แบบ 0[energy:1] เพิ่มใน[gold]กองทิ้ง[/gold]",
@@ -15299,7 +15299,7 @@
       "focuspower": "+1"
     },
     "image_url": "/static/images/cards/focused_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/focused_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 11\nได้รับ 2 [gold]โฟกัส[/gold]ในเทิร์นนี้",
@@ -15415,7 +15415,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/afterlife.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/afterlife.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]อัญเชิญ[/gold] 9",
@@ -15463,7 +15463,7 @@
       "preptimepower": "+2"
     },
     "image_url": "/static/images/cards/prep_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prep_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ตอนเริ่มต้นเทิร์น ได้รับ 6 [gold]ความกำยำ[/gold]",
@@ -15499,7 +15499,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/beacon_of_hope.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beacon_of_hope.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15576,7 +15576,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/rebound.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rebound.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 12\nนำการ์ดที่คุณเล่นใบต่อไปกลับไปวางไว้บนสุดของ[gold]กองจั่ว[/gold]",
@@ -15727,7 +15727,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/infection.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/infection.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15772,7 +15772,7 @@
       "calculationextra": "+2"
     },
     "image_url": "/static/images/cards/beat_into_shape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_into_shape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 7\n[gold]หลอมสร้าง[/gold] X\n[gold]หลอมสร้าง[/gold]อีก 7 ต่อการโจมตีศัตรูในเทิร์นนี้ (ครั้งเว้นครั้ง)",
@@ -15850,7 +15850,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/stack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ[gold]บล็อก[/gold]ตามจำนวนการ์ดใน[gold]กองทิ้ง[/gold] +3",
@@ -16098,7 +16098,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/poor_sleep.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/poor_sleep.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16341,7 +16341,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/big_bang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/big_bang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16389,7 +16389,7 @@
       "poison": "+3"
     },
     "image_url": "/static/images/cards/bubble_bubble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ถ้าศัตรูมี[gold]พิษ[/gold] สร้าง 12 [gold]พิษ[/gold]",
@@ -16427,7 +16427,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/clash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/clash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "จะใช้ได้ก็ต่อเมื่อทั้ง[gold]มือ[/gold]เป็นการ์ดโจมตี\nสร้างความเสียหาย 18",
@@ -16466,7 +16466,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/deaths_door.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/deaths_door.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 7 [gold]บล็อก[/gold]\nถ้าคุณเคยสร้าง[gold]อายุขัย[/gold]ในเทิร์นนี้ ได้รับ[gold]บล็อก[/gold]เพิ่ม 2 ครั้ง",
@@ -17069,7 +17069,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/speedster.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/speedster.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17326,7 +17326,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sovereign_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sovereign_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17574,7 +17574,7 @@
       "hailstormpower": "+2"
     },
     "image_url": "/static/images/cards/hailstorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hailstorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ตอนจบเทิร์น ถ้าคุณมี[gold]น้ำแข็ง[/gold] สร้างความเสียหาย 8 ใส่ศัตรูทั้งหมด",
@@ -17616,7 +17616,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/soul_storm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul_storm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 9\nสร้างความเสียหายเพิ่ม 3 ตามจำนวน[gold]วิญญาณ[/gold]ใน[gold]กองสลาย[/gold]",
@@ -17742,7 +17742,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/boost_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/boost_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 9 [gold]บล็อก[/gold]\nเพิ่ม[gold]ความมึนงง[/gold] 1 ใบเข้า[gold]กองทิ้ง[/gold]",
@@ -17957,7 +17957,7 @@
       "thunderpower": "+2"
     },
     "image_url": "/static/images/cards/thunder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/thunder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณ[gold]ปล่อยพลังสายฟ้า[/gold] สร้างความเสียหาย 8 ใส่ศัตรูแต่ละตัวที่ถูกสายฟ้าโจมตี",
@@ -18344,7 +18344,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/fight_me.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 6 จำนวน 2 ครั้ง\nได้รับ 4 [gold]ความแข็งแรง[/gold]\nศัตรูได้รับ 1 [gold]ความแข็งแรง[/gold]",
@@ -18475,7 +18475,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/blade_of_ink.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/blade_of_ink.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18564,7 +18564,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/right_hand_hand.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/right_hand_hand.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osty[/gold]สร้างความเสียหาย 6\nทุกครั้งที่คุณเล่นการ์ดค่าร่าย [energy:2] ขึ้นไป นำการ์ดนี้จาก[gold]กองทิ้ง[/gold]กลับขึ้น[gold]มือ[/gold]",
@@ -18839,7 +18839,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/barrage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/barrage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 7 ต่อลูกแก้วที่ถูก[gold]ปลุกเสก[/gold]",
@@ -18923,7 +18923,7 @@
       "dansemacabrepower": "+2"
     },
     "image_url": "/static/images/cards/danse_macabre.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/danse_macabre.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณเล่นการ์ดค่าร่าย [energy:2] ขึ้นไป ได้รับ 6 [gold]บล็อก[/gold]",
@@ -19047,7 +19047,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/bombardment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bombardment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 24\nตอนเริ่มต้นเทิร์น เล่นจาก[gold]กองสลาย[/gold]",
@@ -19128,7 +19128,7 @@
       "extrablock": "+2"
     },
     "image_url": "/static/images/cards/fasten.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fasten.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับเพิ่ม 7 [gold]บล็อก[/gold]จากการ์ดป้องกัน",
@@ -19166,7 +19166,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/beat_down.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_down.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "เล่นการ์ดโจมตี 4 ใบแบบสุ่มจาก[gold]กองทิ้ง[/gold]",
@@ -19426,7 +19426,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/reaper_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reaper_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19473,7 +19473,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/void_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/void_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19521,7 +19521,7 @@
       "serpentformpower": "+2"
     },
     "image_url": "/static/images/cards/serpent_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/serpent_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณเล่นการ์ด สร้างความเสียหาย 6 ใส่ศัตรู 1 ตัวแบบสุ่ม",
@@ -19595,7 +19595,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/quadcast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quadcast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19776,7 +19776,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/drum_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/drum_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "จั่วการ์ด 3 ใบ\nตอนเริ่มต้นเทิร์น [gold]สลาย[/gold]การ์ดใบบนสุดของ[gold]กองจั่ว[/gold]",
@@ -20038,7 +20038,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/minion_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 9\nจั่วการ์ด 1 ใบ",
@@ -20083,7 +20083,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/minion_sacrifice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_sacrifice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 12 [gold]บล็อก[/gold]",
@@ -20165,7 +20165,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/wisp.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wisp.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20246,7 +20246,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/soul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "จั่วการ์ด 3 ใบ",
@@ -20362,7 +20362,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/intercept.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/intercept.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 13 [gold]บล็อก[/gold]\nดึงการโจมตีทั้งหมดในเทิร์นนี้ที่เล็งผู้เล่นอื่นมาที่คุณแทน",
@@ -20556,7 +20556,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/hello_world.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hello_world.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20722,7 +20722,7 @@
       "strengthpower": "+1"
     },
     "image_url": "/static/images/cards/resonance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/resonance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 2 [gold]ความแข็งแรง[/gold] ศัตรูทั้งหมดเสีย 1 [gold]ความแข็งแรง[/gold]",
@@ -20850,7 +20850,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/lightning_rod.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lightning_rod.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 7 [gold]บล็อก[/gold]\nตอนเริ่มต้นเทิร์นในอีก 1 เทิร์น [gold]ปลุกเสก[/gold] 1 [gold]สายฟ้า[/gold]",
@@ -20969,7 +20969,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/delay.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/delay.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 13 [gold]บล็อก[/gold]\nและเทิร์นถัดไป\nได้รับ [energy:2]",
@@ -21016,7 +21016,7 @@
       "poison": "+2"
     },
     "image_url": "/static/images/cards/haze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้าง 6 [gold]พิษ[/gold]ใส่ศัตรูทั้งหมด",
@@ -21188,7 +21188,7 @@
       "blackholepower": "+1"
     },
     "image_url": "/static/images/cards/black_hole.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/black_hole.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ทุกครั้งที่คุณจ่ายหรือได้รับ [star:1] สร้างความเสียหาย 4 ใส่ศัตรูทั้งหมด",
@@ -21268,7 +21268,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/ice_lance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ice_lance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 24\n[gold]ปลุกเสก[/gold] 3 [gold]น้ำแข็ง[/gold]",
@@ -21382,7 +21382,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/begone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/begone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "เลือกการ์ด 1 ใบใน[gold]มือ[/gold]เพื่อ[gold]แปรสภาพ[/gold]ให้เป็น[gold]ลูกน้องจู่โจม+[/gold]",
@@ -21472,7 +21472,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/bodyguard.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bodyguard.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]อัญเชิญ[/gold] 7",
@@ -22120,7 +22120,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/believe_in_you.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/believe_in_you.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ผู้เล่นคนอื่น 1 คนได้รับ [energy:3]",
@@ -22161,7 +22161,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/fuel.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fuel.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ [energy:1]\nจั่วการ์ด 2 ใบ",
@@ -22326,7 +22326,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/furnace.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/furnace.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ตอนเริ่มต้นเทิร์น [gold]หลอมสร้าง[/gold] 6",
@@ -22366,7 +22366,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/turbo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/turbo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ [energy:3]\nเพิ่ม[gold]ความว่างเปล่า[/gold] 1 ใบเข้า[gold]กองทิ้ง[/gold]",
@@ -22404,7 +22404,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/distraction.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/distraction.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22615,7 +22615,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/brightest_flame.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/brightest_flame.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ [energy:3]\nจั่วการ์ด 3 ใบ\nเสีย 1 HP สูงสุด",
@@ -22821,7 +22821,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/beckon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beckon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22900,7 +22900,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/scrawl.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/scrawl.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22944,7 +22944,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/mimic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mimic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22990,7 +22990,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/bone_shards.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bone_shards.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ถ้า[gold]Osty[/gold]มีชีวิตอยู่ เขาจะสร้างความเสียหาย 12 ใส่ศัตรูทั้งหมด และคุณได้รับ 12 [gold]บล็อก[/gold]\nจากนั้น[gold]Osty[/gold]จะตาย",
@@ -23026,7 +23026,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/debris.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debris.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23068,7 +23068,7 @@
       "cost": 7
     },
     "image_url": "/static/images/cards/banshees_cry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/banshees_cry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23160,7 +23160,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/abrasive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/abrasive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "ได้รับ 1 [gold]ความชำนาญ[/gold]\nได้รับ 6 [gold]หนาม[/gold]",
@@ -23249,7 +23249,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/hotfix.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hotfix.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23290,7 +23290,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/hang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "สร้างความเสียหาย 13\nการ์ดแขวนคอทั้งหมดสร้างความเสียหายใส่ศัตรูตัวนี้เป็น 2 เท่า",
@@ -23329,7 +23329,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/jackpot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/jackpot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23640,7 +23640,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/bad_luck.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bad_luck.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23836,7 +23836,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/outmaneuver.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outmaneuver.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "เทิร์นถัดไป ได้รับ [energy:3]",

--- a/data/tur/cards.json
+++ b/data/tur/cards.json
@@ -158,7 +158,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/afterlife.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/afterlife.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9 [gold]Çağır[/gold].",
@@ -359,7 +359,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/subroutine.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/subroutine.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -636,7 +636,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/veilpiercer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/veilpiercer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13 hasar ver.\nSonraki oynayacağın [gold]Ruhani[/gold] kartın maliyeti 0 [energy:1] olur.",
@@ -763,7 +763,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/trash_to_treasure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/trash_to_treasure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -839,7 +839,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/hang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13 hasar ver.\nTÜM As kartlarının bu düşmana vereceği hasarı ikiye katla.",
@@ -878,7 +878,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/astral_pulse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/astral_pulse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM düşmanlara 18 hasar ver.",
@@ -990,7 +990,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/ignition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ignition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1073,7 +1073,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/the_hunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_hunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "15 hasar ver.\nEğer [gold]Öldürürse[/gold] fazladan bir kart ödülü elde et.",
@@ -1116,7 +1116,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/lunar_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lunar_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Bu tur oynanmış olan her Beceri kartı için 5 hasar ver.",
@@ -1243,7 +1243,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/luminesce.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/luminesce.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3] elde et.",
@@ -1290,7 +1290,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/disintegration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/disintegration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -1330,7 +1330,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/severance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/severance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "18 hasar ver.\n[gold]Çekme Deste[/gold]'ne, [gold]El[/gold]'ine ve [gold]Atık Deste[/gold]'ne bir [gold]Ruh[/gold] ekle.",
@@ -1366,7 +1366,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/reaper_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reaper_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1403,7 +1403,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/greed.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/greed.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1580,7 +1580,7 @@
       "smokestackpower": "+2"
     },
     "image_url": "/static/images/cards/smokestack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/smokestack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Her Durum kartı oluşturduğunda TÜM düşmanlara 7 hasar ver.",
@@ -1622,7 +1622,7 @@
       "summon": "+1"
     },
     "image_url": "/static/images/cards/dirge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dirge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "X kez 4 [gold]Çağır[/gold].\n[gold]Çekme Deste[/gold]'ne X adet [gold]Ruh+[/gold] ekle.",
@@ -1722,7 +1722,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/abrasive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/abrasive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "1 [gold]Beceriklilik[/gold] elde et.\n6 [gold]Diken[/gold] elde et.",
@@ -1763,7 +1763,7 @@
       "corrosivewave": "+1"
     },
     "image_url": "/static/images/cards/corrosive_wave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/corrosive_wave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Bu tur her kart çektiğinde TÜM düşmanlara 3 [gold]Zehir[/gold] uygula.",
@@ -1808,7 +1808,7 @@
       "poison": "+3"
     },
     "image_url": "/static/images/cards/bubble_bubble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Eğer düşman [gold]Zehir[/gold]'den etkilenmişse, 12 [gold]Zehir[/gold] uygula.",
@@ -1847,7 +1847,7 @@
       "cost": 7
     },
     "image_url": "/static/images/cards/banshees_cry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/banshees_cry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1962,7 +1962,7 @@
       "extrablock": "+2"
     },
     "image_url": "/static/images/cards/fasten.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fasten.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Savunma kartlarından fazladan 7 [gold]Blok[/gold] elde et.",
@@ -2002,7 +2002,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/transfigure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/transfigure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2093,7 +2093,7 @@
       "sleightoffleshpower": "+4"
     },
     "image_url": "/static/images/cards/sleight_of_flesh.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sleight_of_flesh.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Bir düşmana her güçsüzleştirme uyguladığında, düşman 13 hasar alır.",
@@ -2178,7 +2178,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/i_am_invincible.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/i_am_invincible.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13 [gold]Blok[/gold] elde et.\nTurunun sonunda bu kart [gold]Çekme Deste[/gold]'nin en üstündeyse otomatik olarak oynanır.",
@@ -2219,7 +2219,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/fuel.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fuel.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:1] elde et.\n2 kart çek.",
@@ -2312,7 +2312,7 @@
       "strength": "+2"
     },
     "image_url": "/static/images/cards/feeding_frenzy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Bu tur için 7 [gold]Kuvvet[/gold] elde et.",
@@ -2477,7 +2477,7 @@
       "damage": "+8"
     },
     "image_url": "/static/images/cards/knockout_blow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockout_blow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "38 hasar ver.\nBu kart bir düşmanı öldürürse [star:5] elde et.",
@@ -2524,7 +2524,7 @@
       "debilitatepower": "+1"
     },
     "image_url": "/static/images/cards/debilitate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debilitate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "12 hasar ver.\nSonraki 4 tur boyunca [gold]Savunmasız[/gold] ve [gold]Zayıf[/gold] düşman üzerinde iki kat daha etkili olur.",
@@ -2641,7 +2641,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/bombardment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bombardment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "24 hasar ver.\nBu kart, turunun başında [gold]Tüketme Deste[/gold]'nde ise kendi kendine oynanır.",
@@ -2732,7 +2732,7 @@
       "stranglepower": "+1"
     },
     "image_url": "/static/images/cards/strangle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/strangle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "10 hasar ver.\nBu tur her kart oynadığında düşman 3 CP kaybeder.",
@@ -2822,7 +2822,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/void_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/void_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2863,7 +2863,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/call_of_the_void.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/call_of_the_void.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -2943,7 +2943,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/gunk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gunk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "3 kez 5 hasar ver.\n[gold]Atık Deste[/gold]'ne bir [gold]Yapış Yapış[/gold] ekle.",
@@ -2982,7 +2982,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/ice_lance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ice_lance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "24 hasar ver.\n3 [gold]Buz[/gold] [gold]Oluştur[/gold].",
@@ -3101,7 +3101,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/big_bang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/big_bang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3145,7 +3145,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/conflagration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conflagration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM düşmanlara 8 hasar ver.\nBu tur oynadığın her Saldırı için fazladan 3 hasar verir.",
@@ -3184,7 +3184,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/jackpot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/jackpot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "30 hasar ver.\n[gold]El[/gold]'ine rastgele 3 adet  [gold]Geliştirilmiş[/gold] 0 [energy:1] kart ekle.",
@@ -3272,7 +3272,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/knife_trap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knife_trap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Tüketim Deste[/gold]'ndeki tüm [gold]Kamaları[/gold] [gold]Geliştir[/gold] ve düşmana oyna.",
@@ -3350,7 +3350,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/glasswork.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glasswork.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "8 [gold]Blok[/gold] elde et.\n1 [gold]Cam[/gold] [gold]Oluştur[/gold].",
@@ -3558,7 +3558,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/arsenal.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/arsenal.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3594,7 +3594,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/enthralled.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enthralled.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3637,7 +3637,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/murder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/murder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3675,7 +3675,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/begone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/begone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]El[/gold]'indeki kartlardan birini seç ve [gold]Uşak Saldırısı+[/gold] kartına [gold]Dönüştür[/gold].",
@@ -3806,7 +3806,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/caltrops.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/caltrops.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Saldırıldığında geri 5 hasar ver.",
@@ -3883,7 +3883,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/furnace.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/furnace.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Turunun başında 6 [gold]Döv[/gold].",
@@ -4000,7 +4000,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/colossus.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/colossus.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "8 [gold]Blok[/gold] elde et.\nBu tur, [gold]Savunmasız[/gold] olan düşmanlardan %50 daha az hasar al.",
@@ -4038,7 +4038,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/giant_rock.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/giant_rock.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "20 hasar ver.",
@@ -4078,7 +4078,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/maul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/maul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "İki kez 6 hasar ver.\nBu savaşta TÜM Deş kartlarının hasarını 2 artır.",
@@ -4116,7 +4116,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/distraction.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/distraction.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4331,7 +4331,7 @@
       "hailstormpower": "+2"
     },
     "image_url": "/static/images/cards/hailstorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hailstorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Turunun sonunda [gold]Buz[/gold]'a sahipsen TÜM düşmanlara 8 hasar ver.",
@@ -4407,7 +4407,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/quadcast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quadcast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4493,7 +4493,7 @@
       "vigorpower": "+2"
     },
     "image_url": "/static/images/cards/terraforming.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/terraforming.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "8 [gold]Dinç[/gold] elde et.",
@@ -4619,7 +4619,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/invoke.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/invoke.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sonraki tur 3 [gold]Çağır[/gold] ve [energy:3] elde et.",
@@ -4663,7 +4663,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sovereign_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sovereign_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4706,7 +4706,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM düşmanlara 11 hasar ver.",
@@ -4788,7 +4788,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/brightest_flame.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/brightest_flame.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3] elde et.\n3 kart çek.\n1 Maksimum CP kaybet.",
@@ -4828,7 +4828,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/energy_surge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/energy_surge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM oyuncular [energy:3] elde eder.",
@@ -4869,7 +4869,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/infection.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/infection.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4910,7 +4910,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/entropy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entropy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5085,7 +5085,7 @@
       "strengthloss": "+1"
     },
     "image_url": "/static/images/cards/crush_under.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crush_under.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM düşmanlara 8 hasar ver. Bu turda tüm düşmanlar 2 [gold]Kuvvet[/gold] kaybeder.",
@@ -5162,7 +5162,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/beat_down.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_down.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Atık Deste[/gold]'nden rastgele 4 Saldırı kartı oyna.",
@@ -5245,7 +5245,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/catastrophe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/catastrophe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Çekme Deste[/gold]'nden rastgele 3 kart oyna.",
@@ -5283,7 +5283,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/conqueror.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conqueror.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "5 [gold]Döv[/gold].\n[gold]Egemen Kılıcı[/gold] düşmana bu tur iki kat daha fazla hasar verir.",
@@ -5319,7 +5319,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/calamity.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/calamity.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5357,7 +5357,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/lantern_key.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lantern_key.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5401,7 +5401,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/photon_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/photon_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13 hasar ver.\n2 kart çek.\n[gold]El[/gold]'indeki 1 kartı [gold]Çekme Deste[/gold]'nin en üstüne koy.",
@@ -5482,7 +5482,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/spinner.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spinner.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "1 [gold]Cam[/gold] [gold]Oluştur[/gold].\nTurunun başında 1 [gold]Cam[/gold] [gold]Oluştur[/gold].",
@@ -5565,7 +5565,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/vicious.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/vicious.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Her [gold]Savunmasız[/gold] uyguladığında 2 kart çek.",
@@ -5645,7 +5645,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/voltaic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/voltaic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5702,7 +5702,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/gamma_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gamma_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "18 hasar ver.\n2 [gold]Zayıf[/gold] uygula.\n2 [gold]Savunmasız[/gold] uygula.",
@@ -5740,7 +5740,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/spoils_map.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_map.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5782,7 +5782,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/spite.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spite.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "5 hasar ver.\nBu turda CP kaybettiysen\n3 kez vurur.",
@@ -5822,7 +5822,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/boost_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/boost_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9 [gold]Blok[/gold] elde et.\n[gold]Atık Deste[/gold]'ne bir [gold]Sersemlemiş[/gold] ekle.",
@@ -5862,7 +5862,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/delay.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/delay.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13 [gold]Blok[/gold] elde et.\nBir sonraki tur\n[energy:2] elde et.",
@@ -6070,7 +6070,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/rebound.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rebound.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "12 hasar ver.\nBu tur sonraki oynayacağın kartı [gold]Çekme Deste[/gold]'nin en üstüne koy.",
@@ -6110,7 +6110,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/summon_forth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/summon_forth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "11 [gold]Döv[/gold].\n[gold]Egemen Kılıcı[/gold]'nı herhangi bir desteden [gold]El[/gold]'ine ekle.",
@@ -6193,7 +6193,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/hidden_daggers.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_daggers.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Elinden 2 kartı çıkar.\n[gold]El[/gold]'ine 2 [gold]Kama+[/gold] ekle.",
@@ -6233,7 +6233,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/up_my_sleeve.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/up_my_sleeve.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]El[/gold]'ine 4 [gold]Kama[/gold] ekle.\nBu kartın maliyetini 1 azalt.",
@@ -6279,7 +6279,7 @@
       "starnextturnpower": "+1"
     },
     "image_url": "/static/images/cards/hidden_cache.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_cache.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[star:1] elde et.\nSonraki turda [star:4] elde et.",
@@ -6483,7 +6483,7 @@
       "thunderpower": "+2"
     },
     "image_url": "/static/images/cards/thunder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/thunder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Her [gold]Yıldırım Tetiklediğinde[/gold] hasar alan her düşmana ayrıca 8 hasar ver.",
@@ -6600,7 +6600,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/shadow_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shadow_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "15 [gold]Blok[/gold] elde et.\n1 [gold]Karanlık[/gold] [gold]Oluştur[/gold].",
@@ -6676,7 +6676,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/bury.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bury.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "63 hasar ver.",
@@ -6712,7 +6712,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/largesse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/largesse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Başka bir oyuncunun [gold]El[/gold]'ine  [gold]Geliştirilmiş[/gold] rastgele bir Renksiz kart ekle.",
@@ -7010,7 +7010,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/seeker_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeker_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "12 hasar ver.\n[gold]El[/gold]'ine koymak için [gold]Çekme Deste[/gold]'ndeki 3 karttan 1 tanesini seç.",
@@ -7092,7 +7092,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/hegemony.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hegemony.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "18 hasar ver.\nBir sonraki tur [energy:3] elde et.",
@@ -7249,7 +7249,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/reap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "33 hasar ver.",
@@ -7292,7 +7292,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/precise_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/precise_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7339,7 +7339,7 @@
       "phantombladespower": "+3"
     },
     "image_url": "/static/images/cards/phantom_blades.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/phantom_blades.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Kamaların[/gold] [gold]Sakla[/gold] elde eder.\nHer tur oynadığın ilk [gold]Kama[/gold] fazladan 12 hasar verir.",
@@ -7474,7 +7474,7 @@
       "preptimepower": "+2"
     },
     "image_url": "/static/images/cards/prep_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prep_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Turunun başında 6 [gold]Dinç[/gold] elde et.",
@@ -7550,7 +7550,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/uproar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/uproar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "İki kez 7 hasar ver.\n[gold]Çekme Deste[/gold]'nden rastgele bir Saldırı oyna.",
@@ -7788,7 +7788,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/stratagem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stratagem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7873,7 +7873,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/alignment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/alignment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3] elde et.",
@@ -7909,7 +7909,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/juggling.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/juggling.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8044,7 +8044,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/prowess.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "2 [gold]Kuvvet[/gold] elde et.\n2 [gold]Beceriklilik[/gold] elde et.",
@@ -8082,7 +8082,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/venerate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/venerate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[star:3] elde et.",
@@ -8205,7 +8205,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/speedster.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/speedster.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8245,7 +8245,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/whistle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/whistle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "44 hasar ver.\nDüşmanı [gold]Sersemlet[/gold].",
@@ -8328,7 +8328,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/gather_light.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gather_light.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "11 [gold]Blok[/gold] elde et.\n[star:1] elde et.",
@@ -8455,7 +8455,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/refract.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refract.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "İki kez 12 hasar ver.\n2 [gold]Cam[/gold] [gold]Oluştur[/gold].",
@@ -8859,7 +8859,7 @@
       "blackholepower": "+1"
     },
     "image_url": "/static/images/cards/black_hole.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/black_hole.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[star:1] harcadığında veya elde ettiğinde, TÜM düşmanlara 4 hasar ver.",
@@ -8940,7 +8940,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/scrawl.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/scrawl.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9232,7 +9232,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/falling_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/falling_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "12 hasar ver.\n1 [gold]Zayıf[/gold] uygula.\n1 [gold]Savunmasız[/gold] uygula.",
@@ -9270,7 +9270,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/foregone_conclusion.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/foregone_conclusion.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sonraki turda [gold]Çekme Deste[/gold]'nden 3 kartı [gold]El[/gold]'ine koy.",
@@ -9386,7 +9386,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/shroud.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shroud.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Her [gold]Kader[/gold] uyguladığında 3 [gold]Blok[/gold] elde et.",
@@ -9502,7 +9502,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/legion_of_bone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/legion_of_bone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM oyuncular 8 [gold]Çağırır[/gold].",
@@ -9548,7 +9548,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/bone_shards.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bone_shards.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Eğer [gold]Osti[/gold] hayattaysa TÜM düşmanlara 12 hasar verir ve 12 [gold]Blok[/gold] elde edersin.\n[gold]Osti[/gold] ölür.",
@@ -9625,7 +9625,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/convergence.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/convergence.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sonraki turunda\n[energy:1] ve [star:2] elde et.\nBu turda [gold]El[/gold]'ini [gold]Sakla[/gold].",
@@ -9711,7 +9711,7 @@
       "strength": "+3"
     },
     "image_url": "/static/images/cards/coordinate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Başka bir oyuncuya bu tur için 8 [gold]Kuvvet[/gold] ver.",
@@ -9752,7 +9752,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/mimic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mimic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9883,7 +9883,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/bodyguard.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bodyguard.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "7 [gold]Çağır[/gold].",
@@ -9964,7 +9964,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/cosmic_indifference.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cosmic_indifference.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9 [gold]Blok[/gold] elde et.\n[gold]Atık Deste[/gold]'nden bir kartı [gold]Çekme Deste[/gold]'nin en üstüne koy.",
@@ -10002,7 +10002,7 @@
       "gold": "+5"
     },
     "image_url": "/static/images/cards/royalties.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royalties.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "Savaşın sonunda 35 [gold]Altın[/gold] elde et.",
@@ -10043,7 +10043,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/royal_gamble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royal_gamble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10124,7 +10124,7 @@
       "increase": "+2"
     },
     "image_url": "/static/images/cards/kingly_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/kingly_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "10 hasar ver.\nBu kartı her çektiğinde kartın hasarını bu savaş için 6 artır.",
@@ -10162,7 +10162,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/quasar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quasar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]El[/gold]'ine eklemek için [gold]Geliştirilmiş[/gold] rastgele 3 Renksiz karttan 1 tanesini seç.",
@@ -10379,7 +10379,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/comet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/comet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "44 hasar ver.\n3 [gold]Zayıf[/gold] uygula.\n3 [gold]Savunmasız[/gold] uygula.",
@@ -10583,7 +10583,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/bad_luck.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bad_luck.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10667,7 +10667,7 @@
       "blockonexhaust": "+1"
     },
     "image_url": "/static/images/cards/spirit_of_ash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spirit_of_ash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Her [gold]Ruhani[/gold] bir kart oynadığında 5 [gold]Blok[/gold] elde et.",
@@ -10706,7 +10706,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/refine_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refine_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13 [gold]Döv[/gold].\nSonraki tur [energy:1] elde et.",
@@ -10792,7 +10792,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sword_sage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sword_sage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10828,7 +10828,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/unmovable.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/unmovable.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10959,7 +10959,7 @@
       "crimsonmantlepower": "+2"
     },
     "image_url": "/static/images/cards/crimson_mantle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crimson_mantle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Turunun başında 1 CP kaybet ve 10 [gold]Blok[/gold] elde et.",
@@ -11046,7 +11046,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/defile.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/defile.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "17 hasar ver.",
@@ -11284,7 +11284,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/hello_world.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hello_world.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11498,7 +11498,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/graveblast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/graveblast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "6 hasar ver.\n[gold]Atık Deste[/gold]'nden bir kartı [gold]El[/gold]'ine koy.",
@@ -11540,7 +11540,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/modded.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/modded.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "1 Küre Yuvası elde et.\n2 kart çek. Bu kartın maliyetini 1 artır.",
@@ -11576,7 +11576,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/debris.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debris.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11617,7 +11617,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/monologue.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/monologue.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11657,7 +11657,7 @@
       "hploss": "+2"
     },
     "image_url": "/static/images/cards/haunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Her [gold]Ruh[/gold] kartı oynadığında rastgele bir düşman 8 CP kaybeder.",
@@ -11695,7 +11695,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/omnislice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/omnislice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "11 hasar ver.\nDiğer TÜM düşmanlara aynı miktarda hasar ver.",
@@ -11733,7 +11733,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/the_sealed_throne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_sealed_throne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11774,7 +11774,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/demesne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demesne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -11817,7 +11817,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/blade_of_ink.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/blade_of_ink.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]El[/gold]'ine 3 [purple]Mürekkepli[/purple] [gold]Kama[/gold] ekle.",
@@ -11859,7 +11859,7 @@
       "cards": "+2"
     },
     "image_url": "/static/images/cards/decisions_decisions.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/decisions_decisions.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "5 kart çek.\n[gold]El[/gold]'inden bir Beceri kartı seç ve 3 kez oyna.",
@@ -11994,7 +11994,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/bundle_of_joy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bundle_of_joy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]El[/gold]'ine rastgele 4 Renksiz kart ekle.",
@@ -12037,7 +12037,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/ultimate_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "20 hasar ver.",
@@ -12077,7 +12077,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/ultimate_defend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_defend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "15 [gold]Blok[/gold] elde et.",
@@ -12151,7 +12151,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/nostalgia.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/nostalgia.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12191,7 +12191,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -12241,7 +12241,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/neurosurge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neurosurge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:4] elde et.\n2 kart çek.\nTurunun başında kendine 3 [gold]Kader[/gold] uygula.",
@@ -12287,7 +12287,7 @@
       "platingpower": "+3"
     },
     "image_url": "/static/images/cards/neutron_aegis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neutron_aegis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "11 [gold]Zırh[/gold] elde et.",
@@ -12336,7 +12336,7 @@
       "focuspower": "+1"
     },
     "image_url": "/static/images/cards/focused_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/focused_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "11 hasar ver.\nBu tur 2 [gold]Odak[/gold] elde et.",
@@ -12418,7 +12418,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/automation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/automation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12456,7 +12456,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/manifest_authority.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/manifest_authority.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "8 [gold]Blok[/gold] elde et.\n[gold]El[/gold]'ine [gold]Geliştirilmiş[/gold] rastgele 1 Renksiz kart ekle.",
@@ -12546,7 +12546,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/lightning_rod.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lightning_rod.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "7 [gold]Blok[/gold] elde et.\nSonraki 2 turun başında 1 [gold]Yıldırım[/gold] [gold]Oluştur[/gold].",
@@ -12585,7 +12585,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/glow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[star:2] elde et.\n1 kart çek.\nSonraki turunda 1 kart çek.",
@@ -12626,7 +12626,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/shining_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shining_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "11 hasar ver.\n[star:2] elde et.\nBu kartı [gold]Çekme Deste[/gold]'nin en üstüne koy.",
@@ -12939,7 +12939,7 @@
       "damage": "+10"
     },
     "image_url": "/static/images/cards/devastate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devastate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "40 hasar ver.",
@@ -13025,7 +13025,7 @@
       "poison": "+2"
     },
     "image_url": "/static/images/cards/haze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM düşmanlara 6 [gold]Zehir[/gold] uygula.",
@@ -13072,7 +13072,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/relax.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/relax.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "17 [gold]Blok[/gold] elde et.\nSonraki turda 3 kart çek ve [energy:3] elde et.",
@@ -13196,7 +13196,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/rocket_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rocket_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "14 hasar ver.\n2 kart çek.\nHer Durum kartı oluşturduğunda bu kartın maliyeti, oynanana kadar 0 [energy:1] olur.",
@@ -13236,7 +13236,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/soul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "3 kart çek.",
@@ -13281,7 +13281,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/soul_storm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul_storm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9 hasar ver.\n[gold]Tüketme Deste[/gold]'ndeki her [gold]Ruh[/gold] için fazladan 3 hasar verir.",
@@ -13321,7 +13321,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/wisp.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wisp.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13408,7 +13408,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/seance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13449,7 +13449,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/eidolon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/eidolon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13497,7 +13497,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/apparition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/apparition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13704,7 +13704,7 @@
       "replay": "+1"
     },
     "image_url": "/static/images/cards/hidden_gem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_gem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "[gold]Çekme Deste[/gold]'nde [gold]Yeniden Oyna[/gold]'ya sahip olmayan rastgele bir karta 3 [gold]Yeniden Oyna[/gold] ekle.",
@@ -13754,7 +13754,7 @@
       "sicempower": "+1"
     },
     "image_url": "/static/images/cards/sic_em.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sic_em.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osti[/gold] 6 hasar verir.\n[gold]Osti[/gold] bu turda bu düşmana her vurduğunda 3 [gold]Çağır[/gold].",
@@ -14036,7 +14036,7 @@
       "outbreakpower": "+4"
     },
     "image_url": "/static/images/cards/outbreak.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outbreak.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Her 3 [gold]Zehir[/gold] uygulayışında TÜM düşmanlara 15 hasar ver.",
@@ -14074,7 +14074,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/believe_in_you.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/believe_in_you.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Bir diğer oyuncu [energy:3] elde eder.",
@@ -14152,7 +14152,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/helix_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/helix_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Bu turda harcadığın her [energy:1] için 5 hasar ver.",
@@ -14195,7 +14195,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/rattle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rattle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osti[/gold] 9 hasar verir.\nBu tur saldırdığı sayı kadar bir kez daha vurur.",
@@ -14244,7 +14244,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/fight_me.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "İki kez 6 hasar ver.\n4 [gold]Kuvvet[/gold] elde et.\nDüşman 1 [gold]Kuvvet[/gold] elde eder.",
@@ -14290,7 +14290,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/drum_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/drum_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "3 kart çek.\nTurunun başında [gold]Çekme Deste[/gold]'nin en üstündeki kartı [gold]Tüket[/gold].",
@@ -14329,7 +14329,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/spoils_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "8 [gold]Döv[/gold].\n2 kart çek.",
@@ -14407,7 +14407,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/fight_through.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_through.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "17 [gold]Blok[/gold] elde et.\n[gold]Atık Destene[/gold] 2 [gold]Yara[/gold] ekle.",
@@ -14447,7 +14447,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/wrought_in_war.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wrought_in_war.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9 hasar ver.\n9 [gold]Döv[/gold].",
@@ -14694,7 +14694,7 @@
       "parrypower": "+4"
     },
     "image_url": "/static/images/cards/parry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/parry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Egemen Kılıcı[/gold]'nı her oynadığında 14 [gold]Blok[/gold] elde et.",
@@ -14732,7 +14732,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/pagestorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pagestorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14774,7 +14774,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/right_hand_hand.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/right_hand_hand.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osti[/gold] 6 hasar verir.\nHer [energy:2] veya daha fazla maliyeti olan bir kart oynadığında bu kartı [gold]Atık Deste[/gold]'nden tekrar [gold]El[/gold]'ine koy.",
@@ -14848,7 +14848,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/entrench.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entrench.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14930,7 +14930,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/misery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/misery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9 hasar ver.\nBir düşmandaki güçsüzleştirmeleri diğer TÜM düşmanlara uygula.",
@@ -15017,7 +15017,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/ricochet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ricochet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "5 kez rastgele bir düşmana 3 hasar ver.",
@@ -15061,7 +15061,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/synchronize.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synchronize.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15102,7 +15102,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/synthesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synthesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "18 hasar ver.\nSonraki oynayacağın Güç kartının maliyeti 0 [energy:1] olur.",
@@ -15226,7 +15226,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/volley.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/volley.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "X kez rastgele bir düşmana 14 hasar ver.",
@@ -15345,7 +15345,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/crash_landing.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crash_landing.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM düşmanlara 26 hasar ver.\n[gold]El[/gold]'ini [gold]Moloz[/gold] ile doldur.",
@@ -15516,7 +15516,7 @@
       "sneakypower": "+1"
     },
     "image_url": "/static/images/cards/sneaky.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sneaky.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Başka bir oyuncu, bir düşmana her saldırdığında 2 [gold]Blok[/gold] elde et.",
@@ -15609,7 +15609,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/bulwark.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulwark.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "16 [gold]Blok[/gold] elde et.\n13 [gold]Döv[/gold].",
@@ -15686,7 +15686,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/pale_blue_dot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pale_blue_dot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Bir turda 5 veya daha fazla kart oynarsan bir sonraki turunun başında fazladan 2 kart çek.",
@@ -15886,7 +15886,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/spectrum_shift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spectrum_shift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15965,7 +15965,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/splash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/splash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Başka bir karaktere ait  [gold]Geliştirilmiş[/gold] rastgele 3 Saldırı kartından 1 tanesini [gold]El[/gold]'ine eklemek için seç. Bu tur oynaması ücretsiz olur.",
@@ -16138,7 +16138,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/supermassive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/supermassive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "5 hasar ver.\nBu savaşta oluşturduğun her kart için fazladan 4 hasar verir.",
@@ -16397,7 +16397,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/squeeze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/squeeze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osti[/gold] 25 hasar verir.\nTÜM diğer [gold]Osti[/gold] Saldırıların için fazladan 6 hasar verir.",
@@ -16437,7 +16437,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/compact.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/compact.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "7 [gold]Blok[/gold] elde et.\n[gold]El[/gold]'indeki tüm Durum kartlarını [gold]Benzin+[/gold] kartına [gold]Dönüştür[/gold].",
@@ -16517,7 +16517,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/rally.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rally.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM oyuncular 17 [gold]Blok[/gold] elde eder.",
@@ -16718,7 +16718,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/turbo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/turbo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3] elde et.\n[gold]Atık Deste[/gold]'ne bir [gold]Boşluk[/gold] ekle.",
@@ -16790,7 +16790,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/tracking.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tracking.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16880,7 +16880,7 @@
       "vigorpower": "+1"
     },
     "image_url": "/static/images/cards/patter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/patter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "11 [gold]Blok[/gold] elde et.\n3 [gold]Dinç[/gold] elde et.",
@@ -16961,7 +16961,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/tank.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tank.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17135,7 +17135,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/frantic_escape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/frantic_escape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -17178,7 +17178,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/sloth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sloth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -17255,7 +17255,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/tesla_coil.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tesla_coil.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "6 hasar ver.\nTüm [gold]Yıldırım[/gold] Kürelerini düşmana hasar verdirt.",
@@ -17469,7 +17469,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/huddle_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/huddle_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM oyuncular 3 kart çeker.",
@@ -17512,7 +17512,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/pull_from_below.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pull_from_below.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Bu savaşta oynanan her [gold]Ruhani[/gold] kart için 7 hasar ver.",
@@ -17551,7 +17551,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/toric_toughness.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/toric_toughness.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "7 [gold]Blok[/gold] elde et.\nSonraki 2 turun başında 7 [gold]Blok[/gold] elde et.",
@@ -17594,7 +17594,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/waste_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/waste_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -17636,7 +17636,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/the_scythe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_scythe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13 hasar ver.\nBu kartın hasarını kalıcı olarak 4 artır.",
@@ -17675,7 +17675,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/beacon_of_hope.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beacon_of_hope.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17916,7 +17916,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/adaptive_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/adaptive_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "23 hasar ver.\nBu kartın 0[energy:1] kopyasını [gold]Atık Destesi[/gold]'ne ekle.",
@@ -17953,7 +17953,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/poor_sleep.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/poor_sleep.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18076,7 +18076,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/flak_cannon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/flak_cannon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM Durum kartlarını [gold]Tüket[/gold].\n[gold]Tüketilen[/gold] her kart için rastgele bir düşmana 11 hasar ver.",
@@ -18201,7 +18201,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/minion_sacrifice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_sacrifice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "12 [gold]Blok[/gold] elde et.",
@@ -18248,7 +18248,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/minion_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9 hasar ver.\n1 kart çek.",
@@ -18341,7 +18341,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/feral.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feral.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18420,7 +18420,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/heirloom_hammer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heirloom_hammer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "25 hasar ver.\n[gold]El[/gold]'indeki bir Renksiz kartı seç. Bu kartın bir kopyasını [gold]El[/gold]'ine koy.",
@@ -18505,7 +18505,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/hotfix.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hotfix.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18597,7 +18597,7 @@
       "strengthpower": "+1"
     },
     "image_url": "/static/images/cards/resonance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/resonance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "2 [gold]Kuvvet[/gold] elde et. TÜM düşmanlar 1 [gold]Kuvvet[/gold] kaybeder.",
@@ -18674,7 +18674,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/reflect.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reflect.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "21 [gold]Blok[/gold] elde et.\nEngellenen saldırı hasarı bu tur düşmanına geri yönlendirilir.",
@@ -18797,7 +18797,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/rend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "15 hasar ver.\nDüşmandaki her eşsiz güçsüzleştirme için fazladan 8 hasar verir.",
@@ -18951,7 +18951,7 @@
       "starsperturn": "+1"
     },
     "image_url": "/static/images/cards/genesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/genesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Turunun başında [star:3] elde et.",
@@ -18989,7 +18989,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/pillar_of_creation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillar_of_creation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Her kart oluşturduğunda 4 [gold]Blok[/gold] elde et.",
@@ -19033,7 +19033,7 @@
       "ostydamage": "+5"
     },
     "image_url": "/static/images/cards/sweeping_gaze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sweeping_gaze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osti[/gold] rastgele bir düşmana 15 hasar verir.",
@@ -19114,7 +19114,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/forbidden_grimoire.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/forbidden_grimoire.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19193,7 +19193,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/barrage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/barrage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Her [gold]Oluşturulan[/gold] Küre için 7 hasar ver.",
@@ -19231,7 +19231,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/salvo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/salvo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "16 hasar ver.\nBu tur [gold]El[/gold]'ini [gold]Sakla[/gold].",
@@ -19269,7 +19269,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/pillage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9 hasar ver.\nSaldırı olmayan bir kart gelene kadar kart çek.",
@@ -19309,7 +19309,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/seven_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seven_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19399,7 +19399,7 @@
       "knockdownpower": "+1"
     },
     "image_url": "/static/images/cards/knockdown.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockdown.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "14 hasar ver.\nDüşman bu turda diğer oyunculardan üç kat daha fazla hasar alır.",
@@ -19498,7 +19498,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/know_thy_place.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/know_thy_place.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19542,7 +19542,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/guiding_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/guiding_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13 hasar ver.\n3 kart çek.",
@@ -19580,7 +19580,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/fisticuffs.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fisticuffs.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9 hasar ver.\nVerdiğin hasarla aynı miktarda [gold]Blok[/gold] elde et.",
@@ -19626,7 +19626,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/consuming_shadow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/consuming_shadow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "3 [gold]Karanlık[/gold] [gold]Oluştur[/gold].\nTurunun sonunda en soldaki Küre'ni [gold]Tetikle[/gold].",
@@ -19672,7 +19672,7 @@
       "rollingboulderpower": "+5"
     },
     "image_url": "/static/images/cards/rolling_boulder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rolling_boulder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Turunun başında TÜM düşmanlara 10 hasar ver ve bu hasarı 5 artır.",
@@ -19710,7 +19710,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/intercept.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/intercept.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "13 [gold]Blok[/gold] elde et.\nBu tur başka bir oyuncuya verilecek tüm saldırıları üstüne çek.",
@@ -19786,7 +19786,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/ascenders_bane.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ascenders_bane.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19829,7 +19829,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/lift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Başka bir oyuncuya 16 [gold]Blok[/gold] ver.",
@@ -19869,7 +19869,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/dredge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dredge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19964,7 +19964,7 @@
       "serpentformpower": "+2"
     },
     "image_url": "/static/images/cards/serpent_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/serpent_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Her kart oynadığında rastgele bir düşmana 6 hasar ver.",
@@ -20174,7 +20174,7 @@
       "blockforstars": "+1"
     },
     "image_url": "/static/images/cards/child_of_the_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/child_of_the_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Her [star:1] harcadığında harcadığın her [star:1] için 3 [gold]Blok[/gold] elde et.",
@@ -20331,7 +20331,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/stack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Atık Deste[/gold]'ndeki kart sayısı kadar [gold]Blok[/gold] kazan.  +3 Blok daha ekle",
@@ -20468,7 +20468,7 @@
       "strengthloss": "+3"
     },
     "image_url": "/static/images/cards/enfeebling_touch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enfeebling_touch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Düşman bu tur 11 [gold]Kuvvet[/gold] kaybeder.",
@@ -20732,7 +20732,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/mind_rot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mind_rot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -20768,7 +20768,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/spore_mind.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spore_mind.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20849,7 +20849,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/tyranny.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tyranny.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21019,7 +21019,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/collision_course.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/collision_course.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "15 hasar ver.\n[gold]El[/gold]'ine 1 [gold]Moloz[/gold] ekle.",
@@ -21057,7 +21057,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/shatter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shatter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM düşmanlara 15 hasar ver.\nTüm Kürelerini [gold]Tetikle[/gold].",
@@ -21095,7 +21095,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/clash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/clash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Yalnızca [gold]El[/gold]'indeki tüm kartlar Saldırı ise oynanabilir.\n18 hasar ver.",
@@ -21171,7 +21171,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/cascade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cascade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Çekme Deste[/gold]'nin en üstündeki X+1 kartı oyna.",
@@ -21207,7 +21207,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/beckon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beckon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21243,7 +21243,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/hammer_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hammer_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21443,7 +21443,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/dual_wield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Bir Saldırı veya Güç kartı seç. Bu kartın 2 kopyasını [gold]El[/gold]'ine ekle.",
@@ -21962,7 +21962,7 @@
       "strengthloss": "+2"
     },
     "image_url": "/static/images/cards/dying_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dying_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM düşmanlara 11 hasar ver. Bu tur TÜM düşmanlar 11 [gold]Kuvvet[/gold] kaybeder.",
@@ -22011,7 +22011,7 @@
       "dansemacabrepower": "+2"
     },
     "image_url": "/static/images/cards/danse_macabre.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/danse_macabre.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Bedeli en az [energy:2] olan bir kartı her oynadığında 6 [gold]Blok[/gold] elde et.",
@@ -22101,7 +22101,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/necro_mastery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/necro_mastery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "8 [gold]Çağır[/gold].\n[gold]Osti[/gold] her CP kaybettiğinde\nTÜM düşmanlar da aynı miktarda CP kaybeder.",
@@ -22180,7 +22180,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/undeath.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/undeath.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9 [gold]Blok[/gold] elde et.\nBu kartın bir kopyasını [gold]Atık Deste[/gold]'ne ekle.",
@@ -22272,7 +22272,7 @@
       "lethalitypower": "+25"
     },
     "image_url": "/static/images/cards/lethality.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lethality.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Her tur yapacağın ilk Saldırı %75 daha fazla hasar verir.",
@@ -22314,7 +22314,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/deaths_door.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/deaths_door.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "7 [gold]Blok[/gold] elde et.\nEğer bu tur [gold]Kader[/gold] uyguladıysan 2 kez daha [gold]Blok[/gold] elde et.",
@@ -22361,7 +22361,7 @@
       "devourlifepower": "+1"
     },
     "image_url": "/static/images/cards/devour_life.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devour_life.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Her [gold]Ruh[/gold] oynadığında 2 [gold]Çağır[/gold].",
@@ -22453,7 +22453,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/leading_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/leading_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "6 hasar ver.\n[gold]El[/gold]'ine 2 [gold]Kama[/gold] ekle.",
@@ -22578,7 +22578,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/glimpse_beyond.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glimpse_beyond.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM oyuncular [gold]Çekme Deste[/gold]'lerine 4 [gold]Ruh[/gold] ekler.",
@@ -22620,7 +22620,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/make_it_so.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/make_it_so.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "9 hasar ver.\nHer 3 Beceri kartı oynadığında bu kartı [gold]El[/gold]'ine koy.",
@@ -22660,7 +22660,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/production.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/production.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[energy:3] elde et.",
@@ -22739,7 +22739,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/outmaneuver.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outmaneuver.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Sonraki tur [energy:3] elde et.",
@@ -22779,7 +22779,7 @@
       "extradamage": "+2"
     },
     "image_url": "/static/images/cards/gang_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gang_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "5 hasar ver.\nBaşka bir oyuncunun bu turda yaptığı her saldırı için fazladan 7 hasar verir.",
@@ -23028,7 +23028,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/heavenly_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heavenly_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "X kez 10 hasar ver.\nEnerjin 4 veya daha fazlaysa X iki katına çıkar.",
@@ -23245,7 +23245,7 @@
       "dexterity": "+1"
     },
     "image_url": "/static/images/cards/bulk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "1 Küre Yuvası kaybet.\n3 [gold]Kuvvet[/gold] elde et.\n3 [gold]Beceriklilik[/gold] elde et.",
@@ -23281,7 +23281,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/soot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -23376,7 +23376,7 @@
       "iterationpower": "+1"
     },
     "image_url": "/static/images/cards/iteration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/iteration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "Her tur ilk Durum kartı çekişinde 3 kart daha çek.",
@@ -23454,7 +23454,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/seeking_edge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeking_edge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "11 [gold]Döv[/gold].\n[gold]Egemen Kılıcı[/gold] artık TÜM düşmanlara hasar verir.",
@@ -23617,7 +23617,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sculpting_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sculpting_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "12 hasar ver.\n[gold]El[/gold]'indeki bir karta [gold]Ruhani[/gold] ekle.",
@@ -23659,7 +23659,7 @@
       "calculationextra": "+2"
     },
     "image_url": "/static/images/cards/beat_into_shape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_into_shape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "7 hasar ver.\nX [gold]Döv[/gold].\nBu tur düşmana yaptığın her vuruş için fazladan 7 [gold]Dövme[/gold] uygular.",
@@ -23746,7 +23746,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/demonic_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demonic_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23863,7 +23863,7 @@
       "power": "+2"
     },
     "image_url": "/static/images/cards/shockwave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shockwave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "TÜM düşmanlara 5 [gold]Zayıf[/gold] ve [gold]Savunmasız[/gold] uygula.",
@@ -23907,7 +23907,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/snap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/snap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]Osti[/gold] 10 hasar verir.\n[gold]El[/gold]'indeki bir karta [gold]Sakla[/gold] ekle.",

--- a/data/zhs/cards.json
+++ b/data/zhs/cards.json
@@ -31,7 +31,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/seven_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seven_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -69,7 +69,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/omnislice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/omnislice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成11点伤害。\n对所有其他敌人造成等量的伤害。",
@@ -184,7 +184,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/begone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/begone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "选择你[gold]手牌[/gold]中的一张牌，将其[gold]变化[/gold]为[gold]仆从打击+[/gold]。",
@@ -224,7 +224,7 @@
       "strengthloss": "+1"
     },
     "image_url": "/static/images/cards/crush_under.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crush_under.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "对所有敌人造成8点伤害。所有敌人在本回合失去2点[gold]力量[/gold]。",
@@ -262,7 +262,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/undeath.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/undeath.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得9点[gold]格挡[/gold]。\n在[gold]弃牌堆[/gold]放入一张此牌的复制品。",
@@ -311,7 +311,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/fight_me.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_me.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成6点伤害两次。\n获得4点[gold]力量[/gold]。\n该敌人获得1点[gold]力量[/gold]。",
@@ -404,7 +404,7 @@
       "platingpower": "+3"
     },
     "image_url": "/static/images/cards/neutron_aegis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neutron_aegis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得11层[gold]覆甲[/gold]。",
@@ -531,7 +531,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/pagestorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pagestorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -605,7 +605,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/necro_mastery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/necro_mastery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]召唤[/gold]8。\n每当[gold]奥斯提[/gold]失去生命值时，\n所有敌人失去等量生命值。",
@@ -645,7 +645,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/pull_from_below.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pull_from_below.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "本场战斗中每打出过一张[gold]虚无[/gold]牌，此牌就造成7点伤害一次。",
@@ -683,7 +683,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/clash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/clash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "只有在[gold]手牌[/gold]中每一张牌都是攻击牌时才能被打出。\n造成18点伤害。",
@@ -760,7 +760,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/synthesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synthesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成18点伤害。\n你打出的下一张能力牌耗能变为0[energy:1]。",
@@ -849,7 +849,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/minion_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成9点伤害。\n抽1张牌。",
@@ -894,7 +894,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/minion_sacrifice.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/minion_sacrifice.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得12点[gold]格挡[/gold]。",
@@ -936,7 +936,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/heirloom_hammer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heirloom_hammer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成25点伤害。\n选择你[gold]手牌[/gold]中的一张无色牌。将这张牌的一张复制品放入你的[gold]手牌[/gold]。",
@@ -1029,7 +1029,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/gamma_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gamma_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成18点伤害。\n给予2层[gold]虚弱[/gold]。\n给予2层[gold]易伤[/gold]。",
@@ -1083,7 +1083,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/know_thy_place.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/know_thy_place.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1205,7 +1205,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/hello_world.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hello_world.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1339,7 +1339,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/reflect.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reflect.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得21点[gold]格挡[/gold]。\n在本回合将你格挡掉的攻击伤害反弹给攻击者。",
@@ -1416,7 +1416,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/cascade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cascade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "打出你[gold]抽牌堆[/gold]顶部的X+1张牌。",
@@ -1588,7 +1588,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/leading_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/leading_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成6点伤害。\n将2张[gold]小刀[/gold]加入你的[gold]手牌[/gold]。",
@@ -1629,7 +1629,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/photon_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/photon_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成13点伤害。\n抽2张牌。\n将[gold]手牌[/gold]中的一张牌放到[gold]抽牌堆[/gold]顶部。",
@@ -1714,7 +1714,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/spectrum_shift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spectrum_shift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -1844,7 +1844,7 @@
       "strengthpower": "+1"
     },
     "image_url": "/static/images/cards/resonance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/resonance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得2点[gold]力量[/gold]。所有敌人失去1点[gold]力量[/gold]。",
@@ -1922,7 +1922,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/turbo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/turbo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得[energy:3]。\n将一张[gold]虚空[/gold]加入你的[gold]弃牌堆[/gold]。",
@@ -1961,7 +1961,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/ice_lance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ice_lance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成24点伤害。\n[gold]生成[/gold]3个[gold]冰霜[/gold]充能球。",
@@ -2085,7 +2085,7 @@
       "hailstormpower": "+2"
     },
     "image_url": "/static/images/cards/hailstorm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hailstorm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "在你的回合结束时，如果你有[gold]冰霜[/gold]充能球，则对所有敌人造成8点伤害。",
@@ -2204,7 +2204,7 @@
       "damage": "+8"
     },
     "image_url": "/static/images/cards/knockout_blow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockout_blow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成38点伤害。\n如果此牌击杀了敌人，获得[star:5]。",
@@ -2245,7 +2245,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/luminesce.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/luminesce.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得[energy:3]。",
@@ -2422,7 +2422,7 @@
       "preptimepower": "+2"
     },
     "image_url": "/static/images/cards/prep_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prep_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "在你的回合开始时，获得6点[gold]活力[/gold]。",
@@ -2542,7 +2542,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/vicious.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/vicious.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你给予[gold]易伤[/gold]时，抽2张牌。",
@@ -2631,7 +2631,7 @@
       "knockdownpower": "+1"
     },
     "image_url": "/static/images/cards/knockdown.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knockdown.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成14点伤害。\n该敌人在本回合受到的来自其他玩家的伤害变为三倍。",
@@ -2769,7 +2769,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/knife_trap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/knife_trap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "将你[gold]消耗牌堆[/gold]中的所有[gold]小刀[/gold][gold]升级[/gold]然后对一名敌人打出。",
@@ -2926,7 +2926,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/severance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/severance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成18点伤害。\n将一张[gold]灵魂[/gold]分别加入你的[gold]抽牌堆[/gold]，[gold]手牌[/gold]和[gold]弃牌堆[/gold]中。",
@@ -2964,7 +2964,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/pillar_of_creation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillar_of_creation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你生成一张卡牌, 就获得4点[gold]格挡[/gold]。",
@@ -3002,7 +3002,7 @@
       "starsperturn": "+1"
     },
     "image_url": "/static/images/cards/genesis.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/genesis.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "在你的回合开始时，获得[star:3]。",
@@ -3172,7 +3172,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/veilpiercer.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/veilpiercer.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成13点伤害。\n你打出的下一张[gold]虚无[/gold]牌耗能变为0[energy:1]。",
@@ -3219,7 +3219,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sword_sage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sword_sage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3340,7 +3340,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/pillage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pillage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成9点伤害。\n抽牌直到你抽到一张非攻击牌。",
@@ -3425,7 +3425,7 @@
       "extrablock": "+2"
     },
     "image_url": "/static/images/cards/fasten.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fasten.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "从“防御”牌中额外获得7点[gold]格挡[/gold]。",
@@ -3499,7 +3499,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/trash_to_treasure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/trash_to_treasure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -3582,7 +3582,7 @@
       "strength": "+3"
     },
     "image_url": "/static/images/cards/coordinate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/coordinate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "在本回合给予其他玩家8点[gold]力量[/gold]。",
@@ -3620,7 +3620,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/shroud.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shroud.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你给予[gold]灾厄[/gold]时，获得3点[gold]格挡[/gold]。",
@@ -3759,7 +3759,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/compact.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/compact.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得7点[gold]格挡[/gold]。\n将你[gold]手牌[/gold]中的全部状态牌[gold]变化[/gold]为[gold]燃料+[/gold]。",
@@ -3960,7 +3960,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/dual_wield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dual_wield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "选择一张攻击牌或能力牌。将2张此牌的复制品加入你的[gold]手牌[/gold]。",
@@ -4196,7 +4196,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/hang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成13点伤害。\n让所有“吊杀”牌对这名敌人造成的伤害翻倍。",
@@ -4237,7 +4237,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/synchronize.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/synchronize.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4317,7 +4317,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/manifest_authority.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/manifest_authority.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得8点[gold]格挡[/gold]。\n将一张随机[gold]升级过的[/gold]无色牌加入你的[gold]手牌[/gold]。",
@@ -4361,7 +4361,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/sovereign_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sovereign_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4410,7 +4410,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/consuming_shadow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/consuming_shadow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]生成[/gold]3个[gold]黑暗[/gold]充能球。\n在你的回合结束时，[gold]激发[/gold]你最左侧的充能球。",
@@ -4457,7 +4457,7 @@
       "devourlifepower": "+1"
     },
     "image_url": "/static/images/cards/devour_life.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devour_life.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你打出一张[gold]灵魂[/gold]时，[gold]召唤[/gold]2。",
@@ -4582,7 +4582,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/whistle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/whistle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成44点伤害。\n[gold]击晕[/gold]该敌人。",
@@ -4621,7 +4621,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/beckon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beckon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -4710,7 +4710,7 @@
       "poison": "+3"
     },
     "image_url": "/static/images/cards/bubble_bubble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bubble_bubble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "如果敌方拥有[gold]中毒[/gold]，则给予12层[gold]中毒[/gold]。",
@@ -4751,7 +4751,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/snap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/snap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]奥斯提[/gold]造成10点伤害。\n给[gold]手牌[/gold]中的一张牌添加[gold]保留[/gold]。",
@@ -4838,7 +4838,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/invoke.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/invoke.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "在下个回合[gold]召唤[/gold]3并获得[energy:3]。",
@@ -4915,7 +4915,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/quadcast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quadcast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5041,7 +5041,7 @@
       "vigorpower": "+2"
     },
     "image_url": "/static/images/cards/terraforming.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/terraforming.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得8点[gold]活力[/gold]。",
@@ -5193,7 +5193,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/unmovable.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/unmovable.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5270,7 +5270,7 @@
       "block": "+2"
     },
     "image_url": "/static/images/cards/toric_toughness.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/toric_toughness.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得7点[gold]格挡[/gold]。\n在接下来的2个回合开始时，获得7点[gold]格挡[/gold]。",
@@ -5311,7 +5311,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/graveblast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/graveblast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成6点伤害。\n将[gold]弃牌堆[/gold]中的一张牌放入你的[gold]手牌[/gold]。",
@@ -5352,7 +5352,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/bury.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bury.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成63点伤害。",
@@ -5391,7 +5391,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/stack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得等量于与你当前[gold]弃牌堆[/gold]中牌数+3的[gold]格挡[/gold]值。",
@@ -5476,7 +5476,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/blade_of_ink.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/blade_of_ink.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "添加3张[purple]墨影[/purple][gold]小刀[/gold]到你的[gold]手牌[/gold]。",
@@ -5550,7 +5550,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/distraction.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/distraction.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5708,7 +5708,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/jackpot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/jackpot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成30点伤害。\n将3张随机[gold]升级过[/gold]的0[energy:1]的牌加入你的[gold]手牌[/gold]。",
@@ -5751,7 +5751,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/big_bang.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/big_bang.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -5918,7 +5918,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/heavenly_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/heavenly_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成10点伤害X次。\n如果X的最终数值为4或以上，则将X的数值翻倍。",
@@ -6112,7 +6112,7 @@
       "cost": 7
     },
     "image_url": "/static/images/cards/banshees_cry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/banshees_cry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6187,7 +6187,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/make_it_so.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/make_it_so.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成9点伤害。\n你每在一回合内打出3张技能牌，就将这张牌放入你的[gold]手牌[/gold]。",
@@ -6298,7 +6298,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/subroutine.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/subroutine.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6334,7 +6334,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/spore_mind.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spore_mind.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6413,7 +6413,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/cosmic_indifference.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/cosmic_indifference.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得9点[gold]格挡[/gold]。\n将[gold]弃牌堆[/gold]中的一张牌放到你的[gold]抽牌堆[/gold]的顶部。",
@@ -6615,7 +6615,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/the_sealed_throne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_sealed_throne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -6829,7 +6829,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/venerate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/venerate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得[star:3]。",
@@ -6868,7 +6868,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/colossus.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/colossus.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得8点[gold]格挡[/gold]。\n在本回合中，有[gold]易伤[/gold]状态的敌人对你造成的伤害降低50%。",
@@ -6906,7 +6906,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/giant_rock.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/giant_rock.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成20点伤害。",
@@ -6948,7 +6948,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/the_scythe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_scythe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成13点伤害。\n这张牌在本局游戏中的伤害永久性增加4。",
@@ -6987,7 +6987,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/entrench.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entrench.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7023,7 +7023,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/beacon_of_hope.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beacon_of_hope.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7117,7 +7117,7 @@
       "phantombladespower": "+3"
     },
     "image_url": "/static/images/cards/phantom_blades.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/phantom_blades.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]小刀[/gold]获得[gold]保留[/gold]。\n你在每回合打出的第一张[gold]小刀[/gold]额外造成12点伤害。",
@@ -7155,7 +7155,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/eidolon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/eidolon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7412,7 +7412,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/guiding_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/guiding_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成13点伤害。\n抽3张牌。",
@@ -7450,7 +7450,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/ignition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ignition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -7499,7 +7499,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/lightning_rod.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lightning_rod.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得7点[gold]格挡[/gold]。\n在下2个回合开始时,[gold]生成[/gold]1个[gold]闪电[/gold]充能球。",
@@ -7539,7 +7539,7 @@
       "strengthloss": "+3"
     },
     "image_url": "/static/images/cards/enfeebling_touch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enfeebling_touch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "让一名敌人在本回合内失去11点[gold]力量[/gold]。",
@@ -7580,7 +7580,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/rebound.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rebound.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成12点伤害。\n将你在本回合打出的下一张牌放置到你的[gold]抽牌堆[/gold]顶部。",
@@ -7620,7 +7620,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/barrage.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/barrage.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "当前每有一个[gold]充能球[/gold]，造成7点伤害。",
@@ -7706,7 +7706,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/fight_through.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fight_through.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得17点[gold]格挡[/gold]。\n将2张[gold]伤口[/gold]加入你的[gold]弃牌堆[/gold]。",
@@ -7760,7 +7760,7 @@
       "damage": "+11"
     },
     "image_url": "/static/images/cards/comet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/comet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成44点伤害。\n给予3层[gold]虚弱[/gold]。\n给予3层[gold]易伤[/gold]。",
@@ -7843,7 +7843,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/glimpse_beyond.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glimpse_beyond.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "在所有玩家的[gold]抽牌堆[/gold]中加入4张[gold]灵魂[/gold]。",
@@ -7924,7 +7924,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/summon_forth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/summon_forth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]铸造[/gold]11。\n不论何处，将[gold]君王之剑[/gold]放入你的[gold]手牌[/gold]。",
@@ -7962,7 +7962,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/conqueror.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conqueror.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]铸造[/gold]5。\n[gold]君王之剑[/gold]在本回合对敌人造成双倍伤害。",
@@ -8004,7 +8004,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/right_hand_hand.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/right_hand_hand.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]奥斯提[/gold]造成6点伤害。\n每当你打出耗能为[energy:2]或以上的牌，将此牌从[gold]弃牌堆[/gold]放回你的[gold]手牌[/gold]。",
@@ -8163,7 +8163,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/mind_rot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mind_rot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -8402,7 +8402,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/nostalgia.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/nostalgia.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8479,7 +8479,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/spite.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spite.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成5点伤害。\n如果你在本回合失去过生命值，\n则攻击3次。",
@@ -8661,7 +8661,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/demonic_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demonic_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8824,7 +8824,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/infection.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/infection.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -8942,7 +8942,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/largesse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/largesse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "将一张随机的[gold]升级过的[/gold]无色牌添加至一位其他玩家的[gold]手牌[/gold]中。",
@@ -8985,7 +8985,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/sloth.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sloth.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -9024,7 +9024,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/spoils_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]铸造[/gold]8。\n抽2张牌。",
@@ -9195,7 +9195,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/wrought_in_war.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wrought_in_war.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成9点伤害。\n[gold]铸造[/gold]9。",
@@ -9284,7 +9284,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/drum_of_battle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/drum_of_battle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "抽3张牌。\n在你的回合开始时，[gold]消耗[/gold]你的[gold]抽牌堆[/gold]顶部的牌。",
@@ -9363,7 +9363,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/i_am_invincible.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/i_am_invincible.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得13点[gold]格挡[/gold]。\n在你的回合结束时，如果这张牌位于[gold]抽牌堆[/gold]顶部，则将其打出。",
@@ -9639,7 +9639,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/shatter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shatter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "对所有敌人造成15点伤害。\n[gold]激发[/gold]所有充能球。",
@@ -9677,7 +9677,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/lift.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lift.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "给另一名玩家16点[gold]格挡[/gold]。",
@@ -9713,7 +9713,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/enthralled.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/enthralled.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -9845,7 +9845,7 @@
       "ostydamage": "+5"
     },
     "image_url": "/static/images/cards/sweeping_gaze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sweeping_gaze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]奥斯提[/gold]对随机一名敌人造成15点伤害。",
@@ -9971,7 +9971,7 @@
       "cards": "+2"
     },
     "image_url": "/static/images/cards/decisions_decisions.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/decisions_decisions.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "抽5张牌。\n选择你[gold]手牌[/gold]中的一张技能牌，并将其打出3次。",
@@ -10051,7 +10051,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/refract.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refract.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成12点伤害两次。\n[gold]生成[/gold]2个[gold]玻璃[/gold]充能球。",
@@ -10089,7 +10089,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/outmaneuver.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outmaneuver.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "在下个回合获得[energy:3]。",
@@ -10127,7 +10127,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/bodyguard.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bodyguard.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]召唤[/gold]7。",
@@ -10210,7 +10210,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/huddle_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/huddle_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "所有玩家抽3张牌。",
@@ -10291,7 +10291,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/delay.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/delay.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得13点[gold]格挡[/gold]。\n在下个回合，\n获得[energy:2]。",
@@ -10338,7 +10338,7 @@
       "parrypower": "+4"
     },
     "image_url": "/static/images/cards/parry.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/parry.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你打出[gold]君王之剑[/gold]时，获得14点[gold]格挡[/gold]。",
@@ -10379,7 +10379,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/mimic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/mimic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -10420,7 +10420,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/intercept.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/intercept.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得13点[gold]格挡[/gold]。\n将本回合所有要对另一名玩家发起的攻击转移到你的身上。",
@@ -10458,7 +10458,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/fisticuffs.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fisticuffs.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成9点伤害。\n获得等量于所造成伤害的[gold]格挡[/gold]。",
@@ -10547,7 +10547,7 @@
       "summon": "+1"
     },
     "image_url": "/static/images/cards/dirge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dirge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]召唤[/gold]4X次。\n将X张[gold]灵魂+[/gold]添加到你的[gold]抽牌堆[/gold]中。",
@@ -10633,7 +10633,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/seeker_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeker_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成12点伤害。\n从[gold]抽牌堆[/gold]的随机3张牌中选择一张加入你的[gold]手牌[/gold]。",
@@ -10680,7 +10680,7 @@
       "debilitatepower": "+1"
     },
     "image_url": "/static/images/cards/debilitate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debilitate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成12点伤害。\n在接下来的4回合内，该敌人身上的[gold]易伤[/gold]与[gold]虚弱[/gold]效果翻倍。",
@@ -10720,7 +10720,7 @@
       "increase": "+1"
     },
     "image_url": "/static/images/cards/maul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/maul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成6点伤害两次。\n在这场战斗中，将所有“撕咬”牌的伤害增加2。",
@@ -10761,7 +10761,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/rend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成15点伤害。\n该名敌人身上每有一种负面效果，就额外造成8点伤害。",
@@ -10846,7 +10846,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "对所有敌人造成11点伤害。",
@@ -10889,7 +10889,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/reap.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reap.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成33点伤害。",
@@ -10931,7 +10931,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/gather_light.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gather_light.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得11点[gold]格挡[/gold]。\n获得[star:1]。",
@@ -10975,7 +10975,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/relax.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/relax.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得17点[gold]格挡[/gold]。\n下个回合，抽3张牌并获得[energy:3]。",
@@ -11057,7 +11057,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/flak_cannon.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/flak_cannon.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]消耗[/gold]你所有的状态牌。\n每有一张被[gold]消耗[/gold]的牌，就随机对敌人造成11点伤害。",
@@ -11179,7 +11179,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/bundle_of_joy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bundle_of_joy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "将4张随机无色牌添加到你的[gold]手牌[/gold]。",
@@ -11227,7 +11227,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/spinner.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spinner.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]生成[/gold]1个[gold]玻璃[/gold]充能球。\n在你的回合开始时，[gold]生成[/gold]1个[gold]玻璃[/gold]充能球。",
@@ -11495,7 +11495,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/foregone_conclusion.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/foregone_conclusion.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "在下个回合，从你的[gold]抽牌堆[/gold]中选择3张牌放入你的[gold]手牌[/gold]。",
@@ -11573,7 +11573,7 @@
       "heal": "+3"
     },
     "image_url": "/static/images/cards/not_yet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/not_yet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "回复13点生命。",
@@ -11617,7 +11617,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/shining_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shining_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成11点伤害。\n获得[star:2]。\n将这张牌放置于你的[gold]抽牌堆[/gold]顶部。",
@@ -11656,7 +11656,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/alignment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/alignment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得[energy:3]。",
@@ -11741,7 +11741,7 @@
       "vigorpower": "+1"
     },
     "image_url": "/static/images/cards/patter.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/patter.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得11点[gold]格挡[/gold]。\n获得3点[gold]活力[/gold]。",
@@ -11784,7 +11784,7 @@
       "strengthloss": "+2"
     },
     "image_url": "/static/images/cards/dying_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dying_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "对所有敌人造成11点伤害。所有敌人在本回合中失去11点[gold]力量[/gold]。",
@@ -11826,7 +11826,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/astral_pulse.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/astral_pulse.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "对所有敌人造成18点伤害。",
@@ -11905,7 +11905,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/shadow_shield.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shadow_shield.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得15点[gold]格挡[/gold]。\n[gold]生成[/gold]1个[gold]黑暗[/gold]充能球。",
@@ -11982,7 +11982,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/pale_blue_dot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/pale_blue_dot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "如果你在一回合内打出了大于等于5张牌，在下个回合开始时抽2张牌。",
@@ -12020,7 +12020,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/tyranny.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tyranny.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12077,7 +12077,7 @@
       "dexterity": "+1"
     },
     "image_url": "/static/images/cards/bulk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "失去1个充能球栏位。\n获得3点[gold]力量[/gold]。\n获得3点[gold]敏捷[/gold]。",
@@ -12235,7 +12235,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/lunar_blast.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lunar_blast.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "本回合中每打出过一张技能牌，此牌额外造成5点伤害一次。",
@@ -12273,7 +12273,7 @@
       "replay": "+1"
     },
     "image_url": "/static/images/cards/hidden_gem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_gem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "你[gold]抽牌堆[/gold]中的一张没有[gold]重放[/gold]的随机牌获得3层[gold]重放[/gold]。",
@@ -12512,7 +12512,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/juggling.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/juggling.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12552,7 +12552,7 @@
       "summon": "+3"
     },
     "image_url": "/static/images/cards/afterlife.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/afterlife.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]召唤[/gold]9。",
@@ -12641,7 +12641,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/squeeze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/squeeze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]奥斯提[/gold]造成25点伤害。\n你每有一张[gold]奥斯提[/gold]的攻击牌，这张牌就额外造成6点伤害。",
@@ -12680,7 +12680,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/modded.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/modded.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得1个充能球栏位。\n抽2张牌。这张牌的耗能加1。",
@@ -12718,7 +12718,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/catastrophe.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/catastrophe.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "从你的[gold]抽牌堆[/gold]中随机打出3张牌。",
@@ -12803,7 +12803,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/arsenal.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/arsenal.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -12887,7 +12887,7 @@
       "dansemacabrepower": "+2"
     },
     "image_url": "/static/images/cards/danse_macabre.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/danse_macabre.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你打出一张耗能大于等于[energy:2]的牌时，获得6点[gold]格挡[/gold]。",
@@ -12926,7 +12926,7 @@
       "block": "+1"
     },
     "image_url": "/static/images/cards/deaths_door.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/deaths_door.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得7点[gold]格挡[/gold]。\n如果你在本回合中曾给予过[gold]灾厄[/gold]，则额外获得2次[gold]格挡[/gold]。",
@@ -13055,7 +13055,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/reaper_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/reaper_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13228,7 +13228,7 @@
       "outbreakpower": "+4"
     },
     "image_url": "/static/images/cards/outbreak.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/outbreak.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你给予3次[gold]中毒[/gold]，就对所有敌人造成15点伤害。",
@@ -13391,7 +13391,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/convergence.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/convergence.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "在本回合[gold]保留[/gold]你的[gold]手牌[/gold]。\n在下个回合，\n获得[energy:1]与[star:2]。",
@@ -13432,7 +13432,7 @@
       "damage": "+1"
     },
     "image_url": "/static/images/cards/gunk_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gunk_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成5点伤害3次。\n在你的[gold]弃牌堆[/gold]中加入一张[gold]黏液[/gold]。",
@@ -13731,7 +13731,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/refine_blade.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/refine_blade.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]铸造[/gold]13。\n在下个回合获得[energy:1]。",
@@ -13888,7 +13888,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/dredge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/dredge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -13982,7 +13982,7 @@
       "rollingboulderpower": "+5"
     },
     "image_url": "/static/images/cards/rolling_boulder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rolling_boulder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "在你的回合开始时，对所有敌人造成10点伤害，然后将该伤害增加5点。",
@@ -14056,7 +14056,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/scrawl.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/scrawl.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14139,7 +14139,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/rocket_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rocket_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成14点伤害。\n抽2张牌。\n每当你生成状态牌时，此牌的耗能将在下一次打出前降为0[energy:1]。",
@@ -14177,7 +14177,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/lantern_key.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lantern_key.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14218,7 +14218,7 @@
       "blockonexhaust": "+1"
     },
     "image_url": "/static/images/cards/spirit_of_ash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spirit_of_ash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你打出一张[gold]虚无[/gold]牌时，获得5点[gold]格挡[/gold]。",
@@ -14308,7 +14308,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/apparition.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/apparition.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14397,7 +14397,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/soul.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "抽3张牌。",
@@ -14442,7 +14442,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/soul_storm.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soul_storm.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成9点伤害。\n你的[gold]消耗牌堆[/gold]中每有一张[gold]灵魂[/gold]，伤害增加3。",
@@ -14519,7 +14519,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/calamity.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/calamity.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14690,7 +14690,7 @@
       "smokestackpower": "+2"
     },
     "image_url": "/static/images/cards/smokestack.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/smokestack.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你生成一张状态牌时，对所有敌人造成7点伤害。",
@@ -14737,7 +14737,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/hotfix.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hotfix.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14781,7 +14781,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/conflagration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/conflagration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "对所有敌人造成8点伤害。\n你在本回合中每打出过一张其他攻击牌，这张牌的伤害就提升3点。",
@@ -14817,7 +14817,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/soot.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/soot.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -14858,7 +14858,7 @@
       "forge": "+2"
     },
     "image_url": "/static/images/cards/furnace.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/furnace.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "在你的回合开始时，[gold]铸造[/gold]6。",
@@ -14939,7 +14939,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/entropy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/entropy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -14980,7 +14980,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/fuel.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/fuel.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得[energy:1]。\n抽2张牌。",
@@ -15182,7 +15182,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/tesla_coil.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tesla_coil.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成6点伤害。\n对该敌人触发你的所有[gold]闪电[/gold]充能球的被动。",
@@ -15295,7 +15295,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/frantic_escape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/frantic_escape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -15416,7 +15416,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/beat_down.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_down.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "打出你[gold]弃牌堆[/gold]中的4张随机攻击牌。",
@@ -15456,7 +15456,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/the_hunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/the_hunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "造成15点伤害。\n[gold]斩杀[/gold]时，额外获得一次卡牌奖励。",
@@ -15497,7 +15497,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/monologue.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/monologue.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -15699,7 +15699,7 @@
       "ostydamage": "+2"
     },
     "image_url": "/static/images/cards/rattle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rattle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]奥斯提[/gold]造成9点伤害。\n本回合每使用过一次奥斯提攻击牌，此牌就额外造成一次伤害。",
@@ -15775,7 +15775,7 @@
       "gold": "+5"
     },
     "image_url": "/static/images/cards/royalties.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royalties.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": "在战斗结束时，获得35[gold]金币[/gold]。",
@@ -15815,7 +15815,7 @@
       "increase": "+2"
     },
     "image_url": "/static/images/cards/kingly_punch.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/kingly_punch.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成10点伤害。\n每当你抽到这张牌时，在这场战斗中其伤害增加6。",
@@ -15931,7 +15931,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/defile.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/defile.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成17点伤害。",
@@ -15972,7 +15972,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/glasswork.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glasswork.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得8点[gold]格挡[/gold]。\n[gold]生成[/gold]1个[gold]玻璃[/gold]充能球。",
@@ -16053,7 +16053,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/disintegration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/disintegration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -16093,7 +16093,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/production.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/production.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得[energy:3]。",
@@ -16211,7 +16211,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/voltaic.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/voltaic.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16424,7 +16424,7 @@
       "strength": "+2"
     },
     "image_url": "/static/images/cards/feeding_frenzy.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feeding_frenzy.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "在本回合内获得7点[gold]力量[/gold]。",
@@ -16588,7 +16588,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/believe_in_you.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/believe_in_you.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "另一名玩家获得[energy:3]。",
@@ -16672,7 +16672,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/poor_sleep.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/poor_sleep.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16795,7 +16795,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/debris.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/debris.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -16886,7 +16886,7 @@
       "ostydamage": "+3"
     },
     "image_url": "/static/images/cards/bone_shards.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bone_shards.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "如果[gold]奥斯提[/gold]存活，则他对所有敌人造成12点伤害并且你获得12点[gold]格挡[/gold]。\n然后[gold]奥斯提[/gold]死去。",
@@ -16926,7 +16926,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/collision_course.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/collision_course.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成15点伤害。\n将一张[gold]碎屑[/gold]添加至你的[gold]手牌[/gold]。",
@@ -16980,7 +16980,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/abrasive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/abrasive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得1点[gold]敏捷[/gold]。\n获得6点[gold]荆棘[/gold]。",
@@ -17147,7 +17147,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/forbidden_grimoire.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/forbidden_grimoire.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17272,7 +17272,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/ultimate_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成20点伤害。",
@@ -17312,7 +17312,7 @@
       "block": "+4"
     },
     "image_url": "/static/images/cards/ultimate_defend.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ultimate_defend.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得15点[gold]格挡[/gold]。",
@@ -17524,7 +17524,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/salvo.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/salvo.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成16点伤害。\n在本回合[gold]保留[/gold]你的[gold]手牌[/gold]。",
@@ -17562,7 +17562,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/quasar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/quasar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "从3张随机[gold]升级过[/gold]的无色牌中选择1张加入你的[gold]手牌[/gold]。",
@@ -17726,7 +17726,7 @@
       "calculationbase": "+3"
     },
     "image_url": "/static/images/cards/precise_cut.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/precise_cut.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -17773,7 +17773,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/neurosurge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/neurosurge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得[energy:4]。\n抽2张牌。\n在你的回合开始时，给予自身3层[gold]灾厄[/gold]。",
@@ -17820,7 +17820,7 @@
       "stranglepower": "+1"
     },
     "image_url": "/static/images/cards/strangle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/strangle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成10点伤害。\n你在这个回合内每出一张牌，该名敌人都会失去3点生命。",
@@ -17870,7 +17870,7 @@
       "sicempower": "+1"
     },
     "image_url": "/static/images/cards/sic_em.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sic_em.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]奥斯提[/gold]造成6点伤害。\n在本回合内，每当[gold]奥斯提[/gold]攻击这名敌人时，[gold]召唤[/gold]3。",
@@ -17910,7 +17910,7 @@
       "hploss": "+2"
     },
     "image_url": "/static/images/cards/haunt.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haunt.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你打出一张[gold]灵魂[/gold]时，随机一名敌人失去8点生命。",
@@ -17995,7 +17995,7 @@
       "crimsonmantlepower": "+2"
     },
     "image_url": "/static/images/cards/crimson_mantle.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crimson_mantle.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "在你的回合开始时，失去1点生命并获得10点[gold]格挡[/gold]。",
@@ -18159,7 +18159,7 @@
       "blockforstars": "+1"
     },
     "image_url": "/static/images/cards/child_of_the_stars.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/child_of_the_stars.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你花费[star:1]时，每花费一点[star:1]，获得3点[gold]格挡[/gold]。",
@@ -18243,7 +18243,7 @@
       "serpentformpower": "+2"
     },
     "image_url": "/static/images/cards/serpent_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/serpent_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "你每打出一张牌，就对随机一名敌人造成6点伤害。",
@@ -18283,7 +18283,7 @@
       "extradamage": "+2"
     },
     "image_url": "/static/images/cards/gang_up.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/gang_up.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成5点伤害。\n本回合其他玩家每攻击过一次该敌人，该牌造成的伤害就额外增加7点。",
@@ -18480,7 +18480,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/tank.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tank.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18610,7 +18610,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/royal_gamble.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/royal_gamble.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18693,7 +18693,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/energy_surge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/energy_surge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "所有玩家获得[energy:3]。",
@@ -18813,7 +18813,7 @@
       "corrosivewave": "+1"
     },
     "image_url": "/static/images/cards/corrosive_wave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/corrosive_wave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "打出此牌后，你在本回合每抽到一张牌，就给予所有敌人3层[gold]中毒[/gold]。",
@@ -18894,7 +18894,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/automation.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/automation.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -18935,7 +18935,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/brightest_flame.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/brightest_flame.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得[energy:3]。\n抽3张牌。\n失去1点最大生命。",
@@ -19027,7 +19027,7 @@
       "lethalitypower": "+25"
     },
     "image_url": "/static/images/cards/lethality.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/lethality.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每回合的第一张攻击牌会造成75%额外伤害。",
@@ -19153,7 +19153,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/misery.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/misery.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成9点伤害。\n给予其他敌人该名敌人身上的所有负面效果。",
@@ -19273,7 +19273,7 @@
       "damage": "+10"
     },
     "image_url": "/static/images/cards/devastate.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/devastate.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成40点伤害。",
@@ -19349,7 +19349,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/spoils_map.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/spoils_map.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19433,7 +19433,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/call_of_the_void.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/call_of_the_void.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19480,7 +19480,7 @@
       "remove_ethereal": true
     },
     "image_url": "/static/images/cards/void_form.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/void_form.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -19655,7 +19655,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/helix_drill.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/helix_drill.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "在本回合中，每个被使用的[energy:1]，都会使此牌造成5点伤害一次。",
@@ -19739,7 +19739,7 @@
       "sleightoffleshpower": "+4"
     },
     "image_url": "/static/images/cards/sleight_of_flesh.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sleight_of_flesh.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你给予一个敌人负面状态时，使其受到13点伤害。",
@@ -19782,7 +19782,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/waste_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/waste_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": false,
     "upgrade_description": null,
@@ -19822,7 +19822,7 @@
       "cards": "+1"
     },
     "image_url": "/static/images/cards/up_my_sleeve.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/up_my_sleeve.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "将4张[gold]小刀[/gold]加入你的[gold]手牌[/gold]。\n这张牌的耗能减少1。",
@@ -20020,7 +20020,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/stratagem.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/stratagem.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20178,7 +20178,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/murder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/murder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20262,7 +20262,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/greed.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/greed.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20475,7 +20475,7 @@
       "extradamage": "+1"
     },
     "image_url": "/static/images/cards/supermassive.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/supermassive.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成5点伤害。\n你在本场战斗中每生成过一张牌，这张牌就额外造成4点伤害。",
@@ -20632,7 +20632,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/tracking.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/tracking.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20749,7 +20749,7 @@
       "damage": "+6"
     },
     "image_url": "/static/images/cards/bombardment.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bombardment.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成24点伤害。\n你的回合开始时，如果这张牌在你的[gold]消耗牌堆[/gold]中，则将其打出。",
@@ -20791,7 +20791,7 @@
       "stars": "+1"
     },
     "image_url": "/static/images/cards/glow.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/glow.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得[star:2]。\n抽1张牌。\n下一回合抽1张牌。",
@@ -20870,7 +20870,7 @@
     "vars": null,
     "upgrade": null,
     "image_url": "/static/images/cards/ascenders_bane.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ascenders_bane.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -20964,7 +20964,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/volley.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/volley.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "随机对敌人造成14点伤害X次。",
@@ -21043,7 +21043,7 @@
       "repeat": "+1"
     },
     "image_url": "/static/images/cards/ricochet.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/ricochet.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "随机对敌人造成3点伤害5次。",
@@ -21086,7 +21086,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/crash_landing.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/crash_landing.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "对所有敌人造成26点伤害。\n用[gold]碎屑[/gold]填满你的[gold]手牌[/gold]。",
@@ -21131,7 +21131,7 @@
       "iterationpower": "+1"
     },
     "image_url": "/static/images/cards/iteration.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/iteration.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每回合你第一次抽到状态牌时，抽3张牌。",
@@ -21178,7 +21178,7 @@
       "poison": "+2"
     },
     "image_url": "/static/images/cards/haze.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/haze.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "给予所有敌人6层[gold]中毒[/gold]。",
@@ -21219,7 +21219,7 @@
       "forge": "+4"
     },
     "image_url": "/static/images/cards/seeking_edge.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seeking_edge.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "[gold]铸造[/gold]11。\n[gold]君王之剑[/gold]现在会对所有敌人造成伤害。",
@@ -21259,7 +21259,7 @@
       "damage": "+5"
     },
     "image_url": "/static/images/cards/adaptive_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/adaptive_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成23点伤害。\n将这张牌的一张0[energy:1]复制品添加到你的[gold]弃牌堆[/gold]。",
@@ -21342,7 +21342,7 @@
       "add_innate": true
     },
     "image_url": "/static/images/cards/speedster.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/speedster.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21586,7 +21586,7 @@
       "remove_exhaust": true
     },
     "image_url": "/static/images/cards/transfigure.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/transfigure.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21672,7 +21672,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/feral.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/feral.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -21880,7 +21880,7 @@
       "thornspower": "+2"
     },
     "image_url": "/static/images/cards/caltrops.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/caltrops.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你被攻击时，对攻击者造成5点伤害。",
@@ -22041,7 +22041,7 @@
       "forge": "+3"
     },
     "image_url": "/static/images/cards/bulwark.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bulwark.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得16点[gold]格挡[/gold]。\n[gold]铸造[/gold]13。",
@@ -22077,7 +22077,7 @@
       "cost": 1
     },
     "image_url": "/static/images/cards/hammer_time.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hammer_time.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22119,7 +22119,7 @@
       "calculationextra": "+2"
     },
     "image_url": "/static/images/cards/beat_into_shape.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/beat_into_shape.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成7点伤害。\n[gold]铸造[/gold]X。\n本回合此前你每击中过该敌人一次，[gold]铸造[/gold]值就上升7。",
@@ -22490,7 +22490,7 @@
       "cost": 0
     },
     "image_url": "/static/images/cards/seance.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/seance.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -22547,7 +22547,7 @@
       "damage": "+4"
     },
     "image_url": "/static/images/cards/falling_star.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/falling_star.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成12点伤害。\n给予1层[gold]虚弱[/gold]。\n给予1层[gold]易伤[/gold]。",
@@ -22628,7 +22628,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/hidden_daggers.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_daggers.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "丢弃2张牌。\n将2张[gold]小刀+[/gold]加入你的[gold]手牌[/gold]。",
@@ -22674,7 +22674,7 @@
       "starnextturnpower": "+1"
     },
     "image_url": "/static/images/cards/hidden_cache.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hidden_cache.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得[star:1]。\n在下个回合获得[star:4]。",
@@ -22723,7 +22723,7 @@
       "focuspower": "+1"
     },
     "image_url": "/static/images/cards/focused_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/focused_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成11点伤害。\n在本回合获得2点[gold]集中[/gold]。",
@@ -22761,7 +22761,7 @@
       "block": "+5"
     },
     "image_url": "/static/images/cards/rally.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/rally.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "所有玩家获得17点[gold]格挡[/gold]。",
@@ -22801,7 +22801,7 @@
       "damage": "+3"
     },
     "image_url": "/static/images/cards/sculpting_strike.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sculpting_strike.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成12点伤害。\n为一张[gold]手牌[/gold]添加[gold]虚无[/gold]。",
@@ -22891,7 +22891,7 @@
       "thunderpower": "+2"
     },
     "image_url": "/static/images/cards/thunder.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/thunder.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你[gold]激发闪电[/gold]充能球时，对被命中的敌人造成8点伤害。",
@@ -22931,7 +22931,7 @@
       "power": "+2"
     },
     "image_url": "/static/images/cards/shockwave.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/shockwave.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "给予所有敌人5层[gold]虚弱[/gold]和[gold]易伤[/gold]。",
@@ -22973,7 +22973,7 @@
     },
     "upgrade": null,
     "image_url": "/static/images/cards/bad_luck.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/bad_luck.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23017,7 +23017,7 @@
       "energy": "+1"
     },
     "image_url": "/static/images/cards/hegemony.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/hegemony.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成18点伤害。\n在下个回合获得[energy:3]。",
@@ -23070,7 +23070,7 @@
       "strength": "+1"
     },
     "image_url": "/static/images/cards/prowess.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/prowess.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得2点[gold]力量[/gold]。\n获得2点[gold]敏捷[/gold]。",
@@ -23372,7 +23372,7 @@
       "cost": 2
     },
     "image_url": "/static/images/cards/demesne.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/demesne.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23450,7 +23450,7 @@
       "description_changed": true
     },
     "image_url": "/static/images/cards/splash.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/splash.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "从3张其他角色的[gold]升级过的[/gold]攻击牌中选择1张加入你的[gold]手牌[/gold]。这张牌在本回合免费打出。",
@@ -23566,7 +23566,7 @@
       "damage": "+2"
     },
     "image_url": "/static/images/cards/uproar.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/uproar.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "造成7点伤害两次。\n随机打出你的[gold]抽牌堆[/gold]中的1张攻击牌。",
@@ -23606,7 +23606,7 @@
       "summon": "+2"
     },
     "image_url": "/static/images/cards/legion_of_bone.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/legion_of_bone.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "所有玩家[gold]召唤[/gold]8。",
@@ -23649,7 +23649,7 @@
       "block": "+3"
     },
     "image_url": "/static/images/cards/boost_away.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/boost_away.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "获得9点[gold]格挡[/gold]。\n将一张[gold]晕眩[/gold]添加到你的[gold]弃牌堆[/gold]中。",
@@ -23689,7 +23689,7 @@
       "add_retain": true
     },
     "image_url": "/static/images/cards/wisp.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/wisp.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": null,
@@ -23739,7 +23739,7 @@
       "sneakypower": "+1"
     },
     "image_url": "/static/images/cards/sneaky.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/sneaky.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当其他玩家攻击一名敌人时，获得2点[gold]格挡[/gold]。",
@@ -23907,7 +23907,7 @@
       "blackholepower": "+1"
     },
     "image_url": "/static/images/cards/black_hole.webp",
-    "beta_image_url": null,
+    "beta_image_url": "/static/images/cards/beta/black_hole.webp",
     "type_variants": null,
     "can_be_generated_in_combat": null,
     "upgrade_description": "每当你花费或获得[star:1]时，对所有敌人造成4点伤害。",


### PR DESCRIPTION
## Summary

Restores the card-page beta-art toggle that PR #192 silently disabled.

## Root cause

PR #192 changed `card_parser.py` to read `beta_image_url` from the **top-level** `backend/static/images/beta/cards/` tree. That same PR deleted the tree, so the parse during the PR wrote `beta_image_url: null` on **every card** to `data/<lang>/cards.json` for all 14 languages. With `hasBetaArt = !!card.beta_image_url` evaluating false everywhere, the toggle button stopped rendering on the entire site.

PR #193 restored the image files but didn't re-parse, so the data on main still has every `beta_image_url` set to `null`.

## Fix

- `card_parser.py`: read `beta_image_url` from the **historical archive** at `backend/static/images/cards/beta/<id>` (the path that has always driven the toggle, restored to disk by PR #193)
- `monster_parser.py`: revert to slug-matched lookup in `monsters/beta/`, with the existing 3-monster `BETA_ALIASES` for Door / Doormaker / Pael's Legion
- Re-parsed all 14 languages

## Result

| | Before this PR | After |
| --- | --- | --- |
| Cards with `beta_image_url` | 0 / 576 | 266 / 576 |
| Monsters with `beta_image_url` | 2 / 115 | 2 / 115 (unchanged) |
| Toggle resolves to | nothing (button hidden) | pre-promotion archive at `cards/beta/<id>.webp` |

No image files moved or deleted. 16 files changed: 2 parsers + 14 cards.json across all languages.

## Acceptance check

After deploy, `curl /api/cards/ABRASIVE` should return `beta_image_url: /static/images/cards/abrasive.webp /beta/abrasive.webp`, and `/cards/abrasive` should render the toggle button that swaps to the older art.
