### PR TITLE
Navbar: new Stats group, move Devs/API to Tools

### DIFF
--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -63,11 +63,16 @@ const NAV_GROUPS: NavGroup[] = [
     ],
   },
   {
-    label: "Tools",
+    label: "Stats",
     links: [
       { href: "/leaderboards", label: "Leaderboards" },
       { href: "/leaderboards/submit", label: "Submit a Run" },
       { href: "/leaderboards/stats", label: "Stats" },
+    ],
+  },
+  {
+    label: "Tools",
+    links: [
       { href: "/showcase", label: "Showcase" },
       { href: "/knowledge-demon", label: "Knowledge Demon" },
     ],

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -75,14 +75,14 @@ const NAV_GROUPS: NavGroup[] = [
     links: [
       { href: "/showcase", label: "Showcase" },
       { href: "/knowledge-demon", label: "Knowledge Demon" },
+      { href: "/developers", label: "Developers" },
+      { href: `${API_BASE}/docs`, label: "API" },
     ],
   },
   {
     label: "About",
     links: [
       { href: "/about", label: "Spire Codex" },
-      { href: "/developers", label: "Developers" },
-      { href: `${API_BASE}/docs`, label: "API" },
       { href: "/changelog", label: "Changelog" },
       { href: "/thank-you", label: "Thank You" },
       { href: "https://ko-fi.com/yitsy", label: "Ko-fi" },


### PR DESCRIPTION
Reorg the navbar — pull the user-facing community-data items into a top-level **Stats** menu and consolidate the builder-facing entries under **Tools**.

These commits were prepared during PR #222 but didn't make it into the squash. Re-shipping as their own PR.

### Stats (new)
- Leaderboards
- Submit a Run
- Stats

### Tools (was just Showcase + Knowledge Demon)
- Showcase
- Knowledge Demon
- Developers *(from About)*
- API *(from About)*

### About (now strictly site/meta info)
- Spire Codex
- Changelog
- Thank You
- Ko-fi
- Privacy
- Terms

All four group labels were already present in `lib/ui-translations.ts`, so all 14 languages render correctly with no translation work.