### PR TITLE
Add Codex Score — community-meta tier rating per entity

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, HTTPException, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from ..services.runs_db import submit_run, get_stats, claim_runs
-from ..services.run_entity_stats import get_entity_stats
+from ..services.run_entity_stats import get_all_entity_scores, get_entity_stats
 from ..metrics import (
     run_submissions,
     run_character,
@@ -374,11 +374,30 @@ def get_entity_run_stats(request: Request, entity_type: str, entity_id: str):
             "win_rate": 0.0,
             "pick_rate": 0.0,
             "total_runs": 0,
+            "baseline_win_rate": 0.0,
+            "score": None,
             "by_character": [],
             "last_submitted_at": None,
             "last_run_hash": None,
         }
     return stats
+
+
+@router.get("/scores/{entity_type}", tags=["Runs"])
+@limiter.limit("60/minute")
+def get_entity_scores(request: Request, entity_type: str):
+    """All Codex Scores for one entity type, keyed by ID.
+
+    Used by list pages to render the score column / sort by tier
+    without N round-trips to /stats/{type}/{id}. Cached at the same
+    TTL as the per-entity stats since both derive from the same walk.
+    """
+    if entity_type not in _ENTITY_STATS_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"entity_type must be one of {sorted(_ENTITY_STATS_TYPES)}",
+        )
+    return get_all_entity_scores(entity_type)
 
 
 @router.get("/stats", tags=["Runs"])

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -39,6 +39,16 @@ _PREFIX_TO_TYPE = {
     "POTION": "potions",
 }
 
