### PR TITLE
Surface per-character relic expansion on /ancients

### DIFF
--- a/backend/app/routers/ancient_pools.py
+++ b/backend/app/routers/ancient_pools.py
@@ -10,21 +10,47 @@ router = APIRouter(prefix="/api/ancient-pools", tags=["Ancient Pools"])
 
 
 def _load_pools() -> list[dict]:
-    """Load ancient_pools.json.
+    """Load ancient_pools.json and enrich each entry with the parser's
+    `per_character_relics` set (relic IDs the ancient offers as 5
+    distinct character-skinned options in-game — currently just
+    SEA_GLASS via Orobas's DiscoveryTotems).
 
     Tries the version-resolved base first (so beta versions can ship their own
     file), then falls back to DATA_DIR so an unversioned file at the data root
-    works for both stable and beta layouts.
+    works for both stable and beta layouts. Same lookup order for the
+    parsed companion file so a beta drop can override its enrichment.
     """
     candidates = [
         _resolve_base(_get_version()) / "ancient_pools.json",
         DATA_DIR / "ancient_pools.json",
     ]
+    pools: list[dict] = []
     for path in candidates:
         if path.exists():
             with open(path, "r", encoding="utf-8") as f:
-                return json.load(f)
-    return []
+                pools = json.load(f)
+            break
+    if not pools:
+        return []
+
+    # Merge the parser's per-character expansion data. Lookup is best-effort:
+    # if the parsed file is missing (parser hasn't run yet), the response
+    # is identical to the hand file alone — `per_character_relics` just
+    # stays absent so the frontend treats every relic as single-option.
+    parsed_candidates = [
+        _resolve_base(_get_version()) / "ancient_pools_parsed.json",
+        DATA_DIR / "ancient_pools_parsed.json",
+    ]
+    parsed: dict[str, list[str]] = {}
+    for path in parsed_candidates:
+        if path.exists():
+            with open(path, "r", encoding="utf-8") as f:
+                for entry in json.load(f):
+                    parsed[entry["id"]] = entry.get("per_character_relics") or []
+            break
+    for ancient in pools:
+        ancient["per_character_relics"] = parsed.get(ancient["id"], [])
+    return pools
 
 
 @router.get("", tags=["Ancient Pools"])

--- a/frontend/app/ancients/AncientsClient.tsx
+++ b/frontend/app/ancients/AncientsClient.tsx
@@ -25,6 +25,11 @@ interface AncientPool {
   description: string;
   selection: string;
   pools: Pool[];
+  // Relic IDs this ancient offers as 5 distinct in-game options, one
+  // per character (e.g. Orobas's Sea Glass via DiscoveryTotems —
+  // shows up as Demon/Venom/Gear/Lich/Noble Glass). Sourced from the
+  // ancient_pool_parser, merged into the response by the router.
+  per_character_relics?: string[];
 }
 
 interface RelicInfo {
@@ -33,19 +38,32 @@ interface RelicInfo {
   description: string;
   image_url: string | null;
   rarity: string;
+  // Per-character display-name overrides — only Sea Glass populates
+  // this today. Maps character display name → variant title (e.g.
+  // {Ironclad: "Demon Glass", ...}).
+  name_variants?: Record<string, string> | null;
 }
 
 function RelicPill({
   relic,
   relicData,
   lp,
+  isPerCharacter,
 }: {
   relic: PoolRelic;
   relicData: Record<string, RelicInfo>;
   lp: string;
+  isPerCharacter: boolean;
 }) {
   const info = relicData[relic.id];
   const name = info?.name || relic.id.replace(/_/g, " ").toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase());
+  // Order matches how the game iterates ModelDb.AllCharacters.
+  const charOrder = ["Ironclad", "Silent", "Defect", "Necrobinder", "Regent"];
+  const variants = info?.name_variants
+    ? charOrder
+        .filter((c) => info.name_variants && info.name_variants[c])
+        .map((c) => ({ char: c, name: info.name_variants![c] }))
+    : [];
 
   return (
     <div className="flex items-start gap-3 py-2">
@@ -65,11 +83,25 @@ function RelicPill({
           {name}
         </span>
       </Link>
-      {relic.condition && (
-        <span className="text-xs text-[var(--text-muted)] italic leading-relaxed pt-0.5">
-          {relic.condition}
-        </span>
-      )}
+      <div className="flex flex-col gap-0.5 pt-0.5">
+        {relic.condition && (
+          <span className="text-xs text-[var(--text-muted)] italic leading-relaxed">
+            {relic.condition}
+          </span>
+        )}
+        {isPerCharacter && variants.length > 0 && (
+          <span className="text-xs text-[var(--text-muted)] leading-relaxed">
+            <span className="italic">Shows as 5 separate options:</span>{" "}
+            {variants.map((v, i) => (
+              <span key={v.char}>
+                <span className="text-[var(--accent-gold)]">{v.name}</span>
+                <span className="text-[var(--text-muted)]"> ({v.char})</span>
+                {i < variants.length - 1 ? ", " : ""}
+              </span>
+            ))}
+          </span>
+        )}
+      </div>
     </div>
   );
 }
@@ -126,7 +158,13 @@ function AncientSection({
                 )}
                 <div className="divide-y divide-[var(--border-subtle)]">
                   {pool.relics.map((relic) => (
-                    <RelicPill key={relic.id} relic={relic} relicData={relicData} lp={lp} />
+                    <RelicPill
+                      key={relic.id}
+                      relic={relic}
+                      relicData={relicData}
+                      lp={lp}
+                      isPerCharacter={!!ancient.per_character_relics?.includes(relic.id)}
+                    />
                   ))}
                 </div>
               </div>


### PR DESCRIPTION
## Summary

When an ancient offers a relic that the game expands into 5 distinct character-specific options (today: only **Orobas → Sea Glass** via the `DiscoveryTotems` pool), the relic pill on `/ancients` now lists all 5 variants inline. UI-only — no parser changes.

## Render

Under each `SEA_GLASS` entry on the Orobas section:

```
Sea Glass    67% chance (vs Prismatic Gem); character is random unlocked non-current
             Shows as 5 separate options: Demon Glass (Ironclad), Venom Glass (Silent),
             Gear Glass (Defect), Lich Glass (Necrobinder), Noble Glass (Regent)
```

Variant order matches `ModelDb.AllCharacters` from the C# source.

## What changed

- `backend/app/routers/ancient_pools.py` — enriches each pool entry with `per_character_relics` from `data/ancient_pools_parsed.json`. Best-effort: if the parsed file is missing, the endpoint behaves identically to before.
- `frontend/app/ancients/AncientsClient.tsx` — `RelicPill` takes a new `isPerCharacter` prop and renders the variant list using the existing `name_variants` field from `/api/relics`.

## Dependencies

Depends on **PR #195** for the underlying data (`name_variants` on relics, `per_character_relics` on parsed pools). UI degrades to no-op when the fields are absent, so this PR is safe to land before or after #195 — but you'll only see the new line on the page after both are merged + deployed.

## Diff

2 files changed, 74 insertions(+), 10 deletions(-).
