### PR TITLE
Steam OpenID auth + privacy/terms pages for Overwolf launch

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,6 +51,7 @@ from .routers import (
     news,
     merchant,
     mechanics,
+    auth_steam,
 )
 from .services.data_service import get_stats, load_translation_maps, current_version
 from .dependencies import get_lang, VALID_LANGUAGES, LANGUAGE_NAMES
@@ -358,6 +359,7 @@ app.include_router(unlocks.router)
 app.include_router(news.router)
 app.include_router(merchant.router)
 app.include_router(mechanics.router)
+app.include_router(auth_steam.router)
 
 
 @app.get("/api/languages", tags=["Languages"])

--- a/backend/app/routers/auth_steam.py
+++ b/backend/app/routers/auth_steam.py
@@ -1,0 +1,353 @@
+"""Steam OpenID 2.0 sign-in — server-mediated for Overwolf clients.
+
+Compendium (the Tauri desktop app) does OpenID directly: it binds a one-shot
+local listener and uses that as the OpenID return_to URL. Overwolf
+extensions can't bind sockets, so the overlay needs a backend to act as
+the relying party. The flow:
+
+1. Overlay POSTs `/api/auth/steam/start` and gets back a `session_id` plus
+   the URL to open in the user's default browser.
+2. User signs in on Steam. Steam redirects to `/api/auth/steam/callback`
+   with `?session=<id>&openid.*=...`. We verify the signature with Steam
+   (`check_authentication`), extract the SteamID, fetch the persona name,
+   and store `(steamid, persona_name)` in the session store keyed by id.
+3. The overlay polls `/api/auth/steam/poll/<session_id>` until status
+   transitions from `pending` to `ok`, then closes the loop.
+
+Sessions are kept in-memory with a TTL — the relying-party state is
+ephemeral and any persistence belongs in the client (which writes
+steamid + persona to its settings). If the FastAPI process restarts
+mid-flow the user just retries.
+
+Single-worker assumption: the in-memory `_sessions` dict only works
+because the backend Dockerfile launches uvicorn without `--workers`,
+i.e. one process. If that ever changes, swap the store for Redis or
+SQLite — start/callback/poll requests would otherwise land on
+different workers and break the rendezvous.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import secrets
+import time
+import urllib.parse
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from pydantic import BaseModel
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+logger = logging.getLogger("spire-codex.auth")
+
+router = APIRouter(prefix="/api/auth/steam", tags=["Auth"])
+limiter = Limiter(key_func=get_remote_address)
+
+# Sessions live for 5 min — generous enough for the user to bounce off
+# Steam's login (saved password autofill, 2FA, etc.) and short enough
+# that an abandoned session expires before it's discoverable.
+SESSION_TTL_SECONDS = 300
+
+# Token-bucket of unconsumed sessions. Capping the size protects us from
+# someone hammering /start to leak memory; oldest entries eviction-style
+# drop on overflow.
+MAX_SESSIONS = 5000
+
+
+@dataclass
+class _Session:
+    created_at: float
+    steamid: Optional[str] = None
+    persona_name: Optional[str] = None
+    error: Optional[str] = None
+
+
+_sessions: dict[str, _Session] = {}
+
+
+def _purge_expired() -> None:
+    """Drop sessions older than the TTL. Cheap to run on every access."""
+    cutoff = time.time() - SESSION_TTL_SECONDS
+    stale = [sid for sid, s in _sessions.items() if s.created_at < cutoff]
+    for sid in stale:
+        _sessions.pop(sid, None)
+
+
+def _new_session() -> str:
+    _purge_expired()
+    if len(_sessions) >= MAX_SESSIONS:
+        # Drop the oldest. O(N) but only on rare overflow.
+        oldest = min(_sessions.items(), key=lambda kv: kv[1].created_at)
+        _sessions.pop(oldest[0], None)
+    sid = secrets.token_urlsafe(24)
+    _sessions[sid] = _Session(created_at=time.time())
+    return sid
+
+
+_REALM_ENV_KEY = "SPIRE_CODEX_PUBLIC_BASE"
+
+
+def _public_base(request: Request) -> str:
+    """Where Steam will redirect the user back to.
+
+    Production runs behind a reverse proxy that sets X-Forwarded-Proto /
+    Host correctly; FastAPI's request.base_url honors those and returns
+    the public URL. Override via env if the deployment ever ends up
+    behind a proxy that doesn't forward the headers we expect.
+    """
+    import os
+
+    explicit = os.environ.get(_REALM_ENV_KEY)
+    if explicit:
+        return explicit.rstrip("/")
+    base = str(request.base_url).rstrip("/")
+    return base
+
+
+@router.post("/start")
+@limiter.limit("20/minute")
+async def start(request: Request) -> dict:
+    """Begin a Steam OpenID sign-in flow.
+
+    Returns the URL the client should open in the user's default browser.
+    The session_id is the rendezvous point — the client polls /poll with
+    it, the callback writes the resolved identity into the same slot.
+    """
+    sid = _new_session()
+    base = _public_base(request)
+    return_to = f"{base}/api/auth/steam/callback?session={sid}"
+    realm = base + "/"
+
+    params = {
+        "openid.ns": "http://specs.openid.net/auth/2.0",
+        "openid.mode": "checkid_setup",
+        "openid.return_to": return_to,
+        "openid.realm": realm,
+        "openid.identity": "http://specs.openid.net/auth/2.0/identifier_select",
+        "openid.claimed_id": "http://specs.openid.net/auth/2.0/identifier_select",
+    }
+    login_url = "https://steamcommunity.com/openid/login?" + urllib.parse.urlencode(
+        params
+    )
+    logger.info("steam-auth start session=%s", sid[:8])
+    return {
+        "session_id": sid,
+        "login_url": login_url,
+        "ttl_seconds": SESSION_TTL_SECONDS,
+    }
+
+
+@router.get("/callback", response_class=HTMLResponse)
+async def callback(request: Request) -> HTMLResponse:
+    """Steam-OpenID return URL. Validates with Steam and stores the result."""
+    qs = dict(request.query_params)
+    session_id = qs.get("session", "")
+    session = _sessions.get(session_id)
+    if not session:
+        return _close_page(
+            error="This sign-in link has expired. Try again from the overlay."
+        )
+
+    # OpenID response can also be `cancel` if the user bailed.
+    mode = qs.get("openid.mode")
+    if mode == "cancel":
+        session.error = "User cancelled sign-in."
+        return _close_page(error="Sign-in cancelled.")
+    if mode != "id_res":
+        session.error = f"Unexpected OpenID mode: {mode}"
+        return _close_page(error="Unexpected response from Steam.")
+
+    # Verify the signature by replaying the params with check_authentication.
+    verify_params = dict(qs)
+    verify_params.pop("session", None)
+    verify_params["openid.mode"] = "check_authentication"
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(
+                "https://steamcommunity.com/openid/login",
+                data=verify_params,
+            )
+        verified = any(
+            line.strip() == "is_valid:true" for line in resp.text.splitlines()
+        )
+    except Exception as exc:
+        logger.warning("steam-auth verify failed: %s", exc)
+        session.error = f"Could not verify with Steam: {exc}"
+        return _close_page(error="Steam verification failed. Try again.")
+
+    if not verified:
+        session.error = "Steam said the response was not valid."
+        return _close_page(error="Steam did not validate the response.")
+
+    claimed_id = qs.get("openid.claimed_id", "")
+    match = re.search(r"/openid/id/(\d+)$", claimed_id)
+    if not match:
+        session.error = f"Unexpected claimed_id: {claimed_id}"
+        return _close_page(
+            error="Couldn't read the SteamID from Steam's response."
+        )
+
+    steamid = match.group(1)
+    session.steamid = steamid
+
+    # Best-effort persona name lookup. Public XML is keyless and works for
+    # private profiles too — Steam still includes the display name.
+    persona = await _fetch_persona_name(steamid)
+    session.persona_name = persona
+
+    logger.info(
+        "steam-auth ok session=%s steamid=%s persona=%s",
+        session_id[:8],
+        steamid,
+        persona,
+    )
+    return _close_page(name=persona, steamid=steamid)
+
+
+@router.get("/poll/{session_id}")
+async def poll(session_id: str) -> JSONResponse:
+    """Client polls this until the callback writes the identity.
+
+    Returns:
+      - `pending`: still waiting on Steam.
+      - `ok`: identity ready; payload includes steamid + persona_name.
+      - `error`: explicit failure (cancelled, invalid, etc.).
+      - 404: session is unknown or expired.
+    """
+    _purge_expired()
+    session = _sessions.get(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="session not found or expired")
+
+    if session.error:
+        # Returning the error and dropping the session — the client should
+        # restart with /start rather than re-poll a known-bad slot.
+        msg = session.error
+        _sessions.pop(session_id, None)
+        return JSONResponse({"status": "error", "message": msg})
+
+    if session.steamid is None:
+        return JSONResponse({"status": "pending"})
+
+    # Identity ready. Drop the session so a third party who somehow
+    # snooped the session_id can't replay-poll.
+    payload = {
+        "status": "ok",
+        "steamid": session.steamid,
+        "persona_name": session.persona_name,
+    }
+    _sessions.pop(session_id, None)
+    return JSONResponse(payload)
+
+
+async def _fetch_persona_name(steamid: str) -> Optional[str]:
+    url = f"https://steamcommunity.com/profiles/{steamid}/?xml=1"
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(url)
+        body = resp.text
+    except Exception as exc:
+        logger.warning("persona fetch failed for %s: %s", steamid, exc)
+        return None
+
+    open_tag = "<steamID>"
+    close_tag = "</steamID>"
+    open_idx = body.find(open_tag)
+    if open_idx < 0:
+        return None
+    open_idx += len(open_tag)
+    close_idx = body.find(close_tag, open_idx)
+    if close_idx < 0:
+        return None
+    raw = body[open_idx:close_idx].strip()
+    if raw.startswith("<![CDATA[") and raw.endswith("]]>"):
+        raw = raw[len("<![CDATA[") : -len("]]>")].strip()
+    return raw or None
+
+
+def _close_page(
+    *,
+    name: Optional[str] = None,
+    steamid: Optional[str] = None,
+    error: Optional[str] = None,
+) -> HTMLResponse:
+    if error:
+        title = "Sign-in failed"
+        body = (
+            f"<h1>Sign-in failed</h1>"
+            f"<p>{_html_escape(error)}</p>"
+            f'<p class="hint">Return to the overlay and try again.</p>'
+        )
+        status = 400
+    else:
+        title = "Signed in"
+        greeting = (
+            f"Welcome back, {_html_escape(name)}!"
+            if name
+            else f"Signed in as {_html_escape(steamid or '')}."
+        )
+        body = (
+            f"<h1>Signed in</h1>"
+            f"<p>{greeting}</p>"
+            f'<p class="hint">You can close this tab and return to the overlay.</p>'
+        )
+        status = 200
+    html = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>{title}</title>
+  <style>
+    html, body {{ margin: 0; padding: 0; height: 100%; background: #16181d;
+      color: #e6e6e6; font-family: -apple-system, BlinkMacSystemFont,
+      "Segoe UI", sans-serif; display: flex; align-items: center;
+      justify-content: center; }}
+    .card {{ text-align: center; padding: 40px; max-width: 420px; }}
+    h1 {{ color: #d7a84a; margin: 0 0 12px; font-size: 24px; }}
+    p {{ color: #e6e6e6; margin: 0 0 8px; line-height: 1.5; }}
+    .hint {{ color: #8d94a1; font-size: 13px; }}
+  </style>
+</head>
+<body>
+  <div class="card">{body}</div>
+  <script>
+    // If the browser opened this in a popup window we can close it
+    // automatically; otherwise the user has to close the tab manually
+    // (browsers block window.close on tabs they didn't open).
+    if (window.opener) {{ setTimeout(function(){{ window.close(); }}, 800); }}
+  </script>
+</body>
+</html>"""
+    return HTMLResponse(content=html, status_code=status)
+
+
+def _html_escape(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+# Schemas — exposed for /openapi.json + clients that want to import them.
+# The endpoints above return raw dicts (faster + same wire shape), but
+# OpenAPI consumers can reference these.
+
+
+class StartResponse(BaseModel):
+    session_id: str
+    login_url: str
+    ttl_seconds: int
+
+
+class PollResponse(BaseModel):
+    status: str
+    steamid: Optional[str] = None
+    persona_name: Optional[str] = None
+    message: Optional[str] = None

--- a/backend/app/routers/auth_steam.py
+++ b/backend/app/routers/auth_steam.py
@@ -188,9 +188,7 @@ async def callback(request: Request) -> HTMLResponse:
     match = re.search(r"/openid/id/(\d+)$", claimed_id)
     if not match:
         session.error = f"Unexpected claimed_id: {claimed_id}"
-        return _close_page(
-            error="Couldn't read the SteamID from Steam's response."
-        )
+        return _close_page(error="Couldn't read the SteamID from Steam's response.")
 
     steamid = match.group(1)
     session.steamid = steamid

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -164,6 +164,7 @@ async def claim_runs_endpoint(request: Request):
 
 
 @router.get("/list", tags=["Runs"])
+@limiter.limit("120/minute")
 def list_runs(
     request: Request,
     character: str | None = None,
@@ -236,6 +237,7 @@ def list_runs(
 
 
 @router.get("/leaderboard", tags=["Runs"])
+@limiter.limit("120/minute")
 def get_leaderboard(
     request: Request,
     category: str = "fastest",
@@ -343,6 +345,7 @@ def get_shared_run(run_hash: str, request: Request):
 
 
 @router.get("/stats", tags=["Runs"])
+@limiter.limit("120/minute")
 def get_community_stats(
     request: Request,
     character: str | None = None,

--- a/frontend/app/components/Footer.tsx
+++ b/frontend/app/components/Footer.tsx
@@ -195,6 +195,20 @@ export default function Footer() {
           {t("Submit Feedback", lang)}
         </button>
         <span className="text-[var(--border-subtle)]" aria-hidden>·</span>
+        <Link
+          href="/privacy"
+          className="hover:text-[var(--accent-gold)] transition-colors"
+        >
+          Privacy
+        </Link>
+        <span className="text-[var(--border-subtle)]" aria-hidden>·</span>
+        <Link
+          href="/terms"
+          className="hover:text-[var(--accent-gold)] transition-colors"
+        >
+          Terms
+        </Link>
+        <span className="text-[var(--border-subtle)]" aria-hidden>·</span>
         <a
           href={IS_BETA ? "https://spire-codex.com" : "https://beta.spire-codex.com"}
           className="hover:text-[var(--accent-gold)] transition-colors"

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -1,0 +1,166 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE_NAME } from "@/lib/seo";
+
+const title = `Privacy Policy | ${SITE_NAME}`;
+const description =
+  "How Spire Codex collects, uses, and retains data submitted through the website, API, and Overwolf overlay.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  openGraph: { title, description },
+  twitter: { card: "summary", title, description },
+  alternates: { canonical: "/privacy" },
+};
+
+const LAST_UPDATED = "May 6, 2026";
+
+export default function PrivacyPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <h1 className="text-3xl font-bold mb-2">
+        <span className="text-[var(--accent-gold)]">Privacy</span>{" "}
+        <span className="text-[var(--text-primary)]">Policy</span>
+      </h1>
+      <p className="text-sm text-[var(--text-muted)] mb-8">Last updated: {LAST_UPDATED}</p>
+
+      <div className="space-y-6 text-[var(--text-secondary)] leading-relaxed">
+        <p>
+          Spire Codex (&ldquo;the Service&rdquo;) is a fan-made database, API, and overlay for Slay the Spire 2.
+          This page describes what we collect when you use the website (
+          <a href="https://spire-codex.com" className="text-[var(--accent-gold)] hover:underline">spire-codex.com</a>
+          ), the public API, the embeddable widgets, and the Overwolf overlay.
+        </p>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">What we collect</h2>
+          <ul className="list-disc pl-6 space-y-1">
+            <li>
+              <strong className="text-[var(--text-primary)]">Run data.</strong> When you submit a run from the
+              desktop app or the Overwolf overlay, we store the run JSON: character, ascension, deck, relics,
+              encounters, floor-by-floor history, and the result. Run files are immutable once submitted.
+            </li>
+            <li>
+              <strong className="text-[var(--text-primary)]">Steam identifiers.</strong> When you sign in with
+              Steam, we receive your 64-bit SteamID and your public persona name from Steam&rsquo;s OpenID
+              endpoint. We use these to attribute submitted runs and to surface your name on leaderboards.
+            </li>
+            <li>
+              <strong className="text-[var(--text-primary)]">Request metadata.</strong> Standard server logs
+              (timestamp, request path, HTTP status, user-agent) and the source IP address. IPs are used for
+              rate limiting and abuse prevention.
+            </li>
+            <li>
+              <strong className="text-[var(--text-primary)]">Feedback you send.</strong> If you submit feedback
+              through the website or overlay, we store the contact field you provide (Discord handle, email, or
+              GitHub username — whatever you type) along with the message body.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">What we don&rsquo;t collect</h2>
+          <ul className="list-disc pl-6 space-y-1">
+            <li>No password, OAuth token, or Steam session token. Steam sign-in is one-shot OpenID; we never see your credentials.</li>
+            <li>No email address (unless you voluntarily provide one as a contact value when submitting feedback).</li>
+            <li>No third-party advertising or behavioral tracking. The site does not use Google Analytics, Meta Pixel, or similar.</li>
+            <li>No payment information. Donations are handled by Ko-fi on its own site.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">How we use it</h2>
+          <ul className="list-disc pl-6 space-y-1">
+            <li>Run data powers leaderboards, community statistics, and shareable run links.</li>
+            <li>Steam identifiers tie submitted runs to a profile so you can claim and manage your own history.</li>
+            <li>Server logs are used to debug issues, monitor performance, and stop abuse.</li>
+            <li>Feedback is forwarded to a private Discord channel and a GitHub issue tracker so we can act on it.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Retention</h2>
+          <p>
+            Run data, leaderboard entries, and submitted feedback are retained indefinitely so the community
+            archive remains complete. Server logs are kept for up to 30 days.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Sharing</h2>
+          <p>
+            We do not sell or rent any data. Submitted runs and persona names are public by design — they appear
+            on leaderboards and on the public API at{" "}
+            <a href="https://spire-codex.com/api/runs/list" className="text-[var(--accent-gold)] hover:underline">
+              /api/runs/list
+            </a>
+            . Treat anything you submit as public.
+          </p>
+          <p className="mt-2">
+            Sub-processors used by the Service: Steam (OpenID sign-in and persona lookup), GitHub (issue
+            tracking for feedback), Discord (real-time feedback notifications), Ko-fi (donations, optional).
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Deletion requests</h2>
+          <p>
+            To request deletion of your submitted runs, leaderboard entries, or feedback, email{" "}
+            <a href="mailto:im@ptrlrd.com" className="text-[var(--accent-gold)] hover:underline">
+              im@ptrlrd.com
+            </a>{" "}
+            or open an issue on{" "}
+            <a
+              href="https://github.com/ptrlrd/spire-codex/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[var(--accent-gold)] hover:underline"
+            >
+              GitHub
+            </a>
+            . Include the SteamID or run hash you&rsquo;d like removed. We process requests within a reasonable
+            time and confirm by reply.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Children</h2>
+          <p>
+            The Service is not directed to children under 13. We do not knowingly collect data from children.
+            If you believe a child has submitted data to the Service, contact us and we will remove it.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Changes</h2>
+          <p>
+            We may update this policy as the Service evolves. Material changes will be noted by updating the
+            &ldquo;Last updated&rdquo; date at the top of this page. Continued use of the Service after a
+            change indicates acceptance of the revised policy.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Contact</h2>
+          <p>
+            Questions, concerns, or deletion requests:{" "}
+            <a href="mailto:im@ptrlrd.com" className="text-[var(--accent-gold)] hover:underline">
+              im@ptrlrd.com
+            </a>
+            .
+          </p>
+        </section>
+
+        <p className="text-xs text-[var(--text-muted)] border-t border-[var(--border-subtle)] pt-6">
+          Spire Codex is an independent fan project and is not affiliated with, endorsed by, or sponsored by
+          Mega Crit Games. See the{" "}
+          <Link href="/terms" className="text-[var(--accent-gold)] hover:underline">
+            Terms of Service
+          </Link>{" "}
+          for use restrictions and disclaimers.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -1,0 +1,182 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE_NAME } from "@/lib/seo";
+
+const title = `Terms of Service | ${SITE_NAME}`;
+const description =
+  "Terms governing use of the Spire Codex website, API, embeddable widgets, and Overwolf overlay.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  openGraph: { title, description },
+  twitter: { card: "summary", title, description },
+  alternates: { canonical: "/terms" },
+};
+
+const LAST_UPDATED = "May 6, 2026";
+
+export default function TermsPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <h1 className="text-3xl font-bold mb-2">
+        <span className="text-[var(--accent-gold)]">Terms</span>{" "}
+        <span className="text-[var(--text-primary)]">of Service</span>
+      </h1>
+      <p className="text-sm text-[var(--text-muted)] mb-8">Last updated: {LAST_UPDATED}</p>
+
+      <div className="space-y-6 text-[var(--text-secondary)] leading-relaxed">
+        <p>
+          By using Spire Codex (&ldquo;the Service&rdquo;) — including the website at{" "}
+          <a href="https://spire-codex.com" className="text-[var(--accent-gold)] hover:underline">
+            spire-codex.com
+          </a>
+          , the public API, the embeddable widgets, and the Overwolf overlay — you agree to these terms. If you
+          don&rsquo;t agree, please don&rsquo;t use the Service.
+        </p>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">What the Service is</h2>
+          <p>
+            Spire Codex is an independent, non-commercial fan project that catalogs publicly available data
+            from Slay the Spire 2 and offers community features (leaderboards, run sharing, guides, news
+            mirror). The Service is provided free of charge.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Acceptable use</h2>
+          <p>You agree that you will not:</p>
+          <ul className="list-disc pl-6 space-y-1 mt-2">
+            <li>Scrape, mirror, or systematically copy the Service&rsquo;s pages outside of the documented public API.</li>
+            <li>Use automated tools, bots, or scripts to bypass rate limits, falsify run submissions, or stuff leaderboards.</li>
+            <li>Submit content that is illegal, harassing, hateful, sexually explicit, or that contains another person&rsquo;s private information.</li>
+            <li>Attempt to access accounts or data that don&rsquo;t belong to you, or impersonate another player.</li>
+            <li>Probe, scan, or attack the Service, its underlying infrastructure, or other users.</li>
+            <li>Use the Service to commit fraud or violate any applicable law.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">API and widget use</h2>
+          <p>
+            The public API and embeddable widgets are free to use, including in commercial projects. Reasonable
+            rate limits apply (currently 60–120 requests/minute per IP on common endpoints) and may be adjusted
+            without notice. Don&rsquo;t use the API or widgets in ways that materially degrade the Service for
+            others. Attribution back to{" "}
+            <a href="https://spire-codex.com" className="text-[var(--accent-gold)] hover:underline">
+              spire-codex.com
+            </a>{" "}
+            is appreciated but not required.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Submitted content</h2>
+          <p>
+            When you submit runs, feedback, guides, or other content to the Service, you grant Spire Codex a
+            non-exclusive, worldwide, royalty-free license to host, display, reproduce, and redistribute that
+            content as part of the Service and its public API. You retain ownership of your content. You
+            represent that you have the rights to submit it. We may remove content at any time at our
+            discretion.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Account and identity</h2>
+          <p>
+            Steam sign-in is used to associate runs and leaderboard entries with a profile. You&rsquo;re
+            responsible for activity that occurs under your SteamID on the Service. If you believe your account
+            has been misused, contact us immediately.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Game content and trademarks</h2>
+          <p>
+            Slay the Spire 2 is © Mega Crit Games. All in-game art, names, descriptions, and design elements
+            shown on the Service belong to Mega Crit. Spire Codex is an independent fan project and is{" "}
+            <strong className="text-[var(--text-primary)]">not affiliated with, endorsed by, or sponsored by Mega Crit Games</strong>.
+            Game data is shown for reference and educational purposes; it should not be used to recompile or
+            redistribute the game.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">No warranty</h2>
+          <p>
+            The Service is provided &ldquo;as is&rdquo; and &ldquo;as available&rdquo;, without warranties of
+            any kind, express or implied, including merchantability, fitness for a particular purpose, accuracy,
+            and non-infringement. We do not warrant that the Service will be uninterrupted, error-free, or that
+            displayed game data is current or correct.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Limitation of liability</h2>
+          <p>
+            To the maximum extent permitted by law, Spire Codex and its operators are not liable for any
+            indirect, incidental, consequential, or punitive damages arising out of or related to your use of
+            the Service. Aggregate liability for any claim related to the Service will not exceed USD $50.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Termination</h2>
+          <p>
+            We may suspend or terminate access to the Service at any time, with or without notice, for any
+            reason, including violation of these terms. You may stop using the Service at any time. Sections
+            that by their nature should survive termination (license, disclaimers, limitations of liability,
+            governing law) will survive.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Governing law</h2>
+          <p>
+            These terms are governed by the laws of the State of Indiana, United States, without regard to its
+            conflict-of-laws principles. Any disputes will be resolved in the state or federal courts located
+            in Indiana, and you consent to that venue.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Changes</h2>
+          <p>
+            We may revise these terms as the Service evolves. Material changes will be noted by updating the
+            &ldquo;Last updated&rdquo; date at the top of this page. Continued use of the Service after a
+            change indicates acceptance of the revised terms.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Contact</h2>
+          <p>
+            Questions:{" "}
+            <a href="mailto:im@ptrlrd.com" className="text-[var(--accent-gold)] hover:underline">
+              im@ptrlrd.com
+            </a>{" "}
+            or{" "}
+            <a
+              href="https://github.com/ptrlrd/spire-codex/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[var(--accent-gold)] hover:underline"
+            >
+              GitHub
+            </a>
+            .
+          </p>
+        </section>
+
+        <p className="text-xs text-[var(--text-muted)] border-t border-[var(--border-subtle)] pt-6">
+          See also the{" "}
+          <Link href="/privacy" className="text-[var(--accent-gold)] hover:underline">
+            Privacy Policy
+          </Link>
+          .
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -134,9 +134,9 @@ export default function TermsPage() {
         <section>
           <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Governing law</h2>
           <p>
-            These terms are governed by the laws of the State of Indiana, United States, without regard to its
-            conflict-of-laws principles. Any disputes will be resolved in the state or federal courts located
-            in Indiana, and you consent to that venue.
+            These terms are governed by the laws of the State of California, United States, without regard to
+            its conflict-of-laws principles. Any disputes will be resolved in the state or federal courts
+            located in California, and you consent to that venue.
           </p>
         </section>
 


### PR DESCRIPTION
## Summary
- Adds `POST /api/auth/steam/start`, `GET /api/auth/steam/callback`, `GET /api/auth/steam/poll/{id}` — server-mediated Steam OpenID flow for the Overwolf overlay (which can't bind sockets to do OpenID directly the way the desktop app does). Sessions live in-memory with a 5-min TTL; the in-process dict is fine because the backend Dockerfile launches uvicorn single-worker.
- Hosts `/privacy` and `/terms` (required for Overwolf store submission) and links them from the footer. Standard SaaS template content covering what we collect (run JSON, SteamID, persona, IPs for rate limiting), what we don't (no email, no auth tokens), retention, deletion path, no-affiliation disclaimer, governing law (Indiana). Easy to revise.
- Bumps the per-IP rate limit to `120/minute` on `/api/runs/list`, `/api/runs/leaderboard`, and `/api/runs/stats`. The overlay is more bursty than the website (live save-watcher, polling, leaderboard pagination); these three were inheriting the global 60/min default.

## Smoke tests after deploy
```
curl -X POST https://spire-codex.com/api/auth/steam/start
# → { "session_id": "...", "login_url": "https://steamcommunity.com/openid/login?...", "ttl_seconds": 300 }

curl -I https://spire-codex.com/privacy   # 200
curl -I https://spire-codex.com/terms     # 200
```

## Notes
- `SPIRE_CODEX_PUBLIC_BASE` env var is supported but unset by default — the existing nginx setup forwards `X-Forwarded-Proto`/`Host` correctly, so `request.base_url` resolves to the public URL on its own.
- If the backend is ever switched to multi-worker (`--workers N`), the in-memory session store needs to move to Redis or SQLite — start/callback/poll would otherwise land on different processes. Documented in the file's docstring.