+# Codex Score formula constants — see _compute_score for derivation.
+# PRIOR_WEIGHT is how many "virtual baseline picks" we add to every
+# entity to shrink low-N noise toward the global mean. 50 means a
+# 5-pick perfect-record card lands ~mid-tier, not S-tier. SCALE_RANGE
+# is the win-rate delta (vs baseline) that maps to the edges of the
+# 0-100 scale; ±15pp covers the full real-world spread without making
+# moderate over/underperformers saturate.
+_SCORE_PRIOR_WEIGHT = 50
+_SCORE_SCALE_RANGE = 0.15
+
 _CACHE_TTL_SECONDS = 30 * 60  # 30 minutes
 _RUNS_DIR = (
     Path(os.environ.get("DATA_DIR", Path(__file__).resolve().parents[3] / "data"))
@@ -191,6 +201,58 @@ def _maybe_rebuild() -> None:
             _building = False
 
 
+def _baseline_win_rate() -> float:
+    """Global win rate across every submitted run, or 0.5 if empty."""
+    total = _global_totals["total_runs"]
+    if not total:
+        return 0.5
+    return _global_totals["total_wins"] / total
+
+
+def _compute_score(wins: int, picks: int, baseline: float) -> int | None:
+    """0-100 Codex Score for an entity.
+
+    Step 1 — Bayesian shrinkage: blend the entity's wins/picks with
+    `_SCORE_PRIOR_WEIGHT` virtual picks at the baseline win rate. This
+    keeps a 5-pick card at 100% win rate from outranking a 500-pick
+    card at 60% (the high-confidence one wins).
+
+    Step 2 — Map the shrunk delta to 0-100. baseline → 50 (neutral),
+    +SCORE_SCALE_RANGE → 100 (S-tier), -SCORE_SCALE_RANGE → 0 (F-tier).
+    Clamped — saturating cards genuinely belong at the edges.
+    """
+    if picks <= 0:
+        return None
+    shrunk = (wins + baseline * _SCORE_PRIOR_WEIGHT) / (picks + _SCORE_PRIOR_WEIGHT)
+    delta = shrunk - baseline
+    raw = (delta / _SCORE_SCALE_RANGE + 1) * 50
+    return max(0, min(100, round(raw)))
+
+
+def get_all_entity_scores(entity_type: str) -> dict[str, dict[str, Any]]:
+    """All entities of one type, keyed by ID, with score + counts.
+
+    Drives list-page tier sorting and the (planned) tooltip-widget
+    score badge — fetched once by the client and cached locally instead
+    of N round-trips to /stats/{type}/{id}.
+    """
+    _maybe_rebuild()
+    baseline = _baseline_win_rate()
+    out: dict[str, dict[str, Any]] = {}
+    for (etype, eid), agg in _cache.items():
+        if etype != entity_type:
+            continue
+        picks = agg["picks"]
+        wins = agg["wins"]
+        out[eid] = {
+            "score": _compute_score(wins, picks, baseline),
+            "picks": picks,
+            "wins": wins,
+            "win_rate": round(wins / picks * 100, 1) if picks else 0.0,
+        }
+    return out
+
+
 def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
     """Public accessor — returns the aggregate for one entity or None.
 
@@ -221,6 +283,7 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
         )
     ]
     total_runs = _global_totals["total_runs"]
+    baseline = _baseline_win_rate()
     return {
         "entity_type": entity_type,
         "entity_id": entity_id.upper(),
@@ -229,6 +292,8 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
         "win_rate": round(wins / picks * 100, 1) if picks else 0.0,
         "pick_rate": round(picks / total_runs * 100, 1) if total_runs else 0.0,
         "total_runs": total_runs,
+        "baseline_win_rate": round(baseline * 100, 1),
+        "score": _compute_score(wins, picks, baseline),
         "by_character": by_character,
         "last_submitted_at": agg["last_submitted_at"],
         "last_run_hash": agg["last_run_hash"],

--- a/frontend/app/cards/CardsClient.tsx
+++ b/frontend/app/cards/CardsClient.tsx
@@ -8,10 +8,12 @@ import CardGrid from "../components/CardGrid";
 import SearchFilter from "../components/SearchFilter";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { useEntityScores } from "@/lib/use-entity-scores";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 const sortOptions = [
+  { label: "Top tier", value: "score" },
   { label: "A → Z", value: "az" },
   { label: "Z → A", value: "za" },
   { label: "Compendium", value: "compendium" },
@@ -107,13 +109,23 @@ export default function CardsClient({ initialCards }: { initialCards: Card[] }) 
       .then(setCards);
   }, [color, type, rarity, keyword, search, lang]);
 
+  const scores = useEntityScores("cards");
+
   const sortedCards = useMemo(() => {
     const sorted = [...cards];
     if (sort === "az") sorted.sort((a, b) => a.name.localeCompare(b.name));
     else if (sort === "za") sorted.sort((a, b) => b.name.localeCompare(a.name));
     else if (sort === "compendium") sorted.sort((a, b) => a.compendium_order - b.compendium_order);
+    else if (sort === "score") {
+      sorted.sort((a, b) => {
+        const sa = scores[a.id.toUpperCase()]?.score ?? -1;
+        const sb = scores[b.id.toUpperCase()]?.score ?? -1;
+        if (sb !== sa) return sb - sa;
+        return a.compendium_order - b.compendium_order;
+      });
+    }
     return sorted;
-  }, [cards, sort]);
+  }, [cards, sort, scores]);
 
   return (
     <>
@@ -153,7 +165,7 @@ export default function CardsClient({ initialCards }: { initialCards: Card[] }) 
         ]}
       />
 
-      <CardGrid cards={sortedCards} />
+      <CardGrid cards={sortedCards} scores={scores} />
     </>
   );
 }

--- a/frontend/app/components/CardGrid.tsx
+++ b/frontend/app/components/CardGrid.tsx
@@ -6,6 +6,7 @@ import type { Card } from "@/lib/api";
 import { getCardDisplayModel } from "@/lib/card-display";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import RichDescription from "./RichDescription";
+import ScoreBadge from "./ScoreBadge";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -49,7 +50,7 @@ function renderDescription(card: Card, text: string): React.ReactNode {
   return <RichDescription text={normalizedText} energyIcon={energyIcon} />;
 }
 
-function CardItem({ card }: { card: Card }) {
+function CardItem({ card, score }: { card: Card; score?: number | null }) {
   const lp = useLangPrefix();
   const [upgraded, setUpgraded] = useState(false);
   const [betaArt, setBetaArt] = useState(false);
@@ -88,6 +89,7 @@ function CardItem({ card }: { card: Card }) {
           {card.name}{isUpgraded && <span className="text-emerald-400">+</span>}
         </h3>
         <div className="ml-2 flex-shrink-0 flex items-center gap-1">
+          <ScoreBadge score={score} size="sm" />
           <span className={`inline-flex items-center justify-center w-7 h-7 rounded-full bg-[var(--bg-primary)] border text-sm font-bold ${
             isUpgraded && display.upgrade?.cost != null ? "border-emerald-700/50 text-emerald-400" : "border-[var(--border-subtle)] text-[var(--accent-gold)]"
           }`}>
@@ -163,11 +165,22 @@ function CardItem({ card }: { card: Card }) {
   );
 }
 
-export default function CardGrid({ cards }: { cards: Card[] }) {
+export default function CardGrid({
+  cards,
+  scores,
+}: {
+  cards: Card[];
+  /** Optional: map of upper-cased card ID → Codex Score. */
+  scores?: Record<string, { score: number | null }>;
+}) {
   return (
     <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-4">
       {cards.map((card) => (
-        <CardItem key={card.id} card={card} />
+        <CardItem
+          key={card.id}
+          card={card}
+          score={scores?.[card.id.toUpperCase()]?.score}
+        />
       ))}
     </div>
   );

--- a/frontend/app/components/EntityRunStats.tsx
+++ b/frontend/app/components/EntityRunStats.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { cachedFetch } from "@/lib/fetch-cache";
+import ScoreBadge from "@/app/components/ScoreBadge";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -21,6 +22,8 @@ interface EntityStats {
   win_rate: number;
   pick_rate: number;
   total_runs: number;
+  baseline_win_rate: number;
+  score: number | null;
   by_character: CharacterRow[];
   last_submitted_at: string | null;
   last_run_hash: string | null;
@@ -84,6 +87,24 @@ export default function EntityRunStats({ entityType, entityId, entityName }: Pro
 
   return (
     <div className="space-y-5">
+      {/* Codex Score hero — single 0-100 badge that summarizes the
+          entity's community-meta strength. Bayesian-shrunk so low-N
+          entities sit near neutral instead of saturating S/F tiers.
+          See `_compute_score` in run_entity_stats.py for the formula. */}
+      {stats.score != null && (
+        <div className="flex items-center gap-3 pb-4 border-b border-[var(--border-subtle)]">
+          <ScoreBadge score={stats.score} size="lg" showNumber />
+          <div className="text-xs text-[var(--text-muted)] leading-snug">
+            <div className="text-[var(--text-secondary)] font-semibold mb-0.5">
+              Codex Score
+            </div>
+            <div>
+              {stats.win_rate}% win rate vs {stats.baseline_win_rate}% baseline
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Prose summary — also serves as crawlable SEO body content. */}
       <p className="text-sm leading-relaxed text-[var(--text-secondary)]">
         {empty ? (

--- a/frontend/app/components/ScoreBadge.tsx
+++ b/frontend/app/components/ScoreBadge.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+interface ScoreBadgeProps {
+  score: number | null | undefined;
+  /** sm = inline pill, md = list-row chip, lg = detail-page hero badge. */
+  size?: "sm" | "md" | "lg";
+  /** Show the numeric score next to the letter grade. */
+  showNumber?: boolean;
+}
+
+interface Tier {
+  letter: string;
+  /** Inline tailwind classes for bg + border + text. */
+  className: string;
+  label: string;
+}
+
+/**
+ * Score → tier mapping. Bands chosen so the median entity lands in C
+ * and the extremes (S+ / F) require sustained out-of-distribution
+ * performance after Bayesian shrinkage. See `_compute_score` in
+ * backend/app/services/run_entity_stats.py for the underlying math.
+ */
+function scoreToTier(score: number): Tier {
+  if (score >= 90) return { letter: "S", label: "Top tier", className: "bg-amber-950/40 border-amber-700/60 text-amber-300" };
+  if (score >= 78) return { letter: "A", label: "Strong",   className: "bg-emerald-950/40 border-emerald-700/60 text-emerald-300" };
+  if (score >= 65) return { letter: "B", label: "Solid",    className: "bg-sky-950/40 border-sky-700/60 text-sky-300" };
+  if (score >= 50) return { letter: "C", label: "Average",  className: "bg-zinc-800/60 border-zinc-600/60 text-zinc-300" };
+  if (score >= 35) return { letter: "D", label: "Weak",     className: "bg-orange-950/40 border-orange-700/60 text-orange-300" };
+  return { letter: "F", label: "Avoid", className: "bg-rose-950/40 border-rose-800/60 text-rose-300" };
+}
+
+export default function ScoreBadge({ score, size = "md", showNumber = false }: ScoreBadgeProps) {
+  if (score == null) return null;
+  const tier = scoreToTier(score);
+
+  const sizeClasses = {
+    sm: "text-[10px] px-1.5 py-0.5 min-w-[1.5rem]",
+    md: "text-xs px-2 py-0.5 min-w-[1.75rem]",
+    lg: "text-base px-3 py-1.5 min-w-[2.5rem]",
+  }[size];
+
+  const numberSize = {
+    sm: "text-[9px] ml-1",
+    md: "text-[10px] ml-1",
+    lg: "text-sm ml-1.5",
+  }[size];
+
+  return (
+    <span
+      className={`inline-flex items-center justify-center font-bold rounded border ${sizeClasses} ${tier.className}`}
+      title={`Codex Score: ${score} (${tier.label})`}
+    >
+      {tier.letter}
+      {showNumber && <span className={`font-mono font-medium opacity-80 ${numberSize}`}>{score}</span>}
+    </span>
+  );
+}
+
+export { scoreToTier };

--- a/frontend/app/potions/PotionsClient.tsx
+++ b/frontend/app/potions/PotionsClient.tsx
@@ -9,6 +9,8 @@ import SearchFilter from "../components/SearchFilter";
 import RichDescription from "../components/RichDescription";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { useEntityScores } from "@/lib/use-entity-scores";
+import ScoreBadge from "@/app/components/ScoreBadge";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -35,6 +37,7 @@ const poolOptions = [
 ];
 
 const sortOptions = [
+  { label: "Top tier", value: "score" },
   { label: "A → Z", value: "az" },
   { label: "Z → A", value: "za" },
   { label: "Compendium", value: "compendium" },
@@ -87,13 +90,23 @@ export default function PotionsClient({ initialPotions }: { initialPotions: Poti
       .finally(() => setLoading(false));
   }, [rarity, search, pool, lang]);
 
+  const scores = useEntityScores("potions");
+
   const sortedPotions = useMemo(() => {
     const sorted = [...potions];
     if (sort === "az") sorted.sort((a, b) => a.name.localeCompare(b.name));
     else if (sort === "za") sorted.sort((a, b) => b.name.localeCompare(a.name));
     else if (sort === "compendium") sorted.sort((a, b) => a.compendium_order - b.compendium_order);
+    else if (sort === "score") {
+      sorted.sort((a, b) => {
+        const sa = scores[a.id.toUpperCase()]?.score ?? -1;
+        const sb = scores[b.id.toUpperCase()]?.score ?? -1;
+        if (sb !== sa) return sb - sa;
+        return a.compendium_order - b.compendium_order;
+      });
+    }
     return sorted;
-  }, [potions, sort]);
+  }, [potions, sort, scores]);
 
   return (
     <>
@@ -148,10 +161,11 @@ export default function PotionsClient({ initialPotions }: { initialPotions: Poti
                     />
                   )}
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-start justify-between mb-2">
+                    <div className="flex items-start justify-between gap-2 mb-2">
                       <h3 className="font-semibold text-[var(--text-primary)] leading-tight">
                         {potion.name}
                       </h3>
+                      <ScoreBadge score={scores[potion.id.toUpperCase()]?.score} size="sm" />
                     </div>
                     <span
                       className={`text-xs ${style.split(" ").slice(1).join(" ")} mb-3 inline-block`}

--- a/frontend/app/relics/RelicsClient.tsx
+++ b/frontend/app/relics/RelicsClient.tsx
@@ -9,6 +9,8 @@ import SearchFilter from "../components/SearchFilter";
 import RichDescription from "../components/RichDescription";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { useEntityScores } from "@/lib/use-entity-scores";
+import ScoreBadge from "@/app/components/ScoreBadge";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -42,6 +44,7 @@ const poolOptions = [
 ];
 
 const sortOptions = [
+  { label: "Top tier", value: "score" },
   { label: "A → Z", value: "az" },
   { label: "Z → A", value: "za" },
   { label: "Compendium", value: "compendium" },
@@ -92,13 +95,25 @@ export default function RelicsClient({ initialRelics }: { initialRelics: Relic[]
       .then(setRelics);
   }, [rarity, pool, search, lang]);
 
+  const scores = useEntityScores("relics");
+
   const sortedRelics = useMemo(() => {
     const sorted = [...relics];
     if (sort === "az") sorted.sort((a, b) => a.name.localeCompare(b.name));
     else if (sort === "za") sorted.sort((a, b) => b.name.localeCompare(a.name));
     else if (sort === "compendium") sorted.sort((a, b) => a.compendium_order - b.compendium_order);
+    else if (sort === "score") {
+      // Score-sort: scored entities desc, unscored sink to bottom in
+      // compendium order so the list stays stable as new runs land.
+      sorted.sort((a, b) => {
+        const sa = scores[a.id.toUpperCase()]?.score ?? -1;
+        const sb = scores[b.id.toUpperCase()]?.score ?? -1;
+        if (sb !== sa) return sb - sa;
+        return a.compendium_order - b.compendium_order;
+      });
+    }
     return sorted;
-  }, [relics, sort]);
+  }, [relics, sort, scores]);
 
   return (
     <>
@@ -148,10 +163,11 @@ export default function RelicsClient({ initialRelics }: { initialRelics: Relic[]
                   />
                 )}
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-start justify-between mb-2">
+                  <div className="flex items-start justify-between gap-2 mb-2">
                     <h3 className="font-semibold text-[var(--text-primary)] leading-tight">
                       {relic.name}
                     </h3>
+                    <ScoreBadge score={scores[relic.id.toUpperCase()]?.score} size="sm" />
                   </div>
                   <div className="flex items-center gap-2 mb-3 text-xs">
                     <span className={style.split(" ").slice(1).join(" ")}>

--- a/frontend/lib/use-entity-scores.ts
+++ b/frontend/lib/use-entity-scores.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { cachedFetch } from "@/lib/fetch-cache";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+export interface ScoreEntry {
+  score: number | null;
+  picks: number;
+  wins: number;
+  win_rate: number;
+}
+
+export type ScoresMap = Record<string, ScoreEntry>;
+
+/**
+ * Fetch every Codex Score for an entity type once, keyed by uppercase
+ * ID. Backed by `cachedFetch` so concurrent calls dedupe and the
+ * client-side cache survives soft navs. Use this on list pages to
+ * surface tier badges without N round-trips per row.
+ */
+export function useEntityScores(entityType: "cards" | "relics" | "potions"): ScoresMap {
+  const [scores, setScores] = useState<ScoresMap>({});
+
+  useEffect(() => {
+    cachedFetch<ScoresMap>(`${API}/api/runs/scores/${entityType}`)
+      .then(setScores)
+      .catch(() => setScores({}));
+  }, [entityType]);
+
+  return scores;
+}


### PR DESCRIPTION
## What
A single 0-100 score per card / relic / potion that summarizes how strongly it pulls toward winning runs. Visible everywhere the entity appears.

This is **PR #1 of 5** in the stats expansion roadmap (Score → expanded card stats → monster stats → overview → deck doctor → tier list).

## How it looks

**List pages** (cards / relics / potions): new `Top tier` sort option (first in the dropdown), small letter-grade chip in each row's header.

**Detail pages**: large badge above the Stats prose with the win-rate vs baseline comparison. *"Codex Score · 60% win rate vs 50% baseline"*.

## Formula

```
shrunk    = (wins + baseline·PRIOR) / (picks + PRIOR)    # PRIOR = 50
delta     = shrunk − baseline
raw       = (delta / SCALE_RANGE + 1) · 50               # SCALE = 0.15 (±15pp)
score     = clamp(raw, 0, 100)
```

Bayesian shrinkage is the headline. A 5-pick 100% win-rate card lands at ~B-tier, not S+ — because we don't trust the sample yet. Scores stabilize as data accumulates.

### Tier bands
| Range | Letter | Color |
|---|---|---|
| 90–100 | **S** | gold |
| 78–89 | **A** | emerald |
| 65–77 | **B** | sky |
| 50–64 | **C** | zinc |
| 35–49 | **D** | orange |
| 0–34 | **F** | rose |

Median entity sits in C. Edges require sustained out-of-distribution performance.

## Backend
- New `GET /api/runs/scores/<type>` — bulk endpoint so list pages don't N+1
- `get_entity_stats` now also returns `score` + `baseline_win_rate`
- Same cache, same 30-min TTL, same startup pre-warm

## What this unlocks
- **Tier list page** (`/tier-list`) — already half-built, just needs to read scores
- **Programmatic SEO**: "best Necrobinder cards", "best Sozu relics" landing pages auto-generate from sorted score
- Tooltip widget can surface the badge inline (planned for follow-up)