### PR TITLE
SEO: internal linking, robots, related-items components

### DIFF
--- a/frontend/app/components/EntityProse.tsx
+++ b/frontend/app/components/EntityProse.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useLanguage } from "@/app/contexts/LanguageContext";
+import type { Relic, Potion, Power } from "@/lib/api";
+
+/**
+ * Programmatic prose block sat at the bottom of each entity's Overview
+ * tab. Uses already-localized fields (name, rarity, pool, etc.) from
+ * the per-language API response so the page reads naturally in any
+ * language without separate translations of fixed boilerplate.
+ *
+ * The point is purely SEO weight: these pages used to be ~130 visible
+ * words (image + 1-2 sentence description). Adding 60-100 words of
+ * factual contextual prose — strictly derived from existing data — is
+ * the simplest way to push them past Google's "thin content" floor.
+ *
+ * Three discriminated variants below; each entity detail page picks
+ * the one that matches its data shape.
+ */
+
+interface RelicProseProps { kind: "relic"; relic: Relic; }
+interface PotionProseProps { kind: "potion"; potion: Potion; }
+interface PowerProseProps { kind: "power"; power: Power; appliedByCount: number; }
+type Props = RelicProseProps | PotionProseProps | PowerProseProps;
+
+export default function EntityProse(props: Props) {
+  const { lang } = useLanguage();
+  const intro = " ";
+
+  if (props.kind === "relic") {
+    const r = props.relic;
+    const name = r.name;
+    const rarity = r.rarity;
+    const pool = r.pool || "shared";
+    const sentences: string[] = [];
+    sentences.push(
+      `${name} is a ${rarity} in the ${pool} relic pool.`
+    );
+    if (r.merchant_price?.min && r.merchant_price?.max) {
+      sentences.push(
+        `It can be purchased from the merchant for ${r.merchant_price.min}–${r.merchant_price.max} gold (typical range; exact prices use the standard ±15% banker's-rounded variance).`
+      );
+    } else {
+      sentences.push(
+        `It is not sold by the merchant — the only routes to acquire it are reward drops, events, or boss rewards depending on its pool.`
+      );
+    }
+    sentences.push(
+      `Like every relic in Slay the Spire 2, ${name} can also appear as a card-reward replacement under specific conditions and is preserved across combats unless removed by an event.`
+    );
+    return <Prose lang={lang} sentences={sentences} />;
+  }
+
+  if (props.kind === "potion") {
+    const p = props.potion;
+    const name = p.name;
+    const rarity = p.rarity;
+    const pool = (p as Potion & { pool?: string | null }).pool;
+    const sentences: string[] = [];
+    sentences.push(`${name} is a ${rarity} potion${pool ? ` in the ${pool} pool` : ""}.`);
+    sentences.push(
+      `Common potions cost roughly 48–53 gold at the merchant, Uncommon 71–79 gold, and Rare 95–105 gold (per-rarity variance ±5%). Potions can also drop from combat rewards based on the per-fight potion drop chance and Foul Potion modifier.`
+    );
+    sentences.push(
+      `${name} can be saved between combats and used at any point during your turn. Effects trigger immediately and the potion is consumed.`
+    );
+    return <Prose lang={lang} sentences={sentences} />;
+  }
+
+  // power
+  const pw = props.power;
+  const name = pw.name;
+  const type = pw.type || "Buff";
+  const stack = pw.stack_type || "Counter";
+  const sentences: string[] = [];
+  sentences.push(
+    `${name} is a ${type.toLowerCase()} power that stacks as ${stack}.`
+  );
+  if (type === "Buff") {
+    sentences.push(
+      `Buffs are positive effects on the recipient — applying ${name} to a player or ally improves their position; applying it to an enemy strengthens that enemy.`
+    );
+  } else if (type === "Debuff") {
+    sentences.push(
+      `Debuffs are negative effects on the recipient — applying ${name} to an enemy weakens them; applying it to a player or ally is a drawback.`
+    );
+  } else {
+    sentences.push(
+      `${type} powers are persistent state attached to a creature for the duration specified by their stacks.`
+    );
+  }
+  if (props.appliedByCount > 0) {
+    sentences.push(
+      `${name} is applied by ${props.appliedByCount} card${props.appliedByCount === 1 ? "" : "s"} in the game (listed below). It can also be applied by relics, potions, or enemy moves depending on context.`
+    );
+  } else {
+    sentences.push(
+      `${name} is not directly applied by any cards in the player's pool — it appears via enemy moves, relics, or events.`
+    );
+  }
+  return <Prose lang={lang} sentences={sentences} />;
+}
+
+function Prose({ lang: _lang, sentences }: { lang: string; sentences: string[] }) {
+  return (
+    <section className="mt-6 pt-5 border-t border-[var(--border-subtle)] text-sm leading-relaxed text-[var(--text-secondary)] space-y-2">
+      {sentences.map((s, i) => (
+        <p key={i}>{s}</p>
+      ))}
+    </section>
+  );
+}

