### PR TITLE
Clean Details tab: icon + range, vertical lists with tooltips

### DIFF
--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -14,6 +14,7 @@ import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import RelatedCards from "@/app/components/RelatedCards";
 import EntityRunStats from "@/app/components/EntityRunStats";
+import HoverTooltip from "@/app/components/HoverTooltip";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -508,45 +509,58 @@ export default function CardDetail({ initialCard }: { initialCard?: Card | null 
           {/* ===== Details Tab ===== */}
           {tab === "details" && (
             <>
-              {/* Merchant Price */}
+              {/* Merchant Price — bare gold-icon + range, no pill box */}
               {priceRange && (
                 <div className="mb-5">
                   <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-2">
                     {t("Merchant Price", lang)}
                   </h3>
-                  <span className="text-sm px-3 py-1 rounded border bg-amber-950/30 text-[var(--accent-gold)] border-amber-900/30">
-                    {priceRange.min}–{priceRange.max} Gold
-                  </span>
-                  {card.color === "colorless" && (
-                    <span className="text-xs text-[var(--text-muted)] ml-2">
-                      (15% colorless markup)
+                  <div className="flex items-center gap-2 text-sm">
+                    <img
+                      src={`${API}/static/images/ui/rewards/reward_icon_money.webp`}
+                      alt="Gold"
+                      className="w-5 h-5"
+                      crossOrigin="anonymous"
+                    />
+                    <span className="text-[var(--accent-gold)] font-medium">
+                      {priceRange.min}–{priceRange.max}
                     </span>
-                  )}
+                    {card.color === "colorless" && (
+                      <span className="text-xs text-[var(--text-muted)]">
+                        (15% colorless markup)
+                      </span>
+                    )}
+                  </div>
                 </div>
               )}
 
-              {/* Powers Applied */}
+              {/* Powers Applied — vertical list, hyperlinked, hover tooltip */}
               {card.powers_applied && card.powers_applied.length > 0 && (
                 <div className="mb-5">
                   <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-2">
                     {t("Powers Applied", lang)}
                   </h3>
-                  <div className="flex flex-wrap gap-2">
+                  <ul className="space-y-1">
                     {card.powers_applied.map((pa) => {
                       const powerName = pa.power_key || pa.power;
                       const powerId = powerName.replace(/([A-Z])/g, "_$1").replace(/^_/, "").toUpperCase();
+                      const prettyName = pa.power.replace(/([A-Z])/g, " $1").trim();
+                      const data = powerData[pa.power.toLowerCase()];
                       return (
-                        <Link
-                          key={pa.power}
-                          href={`${lp}/powers/${powerId}`}
-                          className="text-xs px-2.5 py-1 rounded bg-purple-950/40 text-purple-300 border border-purple-900/30 hover:border-purple-700/50 hover:bg-purple-950/60 transition-colors"
-                        >
-                          {pa.power.replace(/([A-Z])/g, " $1").trim()}
-                          {pa.amount ? ` ${pa.amount}` : ""}
-                        </Link>
+                        <li key={pa.power}>
+                          <HoverTooltip title={prettyName} content={data?.description}>
+                            <Link
+                              href={`${lp}/powers/${powerId}`}
+                              className="text-sm text-[var(--text-secondary)] hover:text-[var(--accent-gold)] transition-colors"
+                            >
+                              {prettyName}
+                              {pa.amount ? ` ${pa.amount}` : ""}
+                            </Link>
+                          </HoverTooltip>
+                        </li>
                       );
                     })}
-                  </div>
+                  </ul>
                 </div>
               )}
 

--- a/frontend/app/components/HoverTooltip.tsx
+++ b/frontend/app/components/HoverTooltip.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  /** Plain-text body — `[..]` icon tokens and newlines stripped before render. */
+  content: string | null | undefined;
+  /** Bold heading shown above the body (defaults to no heading). */
+  title?: string;
+  className?: string;
+}
+
+function clean(text: string): string {
+  return text.replace(/\[.*?\]/g, "").replace(/\n+/g, " ").trim();
+}
+
+/**
+ * Lightweight hover tooltip for inline links — shows a small popover
+ * above the trigger on mouse-enter. Pointer-events-none so the popover
+ * never traps clicks meant for the underlying link. Mobile users tap
+ * straight through to the linked page.
+ */
+export default function HoverTooltip({ children, content, title, className }: Props) {
+  const [show, setShow] = useState(false);
+  const body = content ? clean(content) : "";
+  if (!body && !title) return <>{children}</>;
+  return (
+    <span
+      className={`relative inline-block ${className ?? ""}`}
+      onMouseEnter={() => setShow(true)}
+      onMouseLeave={() => setShow(false)}
+    >
+      {children}
+      {show && (
+        <span className="absolute z-50 bottom-full left-0 mb-2 w-64 p-2.5 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] shadow-xl pointer-events-none text-left normal-case font-normal">
+          {title && (
+            <span className="block text-xs font-semibold text-[var(--text-primary)] mb-1">
+              {title}
+            </span>
+          )}
+          {body && (
+            <span className="block text-[11px] text-[var(--text-secondary)] leading-relaxed">
+              {body}
+            </span>
+          )}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/app/components/RelatedCards.tsx
+++ b/frontend/app/components/RelatedCards.tsx
@@ -7,6 +7,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import HoverTooltip from "@/app/components/HoverTooltip";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -93,27 +94,20 @@ export default function RelatedCards({ currentId, keywords, tags, color }: Relat
               <h4 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-2">
                 {group.label}
               </h4>
-              <div className="flex flex-wrap gap-2">
+              <ul className="space-y-1">
                 {group.cards.map((card) => (
-                  <Link
-                    key={card.id}
-                    href={`${lp}/cards/${card.id.toLowerCase()}`}
-                    className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] hover:border-[var(--border-accent)] transition-colors text-xs"
-                  >
-                    {card.image_url && (
-                      <img
-                        src={`${API}${card.image_url}`}
-                        alt={card.name}
-                        className="w-6 h-6 object-contain"
-                        loading="lazy"
-                        crossOrigin="anonymous"
-                      />
-                    )}
-                    <span className="text-[var(--text-secondary)]">{card.name}</span>
-                    <span className="text-[var(--text-muted)]">{card.cost}</span>
-                  </Link>
+                  <li key={card.id}>
+                    <HoverTooltip title={card.name} content={card.description}>
+                      <Link
+                        href={`${lp}/cards/${card.id.toLowerCase()}`}
+                        className="text-sm text-[var(--text-secondary)] hover:text-[var(--accent-gold)] transition-colors"
+                      >
+                        {card.name}
+                      </Link>
+                    </HoverTooltip>
+                  </li>
                 ))}
-              </div>
+              </ul>
             </div>
           ))}
         </div>

--- a/frontend/app/components/RelatedItems.tsx
+++ b/frontend/app/components/RelatedItems.tsx
@@ -6,6 +6,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import HoverTooltip from "@/app/components/HoverTooltip";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -13,6 +14,7 @@ interface RelatedItem {
   id: string;
   name: string;
   image_url?: string | null;
+  description?: string | null;
 }
 
 type RouteSegment =
@@ -107,26 +109,20 @@ export default function RelatedItems({
               <h4 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-2">
                 {group.label}
               </h4>
-              <div className="flex flex-wrap gap-2">
+              <ul className="space-y-1">
                 {group.items.map((item) => (
-                  <Link
-                    key={item.id}
-                    href={`${lp}/${route}/${item.id.toLowerCase()}`}
-                    className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] hover:border-[var(--border-accent)] transition-colors text-xs"
-                  >
-                    {item.image_url && (
-                      <img
-                        src={`${API}${item.image_url}`}
-                        alt={item.name}
-                        className="w-6 h-6 object-contain"
-                        loading="lazy"
-                        crossOrigin="anonymous"
-                      />
-                    )}
-                    <span className="text-[var(--text-secondary)]">{item.name}</span>
-                  </Link>
+                  <li key={item.id}>
+                    <HoverTooltip title={item.name} content={item.description}>
+                      <Link
+                        href={`${lp}/${route}/${item.id.toLowerCase()}`}
+                        className="text-sm text-[var(--text-secondary)] hover:text-[var(--accent-gold)] transition-colors"
+                      >
+                        {item.name}
+                      </Link>
+                    </HoverTooltip>
+                  </li>
                 ))}
-              </div>
+              </ul>
             </div>
           ))}
         </div>

--- a/frontend/app/potions/[id]/PotionDetail.tsx
+++ b/frontend/app/potions/[id]/PotionDetail.tsx
@@ -159,9 +159,17 @@ export default function PotionDetail({ initialPotion }: { initialPotion?: Potion
                 <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-2">
                   {t("Merchant Price", lang)}
                 </h3>
-                <span className="text-sm px-3 py-1 rounded border bg-amber-950/30 text-[var(--accent-gold)] border-amber-900/30">
-                  {priceRange.min}–{priceRange.max} Gold
-                </span>
+                <div className="flex items-center gap-2 text-sm">
+                  <img
+                    src={`${API}/static/images/ui/rewards/reward_icon_money.webp`}
+                    alt="Gold"
+                    className="w-5 h-5"
+                    crossOrigin="anonymous"
+                  />
+                  <span className="text-[var(--accent-gold)] font-medium">
+                    {priceRange.min}–{priceRange.max}
+                  </span>
+                </div>
               </div>
             ) : (
               <p className="text-sm text-[var(--text-muted)]">

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -220,9 +220,17 @@ export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | n
                 <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-2">
                   {t("Merchant Price", lang)}
                 </h3>
-                <span className="text-sm px-3 py-1 rounded border bg-amber-950/30 text-[var(--accent-gold)] border-amber-900/30">
-                  {relic.merchant_price.min}–{relic.merchant_price.max} Gold
-                </span>
+                <div className="flex items-center gap-2 text-sm">
+                  <img
+                    src={`${API}/static/images/ui/rewards/reward_icon_money.webp`}
+                    alt="Gold"
+                    className="w-5 h-5"
+                    crossOrigin="anonymous"
+                  />
+                  <span className="text-[var(--accent-gold)] font-medium">
+                    {relic.merchant_price.min}–{relic.merchant_price.max}
+                  </span>
+                </div>
               </div>
             ) : (
               <p className="text-sm text-[var(--text-muted)]">


### PR DESCRIPTION
## Summary

Reworked the Details tab on cards / relics / potions — the chunky pill-box treatment looked overly templated. Going for a layout closer to in-game visual vocabulary.

### Before vs after
**Merchant Price** — was an amber bordered chip `[100-150 Gold]`. Now: gold-coin icon (the same glyph the game uses) + range, no border.

**Powers Applied** (cards) — was a row of purple chips. Now: vertical list of plain hyperlinks. Hover surfaces the power's description in a small popover; click still goes to `/powers/<id>`.

**Related Cards / Related Items** — was wrapped grid of bordered tiles with thumbnails. Now: vertical list of hyperlinks with hover tooltips showing the entity description. Drops the per-row image which was visual noise.

### Implementation
- New `HoverTooltip` component — small popover, `pointer-events-none` so it never intercepts the click meant for the underlying link. Mobile users tap straight through to the linked page.
- `RelatedItems` extended to optionally carry `description` (already returned by relic/potion list endpoints, just wasn't being surfaced).
- No backend changes.