### PR TITLE
Steam OpenID popup endpoint for overlay-direct flow

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -360,6 +360,19 @@ app.include_router(news.router)
 app.include_router(merchant.router)
 app.include_router(mechanics.router)
 app.include_router(auth_steam.router)
+# Overlay-direct OpenID flow uses /auth/steam-popup as Steam's return_to.
+# This is intentionally outside /api/* — it's a user-facing HTML page,
+# not a JSON API — so it's mounted at the app level rather than under
+# the auth_steam router's /api/auth/steam prefix.
+from fastapi.responses import HTMLResponse  # noqa: E402
+
+app.add_api_route(
+    "/auth/steam-popup",
+    auth_steam.steam_popup,
+    methods=["GET"],
+    response_class=HTMLResponse,
+    include_in_schema=False,
+)
 
 
 @app.get("/api/languages", tags=["Languages"])

--- a/backend/app/routers/auth_steam.py
+++ b/backend/app/routers/auth_steam.py
@@ -333,6 +333,75 @@ def _html_escape(text: str) -> str:
     )
 
 
+# ── Static popup (overlay-direct OpenID flow) ────────────────────────────
+#
+# Distinct from the /start /callback /poll flow above. That flow has the
+# spire-codex backend act as the OpenID relying party. The overlay can
+# also do OpenID directly with its own localhost listener as the relying
+# party — but Overwolf's `web.createServer` can't write a custom HTTP
+# response, so the user's browser would land on a blank page after
+# Steam returns. Routing the return_to through this static popup
+# instead lets us greet the user, beacon the openid params back to the
+# overlay's localhost listener, and try to auto-close.
+
+
+async def steam_popup(request: Request) -> HTMLResponse:
+    """Static return-page for the overlay's localhost OpenID flow.
+
+    Reads the `openid.*` params + `localhost_port` from the query string,
+    forwards everything except `localhost_port` to
+    `http://localhost:<port>/callback?...` via an `<img>` beacon, shows a
+    "you can close this tab" message, and best-effort `window.close()`s.
+    No server-side state — multi-worker safe by definition.
+    """
+    html = """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Spire Codex — signed in</title>
+  <style>
+    html, body { margin: 0; padding: 0; height: 100%; background: #16181d;
+      color: #e6e6e6; font-family: -apple-system, BlinkMacSystemFont,
+      "Segoe UI", sans-serif; display: flex; align-items: center;
+      justify-content: center; }
+    .card { text-align: center; padding: 40px; max-width: 420px; }
+    h1 { color: #d7a84a; margin: 0 0 12px; font-size: 24px; }
+    p { color: #e6e6e6; margin: 0 0 8px; line-height: 1.5; }
+    .hint { color: #8d94a1; font-size: 13px; margin-top: 14px; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Signed in</h1>
+    <p>Returning you to Spire Codex…</p>
+    <p class="hint">You can close this tab.</p>
+  </div>
+  <script>
+    (function () {
+      var search = window.location.search || "";
+      var params = new URLSearchParams(search);
+      var port = params.get("localhost_port");
+      // Strip our own localhost_port param before forwarding so Steam's
+      // signed openid.* set is preserved exactly.
+      params.delete("localhost_port");
+      var forwarded = params.toString();
+      if (port && /^\\d{1,5}$/.test(port) && forwarded) {
+        // Browsers special-case http://localhost as a secure context,
+        // so this image beacon from HTTPS works without mixed-content
+        // blocking. Fire-and-forget — we never read the response.
+        var img = new Image();
+        img.src = "http://localhost:" + port + "/callback?" + forwarded;
+      }
+      // window.close() is blocked in some browsers when the tab wasn't
+      // opened via JS. Best-effort — friendly fallback message stays.
+      setTimeout(function () { window.close(); }, 1200);
+    })();
+  </script>
+</body>
+</html>"""
+    return HTMLResponse(content=html)
+
+
 # Schemas — exposed for /openapi.json + clients that want to import them.
 # The endpoints above return raw dicts (faster + same wire shape), but
 # OpenAPI consumers can reference these.


### PR DESCRIPTION
## Summary

Adds a static `GET /auth/steam-popup` endpoint that the Overwolf overlay's Steam OpenID flow uses as Steam's `return_to`. The overlay does OpenID directly with its own localhost listener as the relying party, but `overwolf.web.createServer` can't write a custom HTTP response — so without a popup the user lands on a blank page after Steam returns. The popup:

- Reads `openid.*` params + `localhost_port` from the query string.
- Beacons everything except `localhost_port` to `http://localhost:<port>/callback?...` via an `<img>` tag (browsers special-case `http://localhost` as a secure context, so HTTPS → loopback works without mixed-content blocking).
- Shows a "you can close this tab" greeting and best-effort `window.close()`s.

No server-side state — multi-worker safe by definition.

## URL choice

Mounted at `/auth/steam-popup` (not `/api/auth/steam/popup`) because it's a user-facing HTML page, not a JSON API. Matches the URL the overlay is already pointed at, so no overlay-side change is needed.

## Smoke test after deploy

```
curl -sS 'https://spire-codex.com/auth/steam-popup?localhost_port=12345&openid.foo=bar' \
  | head -20
# → HTML page with the beacon script + close-tab message
```

The existing `/api/auth/steam/{start,callback,poll}` server-mediated flow from #202 is unchanged.
