### PR TITLE
Codex Score: methodology / 'About' page

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, HTTPException, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from ..services.runs_db import submit_run, get_stats, claim_runs
-from ..services.run_entity_stats import get_entity_stats
+from ..services.run_entity_stats import get_all_entity_scores, get_entity_stats
 from ..metrics import (
     run_submissions,
     run_character,
@@ -374,11 +374,30 @@ def get_entity_run_stats(request: Request, entity_type: str, entity_id: str):
             "win_rate": 0.0,
             "pick_rate": 0.0,
             "total_runs": 0,
+            "baseline_win_rate": 0.0,
+            "score": None,
             "by_character": [],
             "last_submitted_at": None,
             "last_run_hash": None,
         }
     return stats
+
+
+@router.get("/scores/{entity_type}", tags=["Runs"])
+@limiter.limit("60/minute")
+def get_entity_scores(request: Request, entity_type: str):
+    """All Codex Scores for one entity type, keyed by ID.
+
+    Used by list pages to render the score column / sort by tier
+    without N round-trips to /stats/{type}/{id}. Cached at the same
+    TTL as the per-entity stats since both derive from the same walk.
+    """
+    if entity_type not in _ENTITY_STATS_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"entity_type must be one of {sorted(_ENTITY_STATS_TYPES)}",
+        )
+    return get_all_entity_scores(entity_type)
 
 
 @router.get("/stats", tags=["Runs"])

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -39,6 +39,16 @@ _PREFIX_TO_TYPE = {
     "POTION": "potions",
 }
 