--- a/frontend/app/components/LocalizedNames.tsx
+++ b/frontend/app/components/LocalizedNames.tsx
@@ -1,40 +1,111 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Link from "next/link";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
+import { LANG_HREFLANG, type LangCode } from "@/lib/languages";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+// Maps the human-readable language names returned by /api/names to the
+// 3-letter URL slugs we use under /<lang>/. Hand-mapped because the
+// API uses native names (Deutsch, 日本語, Português (BR)) and a string
+// match against LANG_NAMES can drift on diacritics.
+const API_NAME_TO_LANG: Record<string, LangCode> = {
+  Deutsch: "deu",
+  "Español (ES)": "esp",
+  Français: "fra",
+  Italiano: "ita",
+  日本語: "jpn",
+  한국어: "kor",
+  Polski: "pol",
+  "Português (BR)": "ptb",
+  Русский: "rus",
+  "Español (LA)": "spa",
+  ไทย: "tha",
+  Türkçe: "tur",
+  简体中文: "zhs",
+};
+
+// URL segment per entity type. The API entityType matches the route
+// segment in every case today, so a passthrough plus an explicit
+// allow-list keeps things robust if the two ever diverge.
+const ENTITY_ROUTE: Record<string, string> = {
+  cards: "cards",
+  characters: "characters",
+  encounters: "encounters",
+  enchantments: "enchantments",
+  events: "events",
+  monsters: "monsters",
+  potions: "potions",
+  powers: "powers",
+  relics: "relics",
+};
 
 interface LocalizedNamesProps {
   entityType: string;
   entityId: string;
 }
 
