### PR TITLE
Navbar: add Privacy and Terms to About menu

### DIFF
--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -81,6 +81,8 @@ const NAV_GROUPS: NavGroup[] = [
       { href: "/changelog", label: "Changelog" },
       { href: "/thank-you", label: "Thank You" },
       { href: "https://ko-fi.com/yitsy", label: "Ko-fi" },
+      { href: "/privacy", label: "Privacy" },
+      { href: "/terms", label: "Terms" },
     ],
   },
   {


### PR DESCRIPTION
Surfaces the new `/privacy` and `/terms` pages from #202 in the About dropdown, after Ko-fi. Footer links were added in #202; this just makes them reachable from the navbar too.