### PR TITLE
Fix beta /mechanics empty + mobile menu off-screen on first paint

### DIFF
--- a/backend/app/services/mechanics_pages.py
+++ b/backend/app/services/mechanics_pages.py
@@ -46,6 +46,12 @@ def _pages_dir() -> Path:
     so a single language-agnostic source tree mirrors the current state. When
     translations land we can introduce per-lang directories without changing
     the API shape.
+
+    Beta vs stable: mechanics prose isn't versioned by game build, so both
+    deploys read from the same `data/mechanics_pages/` tree. The beta
+    docker-compose mounts the stable dir at `/data/mechanics_pages` directly
+    (overlaying the `./data-beta:/data` mount), so this resolver can stay
+    DATA_DIR-relative for both deploys.
     """
     return DATA_DIR / "mechanics_pages"
 

--- a/docker-compose.beta.yml
+++ b/docker-compose.beta.yml
@@ -6,6 +6,10 @@ services:
     container_name: spire-codex-beta-backend
     volumes:
       - ./data-beta:/data
+      # Mechanics prose isn't versioned by game build — overlay the
+      # stable canonical dir on top of the data-beta mount so the beta
+      # backend serves the same mechanics pages as stable.
+      - ./data/mechanics_pages:/data/mechanics_pages:ro
       - ./.secrets:/secrets:ro
     environment:
       - DATA_DIR=/data

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -306,11 +306,17 @@ export default function Navbar() {
               </svg>
             </button>
 
-            {/* Dropdown menu */}
+            {/* Dropdown menu — `right-0` anchors to the burger's relative
+                parent. Layout shifts (e.g. the SiteSwitcher button text
+                growing on beta after /api/versions resolves) used to push
+                the parent past the viewport edge, dragging the dropdown
+                off-screen. The `max-w-[calc(100vw-1rem)]` clamps the
+                dropdown width to viewport-minus-1rem so even if the
+                anchor drifts, the menu stays reachable. */}
             {open && (
               <div
                 ref={menuRef}
-                className="absolute right-0 top-full mt-2 w-48 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-black/30 max-h-[calc(100vh-5rem)] overflow-y-auto"
+                className="absolute right-0 top-full mt-2 w-48 max-w-[calc(100vw-1rem)] rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-black/30 max-h-[calc(100vh-5rem)] overflow-y-auto"
               >
                 {/* Home link */}
                 <div className="py-1">

--- a/frontend/app/components/SiteSwitcher.tsx
+++ b/frontend/app/components/SiteSwitcher.tsx
@@ -118,8 +118,12 @@ export default function SiteSwitcher() {
   const current = allEntries.find((e) => e.isCurrent);
   const others = allEntries.filter((e) => !e.isCurrent);
 
+  // min-w on the beta button so first-paint "beta" → post-fetch
+  // "beta v0.105.1" doesn't widen the navbar after the /api/versions
+  // fetch resolves. The width shift was pushing the mobile burger
+  // dropdown past the viewport edge on narrow screens.
   const buttonClasses = IS_BETA
-    ? "h-9 px-3 rounded-lg text-xs font-semibold bg-emerald-500/15 text-emerald-400 border border-emerald-500/30 hover:bg-emerald-500/25"
+    ? "h-9 px-3 min-w-[7.5rem] rounded-lg text-xs font-semibold bg-emerald-500/15 text-emerald-400 border border-emerald-500/30 hover:bg-emerald-500/25"
     : "h-9 px-3 rounded-lg text-xs font-semibold bg-[var(--accent-gold)]/15 text-[var(--accent-gold)] border border-[var(--accent-gold)]/30 hover:bg-[var(--accent-gold)]/25";
 
   const currentLabel = current?.label ?? (IS_BETA ? "beta" : "main");


### PR DESCRIPTION
## Summary

These two commits were dropped when PR #216 was squash-merged before the follow-up pushes landed (timing race — merge at 23:18 UTC, follow-ups at 01:14 / 01:50 UTC the next day). They're the bug-fix half of #216 that never made it to main, hence /mechanics on beta still returns `[]`.

### `docker-compose.beta.yml` + `backend/app/services/mechanics_pages.py`
Beta backend mounts `./data-beta` at `/data`, but mechanics prose isn't versioned by game build — the markdown lives in the stable canonical `data/mechanics_pages/`. Beta returned an empty list because `/data/mechanics_pages` didn't exist in the beta volume. Overlay the stable dir into the beta container's `/data/mechanics_pages` via a second bind mount; code stays DATA_DIR-relative.

### `SiteSwitcher.tsx` + `Navbar.tsx`
On beta, the SiteSwitcher button text expands from `beta` (~50px) to `beta v0.105.1` (~120px) after the `/api/versions` fetch resolves on first paint. The mid-render width jump shifted the right cluster wide enough to push the burger button (and its right-anchored dropdown) past the viewport edge on narrow mobile screens.

- `min-w-[7.5rem]` on the SiteSwitcher button reserves the post-fetch width up front so the layout doesn't shift.
- `max-w-[calc(100vw-1rem)]` on the burger dropdown clamps it to the viewport regardless of what offsets the anchor parent ends up at.

Once this merges + beta restarts, `https://beta.spire-codex.com/mechanics` will render the full sections list, and the mobile menu won't escape the viewport on first visit.