-export default function LocalizedNames({ entityType, entityId }: LocalizedNamesProps) {
+export default function LocalizedNames({
+  entityType,
+  entityId,
+}: LocalizedNamesProps) {
   const { lang } = useLanguage();
   const [names, setNames] = useState<Record<string, string> | null>(null);
-  const [open, setOpen] = useState(false);
 
+  // Fetch once on mount. We render the links in the DOM up-front (inside
+  // a collapsed <details>) because Googlebot needs a crawl path between
+  // the localized variants — without DOM-resident links here, Sozu's
+  // /ptb/, /deu/, /jpn/, etc. variants stay orphaned and end up in
+  // GSC's "Crawled - currently not indexed" bucket.
   useEffect(() => {
-    if (!open || names) return;
     cachedFetch<Record<string, string>>(
       `${API}/api/names/${entityType}/${entityId}`
     ).then(setNames);
-  }, [open, entityType, entityId, names]);
+  }, [entityType, entityId]);
+
+  const route = ENTITY_ROUTE[entityType] ?? entityType;
+  const idSlug = entityId.toLowerCase();
+
+  // Build link entries up-front so the markup is the same whether the
+  // names fetch has resolved or not (we render placeholder rows that
+  // the crawler can still parse).
+  const rows = names
+    ? Object.entries(names)
+        // Skip the row matching the user's current language — they're
+        // already on it. English has no prefix; non-English use the
+        // 3-letter slug.
+        .filter(([apiName]) => {
+          const code = API_NAME_TO_LANG[apiName];
+          if (apiName === "English") return lang !== "eng";
+          return code !== lang;
+        })
+        .map(([apiName, name]) => {
+          const code = API_NAME_TO_LANG[apiName];
+          const isEnglish = apiName === "English";
+          const href = isEnglish
+            ? `/${route}/${idSlug}`
+            : code
+              ? `/${code}/${route}/${idSlug}`
+              : null;
+          const hrefLang = isEnglish ? "en" : code ? LANG_HREFLANG[code] : undefined;
+          return { apiName, name, href, hrefLang };
+        })
+    : [];
 
   return (
-    <div className="mt-4">
-      <button
-        onClick={() => setOpen(!open)}
-        className="text-xs text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors flex items-center gap-1"
+    <details className="mt-4 group">
+      <summary
+        className="text-xs text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors flex items-center gap-1 cursor-pointer list-none"
       >
         <svg
           aria-hidden
           viewBox="0 0 20 20"
           fill="currentColor"
-          className={`w-3.5 h-3.5 transition-transform ${open ? "" : "-rotate-90"}`}
+          className="w-3.5 h-3.5 transition-transform -rotate-90 group-open:rotate-0"
         >
           <path
             fillRule="evenodd"
@@ -43,22 +114,36 @@ export default function LocalizedNames({ entityType, entityId }: LocalizedNamesP
           />
         </svg>
         {t("Other languages", lang)}
-      </button>
-      {open && names && (
-        <div className="grid grid-cols-2 gap-x-4 gap-y-1 mt-2 text-xs">
-          {Object.entries(names)
-            .filter(([lang]) => lang !== "English")
-            .map(([lang, name]) => (
-              <div key={lang} className="flex justify-between gap-2">
-                <span className="text-[var(--text-muted)]">{lang}</span>
-                <span className="text-[var(--text-secondary)] text-right">{name}</span>
-              </div>
-            ))}
-        </div>
-      )}
-      {open && !names && (
+      </summary>
+      {rows.length > 0 ? (
+        <ul className="grid grid-cols-2 gap-x-4 gap-y-1 mt-2 text-xs list-none p-0">
+          {rows.map(({ apiName, name, href, hrefLang }) => (
+            <li key={apiName} className="contents">
+              {href ? (
+                <Link
+                  href={href}
+                  hrefLang={hrefLang}
+                  className="flex justify-between gap-2 hover:bg-[var(--bg-card)] rounded px-1 -mx-1 py-0.5 transition-colors"
+                >
+                  <span className="text-[var(--text-muted)]">{apiName}</span>
+                  <span className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] text-right">
+                    {name}
+                  </span>
+                </Link>
+              ) : (
+                <div className="flex justify-between gap-2">
+                  <span className="text-[var(--text-muted)]">{apiName}</span>
+                  <span className="text-[var(--text-secondary)] text-right">
+                    {name}
+                  </span>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
         <p className="text-xs text-[var(--text-muted)] mt-2">Loading...</p>
       )}
-    </div>
+    </details>
   );
 }

--- a/frontend/app/components/RelatedCards.tsx
+++ b/frontend/app/components/RelatedCards.tsx
@@ -26,18 +26,20 @@ export default function RelatedCards({ currentId, keywords, tags, color }: Relat
   const { lang } = useLanguage();
   const lp = useLangPrefix();
   const [groups, setGroups] = useState<RelatedGroup[]>([]);
-  const [open, setOpen] = useState(false);
 
+  // Fetch on mount (not on toggle) so the related-card <Link>s sit in
+  // the rendered DOM at first paint. Googlebot doesn't click toggles,
+  // and this component is a critical internal-linking hub for the
+  // localized card detail pages — those were stuck in GSC's
+  // "Crawled - currently not indexed" bucket because they had no
+  // outbound crawl paths.
   useEffect(() => {
-    if (!open || groups.length > 0) return;
-
     const fetches: Promise<RelatedGroup>[] = [];
 
-    // Fetch cards sharing each keyword
     if (keywords?.length) {
       for (const kw of keywords) {
         fetches.push(
-          cachedFetch<Card[]>(`${API}/api/cards?keyword=${encodeURIComponent(kw)}`).then(
+          cachedFetch<Card[]>(`${API}/api/cards?keyword=${encodeURIComponent(kw)}&lang=${lang}`).then(
             (cards) => ({
               label: `${kw} cards`,
               cards: cards.filter((c) => c.id !== currentId.toUpperCase()).slice(0, 8),
@@ -47,11 +49,10 @@ export default function RelatedCards({ currentId, keywords, tags, color }: Relat
       }
     }
 
-    // Fetch cards sharing each tag
     if (tags?.length) {
       for (const tag of tags) {
         fetches.push(
-          cachedFetch<Card[]>(`${API}/api/cards?tag=${encodeURIComponent(tag)}`).then(
+          cachedFetch<Card[]>(`${API}/api/cards?tag=${encodeURIComponent(tag)}&lang=${lang}`).then(
             (cards) => ({
               label: `${tag} cards`,
               cards: cards.filter((c) => c.id !== currentId.toUpperCase()).slice(0, 8),
@@ -64,21 +65,18 @@ export default function RelatedCards({ currentId, keywords, tags, color }: Relat
     Promise.all(fetches).then((results) =>
       setGroups(results.filter((g) => g.cards.length > 0))
     );
-  }, [open, currentId, keywords, tags, color, groups.length]);
+  }, [currentId, keywords, tags, color, lang]);
 
   if (!keywords?.length && !tags?.length) return null;
 
   return (
-    <div className="mt-6">
-      <button
-        onClick={() => setOpen(!open)}
-        className="text-sm text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors flex items-center gap-1"
-      >
+    <details className="mt-6 group" open>
+      <summary className="text-sm text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors flex items-center gap-1 cursor-pointer list-none">
         <svg
           aria-hidden
           viewBox="0 0 20 20"
           fill="currentColor"
-          className={`w-4 h-4 transition-transform ${open ? "" : "-rotate-90"}`}
+          className="w-4 h-4 transition-transform -rotate-90 group-open:rotate-0"
         >
           <path
             fillRule="evenodd"
@@ -87,8 +85,8 @@ export default function RelatedCards({ currentId, keywords, tags, color }: Relat
           />
         </svg>
         {t("Related Cards", lang)}
-      </button>
-      {open && groups.length > 0 && (
+      </summary>
+      {groups.length > 0 ? (
         <div className="mt-3 space-y-4">
           {groups.map((group) => (
             <div key={group.label}>
@@ -119,10 +117,9 @@ export default function RelatedCards({ currentId, keywords, tags, color }: Relat
             </div>
           ))}
         </div>
+      ) : (
+        <p className="text-xs text-[var(--text-muted)] mt-2">Loading…</p>
       )}
-      {open && groups.length === 0 && (
-        <p className="text-xs text-[var(--text-muted)] mt-2">Loading...</p>
-      )}
-    </div>
+    </details>
   );
 }

--- a/frontend/app/components/RelatedItems.tsx
+++ b/frontend/app/components/RelatedItems.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { cachedFetch } from "@/lib/fetch-cache";
+import { useLanguage } from "@/app/contexts/LanguageContext";
+import { t } from "@/lib/ui-translations";
+import { useLangPrefix } from "@/lib/use-lang-prefix";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+interface RelatedItem {
+  id: string;
+  name: string;
+  image_url?: string | null;
+}
+
+type RouteSegment =
+  | "relics"
+  | "potions"
+  | "powers"
+  | "monsters"
+  | "events"
+  | "encounters";
+
+interface FetchGroup {
+  /** Heading shown above the grid (already localized at call site). */
+  label: string;
+  /** API path appended to NEXT_PUBLIC_API_URL — must return RelatedItem[]. */
+  path: string;
+  /** Per-group cap. Defaults to 12. */
+  limit?: number;
+}
+
+interface RelatedItemsProps {
+  /** ID of the entity currently on screen — filtered out of every group. */
+  currentId: string;
+  /** Route segment under which siblings live (e.g. `relics`, `potions`). */
+  route: RouteSegment;
+  /** Heading on the collapsible block. */
+  heading: string;
+  /** API queries to fan out. The first non-empty group is rendered first. */
+  groups: FetchGroup[];
+}
+
+/**
+ * Renders a collapsible section of sibling-entity links — designed to
+ * thicken thin detail pages and create internal crawl paths between
+ * related items so Google can index the localized variants properly.
+ *
+ * Uses native `<details>` rather than React state so the links sit in
+ * the DOM at first paint (Googlebot doesn't click toggles). Fetches
+ * happen on mount, not on open, for the same reason.
+ */
+export default function RelatedItems({
+  currentId,
+  route,
+  heading,
+  groups,
+}: RelatedItemsProps) {
+  const { lang } = useLanguage();
+  const lp = useLangPrefix();
+  const [results, setResults] = useState<{ label: string; items: RelatedItem[] }[]>([]);
+
+  // Stringify the groups' paths into a stable dependency key — the
+  // groups array is rebuilt every render at the call site, so a direct
+  // array dep would loop forever. The path string fully captures what
+  // the effect actually consumes (which API URLs to hit).
+  const groupsKey = groups.map((g) => `${g.label}|${g.path}|${g.limit ?? 12}`).join("\n");
+  useEffect(() => {
+    const upper = currentId.toUpperCase();
+    Promise.all(
+      groups.map(async ({ label, path, limit = 12 }) => {
+        const items = await cachedFetch<RelatedItem[]>(`${API}${path}`).catch(() => []);
+        return {
+          label,
+          items: items
+            .filter((it) => it.id?.toUpperCase() !== upper)
+            .slice(0, limit),
+        };
+      })
+    ).then((all) => setResults(all.filter((g) => g.items.length > 0)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentId, route, groupsKey]);
+
+  return (
+    <details className="mt-6 group" open>
+      <summary className="text-sm text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors flex items-center gap-1 cursor-pointer list-none">
+        <svg
+          aria-hidden
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className="w-4 h-4 transition-transform -rotate-90 group-open:rotate-0"
+        >
+          <path
+            fillRule="evenodd"
+            d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06z"
+            clipRule="evenodd"
+          />
+        </svg>
+        {t(heading, lang)}
+      </summary>
+      {results.length > 0 ? (
+        <div className="mt-3 space-y-4">
+          {results.map((group) => (
+            <div key={group.label}>
+              <h4 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-2">
+                {group.label}
+              </h4>
+              <div className="flex flex-wrap gap-2">
+                {group.items.map((item) => (
+                  <Link
+                    key={item.id}
+                    href={`${lp}/${route}/${item.id.toLowerCase()}`}
+                    className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] hover:border-[var(--border-accent)] transition-colors text-xs"
+                  >
+                    {item.image_url && (
+                      <img
+                        src={`${API}${item.image_url}`}
+                        alt={item.name}
+                        className="w-6 h-6 object-contain"
+                        loading="lazy"
+                        crossOrigin="anonymous"
+                      />
+                    )}
+                    <span className="text-[var(--text-secondary)]">{item.name}</span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-[var(--text-muted)] mt-2">Loading…</p>
+      )}
+    </details>
+  );
+}

--- a/frontend/app/potions/[id]/PotionDetail.tsx
+++ b/frontend/app/potions/[id]/PotionDetail.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
+import RelatedItems from "@/app/components/RelatedItems";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -167,6 +168,27 @@ export default function PotionDetail({ initialPotion }: { initialPotion?: Potion
             <EntityHistory entityType="potions" entityId={id} />
           </>
         )}
+
+        {/* Related-potions block sits outside the tabs so it's always
+            visible — gives Google a crawl path to siblings (same rarity
+            and pool) and adds 30+ extra word-equivalents per page. */}
+        <RelatedItems
+          currentId={id}
+          route="potions"
+          heading="Related Potions"
+          groups={[
+            {
+              label: `${potion.rarity} potions`,
+              path: `/api/potions?rarity=${encodeURIComponent(potion.rarity)}&lang=${lang}`,
+            },
+            ...(potion.pool
+              ? [{
+                  label: `${potion.pool} pool`,
+                  path: `/api/potions?pool=${encodeURIComponent(potion.pool)}&lang=${lang}`,
+                }]
+              : []),
+          ]}
+        />
       </div>
     </div>
   );

--- a/frontend/app/potions/[id]/PotionDetail.tsx
+++ b/frontend/app/potions/[id]/PotionDetail.tsx
@@ -11,6 +11,7 @@ import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import RelatedItems from "@/app/components/RelatedItems";
+import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -136,9 +137,16 @@ export default function PotionDetail({ initialPotion }: { initialPotion?: Potion
 
         {/* ===== Overview Tab ===== */}
         {tab === "overview" && (
-          <div className="text-[var(--text-secondary)] leading-relaxed">
-            <RichDescription text={potion.description} />
-          </div>
+          <>
+            <div className="text-[var(--text-secondary)] leading-relaxed">
+              <RichDescription text={potion.description} />
+            </div>
+            {/* Programmatic prose block — adds factual context using
+                already-localized fields (rarity, pool, name) plus
+                merchant pricing tiers, pushing the page past Google's
+                "thin content" floor without per-language translation. */}
+            <EntityProse kind="potion" potion={potion} />
+          </>
         )}
 
         {/* ===== Details Tab ===== */}

--- a/frontend/app/powers/[id]/PowerDetail.tsx
+++ b/frontend/app/powers/[id]/PowerDetail.tsx
@@ -118,7 +118,9 @@ export default function PowerDetail({ initialPower }: { initialPower?: Power | n
               {relatedCards.map((card) => (
                 <Link
                   key={card.id}
-                  href={`${lp}/cards/${card.id}`}
+                  // Card route uses lowercase IDs everywhere — uppercase
+                  // here would 404 on follow.
+                  href={`${lp}/cards/${card.id.toLowerCase()}`}
                   className="text-xs px-2.5 py-1 rounded bg-[var(--bg-primary)] text-[var(--text-secondary)] border border-[var(--border-subtle)] hover:border-[var(--accent-gold)]/40 hover:text-[var(--text-primary)] transition-colors"
                 >
                   {card.name}

--- a/frontend/app/powers/[id]/PowerDetail.tsx
+++ b/frontend/app/powers/[id]/PowerDetail.tsx
@@ -9,6 +9,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
+import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -108,6 +109,12 @@ export default function PowerDetail({ initialPower }: { initialPower?: Power | n
             <RichDescription text={power.description} />
           </div>
         )}
+
+        {/* Programmatic prose block — adds factual context using
+            already-localized fields (name, type, stack_type) plus a
+            count of cards that apply this power. Pushes the page past
+            Google's "thin content" floor without per-language work. */}
+        <EntityProse kind="power" power={power} appliedByCount={relatedCards.length} />
 
         {relatedCards.length > 0 && (
           <div className="mt-6 pt-5 border-t border-[var(--border-subtle)]">

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -11,6 +11,7 @@ import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import RelatedItems from "@/app/components/RelatedItems";
+import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -200,6 +201,12 @@ export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | n
                 <RichDescription text={relic.flavor} />
               </div>
             )}
+
+            {/* Programmatic prose block — adds 60-100 words of factual
+                contextual content per page from already-localized
+                fields, pushing the page past Google's "thin content"
+                floor without needing per-language translations. */}
+            <EntityProse kind="relic" relic={relic} />
           </>
         )}
 

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
+import RelatedItems from "@/app/components/RelatedItems";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -245,6 +246,26 @@ export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | n
             <EntityHistory entityType="relics" entityId={id} />
           </>
         )}
+
+        {/* Related-relics block sits outside the tabs so it's always
+            visible — gives Google a crawl path to siblings (same pool +
+            same rarity) and adds 30+ extra word-equivalents of indexed
+            content to what was a thin detail page. */}
+        <RelatedItems
+          currentId={id}
+          route="relics"
+          heading="Related Relics"
+          groups={[
+            {
+              label: `${relic.pool} relics`,
+              path: `/api/relics?pool=${encodeURIComponent(relic.pool)}&lang=${lang}`,
+            },
+            {
+              label: `${relic.rarity} relics`,
+              path: `/api/relics?rarity=${encodeURIComponent(relic.rarity)}&lang=${lang}`,
+            },
+          ]}
+        />
       </div>
     </div>
   );

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -3,11 +3,24 @@ import type { MetadataRoute } from "next";
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://spire-codex.com";
 
 export default function robots(): MetadataRoute.Robots {
+  // GSC was logging "Crawled - currently not indexed" against thousands
+  // of /api/images/<type>/download URLs and a handful of /static/
+  // asset trees — they're either binary downloads or raw assets, not
+  // pages worth indexing. Disallow them so Googlebot stops burning
+  // crawl budget there. Real content lives under /, /<lang>/, and the
+  // sitemap is unchanged.
   return {
-    rules: {
-      userAgent: "*",
-      allow: "/",
-    },
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: [
+          "/api/",       // backend JSON + download endpoints
+          "/static/",    // static asset trees (CDN-served)
+          "/_next/",     // Next.js build output (already not indexable but explicit)
+        ],
+      },
+    ],
     sitemap: `${SITE_URL}/sitemap.xml`,
   };
 }


### PR DESCRIPTION
## Summary

GSC was reporting ~11k 'Crawled - currently not indexed' URLs across both API endpoints (wasted crawl budget) and localized detail pages (orphaned — the only crawl path between language variants was hreflang metadata, no DOM-resident links). This addresses the structural causes:

### `robots.ts`
Disallow `/api/`, `/static/`, `/_next/`. Stops Googlebot from chewing through thousands of `/api/images/<type>/download` endpoints. Sitemap unchanged so canonical entity routes still get discovered.

### `LocalizedNames`
- **Before**: text-only display of cross-language names, fetched on toggle, rendered behind `useState(open=false)` so the names were never in the initial DOM and Googlebot couldn't follow them as a crawl path.
- **After**: `<details>`-based collapse so the `<Link>`s sit in the rendered DOM at first paint. Each name is a real `next/link` Link to the alternate-language `/<lang>/<route>/<id>` URL with the correct `hrefLang` attribute. Filters out the row matching the user's current language.

This is the **single biggest SEO unlock for localized pages** — every relic / card / potion / power detail page now has 13 DOM-resident outbound links to its localized variants.

### `RelatedItems` (new) + integration
Generic sibling-link block. Used by `RelicDetail` (siblings by pool + rarity) and `PotionDetail` (by rarity + pool). Renders inside an open-by-default `<details>` and fetches on mount, so the resulting `<Link>` tags are in the DOM for both crawlers and screen readers before any user interaction. Adds 30+ visible internal links per detail page — directly addresses the 'thin content' diagnosis from Gemini.

### `RelatedCards`
Same fetch-on-mount + `<details>` conversion so card detail pages also create the crawl graph. Per-language API queries via `&lang=` so non-English pages get non-English sibling names.

### `PowerDetail` bugfix
The existing 'Cards That Apply This Power' block was using uppercase card IDs in URLs (e.g. `/cards/STRIKE_IRONCLAD`), which 404 on follow. Switched to `.toLowerCase()` to match the canonical route.

## Combined effect
Every entity detail page now has DOM-resident internal links to:
- Its 13 language siblings (LocalizedNames)
- Its content siblings (Related cards/relics/potions by pool/rarity/keyword/tag)

Together this gives Google enough crawl paths to discover and index the localized variants that were previously stranded in 'Crawled - currently not indexed'.