### PR TITLE
Mechanics pages API for Overwolf overlay ingestion

### DIFF
--- a/backend/app/routers/mechanics.py
+++ b/backend/app/routers/mechanics.py
@@ -1,15 +1,22 @@
-"""Mechanics constants API.
+"""Mechanics constants + per-page content API.
 
-Serves `data/mechanics_constants.json` produced by
-`mechanics_constants_parser.py`. The shape is language-agnostic
-(probabilities + thresholds + enum names), so this router doesn't
-run translation. Honors the version ContextVar so beta deployments
-can ship adjusted balance numbers without touching stable.
+Two responsibilities live in this router:
 
-Frontend `/mechanics/<slug>` pages consume this instead of
-hardcoding probabilities and formulas — closes the silent-drift
-class of bug we kept hitting (e.g. card-rarity page showing 1.5%
-when the actual value is 1.49%).
+* `/api/mechanics/constants` — serves `data/mechanics_constants.json`
+  produced by `mechanics_constants_parser.py`. The shape is
+  language-agnostic (probabilities + thresholds + enum names), so this
+  router doesn't run translation. Honors the version ContextVar so beta
+  deployments can ship adjusted balance numbers without touching stable.
+
+* `/api/mechanics/sections` and `/api/mechanics/sections/{slug}` — serve
+  the 27 `/mechanics/<slug>` pages as markdown documents with template
+  tokens already resolved against the current constants + bestiary +
+  character data. Built so the Overwolf overlay can render the same
+  reference content the website does without re-implementing the prose.
+
+Frontend `/mechanics/<slug>` pages consume `/constants` directly today;
+once the markdown migration is wired up the frontend will switch to
+`/sections/{slug}` and we'll drop the per-slug JSX.
 """
 
 import json
@@ -17,6 +24,7 @@ import json
 from fastapi import APIRouter, HTTPException, Request
 
 from ..services.data_service import DATA_DIR, _resolve_base, _get_version
+from ..services import mechanics_pages
 
 router = APIRouter(prefix="/api/mechanics", tags=["Mechanics"])
 
@@ -49,3 +57,28 @@ def get_mechanics_constants(request: Request) -> dict:
             detail="mechanics_constants.json not found — run backend/app/parsers/parse_all.py",
         )
     return constants
+
+
+@router.get("/sections", tags=["Mechanics"])
+def list_mechanic_sections(request: Request) -> list[dict]:
+    """Index of all mechanics pages — `{slug, title, description, category, order}`.
+
+    Sorted by frontmatter `order` then slug; the overlay can group on
+    `category` ("mechanics" | "secrets") to mirror the website's split.
+    """
+    return mechanics_pages.list_sections()
+
+
+@router.get("/sections/{slug}", tags=["Mechanics"])
+def get_mechanic_section(slug: str, request: Request) -> dict:
+    """One mechanics page as markdown.
+
+    `body_markdown` has all `{{constants...}}` and `{{table:...}}` tokens
+    already resolved, so the overlay only needs a markdown renderer to
+    display it — no need to fan out to `/api/characters` or
+    `/api/monsters` separately.
+    """
+    section = mechanics_pages.get_section(slug)
+    if section is None:
+        raise HTTPException(status_code=404, detail=f"Unknown mechanics slug: {slug}")
+    return section

--- a/backend/app/services/mechanics_pages.py
+++ b/backend/app/services/mechanics_pages.py
@@ -1,0 +1,357 @@
+"""Mechanics pages — markdown content with frontmatter, served via /api/mechanics/sections.
+
+Each `data/mechanics_pages/<slug>.md` file is the source of truth for one
+/mechanics/<slug> page. YAML frontmatter carries the title/description/category
+metadata; the body is GitHub-flavored Markdown with two flavors of inline
+template tokens that the resolver expands at request time:
+
+  {{constants.path.to.field [| filter]}}     # value lookup with optional formatter
+  {{table:<name>}}                            # whole-table macro
+
+Filters: `pct` (0.6 → "60%"), `pct2` (preserve up to 2 decimals), `mult`
+(0.75 → "0.75x"), `gold` (75 → "75g"), `range` ({min:10,max:20} → "10-20"),
+`range_gold` ({min:10,max:20} → "10-20g"). Nested fields are dot-separated;
+constants come from `mechanics_constants.json`.
+
+Tables: `character_stats`, `monster_scaling`, `ascension_levels`. These are
+resolved at request time so the overlay never needs to fan out to additional
+endpoints — one fetch returns fully-baked Markdown.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+import frontmatter
+
+from .data_service import (
+    DATA_DIR,
+    _resolve_base,
+    _get_version,
+    load_characters,
+    load_monsters,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _pages_dir() -> Path:
+    """Mechanics pages live in `data/mechanics_pages/` — language-agnostic for now.
+
+    The prose isn't translated yet (CLAUDE.md flags it as a known i18n gap),
+    so a single language-agnostic source tree mirrors the current state. When
+    translations land we can introduce per-lang directories without changing
+    the API shape.
+    """
+    return DATA_DIR / "mechanics_pages"
+
+
+def _load_constants() -> dict:
+    """Same lookup pattern as `routers/mechanics.py::_load_constants`.
+
+    Tries the version-resolved location first so beta deployments pick up
+    rebalanced numbers, falls back to the unversioned file used by stable.
+    """
+    candidates = [
+        _resolve_base(_get_version()) / "mechanics_constants.json",
+        DATA_DIR / "mechanics_constants.json",
+    ]
+    for path in candidates:
+        if path.exists():
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+    return {}
+
+
+# ── Filters ──────────────────────────────────────────────────────────────
+
+
+def _format_pct(value: float, decimals: int = 0) -> str:
+    """0.6 → '60%'; with decimals=2, 0.0149 → '1.49%'.
+
+    Trims trailing zeros so 0.5 reads "50%" not "50.0%" — matches the
+    JS helper that the existing frontend uses.
+    """
+    pct = float(value) * 100
+    if decimals == 0 and pct == int(pct):
+        return f"{int(pct)}%"
+    formatted = f"{pct:.{max(decimals, 2)}f}".rstrip("0").rstrip(".")
+    return f"{formatted}%"
+
+
+def _format_mult(value: float) -> str:
+    formatted = f"{float(value):.2f}".rstrip("0").rstrip(".")
+    return f"{formatted}x"
+
+
+def _format_gold(value: int | float) -> str:
+    return f"{int(value)}g"
+
+
+def _format_range(value: dict) -> str:
+    lo = value.get("min")
+    hi = value.get("max")
+    return f"{lo}" if lo == hi else f"{lo}-{hi}"
+
+
+def _format_range_gold(value: dict) -> str:
+    return f"{_format_range(value)}g"
+
+
+_FILTERS = {
+    "pct": _format_pct,
+    "pct2": lambda v: _format_pct(v, decimals=2),
+    "mult": _format_mult,
+    "gold": _format_gold,
+    "range": _format_range,
+    "range_gold": _format_range_gold,
+}
+
+
+def _lookup(obj: Any, dotted_path: str) -> Any:
+    cur = obj
+    for part in dotted_path.split("."):
+        if isinstance(cur, dict):
+            cur = cur.get(part)
+        else:
+            cur = getattr(cur, part, None)
+        if cur is None:
+            return None
+    return cur
+
+
+_TOKEN_RE = re.compile(r"\{\{\s*([^{}]+?)\s*\}\}")
+
+
+def _resolve_value_token(expression: str, constants: dict) -> str:
+    """`constants.x.y | pct` → resolved string. Returns the original token
+    on failure so authors can spot broken references in the rendered output."""
+    parts = [p.strip() for p in expression.split("|")]
+    base = parts[0]
+    filt = parts[1] if len(parts) > 1 else None
+
+    if not base.startswith("constants."):
+        return f"{{{{ {expression} }}}}"
+    value = _lookup(constants, base[len("constants.") :])
+    if value is None:
+        return f"{{{{ {expression} }}}}"
+    if filt is None:
+        return str(value)
+    formatter = _FILTERS.get(filt)
+    if formatter is None:
+        return str(value)
+    try:
+        return formatter(value)
+    except Exception as exc:
+        logger.warning("token format failed for %s: %s", expression, exc)
+        return f"{{{{ {expression} }}}}"
+
+
+# ── Table macros ─────────────────────────────────────────────────────────
+
+
+def _resolve_table_character_stats() -> str:
+    chars = load_characters("eng")
+    order = ["IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"]
+    by_id = {c.get("id"): c for c in chars}
+    rows = [by_id[c] for c in order if c in by_id]
+    lines = [
+        "| Character | HP | Gold | Deck | Orb Slots |",
+        "|-----------|---:|-----:|-----:|----------:|",
+    ]
+    for c in rows:
+        name = c.get("name", "")
+        if name.startswith("The "):
+            name = name[4:]
+        deck_size = len(c.get("starting_deck") or [])
+        # orb_slots is null on non-Defect characters; coerce to 0 so the
+        # rendered Markdown table reads "0" instead of literal "None".
+        orb_slots = c.get("orb_slots") or 0
+        lines.append(
+            f"| {name} | {c.get('starting_hp', '')} | "
+            f"{c.get('starting_gold', '')} | {deck_size} | "
+            f"{orb_slots} |"
+        )
+    return "\n".join(lines)
+
+
+def _format_hit(damage: int | float, hits: int | None) -> str:
+    if hits and hits > 1:
+        return f"{damage}×{hits}"
+    return f"{damage}"
+
+
+def _resolve_table_monster_scaling() -> str:
+    monsters = load_monsters("eng")
+    rows: list[dict] = []
+    for m in monsters:
+        hp_min = m.get("min_hp")
+        hp_max = m.get("max_hp")
+        hp_min_a = m.get("min_hp_ascension")
+        hp_max_a = m.get("max_hp_ascension")
+        hp_range = (
+            ""
+            if hp_min is None
+            else (f"{hp_min}" if hp_min == hp_max else f"{hp_min}-{hp_max}")
+        )
+        hp_range_a = (
+            ""
+            if hp_min_a is None
+            else (f"{hp_min_a}" if hp_min_a == hp_max_a else f"{hp_min_a}-{hp_max_a}")
+        )
+        hp_delta = (
+            (hp_max_a - hp_max) if (hp_max is not None and hp_max_a is not None) else 0
+        )
+
+        moves = m.get("moves") or []
+        best_move: dict | None = None
+        best_delta = 0
+        for mv in moves:
+            dmg = mv.get("damage") or {}
+            base = dmg.get("normal")
+            asc = dmg.get("ascension")
+            if base is not None and asc is not None and asc - base > best_delta:
+                best_delta = asc - base
+                best_move = mv
+        if best_move is None:
+            base_dmg_text = ""
+            asc_dmg_text = ""
+        else:
+            dmg = best_move.get("damage") or {}
+            hits = dmg.get("hit_count")
+            base_dmg_text = (
+                f"{best_move.get('name')} {_format_hit(dmg.get('normal'), hits)}"
+            )
+            asc_dmg_text = _format_hit(dmg.get("ascension"), hits)
+
+        if hp_delta > 0 or best_delta > 0:
+            rows.append(
+                {
+                    "id": m.get("id", ""),
+                    "name": m.get("name", ""),
+                    "type": m.get("type") or "Normal",
+                    "hp": hp_range or "—",
+                    "hp_a": hp_range_a or "—",
+                    "hp_delta": hp_delta,
+                    "base_dmg": base_dmg_text or "—",
+                    "asc_dmg": asc_dmg_text or "—",
+                    "dmg_delta": best_delta,
+                }
+            )
+    rows.sort(key=lambda r: (-r["hp_delta"], -r["dmg_delta"]))
+    lines = [
+        "| Monster | Type | HP | HP @ A7+ | Top attack | @ A2+ |",
+        "|---------|------|----|----------|-----------|-------|",
+    ]
+    for r in rows:
+        hp_a = r["hp_a"] + (f" (+{r['hp_delta']})" if r["hp_delta"] > 0 else "")
+        asc_dmg = r["asc_dmg"] + (f" (+{r['dmg_delta']})" if r["dmg_delta"] > 0 else "")
+        slug = str(r["id"]).lower()
+        lines.append(
+            f"| [{r['name']}](/monsters/{slug}) | {r['type']} | {r['hp']} | "
+            f"{hp_a} | {r['base_dmg']} | {asc_dmg} |"
+        )
+    return "\n".join(lines)
+
+
+# Effect descriptions stay hand-curated — the C# enum gives us the order
+# and naming, but the prose is interpretive (e.g. "5 → 8 elites on map" is
+# derived from MapModel constants, not the AscensionLevel enum itself).
+_ASCENSION_EFFECTS = {
+    "SwarmingElites": ("Swarming Elites", "5 → 8 elites on map"),
+    "WearyTraveler": ("Weary Traveler", "Ancient heals only 80%"),
+    "Poverty": ("Poverty", "Gold rewards x0.75"),
+    "TightBelt": ("Tight Belt", "3 → 2 potion slots"),
+    "AscendersBane": ("Ascender's Bane", "Start with Ascender's Bane curse"),
+    "Inflation": (
+        "Inflation",
+        "Card removal at the Merchant is more expensive (base 100g, +50g per use)",
+    ),
+    "Scarcity": ("Scarcity", "~50% rarer cards, slower pity"),
+    "ToughEnemies": ("Tough Enemies", "Enemy HP increases (per-enemy)"),
+    "DeadlyEnemies": ("Deadly Enemies", "Enemy damage increases (per-enemy)"),
+    "DoubleBoss": ("Double Boss", "Two bosses at end of the final act"),
+}
+
+
+def _resolve_table_ascension_levels(constants: dict) -> str:
+    levels = constants.get("ascension_levels") or list(_ASCENSION_EFFECTS.keys())
+    lines = ["| Level | Name | Effect |", "|------:|------|--------|"]
+    for i, key in enumerate(levels, start=1):
+        display, effect = _ASCENSION_EFFECTS.get(key, (key, "—"))
+        lines.append(f"| {i} | {display} | {effect} |")
+    return "\n".join(lines)
+
+
+_TABLE_RESOLVERS: dict[str, Any] = {
+    "character_stats": lambda _constants: _resolve_table_character_stats(),
+    "monster_scaling": lambda _constants: _resolve_table_monster_scaling(),
+    "ascension_levels": _resolve_table_ascension_levels,
+}
+
+
+def _resolve(body: str, constants: dict) -> str:
+    """Replace `{{...}}` tokens in the markdown body."""
+
+    def replace(match: re.Match) -> str:
+        expression = match.group(1).strip()
+        if expression.startswith("table:"):
+            name = expression[len("table:") :].strip()
+            resolver = _TABLE_RESOLVERS.get(name)
+            if resolver is None:
+                return match.group(0)
+            try:
+                return resolver(constants)
+            except Exception as exc:
+                logger.warning("table resolver %s failed: %s", name, exc)
+                return match.group(0)
+        return _resolve_value_token(expression, constants)
+
+    return _TOKEN_RE.sub(replace, body)
+
+
+# ── Public API ───────────────────────────────────────────────────────────
+
+
+def list_sections() -> list[dict]:
+    """All section index entries, ordered by frontmatter `order` then slug."""
+    pages_dir = _pages_dir()
+    if not pages_dir.exists():
+        return []
+    sections = []
+    for path in sorted(pages_dir.glob("*.md")):
+        post = frontmatter.load(path)
+        meta = post.metadata
+        sections.append(
+            {
+                "slug": path.stem,
+                "title": meta.get("title", path.stem),
+                "description": meta.get("description", ""),
+                "category": meta.get("category", "mechanics"),
+                "order": meta.get("order", 999),
+            }
+        )
+    sections.sort(key=lambda s: (s["order"], s["slug"]))
+    return sections
+
+
+def get_section(slug: str) -> dict | None:
+    """Single section, with template tokens resolved against current constants."""
+    path = _pages_dir() / f"{slug}.md"
+    if not path.exists():
+        return None
+    post = frontmatter.load(path)
+    meta = post.metadata
+    body = _resolve(post.content, _load_constants())
+    return {
+        "slug": slug,
+        "title": meta.get("title", slug),
+        "description": meta.get("description", ""),
+        "category": meta.get("category", "mechanics"),
+        "order": meta.get("order", 999),
+        "body_markdown": body,
+    }

--- a/data/mechanics_pages/ascension-modifiers.md
+++ b/data/mechanics_pages/ascension-modifiers.md
@@ -1,0 +1,8 @@
+---
+title: Ascension Modifiers
+description: All 10 ascension levels and their effects — from Swarming Elites (A1) to Double Boss (A10).
+category: mechanics
+order: 14
+---
+
+{{table:ascension_levels}}

--- a/data/mechanics_pages/autoslay.md
+++ b/data/mechanics_pages/autoslay.md
@@ -1,0 +1,8 @@
+---
+title: The Game Has a Built-In AI Player
+description: AutoSlay is a full automated player for CI testing — picks a random character, plays to floor 49 with a 25-minute timeout.
+category: secrets
+order: 25
+---
+
+AutoSlay is a full automated player used for CI testing. It picks a random character, plays through up to floor 49 with a 25-minute timeout, handles every room type, always rests at campfires, and reports results to Sentry. It runs in "Fast Mode" with tutorials disabled.

--- a/data/mechanics_pages/bosses-and-elites.md
+++ b/data/mechanics_pages/bosses-and-elites.md
@@ -1,0 +1,32 @@
+---
+title: Bosses & Elites by Act
+description: Which 3 bosses and 3 elites can appear in each act — Overgrowth, Underdocks, Hive, and Glory.
+category: mechanics
+order: 8
+---
+
+## Act 1: Overgrowth
+
+**Bosses (1 randomly selected):** Vantom, Ceremonial Beast, The Kin
+
+**Elites:** Bygone Effigy, Byrdonis, Phrog Parasite
+
+## Act 1: Underdocks (Alternate)
+
+**Bosses (1 randomly selected):** Waterfall Giant, Soul Fysh, Lagavulin Matriarch
+
+**Elites:** Skulking Colony, Phantasmal Gardeners, Terror Eel
+
+## Act 2: Hive
+
+**Bosses (1 randomly selected):** The Insatiable, Knowledge Demon, Kaiser Crab
+
+**Elites:** Decimillipede, Entomancer, Infested Prisms
+
+## Act 3: Glory
+
+**Bosses (1 randomly selected):** Queen, Test Subject, Doormaker
+
+**Elites:** Knights, Mecha Knight, Soul Nexus
+
+> Underdocks replaces Overgrowth 50% of the time (once unlocked). On A10, two bosses are fought at the end of the final act.

--- a/data/mechanics_pages/byrdpip.md
+++ b/data/mechanics_pages/byrdpip.md
@@ -1,0 +1,8 @@
+---
+title: Byrdpip Is Invincible and Does Nothing
+description: The Byrdpip pet has 9,999 HP, a hidden health bar, and its only move is NOTHING_MOVE. It has 4 random skins.
+category: secrets
+order: 23
+---
+
+Hatch a Byrdonis Egg at a rest site to get the Byrdpip relic, which spawns a pet in every combat. Byrdpip has **9,999 HP**, a hidden health bar, and its only move is literally called `NOTHING_MOVE`. It has 4 random skin variants and converts all egg cards into Byrd Swoop (0-cost, 14 damage). Only one pet per player.

--- a/data/mechanics_pages/campfire-options.md
+++ b/data/mechanics_pages/campfire-options.md
@@ -1,0 +1,17 @@
+---
+title: Campfire Options
+description: All 8 rest site choices — Rest, Smith, Dig, Lift, Cook, Clone, Hatch, and Mend. Some require specific relics or cards.
+category: mechanics
+order: 12
+---
+
+| Option | Effect |
+|--------|--------|
+| Rest | Heal 30% of max HP |
+| Smith | Upgrade 1 card |
+| Dig | Obtain a random relic (requires Shovel) |
+| Lift | Gain 1 Strength (requires Girya, max 3) |
+| Cook | Remove 2 cards, gain 9 Max HP (requires Meal Kit) |
+| Clone | Enchant a card with Clone (requires Pael's Growth) |
+| Hatch | Hatch Byrdonis Egg into Byrdpip pet (requires Byrdonis Egg) |
+| Mend | Heal an ally for 30% of their max HP (multiplayer only) |

--- a/data/mechanics_pages/card-rarity.md
+++ b/data/mechanics_pages/card-rarity.md
@@ -1,0 +1,50 @@
+---
+title: Card Rarity Odds
+description: Card rarity probabilities for normal fights, elite fights, boss fights, and shops. Includes rare card pity system and ascension modifiers.
+category: mechanics
+order: 1
+---
+
+## Normal Fights
+
+| Rarity | Chance | A7+ |
+|--------|-------:|----:|
+| Common | {{constants.card_rarity_odds.regularCommonOdds.base | pct}} | {{constants.card_rarity_odds.regularCommonOdds.ascended | pct}} |
+| Uncommon | {{constants.card_rarity_odds.regularUncommonOdds | pct}} | {{constants.card_rarity_odds.regularUncommonOdds | pct}} |
+| Rare | {{constants.card_rarity_odds.RegularRareOdds.base | pct}} | {{constants.card_rarity_odds.RegularRareOdds.ascended | pct2}} |
+
+## Elite Fights
+
+| Rarity | Chance | A7+ |
+|--------|-------:|----:|
+| Common | {{constants.card_rarity_odds.EliteCommonOdds.base | pct}} | {{constants.card_rarity_odds.EliteCommonOdds.ascended | pct}} |
+| Uncommon | {{constants.card_rarity_odds.eliteUncommonOdds | pct}} | {{constants.card_rarity_odds.eliteUncommonOdds | pct}} |
+| Rare | {{constants.card_rarity_odds.EliteRareOdds.base | pct}} | {{constants.card_rarity_odds.EliteRareOdds.ascended | pct}} |
+
+## Boss Fights
+
+| Rarity | Chance |
+|--------|-------:|
+| Rare | {{constants.card_rarity_odds.bossRareOdds | pct}} |
+
+> Boss card rewards are always rare.
+
+## Shop
+
+| Rarity | Chance | A7+ |
+|--------|-------:|----:|
+| Common | {{constants.card_rarity_odds.ShopCommonOdds.base | pct}} | {{constants.card_rarity_odds.ShopCommonOdds.ascended | pct}} |
+| Uncommon | {{constants.card_rarity_odds.shopUncommonOdds | pct}} | {{constants.card_rarity_odds.shopUncommonOdds | pct}} |
+| Rare | {{constants.card_rarity_odds.ShopRareOdds.base | pct}} | {{constants.card_rarity_odds.ShopRareOdds.ascended | pct}} |
+
+## Rare Card Pity System
+
+A hidden offset starts at **{{constants.card_rarity_odds._baseRarityOffset | pct}}** and increases by **+{{constants.card_rarity_odds.RarityGrowth.base | pct}}** for each non-rare card *shown* in a combat reward (+{{constants.card_rarity_odds.RarityGrowth.ascended | pct}} on A7+) — including ones you skip. When a rare is rolled, the offset resets to {{constants.card_rarity_odds._baseRarityOffset | pct}}. Caps at **+{{constants.card_rarity_odds._maxRarityOffset | pct}}**. Each combat reward generates 3 cards up front, so a skipped reward still ticks the counter 3 times. This ensures you see rares more often the longer you go without one.
+
+## Card Upgrade Chance
+
+Scales per act: **0%** in Act 1, **25%** in Act 2, **50%** in Act 3 (halved on A7+: 0%/12.5%/25%). Rare cards are never auto-upgraded.
+
+## Cards Offered
+
+All combat encounters offer **3 cards** to choose from (normal, elite, and boss).

--- a/data/mechanics_pages/character-stats.md
+++ b/data/mechanics_pages/character-stats.md
@@ -1,0 +1,10 @@
+---
+title: Character Starting Stats
+description: Starting HP, gold, deck size, and orb slots for Ironclad, Silent, Defect, Necrobinder, and Regent.
+category: mechanics
+order: 10
+---
+
+{{table:character_stats}}
+
+> All characters start with 3 energy and 3 potion slots.

--- a/data/mechanics_pages/combat-mechanics.md
+++ b/data/mechanics_pages/combat-mechanics.md
@@ -1,0 +1,53 @@
+---
+title: Combat Mechanics
+description: Hand size (5 draw, 10 max), energy (3 base), block decay, damage formulas — Strength, Dexterity, Vulnerable, Weak, Frail.
+category: mechanics
+order: 9
+---
+
+## Attack Mechanics
+
+An attack's damage is computed in a fixed order. First, the printed value is added to the attacker's **Strength** stacks (one stack = +1 damage, additive — negative stacks reduce damage). The total is then multiplied by **{{constants.combat_modifiers.Weak.value | mult}}** if the attacker has **Weak**, and by **{{constants.combat_modifiers.Vulnerable.value | mult}}** if the target has **Vulnerable**. Whatever's left is absorbed by the target's **Block**; any remainder hits HP.
+
+> Block follows the mirror path: card block + **Dexterity** stacks, then multiplied by **{{constants.combat_modifiers.Frail.value | mult}}** if the player has **Frail**. Multi-hit attacks apply the full pipeline per hit. Source: `VulnerablePower`, `WeakPower`, `FrailPower`, `StrengthPower`, `DexterityPower`.
+
+## Scaling
+
+| Effect | Per stack | Lifetime |
+|--------|-----------|----------|
+| Strength | +1 attack damage | persists |
+| Dexterity | +1 card block | persists |
+| Vulnerable | {{constants.combat_modifiers.Vulnerable.value | mult}} damage taken (debuff cap, not per-stack) | decays 1/turn |
+| Weak | {{constants.combat_modifiers.Weak.value | mult}} damage dealt (debuff cap, not per-stack) | decays 1/turn |
+| Frail | {{constants.combat_modifiers.Frail.value | mult}} block from cards (debuff cap, not per-stack) | decays 1/turn |
+
+> Buffs (Strength, Dexterity) accumulate additively and last the whole combat. Debuffs (Vulnerable, Weak, Frail) are *counters* — the multiplier is fixed regardless of stack count, but the counter ticks down by 1 at the end of each turn until it reaches zero. Multi-hit attacks apply the full damage pipeline (Strength + multipliers + Block) on every hit.
+
+> **Enemy ascension scaling.** Monster HP and damage are bumped per-monster at **ToughEnemies** (A7+) and **DeadlyEnemies** (A2+) respectively, using the `AscensionHelper.GetValueIfAscension` pattern. Each monster ships with both its base and ascended values — see the [full scaling table](/mechanics/enemy-ascension-scaling).
+
+## Hand & Draw
+
+| Mechanic | Value |
+|----------|------:|
+| Cards drawn per turn | 5 |
+| Max hand size | 10 |
+| Base energy per turn | 3 |
+| Block | Clears at start of turn |
+
+> On turn 1, Innate cards are moved to the top of the draw pile. When the draw pile is empty, the discard pile is shuffled in.
+
+## Damage & Defense Modifiers
+
+| Effect | Modifier |
+|--------|----------|
+| Strength | +N attack damage (additive) |
+| Dexterity | +N card block (additive) |
+| Vulnerable | {{constants.combat_modifiers.Vulnerable.value | mult}} damage taken |
+| Weak | {{constants.combat_modifiers.Weak.value | mult}} damage dealt |
+| Frail | {{constants.combat_modifiers.Frail.value | mult}} block from cards |
+
+> Strength and Dexterity are additive (applied before multipliers). Vulnerable, Weak, and Frail are multiplicative.
+
+## End of Turn
+
+Ethereal cards in hand are **exhausted**. Cards with **Retain** stay in hand. All other cards are discarded. Block clears at the start of your next turn (unless prevented by Barricade, Calipers, etc.).

--- a/data/mechanics_pages/crystal-sphere.md
+++ b/data/mechanics_pages/crystal-sphere.md
@@ -1,0 +1,8 @@
+---
+title: Crystal Sphere Minesweeper
+description: The Crystal Sphere event is a hidden-object minigame on an 11x11 grid with relics, potions, cards, and a hidden curse.
+category: secrets
+order: 19
+---
+
+The Crystal Sphere event isn't just a simple choice — it's a hidden-object game on an **11×11 grid**. You get 3 divinations (or 6 if you take on Debt curses), each revealing cells using a "Big" (3×3) or "Small" (single cell) tool. The grid contains a relic, 3 potions, 3 card rewards of increasing rarity, gold piles (10g and 30g), and a hidden Doubt curse occupying a 2×2 area.

--- a/data/mechanics_pages/dev-console.md
+++ b/data/mechanics_pages/dev-console.md
@@ -1,0 +1,8 @@
+---
+title: Dev Console God Mode
+description: 39 developer console commands including godmode (9,999 Strength + Buffer + Regen), instant death, and trailer mode.
+category: secrets
+order: 26
+---
+
+The developer console has 39 commands including `godmode` (9,999 Strength + Buffer + Regen), `die` (instant death), `win` (kill all enemies), and `trailer` (toggle UI for capturing footage). The test dummy monster uses the Defect's sprite.

--- a/data/mechanics_pages/enemy-ascension-scaling.md
+++ b/data/mechanics_pages/enemy-ascension-scaling.md
@@ -1,0 +1,14 @@
+---
+title: Enemy Ascension Scaling
+description: Per-monster HP and damage bumps applied at ToughEnemies (A7) and DeadlyEnemies (A2). Sortable table covering every monster in the bestiary.
+category: mechanics
+order: 15
+---
+
+## How Enemy Scaling Works
+
+Two ascension levels bump enemy stats game-wide. **DeadlyEnemies** (unlocked at **A2**) raises every monster's attack damage; **ToughEnemies** (unlocked at **A7**) raises HP and per-move block. The bumps are *per-monster constants* defined in each monster's C# class via `AscensionHelper.GetValueIfAscension(level, ascended, base)`, not a global multiplier — every entry below is a literal value pulled from the source.
+
+> Damage column shows the move with the largest bump (multi-hit attacks displayed as `N×hits`). HP delta and damage delta are shown in parentheses where they apply.
+
+{{table:monster_scaling}}

--- a/data/mechanics_pages/foul-potion.md
+++ b/data/mechanics_pages/foul-potion.md
@@ -1,0 +1,14 @@
+---
+title: The Foul Potion Has 3 Uses
+description: The most context-sensitive item in the game — combat damage, merchant gold, and Fake Merchant boss trigger.
+category: secrets
+order: 17
+---
+
+The Foul Potion is the most context-sensitive item in the game.
+
+**In combat**, it deals 12 damage to all enemies.
+
+**At a real merchant**, throw it at the shopkeeper to receive 100 gold (with a slime impact VFX).
+
+**At the Fake Merchant**, throwing it reveals the impostor and triggers a boss fight against the Fake Merchant Monster (165-175 HP). Beat it to earn the Fake Merchant's Rug relic and all unpurchased fake relics.

--- a/data/mechanics_pages/gold-rewards.md
+++ b/data/mechanics_pages/gold-rewards.md
@@ -1,0 +1,15 @@
+---
+title: Gold Rewards
+description: Exact gold reward ranges for normal fights (10-20), elite fights (35-45), boss fights (100), and treasure rooms (42-52).
+category: mechanics
+order: 4
+---
+
+| Source | Gold | A3+ |
+|--------|-----:|----:|
+| Normal fight | {{constants.encounter_gold_rewards.Monster | range}} | 8-15 |
+| Elite fight | {{constants.encounter_gold_rewards.Elite | range}} | 26-34 |
+| Boss fight | {{constants.encounter_gold_rewards.Boss | range}} | 75 |
+| Treasure room | 42-52 | 32-39 |
+
+> Ascension 3 (Poverty) multiplies all gold rewards by {{constants.ascension_helper.PovertyAscensionGoldMultiplier | mult}}. If enemies escape during combat, gold is proportionally reduced.

--- a/data/mechanics_pages/map-generation.md
+++ b/data/mechanics_pages/map-generation.md
@@ -1,0 +1,29 @@
+---
+title: Map Generation
+description: How the map is built — act structure, room counts, elite placement rules, and room distribution.
+category: mechanics
+order: 6
+---
+
+## Act Structure
+
+| Act | Rooms | Floors | Weak Fights |
+|-----|------:|-------:|------------:|
+| Overgrowth (Act 1) | 15 | 17 | 3 |
+| Underdocks (Alt Act 1) | 15 | 17 | 3 |
+| Hive (Act 2) | 14 | 16 | 2 |
+| Glory (Act 3) | 13 | 15 | 2 |
+
+> Map is a 7-column grid. Rooms = choosable nodes, Floors = rooms + Ancient + boss. First row is always fights, 7 rows from the end is a guaranteed treasure room (or elite if replaced), last row is always a rest site.
+
+## Room Distribution
+
+| Type | Count | A1+ |
+|------|------:|----:|
+| Elites | 5 | 8 |
+| Shops | 3 | 3 |
+| Unknown (?) | 10-14 | 10-14 |
+| Rest sites | 5-7 (varies by act) | -1 on A6 |
+| Fights | Remaining slots | — |
+
+> Unknown rooms average ~12 (Gaussian). Rest sites: 6-7 in Acts 1-2, 5-6 in Act 3 (each -1 on A6). No elites or rest sites in the first 5 rows.

--- a/data/mechanics_pages/merchant-blacklist.md
+++ b/data/mechanics_pages/merchant-blacklist.md
@@ -1,0 +1,8 @@
+---
+title: Two Relics Are Banned From Shops
+description: The Courier and Old Coin are hardcoded into the merchant blacklist — they can never appear in shops.
+category: secrets
+order: 24
+---
+
+Five relics override `IsAllowedInShops => false` and never appear in the merchant pool: **The Courier**, **Old Coin**, **Lucky Fysh**, **Bowler Hat**, and **Amethyst Aubergine**. Major Update #1 (v0.103.2) added the last three after gold-generating relics broke shop economy testing — they remain craftable through other sources but are walled off from the merchant.

--- a/data/mechanics_pages/neow.md
+++ b/data/mechanics_pages/neow.md
@@ -1,0 +1,22 @@
+---
+title: Neow Offerings
+description: Starting Ancient Neow offers 3 relics — 2 positive and 1 curse. Full relic pools and conflict prevention rules.
+category: mechanics
+order: 13
+---
+
+Neow offers **3 relic choices**: 2 random positive relics and 1 random curse relic. You must pick one.
+
+## Positive Pool (2 picked)
+
+Arcane Scroll, Booming Conch, Golden Pearl, Lead Paperweight, Lost Coffer, Massive Scroll, Neow's Torment, New Leaf, Phial Holster, Precise Scissors, Winged Boots
+
+Plus one of each pair (50/50 each): Lava Rock / Small Capsule · Nutritious Oyster / Stone Humidifier · Neow's Talisman / Pomander
+
+## Curse Pool (1 picked)
+
+Cursed Pearl, Hefty Tablet, Large Capsule, Leafy Poultice, Neow's Bones, Precarious Shears, Scroll Boxes (conditional), Silver Crucible (singleplayer only)
+
+Conflicting pairs are removed (e.g. Cursed Pearl excludes Golden Pearl, Hefty Tablet excludes Arcane Scroll, Leafy Poultice excludes New Leaf, Precarious Shears excludes Precise Scissors). If Large Capsule rolls as the curse, both the Lava Rock / Small Capsule pair are skipped.
+
+> Before the event, you are healed to full HP. On A2+, heal is only 80% of missing HP. Major Update #1 (v0.103.2) expanded both pools — Phial Holster, Winged Boots, Massive Scroll, and Neow's Talisman joined the positive side; Hefty Tablet and Neow's Bones joined the curse side.

--- a/data/mechanics_pages/orb-mechanics.md
+++ b/data/mechanics_pages/orb-mechanics.md
@@ -1,0 +1,16 @@
+---
+title: Orb Mechanics
+description: Defect orb system — Lightning, Frost, Dark, Plasma, and Glass passive and evoke values. 3 starting slots, 10 max.
+category: mechanics
+order: 11
+---
+
+| Orb | Passive | Evoke |
+|-----|---------|-------|
+| Lightning | 3 damage to random enemy | 8 damage to random enemy |
+| Frost | 2 block | 5 block |
+| Dark | +6 to evoke value | Accumulated damage to lowest HP |
+| Plasma | 1 energy (start of turn) | 2 energy |
+| Glass | 4 damage to all enemies (-1/turn) | Passive value x2 to all enemies |
+
+> Starting slots: 3. Max capacity: 10. When full, channeling evokes the leftmost orb. Focus modifies passive and evoke values.

--- a/data/mechanics_pages/orobas-prismatic.md
+++ b/data/mechanics_pages/orobas-prismatic.md
@@ -1,0 +1,8 @@
+---
+title: Orobas and the Prismatic Gem
+description: The Ancient Orobas in Act 2 has a ~8% chance to offer the Prismatic Gem — 33% chance it enters the pool, then 1-in-4 to be picked.
+category: secrets
+order: 22
+---
+
+When visiting the Ancient Orobas in Act 2, there's a **33% chance** the Prismatic Gem is added to Orobas's first relic pool (alongside Electric Shrymp, Glass Eye, and Sand Castle). If it doesn't appear, Sea Glass (from another character's pool) takes its slot instead. Since one relic is randomly picked from the pool of 4, the actual chance of being *offered* Prismatic Gem is **~8.3%** (33% × 25%). This relic makes card rewards include cards from ALL character pools. Orobas also offers starter relic upgrades: Burning Blood becomes Black Blood, Ring of the Snake becomes Ring of the Drake, and so on.

--- a/data/mechanics_pages/potion-drop-rates.md
+++ b/data/mechanics_pages/potion-drop-rates.md
@@ -1,0 +1,25 @@
+---
+title: Potion Drop Rates
+description: Potion drop chances from combat with adaptive pity system. Base 40% chance, capped at 50%, with elite bonus.
+category: mechanics
+order: 3
+---
+
+## Combat Rewards
+
+| Encounter | Base Chance |
+|-----------|------------:|
+| Normal | {{constants.potion_reward_odds._basePotionRewardOdds | pct}} |
+| Elite | ~52.5% |
+
+> **Pity system:** +10% each fight without a potion, -10% when one drops. No hard cap in the code. Elite fights add a flat +{{constants.potion_reward_odds.eliteBonus | pct}} bonus without affecting the pity counter. The adaptive counter targets {{constants.potion_reward_odds.targetOdds | pct}}.
+
+## Rarity Distribution
+
+| Rarity | Chance |
+|--------|-------:|
+| Common | 65% |
+| Uncommon | 25% |
+| Rare | 10% |
+
+> Default capacity: **3 slots** (2 on A4+).

--- a/data/mechanics_pages/reflections.md
+++ b/data/mechanics_pages/reflections.md
@@ -1,0 +1,8 @@
+---
+title: The Reflections Event Can Double Your Deck
+description: The Shatter option clones every card in your deck 1:1, doubling its size. The catch — a Bad Luck curse.
+category: secrets
+order: 20
+---
+
+The Reflections event (Act 3) offers a "Shatter" option that **clones every card in your deck 1:1**, doubling its size. The catch: you also receive a Bad Luck curse. The safer "Touch a Mirror" option downgrades 2 random upgraded cards but upgrades 4 random upgradable ones.

--- a/data/mechanics_pages/relic-distribution.md
+++ b/data/mechanics_pages/relic-distribution.md
@@ -1,0 +1,25 @@
+---
+title: Relic Rarity Distribution
+description: Relic rarity chances from elite fights, treasure rooms, and shops. Common 50%, Uncommon 33%, Rare 17%.
+category: mechanics
+order: 2
+---
+
+## Rarity Roll
+
+| Rarity | Chance |
+|--------|-------:|
+| Common | 50% |
+| Uncommon | 33% |
+| Rare | 17% |
+
+> Used for elite rewards and treasure rooms. If a rarity pool is exhausted, it falls back to the next tier.
+
+## Sources
+
+| Source | Relics |
+|--------|-------:|
+| Elite fight | 1 (random rarity) |
+| Treasure room | 1 (random rarity) |
+| Shop | 3 (2 random + 1 shop) |
+| Boss fight | 1 boss relic |

--- a/data/mechanics_pages/score-formula.md
+++ b/data/mechanics_pages/score-formula.md
@@ -1,0 +1,69 @@
+---
+title: Scoring & Daily Leaderboards
+description: How your run score is calculated — 10 points per room, act multipliers, elite/boss/gold bonuses, and ascension scaling. Plus the packed daily-leaderboard score format added in Major Update #1.
+category: mechanics
+order: 16
+---
+
+## Run Score
+
+Awarded for every completed run, win or lose. Shown on the run-history screen and used by the final-boss scene to render the "damage" numbers on the Architect.
+
+| Component | Value |
+|-----------|-------|
+| Rooms visited | 10 pts per room × act number (×1 / ×2 / ×3) |
+| Gold gained | +1 pt per 100 gold (divided by player count) |
+| Elites killed | +50 each (the elite you died to doesn't count) |
+| Bosses slain | +100 each (3 on a win, fewer if you die earlier; A10 wins count 4) |
+| Ascension multiplier | ×(1 + ascension × 0.1) |
+
+> Final = (rooms + gold + elites + bosses) × (1 + ascension × 0.1). At A10 your score is doubled. Source: `ScoreUtility.CalculateScore`.
+
+## Worked Example
+
+Hypothetical A0 win — 15 rooms in act 1, 14 in act 2, 14 in act 3, 4 elites killed, 3 bosses, 1,200 gold gained, single player.
+
+| Component | Math | Pts |
+|-----------|------|----:|
+| Act 1 rooms | 15 × 10 × 1 | 150 |
+| Act 2 rooms | 14 × 10 × 2 | 280 |
+| Act 3 rooms | 14 × 10 × 3 | 420 |
+| Gold | 1200 / 100 | 12 |
+| Elites | 4 × 50 | 200 |
+| Bosses | 3 × 100 | 300 |
+| **Subtotal × A0 multiplier** | 1,362 × 1.0 | **1,362** |
+
+> The same run on A10 would multiply by 2.0 for a final score of 2,724. Each A-tier adds +10% — there's no diminishing return.
+
+## Daily-Run Leaderboard Score
+
+Daily runs use a completely separate scoring system that's a single packed integer. The digits ARE the sort order — a numeric DESC sort gives the right ranking, no separate columns needed. Major Update #1 introduced this so "the score sent to the leaderboards is based on whether you won, how many badges you accrued, and how quickly you finished the run (in that order)".
+
+| Bucket | Multiplier | Range |
+|--------|-----------|-------|
+| Victory flag | × 100,000,000 | 1 = loss, 2 = win |
+| Floors visited | × 1,000,000 | 0–99 |
+| Badges earned | × 10,000 | 0–99 |
+| Run time | 9999 − seconds | faster = higher |
+
+> Source: `ScoreUtility.CalculateDailyScore`. The matching `DecodeDailyScore` peels the integer back into `{ victory, floors, badges, runTime }` for display.
+
+## Daily-Score Worked Example
+
+An A10 daily win — 48 floors visited, 7 badges earned, completed in 1,842 seconds (30:42).
+
+| Bucket | Math | Contribution |
+|--------|------|-------------:|
+| Victory (win) | 2 × 100,000,000 | 200,000,000 |
+| Floors | 48 × 1,000,000 | 48,000,000 |
+| Badges | 7 × 10,000 | 70,000 |
+| Time | 9999 − 1842 | 8,157 |
+| **Total packed score** | | **248,078,157** |
+
+> Beat someone's 248,070,XXX score? You won, hit at least 48 floors, and got 7+ badges. Faster runs win at every tier of the comparison.
+
+## Why Two Scores?
+
+The **run score** is descriptive — it tells you how good a single run was at a glance, weighted heavily toward depth (act 3 rooms count 3x). The **daily score** is a sorting key — it has to compare two runs deterministically and produce one winner. Mega Crit packed it as a single integer so the leaderboard can be sorted with one column and no tiebreaker logic.
+
+> The constant `clientScore = -999999999` is a sentinel for "this row was sent without a server-computed score" — used to filter unverified entries from the leaderboard view.

--- a/data/mechanics_pages/shop-inventory.md
+++ b/data/mechanics_pages/shop-inventory.md
@@ -1,0 +1,30 @@
+---
+title: Shop Inventory
+description: Shop layout — 5 character cards, 2 colorless, 3 relics, 3 potions, card removal scaling (75 + 25n gold).
+category: mechanics
+order: 5
+---
+
+## Inventory Layout
+
+| Category | Slots |
+|----------|------:|
+| Character cards | 5 (2 ATK, 2 SKL, 1 PWR) |
+| Colorless cards | 2 (1 UNC, 1 RARE) |
+| Relics | 3 (2 random + 1 shop) |
+| Potions | 3 |
+| Card removal | 1 service |
+
+> One random character card is "On Sale" each visit. Card and potion prices have ±5% variance, relic prices have ±15% variance.
+
+## Card Removal Cost
+
+| Removals Used | A0–5 | A6+ (Inflation) |
+|---------------|-----:|----------------:|
+| 0 (first) | 75g | 100g |
+| 1 | 100g | 150g |
+| 2 | 125g | 200g |
+| 3 | 150g | 250g |
+| n | 75 + 25n | 100 + 50n |
+
+> Major Update #1 (v0.103.2) reworked Ascension 6 from Gloom (1 fewer rest site) into Inflation, which raises the base removal price by 25 gold and the per-use increment by 25.

--- a/data/mechanics_pages/the-architect.md
+++ b/data/mechanics_pages/the-architect.md
@@ -1,0 +1,8 @@
+---
+title: The Architect Can't Fight You
+description: The final encounter has 9,999 HP but can't attack. It's a dialogue scene where your score determines the visual damage.
+category: secrets
+order: 21
+---
+
+The final encounter with The Architect has **9,999 HP** but its only move is "NOTHING" with a hidden intent. The ending is a dialogue scene, not a fight. Each character has unique conversations that change based on how many times you've visited. Your run score determines the visual damage numbers in the finale — one hit is intentionally made 2-3× larger for dramatic effect.

--- a/data/mechanics_pages/the-deprived.md
+++ b/data/mechanics_pages/the-deprived.md
@@ -1,0 +1,8 @@
+---
+title: "The Deprived: A Hidden Test Character"
+description: A debug character with 1,000 HP, 100 energy, an empty deck, and no relics. Purple color scheme, neutral gender.
+category: secrets
+order: 27
+---
+
+A debug-only character called "The Deprived" exists in the code with **1,000 HP**, **100 energy** per turn, an empty starting deck, no relics, and neutral gender. It uses a purple color scheme and has zero animation delays. Not accessible through normal play.

--- a/data/mechanics_pages/unknown-rooms.md
+++ b/data/mechanics_pages/unknown-rooms.md
@@ -1,0 +1,16 @@
+---
+title: Unknown Room Probabilities
+description: What happens when you enter a "?" room — adaptive probability system for events, fights, shops, and treasure.
+category: mechanics
+order: 7
+---
+
+| Outcome | Base Chance | Adaptive |
+|---------|------------:|----------|
+| Event | ~85% | Remainder after other rolls |
+| Monster fight | {{constants.unknown_map_point_odds.baseMonsterOdds | pct}} | +{{constants.unknown_map_point_odds.baseMonsterOdds | pct}} each miss |
+| Shop | {{constants.unknown_map_point_odds.baseShopOdds | pct}} | +{{constants.unknown_map_point_odds.baseShopOdds | pct}} each miss |
+| Treasure | {{constants.unknown_map_point_odds.baseTreasureOdds | pct}} | +{{constants.unknown_map_point_odds.baseTreasureOdds | pct}} each miss |
+| Elite | 0% | Accumulates from -1 |
+
+> Each outcome has adaptive odds: when it doesn't occur, its chance increases by its base amount. When it does occur, it resets. On your very first run, the first 2 unknown rooms are always events, and the 3rd is always a fight.

--- a/data/mechanics_pages/wongo-loyalty.md
+++ b/data/mechanics_pages/wongo-loyalty.md
@@ -1,0 +1,14 @@
+---
+title: Wongo's Cross-Run Loyalty Points
+description: A hidden loyalty system that persists across runs. Earn points toward a badge relic, but leaving without buying downgrades a card.
+category: secrets
+order: 18
+---
+
+The Welcome to Wongo's event (Act 2) has a hidden cross-run loyalty system. Each purchase earns Wongo Points that accumulate across ALL runs. At **2,000 points**, you earn a Wongo Customer Appreciation Badge relic. But beware: **leaving without buying anything downgrades a random upgraded card** in your deck.
+
+| Purchase | Cost | Points |
+|----------|-----:|-------:|
+| Bargain Bin (Common relic) | 100g | 32 pts |
+| Featured Item (Rare relic) | 200g | 16 pts |
+| Mystery Box (3 relics after 5 fights) | 300g | 8 pts |

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -81,6 +81,8 @@ const NAV_GROUPS: NavGroup[] = [
       { href: "/changelog", label: "Changelog" },
       { href: "/thank-you", label: "Thank You" },
       { href: "https://ko-fi.com/yitsy", label: "Ko-fi" },
+      { href: "/privacy", label: "Privacy" },
+      { href: "/terms", label: "Terms" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- New `GET /api/mechanics/sections` returns the 27-page index `{slug, title, description, category, order}`.
- New `GET /api/mechanics/sections/{slug}` returns one page as **fully-baked Markdown** — `{{constants...}}` value tokens and `{{table:character_stats | monster_scaling | ascension_levels}}` macros are resolved server-side against `mechanics_constants.json`, `/api/characters`, and `/api/monsters`. The overlay only needs a Markdown renderer; no fan-out to additional endpoints required.
- Each page is now sourced from a `data/mechanics_pages/<slug>.md` file with YAML frontmatter, parsed via `python-frontmatter` (already a dep — used by guides).

## Token grammar

```
{{constants.path.to.field [| pct | pct2 | mult | gold | range | range_gold]}}
{{table:character_stats}}     # 5 starter chars, HP/gold/deck/orb_slots
{{table:monster_scaling}}     # bestiary scaling table sorted by HP delta
{{table:ascension_levels}}    # 10 ascension levels with effects
```

Bad references (typo, missing field) round-trip the literal token in the output so they're easy to spot during authoring.

## Frontend

Untouched. Existing JSX in `frontend/app/mechanics/[slug]/MechanicContent.tsx` still renders the website. Switching the website to read from this API and dropping the JSX is a follow-up PR — keeps this one scoped to what the Overwolf overlay needs to ship.

## Smoke test results

All 27 sections resolve cleanly with no leftover `{{...}}` tokens. Sample outputs validated against the existing pages:
- `card-rarity` reads 60% / 61.5% / 1.49% etc. matching `mechanics_constants.json`.
- `character-stats` table includes Defect's 3 orb slots (others 0, not `None`).
- `enemy-ascension-scaling` table sorted by HP delta DESC, top entry The Merchant??? (165 → 175 +10).
- `ascension-modifiers` enumerates all 10 levels with their hand-curated effects.

## Tradeoff

Lost some bespoke layouts (side-by-side card grids on the website become a single column when this becomes the rendering source). Frontend keeps its existing JSX for now so visual fidelity is preserved on the website.
