### PR TITLE
Tier List SEO pack: STS2 keyword + ItemList + FAQ + top-tier preview

### DIFF
--- a/frontend/app/tier-list/cards/page.tsx
+++ b/frontend/app/tier-list/cards/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { SITE_URL, SITE_NAME } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
-import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 import TierList, { type TierEntity } from "@/app/components/TierList";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -39,10 +39,12 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
   const color = sp.color?.toLowerCase();
   const charLabel = COLOR_FILTERS.find((c) => c.value === color)?.label;
   const scope = charLabel && color ? `${charLabel} Cards` : "Cards";
-  const title = `Slay the Spire 2 ${scope} Tier List - Ranked S to F | ${SITE_NAME}`;
+  // Title leads with STS2 abbreviation + full game name to capture both
+  // query phrasings ("sts2 tier list" vs "slay the spire 2 tier list").
+  const title = `STS2 ${scope} Tier List - Slay the Spire 2 Cards Ranked | ${SITE_NAME}`;
   const description = color
-    ? `${charLabel} card tier list for Slay the Spire 2. Every ${charLabel?.toLowerCase()} card ranked S through F based on community win-rate data.`
-    : "Every Slay the Spire 2 card ranked S through F. Tier list driven by Codex Score — community-submitted run win rates with Bayesian shrinkage.";
+    ? `${charLabel} card tier list for Slay the Spire 2 (STS2). Every ${charLabel?.toLowerCase()} card ranked S through F based on community win-rate data.`
+    : "Every Slay the Spire 2 (STS2) card ranked S through F. Tier list driven by Codex Score — community-submitted run win rates with Bayesian shrinkage.";
   const path = `/tier-list/cards${color ? `?color=${color}` : ""}`;
   return {
     title,
@@ -92,13 +94,32 @@ export default async function CardsTierListPage({ searchParams }: PageProps) {
 
   const charLabel = COLOR_FILTERS.find((c) => c.value === color)?.label;
   const heading = charLabel && color ? `${charLabel} Card Tier List` : "Card Tier List";
+  const path = `/tier-list/cards${color ? `?color=${color}` : ""}`;
+
+  // Top-30 by score for the ItemList JSON-LD — gives Google a structured
+  // ranked list it can render as carousel-style rich results. Capped at
+  // 30 because longer ItemLists inflate the JSON without much SEO gain.
+  const rankedItems = [...entities]
+    .filter((e) => e.score != null)
+    .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+    .slice(0, 30)
+    .map((e) => ({
+      name: e.name,
+      path: `/cards/${e.id.toLowerCase()}`,
+    }));
 
   const jsonLd = [
     buildBreadcrumbJsonLd([
       { name: "Home", href: "/" },
       { name: "Tier List", href: "/tier-list" },
-      { name: heading, href: `/tier-list/cards${color ? `?color=${color}` : ""}` },
+      { name: heading, href: path },
     ]),
+    buildCollectionPageJsonLd({
+      name: heading,
+      description: `Slay the Spire 2 (STS2) ${heading.toLowerCase()} ranked by Codex Score from community-submitted run win rates.`,
+      path,
+      items: rankedItems,
+    }),
   ];
 
   return (

--- a/frontend/app/tier-list/page.tsx
+++ b/frontend/app/tier-list/page.tsx
@@ -2,16 +2,26 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { SITE_URL, SITE_NAME } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
-import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import { buildBreadcrumbJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
+import ScoreBadge from "@/app/components/ScoreBadge";
+
+const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_PUBLIC = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: `Slay the Spire 2 Tier List - Cards, Relics, Potions Ranked | ${SITE_NAME}`,
+  // Title leads with both abbreviated ("STS2") and full game name to
+  // match either query phrasing — the actual SERPs we're targeting use
+  // both. Order chosen so the abbreviation lands inside the truncation
+  // window on mobile (Google trims at ~60 chars on phones).
+  title: `STS2 Tier List - Slay the Spire 2 Cards, Relics & Potions Ranked | ${SITE_NAME}`,
   description:
-    "Slay the Spire 2 tier list ranking every card, relic, and potion S through F. Codex Score derived from community-submitted run win rates with Bayesian shrinkage. Updated every 30 minutes.",
+    "STS2 / Slay the Spire 2 tier list ranking every card, relic, and potion S through F. Codex Score from community win rates. Updated daily after every patch.",
   alternates: { canonical: `${SITE_URL}/tier-list` },
   openGraph: {
-    title: `Slay the Spire 2 Tier List | ${SITE_NAME}`,
-    description: "Every card, relic, and potion ranked S through F based on community win-rate data.",
+    title: `STS2 Tier List | ${SITE_NAME}`,
+    description: "Every Slay the Spire 2 card, relic, and potion ranked S → F based on community win-rate data.",
     url: `${SITE_URL}/tier-list`,
     siteName: SITE_NAME,
     type: "website",
@@ -39,12 +49,126 @@ const SECTIONS = [
   },
 ];
 
-export default function TierListIndex() {
+interface TopEntity {
+  id: string;
+  name: string;
+  image_url: string | null;
+  score: number;
+}
+
+interface ScoresResponse {
+  [id: string]: { score: number | null; picks: number; wins: number; win_rate: number };
+}
+
+interface ApiEntity {
+  id: string;
+  name: string;
+  image_url: string | null;
+}
+
+// Pull the top-N scoring entities for one type by joining the bulk
+// scores endpoint against the entity list. Falls back to [] on any
+// fetch error so the page still renders gracefully.
+async function fetchTopEntities(
+  type: "cards" | "relics" | "potions",
+  count: number,
+): Promise<TopEntity[]> {
+  try {
+    const [entitiesRes, scoresRes] = await Promise.all([
+      fetch(`${API_INTERNAL}/api/${type}`, { next: { revalidate: 1800 } }),
+      fetch(`${API_INTERNAL}/api/runs/scores/${type}`, { next: { revalidate: 300 } }),
+    ]);
+    if (!entitiesRes.ok || !scoresRes.ok) return [];
+    const entities = (await entitiesRes.json()) as ApiEntity[];
+    const scores = (await scoresRes.json()) as ScoresResponse;
+    const enriched: TopEntity[] = [];
+    for (const e of entities) {
+      const s = scores[e.id.toUpperCase()]?.score;
+      if (s == null) continue;
+      enriched.push({ id: e.id, name: e.name, image_url: e.image_url, score: s });
+    }
+    enriched.sort((a, b) => b.score - a.score);
+    return enriched.slice(0, count);
+  } catch {
+    return [];
+  }
+}
+
+// Real Q&A targeting People-Also-Ask boxes for STS2 tier-list searches.
+// Answers are factual and short (Google strips long answers from rich
+// results). Updated values are computed at request time from the live
+// score data so they don't go stale.
+function buildFaqEntries(top: { cards: TopEntity[]; relics: TopEntity[]; potions: TopEntity[] }) {
+  const faqs: { question: string; answer: string }[] = [];
+
+  if (top.cards.length) {
+    faqs.push({
+      question: "What is the best card in Slay the Spire 2?",
+      answer: `Based on community win-rate data, ${top.cards[0].name} (Codex Score ${top.cards[0].score}) is currently the highest-rated card across all characters. Tier rankings update every 30 minutes as new runs are submitted.`,
+    });
+  }
+  if (top.relics.length) {
+    faqs.push({
+      question: "What is the best relic in Slay the Spire 2?",
+      answer: `${top.relics[0].name} sits at the top of the relic tier list with a Codex Score of ${top.relics[0].score}, derived from community-submitted run win rates with Bayesian shrinkage so low-pick outliers don't dominate the rankings.`,
+    });
+  }
+  if (top.potions.length) {
+    faqs.push({
+      question: "What is the best potion in Slay the Spire 2?",
+      answer: `${top.potions[0].name} (Codex Score ${top.potions[0].score}) is the top-rated potion based on the win rate of runs that included it.`,
+    });
+  }
+  faqs.push(
+    {
+      question: "How is the Slay the Spire 2 tier list calculated?",
+      answer: "Every card, relic, and potion gets a 0–100 Codex Score based on the win rate of submitted runs that included it, shrunk toward the global baseline using Bayesian methods so a 5-pick perfect record doesn't outrank a 500-pick reliable one. Scores then map to letter grades S through F.",
+    },
+    {
+      question: "How often is the tier list updated?",
+      answer: "Scores rebuild every 30 minutes as new community runs are submitted. The tier list reflects the current meta after the most recent game patch.",
+    },
+    {
+      question: "Is there a tier list per character?",
+      answer: "Yes — the cards tier list filters to Ironclad, Silent, Defect, Necrobinder, Regent, or Colorless. The relics tier list filters by pool. Each filtered view is its own page targeting that character or pool specifically.",
+    },
+  );
+  return faqs;
+}
+
+export default async function TierListIndex() {
+  // Server-render the top-5 of each type so the page has rich content
+  // above the fold (helps SEO crawlers understand the page is a
+  // ranked tier list, not just a navigation hub).
+  const [topCards, topRelics, topPotions] = await Promise.all([
+    fetchTopEntities("cards", 5),
+    fetchTopEntities("relics", 5),
+    fetchTopEntities("potions", 5),
+  ]);
+
+  // ISO 8601 date for the visible "updated" line. force-dynamic means
+  // this is fresh on every request — Google rewards visible-recent
+  // dates on tier-list-style pages.
+  const updatedDate = new Date().toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  const faqs = buildFaqEntries({ cards: topCards, relics: topRelics, potions: topPotions });
+
   const jsonLd = [
     buildBreadcrumbJsonLd([
       { name: "Home", href: "/" },
       { name: "Tier List", href: "/tier-list" },
     ]),
+    buildFAQPageJsonLd(faqs),
+  ];
+
+  const previewBlocks: { title: string; href: string; entities: TopEntity[]; route: string }[] = [
+    { title: "Top-tier Cards right now", href: "/tier-list/cards", route: "cards", entities: topCards },
+    { title: "Top-tier Relics right now", href: "/tier-list/relics", route: "relics", entities: topRelics },
+    { title: "Top-tier Potions right now", href: "/tier-list/potions", route: "potions", entities: topPotions },
   ];
 
   return (
@@ -52,15 +176,25 @@ export default function TierListIndex() {
       <JsonLd data={jsonLd} />
 
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Tier List</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 Tier List</span>
+        <span className="text-[var(--text-muted)] text-xl ml-2">(STS2)</span>
       </h1>
-      <p className="text-sm text-[var(--text-muted)] mb-8 max-w-2xl">
-        Every card, relic, and potion in <em>Slay the Spire 2</em> ranked S through F.
-        Tiers are derived from the <Link href="/leaderboards/scoring" className="text-[var(--accent-gold)] hover:underline">Codex Score</Link>
-        {" "}— a Bayesian-shrunk win-rate metric computed from community-submitted runs. Updated every 30 minutes.
+      <p className="text-sm text-[var(--text-muted)] mb-2">
+        Updated <time dateTime={new Date().toISOString()}>{updatedDate}</time> · Scores rebuild every 30 minutes.
+      </p>
+      <p className="text-base text-[var(--text-secondary)] mb-8 max-w-3xl leading-relaxed">
+        Every card, relic, and potion in <em>Slay the Spire 2</em> ranked S through F using
+        community win-rate data. Tiers are derived from the{" "}
+        <Link href="/leaderboards/scoring" className="text-[var(--accent-gold)] hover:underline">
+          Codex Score
+        </Link>
+        {" "}— a Bayesian-shrunk metric that compares each entity&apos;s win rate to the global
+        baseline, so a 5-pick perfect-record card doesn&apos;t outrank a 500-pick reliable one.
+        Click any tier list below to see the full ranking with character or pool filters.
       </p>
 
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10">
+      {/* Section navigation tiles */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-12">
         {SECTIONS.map((s) => (
           <Link
             key={s.href}
@@ -73,7 +207,64 @@ export default function TierListIndex() {
         ))}
       </div>
 
-      <section className="p-5 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)]">
+      {/* Top-tier preview rows — concrete content above the fold so SEO
+          crawlers immediately see this page is a ranked list, not a
+          nav hub. Each row links straight to the full tier list. */}
+      {previewBlocks.some((b) => b.entities.length > 0) && (
+        <section className="mb-12">
+          <h2 className="text-xl font-semibold text-[var(--accent-gold)] mb-4">
+            What&apos;s top tier right now
+          </h2>
+          <div className="space-y-4">
+            {previewBlocks.map((block) =>
+              block.entities.length === 0 ? null : (
+                <div
+                  key={block.href}
+                  className="p-4 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)]"
+                >
+                  <div className="flex items-baseline justify-between mb-3">
+                    <h3 className="text-sm font-semibold text-[var(--text-primary)]">
+                      {block.title}
+                    </h3>
+                    <Link
+                      href={block.href}
+                      className="text-xs text-[var(--accent-gold)] hover:underline"
+                    >
+                      View full list →
+                    </Link>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {block.entities.map((ent) => (
+                      <Link
+                        key={ent.id}
+                        href={`/${block.route}/${ent.id.toLowerCase()}`}
+                        className="flex flex-col items-center gap-1 w-20 p-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] hover:border-[var(--accent-gold)]/50 transition-colors"
+                      >
+                        {ent.image_url && (
+                          <img
+                            src={`${API_PUBLIC}${ent.image_url}`}
+                            alt={ent.name}
+                            className="w-12 h-12 object-contain"
+                            loading="lazy"
+                            crossOrigin="anonymous"
+                          />
+                        )}
+                        <span className="text-[10px] text-[var(--text-secondary)] text-center leading-tight line-clamp-2 min-h-[1.5rem]">
+                          {ent.name}
+                        </span>
+                        <ScoreBadge score={ent.score} size="sm" showNumber />
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              )
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* Methodology block (kept from original) */}
+      <section className="p-5 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] mb-10">
         <h2 className="text-base font-semibold text-[var(--text-primary)] mb-2">
           How the rankings work
         </h2>
@@ -96,6 +287,39 @@ export default function TierListIndex() {
         >
           → Full methodology
         </Link>
+      </section>
+
+      {/* FAQ — also wired up as FAQPage JSON-LD above so each Q can
+          land in Google's People-Also-Ask box. */}
+      <section className="mb-4">
+        <h2 className="text-xl font-semibold text-[var(--accent-gold)] mb-4">Frequently asked</h2>
+        <div className="space-y-2">
+          {faqs.map((faq, i) => (
+            <details
+              key={i}
+              className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] group"
+            >
+              <summary className="cursor-pointer p-4 text-sm font-medium text-[var(--text-primary)] hover:text-[var(--accent-gold)] transition-colors flex items-start justify-between gap-3 list-none">
+                <span>{faq.question}</span>
+                <svg
+                  aria-hidden
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  className="w-4 h-4 mt-0.5 flex-shrink-0 transition-transform -rotate-90 group-open:rotate-0 text-[var(--text-muted)]"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </summary>
+              <div className="px-4 pb-4 text-sm text-[var(--text-secondary)] leading-relaxed">
+                {faq.answer}
+              </div>
+            </details>
+          ))}
+        </div>
       </section>
     </div>
   );

--- a/frontend/app/tier-list/potions/page.tsx
+++ b/frontend/app/tier-list/potions/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { SITE_URL, SITE_NAME } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
-import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 import TierList, { type TierEntity } from "@/app/components/TierList";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -21,13 +21,13 @@ interface ScoresMap {
 }
 
 export const metadata: Metadata = {
-  title: `Slay the Spire 2 Potion Tier List - All 63 Potions Ranked | ${SITE_NAME}`,
+  title: `STS2 Potion Tier List - All 63 Slay the Spire 2 Potions Ranked | ${SITE_NAME}`,
   description:
-    "Every Slay the Spire 2 potion ranked S through F by community win rate. Codex Score with Bayesian shrinkage. Updated every 30 minutes.",
+    "Every Slay the Spire 2 (STS2) potion ranked S through F by community win rate. Codex Score with Bayesian shrinkage. Updated every 30 minutes.",
   alternates: { canonical: `${SITE_URL}/tier-list/potions` },
   openGraph: {
-    title: `Slay the Spire 2 Potion Tier List | ${SITE_NAME}`,
-    description: "Every potion ranked S through F by community win-rate data.",
+    title: `STS2 Potion Tier List | ${SITE_NAME}`,
+    description: "Every Slay the Spire 2 potion ranked S through F by community win-rate data.",
     url: `${SITE_URL}/tier-list/potions`,
     siteName: SITE_NAME,
     type: "website",
@@ -58,12 +58,29 @@ export default async function PotionsTierListPage() {
     score: scores[p.id.toUpperCase()]?.score ?? null,
   }));
 
+  // Top-30 by score for ItemList JSON-LD — gives Google a structured
+  // ranked list it can render as carousel-style rich results.
+  const rankedItems = [...entities]
+    .filter((e) => e.score != null)
+    .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+    .slice(0, 30)
+    .map((e) => ({
+      name: e.name,
+      path: `/potions/${e.id.toLowerCase()}`,
+    }));
+
   const jsonLd = [
     buildBreadcrumbJsonLd([
       { name: "Home", href: "/" },
       { name: "Tier List", href: "/tier-list" },
       { name: "Potion Tier List", href: "/tier-list/potions" },
     ]),
+    buildCollectionPageJsonLd({
+      name: "Potion Tier List",
+      description: "Every Slay the Spire 2 (STS2) potion ranked by Codex Score from community-submitted run win rates.",
+      path: "/tier-list/potions",
+      items: rankedItems,
+    }),
   ];
 
   return (

--- a/frontend/app/tier-list/relics/page.tsx
+++ b/frontend/app/tier-list/relics/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { SITE_URL, SITE_NAME } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
-import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 import TierList, { type TierEntity } from "@/app/components/TierList";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -39,10 +39,10 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
   const pool = sp.pool?.toLowerCase();
   const poolLabel = POOL_FILTERS.find((p) => p.value === pool)?.label;
   const scope = poolLabel && pool ? `${poolLabel} Relic` : "Relic";
-  const title = `Slay the Spire 2 ${scope} Tier List - Ranked S to F | ${SITE_NAME}`;
+  const title = `STS2 ${scope} Tier List - Slay the Spire 2 Relics Ranked | ${SITE_NAME}`;
   const description = pool
-    ? `${poolLabel} relic tier list for Slay the Spire 2. Every relic in the ${pool} pool ranked S through F by community win rate.`
-    : "Every Slay the Spire 2 relic ranked S through F. Codex Score from community-submitted run win rates with Bayesian shrinkage.";
+    ? `${poolLabel} relic tier list for Slay the Spire 2 (STS2). Every relic in the ${pool} pool ranked S through F by community win rate.`
+    : "Every Slay the Spire 2 (STS2) relic ranked S through F. Codex Score from community-submitted run win rates with Bayesian shrinkage.";
   const path = `/tier-list/relics${pool ? `?pool=${pool}` : ""}`;
   return {
     title,
@@ -82,13 +82,31 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
 
   const poolLabel = POOL_FILTERS.find((p) => p.value === pool)?.label;
   const heading = poolLabel && pool ? `${poolLabel} Relic Tier List` : "Relic Tier List";
+  const path = `/tier-list/relics${pool ? `?pool=${pool}` : ""}`;
+
+  // Top-30 by score for ItemList JSON-LD — gives Google a structured
+  // ranked list it can render as carousel-style rich results.
+  const rankedItems = [...entities]
+    .filter((e) => e.score != null)
+    .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+    .slice(0, 30)
+    .map((e) => ({
+      name: e.name,
+      path: `/relics/${e.id.toLowerCase()}`,
+    }));
 
   const jsonLd = [
     buildBreadcrumbJsonLd([
       { name: "Home", href: "/" },
       { name: "Tier List", href: "/tier-list" },
-      { name: heading, href: `/tier-list/relics${pool ? `?pool=${pool}` : ""}` },
+      { name: heading, href: path },
     ]),
+    buildCollectionPageJsonLd({
+      name: heading,
+      description: `Slay the Spire 2 (STS2) ${heading.toLowerCase()} ranked by Codex Score from community-submitted run win rates.`,
+      path,
+      items: rankedItems,
+    }),
   ];
 
   return (


### PR DESCRIPTION
Targeting top-of-search for *"sts2 tier list"* and adjacent queries. Five SEO improvements bundled — every change is server-rendered + JSON-LD, so Googlebot picks them up on first crawl without executing JS.

## Changes

### 1. STS2 abbreviation in titles + H1
People search both 'sts2' and 'slay the spire 2'. Titles now read **"STS2 [Card] Tier List - Slay the Spire 2 [...]"** so we hit either phrasing. STS2 lands inside the ~60-char mobile truncation window.

H1 on the landing reads **"Slay the Spire 2 Tier List (STS2)"** — both query variants on-page.

### 2. ItemList JSON-LD on all three sub-pages
Top-30 entities by score, in ranked order. Qualifies for Google's carousel rich snippet (*"1. Strike, 2. Bash, ..."* rendered directly in SERPs).

### 3. "What's top tier right now" preview on landing
Old above-the-fold was 3 nav tiles + brief intro = Google reads it as a nav hub, not a tier list. Now also renders **top-5 cards / relics / potions inline with images + score badges**, sourced live from `/api/runs/scores/<type>`. Each block links to the full sub-page.

### 4. FAQPage schema (6 questions)
Captures People-Also-Ask. Top-entity answers are computed at request time from live score data so they don't go stale. Visible `<details>/<summary>` UI mirrors the schema:

- What is the best card in Slay the Spire 2?
- What is the best relic in Slay the Spire 2?
- What is the best potion in Slay the Spire 2?
- How is the Slay the Spire 2 tier list calculated?
- How often is the tier list updated?
- Is there a tier list per character?

### 5. Visible "Updated <date>" timestamp
Tier lists live or die on freshness. `force-dynamic` re-renders on every request, so the date shown is always today. Wrapped in `<time dateTime=…>` for search-engine parsing.

## What this unlocks (over time)
- Top-of-search candidacy for **"sts2 tier list"** + 13 long-tail variants (per character / per pool from PR #229)
- People-Also-Ask box wins for the FAQ questions
- Carousel-style rich snippets via ItemList for the cards/relics/potions sub-pages
- Better CTR from the rich SERP treatment

Off-page work (Reddit/Discord/Steam guide outreach) is still on you — but this pack maxes out the on-page side.

Stacks cleanly on main — no backend changes.