### PR TITLE
i18n: ship STS2 keyword to 13 localized variants (follow-up #231)

### DIFF
--- a/frontend/lib/languages.ts
+++ b/frontend/lib/languages.ts
@@ -43,21 +43,27 @@ export const LANG_NAMES: Record<LangCode, string> = {
   zhs: "简体中文",
 };
 
-/** Localized "Slay the Spire 2" game name for meta descriptions */
+/**
+ * Localized "Slay the Spire 2" game name. Includes "(STS2)" inline
+ * because the abbreviation is universal — players across every locale
+ * type "sts2" into Google. Threaded through every [lang] page's title,
+ * meta description, JSON-LD, and H1 via the `gameName` variable, so
+ * this single source ships the abbreviation to all 52+ localized pages.
+ */
 export const LANG_GAME_NAME: Record<LangCode, string> = {
-  deu: "Slay the Spire 2",
-  esp: "Slay the Spire 2",
-  fra: "Slay the Spire 2",
-  ita: "Slay the Spire 2",
-  jpn: "スレイ・ザ・スパイア2",
-  kor: "슬레이 더 스파이어 2",
-  pol: "Slay the Spire 2",
-  ptb: "Slay the Spire 2",
-  rus: "Slay the Spire 2",
-  spa: "Slay the Spire 2",
-  tha: "Slay the Spire 2",
-  tur: "Slay the Spire 2",
-  zhs: "杀戮尖塔2",
+  deu: "Slay the Spire 2 (STS2)",
+  esp: "Slay the Spire 2 (STS2)",
+  fra: "Slay the Spire 2 (STS2)",
+  ita: "Slay the Spire 2 (STS2)",
+  jpn: "スレイ・ザ・スパイア2 (STS2)",
+  kor: "슬레이 더 스파이어 2 (STS2)",
+  pol: "Slay the Spire 2 (STS2)",
+  ptb: "Slay the Spire 2 (STS2)",
+  rus: "Slay the Spire 2 (STS2)",
+  spa: "Slay the Spire 2 (STS2)",
+  tha: "Slay the Spire 2 (STS2)",
+  tur: "Slay the Spire 2 (STS2)",
+  zhs: "杀戮尖塔2 (STS2)",
 };
 
 /** Localized "Database" for title/descriptions */


### PR DESCRIPTION
Follow-up to PR #231 — the i18n commit got dropped from #231's squash merge (gh's PR HEAD was cached at the first commit when the merge fired). Re-shipping the same single-line fix to `lib/languages.ts`.

`LANG_GAME_NAME` map now includes `(STS2)` inline. Every `/[lang]/*` page interpolates this map into titles, descriptions, JSON-LD, and H1s — so this single source ships the abbreviation to all 52+ localized pages automatically.

| Locale | After |
|---|---|
| /deu, /esp, /fra, /ita, /pol, /ptb, /rus, /spa, /tha, /tur | `Slay the Spire 2 (STS2)` |
| /jpn | `スレイ・ザ・スパイア2 (STS2)` |
| /kor | `슬레이 더 스파이어 2 (STS2)` |
| /zhs | `杀戮尖塔2 (STS2)` |

Abbreviation stays in Latin script across all locales because 'STS2' is the universal community shorthand — international players still type 'sts2' into Google rather than localized abbreviation forms (which don't exist for STS2 yet).