### PR TITLE
Declare name_variants on Relic Pydantic schema

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -113,6 +113,12 @@ class Relic(BaseModel):
     merchant_price: MerchantPrice | None = None
     image_url: str | None = None
     image_variants: dict[str, str] | None = None
+    # Per-character title overrides — only Sea Glass populates this
+    # today (Demon Glass for Ironclad, Venom Glass for Silent, etc.).
+    # Pydantic's response_model would silently strip the field if it
+    # weren't declared here; the parser writes it but FastAPI dropped
+    # it on the way out.
+    name_variants: dict[str, str] | None = None
     notes: list[str] | None = None
     compendium_order: int = 0
 


### PR DESCRIPTION
## Why nothing rendered

PR #195 added `name_variants` to the parser output and `data/<lang>/relics.json` correctly contains:

```json
"name_variants": {"Ironclad": "Demon Glass", "Silent": "Venom Glass", ...}
```

…but `GET /api/relics/SEA_GLASS` on prod returns no such field. That's because the relic endpoints are wrapped in `response_model=Relic`, and FastAPI silently strips any key that isn't declared on the Pydantic schema. The field made it into the JSON file, never made it through the API.

## Fix

Declare `name_variants: dict[str, str] | None = None` on `class Relic(BaseModel)` in `backend/app/models/schemas.py`.

## After deploy

- `GET /api/relics/SEA_GLASS` includes `name_variants`
- `/relics/sea_glass` shows the "Known as" line under the rarity row
- `/ancients` (Orobas section) shows the per-character expansion on the Sea Glass pill (PR #196)

## Diff

1 file, 6 insertions (5 lines of comment + 1 field). Identical schema treatment that `image_variants` already gets.
