### PR TITLE
Run stats: fix /runs/<hash> link, warm cache on startup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -116,6 +116,30 @@ app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 
+# Pre-warm the per-entity run-stats cache in a background thread on
+# startup so the first user request to /api/runs/stats/<type>/<id>
+# doesn't block on a 5-10s walk of every submitted run JSON. Run in
+# the background so container readiness probes don't have to wait on
+# it; beta deploys (no run submissions) skip the warm-up.
+@app.on_event("startup")
+def _warm_run_entity_stats() -> None:
+    if IS_BETA_BACKEND:
+        return
+    import threading
+
+    from .services.run_entity_stats import _build_cache
+
+    def _warm():
+        try:
+            _build_cache()
+        except Exception:
+            # Best-effort warm-up — if it fails, the lazy first-request
+            # path still rebuilds correctly.
+            pass
+
+    threading.Thread(target=_warm, daemon=True, name="run-stats-warmup").start()
+
+
 _VERSION_RE = re.compile(r"^v?\d+\.\d+")
 
 

--- a/frontend/app/components/EntityRunStats.tsx
+++ b/frontend/app/components/EntityRunStats.tsx
@@ -115,7 +115,10 @@ export default function EntityRunStats({ entityType, entityId, entityName }: Pro
               <>
                 {" "}in run{" "}
                 <Link
-                  href={`/runs/shared/${stats.last_run_hash}`}
+                  // Frontend route is /runs/<hash>; the /shared/ segment
+                  // exists only on the backend API (/api/runs/shared/<hash>)
+                  // and was an early copy-paste mistake here.
+                  href={`/runs/${stats.last_run_hash}`}
                   className="text-[var(--accent-gold)] hover:underline font-mono text-xs"
                 >
                   #{stats.last_run_hash.slice(0, 8)}


### PR DESCRIPTION
## Summary

Two bugs on the new Stats tab surfaced on /cards/acrobatics:

### 1. Broken 'last picked in run' link
The link was pointing at `/runs/shared/<hash>`, which is the **backend API** route (`/api/runs/shared/...`). The actual frontend page route is just `/runs/<hash>`. Click → 404. Dropped the `/shared/` segment.

### 2. Slow first load
The per-entity cache builds on first request — that's a walk of 8,500+ submitted run JSONs and takes 5-10 seconds. Subsequent requests within 30 minutes are instant. Pre-warm in a background thread on FastAPI startup so the very first user hit on the Stats tab doesn't block.

- Backgrounded via `threading.Thread(daemon=True)` so the container readiness probe doesn't wait on it.
- Beta backend (`DISABLE_RUN_SUBMISSIONS=1`) skips the warm-up — no runs to aggregate.
- Cache rebuild path on TTL expiry stays unchanged; only the post-startup first hit changes.