### PR TITLE
Visual tier list — /tier-list landing + cards/relics/potions

### DIFF
--- a/frontend/app/cards/CardsClient.tsx
+++ b/frontend/app/cards/CardsClient.tsx
@@ -165,7 +165,7 @@ export default function CardsClient({ initialCards }: { initialCards: Card[] }) 
         ]}
       />
 
-      <CardGrid cards={sortedCards} scores={scores} />
+      <CardGrid cards={sortedCards} />
     </>
   );
 }

--- a/frontend/app/components/CardGrid.tsx
+++ b/frontend/app/components/CardGrid.tsx
@@ -6,7 +6,6 @@ import type { Card } from "@/lib/api";
 import { getCardDisplayModel } from "@/lib/card-display";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import RichDescription from "./RichDescription";
-import ScoreBadge from "./ScoreBadge";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -50,7 +49,7 @@ function renderDescription(card: Card, text: string): React.ReactNode {
   return <RichDescription text={normalizedText} energyIcon={energyIcon} />;
 }
 
-function CardItem({ card, score }: { card: Card; score?: number | null }) {
+function CardItem({ card }: { card: Card }) {
   const lp = useLangPrefix();
   const [upgraded, setUpgraded] = useState(false);
   const [betaArt, setBetaArt] = useState(false);
@@ -89,7 +88,6 @@ function CardItem({ card, score }: { card: Card; score?: number | null }) {
           {card.name}{isUpgraded && <span className="text-emerald-400">+</span>}
         </h3>
         <div className="ml-2 flex-shrink-0 flex items-center gap-1">
-          <ScoreBadge score={score} size="sm" />
           <span className={`inline-flex items-center justify-center w-7 h-7 rounded-full bg-[var(--bg-primary)] border text-sm font-bold ${
             isUpgraded && display.upgrade?.cost != null ? "border-emerald-700/50 text-emerald-400" : "border-[var(--border-subtle)] text-[var(--accent-gold)]"
           }`}>
@@ -165,22 +163,11 @@ function CardItem({ card, score }: { card: Card; score?: number | null }) {
   );
 }
 
-export default function CardGrid({
-  cards,
-  scores,
-}: {
-  cards: Card[];
-  /** Optional: map of upper-cased card ID → Codex Score. */
-  scores?: Record<string, { score: number | null }>;
-}) {
+export default function CardGrid({ cards }: { cards: Card[] }) {
   return (
     <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-4">
       {cards.map((card) => (
-        <CardItem
-          key={card.id}
-          card={card}
-          score={scores?.[card.id.toUpperCase()]?.score}
-        />
+        <CardItem key={card.id} card={card} />
       ))}
     </div>
   );

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -19,7 +19,7 @@ interface NavGroup {
   links: { href: string; label: string }[];
 }
 
-const BETA_HIDDEN = new Set(["/guides", "/showcase", "/leaderboards", "/leaderboards/submit", "/leaderboards/stats", "/leaderboards/scoring"]);
+const BETA_HIDDEN = new Set(["/guides", "/showcase", "/leaderboards", "/leaderboards/submit", "/leaderboards/stats", "/leaderboards/scoring", "/tier-list"]);
 
 // Routes that should only highlight on exact match (not prefix match)
 const EXACT_MATCH = new Set(["/leaderboards"]);
@@ -65,6 +65,7 @@ const NAV_GROUPS: NavGroup[] = [
   {
     label: "Stats",
     links: [
+      { href: "/tier-list", label: "Tier List" },
       { href: "/leaderboards", label: "Leaderboards" },
       { href: "/leaderboards/submit", label: "Submit a Run" },
       { href: "/leaderboards/stats", label: "Stats" },

--- a/frontend/app/components/TierList.tsx
+++ b/frontend/app/components/TierList.tsx
@@ -1,0 +1,162 @@
+import Link from "next/link";
+
+const API_PUBLIC = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export interface TierEntity {
+  id: string;
+  name: string;
+  image_url: string | null;
+  /** Codex Score 0-100, or null if entity has no submitted-run data. */
+  score: number | null;
+}
+
+interface Tier {
+  letter: "S" | "A" | "B" | "C" | "D" | "F";
+  /** Inclusive lower bound — entities with score >= min land in this tier. */
+  min: number;
+  className: string;
+  label: string;
+}
+
+// Tier bands match _compute_score in run_entity_stats.py and the
+// scoreToTier function in ScoreBadge. Keep the three in sync.
+const TIERS: Tier[] = [
+  { letter: "S", min: 90, className: "bg-amber-950/40 border-amber-700/60 text-amber-300",     label: "Top tier" },
+  { letter: "A", min: 78, className: "bg-emerald-950/40 border-emerald-700/60 text-emerald-300", label: "Strong" },
+  { letter: "B", min: 65, className: "bg-sky-950/40 border-sky-700/60 text-sky-300",           label: "Solid" },
+  { letter: "C", min: 50, className: "bg-zinc-800/60 border-zinc-600/60 text-zinc-300",        label: "Average" },
+  { letter: "D", min: 35, className: "bg-orange-950/40 border-orange-700/60 text-orange-300",  label: "Weak" },
+  { letter: "F", min: 0,  className: "bg-rose-950/40 border-rose-800/60 text-rose-300",        label: "Avoid" },
+];
+
+function tierForScore(score: number): Tier {
+  for (const t of TIERS) {
+    if (score >= t.min) return t;
+  }
+  // Unreachable — last tier has min:0 so any score matches
+  return TIERS[TIERS.length - 1];
+}
+
+interface TierListProps {
+  /** Entity-list URL segment (e.g. "cards", "relics", "potions"). */
+  route: "cards" | "relics" | "potions";
+  /** Entities with their scores. Will be grouped + sorted internally. */
+  entities: TierEntity[];
+  /** Show scoreless entities in their own row at the bottom. */
+  showUnrated?: boolean;
+}
+
+/**
+ * Tier-list visual: S → F rows of entity thumbnails. Server-renderable
+ * (no client state). Each row shows tier letter on the left + a wrap
+ * grid of small image+name tiles on the right, sorted by score desc
+ * within the tier. Designed for the /tier-list/* pages but reusable
+ * anywhere we want a tier-grouped display.
+ */
+export default function TierList({ route, entities, showUnrated = true }: TierListProps) {
+  // Group entities by tier — scoreless go to the bottom in a separate
+  // "Unrated" row so they're still discoverable but don't pollute the
+  // tier signal. Within each tier, sort by score desc, then by name
+  // for deterministic ordering at score ties.
+  const grouped = new Map<string, TierEntity[]>();
+  const unrated: TierEntity[] = [];
+
+  for (const ent of entities) {
+    if (ent.score == null) {
+      unrated.push(ent);
+      continue;
+    }
+    const tier = tierForScore(ent.score);
+    const bucket = grouped.get(tier.letter) ?? [];
+    bucket.push(ent);
+    grouped.set(tier.letter, bucket);
+  }
+
+  for (const bucket of grouped.values()) {
+    bucket.sort((a, b) => {
+      const sa = a.score ?? 0;
+      const sb = b.score ?? 0;
+      if (sb !== sa) return sb - sa;
+      return a.name.localeCompare(b.name);
+    });
+  }
+  unrated.sort((a, b) => a.name.localeCompare(b.name));
+
+  const rows: { tier: Tier | null; items: TierEntity[] }[] = [];
+  for (const tier of TIERS) {
+    const items = grouped.get(tier.letter);
+    if (items && items.length) rows.push({ tier, items });
+  }
+  if (showUnrated && unrated.length) {
+    rows.push({ tier: null, items: unrated });
+  }
+
+  if (rows.length === 0) {
+    return (
+      <p className="text-sm text-[var(--text-muted)] py-8 text-center">
+        No data available — submit a run to seed this tier list.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {rows.map(({ tier, items }) => (
+        <div
+          key={tier?.letter ?? "unrated"}
+          className="flex flex-col sm:flex-row gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] overflow-hidden"
+        >
+          {/* Tier letter rail */}
+          <div
+            className={`flex-shrink-0 flex sm:flex-col items-center justify-center sm:w-24 px-4 py-3 sm:py-4 border-b sm:border-b-0 sm:border-r ${
+              tier
+                ? `${tier.className} border-current/20`
+                : "bg-zinc-900/40 border-zinc-700/40 text-zinc-500"
+            }`}
+          >
+            <span className="text-3xl sm:text-4xl font-bold leading-none">
+              {tier?.letter ?? "—"}
+            </span>
+            <span className="text-[10px] uppercase tracking-wider opacity-70 ml-2 sm:ml-0 sm:mt-1.5">
+              {tier?.label ?? "Unrated"}
+            </span>
+          </div>
+
+          {/* Entity tile grid */}
+          <div className="flex flex-wrap gap-2 p-3 flex-1 min-w-0">
+            {items.map((ent) => (
+              <Link
+                key={ent.id}
+                href={`/${route}/${ent.id.toLowerCase()}`}
+                title={ent.score != null ? `${ent.name} (Score ${ent.score})` : ent.name}
+                className="group relative flex flex-col items-center gap-1 w-16 sm:w-20 p-1.5 rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] hover:border-[var(--accent-gold)]/50 transition-colors"
+              >
+                {ent.image_url ? (
+                  <img
+                    src={`${API_PUBLIC}${ent.image_url}`}
+                    alt={ent.name}
+                    className="w-12 h-12 sm:w-14 sm:h-14 object-contain"
+                    loading="lazy"
+                    crossOrigin="anonymous"
+                  />
+                ) : (
+                  <div className="w-12 h-12 sm:w-14 sm:h-14 rounded bg-[var(--bg-card)] flex items-center justify-center text-xs text-[var(--text-muted)]">
+                    ?
+                  </div>
+                )}
+                <span className="text-[10px] sm:text-[11px] text-[var(--text-secondary)] text-center leading-tight line-clamp-2 min-h-[1.5rem]">
+                  {ent.name}
+                </span>
+                {ent.score != null && (
+                  <span className="text-[9px] font-mono tabular-nums text-[var(--text-muted)]">
+                    {ent.score}
+                  </span>
+                )}
+              </Link>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/app/potions/PotionsClient.tsx
+++ b/frontend/app/potions/PotionsClient.tsx
@@ -10,7 +10,6 @@ import RichDescription from "../components/RichDescription";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { useEntityScores } from "@/lib/use-entity-scores";
-import ScoreBadge from "@/app/components/ScoreBadge";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -161,11 +160,10 @@ export default function PotionsClient({ initialPotions }: { initialPotions: Poti
                     />
                   )}
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-start justify-between gap-2 mb-2">
+                    <div className="flex items-start justify-between mb-2">
                       <h3 className="font-semibold text-[var(--text-primary)] leading-tight">
                         {potion.name}
                       </h3>
-                      <ScoreBadge score={scores[potion.id.toUpperCase()]?.score} size="sm" />
                     </div>
                     <span
                       className={`text-xs ${style.split(" ").slice(1).join(" ")} mb-3 inline-block`}

--- a/frontend/app/relics/RelicsClient.tsx
+++ b/frontend/app/relics/RelicsClient.tsx
@@ -10,7 +10,6 @@ import RichDescription from "../components/RichDescription";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { useEntityScores } from "@/lib/use-entity-scores";
-import ScoreBadge from "@/app/components/ScoreBadge";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -163,11 +162,10 @@ export default function RelicsClient({ initialRelics }: { initialRelics: Relic[]
                   />
                 )}
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-start justify-between gap-2 mb-2">
+                  <div className="flex items-start justify-between mb-2">
                     <h3 className="font-semibold text-[var(--text-primary)] leading-tight">
                       {relic.name}
                     </h3>
-                    <ScoreBadge score={scores[relic.id.toUpperCase()]?.score} size="sm" />
                   </div>
                   <div className="flex items-center gap-2 mb-3 text-xs">
                     <span className={style.split(" ").slice(1).join(" ")}>

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -28,6 +28,14 @@ const STATIC_PAGES = [
   { path: "/leaderboards", priority: 0.7, changeFrequency: "daily" as const },
   { path: "/leaderboards/submit", priority: 0.6, changeFrequency: "monthly" as const },
   { path: "/leaderboards/stats", priority: 0.8, changeFrequency: "daily" as const },
+  { path: "/leaderboards/scoring", priority: 0.6, changeFrequency: "monthly" as const },
+  // Tier list — high priority, daily changefreq because scores update
+  // every 30 minutes as new runs arrive. Per-character variants are
+  // crawled via the in-DOM filter <Link>s on /tier-list/cards.
+  { path: "/tier-list", priority: 0.9, changeFrequency: "daily" as const },
+  { path: "/tier-list/cards", priority: 0.9, changeFrequency: "daily" as const },
+  { path: "/tier-list/relics", priority: 0.9, changeFrequency: "daily" as const },
+  { path: "/tier-list/potions", priority: 0.8, changeFrequency: "daily" as const },
   { path: "/compare", priority: 0.6, changeFrequency: "weekly" as const },
   { path: "/showcase", priority: 0.5, changeFrequency: "monthly" as const },
   { path: "/developers", priority: 0.5, changeFrequency: "monthly" as const },

--- a/frontend/app/tier-list/cards/page.tsx
+++ b/frontend/app/tier-list/cards/page.tsx
@@ -1,0 +1,147 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE_URL, SITE_NAME } from "@/lib/seo";
+import JsonLd from "@/app/components/JsonLd";
+import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import TierList, { type TierEntity } from "@/app/components/TierList";
+
+const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export const dynamic = "force-dynamic"; // scores update every 30 minutes
+
+interface ApiCard {
+  id: string;
+  name: string;
+  image_url: string | null;
+  color: string;
+}
+
+interface ScoresMap {
+  [id: string]: { score: number | null; picks: number; wins: number; win_rate: number };
+}
+
+const COLOR_FILTERS = [
+  { value: "",            label: "All cards" },
+  { value: "ironclad",    label: "Ironclad" },
+  { value: "silent",      label: "Silent" },
+  { value: "defect",      label: "Defect" },
+  { value: "necrobinder", label: "Necrobinder" },
+  { value: "regent",      label: "Regent" },
+  { value: "colorless",   label: "Colorless" },
+];
+
+interface PageProps {
+  searchParams: Promise<{ color?: string }>;
+}
+
+export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
+  const sp = await searchParams;
+  const color = sp.color?.toLowerCase();
+  const charLabel = COLOR_FILTERS.find((c) => c.value === color)?.label;
+  const scope = charLabel && color ? `${charLabel} Cards` : "Cards";
+  const title = `Slay the Spire 2 ${scope} Tier List - Ranked S to F | ${SITE_NAME}`;
+  const description = color
+    ? `${charLabel} card tier list for Slay the Spire 2. Every ${charLabel?.toLowerCase()} card ranked S through F based on community win-rate data.`
+    : "Every Slay the Spire 2 card ranked S through F. Tier list driven by Codex Score — community-submitted run win rates with Bayesian shrinkage.";
+  const path = `/tier-list/cards${color ? `?color=${color}` : ""}`;
+  return {
+    title,
+    description,
+    alternates: { canonical: `${SITE_URL}${path}` },
+    openGraph: {
+      title,
+      description,
+      url: `${SITE_URL}${path}`,
+      siteName: SITE_NAME,
+      type: "website",
+    },
+  };
+}
+
+async function fetchData(color?: string): Promise<{ cards: ApiCard[]; scores: ScoresMap }> {
+  // Two parallel fetches: the entity list (filtered by color server-side
+  // to keep payloads small) + the bulk-scores map. Failures degrade
+  // gracefully to empty so the page still renders the "no data" state
+  // instead of a 500 (e.g. during cold-start cache miss).
+  const cardsUrl = `${API_INTERNAL}/api/cards${color ? `?color=${color}` : ""}`;
+  const scoresUrl = `${API_INTERNAL}/api/runs/scores/cards`;
+  try {
+    const [cardsRes, scoresRes] = await Promise.all([
+      fetch(cardsUrl, { next: { revalidate: 1800 } }),
+      fetch(scoresUrl, { next: { revalidate: 300 } }),
+    ]);
+    const cards = cardsRes.ok ? ((await cardsRes.json()) as ApiCard[]) : [];
+    const scores = scoresRes.ok ? ((await scoresRes.json()) as ScoresMap) : {};
+    return { cards, scores };
+  } catch {
+    return { cards: [], scores: {} };
+  }
+}
+
+export default async function CardsTierListPage({ searchParams }: PageProps) {
+  const sp = await searchParams;
+  const color = sp.color?.toLowerCase();
+  const { cards, scores } = await fetchData(color);
+
+  const entities: TierEntity[] = cards.map((c) => ({
+    id: c.id,
+    name: c.name,
+    image_url: c.image_url,
+    score: scores[c.id.toUpperCase()]?.score ?? null,
+  }));
+
+  const charLabel = COLOR_FILTERS.find((c) => c.value === color)?.label;
+  const heading = charLabel && color ? `${charLabel} Card Tier List` : "Card Tier List";
+
+  const jsonLd = [
+    buildBreadcrumbJsonLd([
+      { name: "Home", href: "/" },
+      { name: "Tier List", href: "/tier-list" },
+      { name: heading, href: `/tier-list/cards${color ? `?color=${color}` : ""}` },
+    ]),
+  ];
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <JsonLd data={jsonLd} />
+
+      <div className="flex items-baseline gap-3 mb-2 flex-wrap">
+        <h1 className="text-3xl font-bold">
+          <span className="text-[var(--accent-gold)]">{heading}</span>
+        </h1>
+        <span className="text-sm text-[var(--text-muted)]">{entities.length.toLocaleString()} cards</span>
+      </div>
+      <p className="text-sm text-[var(--text-muted)] mb-6">
+        Ranked by <Link href="/leaderboards/scoring" className="text-[var(--accent-gold)] hover:underline">Codex Score</Link> —
+        community-submitted run win rates, Bayesian-shrunk so low-pick cards stay near neutral.
+        Click any card for full stats.
+      </p>
+
+      {/* Character filter — anchor links so each filtered view is its
+          own indexable URL (good for "ironclad tier list" SEO). */}
+      <div className="flex flex-wrap gap-1.5 mb-6">
+        {COLOR_FILTERS.map((opt) => {
+          const isActive = (color ?? "") === opt.value;
+          const href = opt.value
+            ? `/tier-list/cards?color=${opt.value}`
+            : "/tier-list/cards";
+          return (
+            <Link
+              key={opt.value || "all"}
+              href={href}
+              className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
+                isActive
+                  ? "bg-[var(--accent-gold)]/10 border-[var(--accent-gold)]/40 text-[var(--accent-gold)]"
+                  : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
+              }`}
+            >
+              {opt.label}
+            </Link>
+          );
+        })}
+      </div>
+
+      <TierList route="cards" entities={entities} />
+    </div>
+  );
+}

--- a/frontend/app/tier-list/page.tsx
+++ b/frontend/app/tier-list/page.tsx
@@ -1,0 +1,102 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE_URL, SITE_NAME } from "@/lib/seo";
+import JsonLd from "@/app/components/JsonLd";
+import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
+
+export const metadata: Metadata = {
+  title: `Slay the Spire 2 Tier List - Cards, Relics, Potions Ranked | ${SITE_NAME}`,
+  description:
+    "Slay the Spire 2 tier list ranking every card, relic, and potion S through F. Codex Score derived from community-submitted run win rates with Bayesian shrinkage. Updated every 30 minutes.",
+  alternates: { canonical: `${SITE_URL}/tier-list` },
+  openGraph: {
+    title: `Slay the Spire 2 Tier List | ${SITE_NAME}`,
+    description: "Every card, relic, and potion ranked S through F based on community win-rate data.",
+    url: `${SITE_URL}/tier-list`,
+    siteName: SITE_NAME,
+    type: "website",
+  },
+};
+
+const SECTIONS = [
+  {
+    href: "/tier-list/cards",
+    label: "Card Tier List",
+    description: "All 576 cards ranked S → F. Filter by character (Ironclad, Silent, Defect, Necrobinder, Regent).",
+    accent: "from-amber-500/20 to-amber-700/10 border-amber-700/40",
+  },
+  {
+    href: "/tier-list/relics",
+    label: "Relic Tier List",
+    description: "289 relics ranked across every pool. Filter by Shared, Boss, Shop, Event, or character.",
+    accent: "from-emerald-500/20 to-emerald-700/10 border-emerald-700/40",
+  },
+  {
+    href: "/tier-list/potions",
+    label: "Potion Tier List",
+    description: "All 63 potions ranked. Smaller pool, easier to memorize the top picks.",
+    accent: "from-sky-500/20 to-sky-700/10 border-sky-700/40",
+  },
+];
+
+export default function TierListIndex() {
+  const jsonLd = [
+    buildBreadcrumbJsonLd([
+      { name: "Home", href: "/" },
+      { name: "Tier List", href: "/tier-list" },
+    ]),
+  ];
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <JsonLd data={jsonLd} />
+
+      <h1 className="text-3xl font-bold mb-2">
+        <span className="text-[var(--accent-gold)]">Tier List</span>
+      </h1>
+      <p className="text-sm text-[var(--text-muted)] mb-8 max-w-2xl">
+        Every card, relic, and potion in <em>Slay the Spire 2</em> ranked S through F.
+        Tiers are derived from the <Link href="/leaderboards/scoring" className="text-[var(--accent-gold)] hover:underline">Codex Score</Link>
+        {" "}— a Bayesian-shrunk win-rate metric computed from community-submitted runs. Updated every 30 minutes.
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10">
+        {SECTIONS.map((s) => (
+          <Link
+            key={s.href}
+            href={s.href}
+            className={`block p-5 rounded-lg border bg-gradient-to-br ${s.accent} hover:scale-[1.02] transition-transform`}
+          >
+            <h2 className="text-lg font-bold text-[var(--text-primary)] mb-2">{s.label}</h2>
+            <p className="text-xs text-[var(--text-secondary)] leading-relaxed">{s.description}</p>
+          </Link>
+        ))}
+      </div>
+
+      <section className="p-5 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)]">
+        <h2 className="text-base font-semibold text-[var(--text-primary)] mb-2">
+          How the rankings work
+        </h2>
+        <p className="text-sm text-[var(--text-secondary)] leading-relaxed mb-3">
+          Each entity is given a 0–100 Codex Score based on the win rate of runs that included it,
+          shrunk toward the global baseline so a 5-pick perfect-record card doesn&apos;t outrank a
+          500-pick reliable one. Scores map to letter grades:
+        </p>
+        <div className="text-xs text-[var(--text-muted)] space-y-1">
+          <div><strong className="text-amber-300">S (90+)</strong> · genuinely elite</div>
+          <div><strong className="text-emerald-300">A (78–89)</strong> · reliable engine pieces</div>
+          <div><strong className="text-sky-300">B (65–77)</strong> · above-average</div>
+          <div><strong className="text-zinc-300">C (50–64)</strong> · average</div>
+          <div><strong className="text-orange-300">D (35–49)</strong> · niche or filler</div>
+          <div><strong className="text-rose-300">F (0–34)</strong> · actively pulls toward losses</div>
+        </div>
+        <Link
+          href="/leaderboards/scoring"
+          className="inline-block mt-4 text-sm font-medium text-[var(--accent-gold)] hover:underline"
+        >
+          → Full methodology
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/tier-list/potions/page.tsx
+++ b/frontend/app/tier-list/potions/page.tsx
@@ -1,0 +1,87 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE_URL, SITE_NAME } from "@/lib/seo";
+import JsonLd from "@/app/components/JsonLd";
+import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import TierList, { type TierEntity } from "@/app/components/TierList";
+
+const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export const dynamic = "force-dynamic";
+
+interface ApiPotion {
+  id: string;
+  name: string;
+  image_url: string | null;
+  pool?: string | null;
+}
+
+interface ScoresMap {
+  [id: string]: { score: number | null };
+}
+
+export const metadata: Metadata = {
+  title: `Slay the Spire 2 Potion Tier List - All 63 Potions Ranked | ${SITE_NAME}`,
+  description:
+    "Every Slay the Spire 2 potion ranked S through F by community win rate. Codex Score with Bayesian shrinkage. Updated every 30 minutes.",
+  alternates: { canonical: `${SITE_URL}/tier-list/potions` },
+  openGraph: {
+    title: `Slay the Spire 2 Potion Tier List | ${SITE_NAME}`,
+    description: "Every potion ranked S through F by community win-rate data.",
+    url: `${SITE_URL}/tier-list/potions`,
+    siteName: SITE_NAME,
+    type: "website",
+  },
+};
+
+async function fetchData(): Promise<{ potions: ApiPotion[]; scores: ScoresMap }> {
+  try {
+    const [potionsRes, scoresRes] = await Promise.all([
+      fetch(`${API_INTERNAL}/api/potions`, { next: { revalidate: 1800 } }),
+      fetch(`${API_INTERNAL}/api/runs/scores/potions`, { next: { revalidate: 300 } }),
+    ]);
+    const potions = potionsRes.ok ? ((await potionsRes.json()) as ApiPotion[]) : [];
+    const scores = scoresRes.ok ? ((await scoresRes.json()) as ScoresMap) : {};
+    return { potions, scores };
+  } catch {
+    return { potions: [], scores: {} };
+  }
+}
+
+export default async function PotionsTierListPage() {
+  const { potions, scores } = await fetchData();
+
+  const entities: TierEntity[] = potions.map((p) => ({
+    id: p.id,
+    name: p.name,
+    image_url: p.image_url,
+    score: scores[p.id.toUpperCase()]?.score ?? null,
+  }));
+
+  const jsonLd = [
+    buildBreadcrumbJsonLd([
+      { name: "Home", href: "/" },
+      { name: "Tier List", href: "/tier-list" },
+      { name: "Potion Tier List", href: "/tier-list/potions" },
+    ]),
+  ];
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <JsonLd data={jsonLd} />
+
+      <div className="flex items-baseline gap-3 mb-2 flex-wrap">
+        <h1 className="text-3xl font-bold">
+          <span className="text-[var(--accent-gold)]">Potion Tier List</span>
+        </h1>
+        <span className="text-sm text-[var(--text-muted)]">{entities.length.toLocaleString()} potions</span>
+      </div>
+      <p className="text-sm text-[var(--text-muted)] mb-6">
+        Ranked by <Link href="/leaderboards/scoring" className="text-[var(--accent-gold)] hover:underline">Codex Score</Link> —
+        community win-rate data with Bayesian shrinkage. Click any potion for full stats.
+      </p>
+
+      <TierList route="potions" entities={entities} />
+    </div>
+  );
+}

--- a/frontend/app/tier-list/relics/page.tsx
+++ b/frontend/app/tier-list/relics/page.tsx
@@ -1,0 +1,133 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE_URL, SITE_NAME } from "@/lib/seo";
+import JsonLd from "@/app/components/JsonLd";
+import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import TierList, { type TierEntity } from "@/app/components/TierList";
+
+const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export const dynamic = "force-dynamic";
+
+interface ApiRelic {
+  id: string;
+  name: string;
+  image_url: string | null;
+  pool: string;
+}
+
+interface ScoresMap {
+  [id: string]: { score: number | null };
+}
+
+const POOL_FILTERS = [
+  { value: "",            label: "All relics" },
+  { value: "shared",      label: "Shared" },
+  { value: "ironclad",    label: "Ironclad" },
+  { value: "silent",      label: "Silent" },
+  { value: "defect",      label: "Defect" },
+  { value: "necrobinder", label: "Necrobinder" },
+  { value: "regent",      label: "Regent" },
+];
+
+interface PageProps {
+  searchParams: Promise<{ pool?: string }>;
+}
+
+export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
+  const sp = await searchParams;
+  const pool = sp.pool?.toLowerCase();
+  const poolLabel = POOL_FILTERS.find((p) => p.value === pool)?.label;
+  const scope = poolLabel && pool ? `${poolLabel} Relic` : "Relic";
+  const title = `Slay the Spire 2 ${scope} Tier List - Ranked S to F | ${SITE_NAME}`;
+  const description = pool
+    ? `${poolLabel} relic tier list for Slay the Spire 2. Every relic in the ${pool} pool ranked S through F by community win rate.`
+    : "Every Slay the Spire 2 relic ranked S through F. Codex Score from community-submitted run win rates with Bayesian shrinkage.";
+  const path = `/tier-list/relics${pool ? `?pool=${pool}` : ""}`;
+  return {
+    title,
+    description,
+    alternates: { canonical: `${SITE_URL}${path}` },
+    openGraph: { title, description, url: `${SITE_URL}${path}`, siteName: SITE_NAME, type: "website" },
+  };
+}
+
+async function fetchData(pool?: string): Promise<{ relics: ApiRelic[]; scores: ScoresMap }> {
+  const relicsUrl = `${API_INTERNAL}/api/relics${pool ? `?pool=${pool}` : ""}`;
+  const scoresUrl = `${API_INTERNAL}/api/runs/scores/relics`;
+  try {
+    const [relicsRes, scoresRes] = await Promise.all([
+      fetch(relicsUrl, { next: { revalidate: 1800 } }),
+      fetch(scoresUrl, { next: { revalidate: 300 } }),
+    ]);
+    const relics = relicsRes.ok ? ((await relicsRes.json()) as ApiRelic[]) : [];
+    const scores = scoresRes.ok ? ((await scoresRes.json()) as ScoresMap) : {};
+    return { relics, scores };
+  } catch {
+    return { relics: [], scores: {} };
+  }
+}
+
+export default async function RelicsTierListPage({ searchParams }: PageProps) {
+  const sp = await searchParams;
+  const pool = sp.pool?.toLowerCase();
+  const { relics, scores } = await fetchData(pool);
+
+  const entities: TierEntity[] = relics.map((r) => ({
+    id: r.id,
+    name: r.name,
+    image_url: r.image_url,
+    score: scores[r.id.toUpperCase()]?.score ?? null,
+  }));
+
+  const poolLabel = POOL_FILTERS.find((p) => p.value === pool)?.label;
+  const heading = poolLabel && pool ? `${poolLabel} Relic Tier List` : "Relic Tier List";
+
+  const jsonLd = [
+    buildBreadcrumbJsonLd([
+      { name: "Home", href: "/" },
+      { name: "Tier List", href: "/tier-list" },
+      { name: heading, href: `/tier-list/relics${pool ? `?pool=${pool}` : ""}` },
+    ]),
+  ];
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <JsonLd data={jsonLd} />
+
+      <div className="flex items-baseline gap-3 mb-2 flex-wrap">
+        <h1 className="text-3xl font-bold">
+          <span className="text-[var(--accent-gold)]">{heading}</span>
+        </h1>
+        <span className="text-sm text-[var(--text-muted)]">{entities.length.toLocaleString()} relics</span>
+      </div>
+      <p className="text-sm text-[var(--text-muted)] mb-6">
+        Ranked by <Link href="/leaderboards/scoring" className="text-[var(--accent-gold)] hover:underline">Codex Score</Link> —
+        community win-rate data with Bayesian shrinkage so a 5-pick relic doesn&apos;t outrank a
+        500-pick one. Click any relic for full stats.
+      </p>
+
+      <div className="flex flex-wrap gap-1.5 mb-6">
+        {POOL_FILTERS.map((opt) => {
+          const isActive = (pool ?? "") === opt.value;
+          const href = opt.value ? `/tier-list/relics?pool=${opt.value}` : "/tier-list/relics";
+          return (
+            <Link
+              key={opt.value || "all"}
+              href={href}
+              className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
+                isActive
+                  ? "bg-[var(--accent-gold)]/10 border-[var(--accent-gold)]/40 text-[var(--accent-gold)]"
+                  : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
+              }`}
+            >
+              {opt.label}
+            </Link>
+          );
+        })}
+      </div>
+
+      <TierList route="relics" entities={entities} />
+    </div>
+  );
+}


### PR DESCRIPTION
## What
The actual visual tier list. Classic S→F rows of entity tiles, sortable by character/pool, server-rendered for SEO.

**Stacks on top of #225** (which stacks on #224). Merge in order: 224 → 225 → 226.

## Pages
| URL | What |
|---|---|
| `/tier-list` | Landing index — pretty cards for cards/relics/potions tiers + scoring explainer |
| `/tier-list/cards` | All 576 cards. Filter: `?color=ironclad|silent|defect|necrobinder|regent|colorless` |
| `/tier-list/relics` | All 289 relics. Filter: `?pool=shared|ironclad|silent|defect|necrobinder|regent` |
| `/tier-list/potions` | All 63 potions. No filter (small enough). |

## Layout
Tier letter rail on the left (color-coded badge matching ScoreBadge tiers), tile grid on the right. Each tile = entity image + name + numeric score. Click tile → detail page. Scoreless entities go to a final `Unrated` row so they're still discoverable but don't pollute tier ranking.

## SEO play
**Filters are URL anchor links, not client state.** Each filter view is its own indexable URL with its own `generateMetadata` title + canonical:
- "Slay the Spire 2 Card Tier List - Ranked S to F"
- "Slay the Spire 2 Ironclad Cards Tier List - Ranked S to F"
- "Slay the Spire 2 Defect Relic Tier List"
- etc.

That's ~14 indexable tier-list URLs out of the box, all targeting different long-tail searches.

Sitemap: added all 4 root paths at priority 0.8–0.9 with daily changeFrequency (scores rebuild every 30 min).

## Nav
`Tier List` becomes the **first entry** in the Stats menu (most user-facing, highest expected CTR). Hidden on beta.

## Reused infra
- Codex Score backend / `/api/runs/scores/<type>` endpoint (PR #224)
- Score-tier color bands match ScoreBadge / scoreToTier exactly so the three stay in sync
- Bayesian shrinkage means low-pick entities sit near neutral instead of saturating S/F (already proven in #224 sanity tests)

## What's next (not in this PR)
- Per-character/pool subroute pages (`/tier-list/cards/ironclad` instead of `?color=ironclad`) — would be cleaner URLs but adds 14 routes; can roll later
- Tier list embeds (Discord-shareable images) — separate workstream
- Per-ascension tier lists once high-A samples are statistically meaningful