### PR TITLE
Mobile fixes: leaderboard char chips + submit page

### DIFF
--- a/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
+++ b/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
@@ -221,11 +221,18 @@ export default function LeaderboardBrowseClient() {
       {/* Leaderboard tabs content */}
       {isLeaderboard && (
         <>
-          {/* Character filter toggle buttons */}
+          {/* Character filter toggle buttons.
+              Mobile (<sm): icon-only square chips so 5 characters + "All"
+              fit one row even on a 360px viewport. The localized name
+              ("Sentinelle de fer" etc.) was the worst offender — French/
+              German/Polish characters spilled the row to two lines on
+              every phone breakpoint. Tooltip + aria-label preserve the
+              name semantics for screen readers. sm+ shows name as before. */}
           <div className="flex flex-wrap gap-2 mb-4">
             <button
               onClick={() => setLbChar("")}
-              className={`text-sm px-3 py-1.5 rounded-lg border transition-colors ${
+              aria-label={t("All", lang)}
+              className={`text-sm h-9 sm:h-auto sm:px-3 sm:py-1.5 px-3 rounded-lg border transition-colors ${
                 lbChar === ""
                   ? "bg-[var(--accent-gold)] text-[var(--bg-primary)] border-[var(--accent-gold)]"
                   : "bg-[var(--bg-primary)] border-[var(--border-subtle)] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
@@ -237,7 +244,9 @@ export default function LeaderboardBrowseClient() {
               <button
                 key={ch}
                 onClick={() => setLbChar(ch.toUpperCase())}
-                className={`text-sm px-3 py-1.5 rounded-lg border transition-colors ${
+                title={charName(ch)}
+                aria-label={charName(ch)}
+                className={`flex items-center justify-center gap-1.5 h-9 sm:h-auto px-2 sm:px-3 sm:py-1.5 rounded-lg border transition-colors ${
                   lbChar === ch.toUpperCase()
                     ? "border-transparent text-[var(--bg-primary)]"
                     : "bg-[var(--bg-primary)] border-[var(--border-subtle)] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
@@ -248,7 +257,15 @@ export default function LeaderboardBrowseClient() {
                     : undefined
                 }
               >
-                {charName(ch)}
+                <img
+                  src={`${API}/static/images/characters/char_select_${ch.toLowerCase()}.webp`}
+                  alt=""
+                  aria-hidden
+                  className="w-6 h-6 object-contain flex-shrink-0"
+                  loading="lazy"
+                  crossOrigin="anonymous"
+                />
+                <span className="hidden sm:inline text-sm">{charName(ch)}</span>
               </button>
             ))}
           </div>

--- a/frontend/app/leaderboards/submit/SubmitRunClient.tsx
+++ b/frontend/app/leaderboards/submit/SubmitRunClient.tsx
@@ -314,57 +314,83 @@ export default function SubmitRunClient() {
       </p>
 
       <div className="space-y-4">
-        {/* Username */}
+        {/* Username — full width on mobile, fixed-width on sm+ where the
+            sparse layout looked goofy with a 100% input. */}
         <input
           type="text"
           value={username}
           onChange={(e) => setUsername(e.target.value.slice(0, 25))}
           placeholder={t("Username (optional)", lang)}
           maxLength={25}
-          className="px-3 py-2 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm focus:outline-none focus:border-[var(--accent-gold)] w-48"
+          className="px-3 py-2 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm focus:outline-none focus:border-[var(--accent-gold)] w-full sm:w-48"
         />
 
-        {/* File Upload with drag-and-drop */}
+        {/* File Upload with drag-and-drop. Mobile gets shorter padding
+            (p-4 instead of p-6) and the path-help is collapsed into a
+            <details> so the long save-game paths don't blow up the
+            viewport. Mobile also gets a touch-friendly button copy
+            since drag-and-drop is desktop-only. */}
         <div
           onDragEnter={handleDragEnter}
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
-          className={`bg-[var(--bg-card)] rounded-xl p-6 text-center transition-colors ${
+          className={`bg-[var(--bg-card)] rounded-xl p-4 sm:p-6 text-center transition-colors ${
             isDragging
               ? "border-2 border-solid border-[var(--accent-gold)] bg-[var(--accent-gold)]/5"
               : "border border-dashed border-[var(--border-accent)]"
           }`}
         >
-          <p className="text-sm text-[var(--text-secondary)] mb-1">
+          <p className="text-sm text-[var(--text-secondary)] mb-3">
             {isDragging
               ? t("Drop files here...", lang)
-              : t("Drag & drop .run files here, or click to select", lang)}
+              : (
+                <>
+                  <span className="hidden sm:inline">{t("Drag & drop .run files here, or click to select", lang)}</span>
+                  <span className="sm:hidden">{t("Tap below to choose .run files", lang)}</span>
+                </>
+              )}
           </p>
-          <div className="text-left mb-3 space-y-1 text-xs text-[var(--text-muted)]">
-            <p>
-              <strong className="text-[var(--text-secondary)]">Windows:</strong>{" "}
-              <code className="bg-[var(--bg-primary)] px-1 rounded">
-                %AppData%/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history
-              </code>
-            </p>
-            <p>
-              <strong className="text-[var(--text-secondary)]">macOS:</strong>{" "}
-              <code className="bg-[var(--bg-primary)] px-1 rounded">
-                ~/Library/Application
-                Support/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history
-              </code>
-            </p>
-            <p>
-              <strong className="text-[var(--text-secondary)]">
-                Linux / Steam Deck:
-              </strong>{" "}
-              <code className="bg-[var(--bg-primary)] px-1 rounded">
-                ~/.local/share/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history
-              </code>
-            </p>
-          </div>
-          <label className="inline-block px-5 py-2 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-[var(--bg-primary)] hover:opacity-90 transition-opacity cursor-pointer">
+
+          <details className="text-left mb-3 text-xs text-[var(--text-muted)] group">
+            <summary className="cursor-pointer text-[var(--text-secondary)] hover:text-[var(--text-primary)] inline-flex items-center gap-1 select-none">
+              <svg
+                aria-hidden
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="w-3.5 h-3.5 transition-transform -rotate-90 group-open:rotate-0"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              {t("Where are my run files?", lang)}
+            </summary>
+            <div className="mt-2 space-y-1.5">
+              <div>
+                <strong className="text-[var(--text-secondary)] block sm:inline">Windows</strong>
+                <code className="block sm:inline sm:ml-1 mt-0.5 sm:mt-0 bg-[var(--bg-primary)] px-1.5 py-0.5 rounded break-all">
+                  %AppData%/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history
+                </code>
+              </div>
+              <div>
+                <strong className="text-[var(--text-secondary)] block sm:inline">macOS</strong>
+                <code className="block sm:inline sm:ml-1 mt-0.5 sm:mt-0 bg-[var(--bg-primary)] px-1.5 py-0.5 rounded break-all">
+                  ~/Library/Application Support/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history
+                </code>
+              </div>
+              <div>
+                <strong className="text-[var(--text-secondary)] block sm:inline">Linux / Steam Deck</strong>
+                <code className="block sm:inline sm:ml-1 mt-0.5 sm:mt-0 bg-[var(--bg-primary)] px-1.5 py-0.5 rounded break-all">
+                  ~/.local/share/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history
+                </code>
+              </div>
+            </div>
+          </details>
+
+          <label className="inline-block w-full sm:w-auto px-5 py-2.5 sm:py-2 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-[var(--bg-primary)] hover:opacity-90 transition-opacity cursor-pointer">
             {t("Choose Files", lang)}
             <input
               ref={fileInputRef}
@@ -430,7 +456,7 @@ export default function SubmitRunClient() {
           <button
             onClick={parseRun}
             disabled={!jsonInput.trim()}
-            className="mt-2 px-5 py-2 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-[var(--bg-primary)] hover:opacity-90 transition-opacity disabled:opacity-50"
+            className="mt-2 w-full sm:w-auto px-5 py-2.5 sm:py-2 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-[var(--bg-primary)] hover:opacity-90 transition-opacity disabled:opacity-50"
           >
             {t("Analyze Run", lang)}
           </button>


### PR DESCRIPTION
Two unrelated mobile fixes shipped together — both immediately visible to anyone on a phone, both independent of the score/tier-list stack.

## 1. Leaderboard character pills (Fastest / Highest Ascension)
**Problem:** localized character names overflowed to two rows on every phone width — "Sentinelle de fer" / "Necrobinder" / "Регент" were the worst offenders.

**Fix:** mobile (<sm) shows an icon-only square chip with the in-game char_select portrait. `title` + `aria-label` preserve the localized name for screen readers. sm+ keeps the icon + name layout.

## 2. Submit a Run page
Multiple mobile usability problems addressed:
- **Username input** was fixed `w-48` → now `w-full sm:w-48`
- **File-path help** (Windows / macOS / Linux save dirs) was inline `<p>`s that overflowed horizontally on every phone. Now in a collapsible `<details>` ("Where are my run files?") with `break-all` on the code blocks.
- **Drop-zone copy** said *"Drag & drop .run files here"* on touch devices. Mobile now reads *"Tap below to choose .run files"*.
- **Choose Files / Analyze Run buttons** are full-width with bigger tap targets (`py-2.5`) on mobile.
- **Drop-zone padding** tightened `p-6` → `p-4` on mobile so content shows above the fold.