### PR TITLE
Per-entity run stats — new Stats tab on relic / potion / card pages

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from ..services.runs_db import submit_run, get_stats, claim_runs
+from ..services.run_entity_stats import get_entity_stats
 from ..metrics import (
     run_submissions,
     run_character,
@@ -342,6 +343,42 @@ def get_shared_run(run_hash: str, request: Request):
                     return json.load(f)
 
     raise HTTPException(status_code=404, detail="Run data not available")
+
+
+# Per-entity run stats — drives the "Stats" tab on each detail page.
+# Aggregates which runs picked a specific relic / card / potion, the
+# win rate when picked, the per-character distribution, and the most
+# recent submission. Cache is precomputed in process memory; first
+# request after TTL expiry blocks for the rebuild (a few seconds).
+_ENTITY_STATS_TYPES = {"relics", "cards", "potions"}
+
+
+@router.get("/stats/{entity_type}/{entity_id}", tags=["Runs"])
+@limiter.limit("120/minute")
+def get_entity_run_stats(request: Request, entity_type: str, entity_id: str):
+    if entity_type not in _ENTITY_STATS_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"entity_type must be one of {sorted(_ENTITY_STATS_TYPES)}",
+        )
+    stats = get_entity_stats(entity_type, entity_id)
+    if stats is None:
+        # Entity hasn't appeared in any submitted run yet — return a
+        # zero-filled stub so the UI can render "No runs yet" gracefully
+        # without a separate not-found branch.
+        return {
+            "entity_type": entity_type,
+            "entity_id": entity_id.upper(),
+            "picks": 0,
+            "wins": 0,
+            "win_rate": 0.0,
+            "pick_rate": 0.0,
+            "total_runs": 0,
+            "by_character": [],
+            "last_submitted_at": None,
+            "last_run_hash": None,
+        }
+    return stats
 
 
 @router.get("/stats", tags=["Runs"])

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -1,0 +1,235 @@
+"""Per-entity run statistics — cached aggregator.
+
+For each relic / card / potion, walks every submitted run JSON once,
+counts how many runs include it (per character), how many of those
+runs were wins, and tracks the most-recent submission. The result is
+served from `/api/runs/stats/{entity_type}/{entity_id}` to power the
+"Stats" tab on each detail page.
+
+Cache strategy:
+- First request triggers a full walk of `data/runs/*.json` joined
+  against the runs DB (for character, win, submitted_at, run_hash).
+- Result lives in process memory keyed by (entity_type, entity_id).
+- TTL is `_CACHE_TTL_SECONDS`; a request after expiry kicks off a
+  rebuild. Rebuild is single-shot (a re-entry while building gets the
+  stale snapshot and skips the rebuild).
+- Run submissions are infrequent enough that a 30-minute TTL is fine
+  without invalidation hooks.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+from .runs_db import get_conn
+
+logger = logging.getLogger(__name__)
+
+# `RELIC.SOZU` → ("relics", "SOZU"). We strip the namespace prefix so
+# the cache key matches the URL slug used by every other endpoint.
+_PREFIX_TO_TYPE = {
+    "RELIC": "relics",
+    "CARD": "cards",
+    "POTION": "potions",
+}
+
+_CACHE_TTL_SECONDS = 30 * 60  # 30 minutes
+_RUNS_DIR = (
+    Path(os.environ.get("DATA_DIR", Path(__file__).resolve().parents[3] / "data"))
+    / "runs"
+)
+
+# In-memory cache: { (entity_type, entity_id): aggregate_dict }
+# `_cache_built_at` is the unix timestamp of the last full rebuild.
+# `_global_totals` holds total_runs / total_wins so callers can compute
+# pick rate without re-querying the DB.
+_lock = threading.Lock()
+_cache: dict[tuple[str, str], dict[str, Any]] = {}
+_global_totals: dict[str, int] = {"total_runs": 0, "total_wins": 0}
+_cache_built_at: float = 0.0
+_building: bool = False
+
+
+def _strip_prefix(raw: str) -> tuple[str, str] | None:
+    """`RELIC.SOZU` → ('relics', 'SOZU'); unrecognized prefix → None."""
+    if not raw or "." not in raw:
+        return None
+    prefix, rest = raw.split(".", 1)
+    entity_type = _PREFIX_TO_TYPE.get(prefix.upper())
+    if not entity_type:
+        return None
+    return entity_type, rest
+
+
+def _strip_character_prefix(raw: str | None) -> str:
+    """`CHARACTER.DEFECT` → 'DEFECT'; bare values pass through."""
+    if not raw:
+        return ""
+    return raw.split(".", 1)[1] if raw.startswith("CHARACTER.") else raw
+
+
+def _walk_run_entities(blob: dict) -> Iterable[tuple[str, str]]:
+    """Emit every (entity_type, entity_id) seen in this run.
+
+    Cards from the deck dedupe per-instance — if a deck has 5 Strikes
+    we count 5 picks of Strike, NOT one. That matches user intuition
+    ("how often does this card appear in runs"). To switch to "runs
+    that contain at least one X" instead, set() the iterable.
+    """
+    for player in blob.get("players") or []:
+        for relic in player.get("relics") or []:
+            stripped = _strip_prefix(relic.get("id", ""))
+            if stripped:
+                yield stripped
+        for card in player.get("deck") or []:
+            stripped = _strip_prefix(card.get("id", ""))
+            if stripped:
+                yield stripped
+        for potion in player.get("potions") or []:
+            stripped = _strip_prefix(potion.get("id", ""))
+            if stripped:
+                yield stripped
+
+
+def _build_cache() -> None:
+    """Walk every run JSON + DB row, populate the per-entity aggregate."""
+    new_cache: dict[tuple[str, str], dict[str, Any]] = {}
+    new_totals = {"total_runs": 0, "total_wins": 0}
+
+    with get_conn() as conn:
+        rows = conn.execute(
+            "SELECT run_hash, character, win, submitted_at FROM runs"
+        ).fetchall()
+
+    for row in rows:
+        new_totals["total_runs"] += 1
+        if row["win"]:
+            new_totals["total_wins"] += 1
+        run_hash = row["run_hash"]
+        character = _strip_character_prefix(row["character"])
+        is_win = bool(row["win"])
+        submitted = row["submitted_at"]
+
+        path = _RUNS_DIR / f"{run_hash}.json"
+        if not path.exists():
+            continue
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                blob = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning("skipping unreadable run %s: %s", run_hash, e)
+            continue
+
+        # Dedupe per-run: a deck with 5 Strikes still only counts ONE
+        # pick of "this run had Strike". We count run-level membership
+        # so the win-rate metric is "win rate when X is in your deck"
+        # rather than skewed by deck composition.
+        seen: set[tuple[str, str]] = set()
+        for entity in _walk_run_entities(blob):
+            seen.add(entity)
+
+        for entity in seen:
+            agg = new_cache.setdefault(
+                entity,
+                {
+                    "picks": 0,
+                    "wins": 0,
+                    "by_character": {},
+                    "last_submitted_at": None,
+                    "last_run_hash": None,
+                },
+            )
+            agg["picks"] += 1
+            if is_win:
+                agg["wins"] += 1
+            char_agg = agg["by_character"].setdefault(
+                character, {"picks": 0, "wins": 0}
+            )
+            char_agg["picks"] += 1
+            if is_win:
+                char_agg["wins"] += 1
+            # ISO-string timestamps sort lexicographically with the
+            # right semantics, so a max() comparison "just works".
+            if not agg["last_submitted_at"] or (
+                submitted and submitted > agg["last_submitted_at"]
+            ):
+                agg["last_submitted_at"] = submitted
+                agg["last_run_hash"] = run_hash
+
+    global _cache, _cache_built_at, _global_totals
+    _cache = new_cache
+    _global_totals = new_totals
+    _cache_built_at = time.time()
+    logger.info(
+        "run-entity-stats cache rebuilt: %d entities across %d runs",
+        len(new_cache),
+        new_totals["total_runs"],
+    )
+
+
+def _maybe_rebuild() -> None:
+    global _building
+    age = time.time() - _cache_built_at
+    if age < _CACHE_TTL_SECONDS:
+        return
+    with _lock:
+        if _building:
+            return
+        if time.time() - _cache_built_at < _CACHE_TTL_SECONDS:
+            return
+        _building = True
+    try:
+        _build_cache()
+    finally:
+        with _lock:
+            _building = False
+
+
+def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
+    """Public accessor — returns the aggregate for one entity or None.
+
+    Triggers a cache rebuild if the existing one is stale. First call
+    blocks while the initial build runs (a few seconds at current run
+    counts); subsequent calls within the TTL window are O(1).
+    """
+    _maybe_rebuild()
+    key = (entity_type, entity_id.upper())
+    agg = _cache.get(key)
+    if agg is None:
+        return None
+    picks = agg["picks"]
+    wins = agg["wins"]
+    by_character = [
+        {
+            "character": ch,
+            "picks": stats["picks"],
+            "wins": stats["wins"],
+            "win_rate": round(stats["wins"] / stats["picks"] * 100, 1)
+            if stats["picks"]
+            else 0.0,
+        }
+        for ch, stats in sorted(
+            agg["by_character"].items(),
+            key=lambda kv: kv[1]["picks"],
+            reverse=True,
+        )
+    ]
+    total_runs = _global_totals["total_runs"]
+    return {
+        "entity_type": entity_type,
+        "entity_id": entity_id.upper(),
+        "picks": picks,
+        "wins": wins,
+        "win_rate": round(wins / picks * 100, 1) if picks else 0.0,
+        "pick_rate": round(picks / total_runs * 100, 1) if total_runs else 0.0,
+        "total_runs": total_runs,
+        "by_character": by_character,
+        "last_submitted_at": agg["last_submitted_at"],
+        "last_run_hash": agg["last_run_hash"],
+    }

--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -13,6 +13,7 @@ import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import RelatedCards from "@/app/components/RelatedCards";
+import EntityRunStats from "@/app/components/EntityRunStats";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -147,7 +148,7 @@ function getMerchantPriceRange(rarity: string, color: string): { min: number; ma
   return { min: Math.floor(base * 0.95), max: Math.ceil(base * 1.05) };
 }
 
-type Tab = "overview" | "details" | "info";
+type Tab = "overview" | "details" | "stats" | "info";
 
 export default function CardDetail({ initialCard }: { initialCard?: Card | null } = {}) {
   const params = useParams();
@@ -275,6 +276,7 @@ export default function CardDetail({ initialCard }: { initialCard?: Card | null 
   const tabs: { key: Tab; label: string }[] = [
     { key: "overview", label: t("Overview", lang) },
     { key: "details", label: t("Details", lang) },
+    { key: "stats", label: t("Stats", lang) },
     { key: "info", label: t("Info", lang) },
   ];
 
@@ -556,6 +558,11 @@ export default function CardDetail({ initialCard }: { initialCard?: Card | null 
                 color={card.color}
               />
             </>
+          )}
+
+          {/* ===== Stats Tab — community run aggregates ===== */}
+          {tab === "stats" && card && (
+            <EntityRunStats entityType="cards" entityId={id} entityName={card.name} />
           )}
 
           {/* ===== Info Tab ===== */}

--- a/frontend/app/components/EntityRunStats.tsx
+++ b/frontend/app/components/EntityRunStats.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { cachedFetch } from "@/lib/fetch-cache";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -90,9 +91,9 @@ export default function EntityRunStats({ entityType, entityId, entityName }: Pro
             {entityName} hasn&apos;t appeared in any submitted community run yet
             (across {stats.total_runs.toLocaleString()} total runs tracked).
             Submit a run that includes it via{" "}
-            <a href="/leaderboards/submit" className="text-[var(--accent-gold)] hover:underline">
+            <Link href="/leaderboards/submit" className="text-[var(--accent-gold)] hover:underline">
               the runs page
-            </a>{" "}
+            </Link>{" "}
             to seed this section.
           </>
         ) : (
@@ -113,12 +114,12 @@ export default function EntityRunStats({ entityType, entityId, entityName }: Pro
             {stats.last_run_hash && (
               <>
                 {" "}in run{" "}
-                <a
+                <Link
                   href={`/runs/shared/${stats.last_run_hash}`}
                   className="text-[var(--accent-gold)] hover:underline font-mono text-xs"
                 >
                   #{stats.last_run_hash.slice(0, 8)}
-                </a>
+                </Link>
               </>
             )}
             .

--- a/frontend/app/components/EntityRunStats.tsx
+++ b/frontend/app/components/EntityRunStats.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { cachedFetch } from "@/lib/fetch-cache";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+interface CharacterRow {
+  character: string;
+  picks: number;
+  wins: number;
+  win_rate: number;
+}
+
+interface EntityStats {
+  entity_type: string;
+  entity_id: string;
+  picks: number;
+  wins: number;
+  win_rate: number;
+  pick_rate: number;
+  total_runs: number;
+  by_character: CharacterRow[];
+  last_submitted_at: string | null;
+  last_run_hash: string | null;
+}
+
+interface Props {
+  entityType: "relics" | "cards" | "potions";
+  entityId: string;
+  /** Display name for the prose summary (e.g. "Sozu", "Strike"). */
+  entityName: string;
+}
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return "—";
+  // SQLite stores `YYYY-MM-DD HH:MM:SS` without TZ; treat as UTC.
+  const safe = iso.includes("T") ? iso : iso.replace(" ", "T") + "Z";
+  const ts = new Date(safe).getTime();
+  if (Number.isNaN(ts)) return iso;
+  const diffSec = Math.max(0, (Date.now() - ts) / 1000);
+  const minutes = diffSec / 60;
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${Math.floor(minutes)}m ago`;
+  const hours = minutes / 60;
+  if (hours < 24) return `${Math.floor(hours)}h ago`;
+  const days = hours / 24;
+  if (days < 30) return `${Math.floor(days)}d ago`;
+  const months = days / 30;
+  if (months < 12) return `${Math.floor(months)}mo ago`;
+  return `${Math.floor(months / 12)}y ago`;
+}
+
+function characterPretty(c: string): string {
+  // Names from the runs DB are uppercase enum values (IRONCLAD,
+  // NECROBINDER). Title-case for display.
+  if (!c) return "—";
+  return c[0] + c.slice(1).toLowerCase();
+}
+
+/**
+ * "Stats" tab content — community-run aggregates for one entity.
+ * Layout: factual prose summary on top (doubles as SEO body content),
+ * full per-character breakdown table below. Renders a graceful empty
+ * state when the entity has no submitted runs yet so SEO crawlers
+ * still see something other than spinners.
+ */
+export default function EntityRunStats({ entityType, entityId, entityName }: Props) {
+  const [stats, setStats] = useState<EntityStats | null>(null);
+
+  useEffect(() => {
+    cachedFetch<EntityStats>(`${API}/api/runs/stats/${entityType}/${entityId}`).then(setStats);
+  }, [entityType, entityId]);
+
+  if (!stats) {
+    return <p className="text-sm text-[var(--text-muted)]">Loading run stats…</p>;
+  }
+
+  const empty = stats.picks === 0;
+  const top = stats.by_character[0];
+  const last = relativeTime(stats.last_submitted_at);
+  const maxCharPicks = top?.picks ?? 0;
+
+  return (
+    <div className="space-y-5">
+      {/* Prose summary — also serves as crawlable SEO body content. */}
+      <p className="text-sm leading-relaxed text-[var(--text-secondary)]">
+        {empty ? (
+          <>
+            {entityName} hasn&apos;t appeared in any submitted community run yet
+            (across {stats.total_runs.toLocaleString()} total runs tracked).
+            Submit a run that includes it via{" "}
+            <a href="/leaderboards/submit" className="text-[var(--accent-gold)] hover:underline">
+              the runs page
+            </a>{" "}
+            to seed this section.
+          </>
+        ) : (
+          <>
+            <strong className="text-[var(--text-primary)]">{stats.win_rate}%</strong> win
+            rate across <strong>{stats.picks.toLocaleString()}</strong> picks
+            {top && (
+              <>
+                . Most often taken by{" "}
+                <strong className="text-[var(--text-primary)]">
+                  {characterPretty(top.character)}
+                </strong>{" "}
+                players ({top.picks.toLocaleString()} picks ·{" "}
+                {Math.round((top.picks / stats.picks) * 100)}% share)
+              </>
+            )}
+            . Last picked <strong>{last}</strong>
+            {stats.last_run_hash && (
+              <>
+                {" "}in run{" "}
+                <a
+                  href={`/runs/shared/${stats.last_run_hash}`}
+                  className="text-[var(--accent-gold)] hover:underline font-mono text-xs"
+                >
+                  #{stats.last_run_hash.slice(0, 8)}
+                </a>
+              </>
+            )}
+            .
+          </>
+        )}
+      </p>
+
+      {/* Per-character breakdown table — hidden when empty. */}
+      {!empty && stats.by_character.length > 0 && (
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-2">
+            Picks by character
+          </h3>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-xs uppercase tracking-wider text-[var(--text-muted)] border-b border-[var(--border-subtle)]">
+                  <th className="text-left py-2 pr-3 font-semibold">Character</th>
+                  <th className="text-right py-2 px-3 font-semibold">Picks</th>
+                  <th className="text-right py-2 px-3 font-semibold">Win Rate</th>
+                  <th className="text-left py-2 pl-3 font-semibold w-1/3">Distribution</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stats.by_character.map((row) => {
+                  const pct = maxCharPicks ? (row.picks / maxCharPicks) * 100 : 0;
+                  return (
+                    <tr
+                      key={row.character}
+                      className="border-b border-[var(--border-subtle)] last:border-b-0"
+                    >
+                      <td className="py-2 pr-3 text-[var(--text-secondary)]">
+                        {characterPretty(row.character)}
+                      </td>
+                      <td className="py-2 px-3 text-right text-[var(--text-secondary)] font-mono tabular-nums">
+                        {row.picks.toLocaleString()}
+                      </td>
+                      <td className="py-2 px-3 text-right text-[var(--text-secondary)] font-mono tabular-nums">
+                        {row.win_rate}%
+                      </td>
+                      <td className="py-2 pl-3">
+                        <div className="h-1.5 w-full rounded-full bg-[var(--bg-primary)]">
+                          <div
+                            className="h-1.5 rounded-full bg-[var(--accent-gold)]/60"
+                            style={{ width: `${pct}%` }}
+                          />
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      <p className="text-xs text-[var(--text-muted)]">
+        Stats reflect community-submitted runs only and refresh every 30 minutes.
+        {stats.total_runs > 0 && (
+          <>
+            {" "}Pick rate: <strong>{stats.pick_rate}%</strong> of {stats.total_runs.toLocaleString()} tracked runs.
+          </>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/frontend/app/potions/[id]/PotionDetail.tsx
+++ b/frontend/app/potions/[id]/PotionDetail.tsx
@@ -12,6 +12,7 @@ import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import RelatedItems from "@/app/components/RelatedItems";
 import EntityProse from "@/app/components/EntityProse";
+import EntityRunStats from "@/app/components/EntityRunStats";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -35,7 +36,7 @@ function getPotionMerchantPriceRange(rarity: string): { min: number; max: number
   }
 }
 
-type Tab = "overview" | "details" | "info";
+type Tab = "overview" | "details" | "stats" | "info";
 
 export default function PotionDetail({ initialPotion }: { initialPotion?: Potion | null } = {}) {
   const { id } = useParams<{ id: string }>();
@@ -80,6 +81,7 @@ export default function PotionDetail({ initialPotion }: { initialPotion?: Potion
   const tabs: { key: Tab; label: string }[] = [
     { key: "overview", label: t("Overview", lang) },
     { key: "details", label: t("Details", lang) },
+    { key: "stats", label: t("Stats", lang) },
     { key: "info", label: t("Info", lang) },
   ];
 
@@ -167,6 +169,11 @@ export default function PotionDetail({ initialPotion }: { initialPotion?: Potion
               </p>
             )}
           </>
+        )}
+
+        {/* ===== Stats Tab — community run aggregates ===== */}
+        {tab === "stats" && (
+          <EntityRunStats entityType="potions" entityId={id} entityName={potion.name} />
         )}
 
         {/* ===== Info Tab ===== */}

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -12,6 +12,7 @@ import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import RelatedItems from "@/app/components/RelatedItems";
 import EntityProse from "@/app/components/EntityProse";
+import EntityRunStats from "@/app/components/EntityRunStats";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -27,7 +28,7 @@ const rarityColorMap: Record<string, string> = {
 };
 
 
-type Tab = "overview" | "details" | "info";
+type Tab = "overview" | "details" | "stats" | "info";
 
 export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | null } = {}) {
   const { id } = useParams<{ id: string }>();
@@ -82,6 +83,7 @@ export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | n
   const tabs: { key: Tab; label: string }[] = [
     { key: "overview", label: t("Overview", lang) },
     { key: "details", label: t("Details", lang) },
+    { key: "stats", label: t("Stats", lang) },
     { key: "info", label: t("Info", lang) },
   ];
 
@@ -244,6 +246,11 @@ export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | n
               </div>
             )}
           </>
+        )}
+
+        {/* ===== Stats Tab — community run aggregates ===== */}
+        {tab === "stats" && (
+          <EntityRunStats entityType="relics" entityId={id} entityName={relic.name} />
         )}
 
         {/* ===== Info Tab ===== */}


### PR DESCRIPTION
## Summary

Surfaces community-run aggregates per entity behind a new `Stats` tab on each detail page. Layout is the Option D you picked — a one-paragraph factual summary on top (also serves as crawlable SEO body content) plus a per-character breakdown table below with picks, win rate, and a distribution bar.

### Backend
- New service `backend/app/services/run_entity_stats.py` walks every run JSON in `data/runs/*.json` once, joined against the runs DB for character / win / submitted_at / run_hash, and aggregates per-entity picks, wins, last submission, and per-character breakdowns. Cache lives in process memory with a 30-minute TTL; rebuild is single-shot guarded by a lock so concurrent first-requesters don't all walk the filesystem in parallel.
- New endpoint `GET /api/runs/stats/{entity_type}/{entity_id}` returns the aggregate. `entity_type` ∈ {relics, cards, potions}. Empty result returns a zero-filled stub instead of 404 so the UI can render a graceful 'no runs yet' state without a separate not-found branch.
- **Pick-counting is run-level, not deck-instance-level**: a deck with 5 Strikes counts ONE pick of Strike. Makes win-rate read as 'win rate when X is in your deck' instead of getting skewed by composition.

### Frontend
- New `EntityRunStats` component fetches the aggregate and renders the Option D layout. Pretty-prints character names, computes relative timestamps client-side (h/d/mo ago), and links the most-recent run to `/runs/shared/<hash>`.
- 'Stats' tab wired into RelicDetail, PotionDetail, and CardDetail next to the existing Overview / Details / Info tabs.

Builds on top of the prose blocks + related-items grids from #217 — every entity detail page now has crawlable factual content covering: localized name+description, contextual prose, sibling internal links, cross-language links, AND community-run win rates.