### PR TITLE
Surface Sea Glass per-character name variants

### DIFF
--- a/backend/app/parsers/ancient_pool_parser.py
+++ b/backend/app/parsers/ancient_pool_parser.py
@@ -66,6 +66,20 @@ _RELIC_PATTERNS = (
     re.compile(r"ModelDb\.Relic<(\w+)>"),
 )
 
+# A few relics (today: just SeaGlass) reskin themselves per character.
+# When an event creates one with `relic.CharacterId = ...` inside a
+# `foreach (CharacterModel x in ModelDb.AllCharacters)`, the player
+# actually sees five distinct options on that screen — one for each
+# character variant (Demon/Venom/Gear/Lich/Noble Glass for Sea Glass).
+# Capture this so the parsed pool reflects the in-game option count and
+# the drift check can flag a hand file that lists the relic only once.
+_PER_CHARACTER_FOREACH = re.compile(
+    r"foreach\s*\(\s*CharacterModel\s+\w+\s+in\s+ModelDb\.AllCharacters\s*\)\s*\{(?P<body>.*?)\}",
+    re.DOTALL,
+)
+_RELIC_INSTANCE = re.compile(r"ModelDb\.Relic<(\w+)>\(\)\.ToMutable\(\)")
+_CHARACTER_ID_ASSIGN = re.compile(r"\.CharacterId\s*=\s*\w+\.Id")
+
 
 def parse_ancient_relics(filepath) -> set[str]:
     """Return the set of relic IDs an ancient .cs file can offer."""
@@ -79,11 +93,35 @@ def parse_ancient_relics(filepath) -> set[str]:
     return {class_name_to_id(n) for n in class_names}
 
 
-def parse_all_ancients() -> dict[str, set[str]]:
-    """Walk every known ancient .cs file and collect relic IDs per ancient."""
-    out: dict[str, set[str]] = {}
+def parse_per_character_relics(filepath) -> set[str]:
+    """Return the set of relic IDs that the ancient offers as 5 separate
+    per-character options (the `foreach AllCharacters { relic.CharacterId
+    = x.Id }` shape, e.g. Orobas's DiscoveryTotems pool with Sea Glass)."""
+    if not filepath.exists():
+        return set()
+    content = filepath.read_text(encoding="utf-8")
+    out: set[str] = set()
+    for fe in _PER_CHARACTER_FOREACH.finditer(content):
+        body = fe.group("body")
+        if not _CHARACTER_ID_ASSIGN.search(body):
+            continue
+        for rm in _RELIC_INSTANCE.finditer(body):
+            out.add(class_name_to_id(rm.group(1)))
+    return out
+
+
+def parse_all_ancients() -> dict[str, dict[str, set[str]]]:
+    """Walk every known ancient .cs file. Returns
+    `{ancient_id: {"all": {ids}, "per_character": {ids}}}`. The
+    `per_character` set is a strict subset of `all` and just flags
+    which relics expand to 5 in-game options."""
+    out: dict[str, dict[str, set[str]]] = {}
     for ancient_id, filename in ANCIENT_FILES.items():
-        out[ancient_id] = parse_ancient_relics(EVENTS_DIR / filename)
+        path = EVENTS_DIR / filename
+        out[ancient_id] = {
+            "all": parse_ancient_relics(path),
+            "per_character": parse_per_character_relics(path),
+        }
     return out
 
 
@@ -110,21 +148,28 @@ def load_hand_coded() -> dict[str, set[str]]:
     return out
 
 
-def diff_against_hand_coded(parsed: dict[str, set[str]]) -> list[str]:
+def diff_against_hand_coded(parsed: dict[str, dict[str, set[str]]]) -> list[str]:
     """Return human-readable drift lines comparing parsed vs hand-coded.
 
     Each line names an ancient and lists relic IDs that diverge in
-    either direction. Empty list = no drift; the hand file is in sync
-    with the C# extraction.
+    either direction. Also flags any per-character-expanding relic
+    (e.g. Sea Glass) whose hand-file entry doesn't mention the 5
+    character variants.
     """
     hand = load_hand_coded()
     drift: list[str] = []
     for ancient_id in sorted(set(parsed) | set(hand)):
-        c_set = parsed.get(ancient_id, set())
+        c_set = parsed.get(ancient_id, {}).get("all", set())
+        per_char = parsed.get(ancient_id, {}).get("per_character", set())
         h_set = hand.get(ancient_id, set())
         only_in_c = c_set - h_set
         only_in_h = h_set - c_set
-        if not (only_in_c or only_in_h):
+        # Per-character relics in C# whose hand entry doesn't note
+        # they expand to 5 options. We can't reliably parse the hand
+        # file's free-form `description`/`condition` strings, so just
+        # surface a hint when the relic is on the per-character list.
+        per_char_present = per_char & h_set
+        if not (only_in_c or only_in_h or per_char_present):
             continue
         parts: list[str] = [f"  {ancient_id}:"]
         if only_in_c:
@@ -135,20 +180,31 @@ def diff_against_hand_coded(parsed: dict[str, set[str]]) -> list[str]:
             parts.append(
                 f"    - {len(only_in_h)} in hand file but not in C#: {sorted(only_in_h)}"
             )
+        if per_char_present:
+            parts.append(
+                f"    ! per-character expansion (5 options shown in-game): {sorted(per_char_present)}"
+            )
         drift.append("\n".join(parts))
     return drift
 
 
-def write_parsed_output(parsed: dict[str, set[str]]) -> None:
+def write_parsed_output(parsed: dict[str, dict[str, set[str]]]) -> None:
     """Persist the parsed relic lists to `data/ancient_pools_parsed.json`.
 
-    Written sorted for stable diffs across parse runs. Consumers (CI,
-    review tooling) can compare this file against `ancient_pools.json`
-    without re-running the parser themselves.
+    Written sorted for stable diffs across parse runs. Each ancient
+    entry carries `relics` (every relic the ancient can offer) and
+    `per_character_relics` (the subset that expands to 5 in-game
+    options, one per character). The expanded list lets the relic
+    page cross-reference Sea Glass → Orobas without parsing the C#
+    again, and lets the drift check flag stale hand-file entries.
     """
     out_file = DATA_DIR / "ancient_pools_parsed.json"
     out = [
-        {"id": ancient_id, "relics": sorted(parsed[ancient_id])}
+        {
+            "id": ancient_id,
+            "relics": sorted(parsed[ancient_id]["all"]),
+            "per_character_relics": sorted(parsed[ancient_id]["per_character"]) or None,
+        }
         for ancient_id in sorted(parsed)
     ]
     out_file.parent.mkdir(parents=True, exist_ok=True)
@@ -160,7 +216,7 @@ def write_parsed_output(parsed: dict[str, set[str]]) -> None:
 def main() -> None:
     parsed = parse_all_ancients()
     write_parsed_output(parsed)
-    total = sum(len(v) for v in parsed.values())
+    total = sum(len(v["all"]) for v in parsed.values())
     print(
         f"Parsed {total} relic offerings across {len(parsed)} ancients "
         f"-> data/ancient_pools_parsed.json"

--- a/backend/app/parsers/relic_parser.py
+++ b/backend/app/parsers/relic_parser.py
@@ -143,6 +143,25 @@ def parse_single_relic(
     description_raw = localization.get(f"{relic_id}.description", "")
     flavor = localization.get(f"{relic_id}.flavor", "")
 
+    # Per-character title overrides — Sea Glass renames itself to
+    # "Demon Glass" / "Venom Glass" / "Gear Glass" / "Lich Glass" /
+    # "Noble Glass" depending on which character holds it. Pattern:
+    # `<RELIC>.<CHAR>.title` in `relics.json`. Surfaced as
+    # `name_variants` so detail pages can list alternate names without
+    # parsing localization at render time.
+    NAME_VARIANT_CHARS = {
+        "IRONCLAD": "Ironclad",
+        "SILENT": "Silent",
+        "DEFECT": "Defect",
+        "NECROBINDER": "Necrobinder",
+        "REGENT": "Regent",
+    }
+    name_variants: dict[str, str] = {}
+    for char_key, char_label in NAME_VARIANT_CHARS.items():
+        variant_title = localization.get(f"{relic_id}.{char_key}.title")
+        if variant_title and variant_title != title:
+            name_variants[char_label] = variant_title
+
     # Resolve templates, keep color tags for frontend rendering
     description_resolved = resolve_description(description_raw, all_vars)
     desc_clean = description_resolved
@@ -237,6 +256,7 @@ def parse_single_relic(
         "merchant_price": merchant_price,
         "image_url": image_url,
         "image_variants": image_variants if image_variants else None,
+        "name_variants": name_variants if name_variants else None,
         "notes": notes,
     }
 

--- a/data/ancient_pools_parsed.json
+++ b/data/ancient_pools_parsed.json
@@ -14,7 +14,8 @@
       "SNECKO_EYE",
       "SOZU",
       "VELVET_CHOKER"
-    ]
+    ],
+    "per_character_relics": null
   },
   {
     "id": "NEOW",
@@ -44,7 +45,8 @@
       "SMALL_CAPSULE",
       "STONE_HUMIDIFIER",
       "WINGED_BOOTS"
-    ]
+    ],
+    "per_character_relics": null
   },
   {
     "id": "NONUPEIPE",
@@ -59,7 +61,8 @@
       "JEWELRY_BOX",
       "LOOMING_FRUIT",
       "SIGNET_RING"
-    ]
+    ],
+    "per_character_relics": null
   },
   {
     "id": "OROBAS",
@@ -74,6 +77,9 @@
       "SAND_CASTLE",
       "SEA_GLASS",
       "TOUCH_OF_OROBAS"
+    ],
+    "per_character_relics": [
+      "SEA_GLASS"
     ]
   },
   {
@@ -89,7 +95,8 @@
       "PAELS_TEARS",
       "PAELS_TOOTH",
       "PAELS_WING"
-    ]
+    ],
+    "per_character_relics": null
   },
   {
     "id": "TANX",
@@ -104,7 +111,8 @@
       "THROWING_AXE",
       "TRI_BOOMERANG",
       "WAR_HAMMER"
-    ]
+    ],
+    "per_character_relics": null
   },
   {
     "id": "TEZCATARA",
@@ -119,7 +127,8 @@
       "TOY_BOX",
       "VERY_HOT_COCOA",
       "YUMMY_COOKIE"
-    ]
+    ],
+    "per_character_relics": null
   },
   {
     "id": "VAKUU",
@@ -134,6 +143,7 @@
       "PRESERVED_FOG",
       "SERE_TALON",
       "WHISPERING_EARRING"
-    ]
+    ],
+    "per_character_relics": null
   }
 ]

--- a/data/deu/relics.json
+++ b/data/deu/relics.json
@@ -14,6 +14,7 @@
     },
     "image_url": "/static/images/relics/ruined_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 80
@@ -33,6 +34,7 @@
     },
     "image_url": "/static/images/relics/akabeko.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 40
@@ -48,6 +50,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/alchemical_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 160
@@ -63,6 +66,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/old_coin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 81
@@ -78,6 +82,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/amethyst_aubergine.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 10
@@ -97,6 +102,7 @@
     },
     "image_url": "/static/images/relics/anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 11
@@ -116,6 +122,7 @@
     },
     "image_url": "/static/images/relics/fake_anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 257
@@ -131,6 +138,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/archaic_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 161
@@ -146,6 +154,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/arcane_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 162
@@ -161,6 +170,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/crossbow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 163
@@ -180,6 +190,7 @@
     },
     "image_url": "/static/images/relics/candelabra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 41
@@ -199,6 +210,7 @@
     },
     "image_url": "/static/images/relics/vambrace.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 42
@@ -214,6 +226,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/astrolabe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 164
@@ -229,6 +242,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/choices_paradox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 165
@@ -248,6 +262,7 @@
     },
     "image_url": "/static/images/relics/funerary_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 43
@@ -263,6 +278,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/touch_of_orobas.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 166
@@ -278,6 +294,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bing_bong.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 258
@@ -297,6 +314,7 @@
     },
     "image_url": "/static/images/relics/pear.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 44
@@ -312,6 +330,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pomander.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 167
@@ -331,6 +350,7 @@
     },
     "image_url": "/static/images/relics/bellows.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 82
@@ -346,6 +366,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lead_paperweight.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 168
@@ -361,6 +382,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blood_soaked_rose.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 169
@@ -380,6 +402,7 @@
     },
     "image_url": "/static/images/relics/blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 12
@@ -399,6 +422,7 @@
     },
     "image_url": "/static/images/relics/fake_blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 259
@@ -414,6 +438,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/leafy_poultice.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 170
@@ -429,6 +454,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/booming_conch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 171
@@ -444,6 +470,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/burning_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 0
@@ -463,6 +490,7 @@
     },
     "image_url": "/static/images/relics/letter_opener.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 45
@@ -478,6 +506,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/brilliant_scarf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 172
@@ -497,6 +526,7 @@
     },
     "image_url": "/static/images/relics/bronze_scales.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 13
@@ -516,6 +546,7 @@
     },
     "image_url": "/static/images/relics/bread.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 130
@@ -535,6 +566,7 @@
     },
     "image_url": "/static/images/relics/book_of_five_rings.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 14
@@ -554,6 +586,7 @@
     },
     "image_url": "/static/images/relics/book_repair_knife.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 46
@@ -569,6 +602,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pandoras_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 173
@@ -588,6 +622,7 @@
     },
     "image_url": "/static/images/relics/charons_ashes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 83
@@ -607,6 +642,7 @@
     },
     "image_url": "/static/images/relics/chemical_x.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 131
@@ -626,6 +662,7 @@
     },
     "image_url": "/static/images/relics/lasting_candy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 47
@@ -645,6 +682,7 @@
     },
     "image_url": "/static/images/relics/ornamental_fan.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -664,6 +702,7 @@
     },
     "image_url": "/static/images/relics/the_abacus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 132
@@ -679,6 +718,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_boot.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 260
@@ -694,6 +734,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/chosen_cheese.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 261
@@ -709,6 +750,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/diamond_diadem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 174
@@ -724,6 +766,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/biiig_hug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 175
@@ -743,6 +786,7 @@
     },
     "image_url": "/static/images/relics/art_of_war.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 84
@@ -758,6 +802,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_courier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 85
@@ -777,6 +822,7 @@
     },
     "image_url": "/static/images/relics/dollys_mirror.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 133
@@ -796,6 +842,7 @@
     },
     "image_url": "/static/images/relics/dragon_fruit.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 134
@@ -811,6 +858,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_drake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 1
@@ -830,6 +878,7 @@
     },
     "image_url": "/static/images/relics/helical_dart.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 86
@@ -845,6 +894,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fragrant_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 262
@@ -860,6 +910,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/darkstone_periapt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 263
@@ -879,6 +930,7 @@
     },
     "image_url": "/static/images/relics/demon_tongue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 87
@@ -894,6 +946,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sere_talon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 176
@@ -913,6 +966,7 @@
     },
     "image_url": "/static/images/relics/lizard_tail.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 88
@@ -932,6 +986,7 @@
     },
     "image_url": "/static/images/relics/regal_pillow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 15
@@ -947,6 +1002,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bound_phylactery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 2
@@ -962,6 +1018,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/preserved_fog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 177
@@ -981,6 +1038,7 @@
     },
     "image_url": "/static/images/relics/ice_cream.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 89
@@ -996,6 +1054,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/iron_club.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 178
@@ -1011,6 +1070,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ectoplasm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 179
@@ -1026,6 +1086,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/electric_shrymp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 180
@@ -1045,6 +1106,7 @@
     },
     "image_url": "/static/images/relics/ivory_tile.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 90
@@ -1060,6 +1122,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phylactery_unbound.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 3
@@ -1079,6 +1142,7 @@
     },
     "image_url": "/static/images/relics/strawberry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 16
@@ -1098,6 +1162,7 @@
     },
     "image_url": "/static/images/relics/meal_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 17
@@ -1117,6 +1182,7 @@
     },
     "image_url": "/static/images/relics/eternal_feather.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 49
@@ -1136,6 +1202,7 @@
     },
     "image_url": "/static/images/relics/fencing_manual.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 18
@@ -1155,6 +1222,7 @@
     },
     "image_url": "/static/images/relics/data_disk.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 19
@@ -1170,6 +1238,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fiddle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 181
@@ -1185,6 +1254,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/delicate_frond.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 182
@@ -1204,6 +1274,7 @@
     },
     "image_url": "/static/images/relics/meat_on_the_bone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 91
@@ -1219,6 +1290,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/meat_cleaver.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 183
@@ -1238,6 +1310,7 @@
     },
     "image_url": "/static/images/relics/wing_charm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 135
@@ -1253,6 +1326,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/whispering_earring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 184
@@ -1268,6 +1342,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/byrdpip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 264
@@ -1283,6 +1358,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fresnel_lens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 265
@@ -1302,6 +1378,7 @@
     },
     "image_url": "/static/images/relics/happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 20
@@ -1321,6 +1398,7 @@
     },
     "image_url": "/static/images/relics/fake_happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 266
@@ -1340,6 +1418,7 @@
     },
     "image_url": "/static/images/relics/sparkling_rouge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -1359,6 +1438,7 @@
     },
     "image_url": "/static/images/relics/intimidating_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 92
@@ -1374,6 +1454,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lords_parasol.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 185
@@ -1393,6 +1474,7 @@
     },
     "image_url": "/static/images/relics/galactic_dust.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 51
@@ -1412,6 +1494,7 @@
     },
     "image_url": "/static/images/relics/prayer_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 93
@@ -1427,6 +1510,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/winged_boots.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 186
@@ -1446,6 +1530,7 @@
     },
     "image_url": "/static/images/relics/frozen_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 94
@@ -1465,6 +1550,7 @@
     },
     "image_url": "/static/images/relics/emotion_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 95
@@ -1484,6 +1570,7 @@
     },
     "image_url": "/static/images/relics/ghost_seed.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 136
@@ -1499,6 +1586,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/infused_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 4
@@ -1514,6 +1602,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/history_course.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 267
@@ -1533,6 +1622,7 @@
     },
     "image_url": "/static/images/relics/molten_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 96
@@ -1548,6 +1638,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blessed_antler.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 187
@@ -1563,6 +1654,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cracked_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 5
@@ -1582,6 +1674,7 @@
     },
     "image_url": "/static/images/relics/girya.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 97
@@ -1597,6 +1690,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glass_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 188
@@ -1612,6 +1706,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glitter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 189
@@ -1627,6 +1722,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ember_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 268
@@ -1642,6 +1738,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lucky_fysh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 52
@@ -1661,6 +1758,7 @@
     },
     "image_url": "/static/images/relics/gold_plated_cables.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 53
@@ -1676,6 +1774,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 190
@@ -1691,6 +1790,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_compass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 191
@@ -1710,6 +1810,7 @@
     },
     "image_url": "/static/images/relics/joss_paper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -1725,6 +1826,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/seal_of_gold.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 192
@@ -1744,6 +1846,7 @@
     },
     "image_url": "/static/images/relics/gremlin_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 55
@@ -1759,6 +1862,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/large_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 193
@@ -1778,6 +1882,7 @@
     },
     "image_url": "/static/images/relics/big_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 98
@@ -1793,6 +1898,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/big_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 269
@@ -1808,6 +1914,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_right.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 6
@@ -1823,6 +1930,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_destiny.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 7
@@ -1842,6 +1950,7 @@
     },
     "image_url": "/static/images/relics/belt_buckle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 137
@@ -1861,6 +1970,7 @@
     },
     "image_url": "/static/images/relics/gorget.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 21
@@ -1876,6 +1986,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hand_drill.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 270
@@ -1895,6 +2006,7 @@
     },
     "image_url": "/static/images/relics/tough_bandages.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 99
@@ -1910,6 +2022,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precarious_shears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 194
@@ -1929,6 +2042,7 @@
     },
     "image_url": "/static/images/relics/horn_cleat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 56
@@ -1944,6 +2058,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/beautiful_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 195
@@ -1963,6 +2078,7 @@
     },
     "image_url": "/static/images/relics/unceasing_top.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 100
@@ -1978,6 +2094,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jeweled_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 196
@@ -1997,6 +2114,7 @@
     },
     "image_url": "/static/images/relics/juzu_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 22
@@ -2016,6 +2134,7 @@
     },
     "image_url": "/static/images/relics/captains_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 101
@@ -2035,6 +2154,7 @@
     },
     "image_url": "/static/images/relics/cauldron.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 138
@@ -2054,6 +2174,7 @@
     },
     "image_url": "/static/images/relics/kifuda.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 139
@@ -2069,6 +2190,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/scroll_boxes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 197
@@ -2084,6 +2206,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/claws.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 198
@@ -2099,6 +2222,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/small_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 199
@@ -2118,6 +2242,7 @@
     },
     "image_url": "/static/images/relics/ringing_triangle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 140
@@ -2133,6 +2258,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hefty_tablet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 200
@@ -2152,6 +2278,7 @@
     },
     "image_url": "/static/images/relics/bone_flute.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 23
@@ -2167,6 +2294,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bone_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 271
@@ -2186,6 +2314,7 @@
     },
     "image_url": "/static/images/relics/gnarled_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 141
@@ -2205,6 +2334,7 @@
     },
     "image_url": "/static/images/relics/twisted_funnel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 57
@@ -2224,6 +2354,7 @@
     },
     "image_url": "/static/images/relics/festive_popper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 24
@@ -2243,6 +2374,7 @@
     },
     "image_url": "/static/images/relics/screaming_flagon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 142
@@ -2262,6 +2394,7 @@
     },
     "image_url": "/static/images/relics/war_paint.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 25
@@ -2277,6 +2410,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/war_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 201
@@ -2296,6 +2430,7 @@
     },
     "image_url": "/static/images/relics/chandelier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 102
@@ -2315,6 +2450,7 @@
     },
     "image_url": "/static/images/relics/ripple_basin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 58
@@ -2334,6 +2470,7 @@
     },
     "image_url": "/static/images/relics/kunai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 103
@@ -2353,6 +2490,7 @@
     },
     "image_url": "/static/images/relics/kusarigama.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 59
@@ -2372,6 +2510,7 @@
     },
     "image_url": "/static/images/relics/royal_stamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 143
@@ -2387,6 +2526,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/royal_poison.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 272
@@ -2402,6 +2542,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pumpkin_candle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 202
@@ -2421,6 +2562,7 @@
     },
     "image_url": "/static/images/relics/lantern.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 26
@@ -2440,6 +2582,7 @@
     },
     "image_url": "/static/images/relics/lava_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 144
@@ -2455,6 +2598,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lava_rock.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 203
@@ -2476,6 +2620,7 @@
       "Necrobinder": "/static/images/relics/yummy_cookie_necrobinder.webp",
       "Regent": "/static/images/relics/yummy_cookie_regent.webp"
     },
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 204
@@ -2491,6 +2636,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/empty_cage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 205
@@ -2510,6 +2656,7 @@
     },
     "image_url": "/static/images/relics/lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 145
@@ -2529,6 +2676,7 @@
     },
     "image_url": "/static/images/relics/fake_lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 273
@@ -2548,6 +2696,7 @@
     },
     "image_url": "/static/images/relics/bookmark.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 104
@@ -2567,6 +2716,7 @@
     },
     "image_url": "/static/images/relics/lunar_pastry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 105
@@ -2586,6 +2736,7 @@
     },
     "image_url": "/static/images/relics/mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 106
@@ -2605,6 +2756,7 @@
     },
     "image_url": "/static/images/relics/fake_mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 274
@@ -2624,6 +2776,7 @@
     },
     "image_url": "/static/images/relics/cloak_clasp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 107
@@ -2639,6 +2792,13 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sea_glass.webp",
     "image_variants": null,
+    "name_variants": {
+      "Ironclad": "Dämonenglas",
+      "Silent": "Giftglas",
+      "Defect": "Geräteglas",
+      "Necrobinder": "Lichglas",
+      "Regent": "Adelsglas"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 206
@@ -2654,6 +2814,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bowler_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 60
@@ -2673,6 +2834,7 @@
     },
     "image_url": "/static/images/relics/metronome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 108
@@ -2692,6 +2854,7 @@
     },
     "image_url": "/static/images/relics/mini_regent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 109
@@ -2711,6 +2874,7 @@
     },
     "image_url": "/static/images/relics/miniature_cannon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 61
@@ -2730,6 +2894,7 @@
     },
     "image_url": "/static/images/relics/miniature_tent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 146
@@ -2749,6 +2914,7 @@
     },
     "image_url": "/static/images/relics/membership_card.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 147
@@ -2764,6 +2930,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/mr_struggles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 275
@@ -2783,6 +2950,7 @@
     },
     "image_url": "/static/images/relics/mummified_hand.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 110
@@ -2802,6 +2970,7 @@
     },
     "image_url": "/static/images/relics/bag_of_marbles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 27
@@ -2821,6 +2990,7 @@
     },
     "image_url": "/static/images/relics/mystic_lighter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 148
@@ -2836,6 +3006,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/storybook.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 207
@@ -2851,6 +3022,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_oyster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 208
@@ -2866,6 +3038,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_soup.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 209
@@ -2881,6 +3054,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_torment.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 210
@@ -2896,6 +3070,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_bones.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 211
@@ -2911,6 +3086,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_talisman.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 212
@@ -2926,6 +3102,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/new_leaf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 213
@@ -2945,6 +3122,7 @@
     },
     "image_url": "/static/images/relics/ninja_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 149
@@ -2964,6 +3142,7 @@
     },
     "image_url": "/static/images/relics/nunchaku.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 62
@@ -2983,6 +3162,7 @@
     },
     "image_url": "/static/images/relics/orange_dough.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 111
@@ -3002,6 +3182,7 @@
     },
     "image_url": "/static/images/relics/orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -3021,6 +3202,7 @@
     },
     "image_url": "/static/images/relics/fake_orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 276
@@ -3036,6 +3218,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 214
@@ -3051,6 +3234,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 215
@@ -3066,6 +3250,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_flesh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 216
@@ -3081,6 +3266,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_wing.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 217
@@ -3096,6 +3282,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 218
@@ -3111,6 +3298,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_claw.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 219
@@ -3126,6 +3314,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_legion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 220
@@ -3141,6 +3330,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 221
@@ -3156,6 +3346,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_growth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 222
@@ -3171,6 +3362,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 223
@@ -3190,6 +3382,7 @@
     },
     "image_url": "/static/images/relics/pantograph.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 64
@@ -3209,6 +3402,7 @@
     },
     "image_url": "/static/images/relics/paper_krane.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 112
@@ -3228,6 +3422,7 @@
     },
     "image_url": "/static/images/relics/paper_phrog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 65
@@ -3247,6 +3442,7 @@
     },
     "image_url": "/static/images/relics/parrying_shield.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 66
@@ -3262,6 +3458,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fur_coat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 224
@@ -3281,6 +3478,7 @@
     },
     "image_url": "/static/images/relics/pendulum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 28
@@ -3300,6 +3498,7 @@
     },
     "image_url": "/static/images/relics/permafrost.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 67
@@ -3315,6 +3514,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phial_holster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 225
@@ -3334,6 +3534,7 @@
     },
     "image_url": "/static/images/relics/orrery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 150
@@ -3353,6 +3554,7 @@
     },
     "image_url": "/static/images/relics/planisphere.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -3372,6 +3574,7 @@
     },
     "image_url": "/static/images/relics/beating_remnant.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 113
@@ -3387,6 +3590,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pollinous_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 277
@@ -3402,6 +3606,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/prismatic_gem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 226
@@ -3417,6 +3622,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precise_scissors.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 227
@@ -3436,6 +3642,7 @@
     },
     "image_url": "/static/images/relics/mercury_hourglass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 69
@@ -3455,6 +3662,7 @@
     },
     "image_url": "/static/images/relics/razor_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 114
@@ -3474,6 +3682,7 @@
     },
     "image_url": "/static/images/relics/regalite.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 70
@@ -3493,6 +3702,7 @@
     },
     "image_url": "/static/images/relics/rainbow_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 115
@@ -3508,6 +3718,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/circlet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "None",
     "compendium_order": 292
@@ -3527,6 +3738,7 @@
     },
     "image_url": "/static/images/relics/reptile_trinket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 71
@@ -3546,6 +3758,7 @@
     },
     "image_url": "/static/images/relics/sturdy_clamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 116
@@ -3565,6 +3778,7 @@
     },
     "image_url": "/static/images/relics/red_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 29
@@ -3584,6 +3798,7 @@
     },
     "image_url": "/static/images/relics/red_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 30
@@ -3599,6 +3814,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/calling_bell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 228
@@ -3614,6 +3830,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/runic_pyramid.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 229
@@ -3633,6 +3850,7 @@
     },
     "image_url": "/static/images/relics/runic_capacitor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 151
@@ -3652,6 +3870,7 @@
     },
     "image_url": "/static/images/relics/burning_sticks.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 152
@@ -3667,6 +3886,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 230
@@ -3682,6 +3902,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/velvet_choker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 231
@@ -3697,6 +3918,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sand_castle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 232
@@ -3716,6 +3938,7 @@
     },
     "image_url": "/static/images/relics/shovel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 117
@@ -3735,6 +3958,7 @@
     },
     "image_url": "/static/images/relics/strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 31
@@ -3754,6 +3978,7 @@
     },
     "image_url": "/static/images/relics/fake_strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 278
@@ -3769,6 +3994,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_snake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 8
@@ -3788,6 +4014,7 @@
     },
     "image_url": "/static/images/relics/whetstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 32
@@ -3807,6 +4034,7 @@
     },
     "image_url": "/static/images/relics/sling_of_courage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 153
@@ -3822,6 +4050,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jewelry_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 233
@@ -3841,6 +4070,7 @@
     },
     "image_url": "/static/images/relics/pen_nib.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 72
@@ -3856,6 +4086,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 234
@@ -3871,6 +4102,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 9
@@ -3890,6 +4122,7 @@
     },
     "image_url": "/static/images/relics/brimstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 154
@@ -3905,6 +4138,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_jade.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 279
@@ -3920,6 +4154,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 280
@@ -3939,6 +4174,7 @@
     },
     "image_url": "/static/images/relics/dingy_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 155
@@ -3958,6 +4194,7 @@
     },
     "image_url": "/static/images/relics/self_forming_clay.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 73
@@ -3977,6 +4214,7 @@
     },
     "image_url": "/static/images/relics/oddly_smooth_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 33
@@ -3996,6 +4234,7 @@
     },
     "image_url": "/static/images/relics/shuriken.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 118
@@ -4015,6 +4254,7 @@
     },
     "image_url": "/static/images/relics/undying_sigil.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 156
@@ -4030,6 +4270,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/signet_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 235
@@ -4045,6 +4286,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/silver_crucible.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 236
@@ -4060,6 +4302,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 237
@@ -4079,6 +4322,7 @@
     },
     "image_url": "/static/images/relics/fake_snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 281
@@ -4098,6 +4342,7 @@
     },
     "image_url": "/static/images/relics/snecko_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 34
@@ -4113,6 +4358,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sozu.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 238
@@ -4128,6 +4374,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/maw_bank.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 282
@@ -4147,6 +4394,7 @@
     },
     "image_url": "/static/images/relics/gambling_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 119
@@ -4166,6 +4414,7 @@
     },
     "image_url": "/static/images/relics/game_piece.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 120
@@ -4181,6 +4430,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/music_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 239
@@ -4196,6 +4446,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toy_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": [
       "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed.",
       "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
@@ -4218,6 +4469,7 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
+    "name_variants": null,
     "notes": [
       "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
       "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
@@ -4236,6 +4488,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/spiked_gauntlets.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 242
@@ -4251,6 +4504,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dusty_tome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 243
@@ -4266,6 +4520,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/philosophers_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 244
@@ -4285,6 +4540,7 @@
     },
     "image_url": "/static/images/relics/stone_cracker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 74
@@ -4300,6 +4556,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/stone_humidifier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 245
@@ -4319,6 +4576,7 @@
     },
     "image_url": "/static/images/relics/stone_calendar.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 121
@@ -4338,6 +4596,7 @@
     },
     "image_url": "/static/images/relics/tuning_fork.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -4357,6 +4616,7 @@
     },
     "image_url": "/static/images/relics/punch_dagger.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 157
@@ -4372,6 +4632,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/radiant_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 246
@@ -4391,6 +4652,7 @@
     },
     "image_url": "/static/images/relics/power_cell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 122
@@ -4410,6 +4672,7 @@
     },
     "image_url": "/static/images/relics/symbiotic_virus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 76
@@ -4425,6 +4688,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tanxs_whistle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 247
@@ -4444,6 +4708,7 @@
     },
     "image_url": "/static/images/relics/bag_of_preparation.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 35
@@ -4463,6 +4728,7 @@
     },
     "image_url": "/static/images/relics/pocketwatch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 123
@@ -4478,6 +4744,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tea_of_discourtesy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 283
@@ -4493,6 +4760,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fake_merchants_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 284
@@ -4512,6 +4780,7 @@
     },
     "image_url": "/static/images/relics/tingsha.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 77
@@ -4527,6 +4796,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/daughter_of_the_wind.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 285
@@ -4546,6 +4816,7 @@
     },
     "image_url": "/static/images/relics/toxic_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 124
@@ -4565,6 +4836,7 @@
     },
     "image_url": "/static/images/relics/potion_belt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 36
@@ -4580,6 +4852,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dream_catcher.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 286
@@ -4595,6 +4868,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/driftwood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 248
@@ -4610,6 +4884,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tri_boomerang.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 249
@@ -4629,6 +4904,7 @@
     },
     "image_url": "/static/images/relics/venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 37
@@ -4648,6 +4924,7 @@
     },
     "image_url": "/static/images/relics/fake_venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 287
@@ -4667,6 +4944,7 @@
     },
     "image_url": "/static/images/relics/vajra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 38
@@ -4682,6 +4960,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cursed_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 250
@@ -4697,6 +4976,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/forgotten_soul.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 288
@@ -4712,6 +4992,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 251
@@ -4727,6 +5008,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_wisp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 289
@@ -4746,6 +5028,7 @@
     },
     "image_url": "/static/images/relics/petrified_toad.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -4765,6 +5048,7 @@
     },
     "image_url": "/static/images/relics/unsettling_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 125
@@ -4784,6 +5068,7 @@
     },
     "image_url": "/static/images/relics/vexing_puzzlebox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 126
@@ -4803,6 +5088,7 @@
     },
     "image_url": "/static/images/relics/vitruvian_minion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 158
@@ -4818,6 +5104,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/distinguished_cape.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 252
@@ -4837,6 +5124,7 @@
     },
     "image_url": "/static/images/relics/white_beast_statue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 127
@@ -4856,6 +5144,7 @@
     },
     "image_url": "/static/images/relics/white_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 128
@@ -4875,6 +5164,7 @@
     },
     "image_url": "/static/images/relics/toolbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 159
@@ -4894,6 +5184,7 @@
     },
     "image_url": "/static/images/relics/tiny_mailbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 79
@@ -4913,6 +5204,7 @@
     },
     "image_url": "/static/images/relics/tungsten_rod.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 129
@@ -4928,6 +5220,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongo_customer_appreciation_badge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 290
@@ -4943,6 +5236,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongos_mystery_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 291
@@ -4958,6 +5252,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/massive_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 253
@@ -4973,6 +5268,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/throwing_axe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 254
@@ -4988,6 +5284,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toasty_mittens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 255
@@ -5007,6 +5304,7 @@
     },
     "image_url": "/static/images/relics/centennial_puzzle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 39
@@ -5022,6 +5320,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/very_hot_cocoa.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 256

--- a/data/eng/relics.json
+++ b/data/eng/relics.json
@@ -14,6 +14,7 @@
     },
     "image_url": "/static/images/relics/akabeko.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 40
@@ -29,6 +30,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/alchemical_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 160
@@ -44,6 +46,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/amethyst_aubergine.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 10
@@ -63,6 +66,7 @@
     },
     "image_url": "/static/images/relics/anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 11
@@ -82,6 +86,7 @@
     },
     "image_url": "/static/images/relics/fake_anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 257
@@ -97,6 +102,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/arcane_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 161
@@ -112,6 +118,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/archaic_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 162
@@ -131,6 +138,7 @@
     },
     "image_url": "/static/images/relics/art_of_war.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 80
@@ -146,6 +154,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/astrolabe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 163
@@ -165,6 +174,7 @@
     },
     "image_url": "/static/images/relics/bag_of_marbles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 12
@@ -184,6 +194,7 @@
     },
     "image_url": "/static/images/relics/bag_of_preparation.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 13
@@ -203,6 +214,7 @@
     },
     "image_url": "/static/images/relics/beating_remnant.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 81
@@ -218,6 +230,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/beautiful_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 164
@@ -237,6 +250,7 @@
     },
     "image_url": "/static/images/relics/bellows.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 82
@@ -256,6 +270,7 @@
     },
     "image_url": "/static/images/relics/belt_buckle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 130
@@ -275,6 +290,7 @@
     },
     "image_url": "/static/images/relics/big_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 83
@@ -290,6 +306,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/big_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 258
@@ -305,6 +322,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/biiig_hug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 165
@@ -320,6 +338,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bing_bong.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 259
@@ -335,6 +354,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 0
@@ -350,6 +370,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 166
@@ -365,6 +386,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blessed_antler.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 167
@@ -384,6 +406,7 @@
     },
     "image_url": "/static/images/relics/blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 14
@@ -403,6 +426,7 @@
     },
     "image_url": "/static/images/relics/fake_blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 260
@@ -418,6 +442,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blood_soaked_rose.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 168
@@ -437,6 +462,7 @@
     },
     "image_url": "/static/images/relics/bone_flute.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 15
@@ -452,6 +478,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bone_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 261
@@ -471,6 +498,7 @@
     },
     "image_url": "/static/images/relics/book_repair_knife.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 41
@@ -490,6 +518,7 @@
     },
     "image_url": "/static/images/relics/book_of_five_rings.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 16
@@ -509,6 +538,7 @@
     },
     "image_url": "/static/images/relics/bookmark.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 84
@@ -524,6 +554,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/booming_conch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 169
@@ -539,6 +570,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bound_phylactery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 1
@@ -554,6 +586,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bowler_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 42
@@ -573,6 +606,7 @@
     },
     "image_url": "/static/images/relics/bread.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 131
@@ -588,6 +622,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/brilliant_scarf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 170
@@ -607,6 +642,7 @@
     },
     "image_url": "/static/images/relics/brimstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 132
@@ -626,6 +662,7 @@
     },
     "image_url": "/static/images/relics/bronze_scales.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 17
@@ -641,6 +678,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/burning_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 2
@@ -660,6 +698,7 @@
     },
     "image_url": "/static/images/relics/burning_sticks.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 133
@@ -675,6 +714,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/byrdpip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 262
@@ -690,6 +730,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/calling_bell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 171
@@ -709,6 +750,7 @@
     },
     "image_url": "/static/images/relics/candelabra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 43
@@ -728,6 +770,7 @@
     },
     "image_url": "/static/images/relics/captains_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 85
@@ -747,6 +790,7 @@
     },
     "image_url": "/static/images/relics/cauldron.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 134
@@ -766,6 +810,7 @@
     },
     "image_url": "/static/images/relics/centennial_puzzle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 18
@@ -785,6 +830,7 @@
     },
     "image_url": "/static/images/relics/chandelier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 86
@@ -804,6 +850,7 @@
     },
     "image_url": "/static/images/relics/charons_ashes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 87
@@ -823,6 +870,7 @@
     },
     "image_url": "/static/images/relics/chemical_x.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 135
@@ -838,6 +886,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/choices_paradox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 172
@@ -853,6 +902,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/circlet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "None",
     "compendium_order": 292
@@ -868,6 +918,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/claws.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 173
@@ -887,6 +938,7 @@
     },
     "image_url": "/static/images/relics/cloak_clasp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 88
@@ -902,6 +954,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cracked_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 3
@@ -917,6 +970,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/crossbow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 174
@@ -932,6 +986,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cursed_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 175
@@ -947,6 +1002,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/darkstone_periapt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 263
@@ -966,6 +1022,7 @@
     },
     "image_url": "/static/images/relics/data_disk.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 19
@@ -981,6 +1038,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/daughter_of_the_wind.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 264
@@ -996,6 +1054,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/delicate_frond.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 176
@@ -1015,6 +1074,7 @@
     },
     "image_url": "/static/images/relics/demon_tongue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 89
@@ -1030,6 +1090,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/diamond_diadem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 177
@@ -1049,6 +1110,7 @@
     },
     "image_url": "/static/images/relics/dingy_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 136
@@ -1064,6 +1126,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/distinguished_cape.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 178
@@ -1079,6 +1142,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_destiny.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 4
@@ -1094,6 +1158,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_right.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 5
@@ -1113,6 +1178,7 @@
     },
     "image_url": "/static/images/relics/dollys_mirror.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 137
@@ -1132,6 +1198,7 @@
     },
     "image_url": "/static/images/relics/dragon_fruit.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 138
@@ -1147,6 +1214,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dream_catcher.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 265
@@ -1162,6 +1230,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/driftwood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 179
@@ -1177,6 +1246,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dusty_tome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 180
@@ -1192,6 +1262,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ectoplasm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 181
@@ -1207,6 +1278,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/electric_shrymp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 182
@@ -1222,6 +1294,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ember_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 266
@@ -1241,6 +1314,7 @@
     },
     "image_url": "/static/images/relics/emotion_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 90
@@ -1256,6 +1330,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/empty_cage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 183
@@ -1275,6 +1350,7 @@
     },
     "image_url": "/static/images/relics/eternal_feather.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 44
@@ -1294,6 +1370,7 @@
     },
     "image_url": "/static/images/relics/fencing_manual.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 20
@@ -1313,6 +1390,7 @@
     },
     "image_url": "/static/images/relics/festive_popper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 21
@@ -1328,6 +1406,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fiddle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 184
@@ -1343,6 +1422,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/forgotten_soul.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 267
@@ -1358,6 +1438,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fragrant_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 268
@@ -1373,6 +1454,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fresnel_lens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 269
@@ -1392,6 +1474,7 @@
     },
     "image_url": "/static/images/relics/frozen_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 91
@@ -1411,6 +1494,7 @@
     },
     "image_url": "/static/images/relics/funerary_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 45
@@ -1426,6 +1510,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fur_coat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 185
@@ -1445,6 +1530,7 @@
     },
     "image_url": "/static/images/relics/galactic_dust.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 46
@@ -1464,6 +1550,7 @@
     },
     "image_url": "/static/images/relics/gambling_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 92
@@ -1483,6 +1570,7 @@
     },
     "image_url": "/static/images/relics/game_piece.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 93
@@ -1502,6 +1590,7 @@
     },
     "image_url": "/static/images/relics/ghost_seed.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 139
@@ -1521,6 +1610,7 @@
     },
     "image_url": "/static/images/relics/girya.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 94
@@ -1536,6 +1626,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glass_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 186
@@ -1551,6 +1642,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glitter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 187
@@ -1570,6 +1662,7 @@
     },
     "image_url": "/static/images/relics/gnarled_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 140
@@ -1589,6 +1682,7 @@
     },
     "image_url": "/static/images/relics/gold_plated_cables.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 47
@@ -1604,6 +1698,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_compass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 188
@@ -1619,6 +1714,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 189
@@ -1638,6 +1734,7 @@
     },
     "image_url": "/static/images/relics/gorget.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 22
@@ -1657,6 +1754,7 @@
     },
     "image_url": "/static/images/relics/gremlin_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -1672,6 +1770,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hand_drill.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 270
@@ -1691,6 +1790,7 @@
     },
     "image_url": "/static/images/relics/happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 23
@@ -1710,6 +1810,7 @@
     },
     "image_url": "/static/images/relics/fake_happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 271
@@ -1725,6 +1826,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hefty_tablet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 190
@@ -1744,6 +1846,7 @@
     },
     "image_url": "/static/images/relics/helical_dart.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 95
@@ -1759,6 +1862,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/history_course.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 272
@@ -1778,6 +1882,7 @@
     },
     "image_url": "/static/images/relics/horn_cleat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 49
@@ -1797,6 +1902,7 @@
     },
     "image_url": "/static/images/relics/ice_cream.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 96
@@ -1812,6 +1918,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/infused_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 6
@@ -1831,6 +1938,7 @@
     },
     "image_url": "/static/images/relics/intimidating_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 97
@@ -1846,6 +1954,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/iron_club.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 191
@@ -1865,6 +1974,7 @@
     },
     "image_url": "/static/images/relics/ivory_tile.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 98
@@ -1880,6 +1990,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jeweled_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 192
@@ -1895,6 +2006,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jewelry_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 193
@@ -1914,6 +2026,7 @@
     },
     "image_url": "/static/images/relics/joss_paper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -1933,6 +2046,7 @@
     },
     "image_url": "/static/images/relics/juzu_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 24
@@ -1952,6 +2066,7 @@
     },
     "image_url": "/static/images/relics/kifuda.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 141
@@ -1971,6 +2086,7 @@
     },
     "image_url": "/static/images/relics/kunai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 99
@@ -1990,6 +2106,7 @@
     },
     "image_url": "/static/images/relics/kusarigama.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 51
@@ -2009,6 +2126,7 @@
     },
     "image_url": "/static/images/relics/lantern.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 25
@@ -2024,6 +2142,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/large_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 194
@@ -2043,6 +2162,7 @@
     },
     "image_url": "/static/images/relics/lasting_candy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 52
@@ -2062,6 +2182,7 @@
     },
     "image_url": "/static/images/relics/lava_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 142
@@ -2077,6 +2198,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lava_rock.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 195
@@ -2092,6 +2214,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lead_paperweight.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 196
@@ -2107,6 +2230,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/leafy_poultice.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 197
@@ -2126,6 +2250,7 @@
     },
     "image_url": "/static/images/relics/lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 143
@@ -2145,6 +2270,7 @@
     },
     "image_url": "/static/images/relics/fake_lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 273
@@ -2164,6 +2290,7 @@
     },
     "image_url": "/static/images/relics/letter_opener.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 53
@@ -2183,6 +2310,7 @@
     },
     "image_url": "/static/images/relics/lizard_tail.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 100
@@ -2201,6 +2329,7 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
+    "name_variants": null,
     "notes": [
       "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
       "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
@@ -2219,6 +2348,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lords_parasol.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 199
@@ -2234,6 +2364,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 200
@@ -2249,6 +2380,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_wisp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 274
@@ -2264,6 +2396,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lucky_fysh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -2283,6 +2416,7 @@
     },
     "image_url": "/static/images/relics/lunar_pastry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 101
@@ -2302,6 +2436,7 @@
     },
     "image_url": "/static/images/relics/mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 102
@@ -2321,6 +2456,7 @@
     },
     "image_url": "/static/images/relics/fake_mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 275
@@ -2336,6 +2472,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/massive_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 201
@@ -2351,6 +2488,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/maw_bank.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 276
@@ -2370,6 +2508,7 @@
     },
     "image_url": "/static/images/relics/meal_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 26
@@ -2385,6 +2524,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/meat_cleaver.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 202
@@ -2404,6 +2544,7 @@
     },
     "image_url": "/static/images/relics/meat_on_the_bone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 103
@@ -2423,6 +2564,7 @@
     },
     "image_url": "/static/images/relics/membership_card.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 144
@@ -2442,6 +2584,7 @@
     },
     "image_url": "/static/images/relics/mercury_hourglass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 55
@@ -2461,6 +2604,7 @@
     },
     "image_url": "/static/images/relics/metronome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 104
@@ -2480,6 +2624,7 @@
     },
     "image_url": "/static/images/relics/mini_regent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 105
@@ -2499,6 +2644,7 @@
     },
     "image_url": "/static/images/relics/miniature_cannon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 56
@@ -2518,6 +2664,7 @@
     },
     "image_url": "/static/images/relics/miniature_tent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 145
@@ -2537,6 +2684,7 @@
     },
     "image_url": "/static/images/relics/molten_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 106
@@ -2552,6 +2700,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/mr_struggles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 277
@@ -2571,6 +2720,7 @@
     },
     "image_url": "/static/images/relics/mummified_hand.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 107
@@ -2586,6 +2736,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/music_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 203
@@ -2605,6 +2756,7 @@
     },
     "image_url": "/static/images/relics/mystic_lighter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 146
@@ -2620,6 +2772,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_bones.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 204
@@ -2635,6 +2788,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_talisman.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 205
@@ -2650,6 +2804,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_torment.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 206
@@ -2665,6 +2820,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/new_leaf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 207
@@ -2684,6 +2840,7 @@
     },
     "image_url": "/static/images/relics/ninja_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 147
@@ -2703,6 +2860,7 @@
     },
     "image_url": "/static/images/relics/nunchaku.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 57
@@ -2718,6 +2876,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_oyster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 208
@@ -2733,6 +2892,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_soup.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 209
@@ -2752,6 +2912,7 @@
     },
     "image_url": "/static/images/relics/oddly_smooth_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 27
@@ -2767,6 +2928,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/old_coin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 108
@@ -2786,6 +2948,7 @@
     },
     "image_url": "/static/images/relics/orange_dough.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 109
@@ -2805,6 +2968,7 @@
     },
     "image_url": "/static/images/relics/orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 58
@@ -2824,6 +2988,7 @@
     },
     "image_url": "/static/images/relics/fake_orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 278
@@ -2843,6 +3008,7 @@
     },
     "image_url": "/static/images/relics/ornamental_fan.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 59
@@ -2862,6 +3028,7 @@
     },
     "image_url": "/static/images/relics/orrery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 148
@@ -2877,6 +3044,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 210
@@ -2892,6 +3060,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_claw.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 211
@@ -2907,6 +3076,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 212
@@ -2922,6 +3092,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_flesh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 213
@@ -2937,6 +3108,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_growth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 214
@@ -2952,6 +3124,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 215
@@ -2967,6 +3140,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_legion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 216
@@ -2982,6 +3156,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 217
@@ -2997,6 +3172,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 218
@@ -3012,6 +3188,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_wing.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 219
@@ -3027,6 +3204,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pandoras_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 220
@@ -3046,6 +3224,7 @@
     },
     "image_url": "/static/images/relics/pantograph.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 60
@@ -3065,6 +3244,7 @@
     },
     "image_url": "/static/images/relics/paper_krane.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 110
@@ -3084,6 +3264,7 @@
     },
     "image_url": "/static/images/relics/paper_phrog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 61
@@ -3103,6 +3284,7 @@
     },
     "image_url": "/static/images/relics/parrying_shield.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 62
@@ -3122,6 +3304,7 @@
     },
     "image_url": "/static/images/relics/pear.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -3141,6 +3324,7 @@
     },
     "image_url": "/static/images/relics/pen_nib.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 64
@@ -3160,6 +3344,7 @@
     },
     "image_url": "/static/images/relics/pendulum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 28
@@ -3179,6 +3364,7 @@
     },
     "image_url": "/static/images/relics/permafrost.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 65
@@ -3198,6 +3384,7 @@
     },
     "image_url": "/static/images/relics/petrified_toad.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 66
@@ -3213,6 +3400,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phial_holster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 221
@@ -3228,6 +3416,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/philosophers_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 222
@@ -3243,6 +3432,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phylactery_unbound.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 7
@@ -3262,6 +3452,7 @@
     },
     "image_url": "/static/images/relics/planisphere.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 67
@@ -3281,6 +3472,7 @@
     },
     "image_url": "/static/images/relics/pocketwatch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 111
@@ -3296,6 +3488,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pollinous_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 279
@@ -3311,6 +3504,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pomander.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 223
@@ -3330,6 +3524,7 @@
     },
     "image_url": "/static/images/relics/potion_belt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 29
@@ -3349,6 +3544,7 @@
     },
     "image_url": "/static/images/relics/power_cell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 112
@@ -3368,6 +3564,7 @@
     },
     "image_url": "/static/images/relics/prayer_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 113
@@ -3383,6 +3580,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precarious_shears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 224
@@ -3398,6 +3596,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precise_scissors.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 225
@@ -3413,6 +3612,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/preserved_fog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 226
@@ -3428,6 +3628,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/prismatic_gem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 227
@@ -3443,6 +3644,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pumpkin_candle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 228
@@ -3462,6 +3664,7 @@
     },
     "image_url": "/static/images/relics/punch_dagger.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 149
@@ -3477,6 +3680,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/radiant_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 229
@@ -3496,6 +3700,7 @@
     },
     "image_url": "/static/images/relics/rainbow_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 114
@@ -3515,6 +3720,7 @@
     },
     "image_url": "/static/images/relics/razor_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 115
@@ -3534,6 +3740,7 @@
     },
     "image_url": "/static/images/relics/red_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 30
@@ -3553,6 +3760,7 @@
     },
     "image_url": "/static/images/relics/red_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 31
@@ -3572,6 +3780,7 @@
     },
     "image_url": "/static/images/relics/regal_pillow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 32
@@ -3591,6 +3800,7 @@
     },
     "image_url": "/static/images/relics/regalite.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -3610,6 +3820,7 @@
     },
     "image_url": "/static/images/relics/reptile_trinket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 69
@@ -3625,6 +3836,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_drake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 8
@@ -3640,6 +3852,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_snake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 9
@@ -3659,6 +3872,7 @@
     },
     "image_url": "/static/images/relics/ringing_triangle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 150
@@ -3678,6 +3892,7 @@
     },
     "image_url": "/static/images/relics/ripple_basin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 70
@@ -3693,6 +3908,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/royal_poison.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 280
@@ -3712,6 +3928,7 @@
     },
     "image_url": "/static/images/relics/royal_stamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 151
@@ -3731,6 +3948,7 @@
     },
     "image_url": "/static/images/relics/ruined_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 116
@@ -3750,6 +3968,7 @@
     },
     "image_url": "/static/images/relics/runic_capacitor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 152
@@ -3765,6 +3984,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/runic_pyramid.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 230
@@ -3780,6 +4000,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 231
@@ -3795,6 +4016,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sand_castle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 232
@@ -3814,6 +4036,7 @@
     },
     "image_url": "/static/images/relics/screaming_flagon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 153
@@ -3829,6 +4052,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/scroll_boxes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 233
@@ -3844,6 +4068,13 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sea_glass.webp",
     "image_variants": null,
+    "name_variants": {
+      "Ironclad": "Demon Glass",
+      "Silent": "Venom Glass",
+      "Defect": "Gear Glass",
+      "Necrobinder": "Lich Glass",
+      "Regent": "Noble Glass"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 234
@@ -3859,6 +4090,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/seal_of_gold.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 235
@@ -3878,6 +4110,7 @@
     },
     "image_url": "/static/images/relics/self_forming_clay.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 71
@@ -3893,6 +4126,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sere_talon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 236
@@ -3912,6 +4146,7 @@
     },
     "image_url": "/static/images/relics/shovel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 117
@@ -3931,6 +4166,7 @@
     },
     "image_url": "/static/images/relics/shuriken.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 118
@@ -3946,6 +4182,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/signet_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 237
@@ -3961,6 +4198,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/silver_crucible.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 238
@@ -3980,6 +4218,7 @@
     },
     "image_url": "/static/images/relics/sling_of_courage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 154
@@ -3995,6 +4234,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/small_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 239
@@ -4010,6 +4250,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 240
@@ -4029,6 +4270,7 @@
     },
     "image_url": "/static/images/relics/fake_snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 281
@@ -4048,6 +4290,7 @@
     },
     "image_url": "/static/images/relics/snecko_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 33
@@ -4063,6 +4306,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sozu.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 241
@@ -4082,6 +4326,7 @@
     },
     "image_url": "/static/images/relics/sparkling_rouge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 72
@@ -4097,6 +4342,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/spiked_gauntlets.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 242
@@ -4116,6 +4362,7 @@
     },
     "image_url": "/static/images/relics/stone_calendar.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 119
@@ -4135,6 +4382,7 @@
     },
     "image_url": "/static/images/relics/stone_cracker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 73
@@ -4150,6 +4398,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/stone_humidifier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 243
@@ -4165,6 +4414,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/storybook.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 244
@@ -4184,6 +4434,7 @@
     },
     "image_url": "/static/images/relics/strawberry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 34
@@ -4203,6 +4454,7 @@
     },
     "image_url": "/static/images/relics/strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 35
@@ -4222,6 +4474,7 @@
     },
     "image_url": "/static/images/relics/fake_strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 282
@@ -4241,6 +4494,7 @@
     },
     "image_url": "/static/images/relics/sturdy_clamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 120
@@ -4256,6 +4510,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_jade.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 283
@@ -4271,6 +4526,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 284
@@ -4290,6 +4546,7 @@
     },
     "image_url": "/static/images/relics/symbiotic_virus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 74
@@ -4305,6 +4562,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tanxs_whistle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 245
@@ -4320,6 +4578,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tea_of_discourtesy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 285
@@ -4339,6 +4598,7 @@
     },
     "image_url": "/static/images/relics/the_abacus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 155
@@ -4354,6 +4614,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_boot.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 286
@@ -4369,6 +4630,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/chosen_cheese.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 287
@@ -4384,6 +4646,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_courier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 121
@@ -4399,6 +4662,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fake_merchants_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 288
@@ -4414,6 +4678,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/throwing_axe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 246
@@ -4433,6 +4698,7 @@
     },
     "image_url": "/static/images/relics/tingsha.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -4452,6 +4718,7 @@
     },
     "image_url": "/static/images/relics/tiny_mailbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 76
@@ -4467,6 +4734,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toasty_mittens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 247
@@ -4486,6 +4754,7 @@
     },
     "image_url": "/static/images/relics/toolbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 156
@@ -4501,6 +4770,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/touch_of_orobas.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 248
@@ -4520,6 +4790,7 @@
     },
     "image_url": "/static/images/relics/tough_bandages.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 122
@@ -4539,6 +4810,7 @@
     },
     "image_url": "/static/images/relics/toxic_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 123
@@ -4554,6 +4826,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toy_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": [
       "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed.",
       "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
@@ -4573,6 +4846,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tri_boomerang.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 250
@@ -4592,6 +4866,7 @@
     },
     "image_url": "/static/images/relics/tungsten_rod.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 124
@@ -4611,6 +4886,7 @@
     },
     "image_url": "/static/images/relics/tuning_fork.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 77
@@ -4630,6 +4906,7 @@
     },
     "image_url": "/static/images/relics/twisted_funnel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -4649,6 +4926,7 @@
     },
     "image_url": "/static/images/relics/unceasing_top.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 125
@@ -4668,6 +4946,7 @@
     },
     "image_url": "/static/images/relics/undying_sigil.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 157
@@ -4687,6 +4966,7 @@
     },
     "image_url": "/static/images/relics/unsettling_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 126
@@ -4706,6 +4986,7 @@
     },
     "image_url": "/static/images/relics/vajra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 36
@@ -4725,6 +5006,7 @@
     },
     "image_url": "/static/images/relics/vambrace.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 79
@@ -4740,6 +5022,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/velvet_choker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 251
@@ -4759,6 +5042,7 @@
     },
     "image_url": "/static/images/relics/venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 37
@@ -4778,6 +5062,7 @@
     },
     "image_url": "/static/images/relics/fake_venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 289
@@ -4793,6 +5078,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/very_hot_cocoa.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 252
@@ -4812,6 +5098,7 @@
     },
     "image_url": "/static/images/relics/vexing_puzzlebox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 127
@@ -4831,6 +5118,7 @@
     },
     "image_url": "/static/images/relics/vitruvian_minion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 158
@@ -4846,6 +5134,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/war_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 253
@@ -4865,6 +5154,7 @@
     },
     "image_url": "/static/images/relics/war_paint.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 38
@@ -4884,6 +5174,7 @@
     },
     "image_url": "/static/images/relics/whetstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 39
@@ -4899,6 +5190,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/whispering_earring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 254
@@ -4918,6 +5210,7 @@
     },
     "image_url": "/static/images/relics/white_beast_statue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 128
@@ -4937,6 +5230,7 @@
     },
     "image_url": "/static/images/relics/white_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 129
@@ -4956,6 +5250,7 @@
     },
     "image_url": "/static/images/relics/wing_charm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 159
@@ -4971,6 +5266,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/winged_boots.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 255
@@ -4986,6 +5282,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongo_customer_appreciation_badge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 290
@@ -5001,6 +5298,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongos_mystery_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 291
@@ -5022,6 +5320,7 @@
       "Necrobinder": "/static/images/relics/yummy_cookie_necrobinder.webp",
       "Regent": "/static/images/relics/yummy_cookie_regent.webp"
     },
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 256

--- a/data/esp/relics.json
+++ b/data/esp/relics.json
@@ -14,6 +14,7 @@
     },
     "image_url": "/static/images/relics/ornamental_fan.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 40
@@ -33,6 +34,7 @@
     },
     "image_url": "/static/images/relics/sturdy_clamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 80
@@ -48,6 +50,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/biiig_hug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 160
@@ -67,6 +70,7 @@
     },
     "image_url": "/static/images/relics/letter_opener.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 41
@@ -82,6 +86,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fur_coat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 161
@@ -101,6 +106,7 @@
     },
     "image_url": "/static/images/relics/centennial_puzzle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 10
@@ -120,6 +126,7 @@
     },
     "image_url": "/static/images/relics/reptile_trinket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 42
@@ -139,6 +146,7 @@
     },
     "image_url": "/static/images/relics/akabeko.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 43
@@ -154,6 +162,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_wing.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 162
@@ -169,6 +178,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/maw_bank.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 257
@@ -188,6 +198,7 @@
     },
     "image_url": "/static/images/relics/dingy_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 130
@@ -203,6 +214,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/forgotten_soul.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 258
@@ -222,6 +234,7 @@
     },
     "image_url": "/static/images/relics/regal_pillow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 11
@@ -241,6 +254,7 @@
     },
     "image_url": "/static/images/relics/wing_charm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 131
@@ -260,6 +274,7 @@
     },
     "image_url": "/static/images/relics/anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 12
@@ -279,6 +294,7 @@
     },
     "image_url": "/static/images/relics/rainbow_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 81
@@ -294,6 +310,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/signet_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 163
@@ -309,6 +326,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_drake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 0
@@ -324,6 +342,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_snake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 1
@@ -339,6 +358,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 164
@@ -358,6 +378,7 @@
     },
     "image_url": "/static/images/relics/self_forming_clay.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 44
@@ -377,6 +398,7 @@
     },
     "image_url": "/static/images/relics/art_of_war.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 82
@@ -392,6 +414,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/astrolabe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 165
@@ -407,6 +430,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dream_catcher.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 259
@@ -426,6 +450,7 @@
     },
     "image_url": "/static/images/relics/vambrace.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 45
@@ -445,6 +470,7 @@
     },
     "image_url": "/static/images/relics/brimstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 132
@@ -460,6 +486,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/crossbow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 166
@@ -475,6 +502,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/amethyst_aubergine.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 13
@@ -494,6 +522,7 @@
     },
     "image_url": "/static/images/relics/joss_paper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 46
@@ -509,6 +538,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bing_bong.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 260
@@ -528,6 +558,7 @@
     },
     "image_url": "/static/images/relics/meal_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 14
@@ -543,6 +574,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongos_mystery_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 261
@@ -562,6 +594,7 @@
     },
     "image_url": "/static/images/relics/bag_of_marbles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 15
@@ -581,6 +614,7 @@
     },
     "image_url": "/static/images/relics/bag_of_preparation.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 16
@@ -596,6 +630,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bowler_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 47
@@ -611,6 +646,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_boot.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 262
@@ -626,6 +662,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/beautiful_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 167
@@ -645,6 +682,7 @@
     },
     "image_url": "/static/images/relics/cloak_clasp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 83
@@ -660,6 +698,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_compass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 168
@@ -675,6 +714,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/brilliant_scarf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 169
@@ -694,6 +734,7 @@
     },
     "image_url": "/static/images/relics/tiny_mailbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -709,6 +750,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tri_boomerang.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 170
@@ -728,6 +770,7 @@
     },
     "image_url": "/static/images/relics/gold_plated_cables.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 49
@@ -743,6 +786,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pandoras_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 171
@@ -762,6 +806,7 @@
     },
     "image_url": "/static/images/relics/toolbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 133
@@ -777,6 +822,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toy_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": [
       "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed.",
       "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
@@ -796,6 +842,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/scroll_boxes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 173
@@ -815,6 +862,7 @@
     },
     "image_url": "/static/images/relics/vexing_puzzlebox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 84
@@ -830,6 +878,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/music_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 174
@@ -849,6 +898,7 @@
     },
     "image_url": "/static/images/relics/red_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 17
@@ -868,6 +918,7 @@
     },
     "image_url": "/static/images/relics/cauldron.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 134
@@ -887,6 +938,7 @@
     },
     "image_url": "/static/images/relics/stone_calendar.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 85
@@ -902,6 +954,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/calling_bell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 175
@@ -921,6 +974,7 @@
     },
     "image_url": "/static/images/relics/chandelier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 86
@@ -940,6 +994,7 @@
     },
     "image_url": "/static/images/relics/candelabra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -955,6 +1010,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/distinguished_cape.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 176
@@ -970,6 +1026,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/booming_conch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 177
@@ -989,6 +1046,7 @@
     },
     "image_url": "/static/images/relics/lasting_candy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 51
@@ -1008,6 +1066,7 @@
     },
     "image_url": "/static/images/relics/meat_on_the_bone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 87
@@ -1023,6 +1082,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_flesh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 178
@@ -1038,6 +1098,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sand_castle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 179
@@ -1053,6 +1114,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/leafy_poultice.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 180
@@ -1072,6 +1134,7 @@
     },
     "image_url": "/static/images/relics/power_cell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 88
@@ -1091,6 +1154,7 @@
     },
     "image_url": "/static/images/relics/charons_ashes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 89
@@ -1110,6 +1174,7 @@
     },
     "image_url": "/static/images/relics/emotion_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 90
@@ -1125,6 +1190,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/very_hot_cocoa.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 181
@@ -1144,6 +1210,7 @@
     },
     "image_url": "/static/images/relics/potion_belt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 18
@@ -1159,6 +1226,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/history_course.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 263
@@ -1174,6 +1242,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/alchemical_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 182
@@ -1193,6 +1262,7 @@
     },
     "image_url": "/static/images/relics/lizard_tail.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 91
@@ -1212,6 +1282,7 @@
     },
     "image_url": "/static/images/relics/runic_capacitor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 135
@@ -1227,6 +1298,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blessed_antler.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 183
@@ -1246,6 +1318,7 @@
     },
     "image_url": "/static/images/relics/horn_cleat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 52
@@ -1264,6 +1337,7 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
+    "name_variants": null,
     "notes": [
       "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
       "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
@@ -1282,6 +1356,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/circlet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "None",
     "compendium_order": 292
@@ -1297,6 +1372,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/silver_crucible.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 185
@@ -1316,6 +1392,7 @@
     },
     "image_url": "/static/images/relics/snecko_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 19
@@ -1331,6 +1408,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/meat_cleaver.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 186
@@ -1350,6 +1428,7 @@
     },
     "image_url": "/static/images/relics/book_repair_knife.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 53
@@ -1369,6 +1448,7 @@
     },
     "image_url": "/static/images/relics/ripple_basin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -1384,6 +1464,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 187
@@ -1403,6 +1484,7 @@
     },
     "image_url": "/static/images/relics/gremlin_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 55
@@ -1418,6 +1500,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/large_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 188
@@ -1433,6 +1516,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/small_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 189
@@ -1452,6 +1536,7 @@
     },
     "image_url": "/static/images/relics/punch_dagger.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 136
@@ -1471,6 +1556,7 @@
     },
     "image_url": "/static/images/relics/helical_dart.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 92
@@ -1486,6 +1572,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_right.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 2
@@ -1501,6 +1588,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_destiny.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 3
@@ -1516,6 +1604,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/diamond_diadem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 190
@@ -1535,6 +1624,7 @@
     },
     "image_url": "/static/images/relics/tuning_fork.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 56
@@ -1550,6 +1640,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/archaic_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 191
@@ -1565,6 +1656,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 192
@@ -1584,6 +1676,7 @@
     },
     "image_url": "/static/images/relics/razor_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 93
@@ -1603,6 +1696,7 @@
     },
     "image_url": "/static/images/relics/data_disk.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 20
@@ -1618,6 +1712,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ectoplasm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 193
@@ -1637,6 +1732,7 @@
     },
     "image_url": "/static/images/relics/twisted_funnel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 57
@@ -1656,6 +1752,7 @@
     },
     "image_url": "/static/images/relics/mystic_lighter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 137
@@ -1675,6 +1772,7 @@
     },
     "image_url": "/static/images/relics/vitruvian_minion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 138
@@ -1694,6 +1792,7 @@
     },
     "image_url": "/static/images/relics/bronze_scales.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 21
@@ -1713,6 +1812,7 @@
     },
     "image_url": "/static/images/relics/parrying_shield.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 58
@@ -1728,6 +1828,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_jade.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 264
@@ -1743,6 +1844,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 265
@@ -1762,6 +1864,7 @@
     },
     "image_url": "/static/images/relics/dollys_mirror.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 139
@@ -1781,6 +1884,7 @@
     },
     "image_url": "/static/images/relics/white_beast_statue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 94
@@ -1800,6 +1904,7 @@
     },
     "image_url": "/static/images/relics/white_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 95
@@ -1815,6 +1920,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 194
@@ -1834,6 +1940,7 @@
     },
     "image_url": "/static/images/relics/lantern.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 22
@@ -1853,6 +1960,7 @@
     },
     "image_url": "/static/images/relics/gambling_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 96
@@ -1868,6 +1976,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phylactery_unbound.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 4
@@ -1883,6 +1992,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bound_phylactery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 5
@@ -1902,6 +2012,7 @@
     },
     "image_url": "/static/images/relics/bone_flute.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 23
@@ -1921,6 +2032,7 @@
     },
     "image_url": "/static/images/relics/happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 24
@@ -1940,6 +2052,7 @@
     },
     "image_url": "/static/images/relics/strawberry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 25
@@ -1955,6 +2068,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_wisp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 266
@@ -1974,6 +2088,7 @@
     },
     "image_url": "/static/images/relics/bellows.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 97
@@ -1995,6 +2110,7 @@
       "Necrobinder": "/static/images/relics/yummy_cookie_necrobinder.webp",
       "Regent": "/static/images/relics/yummy_cookie_regent.webp"
     },
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 195
@@ -2010,6 +2126,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/velvet_choker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 196
@@ -2025,6 +2142,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_claw.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 197
@@ -2040,6 +2158,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sere_talon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 198
@@ -2055,6 +2174,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/claws.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 199
@@ -2070,6 +2190,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/iron_club.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 200
@@ -2085,6 +2206,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/prismatic_gem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 201
@@ -2100,6 +2222,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/massive_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 202
@@ -2119,6 +2242,7 @@
     },
     "image_url": "/static/images/relics/gorget.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 26
@@ -2138,6 +2262,7 @@
     },
     "image_url": "/static/images/relics/paper_krane.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 98
@@ -2153,6 +2278,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/spiked_gauntlets.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 203
@@ -2168,6 +2294,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/throwing_axe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 204
@@ -2187,6 +2314,7 @@
     },
     "image_url": "/static/images/relics/belt_buckle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 140
@@ -2206,6 +2334,7 @@
     },
     "image_url": "/static/images/relics/ice_cream.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 99
@@ -2221,6 +2350,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/delicate_frond.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 205
@@ -2236,6 +2366,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/daughter_of_the_wind.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 267
@@ -2251,6 +2382,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/new_leaf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 206
@@ -2270,6 +2402,7 @@
     },
     "image_url": "/static/images/relics/sling_of_courage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 141
@@ -2285,6 +2418,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fragrant_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 268
@@ -2300,6 +2434,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/big_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 269
@@ -2319,6 +2454,7 @@
     },
     "image_url": "/static/images/relics/frozen_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 100
@@ -2338,6 +2474,7 @@
     },
     "image_url": "/static/images/relics/molten_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 101
@@ -2357,6 +2494,7 @@
     },
     "image_url": "/static/images/relics/toxic_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 102
@@ -2372,6 +2510,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/stone_humidifier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 207
@@ -2391,6 +2530,7 @@
     },
     "image_url": "/static/images/relics/burning_sticks.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 142
@@ -2406,6 +2546,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongo_customer_appreciation_badge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 270
@@ -2421,6 +2562,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/byrdpip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 271
@@ -2440,6 +2582,7 @@
     },
     "image_url": "/static/images/relics/screaming_flagon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 143
@@ -2455,6 +2598,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/empty_cage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 208
@@ -2470,6 +2614,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jewelry_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 209
@@ -2489,6 +2634,7 @@
     },
     "image_url": "/static/images/relics/venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 27
@@ -2508,6 +2654,7 @@
     },
     "image_url": "/static/images/relics/kifuda.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 144
@@ -2527,6 +2674,7 @@
     },
     "image_url": "/static/images/relics/kunai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 103
@@ -2546,6 +2694,7 @@
     },
     "image_url": "/static/images/relics/kusarigama.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 59
@@ -2565,6 +2714,7 @@
     },
     "image_url": "/static/images/relics/festive_popper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 28
@@ -2580,6 +2730,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_legion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 210
@@ -2599,6 +2750,7 @@
     },
     "image_url": "/static/images/relics/demon_tongue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 104
@@ -2614,6 +2766,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fresnel_lens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 272
@@ -2629,6 +2782,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/storybook.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 211
@@ -2648,6 +2802,7 @@
     },
     "image_url": "/static/images/relics/book_of_five_rings.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 29
@@ -2667,6 +2822,7 @@
     },
     "image_url": "/static/images/relics/ivory_tile.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 105
@@ -2682,6 +2838,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 212
@@ -2701,6 +2858,7 @@
     },
     "image_url": "/static/images/relics/lava_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 145
@@ -2720,6 +2878,7 @@
     },
     "image_url": "/static/images/relics/unsettling_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 106
@@ -2735,6 +2894,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/electric_shrymp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 213
@@ -2750,6 +2910,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/driftwood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 214
@@ -2769,6 +2930,7 @@
     },
     "image_url": "/static/images/relics/mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 107
@@ -2788,6 +2950,7 @@
     },
     "image_url": "/static/images/relics/mummified_hand.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 108
@@ -2807,6 +2970,7 @@
     },
     "image_url": "/static/images/relics/fencing_manual.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 30
@@ -2826,6 +2990,7 @@
     },
     "image_url": "/static/images/relics/bookmark.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 109
@@ -2841,6 +3006,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/war_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 215
@@ -2860,6 +3026,7 @@
     },
     "image_url": "/static/images/relics/gnarled_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 146
@@ -2879,6 +3046,7 @@
     },
     "image_url": "/static/images/relics/orange_dough.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 110
@@ -2898,6 +3066,7 @@
     },
     "image_url": "/static/images/relics/metronome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 111
@@ -2917,6 +3086,7 @@
     },
     "image_url": "/static/images/relics/miniature_tent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 147
@@ -2936,6 +3106,7 @@
     },
     "image_url": "/static/images/relics/miniature_cannon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 60
@@ -2955,6 +3126,7 @@
     },
     "image_url": "/static/images/relics/mini_regent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 112
@@ -2970,6 +3142,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toasty_mittens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 216
@@ -2985,6 +3158,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/old_coin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 113
@@ -3004,6 +3178,7 @@
     },
     "image_url": "/static/images/relics/strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 31
@@ -3019,6 +3194,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jeweled_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 217
@@ -3038,6 +3214,7 @@
     },
     "image_url": "/static/images/relics/funerary_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 61
@@ -3057,6 +3234,7 @@
     },
     "image_url": "/static/images/relics/red_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 32
@@ -3072,6 +3250,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_bones.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 218
@@ -3087,6 +3266,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/preserved_fog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 219
@@ -3106,6 +3286,7 @@
     },
     "image_url": "/static/images/relics/nunchaku.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 62
@@ -3121,6 +3302,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cracked_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 6
@@ -3136,6 +3318,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/infused_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 7
@@ -3151,6 +3334,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pollinous_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 273
@@ -3166,6 +3350,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 220
@@ -3181,6 +3366,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 221
@@ -3196,6 +3382,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glass_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 222
@@ -3215,6 +3402,7 @@
     },
     "image_url": "/static/images/relics/orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -3230,6 +3418,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_oyster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 223
@@ -3249,6 +3438,7 @@
     },
     "image_url": "/static/images/relics/shovel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 114
@@ -3268,6 +3458,7 @@
     },
     "image_url": "/static/images/relics/bread.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 148
@@ -3287,6 +3478,7 @@
     },
     "image_url": "/static/images/relics/pantograph.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 64
@@ -3302,6 +3494,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/choices_paradox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 224
@@ -3321,6 +3514,7 @@
     },
     "image_url": "/static/images/relics/lunar_pastry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 115
@@ -3336,6 +3530,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/whispering_earring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 225
@@ -3355,6 +3550,7 @@
     },
     "image_url": "/static/images/relics/pear.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 65
@@ -3370,6 +3566,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/arcane_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 226
@@ -3389,6 +3586,7 @@
     },
     "image_url": "/static/images/relics/ninja_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 149
@@ -3404,6 +3602,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/darkstone_periapt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 274
@@ -3419,6 +3618,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 227
@@ -3434,6 +3634,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cursed_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 228
@@ -3449,6 +3650,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/radiant_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 229
@@ -3468,6 +3670,7 @@
     },
     "image_url": "/static/images/relics/permafrost.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 66
@@ -3487,6 +3690,7 @@
     },
     "image_url": "/static/images/relics/girya.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 116
@@ -3502,6 +3706,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lucky_fysh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 67
@@ -3517,6 +3722,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phial_holster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 230
@@ -3536,6 +3742,7 @@
     },
     "image_url": "/static/images/relics/whetstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 33
@@ -3555,6 +3762,7 @@
     },
     "image_url": "/static/images/relics/oddly_smooth_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 34
@@ -3570,6 +3778,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/philosophers_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 231
@@ -3589,6 +3798,7 @@
     },
     "image_url": "/static/images/relics/game_piece.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 117
@@ -3608,6 +3818,7 @@
     },
     "image_url": "/static/images/relics/sparkling_rouge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -3627,6 +3838,7 @@
     },
     "image_url": "/static/images/relics/war_paint.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 35
@@ -3642,6 +3854,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/runic_pyramid.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 232
@@ -3657,6 +3870,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lead_paperweight.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 233
@@ -3676,6 +3890,7 @@
     },
     "image_url": "/static/images/relics/dragon_fruit.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 150
@@ -3695,6 +3910,7 @@
     },
     "image_url": "/static/images/relics/orrery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 151
@@ -3714,6 +3930,7 @@
     },
     "image_url": "/static/images/relics/planisphere.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 69
@@ -3733,6 +3950,7 @@
     },
     "image_url": "/static/images/relics/eternal_feather.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 70
@@ -3752,6 +3970,7 @@
     },
     "image_url": "/static/images/relics/pen_nib.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 71
@@ -3771,6 +3990,7 @@
     },
     "image_url": "/static/images/relics/galactic_dust.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 72
@@ -3786,6 +4006,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pomander.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 234
@@ -3805,6 +4026,7 @@
     },
     "image_url": "/static/images/relics/juzu_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 36
@@ -3820,6 +4042,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glitter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 235
@@ -3839,6 +4062,7 @@
     },
     "image_url": "/static/images/relics/pendulum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 37
@@ -3854,6 +4078,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/chosen_cheese.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 275
@@ -3873,6 +4098,7 @@
     },
     "image_url": "/static/images/relics/regalite.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 73
@@ -3892,6 +4118,7 @@
     },
     "image_url": "/static/images/relics/pocketwatch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 118
@@ -3911,6 +4138,7 @@
     },
     "image_url": "/static/images/relics/mercury_hourglass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 74
@@ -3930,6 +4158,7 @@
     },
     "image_url": "/static/images/relics/beating_remnant.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 119
@@ -3945,6 +4174,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_courier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 120
@@ -3964,6 +4194,7 @@
     },
     "image_url": "/static/images/relics/paper_phrog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -3979,6 +4210,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lava_rock.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 236
@@ -3998,6 +4230,7 @@
     },
     "image_url": "/static/images/relics/stone_cracker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 76
@@ -4013,6 +4246,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blood_soaked_rose.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 237
@@ -4032,6 +4266,7 @@
     },
     "image_url": "/static/images/relics/prayer_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 121
@@ -4047,6 +4282,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 238
@@ -4062,6 +4298,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/burning_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 8
@@ -4077,6 +4314,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 9
@@ -4092,6 +4330,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 239
@@ -4111,6 +4350,7 @@
     },
     "image_url": "/static/images/relics/petrified_toad.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 77
@@ -4126,6 +4366,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/seal_of_gold.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 240
@@ -4145,6 +4386,7 @@
     },
     "image_url": "/static/images/relics/royal_stamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 152
@@ -4164,6 +4406,7 @@
     },
     "image_url": "/static/images/relics/ghost_seed.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 153
@@ -4183,6 +4426,7 @@
     },
     "image_url": "/static/images/relics/shuriken.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 122
@@ -4202,6 +4446,7 @@
     },
     "image_url": "/static/images/relics/undying_sigil.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 154
@@ -4217,6 +4462,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tanxs_whistle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 241
@@ -4236,6 +4482,7 @@
     },
     "image_url": "/static/images/relics/big_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 123
@@ -4251,6 +4498,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lords_parasol.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 242
@@ -4266,6 +4514,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_soup.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 243
@@ -4281,6 +4530,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sozu.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 244
@@ -4296,6 +4546,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/mr_struggles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 276
@@ -4315,6 +4566,7 @@
     },
     "image_url": "/static/images/relics/chemical_x.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 155
@@ -4330,6 +4582,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hefty_tablet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 245
@@ -4345,6 +4598,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hand_drill.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 277
@@ -4360,6 +4614,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_talisman.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 246
@@ -4379,6 +4634,7 @@
     },
     "image_url": "/static/images/relics/membership_card.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 156
@@ -4394,6 +4650,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precarious_shears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 247
@@ -4409,6 +4666,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precise_scissors.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 248
@@ -4428,6 +4686,7 @@
     },
     "image_url": "/static/images/relics/captains_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 124
@@ -4447,6 +4706,7 @@
     },
     "image_url": "/static/images/relics/tingsha.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -4462,6 +4722,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dusty_tome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 249
@@ -4477,6 +4738,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/touch_of_orobas.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 250
@@ -4492,6 +4754,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_torment.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 251
@@ -4511,6 +4774,7 @@
     },
     "image_url": "/static/images/relics/ringing_triangle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 157
@@ -4530,6 +4794,7 @@
     },
     "image_url": "/static/images/relics/unceasing_top.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 125
@@ -4545,6 +4810,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_growth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 252
@@ -4560,6 +4826,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ember_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 278
@@ -4575,6 +4842,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bone_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 279
@@ -4590,6 +4858,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tea_of_discourtesy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 280
@@ -4609,6 +4878,7 @@
     },
     "image_url": "/static/images/relics/vajra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 38
@@ -4628,6 +4898,7 @@
     },
     "image_url": "/static/images/relics/tungsten_rod.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 126
@@ -4643,6 +4914,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pumpkin_candle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 253
@@ -4662,6 +4934,7 @@
     },
     "image_url": "/static/images/relics/tough_bandages.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 127
@@ -4677,6 +4950,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/royal_poison.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 281
@@ -4696,6 +4970,7 @@
     },
     "image_url": "/static/images/relics/blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 39
@@ -4711,6 +4986,13 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sea_glass.webp",
     "image_variants": null,
+    "name_variants": {
+      "Ironclad": "Vidrio de demonio",
+      "Silent": "Vidrio de veneno",
+      "Defect": "Vidrio de constructo",
+      "Necrobinder": "Vidrio de liche",
+      "Regent": "Vidrio de noble"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 254
@@ -4726,6 +5008,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fiddle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 255
@@ -4745,6 +5028,7 @@
     },
     "image_url": "/static/images/relics/symbiotic_virus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 79
@@ -4764,6 +5048,7 @@
     },
     "image_url": "/static/images/relics/lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 158
@@ -4779,6 +5064,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/winged_boots.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 256
@@ -4798,6 +5084,7 @@
     },
     "image_url": "/static/images/relics/ruined_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 128
@@ -4817,6 +5104,7 @@
     },
     "image_url": "/static/images/relics/intimidating_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 129
@@ -4832,6 +5120,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fake_merchants_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 282
@@ -4851,6 +5140,7 @@
     },
     "image_url": "/static/images/relics/fake_anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 283
@@ -4870,6 +5160,7 @@
     },
     "image_url": "/static/images/relics/fake_happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 284
@@ -4889,6 +5180,7 @@
     },
     "image_url": "/static/images/relics/fake_venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 285
@@ -4908,6 +5200,7 @@
     },
     "image_url": "/static/images/relics/fake_mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 286
@@ -4927,6 +5220,7 @@
     },
     "image_url": "/static/images/relics/fake_strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 287
@@ -4946,6 +5240,7 @@
     },
     "image_url": "/static/images/relics/fake_snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 288
@@ -4965,6 +5260,7 @@
     },
     "image_url": "/static/images/relics/fake_orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 289
@@ -4984,6 +5280,7 @@
     },
     "image_url": "/static/images/relics/fake_blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 290
@@ -5003,6 +5300,7 @@
     },
     "image_url": "/static/images/relics/fake_lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 291
@@ -5022,6 +5320,7 @@
     },
     "image_url": "/static/images/relics/the_abacus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 159

--- a/data/fra/relics.json
+++ b/data/fra/relics.json
@@ -10,6 +10,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_wing.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 160
@@ -29,6 +30,7 @@
     },
     "image_url": "/static/images/relics/wing_charm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 130
@@ -48,6 +50,7 @@
     },
     "image_url": "/static/images/relics/akabeko.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 40
@@ -63,6 +66,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/darkstone_periapt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 257
@@ -82,6 +86,7 @@
     },
     "image_url": "/static/images/relics/anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 10
@@ -101,6 +106,7 @@
     },
     "image_url": "/static/images/relics/fake_anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 258
@@ -120,6 +126,7 @@
     },
     "image_url": "/static/images/relics/rainbow_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 80
@@ -135,6 +142,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_drake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 0
@@ -150,6 +158,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_snake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 1
@@ -165,6 +174,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/signet_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 161
@@ -180,6 +190,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/crossbow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 162
@@ -199,6 +210,7 @@
     },
     "image_url": "/static/images/relics/self_forming_clay.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 41
@@ -214,6 +226,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/astrolabe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 163
@@ -229,6 +242,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dream_catcher.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 259
@@ -244,6 +258,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/amethyst_aubergine.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 11
@@ -263,6 +278,7 @@
     },
     "image_url": "/static/images/relics/tough_bandages.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 81
@@ -282,6 +298,7 @@
     },
     "image_url": "/static/images/relics/captains_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 82
@@ -301,6 +318,7 @@
     },
     "image_url": "/static/images/relics/ripple_basin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 42
@@ -320,6 +338,7 @@
     },
     "image_url": "/static/images/relics/joss_paper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 43
@@ -335,6 +354,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bing_bong.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 260
@@ -350,6 +370,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blessed_antler.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 164
@@ -365,6 +386,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/driftwood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 165
@@ -384,6 +406,7 @@
     },
     "image_url": "/static/images/relics/lasting_candy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 44
@@ -399,6 +422,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/winged_boots.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 166
@@ -414,6 +438,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/whispering_earring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 167
@@ -433,6 +458,7 @@
     },
     "image_url": "/static/images/relics/cloak_clasp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 83
@@ -452,6 +478,7 @@
     },
     "image_url": "/static/images/relics/belt_buckle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 131
@@ -471,6 +498,7 @@
     },
     "image_url": "/static/images/relics/parrying_shield.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 45
@@ -486,6 +514,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_compass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 168
@@ -501,6 +530,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pandoras_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 169
@@ -516,6 +546,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/music_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 170
@@ -535,6 +566,7 @@
     },
     "image_url": "/static/images/relics/toolbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 132
@@ -554,6 +586,7 @@
     },
     "image_url": "/static/images/relics/juzu_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 12
@@ -569,6 +602,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/beautiful_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 171
@@ -588,6 +622,7 @@
     },
     "image_url": "/static/images/relics/vambrace.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 46
@@ -607,6 +642,7 @@
     },
     "image_url": "/static/images/relics/reptile_trinket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 47
@@ -626,6 +662,7 @@
     },
     "image_url": "/static/images/relics/mystic_lighter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 133
@@ -641,6 +678,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/preserved_fog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 172
@@ -660,6 +698,7 @@
     },
     "image_url": "/static/images/relics/burning_sticks.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 134
@@ -675,6 +714,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/empty_cage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 173
@@ -690,6 +730,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/alchemical_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 174
@@ -705,6 +746,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/scroll_boxes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 175
@@ -720,6 +762,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toy_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": [
       "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed.",
       "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
@@ -743,6 +786,7 @@
     },
     "image_url": "/static/images/relics/stone_calendar.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 84
@@ -762,6 +806,7 @@
     },
     "image_url": "/static/images/relics/candelabra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -781,6 +826,7 @@
     },
     "image_url": "/static/images/relics/miniature_cannon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 49
@@ -796,6 +842,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/distinguished_cape.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 177
@@ -815,6 +862,7 @@
     },
     "image_url": "/static/images/relics/membership_card.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 135
@@ -834,6 +882,7 @@
     },
     "image_url": "/static/images/relics/ruined_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 85
@@ -853,6 +902,7 @@
     },
     "image_url": "/static/images/relics/intimidating_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 86
@@ -872,6 +922,7 @@
     },
     "image_url": "/static/images/relics/vexing_puzzlebox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 87
@@ -887,6 +938,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/leafy_poultice.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 178
@@ -906,6 +958,7 @@
     },
     "image_url": "/static/images/relics/potion_belt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 13
@@ -925,6 +978,7 @@
     },
     "image_url": "/static/images/relics/charons_ashes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 88
@@ -940,6 +994,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_flesh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 179
@@ -955,6 +1010,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fragrant_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 261
@@ -974,6 +1030,7 @@
     },
     "image_url": "/static/images/relics/chandelier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 89
@@ -989,6 +1046,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bowler_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -1008,6 +1066,7 @@
     },
     "image_url": "/static/images/relics/cauldron.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 136
@@ -1023,6 +1082,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/very_hot_cocoa.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 180
@@ -1038,6 +1098,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sand_castle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 181
@@ -1053,6 +1114,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precise_scissors.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 182
@@ -1068,6 +1130,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/calling_bell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 183
@@ -1083,6 +1146,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jewelry_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 184
@@ -1098,6 +1162,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 185
@@ -1117,6 +1182,7 @@
     },
     "image_url": "/static/images/relics/chemical_x.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 137
@@ -1136,6 +1202,7 @@
     },
     "image_url": "/static/images/relics/runic_capacitor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 138
@@ -1151,6 +1218,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/booming_conch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 186
@@ -1166,6 +1234,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 187
@@ -1185,6 +1254,7 @@
     },
     "image_url": "/static/images/relics/gremlin_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 51
@@ -1204,6 +1274,7 @@
     },
     "image_url": "/static/images/relics/letter_opener.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 52
@@ -1219,6 +1290,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/meat_cleaver.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 188
@@ -1238,6 +1310,7 @@
     },
     "image_url": "/static/images/relics/book_repair_knife.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 53
@@ -1257,6 +1330,7 @@
     },
     "image_url": "/static/images/relics/petrified_toad.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -1272,6 +1346,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/silver_crucible.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 189
@@ -1287,6 +1362,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/electric_shrymp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 190
@@ -1306,6 +1382,7 @@
     },
     "image_url": "/static/images/relics/snecko_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 14
@@ -1325,6 +1402,7 @@
     },
     "image_url": "/static/images/relics/red_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 15
@@ -1344,6 +1422,7 @@
     },
     "image_url": "/static/images/relics/ice_cream.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 90
@@ -1363,6 +1442,7 @@
     },
     "image_url": "/static/images/relics/gold_plated_cables.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 55
@@ -1378,6 +1458,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/archaic_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 191
@@ -1393,6 +1474,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 192
@@ -1412,6 +1494,7 @@
     },
     "image_url": "/static/images/relics/razor_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 91
@@ -1427,6 +1510,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_destiny.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 2
@@ -1442,6 +1526,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/circlet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "None",
     "compendium_order": 292
@@ -1457,6 +1542,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/diamond_diadem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 193
@@ -1476,6 +1562,7 @@
     },
     "image_url": "/static/images/relics/tuning_fork.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 56
@@ -1495,6 +1582,7 @@
     },
     "image_url": "/static/images/relics/data_disk.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 16
@@ -1510,6 +1598,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_right.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 3
@@ -1531,6 +1620,7 @@
       "Necrobinder": "/static/images/relics/yummy_cookie_necrobinder.webp",
       "Regent": "/static/images/relics/yummy_cookie_regent.webp"
     },
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 194
@@ -1546,6 +1636,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ectoplasm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 195
@@ -1561,6 +1652,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/choices_paradox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 196
@@ -1580,6 +1672,7 @@
     },
     "image_url": "/static/images/relics/twisted_funnel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 57
@@ -1595,6 +1688,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_growth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 197
@@ -1614,6 +1708,7 @@
     },
     "image_url": "/static/images/relics/sparkling_rouge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 58
@@ -1629,6 +1724,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_wisp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 262
@@ -1644,6 +1740,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/daughter_of_the_wind.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 263
@@ -1663,6 +1760,7 @@
     },
     "image_url": "/static/images/relics/blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 17
@@ -1682,6 +1780,7 @@
     },
     "image_url": "/static/images/relics/fake_blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 264
@@ -1701,6 +1800,7 @@
     },
     "image_url": "/static/images/relics/happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 18
@@ -1720,6 +1820,7 @@
     },
     "image_url": "/static/images/relics/fake_happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 265
@@ -1739,6 +1840,7 @@
     },
     "image_url": "/static/images/relics/helical_dart.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 92
@@ -1758,6 +1860,7 @@
     },
     "image_url": "/static/images/relics/bone_flute.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 19
@@ -1773,6 +1876,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precarious_shears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 198
@@ -1788,6 +1892,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/delicate_frond.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 199
@@ -1807,6 +1912,7 @@
     },
     "image_url": "/static/images/relics/strawberry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 20
@@ -1822,6 +1928,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/chosen_cheese.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 266
@@ -1841,6 +1948,7 @@
     },
     "image_url": "/static/images/relics/sling_of_courage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 139
@@ -1860,6 +1968,7 @@
     },
     "image_url": "/static/images/relics/dragon_fruit.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 140
@@ -1878,6 +1987,7 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
+    "name_variants": null,
     "notes": [
       "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
       "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
@@ -1896,6 +2006,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/spiked_gauntlets.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 201
@@ -1915,6 +2026,7 @@
     },
     "image_url": "/static/images/relics/lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 141
@@ -1934,6 +2046,7 @@
     },
     "image_url": "/static/images/relics/fake_lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 267
@@ -1953,6 +2066,7 @@
     },
     "image_url": "/static/images/relics/girya.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 93
@@ -1972,6 +2086,7 @@
     },
     "image_url": "/static/images/relics/gorget.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 21
@@ -1987,6 +2102,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/iron_club.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 202
@@ -2006,6 +2122,7 @@
     },
     "image_url": "/static/images/relics/ghost_seed.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 142
@@ -2025,6 +2142,7 @@
     },
     "image_url": "/static/images/relics/big_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 94
@@ -2040,6 +2158,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/large_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 203
@@ -2055,6 +2174,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_claw.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 204
@@ -2070,6 +2190,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/claws.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 205
@@ -2085,6 +2206,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dusty_tome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 206
@@ -2100,6 +2222,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/biiig_hug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 207
@@ -2115,6 +2238,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/big_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 268
@@ -2134,6 +2258,7 @@
     },
     "image_url": "/static/images/relics/paper_krane.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 95
@@ -2149,6 +2274,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/throwing_axe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 208
@@ -2164,6 +2290,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/stone_humidifier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 209
@@ -2179,6 +2306,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_oyster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 210
@@ -2198,6 +2326,7 @@
     },
     "image_url": "/static/images/relics/gambling_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 96
@@ -2213,6 +2342,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/prismatic_gem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 211
@@ -2232,6 +2362,7 @@
     },
     "image_url": "/static/images/relics/kifuda.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 143
@@ -2251,6 +2382,7 @@
     },
     "image_url": "/static/images/relics/paper_phrog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 59
@@ -2270,6 +2402,7 @@
     },
     "image_url": "/static/images/relics/kunai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 97
@@ -2289,6 +2422,7 @@
     },
     "image_url": "/static/images/relics/kusarigama.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 60
@@ -2308,6 +2442,7 @@
     },
     "image_url": "/static/images/relics/the_abacus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 144
@@ -2327,6 +2462,7 @@
     },
     "image_url": "/static/images/relics/art_of_war.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 98
@@ -2342,6 +2478,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_boot.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 269
@@ -2361,6 +2498,7 @@
     },
     "image_url": "/static/images/relics/unsettling_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 99
@@ -2380,6 +2518,7 @@
     },
     "image_url": "/static/images/relics/lava_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 145
@@ -2399,6 +2538,7 @@
     },
     "image_url": "/static/images/relics/demon_tongue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 100
@@ -2418,6 +2558,7 @@
     },
     "image_url": "/static/images/relics/lantern.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 22
@@ -2433,6 +2574,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pumpkin_candle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 212
@@ -2448,6 +2590,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 213
@@ -2463,6 +2606,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_courier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 101
@@ -2478,6 +2622,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fake_merchants_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 270
@@ -2493,6 +2638,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fresnel_lens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 271
@@ -2508,6 +2654,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/storybook.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 214
@@ -2527,6 +2674,7 @@
     },
     "image_url": "/static/images/relics/book_of_five_rings.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 23
@@ -2542,6 +2690,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_legion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 215
@@ -2561,6 +2710,7 @@
     },
     "image_url": "/static/images/relics/mummified_hand.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 102
@@ -2580,6 +2730,7 @@
     },
     "image_url": "/static/images/relics/mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 103
@@ -2599,6 +2750,7 @@
     },
     "image_url": "/static/images/relics/fake_mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 272
@@ -2618,6 +2770,7 @@
     },
     "image_url": "/static/images/relics/strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 24
@@ -2637,6 +2790,7 @@
     },
     "image_url": "/static/images/relics/fake_strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 273
@@ -2652,6 +2806,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fur_coat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 216
@@ -2667,6 +2822,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/history_course.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 274
@@ -2686,6 +2842,7 @@
     },
     "image_url": "/static/images/relics/fencing_manual.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 25
@@ -2705,6 +2862,7 @@
     },
     "image_url": "/static/images/relics/bookmark.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 104
@@ -2720,6 +2878,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/war_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 217
@@ -2739,6 +2898,7 @@
     },
     "image_url": "/static/images/relics/gnarled_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 146
@@ -2758,6 +2918,7 @@
     },
     "image_url": "/static/images/relics/stone_cracker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 61
@@ -2777,6 +2938,7 @@
     },
     "image_url": "/static/images/relics/funerary_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 62
@@ -2796,6 +2958,7 @@
     },
     "image_url": "/static/images/relics/red_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 26
@@ -2811,6 +2974,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jeweled_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 218
@@ -2830,6 +2994,7 @@
     },
     "image_url": "/static/images/relics/mini_regent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 105
@@ -2849,6 +3014,7 @@
     },
     "image_url": "/static/images/relics/tiny_mailbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -2868,6 +3034,7 @@
     },
     "image_url": "/static/images/relics/dollys_mirror.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 147
@@ -2883,6 +3050,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toasty_mittens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 219
@@ -2898,6 +3066,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/mr_struggles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 275
@@ -2917,6 +3086,7 @@
     },
     "image_url": "/static/images/relics/pocketwatch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 106
@@ -2936,6 +3106,7 @@
     },
     "image_url": "/static/images/relics/prayer_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 107
@@ -2955,6 +3126,7 @@
     },
     "image_url": "/static/images/relics/metronome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 108
@@ -2970,6 +3142,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/new_leaf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 220
@@ -2985,6 +3158,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cracked_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 4
@@ -3000,6 +3174,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/infused_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 5
@@ -3015,6 +3190,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pollinous_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 276
@@ -3034,6 +3210,7 @@
     },
     "image_url": "/static/images/relics/nunchaku.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 64
@@ -3049,6 +3226,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/byrdpip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 277
@@ -3068,6 +3246,7 @@
     },
     "image_url": "/static/images/relics/regal_pillow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 27
@@ -3087,6 +3266,7 @@
     },
     "image_url": "/static/images/relics/orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 65
@@ -3106,6 +3286,7 @@
     },
     "image_url": "/static/images/relics/fake_orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 278
@@ -3121,6 +3302,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_bones.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 221
@@ -3140,6 +3322,7 @@
     },
     "image_url": "/static/images/relics/meat_on_the_bone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 109
@@ -3155,6 +3338,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glitter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 222
@@ -3174,6 +3358,7 @@
     },
     "image_url": "/static/images/relics/bread.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 148
@@ -3193,6 +3378,7 @@
     },
     "image_url": "/static/images/relics/pantograph.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 66
@@ -3208,6 +3394,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lords_parasol.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 223
@@ -3223,6 +3410,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/arcane_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 224
@@ -3242,6 +3430,7 @@
     },
     "image_url": "/static/images/relics/ninja_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 149
@@ -3257,6 +3446,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/massive_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 225
@@ -3276,6 +3466,7 @@
     },
     "image_url": "/static/images/relics/war_paint.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 28
@@ -3295,6 +3486,7 @@
     },
     "image_url": "/static/images/relics/shovel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 110
@@ -3314,6 +3506,7 @@
     },
     "image_url": "/static/images/relics/pendulum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 29
@@ -3329,6 +3522,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hand_drill.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 279
@@ -3348,6 +3542,7 @@
     },
     "image_url": "/static/images/relics/permafrost.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 67
@@ -3363,6 +3558,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 226
@@ -3378,6 +3574,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cursed_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 227
@@ -3393,6 +3590,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/radiant_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 228
@@ -3408,6 +3606,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/small_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 229
@@ -3423,6 +3622,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phylactery_unbound.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 6
@@ -3438,6 +3638,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bound_phylactery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 7
@@ -3457,6 +3658,7 @@
     },
     "image_url": "/static/images/relics/screaming_flagon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 150
@@ -3472,6 +3674,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/philosophers_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 230
@@ -3487,6 +3690,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lava_rock.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 231
@@ -3506,6 +3710,7 @@
     },
     "image_url": "/static/images/relics/whetstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 30
@@ -3525,6 +3730,7 @@
     },
     "image_url": "/static/images/relics/oddly_smooth_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 31
@@ -3544,6 +3750,7 @@
     },
     "image_url": "/static/images/relics/power_cell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 111
@@ -3563,6 +3770,7 @@
     },
     "image_url": "/static/images/relics/sturdy_clamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 112
@@ -3578,6 +3786,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongo_customer_appreciation_badge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 280
@@ -3597,6 +3806,7 @@
     },
     "image_url": "/static/images/relics/game_piece.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 113
@@ -3612,6 +3822,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/old_coin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 114
@@ -3631,6 +3842,7 @@
     },
     "image_url": "/static/images/relics/planisphere.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -3650,6 +3862,7 @@
     },
     "image_url": "/static/images/relics/orrery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 151
@@ -3669,6 +3882,7 @@
     },
     "image_url": "/static/images/relics/eternal_feather.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 69
@@ -3688,6 +3902,7 @@
     },
     "image_url": "/static/images/relics/punch_dagger.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 152
@@ -3707,6 +3922,7 @@
     },
     "image_url": "/static/images/relics/pen_nib.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 70
@@ -3726,6 +3942,7 @@
     },
     "image_url": "/static/images/relics/pear.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 71
@@ -3741,6 +3958,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/royal_poison.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 281
@@ -3756,6 +3974,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lucky_fysh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 72
@@ -3771,6 +3990,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pomander.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 232
@@ -3790,6 +4010,7 @@
     },
     "image_url": "/static/images/relics/galactic_dust.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 73
@@ -3805,6 +4026,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lead_paperweight.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 233
@@ -3824,6 +4046,7 @@
     },
     "image_url": "/static/images/relics/emotion_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 115
@@ -3843,6 +4066,7 @@
     },
     "image_url": "/static/images/relics/centennial_puzzle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 32
@@ -3858,6 +4082,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/runic_pyramid.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 234
@@ -3877,6 +4102,7 @@
     },
     "image_url": "/static/images/relics/orange_dough.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 116
@@ -3896,6 +4122,7 @@
     },
     "image_url": "/static/images/relics/lunar_pastry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 117
@@ -3915,6 +4142,7 @@
     },
     "image_url": "/static/images/relics/festive_popper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 33
@@ -3934,6 +4162,7 @@
     },
     "image_url": "/static/images/relics/lizard_tail.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 118
@@ -3949,6 +4178,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/velvet_choker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 235
@@ -3964,6 +4194,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blood_soaked_rose.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 236
@@ -3983,6 +4214,7 @@
     },
     "image_url": "/static/images/relics/regalite.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 74
@@ -4002,6 +4234,7 @@
     },
     "image_url": "/static/images/relics/mercury_hourglass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -4021,6 +4254,7 @@
     },
     "image_url": "/static/images/relics/bag_of_marbles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 34
@@ -4040,6 +4274,7 @@
     },
     "image_url": "/static/images/relics/bag_of_preparation.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 35
@@ -4055,6 +4290,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/burning_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 8
@@ -4070,6 +4306,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 237
@@ -4085,6 +4322,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 9
@@ -4100,6 +4338,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 238
@@ -4119,6 +4358,7 @@
     },
     "image_url": "/static/images/relics/vitruvian_minion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 153
@@ -4134,6 +4374,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/seal_of_gold.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 239
@@ -4153,6 +4394,7 @@
     },
     "image_url": "/static/images/relics/undying_sigil.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 154
@@ -4172,6 +4414,7 @@
     },
     "image_url": "/static/images/relics/royal_stamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 155
@@ -4187,6 +4430,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sere_talon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 240
@@ -4206,6 +4450,7 @@
     },
     "image_url": "/static/images/relics/venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 36
@@ -4225,6 +4470,7 @@
     },
     "image_url": "/static/images/relics/fake_venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 282
@@ -4244,6 +4490,7 @@
     },
     "image_url": "/static/images/relics/shuriken.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 119
@@ -4259,6 +4506,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tanxs_whistle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 241
@@ -4278,6 +4526,7 @@
     },
     "image_url": "/static/images/relics/bellows.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 120
@@ -4297,6 +4546,7 @@
     },
     "image_url": "/static/images/relics/brimstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 156
@@ -4312,6 +4562,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_soup.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 242
@@ -4327,6 +4578,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sozu.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 243
@@ -4346,6 +4598,7 @@
     },
     "image_url": "/static/images/relics/white_beast_statue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 121
@@ -4361,6 +4614,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hefty_tablet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 244
@@ -4376,6 +4630,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_talisman.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 245
@@ -4395,6 +4650,7 @@
     },
     "image_url": "/static/images/relics/dingy_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 157
@@ -4414,6 +4670,7 @@
     },
     "image_url": "/static/images/relics/horn_cleat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 76
@@ -4433,6 +4690,7 @@
     },
     "image_url": "/static/images/relics/miniature_tent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 158
@@ -4448,6 +4706,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bone_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 283
@@ -4463,6 +4722,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ember_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 284
@@ -4478,6 +4738,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tea_of_discourtesy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 285
@@ -4493,6 +4754,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongos_mystery_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 286
@@ -4512,6 +4774,7 @@
     },
     "image_url": "/static/images/relics/meal_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 37
@@ -4531,6 +4794,7 @@
     },
     "image_url": "/static/images/relics/tungsten_rod.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 122
@@ -4550,6 +4814,7 @@
     },
     "image_url": "/static/images/relics/tingsha.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 77
@@ -4565,6 +4830,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/maw_bank.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 287
@@ -4580,6 +4846,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/touch_of_orobas.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 246
@@ -4599,6 +4866,7 @@
     },
     "image_url": "/static/images/relics/unceasing_top.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 123
@@ -4614,6 +4882,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_torment.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 247
@@ -4629,6 +4898,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tri_boomerang.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 248
@@ -4648,6 +4918,7 @@
     },
     "image_url": "/static/images/relics/ringing_triangle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 159
@@ -4667,6 +4938,7 @@
     },
     "image_url": "/static/images/relics/ivory_tile.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 124
@@ -4686,6 +4958,7 @@
     },
     "image_url": "/static/images/relics/vajra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 38
@@ -4701,6 +4974,13 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sea_glass.webp",
     "image_variants": null,
+    "name_variants": {
+      "Ironclad": "Verre démoniaque",
+      "Silent": "Verre de venin",
+      "Defect": "Verre engrenage",
+      "Necrobinder": "Verre de la Liche",
+      "Regent": "Verre noble"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 249
@@ -4720,6 +5000,7 @@
     },
     "image_url": "/static/images/relics/beating_remnant.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 125
@@ -4735,6 +5016,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fiddle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 250
@@ -4754,6 +5036,7 @@
     },
     "image_url": "/static/images/relics/symbiotic_virus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -4769,6 +5052,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/forgotten_soul.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 288
@@ -4788,6 +5072,7 @@
     },
     "image_url": "/static/images/relics/bronze_scales.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 39
@@ -4803,6 +5088,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/brilliant_scarf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 251
@@ -4818,6 +5104,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_jade.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 289
@@ -4833,6 +5120,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 290
@@ -4852,6 +5140,7 @@
     },
     "image_url": "/static/images/relics/white_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 126
@@ -4867,6 +5156,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 252
@@ -4882,6 +5172,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phial_holster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 253
@@ -4901,6 +5192,7 @@
     },
     "image_url": "/static/images/relics/ornamental_fan.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 79
@@ -4916,6 +5208,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 254
@@ -4931,6 +5224,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 255
@@ -4950,6 +5244,7 @@
     },
     "image_url": "/static/images/relics/fake_snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 291
@@ -4965,6 +5260,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glass_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 256
@@ -4984,6 +5280,7 @@
     },
     "image_url": "/static/images/relics/molten_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 127
@@ -5003,6 +5300,7 @@
     },
     "image_url": "/static/images/relics/frozen_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 128
@@ -5022,6 +5320,7 @@
     },
     "image_url": "/static/images/relics/toxic_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 129

--- a/data/ita/relics.json
+++ b/data/ita/relics.json
@@ -14,6 +14,7 @@
     },
     "image_url": "/static/images/relics/mystic_lighter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 130
@@ -29,6 +30,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dream_catcher.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 257
@@ -44,6 +46,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_wing.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 160
@@ -59,6 +62,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/darkstone_periapt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 258
@@ -78,6 +82,7 @@
     },
     "image_url": "/static/images/relics/reptile_trinket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 40
@@ -97,6 +102,7 @@
     },
     "image_url": "/static/images/relics/anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 10
@@ -116,6 +122,7 @@
     },
     "image_url": "/static/images/relics/fake_anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 259
@@ -135,6 +142,7 @@
     },
     "image_url": "/static/images/relics/rainbow_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 80
@@ -150,6 +158,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/signet_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 161
@@ -165,6 +174,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_drake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 0
@@ -180,6 +190,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_snake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 1
@@ -195,6 +206,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/forgotten_soul.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 260
@@ -210,6 +222,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/old_coin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 81
@@ -229,6 +242,7 @@
     },
     "image_url": "/static/images/relics/self_forming_clay.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 41
@@ -244,6 +258,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/claws.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 162
@@ -259,6 +274,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sere_talon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 163
@@ -274,6 +290,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_claw.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 164
@@ -289,6 +306,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/throwing_axe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 165
@@ -304,6 +322,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/astrolabe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 166
@@ -323,6 +342,7 @@
     },
     "image_url": "/static/images/relics/ripple_basin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 42
@@ -338,6 +358,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/crossbow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 167
@@ -357,6 +378,7 @@
     },
     "image_url": "/static/images/relics/tungsten_rod.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 82
@@ -376,6 +398,7 @@
     },
     "image_url": "/static/images/relics/burning_sticks.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 131
@@ -395,6 +418,7 @@
     },
     "image_url": "/static/images/relics/tough_bandages.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 83
@@ -414,6 +438,7 @@
     },
     "image_url": "/static/images/relics/joss_paper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 43
@@ -429,6 +454,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongos_mystery_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 261
@@ -444,6 +470,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bing_bong.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 262
@@ -465,6 +492,7 @@
       "Necrobinder": "/static/images/relics/yummy_cookie_necrobinder.webp",
       "Regent": "/static/images/relics/yummy_cookie_regent.webp"
     },
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 168
@@ -484,6 +512,7 @@
     },
     "image_url": "/static/images/relics/horn_cleat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 44
@@ -499,6 +528,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bowler_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 45
@@ -514,6 +544,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tri_boomerang.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 169
@@ -529,6 +560,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/beautiful_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 170
@@ -548,6 +580,7 @@
     },
     "image_url": "/static/images/relics/juzu_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 11
@@ -563,6 +596,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glitter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 171
@@ -582,6 +616,7 @@
     },
     "image_url": "/static/images/relics/meal_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 12
@@ -597,6 +632,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_compass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 172
@@ -616,6 +652,7 @@
     },
     "image_url": "/static/images/relics/cauldron.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 132
@@ -635,6 +672,7 @@
     },
     "image_url": "/static/images/relics/stone_calendar.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 84
@@ -650,6 +688,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/calling_bell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 173
@@ -665,6 +704,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pumpkin_candle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 174
@@ -684,6 +724,7 @@
     },
     "image_url": "/static/images/relics/candelabra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 46
@@ -703,6 +744,7 @@
     },
     "image_url": "/static/images/relics/miniature_cannon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 47
@@ -718,6 +760,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/large_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 175
@@ -733,6 +776,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/small_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 176
@@ -752,6 +796,7 @@
     },
     "image_url": "/static/images/relics/screaming_flagon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 133
@@ -771,6 +816,7 @@
     },
     "image_url": "/static/images/relics/lasting_candy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -786,6 +832,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/music_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 177
@@ -801,6 +848,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_flesh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 178
@@ -816,6 +864,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toy_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": [
       "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed.",
       "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
@@ -835,6 +884,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/scroll_boxes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 180
@@ -854,6 +904,7 @@
     },
     "image_url": "/static/images/relics/toolbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 134
@@ -869,6 +920,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sand_castle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 181
@@ -888,6 +940,7 @@
     },
     "image_url": "/static/images/relics/gold_plated_cables.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 49
@@ -907,6 +960,7 @@
     },
     "image_url": "/static/images/relics/charons_ashes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 85
@@ -922,6 +976,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/circlet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "None",
     "compendium_order": 292
@@ -941,6 +996,7 @@
     },
     "image_url": "/static/images/relics/emotion_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 86
@@ -956,6 +1012,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/velvet_choker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 182
@@ -975,6 +1032,7 @@
     },
     "image_url": "/static/images/relics/potion_belt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 13
@@ -990,6 +1048,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/very_hot_cocoa.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 183
@@ -1009,6 +1068,7 @@
     },
     "image_url": "/static/images/relics/wing_charm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 135
@@ -1028,6 +1088,7 @@
     },
     "image_url": "/static/images/relics/mercury_hourglass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -1047,6 +1108,7 @@
     },
     "image_url": "/static/images/relics/lizard_tail.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 87
@@ -1066,6 +1128,7 @@
     },
     "image_url": "/static/images/relics/book_repair_knife.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 51
@@ -1081,6 +1144,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/booming_conch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 184
@@ -1100,6 +1164,7 @@
     },
     "image_url": "/static/images/relics/runic_capacitor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 136
@@ -1115,6 +1180,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blessed_antler.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 185
@@ -1134,6 +1200,7 @@
     },
     "image_url": "/static/images/relics/gremlin_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 52
@@ -1149,6 +1216,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 186
@@ -1164,6 +1232,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/history_course.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 263
@@ -1183,6 +1252,7 @@
     },
     "image_url": "/static/images/relics/whetstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 14
@@ -1198,6 +1268,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_growth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 187
@@ -1213,6 +1284,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/silver_crucible.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 188
@@ -1232,6 +1304,7 @@
     },
     "image_url": "/static/images/relics/regal_pillow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 15
@@ -1251,6 +1324,7 @@
     },
     "image_url": "/static/images/relics/helical_dart.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 88
@@ -1266,6 +1340,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/archaic_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 189
@@ -1285,6 +1360,7 @@
     },
     "image_url": "/static/images/relics/razor_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 89
@@ -1300,6 +1376,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 190
@@ -1315,6 +1392,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_destiny.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 2
@@ -1330,6 +1408,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/diamond_diadem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 191
@@ -1349,6 +1428,7 @@
     },
     "image_url": "/static/images/relics/tuning_fork.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 53
@@ -1364,6 +1444,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_right.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 3
@@ -1383,6 +1464,7 @@
     },
     "image_url": "/static/images/relics/data_disk.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 16
@@ -1398,6 +1480,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongo_customer_appreciation_badge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 264
@@ -1417,6 +1500,7 @@
     },
     "image_url": "/static/images/relics/lunar_pastry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 90
@@ -1436,6 +1520,7 @@
     },
     "image_url": "/static/images/relics/paper_phrog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -1451,6 +1536,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ectoplasm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 192
@@ -1470,6 +1556,7 @@
     },
     "image_url": "/static/images/relics/ruined_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 91
@@ -1489,6 +1576,7 @@
     },
     "image_url": "/static/images/relics/intimidating_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 92
@@ -1504,6 +1592,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/maw_bank.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 265
@@ -1519,6 +1608,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lead_paperweight.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 193
@@ -1538,6 +1628,7 @@
     },
     "image_url": "/static/images/relics/blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 17
@@ -1557,6 +1648,7 @@
     },
     "image_url": "/static/images/relics/fake_blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 266
@@ -1576,6 +1668,7 @@
     },
     "image_url": "/static/images/relics/cloak_clasp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 93
@@ -1595,6 +1688,7 @@
     },
     "image_url": "/static/images/relics/belt_buckle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 137
@@ -1610,6 +1704,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/daughter_of_the_wind.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 267
@@ -1625,6 +1720,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phylactery_unbound.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 4
@@ -1640,6 +1736,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bound_phylactery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 5
@@ -1659,6 +1756,7 @@
     },
     "image_url": "/static/images/relics/sling_of_courage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 138
@@ -1678,6 +1776,7 @@
     },
     "image_url": "/static/images/relics/happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 18
@@ -1697,6 +1796,7 @@
     },
     "image_url": "/static/images/relics/fake_happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 268
@@ -1716,6 +1816,7 @@
     },
     "image_url": "/static/images/relics/bone_flute.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 19
@@ -1731,6 +1832,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/new_leaf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 194
@@ -1746,6 +1848,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precarious_shears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 195
@@ -1761,6 +1864,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precise_scissors.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 196
@@ -1776,6 +1880,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 197
@@ -1795,6 +1900,7 @@
     },
     "image_url": "/static/images/relics/strawberry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 20
@@ -1810,6 +1916,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/delicate_frond.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 198
@@ -1828,6 +1935,7 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
+    "name_variants": null,
     "notes": [
       "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
       "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
@@ -1850,6 +1958,7 @@
     },
     "image_url": "/static/images/relics/dragon_fruit.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 139
@@ -1865,6 +1974,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/big_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 269
@@ -1880,6 +1990,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fragrant_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 270
@@ -1895,6 +2006,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_wisp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 271
@@ -1910,6 +2022,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/empty_cage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 200
@@ -1925,6 +2038,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/electric_shrymp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 201
@@ -1944,6 +2058,7 @@
     },
     "image_url": "/static/images/relics/ice_cream.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 94
@@ -1959,6 +2074,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/prismatic_gem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 202
@@ -1978,6 +2094,7 @@
     },
     "image_url": "/static/images/relics/gambling_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 95
@@ -1997,6 +2114,7 @@
     },
     "image_url": "/static/images/relics/permafrost.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 55
@@ -2016,6 +2134,7 @@
     },
     "image_url": "/static/images/relics/girya.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 96
@@ -2035,6 +2154,7 @@
     },
     "image_url": "/static/images/relics/gorget.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 21
@@ -2054,6 +2174,7 @@
     },
     "image_url": "/static/images/relics/big_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 97
@@ -2069,6 +2190,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/biiig_hug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 203
@@ -2084,6 +2206,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/byrdpip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 272
@@ -2099,6 +2222,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/spiked_gauntlets.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 204
@@ -2114,6 +2238,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toasty_mittens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 205
@@ -2129,6 +2254,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_courier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 98
@@ -2144,6 +2270,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/chosen_cheese.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 273
@@ -2159,6 +2286,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fake_merchants_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 274
@@ -2178,6 +2306,7 @@
     },
     "image_url": "/static/images/relics/twisted_funnel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 56
@@ -2193,6 +2322,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/leafy_poultice.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 206
@@ -2212,6 +2342,7 @@
     },
     "image_url": "/static/images/relics/orange_dough.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 99
@@ -2231,6 +2362,7 @@
     },
     "image_url": "/static/images/relics/kifuda.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 140
@@ -2250,6 +2382,7 @@
     },
     "image_url": "/static/images/relics/paper_krane.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 100
@@ -2269,6 +2402,7 @@
     },
     "image_url": "/static/images/relics/kunai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 101
@@ -2288,6 +2422,7 @@
     },
     "image_url": "/static/images/relics/kusarigama.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 57
@@ -2307,6 +2442,7 @@
     },
     "image_url": "/static/images/relics/the_abacus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 141
@@ -2326,6 +2462,7 @@
     },
     "image_url": "/static/images/relics/art_of_war.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 102
@@ -2341,6 +2478,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 207
@@ -2360,6 +2498,7 @@
     },
     "image_url": "/static/images/relics/unsettling_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 103
@@ -2379,6 +2518,7 @@
     },
     "image_url": "/static/images/relics/lava_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 142
@@ -2398,6 +2538,7 @@
     },
     "image_url": "/static/images/relics/chandelier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 104
@@ -2417,6 +2558,7 @@
     },
     "image_url": "/static/images/relics/lantern.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 22
@@ -2432,6 +2574,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_legion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 208
@@ -2447,6 +2590,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/driftwood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 209
@@ -2462,6 +2606,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fresnel_lens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 275
@@ -2481,6 +2626,7 @@
     },
     "image_url": "/static/images/relics/book_of_five_rings.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 23
@@ -2496,6 +2642,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/storybook.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 210
@@ -2515,6 +2662,7 @@
     },
     "image_url": "/static/images/relics/demon_tongue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 105
@@ -2530,6 +2678,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_boot.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 276
@@ -2549,6 +2698,7 @@
     },
     "image_url": "/static/images/relics/mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 106
@@ -2568,6 +2718,7 @@
     },
     "image_url": "/static/images/relics/fake_mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 277
@@ -2583,6 +2734,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/meat_cleaver.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 211
@@ -2602,6 +2754,7 @@
     },
     "image_url": "/static/images/relics/mummified_hand.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 107
@@ -2617,6 +2770,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/distinguished_cape.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 212
@@ -2636,6 +2790,7 @@
     },
     "image_url": "/static/images/relics/bellows.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 108
@@ -2655,6 +2810,7 @@
     },
     "image_url": "/static/images/relics/fencing_manual.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 24
@@ -2674,6 +2830,7 @@
     },
     "image_url": "/static/images/relics/gnarled_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 143
@@ -2689,6 +2846,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/war_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 213
@@ -2708,6 +2866,7 @@
     },
     "image_url": "/static/images/relics/funerary_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 58
@@ -2723,6 +2882,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jeweled_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 214
@@ -2742,6 +2902,7 @@
     },
     "image_url": "/static/images/relics/red_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 25
@@ -2757,6 +2918,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/iron_club.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 215
@@ -2772,6 +2934,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/amethyst_aubergine.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 26
@@ -2791,6 +2954,7 @@
     },
     "image_url": "/static/images/relics/metronome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 109
@@ -2810,6 +2974,7 @@
     },
     "image_url": "/static/images/relics/regalite.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 59
@@ -2829,6 +2994,7 @@
     },
     "image_url": "/static/images/relics/tiny_mailbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 60
@@ -2844,6 +3010,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/mr_struggles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 278
@@ -2863,6 +3030,7 @@
     },
     "image_url": "/static/images/relics/sturdy_clamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 110
@@ -2882,6 +3050,7 @@
     },
     "image_url": "/static/images/relics/akabeko.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 61
@@ -2897,6 +3066,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/preserved_fog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 216
@@ -2912,6 +3082,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cracked_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 6
@@ -2927,6 +3098,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/infused_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 7
@@ -2942,6 +3114,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pollinous_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 279
@@ -2961,6 +3134,7 @@
     },
     "image_url": "/static/images/relics/nunchaku.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 62
@@ -2976,6 +3150,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 217
@@ -2991,6 +3166,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 218
@@ -3010,6 +3186,7 @@
     },
     "image_url": "/static/images/relics/fake_snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 280
@@ -3025,6 +3202,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glass_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 219
@@ -3040,6 +3218,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/whispering_earring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 220
@@ -3059,6 +3238,7 @@
     },
     "image_url": "/static/images/relics/orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -3078,6 +3258,7 @@
     },
     "image_url": "/static/images/relics/fake_orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 281
@@ -3097,6 +3278,7 @@
     },
     "image_url": "/static/images/relics/pocketwatch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 111
@@ -3112,6 +3294,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_bones.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 221
@@ -3131,6 +3314,7 @@
     },
     "image_url": "/static/images/relics/meat_on_the_bone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 112
@@ -3146,6 +3330,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_oyster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 222
@@ -3165,6 +3350,7 @@
     },
     "image_url": "/static/images/relics/shovel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 113
@@ -3184,6 +3370,7 @@
     },
     "image_url": "/static/images/relics/bread.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 144
@@ -3203,6 +3390,7 @@
     },
     "image_url": "/static/images/relics/pantograph.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 64
@@ -3218,6 +3406,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/choices_paradox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 223
@@ -3233,6 +3422,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lords_parasol.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 224
@@ -3252,6 +3442,7 @@
     },
     "image_url": "/static/images/relics/game_piece.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 114
@@ -3267,6 +3458,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fur_coat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 225
@@ -3286,6 +3478,7 @@
     },
     "image_url": "/static/images/relics/pendulum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 27
@@ -3305,6 +3498,7 @@
     },
     "image_url": "/static/images/relics/pen_nib.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 65
@@ -3324,6 +3518,7 @@
     },
     "image_url": "/static/images/relics/pear.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 66
@@ -3339,6 +3534,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/arcane_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 226
@@ -3354,6 +3550,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/massive_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 227
@@ -3373,6 +3570,7 @@
     },
     "image_url": "/static/images/relics/ninja_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 145
@@ -3388,6 +3586,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cursed_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 228
@@ -3403,6 +3602,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/radiant_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 229
@@ -3418,6 +3618,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 230
@@ -3433,6 +3634,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lucky_fysh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 67
@@ -3448,6 +3650,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phial_holster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 231
@@ -3467,6 +3670,7 @@
     },
     "image_url": "/static/images/relics/ivory_tile.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 115
@@ -3482,6 +3686,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/philosophers_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 232
@@ -3501,6 +3706,7 @@
     },
     "image_url": "/static/images/relics/oddly_smooth_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 28
@@ -3520,6 +3726,7 @@
     },
     "image_url": "/static/images/relics/power_cell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 116
@@ -3535,6 +3742,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/runic_pyramid.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 233
@@ -3554,6 +3762,7 @@
     },
     "image_url": "/static/images/relics/war_paint.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 29
@@ -3573,6 +3782,7 @@
     },
     "image_url": "/static/images/relics/eternal_feather.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -3592,6 +3802,7 @@
     },
     "image_url": "/static/images/relics/orrery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 146
@@ -3611,6 +3822,7 @@
     },
     "image_url": "/static/images/relics/planisphere.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 69
@@ -3630,6 +3842,7 @@
     },
     "image_url": "/static/images/relics/galactic_dust.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 70
@@ -3645,6 +3858,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pomander.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 234
@@ -3660,6 +3874,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jewelry_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 235
@@ -3679,6 +3894,7 @@
     },
     "image_url": "/static/images/relics/punch_dagger.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 147
@@ -3698,6 +3914,7 @@
     },
     "image_url": "/static/images/relics/mini_regent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 117
@@ -3717,6 +3934,7 @@
     },
     "image_url": "/static/images/relics/beating_remnant.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 118
@@ -3732,6 +3950,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lava_rock.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 236
@@ -3751,6 +3970,7 @@
     },
     "image_url": "/static/images/relics/centennial_puzzle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 30
@@ -3770,6 +3990,7 @@
     },
     "image_url": "/static/images/relics/vexing_puzzlebox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 119
@@ -3785,6 +4006,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blood_soaked_rose.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 237
@@ -3804,6 +4026,7 @@
     },
     "image_url": "/static/images/relics/petrified_toad.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 71
@@ -3823,6 +4046,7 @@
     },
     "image_url": "/static/images/relics/sparkling_rouge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 72
@@ -3842,6 +4066,7 @@
     },
     "image_url": "/static/images/relics/prayer_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 120
@@ -3861,6 +4086,7 @@
     },
     "image_url": "/static/images/relics/bag_of_preparation.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 31
@@ -3880,6 +4106,7 @@
     },
     "image_url": "/static/images/relics/bag_of_marbles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 32
@@ -3895,6 +4122,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 238
@@ -3910,6 +4138,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/burning_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 8
@@ -3925,6 +4154,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 9
@@ -3940,6 +4170,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 239
@@ -3955,6 +4186,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/brilliant_scarf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 240
@@ -3970,6 +4202,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/alchemical_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 241
@@ -3989,6 +4222,7 @@
     },
     "image_url": "/static/images/relics/parrying_shield.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 73
@@ -4008,6 +4242,7 @@
     },
     "image_url": "/static/images/relics/bookmark.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 121
@@ -4027,6 +4262,7 @@
     },
     "image_url": "/static/images/relics/vitruvian_minion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 148
@@ -4046,6 +4282,7 @@
     },
     "image_url": "/static/images/relics/ghost_seed.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 149
@@ -4065,6 +4302,7 @@
     },
     "image_url": "/static/images/relics/shuriken.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 122
@@ -4080,6 +4318,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tanxs_whistle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 242
@@ -4095,6 +4334,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/seal_of_gold.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 243
@@ -4114,6 +4354,7 @@
     },
     "image_url": "/static/images/relics/undying_sigil.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 150
@@ -4133,6 +4374,7 @@
     },
     "image_url": "/static/images/relics/chemical_x.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 151
@@ -4148,6 +4390,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sozu.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 244
@@ -4167,6 +4410,7 @@
     },
     "image_url": "/static/images/relics/stone_cracker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 74
@@ -4182,6 +4426,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_jade.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 282
@@ -4197,6 +4442,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 283
@@ -4216,6 +4462,7 @@
     },
     "image_url": "/static/images/relics/festive_popper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 33
@@ -4235,6 +4482,7 @@
     },
     "image_url": "/static/images/relics/dollys_mirror.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 152
@@ -4254,6 +4502,7 @@
     },
     "image_url": "/static/images/relics/bronze_scales.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 34
@@ -4273,6 +4522,7 @@
     },
     "image_url": "/static/images/relics/white_beast_statue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 123
@@ -4292,6 +4542,7 @@
     },
     "image_url": "/static/images/relics/white_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 124
@@ -4307,6 +4558,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 245
@@ -4322,6 +4574,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/winged_boots.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 246
@@ -4341,6 +4594,7 @@
     },
     "image_url": "/static/images/relics/letter_opener.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -4356,6 +4610,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_talisman.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 247
@@ -4375,6 +4630,7 @@
     },
     "image_url": "/static/images/relics/dingy_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 153
@@ -4390,6 +4646,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hefty_tablet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 248
@@ -4409,6 +4666,7 @@
     },
     "image_url": "/static/images/relics/miniature_tent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 154
@@ -4428,6 +4686,7 @@
     },
     "image_url": "/static/images/relics/red_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 35
@@ -4447,6 +4706,7 @@
     },
     "image_url": "/static/images/relics/snecko_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 36
@@ -4466,6 +4726,7 @@
     },
     "image_url": "/static/images/relics/membership_card.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 155
@@ -4485,6 +4746,7 @@
     },
     "image_url": "/static/images/relics/royal_stamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 156
@@ -4504,6 +4766,7 @@
     },
     "image_url": "/static/images/relics/captains_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 125
@@ -4523,6 +4786,7 @@
     },
     "image_url": "/static/images/relics/tingsha.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 76
@@ -4538,6 +4802,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/touch_of_orobas.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 249
@@ -4553,6 +4818,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dusty_tome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 250
@@ -4568,6 +4834,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_torment.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 251
@@ -4583,6 +4850,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hand_drill.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 284
@@ -4602,6 +4870,7 @@
     },
     "image_url": "/static/images/relics/ringing_triangle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 157
@@ -4621,6 +4890,7 @@
     },
     "image_url": "/static/images/relics/unceasing_top.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 126
@@ -4636,6 +4906,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bone_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 285
@@ -4651,6 +4922,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tea_of_discourtesy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 286
@@ -4666,6 +4938,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ember_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 287
@@ -4681,6 +4954,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/stone_humidifier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 252
@@ -4700,6 +4974,7 @@
     },
     "image_url": "/static/images/relics/strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 37
@@ -4719,6 +4994,7 @@
     },
     "image_url": "/static/images/relics/fake_strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 288
@@ -4738,6 +5014,7 @@
     },
     "image_url": "/static/images/relics/frozen_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 127
@@ -4757,6 +5034,7 @@
     },
     "image_url": "/static/images/relics/toxic_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 128
@@ -4776,6 +5054,7 @@
     },
     "image_url": "/static/images/relics/molten_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 129
@@ -4795,6 +5074,7 @@
     },
     "image_url": "/static/images/relics/vajra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 38
@@ -4814,6 +5094,7 @@
     },
     "image_url": "/static/images/relics/vambrace.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 77
@@ -4829,6 +5110,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pandoras_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 253
@@ -4844,6 +5126,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/royal_poison.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 289
@@ -4863,6 +5146,7 @@
     },
     "image_url": "/static/images/relics/venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 39
@@ -4882,6 +5166,7 @@
     },
     "image_url": "/static/images/relics/fake_venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 290
@@ -4901,6 +5186,7 @@
     },
     "image_url": "/static/images/relics/ornamental_fan.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -4916,6 +5202,13 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sea_glass.webp",
     "image_variants": null,
+    "name_variants": {
+      "Ironclad": "Vetro Demoniaco",
+      "Silent": "Vetro Velenoso",
+      "Defect": "Vetro Meccanico",
+      "Necrobinder": "Vetro Funebre",
+      "Regent": "Vetro Nobile"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 254
@@ -4931,6 +5224,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fiddle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 255
@@ -4950,6 +5244,7 @@
     },
     "image_url": "/static/images/relics/symbiotic_virus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 79
@@ -4969,6 +5264,7 @@
     },
     "image_url": "/static/images/relics/lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 158
@@ -4988,6 +5284,7 @@
     },
     "image_url": "/static/images/relics/fake_lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 291
@@ -5007,6 +5304,7 @@
     },
     "image_url": "/static/images/relics/brimstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 159
@@ -5022,6 +5320,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_soup.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 256

--- a/data/jpn/relics.json
+++ b/data/jpn/relics.json
@@ -10,6 +10,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toasty_mittens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 160
@@ -31,6 +32,7 @@
       "Necrobinder": "/static/images/relics/yummy_cookie_necrobinder.webp",
       "Regent": "/static/images/relics/yummy_cookie_regent.webp"
     },
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 161
@@ -46,6 +48,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toy_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": [
       "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed.",
       "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
@@ -69,6 +72,7 @@
     },
     "image_url": "/static/images/relics/meal_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 10
@@ -84,6 +88,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/claws.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 163
@@ -99,6 +104,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sozu.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 164
@@ -118,6 +124,7 @@
     },
     "image_url": "/static/images/relics/oddly_smooth_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 11
@@ -137,6 +144,7 @@
     },
     "image_url": "/static/images/relics/the_abacus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 130
@@ -156,6 +164,7 @@
     },
     "image_url": "/static/images/relics/mini_regent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 80
@@ -171,6 +180,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cracked_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 0
@@ -190,6 +200,7 @@
     },
     "image_url": "/static/images/relics/bellows.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 81
@@ -205,6 +216,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/iron_club.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 165
@@ -224,6 +236,7 @@
     },
     "image_url": "/static/images/relics/ice_cream.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 82
@@ -239,6 +252,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/astrolabe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 166
@@ -254,6 +268,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/biiig_hug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 167
@@ -269,6 +284,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/amethyst_aubergine.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 12
@@ -288,6 +304,7 @@
     },
     "image_url": "/static/images/relics/anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 13
@@ -307,6 +324,7 @@
     },
     "image_url": "/static/images/relics/fake_anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 257
@@ -326,6 +344,7 @@
     },
     "image_url": "/static/images/relics/strawberry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 14
@@ -341,6 +360,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/infused_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 1
@@ -360,6 +380,7 @@
     },
     "image_url": "/static/images/relics/vitruvian_minion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 131
@@ -375,6 +396,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongo_customer_appreciation_badge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 258
@@ -390,6 +412,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongos_mystery_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 259
@@ -405,6 +428,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/war_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 168
@@ -420,6 +444,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ectoplasm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 169
@@ -439,6 +464,7 @@
     },
     "image_url": "/static/images/relics/eternal_feather.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 40
@@ -458,6 +484,7 @@
     },
     "image_url": "/static/images/relics/orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 41
@@ -477,6 +504,7 @@
     },
     "image_url": "/static/images/relics/fake_orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 260
@@ -492,6 +520,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/music_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 170
@@ -511,6 +540,7 @@
     },
     "image_url": "/static/images/relics/orange_dough.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 83
@@ -526,6 +556,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/touch_of_orobas.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 171
@@ -541,6 +572,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pumpkin_candle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 172
@@ -560,6 +592,7 @@
     },
     "image_url": "/static/images/relics/charons_ashes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 84
@@ -575,6 +608,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glass_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 173
@@ -594,6 +628,7 @@
     },
     "image_url": "/static/images/relics/sparkling_rouge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 42
@@ -613,6 +648,7 @@
     },
     "image_url": "/static/images/relics/gambling_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 85
@@ -632,6 +668,7 @@
     },
     "image_url": "/static/images/relics/kunai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 86
@@ -651,6 +688,7 @@
     },
     "image_url": "/static/images/relics/festive_popper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 15
@@ -666,6 +704,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/crossbow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 174
@@ -685,6 +724,7 @@
     },
     "image_url": "/static/images/relics/gremlin_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 43
@@ -704,6 +744,7 @@
     },
     "image_url": "/static/images/relics/girya.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 87
@@ -723,6 +764,7 @@
     },
     "image_url": "/static/images/relics/chemical_x.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 132
@@ -742,6 +784,7 @@
     },
     "image_url": "/static/images/relics/game_piece.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 88
@@ -761,6 +804,7 @@
     },
     "image_url": "/static/images/relics/gorget.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 16
@@ -776,6 +820,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/circlet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "None",
     "compendium_order": 292
@@ -791,6 +836,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_boot.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 261
@@ -806,6 +852,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/signet_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 175
@@ -825,6 +872,7 @@
     },
     "image_url": "/static/images/relics/chandelier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 89
@@ -844,6 +892,7 @@
     },
     "image_url": "/static/images/relics/shovel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 90
@@ -859,6 +908,13 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sea_glass.webp",
     "image_variants": null,
+    "name_variants": {
+      "Ironclad": "デーモングラス",
+      "Silent": "ヴェノムグラス",
+      "Defect": "ギアグラス",
+      "Necrobinder": "リッチグラス",
+      "Regent": "ノーブルグラス"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 176
@@ -878,6 +934,7 @@
     },
     "image_url": "/static/images/relics/fake_strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 262
@@ -897,6 +954,7 @@
     },
     "image_url": "/static/images/relics/strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 17
@@ -912,6 +970,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 177
@@ -931,6 +990,7 @@
     },
     "image_url": "/static/images/relics/fake_snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 263
@@ -950,6 +1010,7 @@
     },
     "image_url": "/static/images/relics/snecko_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 18
@@ -965,6 +1026,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tanxs_whistle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 178
@@ -984,6 +1046,7 @@
     },
     "image_url": "/static/images/relics/tungsten_rod.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 91
@@ -999,6 +1062,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/diamond_diadem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 179
@@ -1018,6 +1082,7 @@
     },
     "image_url": "/static/images/relics/tingsha.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 44
@@ -1037,6 +1102,7 @@
     },
     "image_url": "/static/images/relics/funerary_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 45
@@ -1056,6 +1122,7 @@
     },
     "image_url": "/static/images/relics/data_disk.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 19
@@ -1075,6 +1142,7 @@
     },
     "image_url": "/static/images/relics/lizard_tail.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 92
@@ -1090,6 +1158,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/spiked_gauntlets.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 180
@@ -1109,6 +1178,7 @@
     },
     "image_url": "/static/images/relics/dragon_fruit.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 133
@@ -1128,6 +1198,7 @@
     },
     "image_url": "/static/images/relics/dollys_mirror.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 134
@@ -1143,6 +1214,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dream_catcher.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 264
@@ -1158,6 +1230,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_drake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 2
@@ -1177,6 +1250,7 @@
     },
     "image_url": "/static/images/relics/nunchaku.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 46
@@ -1192,6 +1266,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_talisman.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 181
@@ -1207,6 +1282,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_torment.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 182
@@ -1222,6 +1298,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_bones.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 183
@@ -1241,6 +1318,7 @@
     },
     "image_url": "/static/images/relics/happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 20
@@ -1260,6 +1338,7 @@
     },
     "image_url": "/static/images/relics/fake_happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 265
@@ -1275,6 +1354,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hand_drill.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 266
@@ -1294,6 +1374,7 @@
     },
     "image_url": "/static/images/relics/bag_of_preparation.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 21
@@ -1309,6 +1390,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/burning_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 3
@@ -1324,6 +1406,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 184
@@ -1339,6 +1422,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 185
@@ -1354,6 +1438,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_claw.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 186
@@ -1369,6 +1454,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 187
@@ -1384,6 +1470,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_wing.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 188
@@ -1399,6 +1486,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_flesh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 189
@@ -1414,6 +1502,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_legion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 190
@@ -1429,6 +1518,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_growth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 191
@@ -1444,6 +1534,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 192
@@ -1459,6 +1550,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 193
@@ -1478,6 +1570,7 @@
     },
     "image_url": "/static/images/relics/parrying_shield.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 47
@@ -1497,6 +1590,7 @@
     },
     "image_url": "/static/images/relics/power_cell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 93
@@ -1516,6 +1610,7 @@
     },
     "image_url": "/static/images/relics/bread.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 135
@@ -1535,6 +1630,7 @@
     },
     "image_url": "/static/images/relics/pantograph.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -1554,6 +1650,7 @@
     },
     "image_url": "/static/images/relics/punch_dagger.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 136
@@ -1569,6 +1666,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pandoras_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 194
@@ -1588,6 +1686,7 @@
     },
     "image_url": "/static/images/relics/big_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 94
@@ -1603,6 +1702,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/byrdpip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 267
@@ -1618,6 +1718,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bing_bong.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 268
@@ -1637,6 +1738,7 @@
     },
     "image_url": "/static/images/relics/bag_of_marbles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 22
@@ -1652,6 +1754,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fiddle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 195
@@ -1667,6 +1770,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fresnel_lens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 269
@@ -1682,6 +1786,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 196
@@ -1697,6 +1802,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 4
@@ -1716,6 +1822,7 @@
     },
     "image_url": "/static/images/relics/brimstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 137
@@ -1731,6 +1838,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/prismatic_gem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 197
@@ -1750,6 +1858,7 @@
     },
     "image_url": "/static/images/relics/belt_buckle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 138
@@ -1765,6 +1874,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/velvet_choker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 198
@@ -1784,6 +1894,7 @@
     },
     "image_url": "/static/images/relics/pen_nib.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 49
@@ -1803,6 +1914,7 @@
     },
     "image_url": "/static/images/relics/white_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 95
@@ -1822,6 +1934,7 @@
     },
     "image_url": "/static/images/relics/horn_cleat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -1837,6 +1950,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pomander.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 199
@@ -1856,6 +1970,7 @@
     },
     "image_url": "/static/images/relics/potion_belt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 23
@@ -1875,6 +1990,7 @@
     },
     "image_url": "/static/images/relics/prayer_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 96
@@ -1894,6 +2010,7 @@
     },
     "image_url": "/static/images/relics/mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 97
@@ -1913,6 +2030,7 @@
     },
     "image_url": "/static/images/relics/fake_mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 270
@@ -1932,6 +2050,7 @@
     },
     "image_url": "/static/images/relics/cloak_clasp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 98
@@ -1951,6 +2070,7 @@
     },
     "image_url": "/static/images/relics/mummified_hand.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 99
@@ -1966,6 +2086,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/mr_struggles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 271
@@ -1985,6 +2106,7 @@
     },
     "image_url": "/static/images/relics/miniature_tent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 139
@@ -2004,6 +2126,7 @@
     },
     "image_url": "/static/images/relics/miniature_cannon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 51
@@ -2023,6 +2146,7 @@
     },
     "image_url": "/static/images/relics/metronome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 100
@@ -2038,6 +2162,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/maw_bank.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 272
@@ -2053,6 +2178,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glitter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 200
@@ -2072,6 +2198,7 @@
     },
     "image_url": "/static/images/relics/lantern.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 24
@@ -2091,6 +2218,7 @@
     },
     "image_url": "/static/images/relics/lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 140
@@ -2110,6 +2238,7 @@
     },
     "image_url": "/static/images/relics/fake_lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 273
@@ -2129,6 +2258,7 @@
     },
     "image_url": "/static/images/relics/runic_capacitor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 141
@@ -2144,6 +2274,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/runic_pyramid.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 201
@@ -2163,6 +2294,7 @@
     },
     "image_url": "/static/images/relics/regalite.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 52
@@ -2182,6 +2314,7 @@
     },
     "image_url": "/static/images/relics/letter_opener.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 53
@@ -2201,6 +2334,7 @@
     },
     "image_url": "/static/images/relics/red_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 25
@@ -2216,6 +2350,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/royal_poison.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 274
@@ -2235,6 +2370,7 @@
     },
     "image_url": "/static/images/relics/vajra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 26
@@ -2254,6 +2390,7 @@
     },
     "image_url": "/static/images/relics/vambrace.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -2273,6 +2410,7 @@
     },
     "image_url": "/static/images/relics/tough_bandages.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 101
@@ -2288,6 +2426,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tri_boomerang.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 202
@@ -2307,6 +2446,7 @@
     },
     "image_url": "/static/images/relics/undying_sigil.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 142
@@ -2326,6 +2466,7 @@
     },
     "image_url": "/static/images/relics/unsettling_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 102
@@ -2345,6 +2486,7 @@
     },
     "image_url": "/static/images/relics/book_of_five_rings.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 27
@@ -2364,6 +2506,7 @@
     },
     "image_url": "/static/images/relics/membership_card.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 143
@@ -2379,6 +2522,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/radiant_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 203
@@ -2398,6 +2542,7 @@
     },
     "image_url": "/static/images/relics/symbiotic_virus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 55
@@ -2417,6 +2562,7 @@
     },
     "image_url": "/static/images/relics/ringing_triangle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 144
@@ -2436,6 +2582,7 @@
     },
     "image_url": "/static/images/relics/joss_paper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 56
@@ -2455,6 +2602,7 @@
     },
     "image_url": "/static/images/relics/frozen_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 103
@@ -2474,6 +2622,7 @@
     },
     "image_url": "/static/images/relics/razor_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 104
@@ -2493,6 +2642,7 @@
     },
     "image_url": "/static/images/relics/fencing_manual.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 28
@@ -2512,6 +2662,7 @@
     },
     "image_url": "/static/images/relics/sling_of_courage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 145
@@ -2527,6 +2678,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precarious_shears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 204
@@ -2542,6 +2694,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/old_coin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 105
@@ -2561,6 +2714,7 @@
     },
     "image_url": "/static/images/relics/venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 29
@@ -2580,6 +2734,7 @@
     },
     "image_url": "/static/images/relics/fake_venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 275
@@ -2595,6 +2750,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/archaic_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 205
@@ -2610,6 +2766,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cursed_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 206
@@ -2625,6 +2782,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/calling_bell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 207
@@ -2640,6 +2798,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fake_merchants_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 276
@@ -2655,6 +2814,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/whispering_earring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 208
@@ -2670,6 +2830,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/large_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 209
@@ -2685,6 +2846,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/big_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 277
@@ -2704,6 +2866,7 @@
     },
     "image_url": "/static/images/relics/cauldron.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 146
@@ -2723,6 +2886,7 @@
     },
     "image_url": "/static/images/relics/orrery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 147
@@ -2738,6 +2902,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 210
@@ -2757,6 +2922,7 @@
     },
     "image_url": "/static/images/relics/intimidating_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 106
@@ -2776,6 +2942,7 @@
     },
     "image_url": "/static/images/relics/art_of_war.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 107
@@ -2791,6 +2958,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jewelry_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 211
@@ -2806,6 +2974,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jeweled_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 212
@@ -2821,6 +2990,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bound_phylactery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 5
@@ -2836,6 +3006,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/small_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 213
@@ -2855,6 +3026,7 @@
     },
     "image_url": "/static/images/relics/tiny_mailbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 57
@@ -2870,6 +3042,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bowler_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 58
@@ -2888,6 +3061,7 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
+    "name_variants": null,
     "notes": [
       "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
       "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
@@ -2906,6 +3080,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/massive_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 215
@@ -2921,6 +3096,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/scroll_boxes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 216
@@ -2936,6 +3112,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sere_talon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 217
@@ -2951,6 +3128,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lucky_fysh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 59
@@ -2970,6 +3148,7 @@
     },
     "image_url": "/static/images/relics/ghost_seed.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 148
@@ -2989,6 +3168,7 @@
     },
     "image_url": "/static/images/relics/ninja_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 149
@@ -3004,6 +3184,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/forgotten_soul.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 278
@@ -3023,6 +3204,7 @@
     },
     "image_url": "/static/images/relics/demon_tongue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 108
@@ -3042,6 +3224,7 @@
     },
     "image_url": "/static/images/relics/emotion_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 109
@@ -3061,6 +3244,7 @@
     },
     "image_url": "/static/images/relics/pocketwatch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 110
@@ -3080,6 +3264,7 @@
     },
     "image_url": "/static/images/relics/war_paint.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 30
@@ -3099,6 +3284,7 @@
     },
     "image_url": "/static/images/relics/ornamental_fan.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 60
@@ -3114,6 +3300,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/throwing_axe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 218
@@ -3133,6 +3320,7 @@
     },
     "image_url": "/static/images/relics/shuriken.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 111
@@ -3152,6 +3340,7 @@
     },
     "image_url": "/static/images/relics/paper_phrog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 61
@@ -3171,6 +3360,7 @@
     },
     "image_url": "/static/images/relics/paper_krane.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 112
@@ -3190,6 +3380,7 @@
     },
     "image_url": "/static/images/relics/pendulum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 31
@@ -3209,6 +3400,7 @@
     },
     "image_url": "/static/images/relics/juzu_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 32
@@ -3228,6 +3420,7 @@
     },
     "image_url": "/static/images/relics/planisphere.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 62
@@ -3247,6 +3440,7 @@
     },
     "image_url": "/static/images/relics/stone_calendar.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 113
@@ -3266,6 +3460,7 @@
     },
     "image_url": "/static/images/relics/lunar_pastry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 114
@@ -3285,6 +3480,7 @@
     },
     "image_url": "/static/images/relics/kifuda.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 150
@@ -3304,6 +3500,7 @@
     },
     "image_url": "/static/images/relics/ruined_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 115
@@ -3319,6 +3516,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_oyster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 219
@@ -3334,6 +3532,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_soup.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 220
@@ -3353,6 +3552,7 @@
     },
     "image_url": "/static/images/relics/bookmark.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 116
@@ -3372,6 +3572,7 @@
     },
     "image_url": "/static/images/relics/twisted_funnel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -3387,6 +3588,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/history_course.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 279
@@ -3406,6 +3608,7 @@
     },
     "image_url": "/static/images/relics/toxic_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 117
@@ -3421,6 +3624,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fur_coat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 221
@@ -3436,6 +3640,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/distinguished_cape.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 222
@@ -3455,6 +3660,7 @@
     },
     "image_url": "/static/images/relics/mercury_hourglass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 64
@@ -3474,6 +3680,7 @@
     },
     "image_url": "/static/images/relics/unceasing_top.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 118
@@ -3493,6 +3700,7 @@
     },
     "image_url": "/static/images/relics/permafrost.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 65
@@ -3512,6 +3720,7 @@
     },
     "image_url": "/static/images/relics/ripple_basin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 66
@@ -3531,6 +3740,7 @@
     },
     "image_url": "/static/images/relics/pear.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 67
@@ -3546,6 +3756,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/driftwood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 223
@@ -3565,6 +3776,7 @@
     },
     "image_url": "/static/images/relics/lava_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 151
@@ -3580,6 +3792,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lava_rock.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 224
@@ -3599,6 +3812,7 @@
     },
     "image_url": "/static/images/relics/molten_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 119
@@ -3614,6 +3828,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/very_hot_cocoa.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 225
@@ -3629,6 +3844,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ember_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 280
@@ -3644,6 +3860,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tea_of_discourtesy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 281
@@ -3663,6 +3880,7 @@
     },
     "image_url": "/static/images/relics/candelabra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -3682,6 +3900,7 @@
     },
     "image_url": "/static/images/relics/reptile_trinket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 69
@@ -3697,6 +3916,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lords_parasol.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 226
@@ -3716,6 +3936,7 @@
     },
     "image_url": "/static/images/relics/royal_stamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 152
@@ -3731,6 +3952,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/preserved_fog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 227
@@ -3750,6 +3972,7 @@
     },
     "image_url": "/static/images/relics/white_beast_statue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 120
@@ -3769,6 +3992,7 @@
     },
     "image_url": "/static/images/relics/centennial_puzzle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 33
@@ -3788,6 +4012,7 @@
     },
     "image_url": "/static/images/relics/stone_cracker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 70
@@ -3803,6 +4028,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 282
@@ -3818,6 +4044,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/stone_humidifier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 228
@@ -3837,6 +4064,7 @@
     },
     "image_url": "/static/images/relics/petrified_toad.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 71
@@ -3852,6 +4080,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sand_castle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 229
@@ -3871,6 +4100,7 @@
     },
     "image_url": "/static/images/relics/whetstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 34
@@ -3886,6 +4116,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blessed_antler.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 230
@@ -3901,6 +4132,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_destiny.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 6
@@ -3916,6 +4148,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_right.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 7
@@ -3935,6 +4168,7 @@
     },
     "image_url": "/static/images/relics/mystic_lighter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 153
@@ -3950,6 +4184,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/arcane_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 231
@@ -3965,6 +4200,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/empty_cage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 232
@@ -3980,6 +4216,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/winged_boots.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 233
@@ -3999,6 +4236,7 @@
     },
     "image_url": "/static/images/relics/gnarled_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 154
@@ -4014,6 +4252,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precise_scissors.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 234
@@ -4029,6 +4268,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/storybook.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 235
@@ -4048,6 +4288,7 @@
     },
     "image_url": "/static/images/relics/screaming_flagon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 155
@@ -4063,6 +4304,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/delicate_frond.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 236
@@ -4078,6 +4320,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_jade.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 283
@@ -4097,6 +4340,7 @@
     },
     "image_url": "/static/images/relics/wing_charm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 156
@@ -4112,6 +4356,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/meat_cleaver.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 237
@@ -4131,6 +4376,7 @@
     },
     "image_url": "/static/images/relics/beating_remnant.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 121
@@ -4150,6 +4396,7 @@
     },
     "image_url": "/static/images/relics/self_forming_clay.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 72
@@ -4169,6 +4416,7 @@
     },
     "image_url": "/static/images/relics/captains_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 122
@@ -4184,6 +4432,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pollinous_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 284
@@ -4199,6 +4448,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fragrant_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 285
@@ -4214,6 +4464,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/new_leaf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 238
@@ -4233,6 +4484,7 @@
     },
     "image_url": "/static/images/relics/dingy_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 157
@@ -4248,6 +4500,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dusty_tome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 239
@@ -4263,6 +4516,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phial_holster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 240
@@ -4278,6 +4532,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/leafy_poultice.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 241
@@ -4297,6 +4552,7 @@
     },
     "image_url": "/static/images/relics/rainbow_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 123
@@ -4312,6 +4568,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_snake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 8
@@ -4331,6 +4588,7 @@
     },
     "image_url": "/static/images/relics/helical_dart.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 124
@@ -4350,6 +4608,7 @@
     },
     "image_url": "/static/images/relics/blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 35
@@ -4369,6 +4628,7 @@
     },
     "image_url": "/static/images/relics/fake_blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 286
@@ -4384,6 +4644,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blood_soaked_rose.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 242
@@ -4403,6 +4664,7 @@
     },
     "image_url": "/static/images/relics/book_repair_knife.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 73
@@ -4418,6 +4680,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phylactery_unbound.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 9
@@ -4437,6 +4700,7 @@
     },
     "image_url": "/static/images/relics/burning_sticks.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 158
@@ -4456,6 +4720,7 @@
     },
     "image_url": "/static/images/relics/ivory_tile.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 125
@@ -4471,6 +4736,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/philosophers_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 243
@@ -4490,6 +4756,7 @@
     },
     "image_url": "/static/images/relics/red_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 36
@@ -4509,6 +4776,7 @@
     },
     "image_url": "/static/images/relics/akabeko.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 74
@@ -4524,6 +4792,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/booming_conch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 244
@@ -4539,6 +4808,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_wisp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 287
@@ -4558,6 +4828,7 @@
     },
     "image_url": "/static/images/relics/toolbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 159
@@ -4573,6 +4844,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/chosen_cheese.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 288
@@ -4588,6 +4860,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/choices_paradox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 245
@@ -4603,6 +4876,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_courier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 126
@@ -4618,6 +4892,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hefty_tablet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 246
@@ -4637,6 +4912,7 @@
     },
     "image_url": "/static/images/relics/gold_plated_cables.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -4652,6 +4928,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 247
@@ -4667,6 +4944,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lead_paperweight.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 248
@@ -4682,6 +4960,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/silver_crucible.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 249
@@ -4701,6 +4980,7 @@
     },
     "image_url": "/static/images/relics/galactic_dust.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 76
@@ -4716,6 +4996,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/alchemical_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 250
@@ -4735,6 +5016,7 @@
     },
     "image_url": "/static/images/relics/kusarigama.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 77
@@ -4754,6 +5036,7 @@
     },
     "image_url": "/static/images/relics/lasting_candy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -4769,6 +5052,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/darkstone_periapt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 289
@@ -4788,6 +5072,7 @@
     },
     "image_url": "/static/images/relics/vexing_puzzlebox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 127
@@ -4803,6 +5088,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/electric_shrymp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 251
@@ -4822,6 +5108,7 @@
     },
     "image_url": "/static/images/relics/bronze_scales.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 37
@@ -4841,6 +5128,7 @@
     },
     "image_url": "/static/images/relics/tuning_fork.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 79
@@ -4860,6 +5148,7 @@
     },
     "image_url": "/static/images/relics/sturdy_clamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 128
@@ -4875,6 +5164,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/daughter_of_the_wind.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 290
@@ -4894,6 +5184,7 @@
     },
     "image_url": "/static/images/relics/bone_flute.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 38
@@ -4913,6 +5204,7 @@
     },
     "image_url": "/static/images/relics/meat_on_the_bone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 129
@@ -4928,6 +5220,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bone_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 291
@@ -4947,6 +5240,7 @@
     },
     "image_url": "/static/images/relics/regal_pillow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 39
@@ -4962,6 +5256,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/brilliant_scarf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 252
@@ -4977,6 +5272,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/beautiful_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 253
@@ -4992,6 +5288,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/seal_of_gold.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 254
@@ -5007,6 +5304,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 255
@@ -5022,6 +5320,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_compass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 256

--- a/data/kor/relics.json
+++ b/data/kor/relics.json
@@ -14,6 +14,7 @@
     },
     "image_url": "/static/images/relics/cauldron.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 130
@@ -29,6 +30,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/spiked_gauntlets.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 160
@@ -48,6 +50,7 @@
     },
     "image_url": "/static/images/relics/emotion_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 80
@@ -67,6 +70,7 @@
     },
     "image_url": "/static/images/relics/fencing_manual.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 10
@@ -82,6 +86,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 161
@@ -101,6 +106,7 @@
     },
     "image_url": "/static/images/relics/game_piece.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 81
@@ -116,6 +122,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/meat_cleaver.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 162
@@ -135,6 +142,7 @@
     },
     "image_url": "/static/images/relics/meat_on_the_bone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 82
@@ -150,6 +158,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/archaic_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 163
@@ -169,6 +178,7 @@
     },
     "image_url": "/static/images/relics/beating_remnant.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 83
@@ -188,6 +198,7 @@
     },
     "image_url": "/static/images/relics/toolbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 131
@@ -207,6 +218,7 @@
     },
     "image_url": "/static/images/relics/ringing_triangle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 132
@@ -226,6 +238,7 @@
     },
     "image_url": "/static/images/relics/symbiotic_virus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 40
@@ -241,6 +254,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bound_phylactery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 0
@@ -260,6 +274,7 @@
     },
     "image_url": "/static/images/relics/bag_of_marbles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 11
@@ -275,6 +290,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lords_parasol.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 164
@@ -294,6 +310,7 @@
     },
     "image_url": "/static/images/relics/gremlin_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 41
@@ -313,6 +330,7 @@
     },
     "image_url": "/static/images/relics/vajra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 12
@@ -332,6 +350,7 @@
     },
     "image_url": "/static/images/relics/oddly_smooth_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 13
@@ -350,6 +369,7 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
+    "name_variants": null,
     "notes": [
       "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
       "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
@@ -368,6 +388,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/distinguished_cape.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 166
@@ -383,6 +404,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_wisp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 257
@@ -398,6 +420,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pollinous_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 258
@@ -413,6 +436,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/leafy_poultice.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 167
@@ -432,6 +456,7 @@
     },
     "image_url": "/static/images/relics/helical_dart.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 84
@@ -447,6 +472,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/winged_boots.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 168
@@ -466,6 +492,7 @@
     },
     "image_url": "/static/images/relics/wing_charm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 133
@@ -485,6 +512,7 @@
     },
     "image_url": "/static/images/relics/razor_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 85
@@ -500,6 +528,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/old_coin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 86
@@ -515,6 +544,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lead_paperweight.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 169
@@ -536,6 +566,7 @@
       "Necrobinder": "/static/images/relics/yummy_cookie_necrobinder.webp",
       "Regent": "/static/images/relics/yummy_cookie_regent.webp"
     },
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 170
@@ -555,6 +586,7 @@
     },
     "image_url": "/static/images/relics/molten_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 87
@@ -570,6 +602,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_torment.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 171
@@ -585,6 +618,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_bones.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 172
@@ -600,6 +634,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_talisman.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 173
@@ -619,6 +654,7 @@
     },
     "image_url": "/static/images/relics/ninja_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 134
@@ -634,6 +670,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/diamond_diadem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 174
@@ -653,6 +690,7 @@
     },
     "image_url": "/static/images/relics/lunar_pastry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 88
@@ -672,6 +710,7 @@
     },
     "image_url": "/static/images/relics/anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 14
@@ -691,6 +730,7 @@
     },
     "image_url": "/static/images/relics/fake_anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 259
@@ -706,6 +746,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/massive_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 175
@@ -721,6 +762,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/large_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 176
@@ -740,6 +782,7 @@
     },
     "image_url": "/static/images/relics/data_disk.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 15
@@ -759,6 +802,7 @@
     },
     "image_url": "/static/images/relics/lizard_tail.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 89
@@ -778,6 +822,7 @@
     },
     "image_url": "/static/images/relics/gambling_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 90
@@ -793,6 +838,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 260
@@ -812,6 +858,7 @@
     },
     "image_url": "/static/images/relics/dollys_mirror.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 135
@@ -831,6 +878,7 @@
     },
     "image_url": "/static/images/relics/power_cell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 91
@@ -846,6 +894,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/storybook.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 177
@@ -861,6 +910,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/scroll_boxes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 178
@@ -880,6 +930,7 @@
     },
     "image_url": "/static/images/relics/twisted_funnel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 42
@@ -895,6 +946,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dream_catcher.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 261
@@ -910,6 +962,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toasty_mittens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 179
@@ -929,6 +982,7 @@
     },
     "image_url": "/static/images/relics/strawberry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 16
@@ -948,6 +1002,7 @@
     },
     "image_url": "/static/images/relics/dingy_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 136
@@ -967,6 +1022,7 @@
     },
     "image_url": "/static/images/relics/lantern.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 17
@@ -986,6 +1042,7 @@
     },
     "image_url": "/static/images/relics/runic_capacitor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 137
@@ -1001,6 +1058,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/runic_pyramid.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 180
@@ -1020,6 +1078,7 @@
     },
     "image_url": "/static/images/relics/regalite.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 43
@@ -1039,6 +1098,7 @@
     },
     "image_url": "/static/images/relics/fake_lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 262
@@ -1058,6 +1118,7 @@
     },
     "image_url": "/static/images/relics/lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 138
@@ -1073,6 +1134,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sere_talon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 181
@@ -1092,6 +1154,7 @@
     },
     "image_url": "/static/images/relics/fake_mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 263
@@ -1111,6 +1174,7 @@
     },
     "image_url": "/static/images/relics/mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 92
@@ -1130,6 +1194,7 @@
     },
     "image_url": "/static/images/relics/cloak_clasp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 93
@@ -1145,6 +1210,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dusty_tome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 182
@@ -1164,6 +1230,7 @@
     },
     "image_url": "/static/images/relics/unceasing_top.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 94
@@ -1179,6 +1246,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/brilliant_scarf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 183
@@ -1198,6 +1266,7 @@
     },
     "image_url": "/static/images/relics/metronome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 95
@@ -1217,6 +1286,7 @@
     },
     "image_url": "/static/images/relics/membership_card.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 139
@@ -1232,6 +1302,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sand_castle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 184
@@ -1247,6 +1318,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fur_coat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 185
@@ -1266,6 +1338,7 @@
     },
     "image_url": "/static/images/relics/gorget.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 18
@@ -1285,6 +1358,7 @@
     },
     "image_url": "/static/images/relics/kifuda.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 140
@@ -1300,6 +1374,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tea_of_discourtesy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 264
@@ -1319,6 +1394,7 @@
     },
     "image_url": "/static/images/relics/rainbow_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 96
@@ -1334,6 +1410,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hefty_tablet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 186
@@ -1353,6 +1430,7 @@
     },
     "image_url": "/static/images/relics/mini_regent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 97
@@ -1372,6 +1450,7 @@
     },
     "image_url": "/static/images/relics/miniature_cannon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 44
@@ -1391,6 +1470,7 @@
     },
     "image_url": "/static/images/relics/miniature_tent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 141
@@ -1410,6 +1490,7 @@
     },
     "image_url": "/static/images/relics/mummified_hand.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 98
@@ -1425,6 +1506,13 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sea_glass.webp",
     "image_variants": null,
+    "name_variants": {
+      "Ironclad": "악마 유리",
+      "Silent": "맹독 유리",
+      "Defect": "톱니 유리",
+      "Necrobinder": "리치 유리",
+      "Regent": "귀족 유리"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 187
@@ -1440,6 +1528,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/daughter_of_the_wind.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 265
@@ -1455,6 +1544,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fiddle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 188
@@ -1470,6 +1560,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glitter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 189
@@ -1489,6 +1580,7 @@
     },
     "image_url": "/static/images/relics/sparkling_rouge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 45
@@ -1504,6 +1596,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/calling_bell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 190
@@ -1523,6 +1616,7 @@
     },
     "image_url": "/static/images/relics/pear.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 46
@@ -1538,6 +1632,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_courier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 99
@@ -1557,6 +1652,7 @@
     },
     "image_url": "/static/images/relics/centennial_puzzle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 19
@@ -1572,6 +1668,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_snake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 1
@@ -1587,6 +1684,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/mr_struggles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 266
@@ -1602,6 +1700,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/velvet_choker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 191
@@ -1621,6 +1720,7 @@
     },
     "image_url": "/static/images/relics/belt_buckle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 142
@@ -1640,6 +1740,7 @@
     },
     "image_url": "/static/images/relics/planisphere.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 47
@@ -1659,6 +1760,7 @@
     },
     "image_url": "/static/images/relics/art_of_war.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 100
@@ -1674,6 +1776,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jeweled_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 192
@@ -1689,6 +1792,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jewelry_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 193
@@ -1704,6 +1808,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/preserved_fog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 194
@@ -1719,6 +1824,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cracked_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 2
@@ -1738,6 +1844,7 @@
     },
     "image_url": "/static/images/relics/undying_sigil.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 143
@@ -1757,6 +1864,7 @@
     },
     "image_url": "/static/images/relics/burning_sticks.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 144
@@ -1772,6 +1880,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precarious_shears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 195
@@ -1787,6 +1896,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/burning_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 3
@@ -1806,6 +1916,7 @@
     },
     "image_url": "/static/images/relics/red_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 20
@@ -1825,6 +1936,7 @@
     },
     "image_url": "/static/images/relics/red_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 21
@@ -1840,6 +1952,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_drake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 4
@@ -1859,6 +1972,7 @@
     },
     "image_url": "/static/images/relics/screaming_flagon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 145
@@ -1874,6 +1988,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/arcane_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 196
@@ -1889,6 +2004,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_jade.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 267
@@ -1908,6 +2024,7 @@
     },
     "image_url": "/static/images/relics/vitruvian_minion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 146
@@ -1923,6 +2040,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/empty_cage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 197
@@ -1938,6 +2056,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bing_bong.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 268
@@ -1953,6 +2072,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/radiant_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 198
@@ -1972,6 +2092,7 @@
     },
     "image_url": "/static/images/relics/bread.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 147
@@ -1991,6 +2112,7 @@
     },
     "image_url": "/static/images/relics/bone_flute.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 22
@@ -2006,6 +2128,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bone_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 269
@@ -2025,6 +2148,7 @@
     },
     "image_url": "/static/images/relics/kusarigama.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -2040,6 +2164,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 199
@@ -2055,6 +2180,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tri_boomerang.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 200
@@ -2074,6 +2200,7 @@
     },
     "image_url": "/static/images/relics/shovel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 101
@@ -2093,6 +2220,7 @@
     },
     "image_url": "/static/images/relics/ivory_tile.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 102
@@ -2108,6 +2236,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fake_merchants_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 270
@@ -2123,6 +2252,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/new_leaf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 201
@@ -2142,6 +2272,7 @@
     },
     "image_url": "/static/images/relics/chandelier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 103
@@ -2157,6 +2288,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/circlet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "None",
     "compendium_order": 292
@@ -2172,6 +2304,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/stone_humidifier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 202
@@ -2191,6 +2324,7 @@
     },
     "image_url": "/static/images/relics/stone_calendar.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 104
@@ -2210,6 +2344,7 @@
     },
     "image_url": "/static/images/relics/petrified_toad.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 49
@@ -2229,6 +2364,7 @@
     },
     "image_url": "/static/images/relics/captains_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 105
@@ -2244,6 +2380,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/choices_paradox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 203
@@ -2263,6 +2400,7 @@
     },
     "image_url": "/static/images/relics/unsettling_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 106
@@ -2282,6 +2420,7 @@
     },
     "image_url": "/static/images/relics/tuning_fork.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -2301,6 +2440,7 @@
     },
     "image_url": "/static/images/relics/horn_cleat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 51
@@ -2316,6 +2456,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/small_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 204
@@ -2331,6 +2472,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/whispering_earring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 205
@@ -2346,6 +2488,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/iron_club.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 206
@@ -2365,6 +2508,7 @@
     },
     "image_url": "/static/images/relics/kunai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 107
@@ -2384,6 +2528,7 @@
     },
     "image_url": "/static/images/relics/mercury_hourglass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 52
@@ -2403,6 +2548,7 @@
     },
     "image_url": "/static/images/relics/whetstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 23
@@ -2422,6 +2568,7 @@
     },
     "image_url": "/static/images/relics/fake_snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 271
@@ -2437,6 +2584,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 207
@@ -2456,6 +2604,7 @@
     },
     "image_url": "/static/images/relics/snecko_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 24
@@ -2471,6 +2620,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sozu.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 208
@@ -2490,6 +2640,7 @@
     },
     "image_url": "/static/images/relics/meal_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 25
@@ -2509,6 +2660,7 @@
     },
     "image_url": "/static/images/relics/mystic_lighter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 148
@@ -2524,6 +2676,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_right.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 5
@@ -2539,6 +2692,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_destiny.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 6
@@ -2558,6 +2712,7 @@
     },
     "image_url": "/static/images/relics/nunchaku.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 53
@@ -2573,6 +2728,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/maw_bank.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 272
@@ -2588,6 +2744,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/beautiful_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 209
@@ -2603,6 +2760,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/astrolabe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 210
@@ -2622,6 +2780,7 @@
     },
     "image_url": "/static/images/relics/ice_cream.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 108
@@ -2641,6 +2800,7 @@
     },
     "image_url": "/static/images/relics/akabeko.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -2660,6 +2820,7 @@
     },
     "image_url": "/static/images/relics/demon_tongue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 109
@@ -2675,6 +2836,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phial_holster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 211
@@ -2690,6 +2852,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 7
@@ -2709,6 +2872,7 @@
     },
     "image_url": "/static/images/relics/frozen_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 110
@@ -2724,6 +2888,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/chosen_cheese.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 273
@@ -2739,6 +2904,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/very_hot_cocoa.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 212
@@ -2754,6 +2920,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/history_course.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 274
@@ -2769,6 +2936,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/alchemical_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 213
@@ -2788,6 +2956,7 @@
     },
     "image_url": "/static/images/relics/juzu_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 26
@@ -2803,6 +2972,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_oyster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 214
@@ -2818,6 +2988,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_soup.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 215
@@ -2837,6 +3008,7 @@
     },
     "image_url": "/static/images/relics/eternal_feather.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 55
@@ -2856,6 +3028,7 @@
     },
     "image_url": "/static/images/relics/permafrost.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 56
@@ -2875,6 +3048,7 @@
     },
     "image_url": "/static/images/relics/lasting_candy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 57
@@ -2890,6 +3064,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/touch_of_orobas.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 216
@@ -2909,6 +3084,7 @@
     },
     "image_url": "/static/images/relics/book_of_five_rings.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 27
@@ -2924,6 +3100,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/music_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 217
@@ -2943,6 +3120,7 @@
     },
     "image_url": "/static/images/relics/fake_orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 275
@@ -2962,6 +3140,7 @@
     },
     "image_url": "/static/images/relics/orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 58
@@ -2981,6 +3160,7 @@
     },
     "image_url": "/static/images/relics/vambrace.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 59
@@ -3000,6 +3180,7 @@
     },
     "image_url": "/static/images/relics/royal_stamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 149
@@ -3015,6 +3196,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/royal_poison.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 276
@@ -3030,6 +3212,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ectoplasm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 218
@@ -3049,6 +3232,7 @@
     },
     "image_url": "/static/images/relics/dragon_fruit.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 150
@@ -3068,6 +3252,7 @@
     },
     "image_url": "/static/images/relics/sling_of_courage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 151
@@ -3087,6 +3272,7 @@
     },
     "image_url": "/static/images/relics/lava_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 152
@@ -3102,6 +3288,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/delicate_frond.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 219
@@ -3121,6 +3308,7 @@
     },
     "image_url": "/static/images/relics/gnarled_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 153
@@ -3136,6 +3324,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongo_customer_appreciation_badge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 277
@@ -3151,6 +3340,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongos_mystery_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 278
@@ -3170,6 +3360,7 @@
     },
     "image_url": "/static/images/relics/intimidating_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 111
@@ -3189,6 +3380,7 @@
     },
     "image_url": "/static/images/relics/toxic_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 112
@@ -3208,6 +3400,7 @@
     },
     "image_url": "/static/images/relics/ghost_seed.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 154
@@ -3223,6 +3416,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glass_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 220
@@ -3238,6 +3432,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/driftwood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 221
@@ -3257,6 +3452,7 @@
     },
     "image_url": "/static/images/relics/fake_venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 279
@@ -3276,6 +3472,7 @@
     },
     "image_url": "/static/images/relics/venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 28
@@ -3295,6 +3492,7 @@
     },
     "image_url": "/static/images/relics/brimstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 155
@@ -3310,6 +3508,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/silver_crucible.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 222
@@ -3329,6 +3528,7 @@
     },
     "image_url": "/static/images/relics/galactic_dust.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 60
@@ -3344,6 +3544,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/signet_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 223
@@ -3359,6 +3560,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 224
@@ -3374,6 +3576,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ember_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 280
@@ -3389,6 +3592,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/forgotten_soul.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 281
@@ -3408,6 +3612,7 @@
     },
     "image_url": "/static/images/relics/self_forming_clay.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 61
@@ -3423,6 +3628,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/amethyst_aubergine.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 29
@@ -3442,6 +3648,7 @@
     },
     "image_url": "/static/images/relics/tiny_mailbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 62
@@ -3457,6 +3664,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toy_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": [
       "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed.",
       "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
@@ -3480,6 +3688,7 @@
     },
     "image_url": "/static/images/relics/funerary_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -3499,6 +3708,7 @@
     },
     "image_url": "/static/images/relics/ornamental_fan.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 64
@@ -3514,6 +3724,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_boot.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 282
@@ -3529,6 +3740,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cursed_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 226
@@ -3548,6 +3760,7 @@
     },
     "image_url": "/static/images/relics/prayer_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 113
@@ -3563,6 +3776,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/electric_shrymp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 227
@@ -3578,6 +3792,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/war_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 228
@@ -3593,6 +3808,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precise_scissors.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 229
@@ -3612,6 +3828,7 @@
     },
     "image_url": "/static/images/relics/paper_phrog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 65
@@ -3631,6 +3848,7 @@
     },
     "image_url": "/static/images/relics/paper_krane.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 114
@@ -3646,6 +3864,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/infused_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 8
@@ -3665,6 +3884,7 @@
     },
     "image_url": "/static/images/relics/the_abacus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 156
@@ -3684,6 +3904,7 @@
     },
     "image_url": "/static/images/relics/orange_dough.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 115
@@ -3703,6 +3924,7 @@
     },
     "image_url": "/static/images/relics/bag_of_preparation.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 30
@@ -3718,6 +3940,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bowler_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 66
@@ -3737,6 +3960,7 @@
     },
     "image_url": "/static/images/relics/tough_bandages.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 116
@@ -3756,6 +3980,7 @@
     },
     "image_url": "/static/images/relics/vexing_puzzlebox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 117
@@ -3771,6 +3996,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/byrdpip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 283
@@ -3786,6 +4012,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/biiig_hug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 230
@@ -3805,6 +4032,7 @@
     },
     "image_url": "/static/images/relics/stone_cracker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 67
@@ -3824,6 +4052,7 @@
     },
     "image_url": "/static/images/relics/ripple_basin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -3843,6 +4072,7 @@
     },
     "image_url": "/static/images/relics/book_repair_knife.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 69
@@ -3862,6 +4092,7 @@
     },
     "image_url": "/static/images/relics/bookmark.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 118
@@ -3881,6 +4112,7 @@
     },
     "image_url": "/static/images/relics/bronze_scales.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 31
@@ -3900,6 +4132,7 @@
     },
     "image_url": "/static/images/relics/parrying_shield.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 70
@@ -3919,6 +4152,7 @@
     },
     "image_url": "/static/images/relics/candelabra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 71
@@ -3934,6 +4168,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blessed_antler.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 231
@@ -3953,6 +4188,7 @@
     },
     "image_url": "/static/images/relics/festive_popper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 32
@@ -3972,6 +4208,7 @@
     },
     "image_url": "/static/images/relics/war_paint.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 33
@@ -3991,6 +4228,7 @@
     },
     "image_url": "/static/images/relics/charons_ashes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 119
@@ -4010,6 +4248,7 @@
     },
     "image_url": "/static/images/relics/big_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 120
@@ -4025,6 +4264,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/big_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 284
@@ -4044,6 +4284,7 @@
     },
     "image_url": "/static/images/relics/chemical_x.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 157
@@ -4063,6 +4304,7 @@
     },
     "image_url": "/static/images/relics/girya.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 121
@@ -4078,6 +4320,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/booming_conch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 232
@@ -4093,6 +4336,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/crossbow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 233
@@ -4108,6 +4352,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/claws.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 234
@@ -4127,6 +4372,7 @@
     },
     "image_url": "/static/images/relics/fake_strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 285
@@ -4146,6 +4392,7 @@
     },
     "image_url": "/static/images/relics/strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 34
@@ -4161,6 +4408,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tanxs_whistle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 235
@@ -4180,6 +4428,7 @@
     },
     "image_url": "/static/images/relics/orrery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 158
@@ -4199,6 +4448,7 @@
     },
     "image_url": "/static/images/relics/tungsten_rod.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 122
@@ -4214,6 +4464,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/throwing_axe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 236
@@ -4233,6 +4484,7 @@
     },
     "image_url": "/static/images/relics/sturdy_clamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 123
@@ -4252,6 +4504,7 @@
     },
     "image_url": "/static/images/relics/tingsha.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 72
@@ -4271,6 +4524,7 @@
     },
     "image_url": "/static/images/relics/ruined_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 124
@@ -4286,6 +4540,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_legion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 237
@@ -4301,6 +4556,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_wing.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 238
@@ -4316,6 +4572,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 239
@@ -4331,6 +4588,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 240
@@ -4346,6 +4604,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_claw.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 241
@@ -4361,6 +4620,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 242
@@ -4376,6 +4636,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_flesh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 243
@@ -4391,6 +4652,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 244
@@ -4406,6 +4668,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_growth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 245
@@ -4421,6 +4684,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 246
@@ -4440,6 +4704,7 @@
     },
     "image_url": "/static/images/relics/reptile_trinket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 73
@@ -4459,6 +4724,7 @@
     },
     "image_url": "/static/images/relics/gold_plated_cables.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 74
@@ -4474,6 +4740,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pandoras_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 247
@@ -4493,6 +4760,7 @@
     },
     "image_url": "/static/images/relics/pantograph.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -4512,6 +4780,7 @@
     },
     "image_url": "/static/images/relics/punch_dagger.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 159
@@ -4531,6 +4800,7 @@
     },
     "image_url": "/static/images/relics/pen_nib.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 76
@@ -4550,6 +4820,7 @@
     },
     "image_url": "/static/images/relics/pendulum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 35
@@ -4569,6 +4840,7 @@
     },
     "image_url": "/static/images/relics/letter_opener.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 77
@@ -4584,6 +4856,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pomander.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 248
@@ -4603,6 +4876,7 @@
     },
     "image_url": "/static/images/relics/potion_belt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 36
@@ -4622,6 +4896,7 @@
     },
     "image_url": "/static/images/relics/shuriken.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 125
@@ -4641,6 +4916,7 @@
     },
     "image_url": "/static/images/relics/bellows.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 126
@@ -4656,6 +4932,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fresnel_lens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 286
@@ -4671,6 +4948,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/prismatic_gem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 249
@@ -4690,6 +4968,7 @@
     },
     "image_url": "/static/images/relics/fake_blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 287
@@ -4709,6 +4988,7 @@
     },
     "image_url": "/static/images/relics/blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 37
@@ -4724,6 +5004,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blood_soaked_rose.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 250
@@ -4743,6 +5024,7 @@
     },
     "image_url": "/static/images/relics/white_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 127
@@ -4762,6 +5044,7 @@
     },
     "image_url": "/static/images/relics/white_beast_statue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 128
@@ -4777,6 +5060,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phylactery_unbound.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 9
@@ -4792,6 +5076,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hand_drill.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 288
@@ -4811,6 +5096,7 @@
     },
     "image_url": "/static/images/relics/fake_happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 289
@@ -4830,6 +5116,7 @@
     },
     "image_url": "/static/images/relics/happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 38
@@ -4845,6 +5132,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lucky_fysh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -4860,6 +5148,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fragrant_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 290
@@ -4879,6 +5168,7 @@
     },
     "image_url": "/static/images/relics/joss_paper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 79
@@ -4894,6 +5184,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/philosophers_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 251
@@ -4909,6 +5200,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pumpkin_candle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 252
@@ -4928,6 +5220,7 @@
     },
     "image_url": "/static/images/relics/regal_pillow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 39
@@ -4943,6 +5236,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lava_rock.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 253
@@ -4958,6 +5252,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_compass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 254
@@ -4973,6 +5268,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/seal_of_gold.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 255
@@ -4988,6 +5284,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 256
@@ -5007,6 +5304,7 @@
     },
     "image_url": "/static/images/relics/pocketwatch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 129
@@ -5022,6 +5320,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/darkstone_periapt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 291

--- a/data/pol/relics.json
+++ b/data/pol/relics.json
@@ -14,6 +14,7 @@
     },
     "image_url": "/static/images/relics/akabeko.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 40
@@ -29,6 +30,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/velvet_choker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 160
@@ -44,6 +46,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/amethyst_aubergine.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 10
@@ -59,6 +62,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/old_coin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 80
@@ -74,6 +78,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fragrant_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 257
@@ -89,6 +94,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/astrolabe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 161
@@ -104,6 +110,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/very_hot_cocoa.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 162
@@ -123,6 +130,7 @@
     },
     "image_url": "/static/images/relics/war_paint.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 11
@@ -142,6 +150,7 @@
     },
     "image_url": "/static/images/relics/white_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 81
@@ -157,6 +166,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_right.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 0
@@ -172,6 +182,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_destiny.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 1
@@ -191,6 +202,7 @@
     },
     "image_url": "/static/images/relics/juzu_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 12
@@ -206,6 +218,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glitter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 163
@@ -225,6 +238,7 @@
     },
     "image_url": "/static/images/relics/dingy_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 130
@@ -240,6 +254,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_boot.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 258
@@ -255,6 +270,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blessed_antler.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 164
@@ -274,6 +290,7 @@
     },
     "image_url": "/static/images/relics/sparkling_rouge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 41
@@ -293,6 +310,7 @@
     },
     "image_url": "/static/images/relics/bread.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 131
@@ -312,6 +330,7 @@
     },
     "image_url": "/static/images/relics/lunar_pastry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 82
@@ -327,6 +346,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toasty_mittens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 165
@@ -342,6 +362,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/brilliant_scarf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 166
@@ -357,6 +378,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hefty_tablet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 167
@@ -372,6 +394,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 168
@@ -387,6 +410,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 2
@@ -406,6 +430,7 @@
     },
     "image_url": "/static/images/relics/snecko_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 13
@@ -425,6 +450,7 @@
     },
     "image_url": "/static/images/relics/red_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 14
@@ -444,6 +470,7 @@
     },
     "image_url": "/static/images/relics/red_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 15
@@ -463,6 +490,7 @@
     },
     "image_url": "/static/images/relics/emotion_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 83
@@ -478,6 +506,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/daughter_of_the_wind.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 259
@@ -493,6 +522,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/delicate_frond.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 169
@@ -508,6 +538,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/circlet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "None",
     "compendium_order": 292
@@ -523,6 +554,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/diamond_diadem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 170
@@ -538,6 +570,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bing_bong.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 260
@@ -557,6 +590,7 @@
     },
     "image_url": "/static/images/relics/vajra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 16
@@ -572,6 +606,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/touch_of_orobas.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 171
@@ -587,6 +622,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/biiig_hug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 172
@@ -602,6 +638,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fake_merchants_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 261
@@ -621,6 +658,7 @@
     },
     "image_url": "/static/images/relics/lasting_candy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 42
@@ -640,6 +678,7 @@
     },
     "image_url": "/static/images/relics/ringing_triangle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 132
@@ -655,6 +694,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ectoplasm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 173
@@ -674,6 +714,7 @@
     },
     "image_url": "/static/images/relics/blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 17
@@ -693,6 +734,7 @@
     },
     "image_url": "/static/images/relics/fake_blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 262
@@ -712,6 +754,7 @@
     },
     "image_url": "/static/images/relics/bone_flute.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 18
@@ -727,6 +770,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fur_coat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 174
@@ -746,6 +790,7 @@
     },
     "image_url": "/static/images/relics/galactic_dust.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 43
@@ -765,6 +810,7 @@
     },
     "image_url": "/static/images/relics/girya.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 84
@@ -784,6 +830,7 @@
     },
     "image_url": "/static/images/relics/self_forming_clay.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 44
@@ -803,6 +850,7 @@
     },
     "image_url": "/static/images/relics/lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 133
@@ -822,6 +870,7 @@
     },
     "image_url": "/static/images/relics/fake_lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 263
@@ -841,6 +890,7 @@
     },
     "image_url": "/static/images/relics/pear.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 45
@@ -856,6 +906,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tanxs_whistle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 175
@@ -871,6 +922,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tea_of_discourtesy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 264
@@ -886,6 +938,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bone_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 265
@@ -901,6 +954,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/choices_paradox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 176
@@ -920,6 +974,7 @@
     },
     "image_url": "/static/images/relics/vexing_puzzlebox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 85
@@ -939,6 +994,7 @@
     },
     "image_url": "/static/images/relics/lizard_tail.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 86
@@ -958,6 +1014,7 @@
     },
     "image_url": "/static/images/relics/demon_tongue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 87
@@ -973,6 +1030,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phial_holster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 177
@@ -992,6 +1050,7 @@
     },
     "image_url": "/static/images/relics/tuning_fork.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 46
@@ -1007,6 +1066,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/philosophers_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 178
@@ -1026,6 +1086,7 @@
     },
     "image_url": "/static/images/relics/stone_calendar.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 88
@@ -1041,6 +1102,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 266
@@ -1056,6 +1118,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/stone_humidifier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 179
@@ -1075,6 +1138,7 @@
     },
     "image_url": "/static/images/relics/stone_cracker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 47
@@ -1090,6 +1154,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lava_rock.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 180
@@ -1109,6 +1174,7 @@
     },
     "image_url": "/static/images/relics/candelabra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -1128,6 +1194,7 @@
     },
     "image_url": "/static/images/relics/membership_card.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 134
@@ -1147,6 +1214,7 @@
     },
     "image_url": "/static/images/relics/meal_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 19
@@ -1166,6 +1234,7 @@
     },
     "image_url": "/static/images/relics/vambrace.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 49
@@ -1185,6 +1254,7 @@
     },
     "image_url": "/static/images/relics/kifuda.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 135
@@ -1204,6 +1274,7 @@
     },
     "image_url": "/static/images/relics/cloak_clasp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 89
@@ -1223,6 +1294,7 @@
     },
     "image_url": "/static/images/relics/mercury_hourglass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -1242,6 +1314,7 @@
     },
     "image_url": "/static/images/relics/horn_cleat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 51
@@ -1261,6 +1334,7 @@
     },
     "image_url": "/static/images/relics/cauldron.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 136
@@ -1276,6 +1350,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/spiked_gauntlets.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 181
@@ -1291,6 +1366,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/preserved_fog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 182
@@ -1310,6 +1386,7 @@
     },
     "image_url": "/static/images/relics/anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 20
@@ -1329,6 +1406,7 @@
     },
     "image_url": "/static/images/relics/fake_anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 267
@@ -1348,6 +1426,7 @@
     },
     "image_url": "/static/images/relics/captains_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 90
@@ -1363,6 +1442,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_bones.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 183
@@ -1378,6 +1458,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 184
@@ -1393,6 +1474,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blood_soaked_rose.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 185
@@ -1408,6 +1490,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lead_paperweight.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 186
@@ -1427,6 +1510,7 @@
     },
     "image_url": "/static/images/relics/royal_stamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 137
@@ -1446,6 +1530,7 @@
     },
     "image_url": "/static/images/relics/regal_pillow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 21
@@ -1461,6 +1546,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/royal_poison.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 268
@@ -1480,6 +1566,7 @@
     },
     "image_url": "/static/images/relics/book_of_five_rings.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 22
@@ -1499,6 +1586,7 @@
     },
     "image_url": "/static/images/relics/kunai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 91
@@ -1514,6 +1602,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongos_mystery_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 269
@@ -1529,6 +1618,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_courier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 92
@@ -1548,6 +1638,7 @@
     },
     "image_url": "/static/images/relics/kusarigama.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 52
@@ -1563,6 +1654,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/crossbow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 187
@@ -1582,6 +1674,7 @@
     },
     "image_url": "/static/images/relics/lava_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 138
@@ -1601,6 +1694,7 @@
     },
     "image_url": "/static/images/relics/lantern.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 23
@@ -1616,6 +1710,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_legion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 188
@@ -1635,6 +1730,7 @@
     },
     "image_url": "/static/images/relics/the_abacus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 139
@@ -1650,6 +1746,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/new_leaf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 189
@@ -1669,6 +1766,7 @@
     },
     "image_url": "/static/images/relics/ice_cream.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 93
@@ -1688,6 +1786,7 @@
     },
     "image_url": "/static/images/relics/dollys_mirror.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 140
@@ -1707,6 +1806,7 @@
     },
     "image_url": "/static/images/relics/strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 24
@@ -1726,6 +1826,7 @@
     },
     "image_url": "/static/images/relics/fake_strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 270
@@ -1745,6 +1846,7 @@
     },
     "image_url": "/static/images/relics/mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 94
@@ -1764,6 +1866,7 @@
     },
     "image_url": "/static/images/relics/fake_mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 271
@@ -1779,6 +1882,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jeweled_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 190
@@ -1798,6 +1902,7 @@
     },
     "image_url": "/static/images/relics/funerary_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 53
@@ -1813,6 +1918,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/massive_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 191
@@ -1828,6 +1934,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/small_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 192
@@ -1843,6 +1950,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bowler_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -1862,6 +1970,7 @@
     },
     "image_url": "/static/images/relics/metronome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 95
@@ -1881,6 +1990,7 @@
     },
     "image_url": "/static/images/relics/bellows.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 96
@@ -1900,6 +2010,7 @@
     },
     "image_url": "/static/images/relics/mini_regent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 97
@@ -1919,6 +2030,7 @@
     },
     "image_url": "/static/images/relics/miniature_cannon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 55
@@ -1938,6 +2050,7 @@
     },
     "image_url": "/static/images/relics/miniature_tent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 141
@@ -1957,6 +2070,7 @@
     },
     "image_url": "/static/images/relics/ripple_basin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 56
@@ -1976,6 +2090,7 @@
     },
     "image_url": "/static/images/relics/mystic_lighter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 142
@@ -1995,6 +2110,7 @@
     },
     "image_url": "/static/images/relics/meat_on_the_bone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 98
@@ -2010,6 +2126,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/war_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 193
@@ -2029,6 +2146,7 @@
     },
     "image_url": "/static/images/relics/prayer_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 99
@@ -2044,6 +2162,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/chosen_cheese.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 272
@@ -2059,6 +2178,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_growth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 194
@@ -2074,6 +2194,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/infused_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 3
@@ -2089,6 +2210,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_jade.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 273
@@ -2104,6 +2226,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precarious_shears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 195
@@ -2123,6 +2246,7 @@
     },
     "image_url": "/static/images/relics/unsettling_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 100
@@ -2142,6 +2266,7 @@
     },
     "image_url": "/static/images/relics/unceasing_top.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 101
@@ -2161,6 +2286,7 @@
     },
     "image_url": "/static/images/relics/data_disk.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 25
@@ -2180,6 +2306,7 @@
     },
     "image_url": "/static/images/relics/nunchaku.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 57
@@ -2199,6 +2326,7 @@
     },
     "image_url": "/static/images/relics/book_repair_knife.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 58
@@ -2218,6 +2346,7 @@
     },
     "image_url": "/static/images/relics/punch_dagger.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 143
@@ -2233,6 +2362,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongo_customer_appreciation_badge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 274
@@ -2248,6 +2378,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_oyster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 196
@@ -2267,6 +2398,7 @@
     },
     "image_url": "/static/images/relics/molten_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 102
@@ -2286,6 +2418,7 @@
     },
     "image_url": "/static/images/relics/power_cell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 103
@@ -2301,6 +2434,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 197
@@ -2316,6 +2450,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 198
@@ -2335,6 +2470,7 @@
     },
     "image_url": "/static/images/relics/fake_snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 275
@@ -2350,6 +2486,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/leafy_poultice.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 199
@@ -2369,6 +2506,7 @@
     },
     "image_url": "/static/images/relics/orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 59
@@ -2388,6 +2526,7 @@
     },
     "image_url": "/static/images/relics/fake_orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 276
@@ -2407,6 +2546,7 @@
     },
     "image_url": "/static/images/relics/reptile_trinket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 60
@@ -2426,6 +2566,7 @@
     },
     "image_url": "/static/images/relics/whetstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 26
@@ -2445,6 +2586,7 @@
     },
     "image_url": "/static/images/relics/razor_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 104
@@ -2464,6 +2606,7 @@
     },
     "image_url": "/static/images/relics/letter_opener.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 61
@@ -2483,6 +2626,7 @@
     },
     "image_url": "/static/images/relics/ornamental_fan.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 62
@@ -2498,6 +2642,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/mr_struggles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 277
@@ -2517,6 +2662,7 @@
     },
     "image_url": "/static/images/relics/pantograph.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -2536,6 +2682,7 @@
     },
     "image_url": "/static/images/relics/joss_paper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 64
@@ -2555,6 +2702,7 @@
     },
     "image_url": "/static/images/relics/paper_phrog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 65
@@ -2574,6 +2722,7 @@
     },
     "image_url": "/static/images/relics/paper_krane.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 105
@@ -2589,6 +2738,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lords_parasol.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 200
@@ -2608,6 +2758,7 @@
     },
     "image_url": "/static/images/relics/potion_belt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 27
@@ -2623,6 +2774,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/maw_bank.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 278
@@ -2638,6 +2790,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/claws.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 201
@@ -2657,6 +2810,7 @@
     },
     "image_url": "/static/images/relics/undying_sigil.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 144
@@ -2672,6 +2826,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ember_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 279
@@ -2687,6 +2842,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_drake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 4
@@ -2702,6 +2858,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_snake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 5
@@ -2721,6 +2878,7 @@
     },
     "image_url": "/static/images/relics/game_piece.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 106
@@ -2736,6 +2894,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/beautiful_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 202
@@ -2755,6 +2914,7 @@
     },
     "image_url": "/static/images/relics/orrery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 145
@@ -2774,6 +2934,7 @@
     },
     "image_url": "/static/images/relics/planisphere.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 66
@@ -2789,6 +2950,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/history_course.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 280
@@ -2804,6 +2966,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pomander.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 203
@@ -2823,6 +2986,7 @@
     },
     "image_url": "/static/images/relics/orange_dough.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 107
@@ -2842,6 +3006,7 @@
     },
     "image_url": "/static/images/relics/fencing_manual.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 28
@@ -2857,6 +3022,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tri_boomerang.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 204
@@ -2876,6 +3042,7 @@
     },
     "image_url": "/static/images/relics/gnarled_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 146
@@ -2891,6 +3058,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/music_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 205
@@ -2910,6 +3078,7 @@
     },
     "image_url": "/static/images/relics/gold_plated_cables.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 67
@@ -2925,6 +3094,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precise_scissors.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 206
@@ -2944,6 +3114,7 @@
     },
     "image_url": "/static/images/relics/sling_of_courage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 147
@@ -2963,6 +3134,7 @@
     },
     "image_url": "/static/images/relics/charons_ashes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 108
@@ -2978,6 +3150,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/radiant_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 207
@@ -2993,6 +3166,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/prismatic_gem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 208
@@ -3008,6 +3182,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cursed_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 209
@@ -3023,6 +3198,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/calling_bell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 210
@@ -3044,6 +3220,7 @@
       "Necrobinder": "/static/images/relics/yummy_cookie_necrobinder.webp",
       "Regent": "/static/images/relics/yummy_cookie_regent.webp"
     },
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 211
@@ -3063,6 +3240,7 @@
     },
     "image_url": "/static/images/relics/intimidating_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 109
@@ -3082,6 +3260,7 @@
     },
     "image_url": "/static/images/relics/tungsten_rod.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 110
@@ -3097,6 +3276,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/byrdpip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 281
@@ -3112,6 +3292,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jewelry_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 212
@@ -3127,6 +3308,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toy_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": [
       "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed.",
       "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
@@ -3146,6 +3328,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/scroll_boxes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 214
@@ -3161,6 +3344,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/empty_cage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 215
@@ -3176,6 +3360,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pandoras_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 216
@@ -3191,6 +3376,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cracked_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 6
@@ -3206,6 +3392,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/burning_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 7
@@ -3225,6 +3412,7 @@
     },
     "image_url": "/static/images/relics/ivory_tile.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 111
@@ -3244,6 +3432,7 @@
     },
     "image_url": "/static/images/relics/regalite.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -3259,6 +3448,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_soup.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 217
@@ -3278,6 +3468,7 @@
     },
     "image_url": "/static/images/relics/burning_sticks.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 148
@@ -3293,6 +3484,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/runic_pyramid.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 218
@@ -3312,6 +3504,7 @@
     },
     "image_url": "/static/images/relics/runic_capacitor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 149
@@ -3331,6 +3524,7 @@
     },
     "image_url": "/static/images/relics/gorget.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 29
@@ -3346,6 +3540,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lucky_fysh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 69
@@ -3361,6 +3556,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 219
@@ -3380,6 +3576,7 @@
     },
     "image_url": "/static/images/relics/gremlin_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 70
@@ -3398,6 +3595,7 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
+    "name_variants": null,
     "notes": [
       "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
       "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
@@ -3416,6 +3614,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 221
@@ -3435,6 +3634,7 @@
     },
     "image_url": "/static/images/relics/bag_of_marbles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 30
@@ -3450,6 +3650,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phylactery_unbound.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 8
@@ -3469,6 +3670,7 @@
     },
     "image_url": "/static/images/relics/venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 31
@@ -3488,6 +3690,7 @@
     },
     "image_url": "/static/images/relics/fake_venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 282
@@ -3507,6 +3710,7 @@
     },
     "image_url": "/static/images/relics/shuriken.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 112
@@ -3526,6 +3730,7 @@
     },
     "image_url": "/static/images/relics/brimstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 150
@@ -3545,6 +3750,7 @@
     },
     "image_url": "/static/images/relics/petrified_toad.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 71
@@ -3560,6 +3766,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_wing.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 222
@@ -3579,6 +3786,7 @@
     },
     "image_url": "/static/images/relics/tiny_mailbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 72
@@ -3598,6 +3806,7 @@
     },
     "image_url": "/static/images/relics/toolbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 151
@@ -3613,6 +3822,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fiddle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 223
@@ -3632,6 +3842,7 @@
     },
     "image_url": "/static/images/relics/twisted_funnel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 73
@@ -3651,6 +3862,7 @@
     },
     "image_url": "/static/images/relics/dragon_fruit.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 152
@@ -3666,6 +3878,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fresnel_lens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 283
@@ -3681,6 +3894,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sozu.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 224
@@ -3700,6 +3914,7 @@
     },
     "image_url": "/static/images/relics/helical_dart.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 113
@@ -3719,6 +3934,7 @@
     },
     "image_url": "/static/images/relics/belt_buckle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 153
@@ -3734,6 +3950,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/silver_crucible.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 225
@@ -3753,6 +3970,7 @@
     },
     "image_url": "/static/images/relics/pen_nib.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 74
@@ -3768,6 +3986,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/archaic_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 226
@@ -3787,6 +4006,7 @@
     },
     "image_url": "/static/images/relics/white_beast_statue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 114
@@ -3806,6 +4026,7 @@
     },
     "image_url": "/static/images/relics/centennial_puzzle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 32
@@ -3821,6 +4042,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/signet_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 227
@@ -3840,6 +4062,7 @@
     },
     "image_url": "/static/images/relics/symbiotic_virus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -3855,6 +4078,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/whispering_earring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 228
@@ -3870,6 +4094,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/alchemical_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 229
@@ -3885,6 +4110,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glass_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 230
@@ -3900,6 +4126,13 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sea_glass.webp",
     "image_variants": null,
+    "name_variants": {
+      "Ironclad": "Karmazynowe szkło",
+      "Silent": "Szmaragdowe szkło",
+      "Defect": "Lazurytowe szkło",
+      "Necrobinder": "Ametystowe szkło",
+      "Regent": "Bursztynowe szkło"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 231
@@ -3919,6 +4152,7 @@
     },
     "image_url": "/static/images/relics/oddly_smooth_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 33
@@ -3934,6 +4168,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_claw.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 232
@@ -3949,6 +4184,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bound_phylactery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 9
@@ -3968,6 +4204,7 @@
     },
     "image_url": "/static/images/relics/art_of_war.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 115
@@ -3983,6 +4220,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/booming_conch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 233
@@ -4002,6 +4240,7 @@
     },
     "image_url": "/static/images/relics/happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 34
@@ -4021,6 +4260,7 @@
     },
     "image_url": "/static/images/relics/fake_happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 284
@@ -4040,6 +4280,7 @@
     },
     "image_url": "/static/images/relics/vitruvian_minion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 154
@@ -4055,6 +4296,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/arcane_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 234
@@ -4070,6 +4312,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_talisman.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 235
@@ -4089,6 +4332,7 @@
     },
     "image_url": "/static/images/relics/parrying_shield.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 76
@@ -4104,6 +4348,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/meat_cleaver.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 236
@@ -4123,6 +4368,7 @@
     },
     "image_url": "/static/images/relics/tingsha.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 77
@@ -4138,6 +4384,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_flesh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 237
@@ -4157,6 +4404,7 @@
     },
     "image_url": "/static/images/relics/toxic_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 116
@@ -4172,6 +4420,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/throwing_axe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 238
@@ -4191,6 +4440,7 @@
     },
     "image_url": "/static/images/relics/bag_of_preparation.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 35
@@ -4210,6 +4460,7 @@
     },
     "image_url": "/static/images/relics/strawberry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 36
@@ -4229,6 +4480,7 @@
     },
     "image_url": "/static/images/relics/rainbow_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 117
@@ -4248,6 +4500,7 @@
     },
     "image_url": "/static/images/relics/beating_remnant.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 118
@@ -4263,6 +4516,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_torment.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 239
@@ -4282,6 +4536,7 @@
     },
     "image_url": "/static/images/relics/ghost_seed.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 155
@@ -4297,6 +4552,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/winged_boots.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 240
@@ -4316,6 +4572,7 @@
     },
     "image_url": "/static/images/relics/pendulum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 37
@@ -4335,6 +4592,7 @@
     },
     "image_url": "/static/images/relics/eternal_feather.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -4350,6 +4608,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/large_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 241
@@ -4365,6 +4624,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/big_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 285
@@ -4384,6 +4644,7 @@
     },
     "image_url": "/static/images/relics/big_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 119
@@ -4399,6 +4660,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hand_drill.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 286
@@ -4418,6 +4680,7 @@
     },
     "image_url": "/static/images/relics/wing_charm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 156
@@ -4437,6 +4700,7 @@
     },
     "image_url": "/static/images/relics/screaming_flagon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 157
@@ -4452,6 +4716,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/darkstone_periapt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 287
@@ -4467,6 +4732,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sere_talon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 242
@@ -4486,6 +4752,7 @@
     },
     "image_url": "/static/images/relics/festive_popper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 38
@@ -4505,6 +4772,7 @@
     },
     "image_url": "/static/images/relics/tough_bandages.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 120
@@ -4524,6 +4792,7 @@
     },
     "image_url": "/static/images/relics/sturdy_clamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 121
@@ -4539,6 +4808,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 243
@@ -4554,6 +4824,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_wisp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 288
@@ -4569,6 +4840,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dusty_tome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 244
@@ -4588,6 +4860,7 @@
     },
     "image_url": "/static/images/relics/bookmark.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 122
@@ -4603,6 +4876,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sand_castle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 245
@@ -4622,6 +4896,7 @@
     },
     "image_url": "/static/images/relics/frozen_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 123
@@ -4637,6 +4912,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/forgotten_soul.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 289
@@ -4652,6 +4928,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pollinous_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 290
@@ -4667,6 +4944,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/storybook.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 246
@@ -4682,6 +4960,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/driftwood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 247
@@ -4701,6 +4980,7 @@
     },
     "image_url": "/static/images/relics/pocketwatch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 124
@@ -4716,6 +4996,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/electric_shrymp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 248
@@ -4735,6 +5016,7 @@
     },
     "image_url": "/static/images/relics/permafrost.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 79
@@ -4754,6 +5036,7 @@
     },
     "image_url": "/static/images/relics/mummified_hand.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 125
@@ -4769,6 +5052,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/distinguished_cape.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 249
@@ -4788,6 +5072,7 @@
     },
     "image_url": "/static/images/relics/ruined_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 126
@@ -4807,6 +5092,7 @@
     },
     "image_url": "/static/images/relics/chemical_x.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 158
@@ -4826,6 +5112,7 @@
     },
     "image_url": "/static/images/relics/ninja_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 159
@@ -4841,6 +5128,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 250
@@ -4856,6 +5144,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 251
@@ -4871,6 +5160,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/seal_of_gold.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 252
@@ -4886,6 +5176,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_compass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 253
@@ -4901,6 +5192,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dream_catcher.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 291
@@ -4920,6 +5212,7 @@
     },
     "image_url": "/static/images/relics/shovel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 127
@@ -4939,6 +5232,7 @@
     },
     "image_url": "/static/images/relics/bronze_scales.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 39
@@ -4954,6 +5248,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 254
@@ -4969,6 +5264,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pumpkin_candle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 255
@@ -4984,6 +5280,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/iron_club.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 256
@@ -5003,6 +5300,7 @@
     },
     "image_url": "/static/images/relics/gambling_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 128
@@ -5022,6 +5320,7 @@
     },
     "image_url": "/static/images/relics/chandelier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 129

--- a/data/ptb/relics.json
+++ b/data/ptb/relics.json
@@ -10,6 +10,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_boot.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 257
@@ -29,6 +30,7 @@
     },
     "image_url": "/static/images/relics/letter_opener.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 40
@@ -48,6 +50,7 @@
     },
     "image_url": "/static/images/relics/punch_dagger.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 130
@@ -67,6 +70,7 @@
     },
     "image_url": "/static/images/relics/akabeko.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 41
@@ -82,6 +86,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/forgotten_soul.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 258
@@ -101,6 +106,7 @@
     },
     "image_url": "/static/images/relics/regal_pillow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 10
@@ -120,6 +126,7 @@
     },
     "image_url": "/static/images/relics/mercury_hourglass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 42
@@ -139,6 +146,7 @@
     },
     "image_url": "/static/images/relics/wing_charm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 131
@@ -154,6 +162,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/darkstone_periapt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 259
@@ -173,6 +182,7 @@
     },
     "image_url": "/static/images/relics/reptile_trinket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 43
@@ -192,6 +202,7 @@
     },
     "image_url": "/static/images/relics/rainbow_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 80
@@ -207,6 +218,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_snake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 0
@@ -222,6 +234,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/signet_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 160
@@ -237,6 +250,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_drake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 1
@@ -252,6 +266,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tanxs_whistle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 161
@@ -267,6 +282,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 162
@@ -286,6 +302,7 @@
     },
     "image_url": "/static/images/relics/self_forming_clay.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 44
@@ -305,6 +322,7 @@
     },
     "image_url": "/static/images/relics/art_of_war.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 81
@@ -320,6 +338,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_wing.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 163
@@ -335,6 +354,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/astrolabe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 164
@@ -350,6 +370,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/byrdpip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 260
@@ -369,6 +390,7 @@
     },
     "image_url": "/static/images/relics/ripple_basin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 45
@@ -384,6 +406,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/crossbow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 165
@@ -403,6 +426,7 @@
     },
     "image_url": "/static/images/relics/tough_bandages.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 82
@@ -422,6 +446,7 @@
     },
     "image_url": "/static/images/relics/tungsten_rod.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 83
@@ -441,6 +466,7 @@
     },
     "image_url": "/static/images/relics/miniature_tent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 132
@@ -460,6 +486,7 @@
     },
     "image_url": "/static/images/relics/sparkling_rouge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 46
@@ -475,6 +502,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/amethyst_aubergine.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 11
@@ -490,6 +518,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bing_bong.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 261
@@ -511,6 +540,7 @@
       "Necrobinder": "/static/images/relics/yummy_cookie_necrobinder.webp",
       "Regent": "/static/images/relics/yummy_cookie_regent.webp"
     },
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 166
@@ -530,6 +560,7 @@
     },
     "image_url": "/static/images/relics/bag_of_marbles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 12
@@ -549,6 +580,7 @@
     },
     "image_url": "/static/images/relics/bag_of_preparation.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 13
@@ -564,6 +596,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/winged_boots.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 167
@@ -579,6 +612,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/beautiful_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 168
@@ -598,6 +632,7 @@
     },
     "image_url": "/static/images/relics/juzu_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 14
@@ -617,6 +652,7 @@
     },
     "image_url": "/static/images/relics/sturdy_clamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 84
@@ -636,6 +672,7 @@
     },
     "image_url": "/static/images/relics/vambrace.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 47
@@ -651,6 +688,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/whispering_earring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 169
@@ -666,6 +704,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hand_drill.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 262
@@ -685,6 +724,7 @@
     },
     "image_url": "/static/images/relics/cloak_clasp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 85
@@ -700,6 +740,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_compass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 170
@@ -719,6 +760,7 @@
     },
     "image_url": "/static/images/relics/gold_plated_cables.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -734,6 +776,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/brilliant_scarf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 171
@@ -753,6 +796,7 @@
     },
     "image_url": "/static/images/relics/vexing_puzzlebox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 86
@@ -768,6 +812,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toy_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": [
       "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed.",
       "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
@@ -791,6 +836,7 @@
     },
     "image_url": "/static/images/relics/toolbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 133
@@ -806,6 +852,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pandoras_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 173
@@ -821,6 +868,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/scroll_boxes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 174
@@ -840,6 +888,7 @@
     },
     "image_url": "/static/images/relics/tiny_mailbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 49
@@ -855,6 +904,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/music_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 175
@@ -874,6 +924,7 @@
     },
     "image_url": "/static/images/relics/cauldron.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 134
@@ -893,6 +944,7 @@
     },
     "image_url": "/static/images/relics/stone_calendar.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 87
@@ -908,6 +960,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/electric_shrymp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 176
@@ -927,6 +980,7 @@
     },
     "image_url": "/static/images/relics/candelabra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -946,6 +1000,7 @@
     },
     "image_url": "/static/images/relics/miniature_cannon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 51
@@ -961,6 +1016,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/distinguished_cape.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 177
@@ -980,6 +1036,7 @@
     },
     "image_url": "/static/images/relics/runic_capacitor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 135
@@ -999,6 +1056,7 @@
     },
     "image_url": "/static/images/relics/lasting_candy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 52
@@ -1018,6 +1076,7 @@
     },
     "image_url": "/static/images/relics/royal_stamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 136
@@ -1033,6 +1092,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_flesh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 178
@@ -1052,6 +1112,7 @@
     },
     "image_url": "/static/images/relics/membership_card.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 137
@@ -1067,6 +1128,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fur_coat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 179
@@ -1082,6 +1144,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sand_castle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 180
@@ -1097,6 +1160,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/leafy_poultice.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 181
@@ -1116,6 +1180,7 @@
     },
     "image_url": "/static/images/relics/lizard_tail.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 88
@@ -1135,6 +1200,7 @@
     },
     "image_url": "/static/images/relics/red_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 15
@@ -1150,6 +1216,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bowler_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 53
@@ -1169,6 +1236,7 @@
     },
     "image_url": "/static/images/relics/big_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 89
@@ -1184,6 +1252,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blessed_antler.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 182
@@ -1203,6 +1272,7 @@
     },
     "image_url": "/static/images/relics/gremlin_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -1218,6 +1288,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 183
@@ -1237,6 +1308,7 @@
     },
     "image_url": "/static/images/relics/emotion_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 90
@@ -1252,6 +1324,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/very_hot_cocoa.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 184
@@ -1267,6 +1340,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tea_of_discourtesy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 263
@@ -1282,6 +1356,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bone_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 264
@@ -1297,6 +1372,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ember_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 265
@@ -1316,6 +1392,7 @@
     },
     "image_url": "/static/images/relics/prayer_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 91
@@ -1335,6 +1412,7 @@
     },
     "image_url": "/static/images/relics/potion_belt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 16
@@ -1354,6 +1432,7 @@
     },
     "image_url": "/static/images/relics/charons_ashes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 92
@@ -1369,6 +1448,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/alchemical_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 185
@@ -1384,6 +1464,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/maw_bank.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 266
@@ -1399,6 +1480,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fragrant_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 267
@@ -1414,6 +1496,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/big_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 268
@@ -1429,6 +1512,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phial_holster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 186
@@ -1444,6 +1528,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/booming_conch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 187
@@ -1459,6 +1544,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/silver_crucible.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 188
@@ -1478,6 +1564,7 @@
     },
     "image_url": "/static/images/relics/snecko_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 17
@@ -1497,6 +1584,7 @@
     },
     "image_url": "/static/images/relics/horn_cleat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 55
@@ -1512,6 +1600,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongos_mystery_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 269
@@ -1531,6 +1620,7 @@
     },
     "image_url": "/static/images/relics/meal_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 18
@@ -1546,6 +1636,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/meat_cleaver.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 189
@@ -1561,6 +1652,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/large_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 190
@@ -1576,6 +1668,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/small_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 191
@@ -1595,6 +1688,7 @@
     },
     "image_url": "/static/images/relics/power_cell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 93
@@ -1614,6 +1708,7 @@
     },
     "image_url": "/static/images/relics/helical_dart.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 94
@@ -1629,6 +1724,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/archaic_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 192
@@ -1648,6 +1744,7 @@
     },
     "image_url": "/static/images/relics/razor_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 95
@@ -1663,6 +1760,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 193
@@ -1678,6 +1776,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_destiny.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 2
@@ -1693,6 +1792,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/diamond_diadem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 194
@@ -1712,6 +1812,7 @@
     },
     "image_url": "/static/images/relics/tuning_fork.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 56
@@ -1727,6 +1828,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_right.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 3
@@ -1746,6 +1848,7 @@
     },
     "image_url": "/static/images/relics/data_disk.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 19
@@ -1761,6 +1864,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ectoplasm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 195
@@ -1780,6 +1884,7 @@
     },
     "image_url": "/static/images/relics/chemical_x.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 138
@@ -1799,6 +1904,7 @@
     },
     "image_url": "/static/images/relics/ruined_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 96
@@ -1818,6 +1924,7 @@
     },
     "image_url": "/static/images/relics/intimidating_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 97
@@ -1837,6 +1944,7 @@
     },
     "image_url": "/static/images/relics/centennial_puzzle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 20
@@ -1856,6 +1964,7 @@
     },
     "image_url": "/static/images/relics/brimstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 139
@@ -1875,6 +1984,7 @@
     },
     "image_url": "/static/images/relics/bronze_scales.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 21
@@ -1894,6 +2004,7 @@
     },
     "image_url": "/static/images/relics/parrying_shield.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 57
@@ -1909,6 +2020,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_jade.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 270
@@ -1924,6 +2036,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 271
@@ -1943,6 +2056,7 @@
     },
     "image_url": "/static/images/relics/dollys_mirror.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 140
@@ -1962,6 +2076,7 @@
     },
     "image_url": "/static/images/relics/white_beast_statue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 98
@@ -1981,6 +2096,7 @@
     },
     "image_url": "/static/images/relics/book_repair_knife.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 58
@@ -2000,6 +2116,7 @@
     },
     "image_url": "/static/images/relics/white_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 99
@@ -2015,6 +2132,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 196
@@ -2030,6 +2148,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/history_course.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 272
@@ -2049,6 +2168,7 @@
     },
     "image_url": "/static/images/relics/gambling_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 100
@@ -2064,6 +2184,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/daughter_of_the_wind.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 273
@@ -2079,6 +2200,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dream_catcher.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 274
@@ -2098,6 +2220,7 @@
     },
     "image_url": "/static/images/relics/belt_buckle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 141
@@ -2117,6 +2240,7 @@
     },
     "image_url": "/static/images/relics/bone_flute.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 22
@@ -2136,6 +2260,7 @@
     },
     "image_url": "/static/images/relics/happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 23
@@ -2155,6 +2280,7 @@
     },
     "image_url": "/static/images/relics/fake_happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 275
@@ -2170,6 +2296,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_wisp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 276
@@ -2189,6 +2316,7 @@
     },
     "image_url": "/static/images/relics/bellows.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 101
@@ -2204,6 +2332,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/new_leaf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 197
@@ -2219,6 +2348,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/delicate_frond.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 198
@@ -2238,6 +2368,7 @@
     },
     "image_url": "/static/images/relics/blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 24
@@ -2257,6 +2388,7 @@
     },
     "image_url": "/static/images/relics/fake_blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 277
@@ -2275,6 +2407,7 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
+    "name_variants": null,
     "notes": [
       "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
       "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
@@ -2297,6 +2430,7 @@
     },
     "image_url": "/static/images/relics/sling_of_courage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 142
@@ -2316,6 +2450,7 @@
     },
     "image_url": "/static/images/relics/twisted_funnel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 59
@@ -2331,6 +2466,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/empty_cage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 200
@@ -2346,6 +2482,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/velvet_choker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 201
@@ -2361,6 +2498,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sere_talon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 202
@@ -2376,6 +2514,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_claw.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 203
@@ -2391,6 +2530,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/claws.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 204
@@ -2406,6 +2546,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/prismatic_gem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 205
@@ -2425,6 +2566,7 @@
     },
     "image_url": "/static/images/relics/gorget.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 25
@@ -2440,6 +2582,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/biiig_hug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 206
@@ -2459,6 +2602,7 @@
     },
     "image_url": "/static/images/relics/paper_krane.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 102
@@ -2474,6 +2618,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lords_parasol.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 207
@@ -2493,6 +2638,7 @@
     },
     "image_url": "/static/images/relics/undying_sigil.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 143
@@ -2508,6 +2654,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongo_customer_appreciation_badge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 278
@@ -2527,6 +2674,7 @@
     },
     "image_url": "/static/images/relics/mystic_lighter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 144
@@ -2546,6 +2694,7 @@
     },
     "image_url": "/static/images/relics/screaming_flagon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 145
@@ -2565,6 +2714,7 @@
     },
     "image_url": "/static/images/relics/kifuda.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 146
@@ -2584,6 +2734,7 @@
     },
     "image_url": "/static/images/relics/kunai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 103
@@ -2603,6 +2754,7 @@
     },
     "image_url": "/static/images/relics/kusarigama.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 60
@@ -2622,6 +2774,7 @@
     },
     "image_url": "/static/images/relics/vitruvian_minion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 147
@@ -2641,6 +2794,7 @@
     },
     "image_url": "/static/images/relics/lantern.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 26
@@ -2660,6 +2814,7 @@
     },
     "image_url": "/static/images/relics/festive_popper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 27
@@ -2675,6 +2830,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_legion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 208
@@ -2690,6 +2846,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fresnel_lens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 279
@@ -2709,6 +2866,7 @@
     },
     "image_url": "/static/images/relics/ornamental_fan.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 61
@@ -2724,6 +2882,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/storybook.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 209
@@ -2743,6 +2902,7 @@
     },
     "image_url": "/static/images/relics/book_of_five_rings.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 28
@@ -2762,6 +2922,7 @@
     },
     "image_url": "/static/images/relics/chandelier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 104
@@ -2777,6 +2938,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toasty_mittens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 210
@@ -2792,6 +2954,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 211
@@ -2811,6 +2974,7 @@
     },
     "image_url": "/static/images/relics/unsettling_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 105
@@ -2830,6 +2994,7 @@
     },
     "image_url": "/static/images/relics/lava_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 148
@@ -2849,6 +3014,7 @@
     },
     "image_url": "/static/images/relics/demon_tongue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 106
@@ -2864,6 +3030,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/throwing_axe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 212
@@ -2879,6 +3046,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/driftwood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 213
@@ -2898,6 +3066,7 @@
     },
     "image_url": "/static/images/relics/regalite.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 62
@@ -2917,6 +3086,7 @@
     },
     "image_url": "/static/images/relics/strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 29
@@ -2936,6 +3106,7 @@
     },
     "image_url": "/static/images/relics/fake_strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 280
@@ -2955,6 +3126,7 @@
     },
     "image_url": "/static/images/relics/mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 107
@@ -2974,6 +3146,7 @@
     },
     "image_url": "/static/images/relics/fake_mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 281
@@ -2989,6 +3162,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/spiked_gauntlets.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 214
@@ -3008,6 +3182,7 @@
     },
     "image_url": "/static/images/relics/fencing_manual.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 30
@@ -3027,6 +3202,7 @@
     },
     "image_url": "/static/images/relics/bookmark.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 108
@@ -3046,6 +3222,7 @@
     },
     "image_url": "/static/images/relics/gnarled_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 149
@@ -3061,6 +3238,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/war_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 215
@@ -3080,6 +3258,7 @@
     },
     "image_url": "/static/images/relics/orange_dough.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 109
@@ -3095,6 +3274,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/iron_club.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 216
@@ -3114,6 +3294,7 @@
     },
     "image_url": "/static/images/relics/metronome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 110
@@ -3129,6 +3310,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/old_coin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 111
@@ -3148,6 +3330,7 @@
     },
     "image_url": "/static/images/relics/strawberry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 31
@@ -3167,6 +3350,7 @@
     },
     "image_url": "/static/images/relics/funerary_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -3186,6 +3370,7 @@
     },
     "image_url": "/static/images/relics/red_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 32
@@ -3201,6 +3386,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jeweled_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 217
@@ -3220,6 +3406,7 @@
     },
     "image_url": "/static/images/relics/mummified_hand.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 112
@@ -3239,6 +3426,7 @@
     },
     "image_url": "/static/images/relics/nunchaku.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 64
@@ -3254,6 +3442,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/preserved_fog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 218
@@ -3269,6 +3458,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/infused_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 4
@@ -3284,6 +3474,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pollinous_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 282
@@ -3299,6 +3490,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cracked_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 5
@@ -3314,6 +3506,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_courier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 113
@@ -3329,6 +3522,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/chosen_cheese.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 283
@@ -3344,6 +3538,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fake_merchants_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 284
@@ -3363,6 +3558,7 @@
     },
     "image_url": "/static/images/relics/the_abacus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 150
@@ -3378,6 +3574,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 219
@@ -3393,6 +3590,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 220
@@ -3412,6 +3610,7 @@
     },
     "image_url": "/static/images/relics/fake_snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 285
@@ -3427,6 +3626,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glass_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 221
@@ -3446,6 +3646,7 @@
     },
     "image_url": "/static/images/relics/orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 65
@@ -3465,6 +3666,7 @@
     },
     "image_url": "/static/images/relics/fake_orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 286
@@ -3484,6 +3686,7 @@
     },
     "image_url": "/static/images/relics/meat_on_the_bone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 114
@@ -3499,6 +3702,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_bones.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 222
@@ -3514,6 +3718,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_oyster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 223
@@ -3533,6 +3738,7 @@
     },
     "image_url": "/static/images/relics/frozen_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 115
@@ -3552,6 +3758,7 @@
     },
     "image_url": "/static/images/relics/molten_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 116
@@ -3571,6 +3778,7 @@
     },
     "image_url": "/static/images/relics/toxic_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 117
@@ -3590,6 +3798,7 @@
     },
     "image_url": "/static/images/relics/burning_sticks.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 151
@@ -3609,6 +3818,7 @@
     },
     "image_url": "/static/images/relics/pantograph.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 66
@@ -3628,6 +3838,7 @@
     },
     "image_url": "/static/images/relics/joss_paper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 67
@@ -3643,6 +3854,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/choices_paradox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 224
@@ -3662,6 +3874,7 @@
     },
     "image_url": "/static/images/relics/oddly_smooth_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 33
@@ -3677,6 +3890,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/philosophers_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 225
@@ -3696,6 +3910,7 @@
     },
     "image_url": "/static/images/relics/whetstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 34
@@ -3715,6 +3930,7 @@
     },
     "image_url": "/static/images/relics/pear.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -3730,6 +3946,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/arcane_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 226
@@ -3745,6 +3962,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/massive_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 227
@@ -3764,6 +3982,7 @@
     },
     "image_url": "/static/images/relics/ninja_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 152
@@ -3783,6 +4002,7 @@
     },
     "image_url": "/static/images/relics/permafrost.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 69
@@ -3802,6 +4022,7 @@
     },
     "image_url": "/static/images/relics/girya.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 118
@@ -3817,6 +4038,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lead_paperweight.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 228
@@ -3832,6 +4054,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lucky_fysh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 70
@@ -3851,6 +4074,7 @@
     },
     "image_url": "/static/images/relics/game_piece.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 119
@@ -3870,6 +4094,7 @@
     },
     "image_url": "/static/images/relics/ivory_tile.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 120
@@ -3885,6 +4110,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/runic_pyramid.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 229
@@ -3904,6 +4130,7 @@
     },
     "image_url": "/static/images/relics/dragon_fruit.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 153
@@ -3923,6 +4150,7 @@
     },
     "image_url": "/static/images/relics/unceasing_top.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 121
@@ -3942,6 +4170,7 @@
     },
     "image_url": "/static/images/relics/orrery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 154
@@ -3961,6 +4190,7 @@
     },
     "image_url": "/static/images/relics/planisphere.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 71
@@ -3980,6 +4210,7 @@
     },
     "image_url": "/static/images/relics/eternal_feather.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 72
@@ -3999,6 +4230,7 @@
     },
     "image_url": "/static/images/relics/galactic_dust.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 73
@@ -4014,6 +4246,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pomander.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 230
@@ -4033,6 +4266,7 @@
     },
     "image_url": "/static/images/relics/pen_nib.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 74
@@ -4048,6 +4282,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jewelry_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 231
@@ -4063,6 +4298,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glitter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 232
@@ -4082,6 +4318,7 @@
     },
     "image_url": "/static/images/relics/shovel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 122
@@ -4101,6 +4338,7 @@
     },
     "image_url": "/static/images/relics/bread.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 155
@@ -4116,6 +4354,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cursed_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 233
@@ -4131,6 +4370,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 234
@@ -4146,6 +4386,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/radiant_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 235
@@ -4165,6 +4406,7 @@
     },
     "image_url": "/static/images/relics/pendulum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 35
@@ -4184,6 +4426,7 @@
     },
     "image_url": "/static/images/relics/mini_regent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 123
@@ -4203,6 +4446,7 @@
     },
     "image_url": "/static/images/relics/pocketwatch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 124
@@ -4222,6 +4466,7 @@
     },
     "image_url": "/static/images/relics/beating_remnant.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 125
@@ -4237,6 +4482,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lava_rock.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 236
@@ -4252,6 +4498,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blood_soaked_rose.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 237
@@ -4271,6 +4518,7 @@
     },
     "image_url": "/static/images/relics/paper_phrog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -4286,6 +4534,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 238
@@ -4301,6 +4550,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/burning_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 6
@@ -4316,6 +4566,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 7
@@ -4331,6 +4582,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 239
@@ -4350,6 +4602,7 @@
     },
     "image_url": "/static/images/relics/petrified_toad.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 76
@@ -4365,6 +4618,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/seal_of_gold.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 240
@@ -4384,6 +4638,7 @@
     },
     "image_url": "/static/images/relics/ghost_seed.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 156
@@ -4403,6 +4658,7 @@
     },
     "image_url": "/static/images/relics/shuriken.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 126
@@ -4418,6 +4674,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/calling_bell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 241
@@ -4433,6 +4690,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_soup.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 242
@@ -4452,6 +4710,7 @@
     },
     "image_url": "/static/images/relics/ice_cream.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 127
@@ -4467,6 +4726,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sozu.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 243
@@ -4482,6 +4742,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/mr_struggles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 287
@@ -4497,6 +4758,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hefty_tablet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 244
@@ -4516,6 +4778,7 @@
     },
     "image_url": "/static/images/relics/stone_cracker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 77
@@ -4531,6 +4794,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phylactery_unbound.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 8
@@ -4546,6 +4810,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bound_phylactery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 9
@@ -4561,6 +4826,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_talisman.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 245
@@ -4580,6 +4846,7 @@
     },
     "image_url": "/static/images/relics/dingy_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 157
@@ -4595,6 +4862,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precise_scissors.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 246
@@ -4610,6 +4878,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precarious_shears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 247
@@ -4625,6 +4894,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/circlet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "None",
     "compendium_order": 292
@@ -4644,6 +4914,7 @@
     },
     "image_url": "/static/images/relics/captains_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 128
@@ -4663,6 +4934,7 @@
     },
     "image_url": "/static/images/relics/tingsha.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -4682,6 +4954,7 @@
     },
     "image_url": "/static/images/relics/war_paint.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 36
@@ -4697,6 +4970,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dusty_tome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 248
@@ -4712,6 +4986,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/touch_of_orobas.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 249
@@ -4727,6 +5002,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_torment.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 250
@@ -4746,6 +5022,7 @@
     },
     "image_url": "/static/images/relics/lunar_pastry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 129
@@ -4761,6 +5038,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tri_boomerang.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 251
@@ -4780,6 +5058,7 @@
     },
     "image_url": "/static/images/relics/ringing_triangle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 158
@@ -4795,6 +5074,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_growth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 252
@@ -4810,6 +5090,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/stone_humidifier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 253
@@ -4829,6 +5110,7 @@
     },
     "image_url": "/static/images/relics/vajra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 37
@@ -4844,6 +5126,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pumpkin_candle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 254
@@ -4859,6 +5142,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/royal_poison.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 288
@@ -4878,6 +5162,7 @@
     },
     "image_url": "/static/images/relics/venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 38
@@ -4897,6 +5182,7 @@
     },
     "image_url": "/static/images/relics/fake_venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 289
@@ -4912,6 +5198,13 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sea_glass.webp",
     "image_variants": null,
+    "name_variants": {
+      "Ironclad": "Vidro Demoníaco",
+      "Silent": "Vidro Venenoso",
+      "Defect": "Vidro Mecânico",
+      "Necrobinder": "Vidro Fúnebre",
+      "Regent": "Vidro Nobre"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 255
@@ -4927,6 +5220,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fiddle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 256
@@ -4946,6 +5240,7 @@
     },
     "image_url": "/static/images/relics/symbiotic_virus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 79
@@ -4965,6 +5260,7 @@
     },
     "image_url": "/static/images/relics/lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 159
@@ -4984,6 +5280,7 @@
     },
     "image_url": "/static/images/relics/fake_lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 290
@@ -5003,6 +5300,7 @@
     },
     "image_url": "/static/images/relics/anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 39
@@ -5022,6 +5320,7 @@
     },
     "image_url": "/static/images/relics/fake_anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 291

--- a/data/rus/relics.json
+++ b/data/rus/relics.json
@@ -14,6 +14,7 @@
     },
     "image_url": "/static/images/relics/membership_card.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 130
@@ -33,6 +34,7 @@
     },
     "image_url": "/static/images/relics/akabeko.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 40
@@ -48,6 +50,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/diamond_diadem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 160
@@ -63,6 +66,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/alchemical_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 161
@@ -78,6 +82,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/amethyst_aubergine.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 10
@@ -97,6 +102,7 @@
     },
     "image_url": "/static/images/relics/undying_sigil.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 131
@@ -112,6 +118,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/darkstone_periapt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 257
@@ -131,6 +138,7 @@
     },
     "image_url": "/static/images/relics/venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 11
@@ -150,6 +158,7 @@
     },
     "image_url": "/static/images/relics/fake_venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 258
@@ -165,6 +174,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/crossbow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 162
@@ -180,6 +190,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fragrant_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 259
@@ -195,6 +206,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/astrolabe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 163
@@ -210,6 +222,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phial_holster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 164
@@ -225,6 +238,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/preserved_fog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 165
@@ -240,6 +254,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/velvet_choker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 166
@@ -259,6 +274,7 @@
     },
     "image_url": "/static/images/relics/power_cell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 80
@@ -278,6 +294,7 @@
     },
     "image_url": "/static/images/relics/white_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 81
@@ -293,6 +310,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bing_bong.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 260
@@ -312,6 +330,7 @@
     },
     "image_url": "/static/images/relics/burning_sticks.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 132
@@ -327,6 +346,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blessed_antler.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 167
@@ -342,6 +362,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glitter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 168
@@ -357,6 +378,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_wisp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 261
@@ -376,6 +398,7 @@
     },
     "image_url": "/static/images/relics/war_paint.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 12
@@ -391,6 +414,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_destiny.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 0
@@ -406,6 +430,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_right.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 1
@@ -421,6 +446,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/large_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 169
@@ -436,6 +462,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/big_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 262
@@ -455,6 +482,7 @@
     },
     "image_url": "/static/images/relics/juzu_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 13
@@ -474,6 +502,7 @@
     },
     "image_url": "/static/images/relics/bronze_scales.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 14
@@ -493,6 +522,7 @@
     },
     "image_url": "/static/images/relics/paper_krane.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 82
@@ -512,6 +542,7 @@
     },
     "image_url": "/static/images/relics/paper_phrog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 41
@@ -531,6 +562,7 @@
     },
     "image_url": "/static/images/relics/vajra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 15
@@ -550,6 +582,7 @@
     },
     "image_url": "/static/images/relics/lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 133
@@ -569,6 +602,7 @@
     },
     "image_url": "/static/images/relics/fake_lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 263
@@ -588,6 +622,7 @@
     },
     "image_url": "/static/images/relics/dingy_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 134
@@ -607,6 +642,7 @@
     },
     "image_url": "/static/images/relics/eternal_feather.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 42
@@ -626,6 +662,7 @@
     },
     "image_url": "/static/images/relics/unceasing_top.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 83
@@ -645,6 +682,7 @@
     },
     "image_url": "/static/images/relics/chemical_x.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 135
@@ -664,6 +702,7 @@
     },
     "image_url": "/static/images/relics/symbiotic_virus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 43
@@ -683,6 +722,7 @@
     },
     "image_url": "/static/images/relics/vitruvian_minion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 136
@@ -704,6 +744,7 @@
       "Necrobinder": "/static/images/relics/yummy_cookie_necrobinder.webp",
       "Regent": "/static/images/relics/yummy_cookie_regent.webp"
     },
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 170
@@ -723,6 +764,7 @@
     },
     "image_url": "/static/images/relics/ripple_basin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 44
@@ -742,6 +784,7 @@
     },
     "image_url": "/static/images/relics/tungsten_rod.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 84
@@ -757,6 +800,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lava_rock.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 171
@@ -772,6 +816,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/distinguished_cape.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 172
@@ -791,6 +836,7 @@
     },
     "image_url": "/static/images/relics/mummified_hand.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 85
@@ -810,6 +856,7 @@
     },
     "image_url": "/static/images/relics/helical_dart.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 86
@@ -829,6 +876,7 @@
     },
     "image_url": "/static/images/relics/galactic_dust.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 45
@@ -848,6 +896,7 @@
     },
     "image_url": "/static/images/relics/girya.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 87
@@ -863,6 +912,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 173
@@ -878,6 +928,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 174
@@ -897,6 +948,7 @@
     },
     "image_url": "/static/images/relics/fake_snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 264
@@ -916,6 +968,7 @@
     },
     "image_url": "/static/images/relics/gorget.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 16
@@ -935,6 +988,7 @@
     },
     "image_url": "/static/images/relics/screaming_flagon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 137
@@ -950,6 +1004,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hefty_tablet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 175
@@ -965,6 +1020,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tea_of_discourtesy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 265
@@ -984,6 +1040,7 @@
     },
     "image_url": "/static/images/relics/pear.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 46
@@ -999,6 +1056,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/delicate_frond.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 176
@@ -1018,6 +1076,7 @@
     },
     "image_url": "/static/images/relics/data_disk.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 17
@@ -1033,6 +1092,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/massive_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 177
@@ -1052,6 +1112,7 @@
     },
     "image_url": "/static/images/relics/lasting_candy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 47
@@ -1067,6 +1128,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/daughter_of_the_wind.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 266
@@ -1086,6 +1148,7 @@
     },
     "image_url": "/static/images/relics/dragon_fruit.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 138
@@ -1101,6 +1164,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/archaic_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 178
@@ -1120,6 +1184,7 @@
     },
     "image_url": "/static/images/relics/stone_cracker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -1135,6 +1200,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/iron_club.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 179
@@ -1154,6 +1220,7 @@
     },
     "image_url": "/static/images/relics/mystic_lighter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 139
@@ -1169,6 +1236,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongos_mystery_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 267
@@ -1188,6 +1256,7 @@
     },
     "image_url": "/static/images/relics/bookmark.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 88
@@ -1207,6 +1276,7 @@
     },
     "image_url": "/static/images/relics/permafrost.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 49
@@ -1226,6 +1296,7 @@
     },
     "image_url": "/static/images/relics/frozen_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 89
@@ -1241,6 +1312,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bound_phylactery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 2
@@ -1260,6 +1332,7 @@
     },
     "image_url": "/static/images/relics/razor_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 90
@@ -1275,6 +1348,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/infused_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 3
@@ -1294,6 +1368,7 @@
     },
     "image_url": "/static/images/relics/ringing_triangle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 140
@@ -1313,6 +1388,7 @@
     },
     "image_url": "/static/images/relics/dollys_mirror.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 141
@@ -1328,6 +1404,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongo_customer_appreciation_badge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 268
@@ -1343,6 +1420,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 180
@@ -1358,6 +1436,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/seal_of_gold.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 181
@@ -1373,6 +1452,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_compass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 182
@@ -1388,6 +1468,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lords_parasol.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 183
@@ -1407,6 +1488,7 @@
     },
     "image_url": "/static/images/relics/ivory_tile.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 91
@@ -1426,6 +1508,7 @@
     },
     "image_url": "/static/images/relics/game_piece.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 92
@@ -1441,6 +1524,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/mr_struggles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 269
@@ -1456,6 +1540,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/chosen_cheese.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 270
@@ -1471,6 +1556,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_growth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 184
@@ -1486,6 +1572,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/brilliant_scarf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 185
@@ -1501,6 +1588,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jeweled_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 186
@@ -1520,6 +1608,7 @@
     },
     "image_url": "/static/images/relics/twisted_funnel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -1539,6 +1628,7 @@
     },
     "image_url": "/static/images/relics/gnarled_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 142
@@ -1558,6 +1648,7 @@
     },
     "image_url": "/static/images/relics/art_of_war.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 93
@@ -1573,6 +1664,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sere_talon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 187
@@ -1592,6 +1684,7 @@
     },
     "image_url": "/static/images/relics/stone_calendar.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 94
@@ -1607,6 +1700,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/stone_humidifier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 188
@@ -1626,6 +1720,7 @@
     },
     "image_url": "/static/images/relics/tuning_fork.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 51
@@ -1645,6 +1740,7 @@
     },
     "image_url": "/static/images/relics/candelabra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 52
@@ -1664,6 +1760,7 @@
     },
     "image_url": "/static/images/relics/captains_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 95
@@ -1683,6 +1780,7 @@
     },
     "image_url": "/static/images/relics/pocketwatch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 96
@@ -1698,6 +1796,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/touch_of_orobas.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 189
@@ -1717,6 +1816,7 @@
     },
     "image_url": "/static/images/relics/kifuda.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 143
@@ -1736,6 +1836,7 @@
     },
     "image_url": "/static/images/relics/strawberry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 18
@@ -1751,6 +1852,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 190
@@ -1770,6 +1872,7 @@
     },
     "image_url": "/static/images/relics/book_of_five_rings.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 19
@@ -1785,6 +1888,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fake_merchants_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 271
@@ -1800,6 +1904,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_claw.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 191
@@ -1815,6 +1920,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/claws.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 192
@@ -1830,6 +1936,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_snake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 4
@@ -1845,6 +1952,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_drake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 5
@@ -1864,6 +1972,7 @@
     },
     "image_url": "/static/images/relics/royal_stamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 144
@@ -1883,6 +1992,7 @@
     },
     "image_url": "/static/images/relics/regal_pillow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 20
@@ -1898,6 +2008,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/royal_poison.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 272
@@ -1913,6 +2024,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_bones.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 193
@@ -1928,6 +2040,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bone_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 273
@@ -1947,6 +2060,7 @@
     },
     "image_url": "/static/images/relics/bone_flute.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 21
@@ -1966,6 +2080,7 @@
     },
     "image_url": "/static/images/relics/cauldron.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 145
@@ -1981,6 +2096,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bowler_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 53
@@ -1996,6 +2112,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/beautiful_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 194
@@ -2015,6 +2132,7 @@
     },
     "image_url": "/static/images/relics/red_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 22
@@ -2034,6 +2152,7 @@
     },
     "image_url": "/static/images/relics/red_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 23
@@ -2053,6 +2172,7 @@
     },
     "image_url": "/static/images/relics/tough_bandages.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 97
@@ -2068,6 +2188,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 195
@@ -2083,6 +2204,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/winged_boots.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 196
@@ -2098,6 +2220,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_wing.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 197
@@ -2117,6 +2240,7 @@
     },
     "image_url": "/static/images/relics/wing_charm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 146
@@ -2136,6 +2260,7 @@
     },
     "image_url": "/static/images/relics/kunai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 98
@@ -2151,6 +2276,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_courier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 99
@@ -2170,6 +2296,7 @@
     },
     "image_url": "/static/images/relics/kusarigama.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -2189,6 +2316,7 @@
     },
     "image_url": "/static/images/relics/lava_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 147
@@ -2204,6 +2332,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_legion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 198
@@ -2219,6 +2348,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/history_course.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 274
@@ -2234,6 +2364,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dream_catcher.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 275
@@ -2253,6 +2384,7 @@
     },
     "image_url": "/static/images/relics/shovel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 100
@@ -2272,6 +2404,7 @@
     },
     "image_url": "/static/images/relics/lunar_pastry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 101
@@ -2287,6 +2420,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/arcane_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 199
@@ -2302,6 +2436,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/small_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 200
@@ -2321,6 +2456,7 @@
     },
     "image_url": "/static/images/relics/mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 102
@@ -2340,6 +2476,7 @@
     },
     "image_url": "/static/images/relics/fake_mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 276
@@ -2359,6 +2496,7 @@
     },
     "image_url": "/static/images/relics/pendulum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 24
@@ -2374,6 +2512,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/biiig_hug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 201
@@ -2389,6 +2528,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/throwing_axe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 202
@@ -2408,6 +2548,7 @@
     },
     "image_url": "/static/images/relics/metronome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 103
@@ -2427,6 +2568,7 @@
     },
     "image_url": "/static/images/relics/bellows.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 104
@@ -2446,6 +2588,7 @@
     },
     "image_url": "/static/images/relics/bag_of_marbles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 25
@@ -2465,6 +2608,7 @@
     },
     "image_url": "/static/images/relics/mini_regent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 105
@@ -2484,6 +2628,7 @@
     },
     "image_url": "/static/images/relics/miniature_tent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 148
@@ -2503,6 +2648,7 @@
     },
     "image_url": "/static/images/relics/miniature_cannon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 55
@@ -2522,6 +2668,7 @@
     },
     "image_url": "/static/images/relics/orrery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 149
@@ -2537,6 +2684,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_boot.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 277
@@ -2556,6 +2704,7 @@
     },
     "image_url": "/static/images/relics/prayer_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 106
@@ -2571,6 +2720,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/war_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 203
@@ -2590,6 +2740,7 @@
     },
     "image_url": "/static/images/relics/ice_cream.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 107
@@ -2605,6 +2756,13 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sea_glass.webp",
     "image_variants": null,
+    "name_variants": {
+      "Ironclad": "Демоническое стеклышко",
+      "Silent": "Ядовитое стеклышко",
+      "Defect": "Механическое стеклышко",
+      "Necrobinder": "Костяное стеклышко",
+      "Regent": "Роскошное стеклышко"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 204
@@ -2624,6 +2782,7 @@
     },
     "image_url": "/static/images/relics/unsettling_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 108
@@ -2643,6 +2802,7 @@
     },
     "image_url": "/static/images/relics/vexing_puzzlebox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 109
@@ -2658,6 +2818,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/music_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 205
@@ -2677,6 +2838,7 @@
     },
     "image_url": "/static/images/relics/meat_on_the_bone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 110
@@ -2696,6 +2858,7 @@
     },
     "image_url": "/static/images/relics/toolbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 150
@@ -2711,6 +2874,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_soup.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 206
@@ -2726,6 +2890,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precise_scissors.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 207
@@ -2745,6 +2910,7 @@
     },
     "image_url": "/static/images/relics/pen_nib.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 56
@@ -2764,6 +2930,7 @@
     },
     "image_url": "/static/images/relics/vambrace.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 57
@@ -2779,6 +2946,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phylactery_unbound.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 6
@@ -2794,6 +2962,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_jade.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 278
@@ -2813,6 +2982,7 @@
     },
     "image_url": "/static/images/relics/letter_opener.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 58
@@ -2832,6 +3002,7 @@
     },
     "image_url": "/static/images/relics/nunchaku.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 59
@@ -2847,6 +3018,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/driftwood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 208
@@ -2862,6 +3034,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/circlet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "None",
     "compendium_order": 292
@@ -2881,6 +3054,7 @@
     },
     "image_url": "/static/images/relics/petrified_toad.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 60
@@ -2896,6 +3070,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 279
@@ -2911,6 +3086,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blood_soaked_rose.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 209
@@ -2930,6 +3106,7 @@
     },
     "image_url": "/static/images/relics/orange_dough.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 111
@@ -2949,6 +3126,7 @@
     },
     "image_url": "/static/images/relics/orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 61
@@ -2968,6 +3146,7 @@
     },
     "image_url": "/static/images/relics/fake_orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 280
@@ -2983,6 +3162,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/radiant_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 210
@@ -2998,6 +3178,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/very_hot_cocoa.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 211
@@ -3017,6 +3198,7 @@
     },
     "image_url": "/static/images/relics/pantograph.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 62
@@ -3032,6 +3214,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/choices_paradox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 212
@@ -3051,6 +3234,7 @@
     },
     "image_url": "/static/images/relics/parrying_shield.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -3066,6 +3250,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/maw_bank.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 281
@@ -3085,6 +3270,7 @@
     },
     "image_url": "/static/images/relics/book_repair_knife.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 64
@@ -3100,6 +3286,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/signet_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 213
@@ -3115,6 +3302,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sand_castle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 214
@@ -3130,6 +3318,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_oyster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 215
@@ -3149,6 +3338,7 @@
     },
     "image_url": "/static/images/relics/planisphere.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 65
@@ -3164,6 +3354,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_flesh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 216
@@ -3183,6 +3374,7 @@
     },
     "image_url": "/static/images/relics/strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 26
@@ -3202,6 +3394,7 @@
     },
     "image_url": "/static/images/relics/fake_strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 282
@@ -3221,6 +3414,7 @@
     },
     "image_url": "/static/images/relics/funerary_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 66
@@ -3240,6 +3434,7 @@
     },
     "image_url": "/static/images/relics/oddly_smooth_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 27
@@ -3255,6 +3450,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/forgotten_soul.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 283
@@ -3274,6 +3470,7 @@
     },
     "image_url": "/static/images/relics/gold_plated_cables.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 67
@@ -3289,6 +3486,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pomander.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 217
@@ -3308,6 +3506,7 @@
     },
     "image_url": "/static/images/relics/fencing_manual.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 28
@@ -3327,6 +3526,7 @@
     },
     "image_url": "/static/images/relics/tiny_mailbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -3346,6 +3546,7 @@
     },
     "image_url": "/static/images/relics/potion_belt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 29
@@ -3365,6 +3566,7 @@
     },
     "image_url": "/static/images/relics/festive_popper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 30
@@ -3384,6 +3586,7 @@
     },
     "image_url": "/static/images/relics/charons_ashes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 112
@@ -3403,6 +3606,7 @@
     },
     "image_url": "/static/images/relics/sling_of_courage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 151
@@ -3418,6 +3622,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/prismatic_gem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 218
@@ -3437,6 +3642,7 @@
     },
     "image_url": "/static/images/relics/ghost_seed.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 152
@@ -3452,6 +3658,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/calling_bell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 219
@@ -3467,6 +3674,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toasty_mittens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 220
@@ -3482,6 +3690,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cursed_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 221
@@ -3501,6 +3710,7 @@
     },
     "image_url": "/static/images/relics/sturdy_clamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 113
@@ -3520,6 +3730,7 @@
     },
     "image_url": "/static/images/relics/belt_buckle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 153
@@ -3535,6 +3746,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/byrdpip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 284
@@ -3554,6 +3766,7 @@
     },
     "image_url": "/static/images/relics/blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 31
@@ -3573,6 +3786,7 @@
     },
     "image_url": "/static/images/relics/fake_blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 285
@@ -3592,6 +3806,7 @@
     },
     "image_url": "/static/images/relics/beating_remnant.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 114
@@ -3607,6 +3822,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/empty_cage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 222
@@ -3622,6 +3838,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/burning_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 7
@@ -3637,6 +3854,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dusty_tome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 223
@@ -3652,6 +3870,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pollinous_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 286
@@ -3671,6 +3890,7 @@
     },
     "image_url": "/static/images/relics/rainbow_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 115
@@ -3686,6 +3906,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precarious_shears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 224
@@ -3701,6 +3922,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/meat_cleaver.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 225
@@ -3720,6 +3942,7 @@
     },
     "image_url": "/static/images/relics/molten_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 116
@@ -3735,6 +3958,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fresnel_lens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 287
@@ -3754,6 +3978,7 @@
     },
     "image_url": "/static/images/relics/regalite.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 69
@@ -3773,6 +3998,7 @@
     },
     "image_url": "/static/images/relics/joss_paper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 70
@@ -3788,6 +4014,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 226
@@ -3807,6 +4034,7 @@
     },
     "image_url": "/static/images/relics/gremlin_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 71
@@ -3826,6 +4054,7 @@
     },
     "image_url": "/static/images/relics/mercury_hourglass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 72
@@ -3841,6 +4070,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/runic_pyramid.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 227
@@ -3860,6 +4090,7 @@
     },
     "image_url": "/static/images/relics/runic_capacitor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 154
@@ -3875,6 +4106,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hand_drill.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 288
@@ -3890,6 +4122,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lucky_fysh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 73
@@ -3905,6 +4138,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 228
@@ -3924,6 +4158,7 @@
     },
     "image_url": "/static/images/relics/self_forming_clay.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 74
@@ -3943,6 +4178,7 @@
     },
     "image_url": "/static/images/relics/sparkling_rouge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -3958,6 +4194,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lead_paperweight.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 229
@@ -3973,6 +4210,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tanxs_whistle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 230
@@ -3992,6 +4230,7 @@
     },
     "image_url": "/static/images/relics/ninja_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 155
@@ -4011,6 +4250,7 @@
     },
     "image_url": "/static/images/relics/brimstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 156
@@ -4026,6 +4266,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/silver_crucible.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 231
@@ -4041,6 +4282,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/storybook.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 232
@@ -4056,6 +4298,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fiddle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 233
@@ -4071,6 +4314,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 234
@@ -4086,6 +4330,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sozu.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 235
@@ -4105,6 +4350,7 @@
     },
     "image_url": "/static/images/relics/ruined_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 117
@@ -4120,6 +4366,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/old_coin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 118
@@ -4139,6 +4386,7 @@
     },
     "image_url": "/static/images/relics/white_beast_statue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 119
@@ -4154,6 +4402,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glass_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 236
@@ -4173,6 +4422,7 @@
     },
     "image_url": "/static/images/relics/centennial_puzzle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 32
@@ -4192,6 +4442,7 @@
     },
     "image_url": "/static/images/relics/bag_of_preparation.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 33
@@ -4211,6 +4462,7 @@
     },
     "image_url": "/static/images/relics/happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 34
@@ -4230,6 +4482,7 @@
     },
     "image_url": "/static/images/relics/fake_happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 289
@@ -4249,6 +4502,7 @@
     },
     "image_url": "/static/images/relics/the_abacus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 157
@@ -4268,6 +4522,7 @@
     },
     "image_url": "/static/images/relics/shuriken.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 120
@@ -4283,6 +4538,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_talisman.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 237
@@ -4302,6 +4558,7 @@
     },
     "image_url": "/static/images/relics/reptile_trinket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 76
@@ -4321,6 +4578,7 @@
     },
     "image_url": "/static/images/relics/meal_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 35
@@ -4340,6 +4598,7 @@
     },
     "image_url": "/static/images/relics/tingsha.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 77
@@ -4359,6 +4618,7 @@
     },
     "image_url": "/static/images/relics/whetstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 36
@@ -4374,6 +4634,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/leafy_poultice.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 238
@@ -4389,6 +4650,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cracked_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 8
@@ -4404,6 +4666,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tri_boomerang.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 239
@@ -4419,6 +4682,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/booming_conch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 240
@@ -4434,6 +4698,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pumpkin_candle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 241
@@ -4453,6 +4718,7 @@
     },
     "image_url": "/static/images/relics/punch_dagger.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 158
@@ -4471,6 +4737,7 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
+    "name_variants": null,
     "notes": [
       "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
       "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
@@ -4489,6 +4756,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_torment.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 243
@@ -4508,6 +4776,7 @@
     },
     "image_url": "/static/images/relics/ornamental_fan.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -4527,6 +4796,7 @@
     },
     "image_url": "/static/images/relics/intimidating_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 121
@@ -4542,6 +4812,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 244
@@ -4561,6 +4832,7 @@
     },
     "image_url": "/static/images/relics/cloak_clasp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 122
@@ -4576,6 +4848,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/philosophers_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 245
@@ -4595,6 +4868,7 @@
     },
     "image_url": "/static/images/relics/gambling_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 123
@@ -4614,6 +4888,7 @@
     },
     "image_url": "/static/images/relics/lantern.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 37
@@ -4633,6 +4908,7 @@
     },
     "image_url": "/static/images/relics/lizard_tail.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 124
@@ -4652,6 +4928,7 @@
     },
     "image_url": "/static/images/relics/bread.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 159
@@ -4671,6 +4948,7 @@
     },
     "image_url": "/static/images/relics/snecko_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 38
@@ -4686,6 +4964,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 246
@@ -4701,6 +4980,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 9
@@ -4720,6 +5000,7 @@
     },
     "image_url": "/static/images/relics/emotion_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 125
@@ -4735,6 +5016,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/new_leaf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 247
@@ -4754,6 +5036,7 @@
     },
     "image_url": "/static/images/relics/chandelier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 126
@@ -4773,6 +5056,7 @@
     },
     "image_url": "/static/images/relics/horn_cleat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 79
@@ -4788,6 +5072,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/whispering_earring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 248
@@ -4803,6 +5088,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/spiked_gauntlets.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 249
@@ -4822,6 +5108,7 @@
     },
     "image_url": "/static/images/relics/big_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 127
@@ -4837,6 +5124,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jewelry_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 250
@@ -4852,6 +5140,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fur_coat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 251
@@ -4867,6 +5156,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ectoplasm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 252
@@ -4882,6 +5172,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/electric_shrymp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 253
@@ -4901,6 +5192,7 @@
     },
     "image_url": "/static/images/relics/toxic_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 128
@@ -4920,6 +5212,7 @@
     },
     "image_url": "/static/images/relics/demon_tongue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 129
@@ -4939,6 +5232,7 @@
     },
     "image_url": "/static/images/relics/anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 39
@@ -4958,6 +5252,7 @@
     },
     "image_url": "/static/images/relics/fake_anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 290
@@ -4973,6 +5268,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ember_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 291
@@ -4988,6 +5284,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pandoras_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 254
@@ -5003,6 +5300,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toy_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": [
       "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed.",
       "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
@@ -5022,6 +5320,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/scroll_boxes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 256

--- a/data/spa/relics.json
+++ b/data/spa/relics.json
@@ -14,6 +14,7 @@
     },
     "image_url": "/static/images/relics/reptile_trinket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 40
@@ -33,6 +34,7 @@
     },
     "image_url": "/static/images/relics/ornamental_fan.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 41
@@ -48,6 +50,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/biiig_hug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 160
@@ -67,6 +70,7 @@
     },
     "image_url": "/static/images/relics/sturdy_clamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 80
@@ -86,6 +90,7 @@
     },
     "image_url": "/static/images/relics/letter_opener.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 42
@@ -101,6 +106,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fur_coat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 161
@@ -120,6 +126,7 @@
     },
     "image_url": "/static/images/relics/akabeko.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 43
@@ -135,6 +142,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_wing.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 162
@@ -154,6 +162,7 @@
     },
     "image_url": "/static/images/relics/dingy_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 130
@@ -169,6 +178,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jewelry_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 163
@@ -184,6 +194,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/forgotten_soul.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 257
@@ -203,6 +214,7 @@
     },
     "image_url": "/static/images/relics/regal_pillow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 10
@@ -222,6 +234,7 @@
     },
     "image_url": "/static/images/relics/wing_charm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 131
@@ -237,6 +250,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/darkstone_periapt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 258
@@ -256,6 +270,7 @@
     },
     "image_url": "/static/images/relics/anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 11
@@ -275,6 +290,7 @@
     },
     "image_url": "/static/images/relics/rainbow_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 81
@@ -290,6 +306,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/signet_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 164
@@ -305,6 +322,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_snake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 0
@@ -320,6 +338,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_drake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 1
@@ -339,6 +358,7 @@
     },
     "image_url": "/static/images/relics/self_forming_clay.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 44
@@ -354,6 +374,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/astrolabe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 165
@@ -369,6 +390,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dream_catcher.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 259
@@ -388,6 +410,7 @@
     },
     "image_url": "/static/images/relics/vambrace.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 45
@@ -407,6 +430,7 @@
     },
     "image_url": "/static/images/relics/brimstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 132
@@ -422,6 +446,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/crossbow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 166
@@ -441,6 +466,7 @@
     },
     "image_url": "/static/images/relics/tungsten_rod.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 82
@@ -456,6 +482,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/amethyst_aubergine.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 12
@@ -475,6 +502,7 @@
     },
     "image_url": "/static/images/relics/joss_paper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 46
@@ -490,6 +518,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongos_mystery_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 260
@@ -505,6 +534,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bing_bong.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 261
@@ -524,6 +554,7 @@
     },
     "image_url": "/static/images/relics/bag_of_marbles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 13
@@ -543,6 +574,7 @@
     },
     "image_url": "/static/images/relics/bag_of_preparation.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 14
@@ -558,6 +590,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bowler_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 47
@@ -577,6 +610,7 @@
     },
     "image_url": "/static/images/relics/juzu_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 15
@@ -592,6 +626,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/beautiful_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 167
@@ -611,6 +646,7 @@
     },
     "image_url": "/static/images/relics/cloak_clasp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 83
@@ -626,6 +662,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_compass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 168
@@ -641,6 +678,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/brilliant_scarf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 169
@@ -656,6 +694,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tri_boomerang.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 170
@@ -675,6 +714,7 @@
     },
     "image_url": "/static/images/relics/tiny_mailbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -694,6 +734,7 @@
     },
     "image_url": "/static/images/relics/gold_plated_cables.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 49
@@ -709,6 +750,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/iron_club.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 171
@@ -724,6 +766,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pandoras_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 172
@@ -743,6 +786,7 @@
     },
     "image_url": "/static/images/relics/toolbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 133
@@ -758,6 +802,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toy_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": [
       "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed.",
       "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
@@ -777,6 +822,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/music_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 174
@@ -792,6 +838,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/scroll_boxes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 175
@@ -811,6 +858,7 @@
     },
     "image_url": "/static/images/relics/red_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 16
@@ -830,6 +878,7 @@
     },
     "image_url": "/static/images/relics/cauldron.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 134
@@ -849,6 +898,7 @@
     },
     "image_url": "/static/images/relics/stone_calendar.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 84
@@ -864,6 +914,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/calling_bell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 176
@@ -883,6 +934,7 @@
     },
     "image_url": "/static/images/relics/chandelier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 85
@@ -902,6 +954,7 @@
     },
     "image_url": "/static/images/relics/candelabra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -917,6 +970,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/distinguished_cape.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 177
@@ -936,6 +990,7 @@
     },
     "image_url": "/static/images/relics/lasting_candy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 51
@@ -955,6 +1010,7 @@
     },
     "image_url": "/static/images/relics/meat_on_the_bone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 86
@@ -970,6 +1026,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_flesh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 178
@@ -989,6 +1046,7 @@
     },
     "image_url": "/static/images/relics/membership_card.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 135
@@ -1008,6 +1066,7 @@
     },
     "image_url": "/static/images/relics/intimidating_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 87
@@ -1023,6 +1082,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sand_castle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 179
@@ -1038,6 +1098,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/leafy_poultice.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 180
@@ -1057,6 +1118,7 @@
     },
     "image_url": "/static/images/relics/miniature_cannon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 52
@@ -1076,6 +1138,7 @@
     },
     "image_url": "/static/images/relics/power_cell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 88
@@ -1095,6 +1158,7 @@
     },
     "image_url": "/static/images/relics/charons_ashes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 89
@@ -1113,6 +1177,7 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
+    "name_variants": null,
     "notes": [
       "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
       "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
@@ -1135,6 +1200,7 @@
     },
     "image_url": "/static/images/relics/emotion_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 90
@@ -1150,6 +1216,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/very_hot_cocoa.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 182
@@ -1169,6 +1236,7 @@
     },
     "image_url": "/static/images/relics/potion_belt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 17
@@ -1184,6 +1252,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/alchemical_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 183
@@ -1199,6 +1268,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 184
@@ -1218,6 +1288,7 @@
     },
     "image_url": "/static/images/relics/lizard_tail.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 91
@@ -1233,6 +1304,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/booming_conch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 185
@@ -1252,6 +1324,7 @@
     },
     "image_url": "/static/images/relics/runic_capacitor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 136
@@ -1267,6 +1340,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blessed_antler.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 186
@@ -1286,6 +1360,7 @@
     },
     "image_url": "/static/images/relics/horn_cleat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 53
@@ -1301,6 +1376,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/silver_crucible.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 187
@@ -1316,6 +1392,13 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sea_glass.webp",
     "image_variants": null,
+    "name_variants": {
+      "Ironclad": "Cristal demoniaco",
+      "Silent": "Cristal de veneno",
+      "Defect": "Cristal mecanizado",
+      "Necrobinder": "Cristal de liche",
+      "Regent": "Cristal noble"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 188
@@ -1335,6 +1418,7 @@
     },
     "image_url": "/static/images/relics/snecko_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 18
@@ -1350,6 +1434,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/meat_cleaver.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 189
@@ -1369,6 +1454,7 @@
     },
     "image_url": "/static/images/relics/book_repair_knife.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -1388,6 +1474,7 @@
     },
     "image_url": "/static/images/relics/ripple_basin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 55
@@ -1403,6 +1490,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 190
@@ -1422,6 +1510,7 @@
     },
     "image_url": "/static/images/relics/gremlin_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 56
@@ -1441,6 +1530,7 @@
     },
     "image_url": "/static/images/relics/meal_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 19
@@ -1456,6 +1546,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/large_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 191
@@ -1471,6 +1562,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/small_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 192
@@ -1490,6 +1582,7 @@
     },
     "image_url": "/static/images/relics/punch_dagger.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 137
@@ -1509,6 +1602,7 @@
     },
     "image_url": "/static/images/relics/helical_dart.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 92
@@ -1524,6 +1618,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_right.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 2
@@ -1539,6 +1634,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_destiny.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 3
@@ -1554,6 +1650,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/circlet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "None",
     "compendium_order": 292
@@ -1569,6 +1666,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/diamond_diadem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 193
@@ -1588,6 +1686,7 @@
     },
     "image_url": "/static/images/relics/tuning_fork.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 57
@@ -1603,6 +1702,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/archaic_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 194
@@ -1618,6 +1718,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 195
@@ -1637,6 +1738,7 @@
     },
     "image_url": "/static/images/relics/razor_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 93
@@ -1656,6 +1758,7 @@
     },
     "image_url": "/static/images/relics/data_disk.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 20
@@ -1671,6 +1774,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ectoplasm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 196
@@ -1686,6 +1790,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_courier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 94
@@ -1705,6 +1810,7 @@
     },
     "image_url": "/static/images/relics/art_of_war.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 95
@@ -1724,6 +1830,7 @@
     },
     "image_url": "/static/images/relics/book_of_five_rings.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 21
@@ -1739,6 +1846,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/chosen_cheese.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 262
@@ -1758,6 +1866,7 @@
     },
     "image_url": "/static/images/relics/the_abacus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 138
@@ -1777,6 +1886,7 @@
     },
     "image_url": "/static/images/relics/twisted_funnel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 58
@@ -1796,6 +1906,7 @@
     },
     "image_url": "/static/images/relics/vitruvian_minion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 139
@@ -1815,6 +1926,7 @@
     },
     "image_url": "/static/images/relics/bronze_scales.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 22
@@ -1834,6 +1946,7 @@
     },
     "image_url": "/static/images/relics/parrying_shield.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 59
@@ -1849,6 +1962,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_jade.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 263
@@ -1864,6 +1978,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 264
@@ -1883,6 +1998,7 @@
     },
     "image_url": "/static/images/relics/dollys_mirror.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 140
@@ -1902,6 +2018,7 @@
     },
     "image_url": "/static/images/relics/white_beast_statue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 96
@@ -1921,6 +2038,7 @@
     },
     "image_url": "/static/images/relics/white_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 97
@@ -1936,6 +2054,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 197
@@ -1955,6 +2074,7 @@
     },
     "image_url": "/static/images/relics/lantern.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 23
@@ -1974,6 +2094,7 @@
     },
     "image_url": "/static/images/relics/gambling_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 98
@@ -1993,6 +2114,7 @@
     },
     "image_url": "/static/images/relics/ivory_tile.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 99
@@ -2008,6 +2130,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bound_phylactery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 4
@@ -2023,6 +2146,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phylactery_unbound.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 5
@@ -2042,6 +2166,7 @@
     },
     "image_url": "/static/images/relics/bone_flute.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 24
@@ -2061,6 +2186,7 @@
     },
     "image_url": "/static/images/relics/happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 25
@@ -2080,6 +2206,7 @@
     },
     "image_url": "/static/images/relics/strawberry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 26
@@ -2099,6 +2226,7 @@
     },
     "image_url": "/static/images/relics/dragon_fruit.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 141
@@ -2114,6 +2242,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_wisp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 265
@@ -2133,6 +2262,7 @@
     },
     "image_url": "/static/images/relics/bellows.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 100
@@ -2154,6 +2284,7 @@
       "Necrobinder": "/static/images/relics/yummy_cookie_necrobinder.webp",
       "Regent": "/static/images/relics/yummy_cookie_regent.webp"
     },
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 198
@@ -2169,6 +2300,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/electric_shrymp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 199
@@ -2184,6 +2316,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/velvet_choker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 200
@@ -2199,6 +2332,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_claw.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 201
@@ -2214,6 +2348,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sere_talon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 202
@@ -2229,6 +2364,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/claws.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 203
@@ -2244,6 +2380,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/prismatic_gem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 204
@@ -2263,6 +2400,7 @@
     },
     "image_url": "/static/images/relics/girya.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 101
@@ -2282,6 +2420,7 @@
     },
     "image_url": "/static/images/relics/lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 142
@@ -2301,6 +2440,7 @@
     },
     "image_url": "/static/images/relics/gorget.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 27
@@ -2316,6 +2456,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/big_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 266
@@ -2335,6 +2476,7 @@
     },
     "image_url": "/static/images/relics/paper_krane.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 102
@@ -2350,6 +2492,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/throwing_axe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 205
@@ -2369,6 +2512,7 @@
     },
     "image_url": "/static/images/relics/belt_buckle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 143
@@ -2388,6 +2532,7 @@
     },
     "image_url": "/static/images/relics/ice_cream.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 103
@@ -2403,6 +2548,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/delicate_frond.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 206
@@ -2418,6 +2564,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/daughter_of_the_wind.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 267
@@ -2433,6 +2580,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/new_leaf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 207
@@ -2452,6 +2600,7 @@
     },
     "image_url": "/static/images/relics/sling_of_courage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 144
@@ -2467,6 +2616,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/maw_bank.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 268
@@ -2486,6 +2636,7 @@
     },
     "image_url": "/static/images/relics/frozen_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 104
@@ -2505,6 +2656,7 @@
     },
     "image_url": "/static/images/relics/molten_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 105
@@ -2524,6 +2676,7 @@
     },
     "image_url": "/static/images/relics/toxic_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 106
@@ -2539,6 +2692,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/stone_humidifier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 208
@@ -2554,6 +2708,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pomander.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 209
@@ -2569,6 +2724,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongo_customer_appreciation_badge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 269
@@ -2584,6 +2740,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/byrdpip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 270
@@ -2603,6 +2760,7 @@
     },
     "image_url": "/static/images/relics/screaming_flagon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 145
@@ -2618,6 +2776,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/empty_cage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 210
@@ -2637,6 +2796,7 @@
     },
     "image_url": "/static/images/relics/kifuda.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 146
@@ -2656,6 +2816,7 @@
     },
     "image_url": "/static/images/relics/kunai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 107
@@ -2675,6 +2836,7 @@
     },
     "image_url": "/static/images/relics/kusarigama.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 60
@@ -2690,6 +2852,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_boot.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 271
@@ -2709,6 +2872,7 @@
     },
     "image_url": "/static/images/relics/festive_popper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 28
@@ -2724,6 +2888,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_legion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 211
@@ -2743,6 +2908,7 @@
     },
     "image_url": "/static/images/relics/demon_tongue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 108
@@ -2758,6 +2924,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fresnel_lens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 272
@@ -2773,6 +2940,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/storybook.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 212
@@ -2788,6 +2956,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/history_course.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 273
@@ -2803,6 +2972,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 213
@@ -2822,6 +2992,7 @@
     },
     "image_url": "/static/images/relics/lava_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 147
@@ -2841,6 +3012,7 @@
     },
     "image_url": "/static/images/relics/unsettling_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 109
@@ -2856,6 +3028,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/driftwood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 214
@@ -2875,6 +3048,7 @@
     },
     "image_url": "/static/images/relics/mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 110
@@ -2894,6 +3068,7 @@
     },
     "image_url": "/static/images/relics/mummified_hand.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 111
@@ -2909,6 +3084,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toasty_mittens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 215
@@ -2928,6 +3104,7 @@
     },
     "image_url": "/static/images/relics/fencing_manual.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 29
@@ -2947,6 +3124,7 @@
     },
     "image_url": "/static/images/relics/bookmark.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 112
@@ -2962,6 +3140,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/war_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 216
@@ -2981,6 +3160,7 @@
     },
     "image_url": "/static/images/relics/gnarled_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 148
@@ -3000,6 +3180,7 @@
     },
     "image_url": "/static/images/relics/orange_dough.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 113
@@ -3019,6 +3200,7 @@
     },
     "image_url": "/static/images/relics/mystic_lighter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 149
@@ -3038,6 +3220,7 @@
     },
     "image_url": "/static/images/relics/metronome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 114
@@ -3057,6 +3240,7 @@
     },
     "image_url": "/static/images/relics/mini_regent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 115
@@ -3076,6 +3260,7 @@
     },
     "image_url": "/static/images/relics/miniature_tent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 150
@@ -3091,6 +3276,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/old_coin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 116
@@ -3110,6 +3296,7 @@
     },
     "image_url": "/static/images/relics/strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 30
@@ -3125,6 +3312,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/spiked_gauntlets.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 217
@@ -3140,6 +3328,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jeweled_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 218
@@ -3159,6 +3348,7 @@
     },
     "image_url": "/static/images/relics/funerary_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 61
@@ -3178,6 +3368,7 @@
     },
     "image_url": "/static/images/relics/red_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 31
@@ -3193,6 +3384,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_bones.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 219
@@ -3208,6 +3400,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/preserved_fog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 220
@@ -3227,6 +3420,7 @@
     },
     "image_url": "/static/images/relics/nunchaku.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 62
@@ -3242,6 +3436,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/infused_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 6
@@ -3257,6 +3452,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pollinous_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 274
@@ -3272,6 +3468,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cracked_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 7
@@ -3287,6 +3484,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 221
@@ -3302,6 +3500,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glass_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 222
@@ -3317,6 +3516,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 223
@@ -3336,6 +3536,7 @@
     },
     "image_url": "/static/images/relics/orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -3351,6 +3552,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_oyster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 224
@@ -3370,6 +3572,7 @@
     },
     "image_url": "/static/images/relics/shovel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 117
@@ -3389,6 +3592,7 @@
     },
     "image_url": "/static/images/relics/burning_sticks.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 151
@@ -3408,6 +3612,7 @@
     },
     "image_url": "/static/images/relics/bread.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 152
@@ -3427,6 +3632,7 @@
     },
     "image_url": "/static/images/relics/pantograph.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 64
@@ -3442,6 +3648,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/choices_paradox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 225
@@ -3461,6 +3668,7 @@
     },
     "image_url": "/static/images/relics/lunar_pastry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 118
@@ -3476,6 +3684,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/whispering_earring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 226
@@ -3495,6 +3704,7 @@
     },
     "image_url": "/static/images/relics/unceasing_top.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 119
@@ -3514,6 +3724,7 @@
     },
     "image_url": "/static/images/relics/pear.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 65
@@ -3529,6 +3740,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/arcane_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 227
@@ -3544,6 +3756,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/massive_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 228
@@ -3563,6 +3776,7 @@
     },
     "image_url": "/static/images/relics/ninja_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 153
@@ -3578,6 +3792,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 229
@@ -3593,6 +3808,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cursed_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 230
@@ -3608,6 +3824,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/radiant_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 231
@@ -3627,6 +3844,7 @@
     },
     "image_url": "/static/images/relics/permafrost.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 66
@@ -3642,6 +3860,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lucky_fysh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 67
@@ -3657,6 +3876,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phial_holster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 232
@@ -3676,6 +3896,7 @@
     },
     "image_url": "/static/images/relics/whetstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 32
@@ -3691,6 +3912,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/philosophers_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 233
@@ -3710,6 +3932,7 @@
     },
     "image_url": "/static/images/relics/oddly_smooth_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 33
@@ -3729,6 +3952,7 @@
     },
     "image_url": "/static/images/relics/game_piece.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 120
@@ -3748,6 +3972,7 @@
     },
     "image_url": "/static/images/relics/sparkling_rouge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -3767,6 +3992,7 @@
     },
     "image_url": "/static/images/relics/war_paint.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 34
@@ -3782,6 +4008,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/runic_pyramid.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 234
@@ -3797,6 +4024,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lead_paperweight.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 235
@@ -3816,6 +4044,7 @@
     },
     "image_url": "/static/images/relics/orrery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 154
@@ -3835,6 +4064,7 @@
     },
     "image_url": "/static/images/relics/planisphere.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 69
@@ -3854,6 +4084,7 @@
     },
     "image_url": "/static/images/relics/eternal_feather.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 70
@@ -3873,6 +4104,7 @@
     },
     "image_url": "/static/images/relics/galactic_dust.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 71
@@ -3892,6 +4124,7 @@
     },
     "image_url": "/static/images/relics/pen_nib.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 72
@@ -3907,6 +4140,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glitter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 236
@@ -3926,6 +4160,7 @@
     },
     "image_url": "/static/images/relics/pendulum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 35
@@ -3945,6 +4180,7 @@
     },
     "image_url": "/static/images/relics/stone_cracker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 73
@@ -3964,6 +4200,7 @@
     },
     "image_url": "/static/images/relics/paper_phrog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 74
@@ -3983,6 +4220,7 @@
     },
     "image_url": "/static/images/relics/regalite.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -4002,6 +4240,7 @@
     },
     "image_url": "/static/images/relics/beating_remnant.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 121
@@ -4021,6 +4260,7 @@
     },
     "image_url": "/static/images/relics/pocketwatch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 122
@@ -4040,6 +4280,7 @@
     },
     "image_url": "/static/images/relics/mercury_hourglass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 76
@@ -4055,6 +4296,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lava_rock.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 237
@@ -4074,6 +4316,7 @@
     },
     "image_url": "/static/images/relics/centennial_puzzle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 36
@@ -4093,6 +4336,7 @@
     },
     "image_url": "/static/images/relics/vexing_puzzlebox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 123
@@ -4108,6 +4352,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blood_soaked_rose.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 238
@@ -4127,6 +4372,7 @@
     },
     "image_url": "/static/images/relics/prayer_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 124
@@ -4142,6 +4388,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 239
@@ -4157,6 +4404,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/burning_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 8
@@ -4172,6 +4420,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 240
@@ -4187,6 +4436,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 9
@@ -4206,6 +4456,7 @@
     },
     "image_url": "/static/images/relics/petrified_toad.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 77
@@ -4221,6 +4472,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/seal_of_gold.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 241
@@ -4240,6 +4492,7 @@
     },
     "image_url": "/static/images/relics/undying_sigil.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 155
@@ -4259,6 +4512,7 @@
     },
     "image_url": "/static/images/relics/royal_stamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 156
@@ -4278,6 +4532,7 @@
     },
     "image_url": "/static/images/relics/ghost_seed.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 157
@@ -4297,6 +4552,7 @@
     },
     "image_url": "/static/images/relics/venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 37
@@ -4312,6 +4568,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fragrant_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 275
@@ -4331,6 +4588,7 @@
     },
     "image_url": "/static/images/relics/shuriken.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 125
@@ -4346,6 +4604,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tanxs_whistle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 242
@@ -4365,6 +4624,7 @@
     },
     "image_url": "/static/images/relics/big_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 126
@@ -4380,6 +4640,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lords_parasol.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 243
@@ -4395,6 +4656,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_soup.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 244
@@ -4410,6 +4672,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sozu.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 245
@@ -4425,6 +4688,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/mr_struggles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 276
@@ -4444,6 +4708,7 @@
     },
     "image_url": "/static/images/relics/chemical_x.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 158
@@ -4459,6 +4724,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hefty_tablet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 246
@@ -4474,6 +4740,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hand_drill.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 277
@@ -4489,6 +4756,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_talisman.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 247
@@ -4504,6 +4772,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precarious_shears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 248
@@ -4519,6 +4788,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precise_scissors.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 249
@@ -4538,6 +4808,7 @@
     },
     "image_url": "/static/images/relics/captains_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 127
@@ -4557,6 +4828,7 @@
     },
     "image_url": "/static/images/relics/tingsha.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -4572,6 +4844,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dusty_tome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 250
@@ -4587,6 +4860,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/touch_of_orobas.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 251
@@ -4602,6 +4876,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_torment.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 252
@@ -4621,6 +4896,7 @@
     },
     "image_url": "/static/images/relics/ringing_triangle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 159
@@ -4636,6 +4912,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_growth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 253
@@ -4651,6 +4928,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ember_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 278
@@ -4666,6 +4944,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bone_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 279
@@ -4681,6 +4960,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tea_of_discourtesy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 280
@@ -4700,6 +4980,7 @@
     },
     "image_url": "/static/images/relics/vajra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 38
@@ -4715,6 +4996,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pumpkin_candle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 254
@@ -4734,6 +5016,7 @@
     },
     "image_url": "/static/images/relics/tough_bandages.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 128
@@ -4749,6 +5032,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/royal_poison.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 281
@@ -4768,6 +5052,7 @@
     },
     "image_url": "/static/images/relics/blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 39
@@ -4783,6 +5068,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fiddle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 255
@@ -4802,6 +5088,7 @@
     },
     "image_url": "/static/images/relics/symbiotic_virus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 79
@@ -4817,6 +5104,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/winged_boots.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 256
@@ -4836,6 +5124,7 @@
     },
     "image_url": "/static/images/relics/ruined_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 129
@@ -4851,6 +5140,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fake_merchants_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 282
@@ -4870,6 +5160,7 @@
     },
     "image_url": "/static/images/relics/fake_anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 283
@@ -4889,6 +5180,7 @@
     },
     "image_url": "/static/images/relics/fake_happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 284
@@ -4908,6 +5200,7 @@
     },
     "image_url": "/static/images/relics/fake_lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 285
@@ -4927,6 +5220,7 @@
     },
     "image_url": "/static/images/relics/fake_mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 286
@@ -4946,6 +5240,7 @@
     },
     "image_url": "/static/images/relics/fake_strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 287
@@ -4965,6 +5260,7 @@
     },
     "image_url": "/static/images/relics/fake_snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 288
@@ -4984,6 +5280,7 @@
     },
     "image_url": "/static/images/relics/fake_orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 289
@@ -5003,6 +5300,7 @@
     },
     "image_url": "/static/images/relics/fake_venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 290
@@ -5022,6 +5320,7 @@
     },
     "image_url": "/static/images/relics/fake_blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 291

--- a/data/tha/relics.json
+++ b/data/tha/relics.json
@@ -14,6 +14,7 @@
     },
     "image_url": "/static/images/relics/akabeko.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 40
@@ -29,6 +30,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/alchemical_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 160
@@ -44,6 +46,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/amethyst_aubergine.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 10
@@ -63,6 +66,7 @@
     },
     "image_url": "/static/images/relics/anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 11
@@ -78,6 +82,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/arcane_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 161
@@ -93,6 +98,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/archaic_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 162
@@ -108,6 +114,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/astrolabe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 163
@@ -127,6 +134,7 @@
     },
     "image_url": "/static/images/relics/bag_of_marbles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 12
@@ -146,6 +154,7 @@
     },
     "image_url": "/static/images/relics/bag_of_preparation.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 13
@@ -165,6 +174,7 @@
     },
     "image_url": "/static/images/relics/beating_remnant.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 80
@@ -180,6 +190,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/beautiful_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 164
@@ -199,6 +210,7 @@
     },
     "image_url": "/static/images/relics/bellows.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 81
@@ -218,6 +230,7 @@
     },
     "image_url": "/static/images/relics/belt_buckle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 130
@@ -237,6 +250,7 @@
     },
     "image_url": "/static/images/relics/big_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 82
@@ -252,6 +266,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/big_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 257
@@ -267,6 +282,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/biiig_hug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 165
@@ -282,6 +298,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bing_bong.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 258
@@ -297,6 +314,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 0
@@ -312,6 +330,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 166
@@ -327,6 +346,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blessed_antler.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 167
@@ -342,6 +362,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blood_soaked_rose.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 168
@@ -361,6 +382,7 @@
     },
     "image_url": "/static/images/relics/blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 14
@@ -380,6 +402,7 @@
     },
     "image_url": "/static/images/relics/bone_flute.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 15
@@ -395,6 +418,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bone_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 259
@@ -414,6 +438,7 @@
     },
     "image_url": "/static/images/relics/book_of_five_rings.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 16
@@ -433,6 +458,7 @@
     },
     "image_url": "/static/images/relics/book_repair_knife.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 41
@@ -448,6 +474,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/booming_conch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 169
@@ -463,6 +490,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bound_phylactery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 1
@@ -478,6 +506,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bowler_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 42
@@ -493,6 +522,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/brilliant_scarf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 170
@@ -512,6 +542,7 @@
     },
     "image_url": "/static/images/relics/brimstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 131
@@ -531,6 +562,7 @@
     },
     "image_url": "/static/images/relics/bronze_scales.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 17
@@ -546,6 +578,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/burning_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 2
@@ -565,6 +598,7 @@
     },
     "image_url": "/static/images/relics/burning_sticks.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 132
@@ -580,6 +614,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/byrdpip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 260
@@ -595,6 +630,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/calling_bell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 171
@@ -614,6 +650,7 @@
     },
     "image_url": "/static/images/relics/candelabra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 43
@@ -633,6 +670,7 @@
     },
     "image_url": "/static/images/relics/captains_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 83
@@ -652,6 +690,7 @@
     },
     "image_url": "/static/images/relics/chandelier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 84
@@ -671,6 +710,7 @@
     },
     "image_url": "/static/images/relics/charons_ashes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 85
@@ -686,6 +726,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/choices_paradox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 172
@@ -701,6 +742,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/claws.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 173
@@ -720,6 +762,7 @@
     },
     "image_url": "/static/images/relics/cloak_clasp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 86
@@ -735,6 +778,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cracked_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 3
@@ -750,6 +794,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cursed_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 174
@@ -765,6 +810,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/darkstone_periapt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 261
@@ -780,6 +826,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/daughter_of_the_wind.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 262
@@ -795,6 +842,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/delicate_frond.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 175
@@ -814,6 +862,7 @@
     },
     "image_url": "/static/images/relics/demon_tongue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 87
@@ -829,6 +878,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/diamond_diadem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 176
@@ -848,6 +898,7 @@
     },
     "image_url": "/static/images/relics/dingy_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 133
@@ -863,6 +914,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/distinguished_cape.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 177
@@ -878,6 +930,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_destiny.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 4
@@ -893,6 +946,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_right.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 5
@@ -912,6 +966,7 @@
     },
     "image_url": "/static/images/relics/dollys_mirror.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 134
@@ -927,6 +982,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/driftwood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 178
@@ -942,6 +998,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ectoplasm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 179
@@ -957,6 +1014,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/electric_shrymp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 180
@@ -972,6 +1030,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ember_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 263
@@ -987,6 +1046,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/empty_cage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 181
@@ -1006,6 +1066,7 @@
     },
     "image_url": "/static/images/relics/eternal_feather.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 44
@@ -1025,6 +1086,7 @@
     },
     "image_url": "/static/images/relics/fake_anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 264
@@ -1044,6 +1106,7 @@
     },
     "image_url": "/static/images/relics/fake_blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 265
@@ -1063,6 +1126,7 @@
     },
     "image_url": "/static/images/relics/fake_happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 266
@@ -1082,6 +1146,7 @@
     },
     "image_url": "/static/images/relics/fake_lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 267
@@ -1097,6 +1162,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fake_merchants_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 268
@@ -1116,6 +1182,7 @@
     },
     "image_url": "/static/images/relics/fake_snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 269
@@ -1135,6 +1202,7 @@
     },
     "image_url": "/static/images/relics/fake_strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 270
@@ -1154,6 +1222,7 @@
     },
     "image_url": "/static/images/relics/fake_venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 271
@@ -1173,6 +1242,7 @@
     },
     "image_url": "/static/images/relics/fencing_manual.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 18
@@ -1192,6 +1262,7 @@
     },
     "image_url": "/static/images/relics/festive_popper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 19
@@ -1207,6 +1278,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fiddle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 182
@@ -1222,6 +1294,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/forgotten_soul.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 272
@@ -1237,6 +1310,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fragrant_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 273
@@ -1252,6 +1326,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fresnel_lens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 274
@@ -1271,6 +1346,7 @@
     },
     "image_url": "/static/images/relics/funerary_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 45
@@ -1286,6 +1362,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fur_coat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 183
@@ -1305,6 +1382,7 @@
     },
     "image_url": "/static/images/relics/galactic_dust.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 46
@@ -1324,6 +1402,7 @@
     },
     "image_url": "/static/images/relics/gambling_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 88
@@ -1343,6 +1422,7 @@
     },
     "image_url": "/static/images/relics/game_piece.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 89
@@ -1362,6 +1442,7 @@
     },
     "image_url": "/static/images/relics/ghost_seed.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 135
@@ -1381,6 +1462,7 @@
     },
     "image_url": "/static/images/relics/girya.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 90
@@ -1396,6 +1478,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glass_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 184
@@ -1415,6 +1498,7 @@
     },
     "image_url": "/static/images/relics/gnarled_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 136
@@ -1434,6 +1518,7 @@
     },
     "image_url": "/static/images/relics/gold_plated_cables.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 47
@@ -1453,6 +1538,7 @@
     },
     "image_url": "/static/images/relics/gorget.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 20
@@ -1472,6 +1558,7 @@
     },
     "image_url": "/static/images/relics/gremlin_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -1487,6 +1574,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hand_drill.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 275
@@ -1506,6 +1594,7 @@
     },
     "image_url": "/static/images/relics/happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 21
@@ -1521,6 +1610,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hefty_tablet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 185
@@ -1540,6 +1630,7 @@
     },
     "image_url": "/static/images/relics/helical_dart.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 91
@@ -1555,6 +1646,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/history_course.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 276
@@ -1574,6 +1666,7 @@
     },
     "image_url": "/static/images/relics/horn_cleat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 49
@@ -1589,6 +1682,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/infused_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 6
@@ -1608,6 +1702,7 @@
     },
     "image_url": "/static/images/relics/intimidating_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 92
@@ -1623,6 +1718,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/iron_club.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 186
@@ -1642,6 +1738,7 @@
     },
     "image_url": "/static/images/relics/ivory_tile.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 93
@@ -1657,6 +1754,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jeweled_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 187
@@ -1672,6 +1770,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jewelry_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 188
@@ -1691,6 +1790,7 @@
     },
     "image_url": "/static/images/relics/joss_paper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -1710,6 +1810,7 @@
     },
     "image_url": "/static/images/relics/kifuda.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 137
@@ -1729,6 +1830,7 @@
     },
     "image_url": "/static/images/relics/kunai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 94
@@ -1748,6 +1850,7 @@
     },
     "image_url": "/static/images/relics/kusarigama.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 51
@@ -1763,6 +1866,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/large_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 189
@@ -1782,6 +1886,7 @@
     },
     "image_url": "/static/images/relics/lasting_candy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 52
@@ -1801,6 +1906,7 @@
     },
     "image_url": "/static/images/relics/lava_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 138
@@ -1816,6 +1922,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/leafy_poultice.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 190
@@ -1835,6 +1942,7 @@
     },
     "image_url": "/static/images/relics/lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 139
@@ -1854,6 +1962,7 @@
     },
     "image_url": "/static/images/relics/letter_opener.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 53
@@ -1873,6 +1982,7 @@
     },
     "image_url": "/static/images/relics/lizard_tail.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 95
@@ -1891,6 +2001,7 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
+    "name_variants": null,
     "notes": [
       "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
       "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
@@ -1909,6 +2020,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lords_parasol.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 192
@@ -1924,6 +2036,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 193
@@ -1939,6 +2052,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lucky_fysh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -1958,6 +2072,7 @@
     },
     "image_url": "/static/images/relics/lunar_pastry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 96
@@ -1973,6 +2088,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/massive_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 194
@@ -1988,6 +2104,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/maw_bank.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 277
@@ -2007,6 +2124,7 @@
     },
     "image_url": "/static/images/relics/meal_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 22
@@ -2022,6 +2140,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/meat_cleaver.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 195
@@ -2041,6 +2160,7 @@
     },
     "image_url": "/static/images/relics/meat_on_the_bone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 97
@@ -2060,6 +2180,7 @@
     },
     "image_url": "/static/images/relics/mercury_hourglass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 55
@@ -2079,6 +2200,7 @@
     },
     "image_url": "/static/images/relics/metronome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 98
@@ -2098,6 +2220,7 @@
     },
     "image_url": "/static/images/relics/mini_regent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 99
@@ -2117,6 +2240,7 @@
     },
     "image_url": "/static/images/relics/miniature_cannon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 56
@@ -2136,6 +2260,7 @@
     },
     "image_url": "/static/images/relics/miniature_tent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 140
@@ -2155,6 +2280,7 @@
     },
     "image_url": "/static/images/relics/molten_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 100
@@ -2170,6 +2296,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/mr_struggles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 278
@@ -2189,6 +2316,7 @@
     },
     "image_url": "/static/images/relics/mummified_hand.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 101
@@ -2208,6 +2336,7 @@
     },
     "image_url": "/static/images/relics/mystic_lighter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 141
@@ -2223,6 +2352,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_bones.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 196
@@ -2238,6 +2368,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_talisman.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 197
@@ -2253,6 +2384,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_torment.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 198
@@ -2268,6 +2400,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/new_leaf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 199
@@ -2283,6 +2416,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_oyster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 200
@@ -2298,6 +2432,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_soup.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 201
@@ -2317,6 +2452,7 @@
     },
     "image_url": "/static/images/relics/oddly_smooth_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 23
@@ -2336,6 +2472,7 @@
     },
     "image_url": "/static/images/relics/orange_dough.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 102
@@ -2355,6 +2492,7 @@
     },
     "image_url": "/static/images/relics/orrery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 142
@@ -2370,6 +2508,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 202
@@ -2385,6 +2524,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_claw.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 203
@@ -2400,6 +2540,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 204
@@ -2415,6 +2556,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_flesh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 205
@@ -2430,6 +2572,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_growth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 206
@@ -2445,6 +2588,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 207
@@ -2460,6 +2604,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_legion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 208
@@ -2475,6 +2620,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 209
@@ -2490,6 +2636,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 210
@@ -2505,6 +2652,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_wing.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 211
@@ -2524,6 +2672,7 @@
     },
     "image_url": "/static/images/relics/pantograph.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 57
@@ -2543,6 +2692,7 @@
     },
     "image_url": "/static/images/relics/paper_krane.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 103
@@ -2562,6 +2712,7 @@
     },
     "image_url": "/static/images/relics/paper_phrog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 58
@@ -2581,6 +2732,7 @@
     },
     "image_url": "/static/images/relics/parrying_shield.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 59
@@ -2600,6 +2752,7 @@
     },
     "image_url": "/static/images/relics/pear.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 60
@@ -2619,6 +2772,7 @@
     },
     "image_url": "/static/images/relics/pendulum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 24
@@ -2638,6 +2792,7 @@
     },
     "image_url": "/static/images/relics/permafrost.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 61
@@ -2657,6 +2812,7 @@
     },
     "image_url": "/static/images/relics/petrified_toad.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 62
@@ -2672,6 +2828,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phial_holster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 212
@@ -2687,6 +2844,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phylactery_unbound.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 7
@@ -2706,6 +2864,7 @@
     },
     "image_url": "/static/images/relics/planisphere.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -2725,6 +2884,7 @@
     },
     "image_url": "/static/images/relics/pocketwatch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 104
@@ -2740,6 +2900,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pollinous_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 279
@@ -2755,6 +2916,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pomander.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 213
@@ -2774,6 +2936,7 @@
     },
     "image_url": "/static/images/relics/potion_belt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 25
@@ -2793,6 +2956,7 @@
     },
     "image_url": "/static/images/relics/power_cell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 105
@@ -2812,6 +2976,7 @@
     },
     "image_url": "/static/images/relics/prayer_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 106
@@ -2827,6 +2992,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precarious_shears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 214
@@ -2842,6 +3008,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precise_scissors.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 215
@@ -2857,6 +3024,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/preserved_fog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 216
@@ -2872,6 +3040,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/prismatic_gem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 217
@@ -2891,6 +3060,7 @@
     },
     "image_url": "/static/images/relics/punch_dagger.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 143
@@ -2906,6 +3076,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/radiant_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 218
@@ -2925,6 +3096,7 @@
     },
     "image_url": "/static/images/relics/rainbow_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 107
@@ -2944,6 +3116,7 @@
     },
     "image_url": "/static/images/relics/razor_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 108
@@ -2963,6 +3136,7 @@
     },
     "image_url": "/static/images/relics/red_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 26
@@ -2982,6 +3156,7 @@
     },
     "image_url": "/static/images/relics/red_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 27
@@ -3001,6 +3176,7 @@
     },
     "image_url": "/static/images/relics/regal_pillow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 28
@@ -3020,6 +3196,7 @@
     },
     "image_url": "/static/images/relics/regalite.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 64
@@ -3039,6 +3216,7 @@
     },
     "image_url": "/static/images/relics/reptile_trinket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 65
@@ -3054,6 +3232,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_drake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 8
@@ -3069,6 +3248,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_snake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 9
@@ -3088,6 +3268,7 @@
     },
     "image_url": "/static/images/relics/ringing_triangle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 144
@@ -3107,6 +3288,7 @@
     },
     "image_url": "/static/images/relics/ripple_basin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 66
@@ -3122,6 +3304,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/royal_poison.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 280
@@ -3141,6 +3324,7 @@
     },
     "image_url": "/static/images/relics/royal_stamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 145
@@ -3160,6 +3344,7 @@
     },
     "image_url": "/static/images/relics/ruined_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 109
@@ -3179,6 +3364,7 @@
     },
     "image_url": "/static/images/relics/runic_capacitor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 146
@@ -3194,6 +3380,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/runic_pyramid.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 219
@@ -3209,6 +3396,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 220
@@ -3228,6 +3416,7 @@
     },
     "image_url": "/static/images/relics/screaming_flagon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 147
@@ -3243,6 +3432,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/scroll_boxes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 221
@@ -3258,6 +3448,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sea_glass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 222
@@ -3273,6 +3464,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/seal_of_gold.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 223
@@ -3292,6 +3484,7 @@
     },
     "image_url": "/static/images/relics/self_forming_clay.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 67
@@ -3307,6 +3500,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sere_talon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 224
@@ -3326,6 +3520,7 @@
     },
     "image_url": "/static/images/relics/shuriken.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 110
@@ -3341,6 +3536,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/signet_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 225
@@ -3356,6 +3552,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/silver_crucible.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 226
@@ -3375,6 +3572,7 @@
     },
     "image_url": "/static/images/relics/sling_of_courage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 148
@@ -3390,6 +3588,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/small_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 227
@@ -3405,6 +3604,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 228
@@ -3424,6 +3624,7 @@
     },
     "image_url": "/static/images/relics/snecko_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 29
@@ -3439,6 +3640,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sozu.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 229
@@ -3458,6 +3660,7 @@
     },
     "image_url": "/static/images/relics/sparkling_rouge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -3473,6 +3676,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/spiked_gauntlets.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 230
@@ -3492,6 +3696,7 @@
     },
     "image_url": "/static/images/relics/stone_calendar.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 111
@@ -3511,6 +3716,7 @@
     },
     "image_url": "/static/images/relics/stone_cracker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 69
@@ -3526,6 +3732,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/stone_humidifier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 231
@@ -3541,6 +3748,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/storybook.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 232
@@ -3560,6 +3768,7 @@
     },
     "image_url": "/static/images/relics/strawberry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 30
@@ -3579,6 +3788,7 @@
     },
     "image_url": "/static/images/relics/strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 31
@@ -3598,6 +3808,7 @@
     },
     "image_url": "/static/images/relics/sturdy_clamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 112
@@ -3613,6 +3824,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_jade.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 281
@@ -3628,6 +3840,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 282
@@ -3647,6 +3860,7 @@
     },
     "image_url": "/static/images/relics/symbiotic_virus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 70
@@ -3662,6 +3876,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tanxs_whistle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 233
@@ -3677,6 +3892,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tea_of_discourtesy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 283
@@ -3696,6 +3912,7 @@
     },
     "image_url": "/static/images/relics/the_abacus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 149
@@ -3711,6 +3928,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_boot.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 284
@@ -3726,6 +3944,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_courier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 113
@@ -3741,6 +3960,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/throwing_axe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 234
@@ -3760,6 +3980,7 @@
     },
     "image_url": "/static/images/relics/tingsha.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 71
@@ -3779,6 +4000,7 @@
     },
     "image_url": "/static/images/relics/tiny_mailbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 72
@@ -3794,6 +4016,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toasty_mittens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 235
@@ -3809,6 +4032,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/touch_of_orobas.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 236
@@ -3828,6 +4052,7 @@
     },
     "image_url": "/static/images/relics/tough_bandages.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 114
@@ -3847,6 +4072,7 @@
     },
     "image_url": "/static/images/relics/toxic_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 115
@@ -3862,6 +4088,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tri_boomerang.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 237
@@ -3881,6 +4108,7 @@
     },
     "image_url": "/static/images/relics/tungsten_rod.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 116
@@ -3900,6 +4128,7 @@
     },
     "image_url": "/static/images/relics/tuning_fork.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 73
@@ -3919,6 +4148,7 @@
     },
     "image_url": "/static/images/relics/twisted_funnel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 74
@@ -3938,6 +4168,7 @@
     },
     "image_url": "/static/images/relics/unceasing_top.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 117
@@ -3957,6 +4188,7 @@
     },
     "image_url": "/static/images/relics/undying_sigil.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 150
@@ -3976,6 +4208,7 @@
     },
     "image_url": "/static/images/relics/unsettling_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 118
@@ -3995,6 +4228,7 @@
     },
     "image_url": "/static/images/relics/vambrace.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -4010,6 +4244,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/velvet_choker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 238
@@ -4029,6 +4264,7 @@
     },
     "image_url": "/static/images/relics/venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 32
@@ -4048,6 +4284,7 @@
     },
     "image_url": "/static/images/relics/vexing_puzzlebox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 119
@@ -4067,6 +4304,7 @@
     },
     "image_url": "/static/images/relics/vitruvian_minion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 151
@@ -4082,6 +4320,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/war_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 239
@@ -4101,6 +4340,7 @@
     },
     "image_url": "/static/images/relics/war_paint.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 33
@@ -4120,6 +4360,7 @@
     },
     "image_url": "/static/images/relics/whetstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 34
@@ -4135,6 +4376,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/whispering_earring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 240
@@ -4154,6 +4396,7 @@
     },
     "image_url": "/static/images/relics/white_beast_statue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 120
@@ -4173,6 +4416,7 @@
     },
     "image_url": "/static/images/relics/white_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 121
@@ -4192,6 +4436,7 @@
     },
     "image_url": "/static/images/relics/wing_charm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 152
@@ -4207,6 +4452,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/winged_boots.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 241
@@ -4222,6 +4468,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongo_customer_appreciation_badge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 285
@@ -4237,6 +4484,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongos_mystery_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 286
@@ -4256,6 +4504,7 @@
     },
     "image_url": "/static/images/relics/nunchaku.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 76
@@ -4271,6 +4520,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toy_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": [
       "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed.",
       "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
@@ -4290,6 +4540,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/music_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 243
@@ -4309,6 +4560,7 @@
     },
     "image_url": "/static/images/relics/toolbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 153
@@ -4324,6 +4576,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pandoras_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 244
@@ -4339,6 +4592,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glitter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 245
@@ -4358,6 +4612,7 @@
     },
     "image_url": "/static/images/relics/bread.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 154
@@ -4377,6 +4632,7 @@
     },
     "image_url": "/static/images/relics/ninja_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 155
@@ -4398,6 +4654,7 @@
       "Necrobinder": "/static/images/relics/yummy_cookie_necrobinder.webp",
       "Regent": "/static/images/relics/yummy_cookie_regent.webp"
     },
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 246
@@ -4417,6 +4674,7 @@
     },
     "image_url": "/static/images/relics/emotion_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 122
@@ -4432,6 +4690,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/chosen_cheese.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 287
@@ -4451,6 +4710,7 @@
     },
     "image_url": "/static/images/relics/data_disk.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 35
@@ -4466,6 +4726,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lead_paperweight.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 247
@@ -4485,6 +4746,7 @@
     },
     "image_url": "/static/images/relics/lantern.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 36
@@ -4504,6 +4766,7 @@
     },
     "image_url": "/static/images/relics/centennial_puzzle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 37
@@ -4519,6 +4782,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dream_catcher.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 288
@@ -4534,6 +4798,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dusty_tome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 248
@@ -4553,6 +4818,7 @@
     },
     "image_url": "/static/images/relics/art_of_war.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 123
@@ -4572,6 +4838,7 @@
     },
     "image_url": "/static/images/relics/bookmark.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 124
@@ -4591,6 +4858,7 @@
     },
     "image_url": "/static/images/relics/membership_card.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 156
@@ -4606,6 +4874,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sand_castle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 249
@@ -4625,6 +4894,7 @@
     },
     "image_url": "/static/images/relics/shovel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 125
@@ -4644,6 +4914,7 @@
     },
     "image_url": "/static/images/relics/ornamental_fan.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 77
@@ -4663,6 +4934,7 @@
     },
     "image_url": "/static/images/relics/mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 126
@@ -4682,6 +4954,7 @@
     },
     "image_url": "/static/images/relics/fake_mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 289
@@ -4697,6 +4970,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/circlet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "None",
     "compendium_order": 292
@@ -4712,6 +4986,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_wisp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 290
@@ -4731,6 +5006,7 @@
     },
     "image_url": "/static/images/relics/vajra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 38
@@ -4746,6 +5022,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/philosophers_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 250
@@ -4765,6 +5042,7 @@
     },
     "image_url": "/static/images/relics/juzu_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 39
@@ -4784,6 +5062,7 @@
     },
     "image_url": "/static/images/relics/chemical_x.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 157
@@ -4799,6 +5078,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/crossbow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 251
@@ -4818,6 +5098,7 @@
     },
     "image_url": "/static/images/relics/cauldron.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 158
@@ -4837,6 +5118,7 @@
     },
     "image_url": "/static/images/relics/pen_nib.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -4852,6 +5134,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lava_rock.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 252
@@ -4867,6 +5150,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_compass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 253
@@ -4882,6 +5166,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pumpkin_candle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 254
@@ -4897,6 +5182,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/old_coin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 127
@@ -4916,6 +5202,7 @@
     },
     "image_url": "/static/images/relics/dragon_fruit.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 159
@@ -4931,6 +5218,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/very_hot_cocoa.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 255
@@ -4950,6 +5238,7 @@
     },
     "image_url": "/static/images/relics/orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 79
@@ -4969,6 +5258,7 @@
     },
     "image_url": "/static/images/relics/fake_orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 291
@@ -4984,6 +5274,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 256
@@ -5003,6 +5294,7 @@
     },
     "image_url": "/static/images/relics/frozen_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 128
@@ -5022,6 +5314,7 @@
     },
     "image_url": "/static/images/relics/ice_cream.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 129

--- a/data/tur/relics.json
+++ b/data/tur/relics.json
@@ -14,6 +14,7 @@
     },
     "image_url": "/static/images/relics/the_abacus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 130
@@ -33,6 +34,7 @@
     },
     "image_url": "/static/images/relics/akabeko.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 40
@@ -52,6 +54,7 @@
     },
     "image_url": "/static/images/relics/toolbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 131
@@ -71,6 +74,7 @@
     },
     "image_url": "/static/images/relics/gold_plated_cables.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 41
@@ -86,6 +90,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/seal_of_gold.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 160
@@ -101,6 +106,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_compass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 161
@@ -116,6 +122,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 162
@@ -131,6 +138,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/amethyst_aubergine.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 10
@@ -146,6 +154,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/crossbow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 163
@@ -165,6 +174,7 @@
     },
     "image_url": "/static/images/relics/pear.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 42
@@ -180,6 +190,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/distinguished_cape.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 164
@@ -199,6 +210,7 @@
     },
     "image_url": "/static/images/relics/centennial_puzzle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 11
@@ -218,6 +230,7 @@
     },
     "image_url": "/static/images/relics/beating_remnant.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 80
@@ -237,6 +250,7 @@
     },
     "image_url": "/static/images/relics/chandelier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 81
@@ -256,6 +270,7 @@
     },
     "image_url": "/static/images/relics/lunar_pastry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 82
@@ -275,6 +290,7 @@
     },
     "image_url": "/static/images/relics/bookmark.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 83
@@ -290,6 +306,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hefty_tablet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 165
@@ -309,6 +326,7 @@
     },
     "image_url": "/static/images/relics/oddly_smooth_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 12
@@ -324,6 +342,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pumpkin_candle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 166
@@ -339,6 +358,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/mr_struggles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 257
@@ -354,6 +374,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_soup.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 167
@@ -369,6 +390,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_oyster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 168
@@ -388,6 +410,7 @@
     },
     "image_url": "/static/images/relics/white_beast_statue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 84
@@ -407,6 +430,7 @@
     },
     "image_url": "/static/images/relics/white_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 85
@@ -426,6 +450,7 @@
     },
     "image_url": "/static/images/relics/book_of_five_rings.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 13
@@ -445,6 +470,7 @@
     },
     "image_url": "/static/images/relics/whetstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 14
@@ -464,6 +490,7 @@
     },
     "image_url": "/static/images/relics/bag_of_marbles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 15
@@ -479,6 +506,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bing_bong.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 258
@@ -498,6 +526,7 @@
     },
     "image_url": "/static/images/relics/gorget.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 16
@@ -513,6 +542,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/empty_cage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 169
@@ -532,6 +562,7 @@
     },
     "image_url": "/static/images/relics/bronze_scales.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 17
@@ -547,6 +578,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/arcane_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 170
@@ -562,6 +594,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/big_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 259
@@ -581,6 +614,7 @@
     },
     "image_url": "/static/images/relics/big_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 86
@@ -596,6 +630,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glass_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 171
@@ -615,6 +650,7 @@
     },
     "image_url": "/static/images/relics/funerary_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 43
@@ -634,6 +670,7 @@
     },
     "image_url": "/static/images/relics/pocketwatch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 87
@@ -653,6 +690,7 @@
     },
     "image_url": "/static/images/relics/sling_of_courage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 132
@@ -672,6 +710,7 @@
     },
     "image_url": "/static/images/relics/charons_ashes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 88
@@ -691,6 +730,7 @@
     },
     "image_url": "/static/images/relics/mercury_hourglass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 44
@@ -710,6 +750,7 @@
     },
     "image_url": "/static/images/relics/ripple_basin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 45
@@ -729,6 +770,7 @@
     },
     "image_url": "/static/images/relics/lasting_candy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 46
@@ -744,6 +786,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/iron_club.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 172
@@ -759,6 +802,13 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sea_glass.webp",
     "image_variants": null,
+    "name_variants": {
+      "Ironclad": "Şeytan Camı",
+      "Silent": "Zehir Camı",
+      "Defect": "Cam Dişli",
+      "Necrobinder": "Lich Camı",
+      "Regent": "Asil Cam"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 173
@@ -774,6 +824,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/massive_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 174
@@ -789,6 +840,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/spiked_gauntlets.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 175
@@ -808,6 +860,7 @@
     },
     "image_url": "/static/images/relics/tuning_fork.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 47
@@ -827,6 +880,7 @@
     },
     "image_url": "/static/images/relics/dollys_mirror.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 133
@@ -846,6 +900,7 @@
     },
     "image_url": "/static/images/relics/pen_nib.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -865,6 +920,7 @@
     },
     "image_url": "/static/images/relics/ice_cream.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 89
@@ -884,6 +940,7 @@
     },
     "image_url": "/static/images/relics/frozen_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 90
@@ -903,6 +960,7 @@
     },
     "image_url": "/static/images/relics/prayer_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 91
@@ -922,6 +980,7 @@
     },
     "image_url": "/static/images/relics/unceasing_top.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 92
@@ -941,6 +1000,7 @@
     },
     "image_url": "/static/images/relics/emotion_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 93
@@ -960,6 +1020,7 @@
     },
     "image_url": "/static/images/relics/undying_sigil.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 134
@@ -979,6 +1040,7 @@
     },
     "image_url": "/static/images/relics/eternal_feather.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 49
@@ -998,6 +1060,7 @@
     },
     "image_url": "/static/images/relics/dragon_fruit.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 135
@@ -1013,6 +1076,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_drake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 0
@@ -1032,6 +1096,7 @@
     },
     "image_url": "/static/images/relics/bread.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 136
@@ -1047,6 +1112,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ectoplasm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 176
@@ -1062,6 +1128,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hand_drill.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 260
@@ -1077,6 +1144,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/electric_shrymp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 177
@@ -1092,6 +1160,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/diamond_diadem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 178
@@ -1107,6 +1176,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/infused_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 1
@@ -1126,6 +1196,7 @@
     },
     "image_url": "/static/images/relics/molten_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 94
@@ -1141,6 +1212,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/old_coin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 95
@@ -1160,6 +1232,7 @@
     },
     "image_url": "/static/images/relics/fencing_manual.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 18
@@ -1179,6 +1252,7 @@
     },
     "image_url": "/static/images/relics/gnarled_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 137
@@ -1194,6 +1268,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/philosophers_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 179
@@ -1213,6 +1288,7 @@
     },
     "image_url": "/static/images/relics/lantern.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 19
@@ -1232,6 +1308,7 @@
     },
     "image_url": "/static/images/relics/ivory_tile.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 96
@@ -1250,6 +1327,7 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
+    "name_variants": null,
     "notes": [
       "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
       "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
@@ -1268,6 +1346,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fresnel_lens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 261
@@ -1283,6 +1362,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/throwing_axe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 181
@@ -1298,6 +1378,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/whispering_earring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 182
@@ -1317,6 +1398,7 @@
     },
     "image_url": "/static/images/relics/galactic_dust.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -1336,6 +1418,7 @@
     },
     "image_url": "/static/images/relics/girya.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 97
@@ -1355,6 +1438,7 @@
     },
     "image_url": "/static/images/relics/gremlin_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 51
@@ -1370,6 +1454,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/byrdpip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 262
@@ -1389,6 +1474,7 @@
     },
     "image_url": "/static/images/relics/rainbow_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 98
@@ -1404,6 +1490,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/brilliant_scarf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 183
@@ -1419,6 +1506,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/silver_crucible.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 184
@@ -1438,6 +1526,7 @@
     },
     "image_url": "/static/images/relics/orrery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 138
@@ -1457,6 +1546,7 @@
     },
     "image_url": "/static/images/relics/power_cell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 99
@@ -1476,6 +1566,7 @@
     },
     "image_url": "/static/images/relics/ghost_seed.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 139
@@ -1495,6 +1586,7 @@
     },
     "image_url": "/static/images/relics/bag_of_preparation.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 20
@@ -1510,6 +1602,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/storybook.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 185
@@ -1529,6 +1622,7 @@
     },
     "image_url": "/static/images/relics/unsettling_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 100
@@ -1548,6 +1642,7 @@
     },
     "image_url": "/static/images/relics/sparkling_rouge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 52
@@ -1563,6 +1658,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/radiant_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 186
@@ -1582,6 +1678,7 @@
     },
     "image_url": "/static/images/relics/razor_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 101
@@ -1601,6 +1698,7 @@
     },
     "image_url": "/static/images/relics/juzu_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 21
@@ -1616,6 +1714,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/velvet_choker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 187
@@ -1635,6 +1734,7 @@
     },
     "image_url": "/static/images/relics/blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 22
@@ -1654,6 +1754,7 @@
     },
     "image_url": "/static/images/relics/fake_blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 263
@@ -1669,6 +1770,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blood_soaked_rose.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 188
@@ -1688,6 +1790,7 @@
     },
     "image_url": "/static/images/relics/wing_charm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 140
@@ -1707,6 +1810,7 @@
     },
     "image_url": "/static/images/relics/captains_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 102
@@ -1722,6 +1826,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 189
@@ -1737,6 +1842,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/darkstone_periapt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 264
@@ -1756,6 +1862,7 @@
     },
     "image_url": "/static/images/relics/punch_dagger.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 141
@@ -1771,6 +1878,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/very_hot_cocoa.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 190
@@ -1786,6 +1894,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_wisp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 265
@@ -1801,6 +1910,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 191
@@ -1820,6 +1930,7 @@
     },
     "image_url": "/static/images/relics/cauldron.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 142
@@ -1839,6 +1950,7 @@
     },
     "image_url": "/static/images/relics/paper_krane.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 103
@@ -1858,6 +1970,7 @@
     },
     "image_url": "/static/images/relics/paper_phrog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 53
@@ -1873,6 +1986,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fiddle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 192
@@ -1892,6 +2006,7 @@
     },
     "image_url": "/static/images/relics/belt_buckle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 143
@@ -1911,6 +2026,7 @@
     },
     "image_url": "/static/images/relics/bone_flute.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 23
@@ -1926,6 +2042,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bone_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 266
@@ -1945,6 +2062,7 @@
     },
     "image_url": "/static/images/relics/meat_on_the_bone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 104
@@ -1964,6 +2082,7 @@
     },
     "image_url": "/static/images/relics/self_forming_clay.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -1983,6 +2102,7 @@
     },
     "image_url": "/static/images/relics/lizard_tail.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 105
@@ -1998,6 +2118,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precise_scissors.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 193
@@ -2017,6 +2138,7 @@
     },
     "image_url": "/static/images/relics/kifuda.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 144
@@ -2036,6 +2158,7 @@
     },
     "image_url": "/static/images/relics/chemical_x.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 145
@@ -2055,6 +2178,7 @@
     },
     "image_url": "/static/images/relics/book_repair_knife.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 55
@@ -2070,6 +2194,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/biiig_hug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 194
@@ -2085,6 +2210,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fragrant_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 267
@@ -2104,6 +2230,7 @@
     },
     "image_url": "/static/images/relics/vambrace.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 56
@@ -2123,6 +2250,7 @@
     },
     "image_url": "/static/images/relics/intimidating_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 106
@@ -2142,6 +2270,7 @@
     },
     "image_url": "/static/images/relics/horn_cleat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 57
@@ -2161,6 +2290,7 @@
     },
     "image_url": "/static/images/relics/royal_stamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 146
@@ -2180,6 +2310,7 @@
     },
     "image_url": "/static/images/relics/regal_pillow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 24
@@ -2195,6 +2326,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/royal_poison.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 268
@@ -2214,6 +2346,7 @@
     },
     "image_url": "/static/images/relics/gambling_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 107
@@ -2229,6 +2362,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sand_castle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 195
@@ -2248,6 +2382,7 @@
     },
     "image_url": "/static/images/relics/kunai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 108
@@ -2263,6 +2398,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sere_talon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 196
@@ -2278,6 +2414,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_courier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 109
@@ -2293,6 +2430,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lead_paperweight.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 197
@@ -2312,6 +2450,7 @@
     },
     "image_url": "/static/images/relics/kusarigama.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 58
@@ -2331,6 +2470,7 @@
     },
     "image_url": "/static/images/relics/festive_popper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 25
@@ -2346,6 +2486,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blessed_antler.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 198
@@ -2365,6 +2506,7 @@
     },
     "image_url": "/static/images/relics/bellows.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 110
@@ -2380,6 +2522,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ember_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 269
@@ -2399,6 +2542,7 @@
     },
     "image_url": "/static/images/relics/brimstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 147
@@ -2418,6 +2562,7 @@
     },
     "image_url": "/static/images/relics/shovel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 111
@@ -2433,6 +2578,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fur_coat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 199
@@ -2448,6 +2594,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/small_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 200
@@ -2467,6 +2614,7 @@
     },
     "image_url": "/static/images/relics/tiny_mailbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 59
@@ -2486,6 +2634,7 @@
     },
     "image_url": "/static/images/relics/red_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 26
@@ -2505,6 +2654,7 @@
     },
     "image_url": "/static/images/relics/red_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 27
@@ -2524,6 +2674,7 @@
     },
     "image_url": "/static/images/relics/twisted_funnel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 60
@@ -2543,6 +2694,7 @@
     },
     "image_url": "/static/images/relics/venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 28
@@ -2562,6 +2714,7 @@
     },
     "image_url": "/static/images/relics/fake_venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 270
@@ -2577,6 +2730,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cursed_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 201
@@ -2596,6 +2750,7 @@
     },
     "image_url": "/static/images/relics/lava_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 148
@@ -2611,6 +2766,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lava_rock.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 202
@@ -2630,6 +2786,7 @@
     },
     "image_url": "/static/images/relics/lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 149
@@ -2649,6 +2806,7 @@
     },
     "image_url": "/static/images/relics/fake_lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 271
@@ -2670,6 +2828,7 @@
       "Necrobinder": "/static/images/relics/yummy_cookie_necrobinder.webp",
       "Regent": "/static/images/relics/yummy_cookie_regent.webp"
     },
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 203
@@ -2685,6 +2844,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lords_parasol.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 204
@@ -2704,6 +2864,7 @@
     },
     "image_url": "/static/images/relics/ruined_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 112
@@ -2723,6 +2884,7 @@
     },
     "image_url": "/static/images/relics/mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 113
@@ -2742,6 +2904,7 @@
     },
     "image_url": "/static/images/relics/fake_mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 272
@@ -2757,6 +2920,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bowler_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 61
@@ -2776,6 +2940,7 @@
     },
     "image_url": "/static/images/relics/metronome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 114
@@ -2795,6 +2960,7 @@
     },
     "image_url": "/static/images/relics/mini_regent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 115
@@ -2814,6 +2980,7 @@
     },
     "image_url": "/static/images/relics/miniature_cannon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 62
@@ -2833,6 +3000,7 @@
     },
     "image_url": "/static/images/relics/miniature_tent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 150
@@ -2852,6 +3020,7 @@
     },
     "image_url": "/static/images/relics/mystic_lighter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 151
@@ -2867,6 +3036,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/preserved_fog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 205
@@ -2886,6 +3056,7 @@
     },
     "image_url": "/static/images/relics/mummified_hand.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 116
@@ -2905,6 +3076,7 @@
     },
     "image_url": "/static/images/relics/happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 29
@@ -2924,6 +3096,7 @@
     },
     "image_url": "/static/images/relics/fake_happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 273
@@ -2939,6 +3112,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jewelry_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 206
@@ -2954,6 +3128,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jeweled_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 207
@@ -2969,6 +3144,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phylactery_unbound.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 2
@@ -2984,6 +3160,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/signet_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 208
@@ -2999,6 +3176,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bound_phylactery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 3
@@ -3014,6 +3192,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/music_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 209
@@ -3029,6 +3208,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/delicate_frond.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 210
@@ -3044,6 +3224,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_torment.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 211
@@ -3059,6 +3240,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_talisman.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 212
@@ -3074,6 +3256,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_bones.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 213
@@ -3089,6 +3272,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tea_of_discourtesy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 274
@@ -3108,6 +3292,7 @@
     },
     "image_url": "/static/images/relics/ninja_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 152
@@ -3127,6 +3312,7 @@
     },
     "image_url": "/static/images/relics/nunchaku.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -3146,6 +3332,7 @@
     },
     "image_url": "/static/images/relics/orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 64
@@ -3165,6 +3352,7 @@
     },
     "image_url": "/static/images/relics/fake_orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 275
@@ -3180,6 +3368,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/touch_of_orobas.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 214
@@ -3199,6 +3388,7 @@
     },
     "image_url": "/static/images/relics/game_piece.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 117
@@ -3214,6 +3404,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toy_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": [
       "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed.",
       "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
@@ -3233,6 +3424,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_flesh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 216
@@ -3248,6 +3440,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 217
@@ -3263,6 +3456,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 218
@@ -3278,6 +3472,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 219
@@ -3293,6 +3488,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 220
@@ -3308,6 +3504,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_wing.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 221
@@ -3323,6 +3520,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 222
@@ -3338,6 +3536,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_growth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 223
@@ -3353,6 +3552,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_claw.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 224
@@ -3368,6 +3568,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_legion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 225
@@ -3383,6 +3584,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pandoras_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 226
@@ -3402,6 +3604,7 @@
     },
     "image_url": "/static/images/relics/pantograph.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 65
@@ -3417,6 +3620,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pomander.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 227
@@ -3432,6 +3636,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/scroll_boxes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 228
@@ -3451,6 +3656,7 @@
     },
     "image_url": "/static/images/relics/dingy_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 153
@@ -3470,6 +3676,7 @@
     },
     "image_url": "/static/images/relics/cloak_clasp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 118
@@ -3485,6 +3692,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/claws.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 229
@@ -3504,6 +3712,7 @@
     },
     "image_url": "/static/images/relics/planisphere.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 66
@@ -3519,6 +3728,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pollinous_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 276
@@ -3534,6 +3744,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/prismatic_gem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 230
@@ -3553,6 +3764,7 @@
     },
     "image_url": "/static/images/relics/regalite.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 67
@@ -3572,6 +3784,7 @@
     },
     "image_url": "/static/images/relics/runic_capacitor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 154
@@ -3587,6 +3800,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/runic_pyramid.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 231
@@ -3602,6 +3816,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dream_catcher.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 277
@@ -3617,6 +3832,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/daughter_of_the_wind.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 278
@@ -3632,6 +3848,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 232
@@ -3651,6 +3868,7 @@
     },
     "image_url": "/static/images/relics/strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 30
@@ -3670,6 +3888,7 @@
     },
     "image_url": "/static/images/relics/fake_strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 279
@@ -3689,6 +3908,7 @@
     },
     "image_url": "/static/images/relics/pendulum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 31
@@ -3708,6 +3928,7 @@
     },
     "image_url": "/static/images/relics/helical_dart.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 119
@@ -3723,6 +3944,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/meat_cleaver.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 233
@@ -3742,6 +3964,7 @@
     },
     "image_url": "/static/images/relics/war_paint.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 32
@@ -3761,6 +3984,7 @@
     },
     "image_url": "/static/images/relics/art_of_war.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 120
@@ -3776,6 +4000,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/war_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 234
@@ -3795,6 +4020,7 @@
     },
     "image_url": "/static/images/relics/parrying_shield.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -3814,6 +4040,7 @@
     },
     "image_url": "/static/images/relics/tough_bandages.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 121
@@ -3833,6 +4060,7 @@
     },
     "image_url": "/static/images/relics/sturdy_clamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 122
@@ -3848,6 +4076,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/chosen_cheese.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 280
@@ -3863,6 +4092,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/choices_paradox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 235
@@ -3882,6 +4112,7 @@
     },
     "image_url": "/static/images/relics/shuriken.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 123
@@ -3897,6 +4128,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glitter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 236
@@ -3916,6 +4148,7 @@
     },
     "image_url": "/static/images/relics/symbiotic_virus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 69
@@ -3931,6 +4164,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/alchemical_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 237
@@ -3950,6 +4184,7 @@
     },
     "image_url": "/static/images/relics/vexing_puzzlebox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 124
@@ -3965,6 +4200,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 4
@@ -3984,6 +4220,7 @@
     },
     "image_url": "/static/images/relics/fake_snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 281
@@ -3999,6 +4236,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 238
@@ -4018,6 +4256,7 @@
     },
     "image_url": "/static/images/relics/snecko_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 33
@@ -4037,6 +4276,7 @@
     },
     "image_url": "/static/images/relics/permafrost.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 70
@@ -4052,6 +4292,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sozu.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 239
@@ -4067,6 +4308,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/driftwood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 240
@@ -4086,6 +4328,7 @@
     },
     "image_url": "/static/images/relics/reptile_trinket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 71
@@ -4105,6 +4348,7 @@
     },
     "image_url": "/static/images/relics/ornamental_fan.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 72
@@ -4120,6 +4364,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toasty_mittens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 241
@@ -4135,6 +4380,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tanxs_whistle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 242
@@ -4150,6 +4396,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/history_course.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 282
@@ -4165,6 +4412,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/circlet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "None",
     "compendium_order": 292
@@ -4180,6 +4428,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 283
@@ -4199,6 +4448,7 @@
     },
     "image_url": "/static/images/relics/stone_cracker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 73
@@ -4214,6 +4464,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/stone_humidifier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 243
@@ -4233,6 +4484,7 @@
     },
     "image_url": "/static/images/relics/stone_calendar.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 125
@@ -4252,6 +4504,7 @@
     },
     "image_url": "/static/images/relics/petrified_toad.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 74
@@ -4267,6 +4520,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precarious_shears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 244
@@ -4286,6 +4540,7 @@
     },
     "image_url": "/static/images/relics/tingsha.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -4301,6 +4556,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dusty_tome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 245
@@ -4320,6 +4576,7 @@
     },
     "image_url": "/static/images/relics/tungsten_rod.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 126
@@ -4339,6 +4596,7 @@
     },
     "image_url": "/static/images/relics/orange_dough.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 127
@@ -4354,6 +4612,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fake_merchants_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 284
@@ -4373,6 +4632,7 @@
     },
     "image_url": "/static/images/relics/joss_paper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 76
@@ -4388,6 +4648,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/forgotten_soul.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 285
@@ -4403,6 +4664,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/astrolabe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 246
@@ -4422,6 +4684,7 @@
     },
     "image_url": "/static/images/relics/vajra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 34
@@ -4441,6 +4704,7 @@
     },
     "image_url": "/static/images/relics/data_disk.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 35
@@ -4460,6 +4724,7 @@
     },
     "image_url": "/static/images/relics/vitruvian_minion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 155
@@ -4475,6 +4740,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/winged_boots.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 247
@@ -4490,6 +4756,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongo_customer_appreciation_badge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 286
@@ -4505,6 +4772,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongos_mystery_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 287
@@ -4520,6 +4788,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/burning_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 5
@@ -4539,6 +4808,7 @@
     },
     "image_url": "/static/images/relics/burning_sticks.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 156
@@ -4554,6 +4824,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/booming_conch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 248
@@ -4569,6 +4840,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/leafy_poultice.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 249
@@ -4588,6 +4860,7 @@
     },
     "image_url": "/static/images/relics/meal_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 36
@@ -4603,6 +4876,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/new_leaf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 250
@@ -4618,6 +4892,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_snake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 6
@@ -4637,6 +4912,7 @@
     },
     "image_url": "/static/images/relics/letter_opener.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 77
@@ -4652,6 +4928,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/beautiful_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 251
@@ -4671,6 +4948,7 @@
     },
     "image_url": "/static/images/relics/toxic_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 128
@@ -4686,6 +4964,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_jade.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 288
@@ -4705,6 +4984,7 @@
     },
     "image_url": "/static/images/relics/anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 37
@@ -4724,6 +5004,7 @@
     },
     "image_url": "/static/images/relics/fake_anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 289
@@ -4739,6 +5020,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cracked_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 7
@@ -4754,6 +5036,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/calling_bell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 252
@@ -4769,6 +5052,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/maw_bank.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 290
@@ -4788,6 +5072,7 @@
     },
     "image_url": "/static/images/relics/strawberry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 38
@@ -4803,6 +5088,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_boot.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 291
@@ -4822,6 +5108,7 @@
     },
     "image_url": "/static/images/relics/ringing_triangle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 157
@@ -4841,6 +5128,7 @@
     },
     "image_url": "/static/images/relics/screaming_flagon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 158
@@ -4860,6 +5148,7 @@
     },
     "image_url": "/static/images/relics/membership_card.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 159
@@ -4875,6 +5164,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tri_boomerang.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 253
@@ -4894,6 +5184,7 @@
     },
     "image_url": "/static/images/relics/potion_belt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 39
@@ -4909,6 +5200,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phial_holster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 254
@@ -4924,6 +5216,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_right.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 8
@@ -4939,6 +5232,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_destiny.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 9
@@ -4954,6 +5248,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/archaic_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 255
@@ -4969,6 +5264,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/large_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 256
@@ -4988,6 +5284,7 @@
     },
     "image_url": "/static/images/relics/candelabra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -5003,6 +5300,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lucky_fysh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 79
@@ -5022,6 +5320,7 @@
     },
     "image_url": "/static/images/relics/demon_tongue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 129

--- a/data/zhs/relics.json
+++ b/data/zhs/relics.json
@@ -10,6 +10,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tri_boomerang.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 160
@@ -29,6 +30,7 @@
     },
     "image_url": "/static/images/relics/ringing_triangle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 130
@@ -48,6 +50,7 @@
     },
     "image_url": "/static/images/relics/unceasing_top.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 80
@@ -67,6 +70,7 @@
     },
     "image_url": "/static/images/relics/unsettling_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 81
@@ -86,6 +90,7 @@
     },
     "image_url": "/static/images/relics/undying_sigil.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 131
@@ -105,6 +110,7 @@
     },
     "image_url": "/static/images/relics/bookmark.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 82
@@ -124,6 +130,7 @@
     },
     "image_url": "/static/images/relics/book_of_five_rings.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 10
@@ -139,6 +146,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glitter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 161
@@ -158,6 +166,7 @@
     },
     "image_url": "/static/images/relics/membership_card.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 132
@@ -173,6 +182,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/whispering_earring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 162
@@ -188,6 +198,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ember_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 257
@@ -207,6 +218,7 @@
     },
     "image_url": "/static/images/relics/juzu_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 11
@@ -222,6 +234,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 163
@@ -237,6 +250,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_claw.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 164
@@ -252,6 +266,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 165
@@ -267,6 +282,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 166
@@ -282,6 +298,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_wing.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 167
@@ -297,6 +314,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_flesh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 168
@@ -312,6 +330,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 169
@@ -327,6 +346,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 170
@@ -342,6 +362,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_growth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 171
@@ -357,6 +378,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/paels_legion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 172
@@ -376,6 +398,7 @@
     },
     "image_url": "/static/images/relics/book_repair_knife.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 40
@@ -395,6 +418,7 @@
     },
     "image_url": "/static/images/relics/symbiotic_virus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 41
@@ -414,6 +438,7 @@
     },
     "image_url": "/static/images/relics/ice_cream.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 83
@@ -433,6 +458,7 @@
     },
     "image_url": "/static/images/relics/frozen_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 84
@@ -452,6 +478,7 @@
     },
     "image_url": "/static/images/relics/bag_of_preparation.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 12
@@ -471,6 +498,7 @@
     },
     "image_url": "/static/images/relics/fencing_manual.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 13
@@ -486,6 +514,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/meat_cleaver.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 173
@@ -501,6 +530,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/claws.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 174
@@ -520,6 +550,7 @@
     },
     "image_url": "/static/images/relics/razor_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 85
@@ -539,6 +570,7 @@
     },
     "image_url": "/static/images/relics/sling_of_courage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 133
@@ -558,6 +590,7 @@
     },
     "image_url": "/static/images/relics/chemical_x.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 134
@@ -573,6 +606,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/crossbow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 175
@@ -588,6 +622,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/beautiful_bracelet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 176
@@ -603,6 +638,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/distinguished_cape.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 177
@@ -618,6 +654,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pumpkin_candle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 178
@@ -637,6 +674,7 @@
     },
     "image_url": "/static/images/relics/charons_ashes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 86
@@ -652,6 +690,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/scroll_boxes.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 179
@@ -667,6 +706,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/history_course.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 258
@@ -686,6 +726,7 @@
     },
     "image_url": "/static/images/relics/stone_calendar.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 87
@@ -701,6 +742,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sere_talon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 180
@@ -720,6 +762,7 @@
     },
     "image_url": "/static/images/relics/nunchaku.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 42
@@ -735,6 +778,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/radiant_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 181
@@ -750,6 +794,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_boot.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 259
@@ -765,6 +810,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/archaic_tooth.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 182
@@ -784,6 +830,7 @@
     },
     "image_url": "/static/images/relics/venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 14
@@ -803,6 +850,7 @@
     },
     "image_url": "/static/images/relics/fake_venerable_tea_set.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 260
@@ -818,6 +866,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/old_coin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 88
@@ -833,6 +882,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/calling_bell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 183
@@ -852,6 +902,7 @@
     },
     "image_url": "/static/images/relics/lasting_candy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 43
@@ -871,6 +922,7 @@
     },
     "image_url": "/static/images/relics/chandelier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 89
@@ -890,6 +942,7 @@
     },
     "image_url": "/static/images/relics/regalite.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 44
@@ -905,6 +958,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fake_merchants_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 261
@@ -920,6 +974,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/signet_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 184
@@ -935,6 +990,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bowler_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 45
@@ -954,6 +1010,7 @@
     },
     "image_url": "/static/images/relics/gremlin_horn.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 46
@@ -973,6 +1030,7 @@
     },
     "image_url": "/static/images/relics/sturdy_clamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 90
@@ -988,6 +1046,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tanxs_whistle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 185
@@ -1007,6 +1066,7 @@
     },
     "image_url": "/static/images/relics/girya.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 91
@@ -1026,6 +1086,7 @@
     },
     "image_url": "/static/images/relics/dollys_mirror.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 135
@@ -1045,6 +1106,7 @@
     },
     "image_url": "/static/images/relics/big_hat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 92
@@ -1060,6 +1122,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/big_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 262
@@ -1079,6 +1142,7 @@
     },
     "image_url": "/static/images/relics/cauldron.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 136
@@ -1094,6 +1158,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/biiig_hug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 186
@@ -1109,6 +1174,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_destiny.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 0
@@ -1124,6 +1190,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/divine_right.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 1
@@ -1139,6 +1206,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/chosen_cheese.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 263
@@ -1154,6 +1222,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/velvet_choker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 187
@@ -1169,6 +1238,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 188
@@ -1184,6 +1254,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/circlet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "None",
     "compendium_order": 292
@@ -1203,6 +1274,7 @@
     },
     "image_url": "/static/images/relics/orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 47
@@ -1222,6 +1294,7 @@
     },
     "image_url": "/static/images/relics/fake_orichalcum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 264
@@ -1237,6 +1310,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/arcane_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 189
@@ -1252,6 +1326,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/delicate_frond.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 190
@@ -1271,6 +1346,7 @@
     },
     "image_url": "/static/images/relics/art_of_war.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 93
@@ -1286,6 +1362,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jeweled_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 191
@@ -1301,6 +1378,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bing_bong.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 265
@@ -1316,6 +1394,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/small_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 192
@@ -1331,6 +1410,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fiddle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 193
@@ -1350,6 +1430,7 @@
     },
     "image_url": "/static/images/relics/blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 15
@@ -1369,6 +1450,7 @@
     },
     "image_url": "/static/images/relics/fake_blood_vial.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 266
@@ -1388,6 +1470,7 @@
     },
     "image_url": "/static/images/relics/tiny_mailbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 48
@@ -1407,6 +1490,7 @@
     },
     "image_url": "/static/images/relics/screaming_flagon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 137
@@ -1422,6 +1506,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dusty_tome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 194
@@ -1441,6 +1526,7 @@
     },
     "image_url": "/static/images/relics/toolbox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 138
@@ -1456,6 +1542,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/maw_bank.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 267
@@ -1471,6 +1558,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/massive_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 195
@@ -1486,6 +1574,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/large_capsule.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 196
@@ -1504,6 +1593,7 @@
       "Cornucopia": "/static/images/relics/looming_fruit.webp",
       "Fruit": "/static/images/relics/looming_fruit_2.webp"
     },
+    "name_variants": null,
     "notes": [
       "Looming Fruit ships two icons (Cornucopia and Fruit). The game picks one per save based on whether your save's UniqueId ends in an even or odd digit, so half the playerbase sees each variant.",
       "Both variants are functionally identical — same +31 Max HP effect — and the choice is permanent for a given save file. Use the toggle above to preview the one your save shows."
@@ -1522,6 +1612,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/spiked_gauntlets.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 198
@@ -1541,6 +1632,7 @@
     },
     "image_url": "/static/images/relics/meat_on_the_bone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 94
@@ -1560,6 +1652,7 @@
     },
     "image_url": "/static/images/relics/mummified_hand.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 95
@@ -1579,6 +1672,7 @@
     },
     "image_url": "/static/images/relics/ghost_seed.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 139
@@ -1598,6 +1692,7 @@
     },
     "image_url": "/static/images/relics/letter_opener.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 49
@@ -1617,6 +1712,7 @@
     },
     "image_url": "/static/images/relics/happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 16
@@ -1636,6 +1732,7 @@
     },
     "image_url": "/static/images/relics/fake_happy_flower.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 268
@@ -1651,6 +1748,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 199
@@ -1670,6 +1768,7 @@
     },
     "image_url": "/static/images/relics/fake_snecko_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 269
@@ -1689,6 +1788,7 @@
     },
     "image_url": "/static/images/relics/snecko_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 17
@@ -1704,6 +1804,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/byrdpip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 270
@@ -1723,6 +1824,7 @@
     },
     "image_url": "/static/images/relics/bag_of_marbles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 18
@@ -1742,6 +1844,7 @@
     },
     "image_url": "/static/images/relics/rainbow_ring.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 96
@@ -1761,6 +1864,7 @@
     },
     "image_url": "/static/images/relics/beating_remnant.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 97
@@ -1780,6 +1884,7 @@
     },
     "image_url": "/static/images/relics/miniature_cannon.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 50
@@ -1799,6 +1904,7 @@
     },
     "image_url": "/static/images/relics/miniature_tent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 140
@@ -1818,6 +1924,7 @@
     },
     "image_url": "/static/images/relics/ninja_scroll.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 141
@@ -1837,6 +1944,7 @@
     },
     "image_url": "/static/images/relics/pocketwatch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 98
@@ -1856,6 +1964,7 @@
     },
     "image_url": "/static/images/relics/demon_tongue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 99
@@ -1875,6 +1984,7 @@
     },
     "image_url": "/static/images/relics/emotion_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 100
@@ -1894,6 +2004,7 @@
     },
     "image_url": "/static/images/relics/oddly_smooth_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 19
@@ -1913,6 +2024,7 @@
     },
     "image_url": "/static/images/relics/war_paint.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 20
@@ -1928,6 +2040,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/war_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 200
@@ -1947,6 +2060,7 @@
     },
     "image_url": "/static/images/relics/shuriken.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 101
@@ -1962,6 +2076,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hand_drill.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 271
@@ -1981,6 +2096,7 @@
     },
     "image_url": "/static/images/relics/strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 21
@@ -2000,6 +2116,7 @@
     },
     "image_url": "/static/images/relics/fake_strike_dummy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 272
@@ -2019,6 +2136,7 @@
     },
     "image_url": "/static/images/relics/twisted_funnel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 51
@@ -2038,6 +2156,7 @@
     },
     "image_url": "/static/images/relics/gnarled_hammer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 142
@@ -2053,6 +2172,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/throwing_axe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 201
@@ -2072,6 +2192,7 @@
     },
     "image_url": "/static/images/relics/gorget.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 22
@@ -2087,6 +2208,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/mr_struggles.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 273
@@ -2106,6 +2228,7 @@
     },
     "image_url": "/static/images/relics/parrying_shield.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 52
@@ -2121,6 +2244,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lucky_fysh.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 53
@@ -2140,6 +2264,7 @@
     },
     "image_url": "/static/images/relics/punch_dagger.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 143
@@ -2155,6 +2280,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/dream_catcher.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 274
@@ -2174,6 +2300,7 @@
     },
     "image_url": "/static/images/relics/ruined_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 102
@@ -2193,6 +2320,7 @@
     },
     "image_url": "/static/images/relics/pendulum.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 23
@@ -2208,6 +2336,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/electric_shrymp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 202
@@ -2223,6 +2352,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/storybook.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 203
@@ -2242,6 +2372,7 @@
     },
     "image_url": "/static/images/relics/data_disk.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 24
@@ -2261,6 +2392,7 @@
     },
     "image_url": "/static/images/relics/cloak_clasp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 103
@@ -2276,6 +2408,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/new_leaf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 204
@@ -2291,6 +2424,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phylactery_unbound.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 2
@@ -2306,6 +2440,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/tea_of_discourtesy.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 275
@@ -2321,6 +2456,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongo_customer_appreciation_badge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 276
@@ -2336,6 +2472,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/wongos_mystery_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 277
@@ -2351,6 +2488,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/astrolabe.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 205
@@ -2370,6 +2508,7 @@
     },
     "image_url": "/static/images/relics/orrery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 144
@@ -2389,6 +2528,7 @@
     },
     "image_url": "/static/images/relics/galactic_dust.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 54
@@ -2408,6 +2548,7 @@
     },
     "image_url": "/static/images/relics/lunar_pastry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 104
@@ -2427,6 +2568,7 @@
     },
     "image_url": "/static/images/relics/kifuda.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 145
@@ -2446,6 +2588,7 @@
     },
     "image_url": "/static/images/relics/lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 146
@@ -2465,6 +2608,7 @@
     },
     "image_url": "/static/images/relics/fake_lees_waffle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 278
@@ -2480,6 +2624,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precarious_shears.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 206
@@ -2495,6 +2640,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/leafy_poultice.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 207
@@ -2514,6 +2660,7 @@
     },
     "image_url": "/static/images/relics/pear.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 55
@@ -2533,6 +2680,7 @@
     },
     "image_url": "/static/images/relics/game_piece.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 105
@@ -2548,6 +2696,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/prismatic_gem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 208
@@ -2563,6 +2712,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pomander.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 209
@@ -2582,6 +2732,7 @@
     },
     "image_url": "/static/images/relics/orange_dough.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 106
@@ -2597,6 +2748,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/touch_of_orobas.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 210
@@ -2616,6 +2768,7 @@
     },
     "image_url": "/static/images/relics/toxic_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 107
@@ -2635,6 +2788,7 @@
     },
     "image_url": "/static/images/relics/mercury_hourglass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 56
@@ -2654,6 +2808,7 @@
     },
     "image_url": "/static/images/relics/permafrost.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 57
@@ -2673,6 +2828,7 @@
     },
     "image_url": "/static/images/relics/eternal_feather.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 58
@@ -2688,6 +2844,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/hefty_tablet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 211
@@ -2703,6 +2860,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sand_castle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 212
@@ -2722,6 +2880,7 @@
     },
     "image_url": "/static/images/relics/ripple_basin.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 59
@@ -2737,6 +2896,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/infused_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 3
@@ -2756,6 +2916,7 @@
     },
     "image_url": "/static/images/relics/planisphere.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 60
@@ -2771,6 +2932,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/driftwood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 213
@@ -2786,6 +2948,13 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sea_glass.webp",
     "image_variants": null,
+    "name_variants": {
+      "Ironclad": "恶魔玻璃",
+      "Silent": "毒液玻璃",
+      "Defect": "齿轮玻璃",
+      "Necrobinder": "巫妖玻璃",
+      "Regent": "贵族玻璃"
+    },
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 214
@@ -2801,6 +2970,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_talisman.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 215
@@ -2816,6 +2986,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_torment.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 216
@@ -2831,6 +3002,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/neows_bones.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 217
@@ -2846,6 +3018,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sozu.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 218
@@ -2861,6 +3034,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pandoras_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 219
@@ -2880,6 +3054,7 @@
     },
     "image_url": "/static/images/relics/dragon_fruit.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 147
@@ -2899,6 +3074,7 @@
     },
     "image_url": "/static/images/relics/lantern.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 25
@@ -2914,6 +3090,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ectoplasm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 220
@@ -2929,6 +3106,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/alchemical_coffer.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 221
@@ -2944,6 +3122,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toasty_mittens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 222
@@ -2963,6 +3142,7 @@
     },
     "image_url": "/static/images/relics/candelabra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 61
@@ -2982,6 +3162,7 @@
     },
     "image_url": "/static/images/relics/vexing_puzzlebox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 108
@@ -2997,6 +3178,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/very_hot_cocoa.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 223
@@ -3016,6 +3198,7 @@
     },
     "image_url": "/static/images/relics/lava_lamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 148
@@ -3031,6 +3214,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lava_rock.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 224
@@ -3050,6 +3234,7 @@
     },
     "image_url": "/static/images/relics/molten_egg.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 109
@@ -3065,6 +3250,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/burning_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 4
@@ -3084,6 +3270,7 @@
     },
     "image_url": "/static/images/relics/burning_sticks.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 149
@@ -3103,6 +3290,7 @@
     },
     "image_url": "/static/images/relics/reptile_trinket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 62
@@ -3118,6 +3306,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_jade.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 279
@@ -3137,6 +3326,7 @@
     },
     "image_url": "/static/images/relics/royal_stamp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 150
@@ -3152,6 +3342,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/royal_poison.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 280
@@ -3167,6 +3358,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/toy_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": [
       "Wax Relics are pulled from the normal relic pool — any non-Ancient relic can be waxed.",
       "Wax Relic rarity: 50% Common, 33% Uncommon, 17% Rare (standard relic rarity roll).",
@@ -3186,6 +3378,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/glass_eye.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 226
@@ -3201,6 +3394,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/jewelry_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 227
@@ -3220,6 +3414,7 @@
     },
     "image_url": "/static/images/relics/white_beast_statue.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 110
@@ -3239,6 +3434,7 @@
     },
     "image_url": "/static/images/relics/white_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 111
@@ -3254,6 +3450,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/silver_crucible.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 228
@@ -3273,6 +3470,7 @@
     },
     "image_url": "/static/images/relics/centennial_puzzle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 26
@@ -3292,6 +3490,7 @@
     },
     "image_url": "/static/images/relics/regal_pillow.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 27
@@ -3307,6 +3506,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fur_coat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 229
@@ -3322,6 +3522,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sword_of_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 281
@@ -3341,6 +3542,7 @@
     },
     "image_url": "/static/images/relics/petrified_toad.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 63
@@ -3356,6 +3558,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/stone_humidifier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 230
@@ -3371,6 +3574,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cracked_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 5
@@ -3390,6 +3594,7 @@
     },
     "image_url": "/static/images/relics/brimstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 151
@@ -3409,6 +3614,7 @@
     },
     "image_url": "/static/images/relics/stone_cracker.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 64
@@ -3428,6 +3634,7 @@
     },
     "image_url": "/static/images/relics/whetstone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 28
@@ -3447,6 +3654,7 @@
     },
     "image_url": "/static/images/relics/mystic_lighter.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 152
@@ -3462,6 +3670,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/empty_cage.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 231
@@ -3481,6 +3690,7 @@
     },
     "image_url": "/static/images/relics/runic_capacitor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 153
@@ -3496,6 +3706,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/runic_pyramid.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 232
@@ -3515,6 +3726,7 @@
     },
     "image_url": "/static/images/relics/the_abacus.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 154
@@ -3530,6 +3742,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/precise_scissors.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 233
@@ -3549,6 +3762,7 @@
     },
     "image_url": "/static/images/relics/ornamental_fan.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 65
@@ -3564,6 +3778,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/amethyst_aubergine.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 29
@@ -3583,6 +3798,7 @@
     },
     "image_url": "/static/images/relics/red_skull.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 30
@@ -3602,6 +3818,7 @@
     },
     "image_url": "/static/images/relics/red_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 31
@@ -3621,6 +3838,7 @@
     },
     "image_url": "/static/images/relics/paper_phrog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 66
@@ -3640,6 +3858,7 @@
     },
     "image_url": "/static/images/relics/paper_krane.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 112
@@ -3659,6 +3878,7 @@
     },
     "image_url": "/static/images/relics/tough_bandages.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 113
@@ -3678,6 +3898,7 @@
     },
     "image_url": "/static/images/relics/vitruvian_minion.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 155
@@ -3693,6 +3914,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bound_phylactery.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 6
@@ -3712,6 +3934,7 @@
     },
     "image_url": "/static/images/relics/pantograph.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 67
@@ -3733,6 +3956,7 @@
       "Necrobinder": "/static/images/relics/yummy_cookie_necrobinder.webp",
       "Regent": "/static/images/relics/yummy_cookie_regent.webp"
     },
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 234
@@ -3748,6 +3972,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/winged_boots.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 235
@@ -3767,6 +3992,7 @@
     },
     "image_url": "/static/images/relics/wing_charm.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 156
@@ -3786,6 +4012,7 @@
     },
     "image_url": "/static/images/relics/dingy_rug.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 157
@@ -3805,6 +4032,7 @@
     },
     "image_url": "/static/images/relics/power_cell.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 114
@@ -3820,6 +4048,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/preserved_fog.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 236
@@ -3839,6 +4068,7 @@
     },
     "image_url": "/static/images/relics/belt_buckle.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 158
@@ -3858,6 +4088,7 @@
     },
     "image_url": "/static/images/relics/vambrace.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 68
@@ -3877,6 +4108,7 @@
     },
     "image_url": "/static/images/relics/self_forming_clay.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 69
@@ -3896,6 +4128,7 @@
     },
     "image_url": "/static/images/relics/captains_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 115
@@ -3915,6 +4148,7 @@
     },
     "image_url": "/static/images/relics/horn_cleat.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 70
@@ -3930,6 +4164,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/brilliant_scarf.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 237
@@ -3949,6 +4184,7 @@
     },
     "image_url": "/static/images/relics/metronome.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 116
@@ -3968,6 +4204,7 @@
     },
     "image_url": "/static/images/relics/festive_popper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 32
@@ -3987,6 +4224,7 @@
     },
     "image_url": "/static/images/relics/mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 117
@@ -4006,6 +4244,7 @@
     },
     "image_url": "/static/images/relics/fake_mango.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 282
@@ -4021,6 +4260,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/pollinous_core.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 283
@@ -4036,6 +4276,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fragrant_mushroom.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 284
@@ -4055,6 +4296,7 @@
     },
     "image_url": "/static/images/relics/kunai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 118
@@ -4074,6 +4316,7 @@
     },
     "image_url": "/static/images/relics/strawberry.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 33
@@ -4093,6 +4336,7 @@
     },
     "image_url": "/static/images/relics/potion_belt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 34
@@ -4108,6 +4352,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/phial_holster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 238
@@ -4123,6 +4368,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/fresnel_lens.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 285
@@ -4138,6 +4384,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_soup.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 239
@@ -4153,6 +4400,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/nutritious_oyster.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 240
@@ -4172,6 +4420,7 @@
     },
     "image_url": "/static/images/relics/funerary_mask.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 71
@@ -4187,6 +4436,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_snake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 7
@@ -4206,6 +4456,7 @@
     },
     "image_url": "/static/images/relics/lizard_tail.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 119
@@ -4225,6 +4476,7 @@
     },
     "image_url": "/static/images/relics/helical_dart.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 120
@@ -4240,6 +4492,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blood_soaked_rose.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 241
@@ -4255,6 +4508,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/cursed_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 242
@@ -4274,6 +4528,7 @@
     },
     "image_url": "/static/images/relics/ivory_tile.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 121
@@ -4289,6 +4544,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/philosophers_stone.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 243
@@ -4308,6 +4564,7 @@
     },
     "image_url": "/static/images/relics/gambling_chip.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 122
@@ -4323,6 +4580,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/blessed_antler.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 244
@@ -4342,6 +4600,7 @@
     },
     "image_url": "/static/images/relics/akabeko.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 72
@@ -4361,6 +4620,7 @@
     },
     "image_url": "/static/images/relics/prayer_wheel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 123
@@ -4376,6 +4636,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/booming_conch.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 245
@@ -4395,6 +4656,7 @@
     },
     "image_url": "/static/images/relics/mini_regent.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 124
@@ -4410,6 +4672,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lost_wisp.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 286
@@ -4425,6 +4688,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/the_courier.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 125
@@ -4440,6 +4704,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/choices_paradox.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 246
@@ -4455,6 +4720,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/forgotten_soul.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 287
@@ -4474,6 +4740,7 @@
     },
     "image_url": "/static/images/relics/vajra.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 35
@@ -4493,6 +4760,7 @@
     },
     "image_url": "/static/images/relics/joss_paper.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 73
@@ -4508,6 +4776,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_pearl.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 247
@@ -4523,6 +4792,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/sai.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 248
@@ -4542,6 +4812,7 @@
     },
     "image_url": "/static/images/relics/pen_nib.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 74
@@ -4561,6 +4832,7 @@
     },
     "image_url": "/static/images/relics/tungsten_rod.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 126
@@ -4576,6 +4848,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/diamond_diadem.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 249
@@ -4591,6 +4864,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/iron_club.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 250
@@ -4606,6 +4880,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lead_paperweight.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 251
@@ -4625,6 +4900,7 @@
     },
     "image_url": "/static/images/relics/bronze_scales.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 36
@@ -4644,6 +4920,7 @@
     },
     "image_url": "/static/images/relics/tingsha.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 75
@@ -4663,6 +4940,7 @@
     },
     "image_url": "/static/images/relics/shovel.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 127
@@ -4682,6 +4960,7 @@
     },
     "image_url": "/static/images/relics/kusarigama.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 76
@@ -4701,6 +4980,7 @@
     },
     "image_url": "/static/images/relics/anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 37
@@ -4720,6 +5000,7 @@
     },
     "image_url": "/static/images/relics/fake_anchor.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 288
@@ -4739,6 +5020,7 @@
     },
     "image_url": "/static/images/relics/gold_plated_cables.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 77
@@ -4754,6 +5036,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/ring_of_the_drake.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 8
@@ -4773,6 +5056,7 @@
     },
     "image_url": "/static/images/relics/sparkling_rouge.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 78
@@ -4792,6 +5076,7 @@
     },
     "image_url": "/static/images/relics/bread.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Shop",
     "compendium_order": 159
@@ -4807,6 +5092,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/music_box.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 252
@@ -4826,6 +5112,7 @@
     },
     "image_url": "/static/images/relics/tuning_fork.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Uncommon",
     "compendium_order": 79
@@ -4841,6 +5128,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/lords_parasol.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 253
@@ -4856,6 +5144,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/daughter_of_the_wind.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 289
@@ -4875,6 +5164,7 @@
     },
     "image_url": "/static/images/relics/bellows.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 128
@@ -4894,6 +5184,7 @@
     },
     "image_url": "/static/images/relics/meal_ticket.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 38
@@ -4913,6 +5204,7 @@
     },
     "image_url": "/static/images/relics/intimidating_helmet.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Rare",
     "compendium_order": 129
@@ -4932,6 +5224,7 @@
     },
     "image_url": "/static/images/relics/bone_flute.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Common",
     "compendium_order": 39
@@ -4947,6 +5240,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/bone_tea.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 290
@@ -4962,6 +5256,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/seal_of_gold.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 254
@@ -4977,6 +5272,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/golden_compass.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 255
@@ -4992,6 +5288,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_star.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Ancient",
     "compendium_order": 256
@@ -5007,6 +5304,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/black_blood.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Starter",
     "compendium_order": 9
@@ -5022,6 +5320,7 @@
     "merchant_price": null,
     "image_url": "/static/images/relics/darkstone_periapt.webp",
     "image_variants": null,
+    "name_variants": null,
     "notes": null,
     "rarity_key": "Event",
     "compendium_order": 291

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -150,6 +150,26 @@ export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | n
           <span className="text-[var(--text-muted)] capitalize">{relic.pool}</span>
         </div>
 
+        {/* Per-character display name overrides — Sea Glass renames itself
+            ("Demon Glass" for Ironclad, "Venom Glass" for Silent, etc.).
+            Surfaced as a single line under the rarity/pool row so visitors
+            can find each variant by name without scrolling. */}
+        {relic.name_variants && Object.keys(relic.name_variants).length > 0 && (
+          <div className="mb-6 -mt-2 text-center">
+            <p className="text-xs text-[var(--text-muted)] mb-1">
+              {t("Known as", lang)}:
+            </p>
+            <div className="flex flex-wrap gap-x-3 gap-y-1 justify-center text-sm">
+              {Object.entries(relic.name_variants).map(([char, variantName]) => (
+                <span key={char}>
+                  <span className="text-[var(--accent-gold)]">{variantName}</span>
+                  <span className="text-[var(--text-muted)]"> ({char})</span>
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* Tabs */}
         <div className="flex gap-1 mb-5 border-b border-[var(--border-subtle)]">
           {tabs.map((tb) => (

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -127,6 +127,11 @@ export interface Relic {
   merchant_price: MerchantPrice | null;
   image_url: string | null;
   image_variants: Record<string, string> | null;
+  // Per-character title overrides — only populated for relics whose
+  // displayed name changes by character (today: just Sea Glass →
+  // Demon/Venom/Gear/Lich/Noble Glass). Keys are character display
+  // names (Ironclad, Silent, Defect, Necrobinder, Regent).
+  name_variants: Record<string, string> | null;
   notes: string[] | null;
   compendium_order: number;
 }


### PR DESCRIPTION
## Summary

Confirmed the Discord report — **Sea Glass renames itself by character** and we weren't surfacing it.

The five variants live in `relics.json` localization as `SEA_GLASS.<CHAR>.title` keys, but the parser was only reading the base `SEA_GLASS.title`. Result: the relic page just said "Sea Glass" with no hint that holders saw "Demon Glass" / "Venom Glass" / etc. in-game.

| Character | Variant name |
| --- | --- |
| Ironclad | Demon Glass |
| Silent | Venom Glass |
| Defect | Gear Glass |
| Necrobinder | Lich Glass |
| Regent | Noble Glass |

(All 14 languages translate the variants — Dämonenglas, デーモングラス, 恶魔玻璃, etc.)

## What changed

- **`relic_parser.py`** — walks the 5 character keys per relic and emits any non-default title overrides as a generic `name_variants` dict. Only Sea Glass populates it today; future per-character relics light up automatically.
- **All 14 languages re-parsed** — `data/<lang>/relics.json` now carries the localized variant names.
- **`Relic` interface** — gains optional `name_variants: Record<string, string>` field.
- **`/relics/[id]`** — renders a "Known as: Demon Glass (Ironclad), Venom Glass (Silent), …" row under the rarity/pool line when populated. No-op for the other 292 relics.

## No image variants

Sea Glass uses one shared `sea_glass.png` for all five characters — no per-character art. Just the title changes.