+# Codex Score formula constants — see _compute_score for derivation.
+# PRIOR_WEIGHT is how many "virtual baseline picks" we add to every
+# entity to shrink low-N noise toward the global mean. 50 means a
+# 5-pick perfect-record card lands ~mid-tier, not S-tier. SCALE_RANGE
+# is the win-rate delta (vs baseline) that maps to the edges of the
+# 0-100 scale; ±15pp covers the full real-world spread without making
+# moderate over/underperformers saturate.
+_SCORE_PRIOR_WEIGHT = 50
+_SCORE_SCALE_RANGE = 0.15
+
 _CACHE_TTL_SECONDS = 30 * 60  # 30 minutes
 _RUNS_DIR = (
     Path(os.environ.get("DATA_DIR", Path(__file__).resolve().parents[3] / "data"))
@@ -191,6 +201,58 @@ def _maybe_rebuild() -> None:
             _building = False
 
 
+def _baseline_win_rate() -> float:
+    """Global win rate across every submitted run, or 0.5 if empty."""
+    total = _global_totals["total_runs"]
+    if not total:
+        return 0.5
+    return _global_totals["total_wins"] / total
+
+
+def _compute_score(wins: int, picks: int, baseline: float) -> int | None:
+    """0-100 Codex Score for an entity.
+
+    Step 1 — Bayesian shrinkage: blend the entity's wins/picks with
+    `_SCORE_PRIOR_WEIGHT` virtual picks at the baseline win rate. This
+    keeps a 5-pick card at 100% win rate from outranking a 500-pick
+    card at 60% (the high-confidence one wins).
+
+    Step 2 — Map the shrunk delta to 0-100. baseline → 50 (neutral),
+    +SCORE_SCALE_RANGE → 100 (S-tier), -SCORE_SCALE_RANGE → 0 (F-tier).
+    Clamped — saturating cards genuinely belong at the edges.
+    """
+    if picks <= 0:
+        return None
+    shrunk = (wins + baseline * _SCORE_PRIOR_WEIGHT) / (picks + _SCORE_PRIOR_WEIGHT)
+    delta = shrunk - baseline
+    raw = (delta / _SCORE_SCALE_RANGE + 1) * 50
+    return max(0, min(100, round(raw)))
+
+
+def get_all_entity_scores(entity_type: str) -> dict[str, dict[str, Any]]:
+    """All entities of one type, keyed by ID, with score + counts.
+
+    Drives list-page tier sorting and the (planned) tooltip-widget
+    score badge — fetched once by the client and cached locally instead
+    of N round-trips to /stats/{type}/{id}.
+    """
+    _maybe_rebuild()
+    baseline = _baseline_win_rate()
+    out: dict[str, dict[str, Any]] = {}
+    for (etype, eid), agg in _cache.items():
+        if etype != entity_type:
+            continue
+        picks = agg["picks"]
+        wins = agg["wins"]
+        out[eid] = {
+            "score": _compute_score(wins, picks, baseline),
+            "picks": picks,
+            "wins": wins,
+            "win_rate": round(wins / picks * 100, 1) if picks else 0.0,
+        }
+    return out
+
+
 def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
     """Public accessor — returns the aggregate for one entity or None.
 
@@ -221,6 +283,7 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
         )
     ]
     total_runs = _global_totals["total_runs"]
+    baseline = _baseline_win_rate()
     return {
         "entity_type": entity_type,
         "entity_id": entity_id.upper(),
@@ -229,6 +292,8 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
         "win_rate": round(wins / picks * 100, 1) if picks else 0.0,
         "pick_rate": round(picks / total_runs * 100, 1) if total_runs else 0.0,
         "total_runs": total_runs,
+        "baseline_win_rate": round(baseline * 100, 1),
+        "score": _compute_score(wins, picks, baseline),
         "by_character": by_character,
         "last_submitted_at": agg["last_submitted_at"],
         "last_run_hash": agg["last_run_hash"],

--- a/frontend/app/cards/CardsClient.tsx
+++ b/frontend/app/cards/CardsClient.tsx
@@ -8,10 +8,12 @@ import CardGrid from "../components/CardGrid";
 import SearchFilter from "../components/SearchFilter";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { useEntityScores } from "@/lib/use-entity-scores";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 const sortOptions = [
+  { label: "Top tier", value: "score" },
   { label: "A → Z", value: "az" },
   { label: "Z → A", value: "za" },
   { label: "Compendium", value: "compendium" },
@@ -107,13 +109,23 @@ export default function CardsClient({ initialCards }: { initialCards: Card[] }) 
       .then(setCards);
   }, [color, type, rarity, keyword, search, lang]);
 
+  const scores = useEntityScores("cards");
+
   const sortedCards = useMemo(() => {
     const sorted = [...cards];
     if (sort === "az") sorted.sort((a, b) => a.name.localeCompare(b.name));
     else if (sort === "za") sorted.sort((a, b) => b.name.localeCompare(a.name));
     else if (sort === "compendium") sorted.sort((a, b) => a.compendium_order - b.compendium_order);
+    else if (sort === "score") {
+      sorted.sort((a, b) => {
+        const sa = scores[a.id.toUpperCase()]?.score ?? -1;
+        const sb = scores[b.id.toUpperCase()]?.score ?? -1;
+        if (sb !== sa) return sb - sa;
+        return a.compendium_order - b.compendium_order;
+      });
+    }
     return sorted;
-  }, [cards, sort]);
+  }, [cards, sort, scores]);
 
   return (
     <>
@@ -153,7 +165,7 @@ export default function CardsClient({ initialCards }: { initialCards: Card[] }) 
         ]}
       />
 
-      <CardGrid cards={sortedCards} />
+      <CardGrid cards={sortedCards} scores={scores} />
     </>
   );
 }

--- a/frontend/app/components/CardGrid.tsx
+++ b/frontend/app/components/CardGrid.tsx
@@ -6,6 +6,7 @@ import type { Card } from "@/lib/api";
 import { getCardDisplayModel } from "@/lib/card-display";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import RichDescription from "./RichDescription";
+import ScoreBadge from "./ScoreBadge";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -49,7 +50,7 @@ function renderDescription(card: Card, text: string): React.ReactNode {
   return <RichDescription text={normalizedText} energyIcon={energyIcon} />;
 }
 
-function CardItem({ card }: { card: Card }) {
+function CardItem({ card, score }: { card: Card; score?: number | null }) {
   const lp = useLangPrefix();
   const [upgraded, setUpgraded] = useState(false);
   const [betaArt, setBetaArt] = useState(false);
@@ -88,6 +89,7 @@ function CardItem({ card }: { card: Card }) {
           {card.name}{isUpgraded && <span className="text-emerald-400">+</span>}
         </h3>
         <div className="ml-2 flex-shrink-0 flex items-center gap-1">
+          <ScoreBadge score={score} size="sm" />
           <span className={`inline-flex items-center justify-center w-7 h-7 rounded-full bg-[var(--bg-primary)] border text-sm font-bold ${
             isUpgraded && display.upgrade?.cost != null ? "border-emerald-700/50 text-emerald-400" : "border-[var(--border-subtle)] text-[var(--accent-gold)]"
           }`}>
@@ -163,11 +165,22 @@ function CardItem({ card }: { card: Card }) {
   );
 }
 
-export default function CardGrid({ cards }: { cards: Card[] }) {
+export default function CardGrid({
+  cards,
+  scores,
+}: {
+  cards: Card[];
+  /** Optional: map of upper-cased card ID → Codex Score. */
+  scores?: Record<string, { score: number | null }>;
+}) {
   return (
     <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-4">
       {cards.map((card) => (
-        <CardItem key={card.id} card={card} />
+        <CardItem
+          key={card.id}
+          card={card}
+          score={scores?.[card.id.toUpperCase()]?.score}
+        />
       ))}
     </div>
   );

--- a/frontend/app/components/EntityRunStats.tsx
+++ b/frontend/app/components/EntityRunStats.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { cachedFetch } from "@/lib/fetch-cache";
+import ScoreBadge from "@/app/components/ScoreBadge";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -21,6 +22,8 @@ interface EntityStats {
   win_rate: number;
   pick_rate: number;
   total_runs: number;
+  baseline_win_rate: number;
+  score: number | null;
   by_character: CharacterRow[];
   last_submitted_at: string | null;
   last_run_hash: string | null;
@@ -84,6 +87,24 @@ export default function EntityRunStats({ entityType, entityId, entityName }: Pro
 
   return (
     <div className="space-y-5">
+      {/* Codex Score hero — single 0-100 badge that summarizes the
+          entity's community-meta strength. Bayesian-shrunk so low-N
+          entities sit near neutral instead of saturating S/F tiers.
+          See `_compute_score` in run_entity_stats.py for the formula. */}
+      {stats.score != null && (
+        <div className="flex items-center gap-3 pb-4 border-b border-[var(--border-subtle)]">
+          <ScoreBadge score={stats.score} size="lg" showNumber />
+          <div className="text-xs text-[var(--text-muted)] leading-snug">
+            <div className="text-[var(--text-secondary)] font-semibold mb-0.5">
+              Codex Score
+            </div>
+            <div>
+              {stats.win_rate}% win rate vs {stats.baseline_win_rate}% baseline
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Prose summary — also serves as crawlable SEO body content. */}
       <p className="text-sm leading-relaxed text-[var(--text-secondary)]">
         {empty ? (

--- a/frontend/app/components/EntityRunStats.tsx
+++ b/frontend/app/components/EntityRunStats.tsx
@@ -100,6 +100,13 @@ export default function EntityRunStats({ entityType, entityId, entityName }: Pro
             </div>
             <div>
               {stats.win_rate}% win rate vs {stats.baseline_win_rate}% baseline
+              {" · "}
+              <Link
+                href="/leaderboards/scoring"
+                className="text-[var(--accent-gold)]/80 hover:text-[var(--accent-gold)] hover:underline"
+              >
+                how is this calculated?
+              </Link>
             </div>
           </div>
         </div>

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -19,7 +19,7 @@ interface NavGroup {
   links: { href: string; label: string }[];
 }
 
-const BETA_HIDDEN = new Set(["/guides", "/showcase", "/leaderboards", "/leaderboards/submit", "/leaderboards/stats"]);
+const BETA_HIDDEN = new Set(["/guides", "/showcase", "/leaderboards", "/leaderboards/submit", "/leaderboards/stats", "/leaderboards/scoring"]);
 
 // Routes that should only highlight on exact match (not prefix match)
 const EXACT_MATCH = new Set(["/leaderboards"]);
@@ -68,6 +68,7 @@ const NAV_GROUPS: NavGroup[] = [
       { href: "/leaderboards", label: "Leaderboards" },
       { href: "/leaderboards/submit", label: "Submit a Run" },
       { href: "/leaderboards/stats", label: "Stats" },
+      { href: "/leaderboards/scoring", label: "Scoring" },
     ],
   },
   {

--- a/frontend/app/components/ScoreBadge.tsx
+++ b/frontend/app/components/ScoreBadge.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+interface ScoreBadgeProps {
+  score: number | null | undefined;
+  /** sm = inline pill, md = list-row chip, lg = detail-page hero badge. */
+  size?: "sm" | "md" | "lg";
+  /** Show the numeric score next to the letter grade. */
+  showNumber?: boolean;
+}
+
+interface Tier {
+  letter: string;
+  /** Inline tailwind classes for bg + border + text. */
+  className: string;
+  label: string;
+}
+
+/**
+ * Score → tier mapping. Bands chosen so the median entity lands in C
+ * and the extremes (S+ / F) require sustained out-of-distribution
+ * performance after Bayesian shrinkage. See `_compute_score` in
+ * backend/app/services/run_entity_stats.py for the underlying math.
+ */
+function scoreToTier(score: number): Tier {
+  if (score >= 90) return { letter: "S", label: "Top tier", className: "bg-amber-950/40 border-amber-700/60 text-amber-300" };
+  if (score >= 78) return { letter: "A", label: "Strong",   className: "bg-emerald-950/40 border-emerald-700/60 text-emerald-300" };
+  if (score >= 65) return { letter: "B", label: "Solid",    className: "bg-sky-950/40 border-sky-700/60 text-sky-300" };
+  if (score >= 50) return { letter: "C", label: "Average",  className: "bg-zinc-800/60 border-zinc-600/60 text-zinc-300" };
+  if (score >= 35) return { letter: "D", label: "Weak",     className: "bg-orange-950/40 border-orange-700/60 text-orange-300" };
+  return { letter: "F", label: "Avoid", className: "bg-rose-950/40 border-rose-800/60 text-rose-300" };
+}
+
+export default function ScoreBadge({ score, size = "md", showNumber = false }: ScoreBadgeProps) {
+  if (score == null) return null;
+  const tier = scoreToTier(score);
+
+  const sizeClasses = {
+    sm: "text-[10px] px-1.5 py-0.5 min-w-[1.5rem]",
+    md: "text-xs px-2 py-0.5 min-w-[1.75rem]",
+    lg: "text-base px-3 py-1.5 min-w-[2.5rem]",
+  }[size];
+
+  const numberSize = {
+    sm: "text-[9px] ml-1",
+    md: "text-[10px] ml-1",
+    lg: "text-sm ml-1.5",
+  }[size];
+
+  return (
+    <span
+      className={`inline-flex items-center justify-center font-bold rounded border ${sizeClasses} ${tier.className}`}
+      title={`Codex Score: ${score} (${tier.label})`}
+    >
+      {tier.letter}
+      {showNumber && <span className={`font-mono font-medium opacity-80 ${numberSize}`}>{score}</span>}
+    </span>
+  );
+}
+
+export { scoreToTier };

--- a/frontend/app/leaderboards/scoring/page.tsx
+++ b/frontend/app/leaderboards/scoring/page.tsx
@@ -1,0 +1,275 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE_URL, SITE_NAME } from "@/lib/seo";
+import JsonLd from "@/app/components/JsonLd";
+import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import ScoreBadge from "@/app/components/ScoreBadge";
+
+export const metadata: Metadata = {
+  title: `Slay the Spire 2 Codex Score - How Tier Ratings Work | ${SITE_NAME}`,
+  description:
+    "How the Codex Score rates every Slay the Spire 2 card, relic, and potion. Bayesian-shrunk win-rate formula, tier bands (S through F), and methodology behind the community-meta ratings.",
+  alternates: { canonical: `${SITE_URL}/leaderboards/scoring` },
+  openGraph: {
+    title: `Codex Score Methodology | ${SITE_NAME}`,
+    description:
+      "How we compute the 0-100 community-meta score on every card / relic / potion. Bayesian shrinkage, tier bands, formula breakdown.",
+    url: `${SITE_URL}/leaderboards/scoring`,
+    siteName: SITE_NAME,
+    type: "article",
+  },
+};
+
+interface ExampleRow {
+  label: string;
+  picks: number;
+  wins: number;
+  score: number;
+}
+
+// Worked examples — should match _compute_score in
+// backend/app/services/run_entity_stats.py exactly. Mirrored here so
+// the page is fully static (no API roundtrip on render).
+const EXAMPLES: ExampleRow[] = [
+  { label: "Massive sample, elite", picks: 1000, wins: 700, score: 100 },
+  { label: "High-N strong", picks: 100, wins: 70, score: 94 },
+  { label: "Mid-N solid", picks: 500, wins: 280, score: 68 },
+  { label: "Small-N perfect", picks: 5, wins: 5, score: 65 },
+  { label: "Average performer", picks: 50, wins: 25, score: 50 },
+  { label: "Small-N total loss", picks: 5, wins: 0, score: 35 },
+  { label: "High-N weak", picks: 200, wins: 60, score: 0 },
+];
+
+const TIERS = [
+  { range: "90 – 100", letter: "S", label: "Top tier", note: "Genuinely elite. Out-of-distribution win rate sustained over hundreds of picks." },
+  { range: "78 – 89",  letter: "A", label: "Strong",   note: "Reliable engine pieces. Picking these is rarely a mistake." },
+  { range: "65 – 77",  letter: "B", label: "Solid",    note: "Above-average. Pick when nothing better is offered." },
+  { range: "50 – 64",  letter: "C", label: "Average",  note: "The middle of the curve. Most cards live here." },
+  { range: "35 – 49",  letter: "D", label: "Weak",     note: "Niche or filler. Skippable in most builds." },
+  { range: "0 – 34",   letter: "F", label: "Avoid",    note: "Actively pulls runs toward losses. Take only if forced." },
+];
+
+export default function ScoringPage() {
+  const jsonLd = [
+    buildBreadcrumbJsonLd([
+      { name: "Home", href: "/" },
+      { name: "Stats", href: "/leaderboards/stats" },
+      { name: "Codex Score", href: "/leaderboards/scoring" },
+    ]),
+  ];
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <JsonLd data={jsonLd} />
+
+      <h1 className="text-3xl font-bold mb-2">
+        <span className="text-[var(--accent-gold)]">Codex Score</span>
+      </h1>
+      <p className="text-sm text-[var(--text-muted)] mb-8">
+        How every card, relic, and potion gets a 0–100 community-meta rating.
+      </p>
+
+      {/* Hero example */}
+      <section className="mb-10 p-5 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)]">
+        <div className="flex items-center gap-4 mb-3">
+          <ScoreBadge score={94} size="lg" showNumber />
+          <div>
+            <h2 className="text-base font-semibold text-[var(--text-primary)]">
+              What is the Codex Score?
+            </h2>
+            <p className="text-xs text-[var(--text-muted)] mt-0.5">
+              Bayesian-shrunk win-rate, mapped to 0–100 with letter-grade tiers.
+            </p>
+          </div>
+        </div>
+        <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
+          Every card, relic, and potion in <em>Slay the Spire 2</em> gets a single number that
+          summarizes <strong>how strongly it pulls toward winning runs</strong> — based purely
+          on community-submitted run data, not opinion. <strong>50</strong> is neutral
+          (the average run wins roughly half the time at A0), <strong>100</strong> is best-in-class,
+          <strong>0</strong> is worst. The same number drives the &ldquo;Top tier&rdquo; sort on
+          every list page and the badge on every detail page.
+        </p>
+      </section>
+
+      {/* Tier bands */}
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold text-[var(--accent-gold)] mb-4">Tier bands</h2>
+        <div className="overflow-x-auto rounded-lg border border-[var(--border-subtle)]">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-xs uppercase tracking-wider text-[var(--text-muted)] border-b border-[var(--border-subtle)] bg-[var(--bg-card)]">
+                <th className="text-left py-2.5 px-4 font-semibold">Range</th>
+                <th className="text-left py-2.5 px-3 font-semibold">Tier</th>
+                <th className="text-left py-2.5 px-3 font-semibold">Label</th>
+                <th className="text-left py-2.5 px-4 font-semibold">What it means</th>
+              </tr>
+            </thead>
+            <tbody>
+              {TIERS.map((t) => {
+                const sample = parseInt(t.range.split("–")[1].trim(), 10);
+                return (
+                  <tr key={t.letter} className="border-b border-[var(--border-subtle)] last:border-b-0">
+                    <td className="py-2.5 px-4 font-mono tabular-nums text-[var(--text-secondary)]">{t.range}</td>
+                    <td className="py-2.5 px-3"><ScoreBadge score={sample} size="md" /></td>
+                    <td className="py-2.5 px-3 text-[var(--text-secondary)]">{t.label}</td>
+                    <td className="py-2.5 px-4 text-[var(--text-secondary)]">{t.note}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Formula */}
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold text-[var(--accent-gold)] mb-4">The formula</h2>
+        <p className="text-sm text-[var(--text-secondary)] leading-relaxed mb-4">
+          The score has two stages: <strong>Bayesian shrinkage</strong> (so a 5-pick perfect
+          card doesn&apos;t outrank a 500-pick reliable one), then a <strong>linear map</strong>
+          {" "}from win-rate-vs-baseline to the 0–100 scale.
+        </p>
+
+        <pre className="text-xs sm:text-sm bg-[var(--bg-primary)] border border-[var(--border-subtle)] rounded-lg p-4 overflow-x-auto leading-relaxed text-[var(--text-secondary)]">
+{`baseline   = total_wins / total_runs       # global win rate
+shrunk     = (wins + baseline · 50) / (picks + 50)
+delta      = shrunk − baseline
+raw        = (delta / 0.15 + 1) · 50
+score      = clamp(raw, 0, 100)            # rounded to integer`}
+        </pre>
+
+        <ul className="text-sm text-[var(--text-secondary)] mt-4 space-y-2 list-disc pl-5">
+          <li>
+            <strong>Prior weight = 50.</strong> Every entity starts with the equivalent of 50
+            virtual picks at the baseline win rate. Real picks accumulate against this prior, so
+            scores stabilize as data grows. A 5-pick card with a perfect record only nudges the
+            prior; a 500-pick card with a strong record overpowers it.
+          </li>
+          <li>
+            <strong>Scale range = ±15pp.</strong> A win-rate gap of 15 percentage points above
+            baseline maps to 100. Scores saturate beyond that — entities outside that band are
+            genuinely off the distribution.
+          </li>
+          <li>
+            <strong>Clamp.</strong> Scores can&apos;t go negative or above 100, even if the math
+            does. The cap is honest: an entity at the cap is &ldquo;at least this good,&rdquo;
+            not necessarily &ldquo;exactly 100.&rdquo;
+          </li>
+        </ul>
+      </section>
+
+      {/* Examples */}
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold text-[var(--accent-gold)] mb-4">Worked examples</h2>
+        <p className="text-sm text-[var(--text-secondary)] leading-relaxed mb-4">
+          Same baseline (50% win rate) for all rows below. Note how sample size matters: the
+          5-pick perfect record gets B-tier, while the 500-pick 56% record gets A-tier.
+        </p>
+        <div className="overflow-x-auto rounded-lg border border-[var(--border-subtle)]">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-xs uppercase tracking-wider text-[var(--text-muted)] border-b border-[var(--border-subtle)] bg-[var(--bg-card)]">
+                <th className="text-left py-2.5 px-4 font-semibold">Scenario</th>
+                <th className="text-right py-2.5 px-3 font-semibold">Picks</th>
+                <th className="text-right py-2.5 px-3 font-semibold">Wins</th>
+                <th className="text-right py-2.5 px-3 font-semibold">Win %</th>
+                <th className="text-left py-2.5 px-4 font-semibold">Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {EXAMPLES.map((ex) => (
+                <tr key={ex.label} className="border-b border-[var(--border-subtle)] last:border-b-0">
+                  <td className="py-2.5 px-4 text-[var(--text-secondary)]">{ex.label}</td>
+                  <td className="py-2.5 px-3 text-right font-mono tabular-nums text-[var(--text-secondary)]">{ex.picks}</td>
+                  <td className="py-2.5 px-3 text-right font-mono tabular-nums text-[var(--text-secondary)]">{ex.wins}</td>
+                  <td className="py-2.5 px-3 text-right font-mono tabular-nums text-[var(--text-secondary)]">{Math.round((ex.wins / ex.picks) * 100)}%</td>
+                  <td className="py-2.5 px-4"><ScoreBadge score={ex.score} size="md" showNumber /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Limitations / disclaimers */}
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold text-[var(--accent-gold)] mb-4">What the score is not</h2>
+        <ul className="text-sm text-[var(--text-secondary)] space-y-3 list-disc pl-5">
+          <li>
+            <strong>Not a personal recommendation.</strong> Score answers &ldquo;what wins for the
+            average submitter?&rdquo; It can&apos;t see your deck, your character, your ascension,
+            or what relics you already have. A C-tier card can be the right pick if it solves
+            <em> your</em> problem.
+          </li>
+          <li>
+            <strong>Not normalized by ascension.</strong> A relic that&apos;s great at A0 and
+            mediocre at A10 gets one blended score. We&apos;ll add per-ascension scoring once the
+            sample size at high ascension is statistically meaningful.
+          </li>
+          <li>
+            <strong>Not normalized by character.</strong> A relic with a 70% win rate on Defect and
+            45% on Ironclad blends to one number. Per-character scoring is on the roadmap (the
+            data is already in the per-character breakdown table on each detail page).
+          </li>
+          <li>
+            <strong>Biased toward submitter pool.</strong> The score reflects runs that real
+            humans bothered to submit — disproportionately wins, disproportionately ranked-mode
+            players. The baseline win rate is computed from the same pool, so the bias largely
+            cancels out for relative ranking. But absolute win rates skew higher than the average
+            player&apos;s.
+          </li>
+          <li>
+            <strong>Refreshes every 30 minutes.</strong> Scores are cached server-side. A run you
+            submit right now will affect the next score rebuild, not the one in your browser.
+          </li>
+        </ul>
+      </section>
+
+      {/* Further reading / cross-links */}
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold text-[var(--accent-gold)] mb-4">See it in action</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <Link
+            href="/cards?sort=score"
+            className="block p-4 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] hover:border-[var(--border-accent)] transition-colors"
+          >
+            <div className="text-sm font-semibold text-[var(--text-primary)] mb-1">Cards by score</div>
+            <div className="text-xs text-[var(--text-muted)]">Top-tier cards, sortable by Codex Score.</div>
+          </Link>
+          <Link
+            href="/relics?sort=score"
+            className="block p-4 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] hover:border-[var(--border-accent)] transition-colors"
+          >
+            <div className="text-sm font-semibold text-[var(--text-primary)] mb-1">Relics by score</div>
+            <div className="text-xs text-[var(--text-muted)]">Best-rated relics across all pools.</div>
+          </Link>
+          <Link
+            href="/potions?sort=score"
+            className="block p-4 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] hover:border-[var(--border-accent)] transition-colors"
+          >
+            <div className="text-sm font-semibold text-[var(--text-primary)] mb-1">Potions by score</div>
+            <div className="text-xs text-[var(--text-muted)]">Tier list of every potion in the game.</div>
+          </Link>
+        </div>
+      </section>
+
+      {/* Submit prompt */}
+      <section className="p-5 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)]">
+        <h3 className="text-base font-semibold text-[var(--text-primary)] mb-2">
+          Improve the scores
+        </h3>
+        <p className="text-sm text-[var(--text-secondary)] leading-relaxed mb-3">
+          Every score gets sharper when more runs are submitted — especially losses, which are
+          chronically underrepresented in community datasets. The submitter pool is the data.
+        </p>
+        <Link
+          href="/leaderboards/submit"
+          className="inline-block text-sm font-medium text-[var(--accent-gold)] hover:underline"
+        >
+          → Submit a run
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/potions/PotionsClient.tsx
+++ b/frontend/app/potions/PotionsClient.tsx
@@ -9,6 +9,8 @@ import SearchFilter from "../components/SearchFilter";
 import RichDescription from "../components/RichDescription";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { useEntityScores } from "@/lib/use-entity-scores";
+import ScoreBadge from "@/app/components/ScoreBadge";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -35,6 +37,7 @@ const poolOptions = [
 ];
 
 const sortOptions = [
+  { label: "Top tier", value: "score" },
   { label: "A → Z", value: "az" },
   { label: "Z → A", value: "za" },
   { label: "Compendium", value: "compendium" },
@@ -87,13 +90,23 @@ export default function PotionsClient({ initialPotions }: { initialPotions: Poti
       .finally(() => setLoading(false));
   }, [rarity, search, pool, lang]);
 
+  const scores = useEntityScores("potions");
+
   const sortedPotions = useMemo(() => {
     const sorted = [...potions];
     if (sort === "az") sorted.sort((a, b) => a.name.localeCompare(b.name));
     else if (sort === "za") sorted.sort((a, b) => b.name.localeCompare(a.name));
     else if (sort === "compendium") sorted.sort((a, b) => a.compendium_order - b.compendium_order);
+    else if (sort === "score") {
+      sorted.sort((a, b) => {
+        const sa = scores[a.id.toUpperCase()]?.score ?? -1;
+        const sb = scores[b.id.toUpperCase()]?.score ?? -1;
+        if (sb !== sa) return sb - sa;
+        return a.compendium_order - b.compendium_order;
+      });
+    }
     return sorted;
-  }, [potions, sort]);
+  }, [potions, sort, scores]);
 
   return (
     <>
@@ -148,10 +161,11 @@ export default function PotionsClient({ initialPotions }: { initialPotions: Poti
                     />
                   )}
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-start justify-between mb-2">
+                    <div className="flex items-start justify-between gap-2 mb-2">
                       <h3 className="font-semibold text-[var(--text-primary)] leading-tight">
                         {potion.name}
                       </h3>
+                      <ScoreBadge score={scores[potion.id.toUpperCase()]?.score} size="sm" />
                     </div>
                     <span
                       className={`text-xs ${style.split(" ").slice(1).join(" ")} mb-3 inline-block`}

--- a/frontend/app/relics/RelicsClient.tsx
+++ b/frontend/app/relics/RelicsClient.tsx
@@ -9,6 +9,8 @@ import SearchFilter from "../components/SearchFilter";
 import RichDescription from "../components/RichDescription";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { useEntityScores } from "@/lib/use-entity-scores";
+import ScoreBadge from "@/app/components/ScoreBadge";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -42,6 +44,7 @@ const poolOptions = [
 ];
 
 const sortOptions = [
+  { label: "Top tier", value: "score" },
   { label: "A → Z", value: "az" },
   { label: "Z → A", value: "za" },
   { label: "Compendium", value: "compendium" },
@@ -92,13 +95,25 @@ export default function RelicsClient({ initialRelics }: { initialRelics: Relic[]
       .then(setRelics);
   }, [rarity, pool, search, lang]);
 
+  const scores = useEntityScores("relics");
+
   const sortedRelics = useMemo(() => {
     const sorted = [...relics];
     if (sort === "az") sorted.sort((a, b) => a.name.localeCompare(b.name));
     else if (sort === "za") sorted.sort((a, b) => b.name.localeCompare(a.name));
     else if (sort === "compendium") sorted.sort((a, b) => a.compendium_order - b.compendium_order);
+    else if (sort === "score") {
+      // Score-sort: scored entities desc, unscored sink to bottom in
+      // compendium order so the list stays stable as new runs land.
+      sorted.sort((a, b) => {
+        const sa = scores[a.id.toUpperCase()]?.score ?? -1;
+        const sb = scores[b.id.toUpperCase()]?.score ?? -1;
+        if (sb !== sa) return sb - sa;
+        return a.compendium_order - b.compendium_order;
+      });
+    }
     return sorted;
-  }, [relics, sort]);
+  }, [relics, sort, scores]);
 
   return (
     <>
@@ -148,10 +163,11 @@ export default function RelicsClient({ initialRelics }: { initialRelics: Relic[]
                   />
                 )}
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-start justify-between mb-2">
+                  <div className="flex items-start justify-between gap-2 mb-2">
                     <h3 className="font-semibold text-[var(--text-primary)] leading-tight">
                       {relic.name}
                     </h3>
+                    <ScoreBadge score={scores[relic.id.toUpperCase()]?.score} size="sm" />
                   </div>
                   <div className="flex items-center gap-2 mb-3 text-xs">
                     <span className={style.split(" ").slice(1).join(" ")}>

--- a/frontend/lib/use-entity-scores.ts
+++ b/frontend/lib/use-entity-scores.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { cachedFetch } from "@/lib/fetch-cache";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+export interface ScoreEntry {
+  score: number | null;
+  picks: number;
+  wins: number;
+  win_rate: number;
+}
+
+export type ScoresMap = Record<string, ScoreEntry>;
+
+/**
+ * Fetch every Codex Score for an entity type once, keyed by uppercase
+ * ID. Backed by `cachedFetch` so concurrent calls dedupe and the
+ * client-side cache survives soft navs. Use this on list pages to
+ * surface tier badges without N round-trips per row.
+ */
+export function useEntityScores(entityType: "cards" | "relics" | "potions"): ScoresMap {
+  const [scores, setScores] = useState<ScoresMap>({});
+
+  useEffect(() => {
+    cachedFetch<ScoresMap>(`${API}/api/runs/scores/${entityType}`)
+      .then(setScores)
+      .catch(() => setScores({}));
+  }, [entityType]);
+
+  return scores;
+}


### PR DESCRIPTION
## What
A public explainer page for the Codex Score, linked from the **Stats** menu and from the *'how is this calculated?'* link beneath every per-entity score badge.

**Stacks on top of #224** (Codex Score backend + UI). Merge that one first.

## URL
`/leaderboards/scoring`

## Sections
1. **Hero example** — live ScoreBadge demonstrating the visual treatment
2. **Tier bands** — S/A/B/C/D/F, each row shows a real badge of that tier + plain-English meaning
3. **Formula** — the full math, then a per-knob breakdown (`PRIOR_WEIGHT`, `SCALE_RANGE`, clamping behavior)
4. **Worked examples** — same scenarios I sanity-checked the implementation against. Shows why a 5-pick perfect record only gets B-tier and why a 200-pick weak entity drops to F
5. **What the score is not** — honest limitations:
   - Not personalized (no deck/character/ascension awareness)
   - Not ascension-normalized
   - Not character-normalized (per-character data exists in the existing breakdown table)
   - Biased toward submitter pool
   - 30-min cache TTL
6. **See it in action** — cross-links to `/cards|relics|potions?sort=score`
7. **Submit prompt** — pushes losses (chronically underrepresented in community datasets) to the submission page

## SEO
- Server component (no client JS for the body)
- Proper `Article` OG tags
- Breadcrumb JSON-LD
- Canonical URL
- Title: *'Slay the Spire 2 Codex Score - How Tier Ratings Work'*

## Discoverability
- Added to **Stats** nav group (4th entry, after Leaderboards / Submit / Stats)
- Inline 'how is this calculated?' link below every score badge on detail pages
- Hidden on beta (since `/leaderboards` is hidden there)