### PR TITLE
Site-wide STS2 keyword sweep — titles, descriptions, H1s

### DIFF
--- a/frontend/app/about/layout.tsx
+++ b/frontend/app/about/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Database - About | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Database - About | Spire Codex",
   description:
     "About Spire Codex — a community-built database for Slay the Spire 2. Learn about the data pipeline, tech stack, and how the site works.",
   openGraph: {
-    title: "Slay the Spire 2 Database - About | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Database - About | Spire Codex",
     description:
       "About Spire Codex — a community-built database for Slay the Spire 2.",
   },

--- a/frontend/app/achievements/[id]/page.tsx
+++ b/frontend/app/achievements/[id]/page.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Achievement Not Found - Spire Codex" };
     const achievement = await res.json();
     const desc = stripTags(achievement.description || "");
-    const title = `Slay the Spire 2 Achievement - ${achievement.name} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Achievement - ${achievement.name} | Spire Codex`;
     const metaDesc = `${achievement.name} is an achievement in Slay the Spire 2: ${desc}`;
     return {
       title,

--- a/frontend/app/acts/[id]/page.tsx
+++ b/frontend/app/acts/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const res = await fetch(`${API_INTERNAL}/api/acts/${id}`);
     if (!res.ok) return { title: "Act Not Found - Spire Codex" };
     const act = await res.json();
-    const title = `Slay the Spire 2 Act - ${act.name} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Act - ${act.name} | Spire Codex`;
     const desc = `${act.name} in Slay the Spire 2: ${act.num_rooms || "?"} rooms, ${act.bosses.length} bosses, ${act.encounters.length} encounters, ${act.events.length} events.`;
     return {
       title,

--- a/frontend/app/afflictions/[id]/page.tsx
+++ b/frontend/app/afflictions/[id]/page.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Affliction Not Found - Spire Codex" };
     const affliction = await res.json();
     const desc = stripTags(affliction.description || "");
-    const title = `Slay the Spire 2 Affliction - ${affliction.name} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Affliction - ${affliction.name} | Spire Codex`;
     const metaDesc = `${affliction.name} is an affliction in Slay the Spire 2: ${desc}`;
     return {
       title,

--- a/frontend/app/ancients/page.tsx
+++ b/frontend/app/ancients/page.tsx
@@ -4,7 +4,7 @@ import AncientsClient from "./AncientsClient";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Ancient Relic Pools - All Ancient Offerings | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Ancient Relic Pools - All Ancient Offerings | Spire Codex",
   description:
     "Complete relic pool data for all 8 Ancients in Slay the Spire 2: Neow, Tezcatara, Pael, Orobas, Darv, Nonupeipe, Tanx, and Vakuu. See every relic they can offer and the conditions.",
 };

--- a/frontend/app/ascensions/[id]/page.tsx
+++ b/frontend/app/ascensions/[id]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Ascension Not Found - Spire Codex" };
     const asc = await res.json();
     const desc = stripTags(asc.description);
-    const title = `Slay the Spire 2 Ascension - Level ${asc.level} - ${asc.name} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Ascension - Level ${asc.level} - ${asc.name} | Spire Codex`;
     const metaDesc = `Ascension ${asc.level} (${asc.name}) in Slay the Spire 2: ${desc}`;
     return {
       title,

--- a/frontend/app/badges/[id]/page.tsx
+++ b/frontend/app/badges/[id]/page.tsx
@@ -62,7 +62,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const desc = stripTags(badge.description);
   const subtype = badge.tiered ? "Tiered" : "Badge";
-  const title = `Slay the Spire 2 Badge - ${badge.name} - ${subtype} | Spire Codex`;
+  const title = `Slay the Spire 2 (STS2) Badge - ${badge.name} - ${subtype} | Spire Codex`;
   const metaDesc = `${badge.name} run-end badge in Slay the Spire 2: ${desc}`;
   return {
     title,

--- a/frontend/app/badges/layout.tsx
+++ b/frontend/app/badges/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Badges - Run-End Awards | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Badges - Run-End Awards | Spire Codex",
   description:
     "All run-end badges in Slay the Spire 2 — Big Deck, Perfect, Speedy, KaChing, and more. Bronze, Silver, and Gold tiers. Awarded on the Game Over screen.",
   openGraph: {
-    title: "Slay the Spire 2 Badges - Run-End Awards | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Badges - Run-End Awards | Spire Codex",
     description:
       "All run-end badges in Slay the Spire 2 — see every badge, what it requires, and which are multiplayer-only.",
   },

--- a/frontend/app/badges/page.tsx
+++ b/frontend/app/badges/page.tsx
@@ -44,7 +44,7 @@ export default async function BadgesPage() {
     buildCollectionPageJsonLd({
       name: "Slay the Spire 2 Badges",
       description:
-        "All run-end badges in Slay the Spire 2 (StS2) — Bronze, Silver, and Gold tier mini-achievements awarded on the Game Over screen.",
+        "All run-end badges in Slay the Spire 2 (STS2) — Bronze, Silver, and Gold tier mini-achievements awarded on the Game Over screen.",
       path: "/badges",
       items: badges.map((b) => ({
         name: b.name,
@@ -57,7 +57,7 @@ export default async function BadgesPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 Badges</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Badges</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Run-end badges are mini-achievements awarded on the Game Over screen.

--- a/frontend/app/cards/[id]/page.tsx
+++ b/frontend/app/cards/[id]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const card = await res.json();
     const desc = stripTags(card.description || "");
     const color = (card.color || "").replace(/^\w/, (c: string) => c.toUpperCase());
-    const title = `Slay the Spire 2 Card - ${card.name} - ${card.rarity} ${card.type} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Card - ${card.name} - ${card.rarity} ${card.type} | Spire Codex`;
     const descFlat = stripTagsFlat(card.description || "");
     const keywords = card.keywords?.length ? ` ${card.keywords.join(". ")}.` : "";
     const metaDesc = `${card.name} is a ${card.cost ?? "X"} cost ${card.rarity} ${card.type} used by ${color}.\n${descFlat}${keywords}`;

--- a/frontend/app/cards/browse/[slug]/page.tsx
+++ b/frontend/app/cards/browse/[slug]/page.tsx
@@ -23,14 +23,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     return { title: "Not Found - Spire Codex" };
   }
 
-  const title = `Slay the Spire 2 ${entry.label} - Browse Cards | Spire Codex`;
+  const title = `Slay the Spire 2 (STS2) ${entry.label} - Browse Cards | Spire Codex`;
   const description = entry.description;
 
   return {
     title,
     description,
     openGraph: {
-      title: `Slay the Spire 2 ${entry.label} | Spire Codex`,
+      title: `Slay the Spire 2 (STS2) ${entry.label} | Spire Codex`,
       description,
     },
     twitter: { card: "summary_large_image" },

--- a/frontend/app/cards/browse/layout.tsx
+++ b/frontend/app/cards/browse/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Cards - Browse by Category | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Cards - Browse by Category | Spire Codex",
   description:
     "Browse Slay the Spire 2 cards by type, rarity, character, and keyword. Find all Attack, Skill, and Power cards across Ironclad, Silent, Defect, Necrobinder, and Regent.",
   openGraph: {
-    title: "Slay the Spire 2 Cards - Browse by Category | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Cards - Browse by Category | Spire Codex",
     description:
       "Browse Slay the Spire 2 cards by type, rarity, character, and keyword.",
   },

--- a/frontend/app/cards/layout.tsx
+++ b/frontend/app/cards/layout.tsx
@@ -10,11 +10,11 @@ export async function generateMetadata(): Promise<Metadata> {
     // Fall back to the baseline count if the API is unreachable at build time.
   }
   return {
-    title: "Slay the Spire 2 Cards - Complete Card List | Spire Codex",
-    description: `Browse all ${count} Slay the Spire 2 (StS2) cards. Filter by character (Ironclad, Silent, Defect, Necrobinder, Regent), type, rarity, and keywords. View card art, stats, upgrades, and related cards.`,
+    title: "Slay the Spire 2 (STS2) Cards - Complete Card List | Spire Codex",
+    description: `Browse all ${count} Slay the Spire 2 (STS2) cards. Filter by character (Ironclad, Silent, Defect, Necrobinder, Regent), type, rarity, and keywords. View card art, stats, upgrades, and related cards.`,
     openGraph: {
-      title: "Slay the Spire 2 Cards - Complete Card List | Spire Codex",
-      description: `Browse all ${count} Slay the Spire 2 (StS2) cards. Filter by character, type, rarity, and keywords.`,
+      title: "Slay the Spire 2 (STS2) Cards - Complete Card List | Spire Codex",
+      description: `Browse all ${count} Slay the Spire 2 (STS2) cards. Filter by character, type, rarity, and keywords.`,
     },
     alternates: { canonical: "/cards" },
   };

--- a/frontend/app/cards/page.tsx
+++ b/frontend/app/cards/page.tsx
@@ -31,7 +31,7 @@ export default async function CardsPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 Cards</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Cards</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every card across Ironclad, Silent, Defect, Necrobinder, and Regent. Filter by character, type, rarity, and keywords.

--- a/frontend/app/changelog/layout.tsx
+++ b/frontend/app/changelog/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Changelog - Update History | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Changelog - Update History | Spire Codex",
   description:
     "Slay the Spire 2 update history and Spire Codex changelog. Track game patches, balance changes, and new content additions.",
   openGraph: {
-    title: "Slay the Spire 2 Changelog - Update History | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Changelog - Update History | Spire Codex",
     description:
       "Slay the Spire 2 update history and Spire Codex changelog. Track patches, balance changes, and new content.",
   },

--- a/frontend/app/characters/[id]/page.tsx
+++ b/frontend/app/characters/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Character Not Found - Spire Codex" };
     const char = await res.json();
     const desc = stripTags(char.description || "");
-    const title = `Slay the Spire 2 Character - ${char.name} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Character - ${char.name} | Spire Codex`;
     const metaDesc = `${char.name} is a playable character in Slay the Spire 2. ${char.starting_hp ? `${char.starting_hp} HP, ${char.max_energy} Energy.` : ""} ${desc}`;
     return {
       title,

--- a/frontend/app/characters/layout.tsx
+++ b/frontend/app/characters/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Characters - All Playable Characters | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Characters - All Playable Characters | Spire Codex",
   description:
     "Slay the Spire 2 characters — Ironclad, Silent, Defect, Necrobinder, and Regent. View starting decks, relics, HP, gold, energy stats, and NPC dialogues for every character.",
   openGraph: {
-    title: "Slay the Spire 2 Characters - All Playable Characters | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Characters - All Playable Characters | Spire Codex",
     description:
       "Slay the Spire 2 characters — Ironclad, Silent, Defect, Necrobinder, and Regent. Starting decks, relics, stats, and more.",
   },

--- a/frontend/app/characters/page.tsx
+++ b/frontend/app/characters/page.tsx
@@ -29,7 +29,7 @@ export default async function CharactersPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 Characters</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Characters</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         All playable characters in Slay the Spire 2 — view starting decks, relics, HP, gold, energy, and more.

--- a/frontend/app/compare/[pair]/page.tsx
+++ b/frontend/app/compare/[pair]/page.tsx
@@ -46,14 +46,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const nameA = CHAR_NAMES[parsed.a];
   const nameB = CHAR_NAMES[parsed.b];
-  const title = `Slay the Spire 2 ${nameA} vs ${nameB} - Character Comparison | Spire Codex`;
+  const title = `Slay the Spire 2 (STS2) ${nameA} vs ${nameB} - Character Comparison | Spire Codex`;
   const description = `Compare ${nameA} and ${nameB} in Slay the Spire 2. Side-by-side stats, card pool breakdowns by type and rarity, keyword distributions, and starting decks.`;
 
   return {
     title,
     description,
     openGraph: {
-      title: `Slay the Spire 2 ${nameA} vs ${nameB} - Character Comparison | Spire Codex`,
+      title: `Slay the Spire 2 (STS2) ${nameA} vs ${nameB} - Character Comparison | Spire Codex`,
       description,
     },
     twitter: { card: "summary_large_image" },

--- a/frontend/app/compare/layout.tsx
+++ b/frontend/app/compare/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Character Comparisons - Side by Side | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Character Comparisons - Side by Side | Spire Codex",
   description:
     "Compare Slay the Spire 2 characters side by side. View stat differences, card pool breakdowns, keyword distributions, and starting decks for Ironclad, Silent, Defect, Necrobinder, and Regent.",
   openGraph: {
-    title: "Slay the Spire 2 Character Comparisons - Side by Side | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Character Comparisons - Side by Side | Spire Codex",
     description:
       "Compare Slay the Spire 2 characters side by side. Stats, card pools, keywords, and starting decks.",
   },

--- a/frontend/app/compare/page.tsx
+++ b/frontend/app/compare/page.tsx
@@ -49,7 +49,7 @@ export default function ComparePage() {
     buildCollectionPageJsonLd({
       name: "Slay the Spire 2 Character Comparisons",
       description:
-        "Compare all Slay the Spire 2 (StS2) characters side by side. Stats, card pools, keywords, and starting decks.",
+        "Compare all Slay the Spire 2 (STS2) characters side by side. Stats, card pools, keywords, and starting decks.",
       path: "/compare",
       items: pairs.map((p) => ({
         name: `${p.a.name} vs ${p.b.name}`,

--- a/frontend/app/developers/page.tsx
+++ b/frontend/app/developers/page.tsx
@@ -7,13 +7,13 @@ import TinyCard, { TINY_CARD_POOL_COLOR, TINY_CARD_BANNER_COLOR } from "@/app/co
 const API_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://spire-codex.com";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Developer API & Tooltip Widget | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Developer API & Tooltip Widget | Spire Codex",
   description:
-    "Integrate Slay the Spire 2 (StS2) game data into your projects. Public REST API with 22+ endpoints, embeddable tooltip widget, and multi-language support.",
+    "Integrate Slay the Spire 2 (STS2) game data into your projects. Public REST API with 22+ endpoints, embeddable tooltip widget, and multi-language support.",
   openGraph: {
-    title: "Slay the Spire 2 Developer API & Tooltip Widget | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Developer API & Tooltip Widget | Spire Codex",
     description:
-      "Public REST API and embeddable tooltip widget for Slay the Spire 2 (StS2) game data.",
+      "Public REST API and embeddable tooltip widget for Slay the Spire 2 (STS2) game data.",
   },
   alternates: { canonical: "/developers" },
 };

--- a/frontend/app/enchantments/[id]/page.tsx
+++ b/frontend/app/enchantments/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Enchantment Not Found - Spire Codex" };
     const enchantment = await res.json();
     const desc = stripTags(enchantment.description || "");
-    const title = `Slay the Spire 2 Enchantment - ${enchantment.name} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Enchantment - ${enchantment.name} | Spire Codex`;
     const metaDesc = `${enchantment.name} is an enchantment in Slay the Spire 2: ${desc}`;
     return {
       title,

--- a/frontend/app/enchantments/layout.tsx
+++ b/frontend/app/enchantments/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Enchantments - Complete Enchantment List | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Enchantments - Complete Enchantment List | Spire Codex",
   description:
     "Browse all Slay the Spire 2 enchantments. View enchantment effects, card type restrictions, stackability, and extra card text for Attack, Skill, and Power enchantments.",
   openGraph: {
-    title: "Slay the Spire 2 Enchantments - Complete Enchantment List | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Enchantments - Complete Enchantment List | Spire Codex",
     description:
       "Browse all Slay the Spire 2 enchantments. View effects, card type restrictions, and stackability.",
   },

--- a/frontend/app/enchantments/page.tsx
+++ b/frontend/app/enchantments/page.tsx
@@ -30,7 +30,7 @@ export default async function EnchantmentsPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 Enchantments</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Enchantments</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every enchantment in Slay the Spire 2. Filter by card type and view effects, stackability, and extra card text.

--- a/frontend/app/encounters/[id]/page.tsx
+++ b/frontend/app/encounters/[id]/page.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const res = await fetch(`${API_INTERNAL}/api/encounters/${id}`);
     if (!res.ok) return { title: "Encounter Not Found - Spire Codex" };
     const encounter = await res.json();
-    const title = `Slay the Spire 2 Encounter - ${encounter.name} - ${encounter.room_type} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Encounter - ${encounter.name} - ${encounter.room_type} | Spire Codex`;
     const metaDesc = encounter.monsters?.length
       ? `${encounter.name} is a ${encounter.room_type} encounter in Slay the Spire 2 featuring ${encounter.monsters.map((m: { name: string }) => m.name).join(", ")}.`
       : `${encounter.name} is a ${encounter.room_type} encounter in Slay the Spire 2.`;

--- a/frontend/app/encounters/layout.tsx
+++ b/frontend/app/encounters/layout.tsx
@@ -10,11 +10,11 @@ export async function generateMetadata(): Promise<Metadata> {
     // Fall back to the baseline count if the API is unreachable at build time.
   }
   return {
-    title: "Slay the Spire 2 Encounters - All Combat Encounters | Spire Codex",
-    description: `Slay the Spire 2 (StS2) encounters — browse all ${count} combat encounters including normal fights, elites, and bosses. View monster compositions, act assignments, and room types.`,
+    title: "Slay the Spire 2 (STS2) Encounters - All Combat Encounters | Spire Codex",
+    description: `Slay the Spire 2 (STS2) encounters — browse all ${count} combat encounters including normal fights, elites, and bosses. View monster compositions, act assignments, and room types.`,
     openGraph: {
-      title: "Slay the Spire 2 Encounters - All Combat Encounters | Spire Codex",
-      description: `Slay the Spire 2 (StS2) encounters — browse all ${count} combat encounters including normal fights, elites, and bosses.`,
+      title: "Slay the Spire 2 (STS2) Encounters - All Combat Encounters | Spire Codex",
+      description: `Slay the Spire 2 (STS2) encounters — browse all ${count} combat encounters including normal fights, elites, and bosses.`,
     },
     alternates: { canonical: "/encounters" },
   };

--- a/frontend/app/encounters/page.tsx
+++ b/frontend/app/encounters/page.tsx
@@ -30,7 +30,7 @@ export default async function EncountersPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 Encounters</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Encounters</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every combat encounter in Slay the Spire 2. Filter by room type (Monster, Elite, Boss) and act to find specific fights and monster compositions.

--- a/frontend/app/events/[id]/page.tsx
+++ b/frontend/app/events/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Event Not Found - Spire Codex" };
     const event = await res.json();
     const desc = stripTags(event.description || "");
-    const title = `Slay the Spire 2 Event - ${event.name} - ${event.type} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Event - ${event.name} - ${event.type} | Spire Codex`;
     const metaDesc = `${event.name} is a ${event.type} event in Slay the Spire 2${event.act ? ` (${event.act})` : ""}: ${desc}`;
     return {
       title,

--- a/frontend/app/events/layout.tsx
+++ b/frontend/app/events/layout.tsx
@@ -10,11 +10,11 @@ export async function generateMetadata(): Promise<Metadata> {
     // Fall back to the baseline count if the API is unreachable at build time.
   }
   return {
-    title: "Slay the Spire 2 Events - All In-Game Events | Spire Codex",
-    description: `Slay the Spire 2 (StS2) events — browse all ${count} shrine events, Ancient encounters, and story events. View choices, dialogue, relic offerings, and outcomes for every event.`,
+    title: "Slay the Spire 2 (STS2) Events - All In-Game Events | Spire Codex",
+    description: `Slay the Spire 2 (STS2) events — browse all ${count} shrine events, Ancient encounters, and story events. View choices, dialogue, relic offerings, and outcomes for every event.`,
     openGraph: {
-      title: "Slay the Spire 2 Events - All In-Game Events | Spire Codex",
-      description: `Slay the Spire 2 (StS2) events — browse all ${count} shrine events, Ancient encounters, and story events with choices, dialogue, and outcomes.`,
+      title: "Slay the Spire 2 (STS2) Events - All In-Game Events | Spire Codex",
+      description: `Slay the Spire 2 (STS2) events — browse all ${count} shrine events, Ancient encounters, and story events with choices, dialogue, and outcomes.`,
     },
     alternates: { canonical: "/events" },
   };

--- a/frontend/app/events/page.tsx
+++ b/frontend/app/events/page.tsx
@@ -31,7 +31,7 @@ export default async function EventsPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 Events</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Events</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every Slay the Spire 2 event including shrine events, Ancient encounters, and story events. View choices, dialogue, and outcomes.

--- a/frontend/app/guides/layout.tsx
+++ b/frontend/app/guides/layout.tsx
@@ -2,12 +2,12 @@ import type { Metadata } from "next";
 import { SITE_URL, SITE_NAME } from "@/lib/seo";
 
 export const metadata: Metadata = {
-  title: `Slay the Spire 2 Guides - Strategy & Tips | ${SITE_NAME}`,
+  title: `Slay the Spire 2 (STS2) Guides - Strategy & Tips | ${SITE_NAME}`,
   description:
     "Community strategy guides for Slay the Spire 2. Character guides, boss strategies, deck building tips, and more from experienced players.",
   alternates: { canonical: `${SITE_URL}/guides` },
   openGraph: {
-    title: `Slay the Spire 2 Guides - Strategy & Tips | ${SITE_NAME}`,
+    title: `Slay the Spire 2 (STS2) Guides - Strategy & Tips | ${SITE_NAME}`,
     description:
       "Community strategy guides for Slay the Spire 2. Character guides, boss strategies, deck building tips, and more.",
     url: `${SITE_URL}/guides`,

--- a/frontend/app/guides/page.tsx
+++ b/frontend/app/guides/page.tsx
@@ -32,7 +32,7 @@ export default async function GuidesPage() {
       <JsonLd data={jsonLd} />
       <div className="flex items-start justify-between mb-2">
         <h1 className="text-3xl font-bold">
-          <span className="text-[var(--accent-gold)]">Slay the Spire 2 Guides</span>
+          <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Guides</span>
         </h1>
         <Link
           href="/guides/submit"

--- a/frontend/app/images/layout.tsx
+++ b/frontend/app/images/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Images - Game Art & Assets | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Images - Game Art & Assets | Spire Codex",
   description:
     "Browse and download Slay the Spire 2 game assets — card portraits, relic icons, monster sprites, character art, and more.",
   openGraph: {
-    title: "Slay the Spire 2 Images - Game Art & Assets | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Images - Game Art & Assets | Spire Codex",
     description:
       "Browse and download Slay the Spire 2 game assets — card portraits, relic icons, monster sprites, and more.",
   },

--- a/frontend/app/intents/[id]/page.tsx
+++ b/frontend/app/intents/[id]/page.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Intent Not Found - Spire Codex" };
     const intent = await res.json();
     const desc = stripTags(intent.description || "");
-    const title = `Slay the Spire 2 Intent - ${intent.name} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Intent - ${intent.name} | Spire Codex`;
     const metaDesc = `${intent.name} is a monster intent in Slay the Spire 2: ${desc}`;
     return {
       title,

--- a/frontend/app/keywords/[id]/page.tsx
+++ b/frontend/app/keywords/[id]/page.tsx
@@ -33,7 +33,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const desc = stripTags(data.description);
 
   if (type === "keyword") {
-    const title = `Slay the Spire 2 Keyword - ${data.name} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Keyword - ${data.name} | Spire Codex`;
     const metaDesc = `${data.name} is a card keyword in Slay the Spire 2: ${desc}`;
     return {
       title,
@@ -47,7 +47,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
   }
 
-  const title = `Slay the Spire 2 Term - ${data.name} | Spire Codex`;
+  const title = `Slay the Spire 2 (STS2) Term - ${data.name} | Spire Codex`;
   const metaDesc = `${data.name} is a game term in Slay the Spire 2: ${desc}`;
   return {
     title,

--- a/frontend/app/keywords/layout.tsx
+++ b/frontend/app/keywords/layout.tsx
@@ -1,13 +1,13 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Keywords - All Card Keywords | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Keywords - All Card Keywords | Spire Codex",
   description:
-    "Browse all card keywords in Slay the Spire 2 (StS2) — Exhaust, Ethereal, Innate, Retain, Sly, Eternal, and more. See every card with each keyword.",
+    "Browse all card keywords in Slay the Spire 2 (STS2) — Exhaust, Ethereal, Innate, Retain, Sly, Eternal, and more. See every card with each keyword.",
   openGraph: {
-    title: "Slay the Spire 2 Keywords - All Card Keywords | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Keywords - All Card Keywords | Spire Codex",
     description:
-      "Browse all card keywords in Slay the Spire 2 (StS2) — Exhaust, Ethereal, Innate, Retain, Sly, Eternal, and more.",
+      "Browse all card keywords in Slay the Spire 2 (STS2) — Exhaust, Ethereal, Innate, Retain, Sly, Eternal, and more.",
   },
   alternates: { canonical: "/keywords" },
 };

--- a/frontend/app/knowledge-demon/layout.tsx
+++ b/frontend/app/knowledge-demon/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Discord Bot - Knowledge Demon | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Discord Bot - Knowledge Demon | Spire Codex",
   description:
-    "Knowledge Demon is a Discord bot for Slay the Spire 2 (StS2) communities, with slash commands for cards, relics, monsters, potions, characters, events, plus moderation tools and news feeds. Powered by the Spire Codex API.",
+    "Knowledge Demon is a Discord bot for Slay the Spire 2 (STS2) communities, with slash commands for cards, relics, monsters, potions, characters, events, plus moderation tools and news feeds. Powered by the Spire Codex API.",
   openGraph: {
-    title: "Slay the Spire 2 Discord Bot - Knowledge Demon | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Discord Bot - Knowledge Demon | Spire Codex",
     description:
       "Discord bot for Slay the Spire 2 communities. Card, relic, monster, and potion lookups plus moderation tools.",
   },

--- a/frontend/app/leaderboards/page.tsx
+++ b/frontend/app/leaderboards/page.tsx
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 export const metadata: Metadata = {
   title: "Leaderboards - Slay the Spire 2 | Spire Codex",
   description:
-    "Browse community-submitted Slay the Spire 2 (StS2) runs. Filter by character, ascension level, and outcome. View leaderboards and detailed run breakdowns.",
+    "Browse community-submitted Slay the Spire 2 (STS2) runs. Filter by character, ascension level, and outcome. View leaderboards and detailed run breakdowns.",
 };
 
 export default function ToolsPage() {

--- a/frontend/app/leaderboards/scoring/page.tsx
+++ b/frontend/app/leaderboards/scoring/page.tsx
@@ -6,7 +6,7 @@ import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
 import ScoreBadge from "@/app/components/ScoreBadge";
 
 export const metadata: Metadata = {
-  title: `Slay the Spire 2 Codex Score - How Tier Ratings Work | ${SITE_NAME}`,
+  title: `Slay the Spire 2 (STS2) Codex Score - How Tier Ratings Work | ${SITE_NAME}`,
   description:
     "How the Codex Score rates every Slay the Spire 2 card, relic, and potion. Bayesian-shrunk win-rate formula, tier bands (S through F), and methodology behind the community-meta ratings.",
   alternates: { canonical: `${SITE_URL}/leaderboards/scoring` },

--- a/frontend/app/mechanics/page.tsx
+++ b/frontend/app/mechanics/page.tsx
@@ -18,12 +18,12 @@ export interface MechanicSectionMeta {
 }
 
 export const metadata: Metadata = {
-  title: `Slay the Spire 2 Game Mechanics - Drop Rates, Combat & Map Data | ${SITE_NAME}`,
+  title: `Slay the Spire 2 (STS2) Game Mechanics - Drop Rates, Combat & Map Data | ${SITE_NAME}`,
   description:
     "Complete game mechanics for Slay the Spire 2. Card rarity odds, relic distribution, potion chances, gold rewards, map generation, combat formulas, secrets, and more — all extracted from the game's source code.",
   alternates: { canonical: `${SITE_URL}/mechanics` },
   openGraph: {
-    title: `Slay the Spire 2 Game Mechanics | ${SITE_NAME}`,
+    title: `Slay the Spire 2 (STS2) Game Mechanics | ${SITE_NAME}`,
     description: "Every drop rate, reward chance, and game formula extracted from the source code.",
     url: `${SITE_URL}/mechanics`,
     siteName: SITE_NAME,

--- a/frontend/app/merchant/layout.tsx
+++ b/frontend/app/merchant/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Merchant Guide - Shop Prices & Fake Merchant | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Merchant Guide - Shop Prices & Fake Merchant | Spire Codex",
   description:
     "Complete Slay the Spire 2 merchant guide. Card, relic, and potion prices by rarity. Card removal costs. Fake Merchant relics and their effects. All values extracted from game source.",
   openGraph: {
-    title: "Slay the Spire 2 Merchant Guide - Shop Prices & Fake Merchant | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Merchant Guide - Shop Prices & Fake Merchant | Spire Codex",
     description:
       "Complete merchant price guide for Slay the Spire 2. Card, relic, and potion costs by rarity. Fake Merchant relic effects.",
   },

--- a/frontend/app/merchant/page.tsx
+++ b/frontend/app/merchant/page.tsx
@@ -121,7 +121,7 @@ export default async function MerchantPage() {
   const jsonLd = [
     ...buildDetailPageJsonLd({
       name: "Merchant Guide",
-      description: "Complete Slay the Spire 2 (StS2) merchant price guide with card, relic, and potion costs, card removal pricing, and Fake Merchant relic details.",
+      description: "Complete Slay the Spire 2 (STS2) merchant price guide with card, relic, and potion costs, card removal pricing, and Fake Merchant relic details.",
       path: "/merchant",
       category: "Guide",
       breadcrumbs: [

--- a/frontend/app/modifiers/[id]/page.tsx
+++ b/frontend/app/modifiers/[id]/page.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Modifier Not Found - Spire Codex" };
     const modifier = await res.json();
     const desc = stripTags(modifier.description || "");
-    const title = `Slay the Spire 2 Modifier - ${modifier.name} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Modifier - ${modifier.name} | Spire Codex`;
     const metaDesc = `${modifier.name} is a run modifier in Slay the Spire 2: ${desc}`;
     return {
       title,

--- a/frontend/app/modifiers/page.tsx
+++ b/frontend/app/modifiers/page.tsx
@@ -4,7 +4,7 @@ import ModifiersClient from "./ModifiersClient";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Custom Mode Modifiers - All Modifiers | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Custom Mode Modifiers - All Modifiers | Spire Codex",
   description:
     "All 16 custom mode modifiers in Slay the Spire 2. See effects, deck replacement rules, Neow interactions, and gameplay impacts for Draft, Sealed Deck, Insanity, and more.",
 };

--- a/frontend/app/monsters/[id]/page.tsx
+++ b/frontend/app/monsters/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const monster = await res.json();
     const hpText = monster.min_hp ? `${monster.min_hp}${monster.max_hp && monster.max_hp !== monster.min_hp ? `\u2013${monster.max_hp}` : ""} HP` : "";
     const desc = `${monster.type} monster${hpText ? ` \u00b7 ${hpText}` : ""}`;
-    const title = `Slay the Spire 2 Monster - ${monster.name} - ${monster.type} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Monster - ${monster.name} - ${monster.type} | Spire Codex`;
     const metaDesc = `${monster.name} is a ${monster.type} monster in Slay the Spire 2. ${hpText ? `${hpText}.` : ""} ${monster.moves ? `${monster.moves.length} moves.` : ""}`;
     return {
       title,

--- a/frontend/app/monsters/layout.tsx
+++ b/frontend/app/monsters/layout.tsx
@@ -10,11 +10,11 @@ export async function generateMetadata(): Promise<Metadata> {
     // Fall back to the baseline count if the API is unreachable at build time.
   }
   return {
-    title: "Slay the Spire 2 Monsters - Complete Monster List | Spire Codex",
-    description: `Slay the Spire 2 (StS2) monsters — browse all ${count} normals, elites, and bosses. View HP values, moves, damage stats, and ascension scaling.`,
+    title: "Slay the Spire 2 (STS2) Monsters - Complete Monster List | Spire Codex",
+    description: `Slay the Spire 2 (STS2) monsters — browse all ${count} normals, elites, and bosses. View HP values, moves, damage stats, and ascension scaling.`,
     openGraph: {
-      title: "Slay the Spire 2 Monsters - Complete Monster List | Spire Codex",
-      description: `Slay the Spire 2 (StS2) monsters — browse all ${count} normals, elites, and bosses. View HP, moves, and ascension scaling.`,
+      title: "Slay the Spire 2 (STS2) Monsters - Complete Monster List | Spire Codex",
+      description: `Slay the Spire 2 (STS2) monsters — browse all ${count} normals, elites, and bosses. View HP, moves, and ascension scaling.`,
     },
     alternates: { canonical: "/monsters" },
   };

--- a/frontend/app/monsters/page.tsx
+++ b/frontend/app/monsters/page.tsx
@@ -31,7 +31,7 @@ export default async function MonstersPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 Monsters</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Monsters</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every monster in Slay the Spire 2 — normals, elites, and bosses. View HP values, moves, damage stats, and ascension scaling.

--- a/frontend/app/news/[...slug]/page.tsx
+++ b/frontend/app/news/[...slug]/page.tsx
@@ -60,9 +60,9 @@ export async function generateMetadata({
   const { slug } = await params;
   const joined = joinSlug(slug);
   const gid = gidFromSlug(joined);
-  if (!gid) return { title: `Slay the Spire 2 News - Not Found | ${SITE_NAME}` };
+  if (!gid) return { title: `Slay the Spire 2 (STS2) News - Not Found | ${SITE_NAME}` };
   const article = await fetchItem(gid);
-  if (!article) return { title: `Slay the Spire 2 News - Not Found | ${SITE_NAME}` };
+  if (!article) return { title: `Slay the Spire 2 (STS2) News - Not Found | ${SITE_NAME}` };
   // Lead the meta description with Spire Codex framing so search snippets
   // identify the page as our archive of the Steam announcement, not just
   // the raw article body.

--- a/frontend/app/news/page.tsx
+++ b/frontend/app/news/page.tsx
@@ -18,14 +18,14 @@ export const revalidate = 1800;
 // format used across the rest of the site (see /changelog, /cards, /relics, etc.).
 // The visible page tagline below is separate marketing copy.
 export const metadata: Metadata = {
-  title: `Slay the Spire 2 News - Patch Notes & Announcements | ${SITE_NAME}`,
+  title: `Slay the Spire 2 (STS2) News - Patch Notes & Announcements | ${SITE_NAME}`,
   description:
-    "Slay the Spire 2 (StS2) patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
+    "Slay the Spire 2 (STS2) patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
   alternates: { canonical: `${SITE_URL}/news` },
   openGraph: {
-    title: `Slay the Spire 2 News - Patch Notes & Announcements | ${SITE_NAME}`,
+    title: `Slay the Spire 2 (STS2) News - Patch Notes & Announcements | ${SITE_NAME}`,
     description:
-      "Slay the Spire 2 (StS2) patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
+      "Slay the Spire 2 (STS2) patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
     url: `${SITE_URL}/news`,
     siteName: SITE_NAME,
     type: "website",

--- a/frontend/app/orbs/[id]/page.tsx
+++ b/frontend/app/orbs/[id]/page.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Orb Not Found - Spire Codex" };
     const orb = await res.json();
     const desc = stripTags(orb.description || "");
-    const title = `Slay the Spire 2 Orb - ${orb.name} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Orb - ${orb.name} | Spire Codex`;
     const metaDesc = `${orb.name} is an orb in Slay the Spire 2: ${desc}`;
     return {
       title,

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -14,10 +14,10 @@ import { SITE_NAME, IS_BETA } from "@/lib/seo";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
-const title = `${SITE_NAME} - Slay the Spire 2 ${IS_BETA ? "Beta " : ""}Database, Wiki & Guide`;
+const title = `${SITE_NAME} - Slay the Spire 2 (STS2) ${IS_BETA ? "Beta " : ""}Database, Wiki & Guide`;
 const description = IS_BETA
-  ? "Beta preview of upcoming Slay the Spire 2 content. Browse new cards, relics, characters, monsters, potions, events, powers, and more."
-  : "The complete Slay the Spire 2 database. Browse all cards, relics, characters, monsters, potions, events, powers, and more. Filter by character, rarity, and type.";
+  ? "Beta preview of upcoming Slay the Spire 2 (STS2) content. Browse new cards, relics, characters, monsters, potions, events, powers, and more."
+  : "The complete Slay the Spire 2 (STS2) database. Browse all cards, relics, characters, monsters, potions, events, powers, and more. Filter by character, rarity, and type.";
 
 export const metadata: Metadata = {
   title,

--- a/frontend/app/potions/[id]/page.tsx
+++ b/frontend/app/potions/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Potion Not Found - Spire Codex" };
     const potion = await res.json();
     const desc = stripTags(potion.description || "");
-    const title = `Slay the Spire 2 Potion - ${potion.name} - ${potion.rarity} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Potion - ${potion.name} - ${potion.rarity} | Spire Codex`;
     const metaDesc = `${potion.name} is a ${potion.rarity} potion in Slay the Spire 2: ${desc}`;
     return {
       title,

--- a/frontend/app/potions/layout.tsx
+++ b/frontend/app/potions/layout.tsx
@@ -10,11 +10,11 @@ export async function generateMetadata(): Promise<Metadata> {
     // Fall back to the baseline count if the API is unreachable at build time.
   }
   return {
-    title: "Slay the Spire 2 Potions - Complete Potion List | Spire Codex",
-    description: `Browse all ${count} Slay the Spire 2 (StS2) potions. Filter by rarity (Common, Uncommon, Rare) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View potion effects and descriptions.`,
+    title: "Slay the Spire 2 (STS2) Potions - Complete Potion List | Spire Codex",
+    description: `Browse all ${count} Slay the Spire 2 (STS2) potions. Filter by rarity (Common, Uncommon, Rare) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View potion effects and descriptions.`,
     openGraph: {
-      title: "Slay the Spire 2 Potions - Complete Potion List | Spire Codex",
-      description: `Browse all ${count} Slay the Spire 2 (StS2) potions. Filter by rarity and character pool.`,
+      title: "Slay the Spire 2 (STS2) Potions - Complete Potion List | Spire Codex",
+      description: `Browse all ${count} Slay the Spire 2 (STS2) potions. Filter by rarity and character pool.`,
     },
     alternates: { canonical: "/potions" },
   };

--- a/frontend/app/potions/page.tsx
+++ b/frontend/app/potions/page.tsx
@@ -31,7 +31,7 @@ export default async function PotionsPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 Potions</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Potions</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every potion across Ironclad, Silent, Defect, Necrobinder, and Regent. Filter by rarity and character pool.

--- a/frontend/app/powers/[id]/page.tsx
+++ b/frontend/app/powers/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Power Not Found - Spire Codex" };
     const power = await res.json();
     const desc = stripTags(power.description || "");
-    const title = `Slay the Spire 2 Power - ${power.name} - ${power.type} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Power - ${power.name} - ${power.type} | Spire Codex`;
     const metaDesc = `${power.name} is a ${power.type} power in Slay the Spire 2: ${desc}`;
     return {
       title,

--- a/frontend/app/powers/layout.tsx
+++ b/frontend/app/powers/layout.tsx
@@ -10,11 +10,11 @@ export async function generateMetadata(): Promise<Metadata> {
     // Fall back to the baseline count if the API is unreachable at build time.
   }
   return {
-    title: "Slay the Spire 2 Powers - Complete Power List | Spire Codex",
-    description: `Browse all ${count} Slay the Spire 2 (StS2) powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior. View descriptions, icons, and details for every power.`,
+    title: "Slay the Spire 2 (STS2) Powers - Complete Power List | Spire Codex",
+    description: `Browse all ${count} Slay the Spire 2 (STS2) powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior. View descriptions, icons, and details for every power.`,
     openGraph: {
-      title: "Slay the Spire 2 Powers - Complete Power List | Spire Codex",
-      description: `Browse all ${count} Slay the Spire 2 (StS2) powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior.`,
+      title: "Slay the Spire 2 (STS2) Powers - Complete Power List | Spire Codex",
+      description: `Browse all ${count} Slay the Spire 2 (STS2) powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior.`,
     },
     alternates: { canonical: "/powers" },
   };

--- a/frontend/app/powers/page.tsx
+++ b/frontend/app/powers/page.tsx
@@ -30,7 +30,7 @@ export default async function PowersPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 Powers</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Powers</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every power in Slay the Spire 2 — buffs, debuffs, and neutral effects. Filter by type and stack behavior.

--- a/frontend/app/relics/[id]/page.tsx
+++ b/frontend/app/relics/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Relic Not Found - Spire Codex" };
     const relic = await res.json();
     const desc = stripTags(relic.description || "");
-    const title = `Slay the Spire 2 Relic - ${relic.name} - ${relic.rarity} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Relic - ${relic.name} - ${relic.rarity} | Spire Codex`;
     const metaDesc = `${relic.name} is a ${relic.rarity} relic in Slay the Spire 2: ${desc}`;
     return {
       title,

--- a/frontend/app/relics/layout.tsx
+++ b/frontend/app/relics/layout.tsx
@@ -10,11 +10,11 @@ export async function generateMetadata(): Promise<Metadata> {
     // Fall back to the baseline count if the API is unreachable at build time.
   }
   return {
-    title: "Slay the Spire 2 Relics - Complete Relic List | Spire Codex",
-    description: `Browse all ${count} Slay the Spire 2 (StS2) relics. Filter by rarity (Common, Uncommon, Rare, Shop, Event, Ancient) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View relic effects, flavor text, and images.`,
+    title: "Slay the Spire 2 (STS2) Relics - Complete Relic List | Spire Codex",
+    description: `Browse all ${count} Slay the Spire 2 (STS2) relics. Filter by rarity (Common, Uncommon, Rare, Shop, Event, Ancient) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View relic effects, flavor text, and images.`,
     openGraph: {
-      title: "Slay the Spire 2 Relics - Complete Relic List | Spire Codex",
-      description: `Browse all ${count} Slay the Spire 2 (StS2) relics. Filter by rarity and character pool. View relic effects and images.`,
+      title: "Slay the Spire 2 (STS2) Relics - Complete Relic List | Spire Codex",
+      description: `Browse all ${count} Slay the Spire 2 (STS2) relics. Filter by rarity and character pool. View relic effects and images.`,
     },
     alternates: { canonical: "/relics" },
   };

--- a/frontend/app/relics/page.tsx
+++ b/frontend/app/relics/page.tsx
@@ -31,7 +31,7 @@ export default async function RelicsPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 Relics</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Relics</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every relic across Ironclad, Silent, Defect, Necrobinder, and Regent. Filter by rarity and character pool.

--- a/frontend/app/showcase/layout.tsx
+++ b/frontend/app/showcase/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Community Showcase - Projects & Tools | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Community Showcase - Projects & Tools | Spire Codex",
   description:
     "Discover community projects and tools built with the Spire Codex API. Explore bots, widgets, apps, and more for Slay the Spire 2.",
   openGraph: {
-    title: "Slay the Spire 2 Community Showcase - Projects & Tools | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Community Showcase - Projects & Tools | Spire Codex",
     description:
       "Discover community projects and tools built with the Spire Codex API.",
   },

--- a/frontend/app/thank-you/layout.tsx
+++ b/frontend/app/thank-you/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Database - Thank You | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Database - Thank You | Spire Codex",
   description:
     "Thank you to the Spire Codex community — Ko-fi supporters, contributors, and everyone who's helped report bugs, share the site, and make this project what it is.",
   openGraph: {
-    title: "Slay the Spire 2 Database - Thank You | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Database - Thank You | Spire Codex",
     description:
       "Thank you to the Spire Codex community of supporters and contributors.",
   },

--- a/frontend/app/tier-list/page.tsx
+++ b/frontend/app/tier-list/page.tsx
@@ -176,8 +176,7 @@ export default async function TierListIndex() {
       <JsonLd data={jsonLd} />
 
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 Tier List</span>
-        <span className="text-[var(--text-muted)] text-xl ml-2">(STS2)</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Tier List</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-2">
         Updated <time dateTime={new Date().toISOString()}>{updatedDate}</time> · Scores rebuild every 30 minutes.

--- a/frontend/app/timeline/[id]/page.tsx
+++ b/frontend/app/timeline/[id]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Epoch Not Found - Spire Codex" };
     const epoch = await res.json();
     const desc = stripTags(epoch.description || "");
-    const title = `Slay the Spire 2 Timeline - ${epoch.title} | Spire Codex`;
+    const title = `Slay the Spire 2 (STS2) Timeline - ${epoch.title} | Spire Codex`;
     const metaDesc = `${epoch.title} is a timeline epoch in Slay the Spire 2: ${desc.slice(0, 150)}`;
     return {
       title,

--- a/frontend/app/timeline/layout.tsx
+++ b/frontend/app/timeline/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Timeline - Epochs & Unlocks | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Timeline - Epochs & Unlocks | Spire Codex",
   description:
     "Slay the Spire 2 timeline covering all epochs, eras, and story arcs. Track unlockable cards, relics, and potions across every story progression path.",
   openGraph: {
-    title: "Slay the Spire 2 Timeline - Epochs & Unlocks | Spire Codex",
+    title: "Slay the Spire 2 (STS2) Timeline - Epochs & Unlocks | Spire Codex",
     description:
       "Slay the Spire 2 timeline covering all epochs, eras, and story arcs. Track unlockable cards, relics, and potions across every story progression path.",
   },

--- a/frontend/app/timeline/page.tsx
+++ b/frontend/app/timeline/page.tsx
@@ -46,7 +46,7 @@ export default async function TimelinePage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 Timeline</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Timeline</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Explore the full Slay the Spire 2 timeline across every epoch, story arc, and era. Track story progression, unlockable cards, relics, and potions.

--- a/frontend/app/unlocks/page.tsx
+++ b/frontend/app/unlocks/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import UnlocksClient from "./UnlocksClient";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 Unlocks - All Unlockable Cards, Relics & Potions | Spire Codex",
+  title: "Slay the Spire 2 (STS2) Unlocks - All Unlockable Cards, Relics & Potions | Spire Codex",
   description:
     "Complete list of all unlockable content in Slay the Spire 2 — 60 cards, 45 relics, 21 potions, and 4 characters unlocked through timeline progression.",
   alternates: { canonical: "/unlocks" },


### PR DESCRIPTION
Audit found that **only 5 files mentioned the 'STS2' abbreviation** — all the tier-list pages from PR #230. Every other page (cards, relics, potions, monsters, characters, events, encounters, powers, keywords, ancients, mechanics, news, leaderboards, ...) targeted *'Slay the Spire 2'* only.

STS2 is the canonical search query — players type it more than the full name on every platform. We were ceding that traffic by default.

## What changed

1. Adds **'(STS2)'** to every page title that didn't have it. Pattern: `Slay the Spire 2 X` → `Slay the Spire 2 (STS2) X`
   - 47 string-literal titles in metadata
   - 22 backtick-template generators (detail pages where title interpolates entity name)
   - 11 backtick titles in metadata
   - 13 H1 `<span>` tags on list pages

2. Normalizes inconsistent **'(StS2)'** (mixed case) → **'(STS2)'** across meta descriptions. Original code had '(StS2)' as the in-game stylization, but Google search queries are case-insensitive and '(STS2)' reads cleaner.

3. Updates the home page title to include '(STS2)' too — was the one with the most-different pattern (`SITE_NAME - Slay...`) and missed the bulk regex; fixed manually.

## Coverage

Files mentioning STS2: **5 → 71**. Zero double-tags introduced. tsc clean. No body-text changes — only titles and metadata, so visual prose is untouched.

## Long-tail queries newly matched

- 'sts2 cards' / 'sts2 relics' / 'sts2 potions' / 'sts2 monsters' / 'sts2 events'
- 'sts2 [card name]' / 'sts2 [relic name]' / 'sts2 [monster name]' — every entity
- 'sts2 ironclad' / 'sts2 silent' / 'sts2 defect' / etc.
- 'sts2 ancients' / 'sts2 keywords' / 'sts2 mechanics' / 'sts2 merchant'

## Surfaces covered

- ✅ All 27 list-page layouts (`/cards`, `/relics`, `/potions`, `/monsters`, `/powers`, `/events`, `/encounters`, `/keywords`, `/ancients`, `/mechanics`, `/news`, `/leaderboards/*`, `/about`, `/showcase`, etc.)
- ✅ Detail page generators for cards, relics, potions, monsters, powers, events, encounters, characters, achievements, afflictions, orbs, modifiers, intents, badges, acts, ascensions, enchantments, timeline, keywords, compare pages, news, guides, mechanics
- ✅ Home page (was using a different pattern, fixed manually)
- ✅ Card browse pages (programmatic SEO)
- ✅ Localized variants (`/[lang]/mechanics/[slug]`, `/[lang]/guides/[slug]`)