### PR TITLE
Hotfix: /tier-list image URLs pointing at localhost

### DIFF
--- a/frontend/app/components/TierList.tsx
+++ b/frontend/app/components/TierList.tsx
@@ -1,6 +1,12 @@
 import Link from "next/link";
 
-const API_PUBLIC = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+// Use ?? not || — production sets NEXT_PUBLIC_API_URL="" intentionally
+// so URLs resolve same-origin (nginx proxies /static to the backend
+// container). With ||, the empty string is falsy and the fallback
+// triggers, baking "http://localhost:8000" into every <img src> the
+// server renders. ?? only triggers on null/undefined, so the empty
+// string passes through and image URLs become relative ("/static/…").
+const API_PUBLIC = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 export interface TierEntity {
   id: string;


### PR DESCRIPTION
Production sets `NEXT_PUBLIC_API_URL=""` (empty) so static URLs resolve same-origin (nginx proxies /static to the backend container).

`TierList.tsx` used `||` for the fallback. Empty string is falsy → fallback fired → every `<img src>` got baked as `http://localhost:8000/static/images/cards/<x>.webp` and broke for every visitor.

Fix: `||` → `??` so empty string passes through. Matches the pattern every other detail-page renderer uses (cards/relics/potions/encounters/events all use `|| ""` as final fallback).

Audited the rest of the app — TierList was the only renderer with this bug.