### PR TITLE
SEO: bidirectional hreflang + locale-aware EntityProse (GSC indexation fix)

### DIFF
--- a/frontend/app/achievements/[id]/page.tsx
+++ b/frontend/app/achievements/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import AchievementDetail from "./AchievementDetail";
-import { stripTags } from "@/lib/seo";
+import { stripTags, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         description: metaDesc,
       },
       twitter: { card: "summary_large_image" },
-      alternates: { canonical: `/achievements/${id}` },
+      alternates: { canonical: `/achievements/${id}`, languages: buildLanguageAlternates(`/achievements/${id}`) },
     };
   } catch {
     return { title: "Spire Codex - Slay the Spire 2 Database" };

--- a/frontend/app/acts/[id]/page.tsx
+++ b/frontend/app/acts/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import ActDetail from "./ActDetail";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd } from "@/lib/jsonld";
-import { stripTags } from "@/lib/seo";
+import { stripTags, buildLanguageAlternates} from "@/lib/seo";
 
 export const dynamic = "force-dynamic";
 
@@ -23,7 +23,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       description: desc,
       openGraph: { title, description: desc },
       twitter: { card: "summary_large_image" },
-      alternates: { canonical: `/acts/${id}` },
+      alternates: { canonical: `/acts/${id}`, languages: buildLanguageAlternates(`/acts/${id}`) },
     };
   } catch {
     return { title: "Spire Codex - Slay the Spire 2 Database" };

--- a/frontend/app/afflictions/[id]/page.tsx
+++ b/frontend/app/afflictions/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import AfflictionDetail from "./AfflictionDetail";
-import { stripTags } from "@/lib/seo";
+import { stripTags, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         description: metaDesc,
       },
       twitter: { card: "summary_large_image" },
-      alternates: { canonical: `/afflictions/${id}` },
+      alternates: { canonical: `/afflictions/${id}`, languages: buildLanguageAlternates(`/afflictions/${id}`) },
     };
   } catch {
     return { title: "Spire Codex - Slay the Spire 2 Database" };

--- a/frontend/app/ascensions/[id]/page.tsx
+++ b/frontend/app/ascensions/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import AscensionDetail from "./AscensionDetail";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { stripTags } from "@/lib/seo";
+import { stripTags, buildLanguageAlternates} from "@/lib/seo";
 
 export const dynamic = "force-dynamic";
 
@@ -24,7 +24,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       description: metaDesc,
       openGraph: { title, description: metaDesc },
       twitter: { card: "summary_large_image" },
-      alternates: { canonical: `/ascensions/${id}` },
+      alternates: { canonical: `/ascensions/${id}`, languages: buildLanguageAlternates(`/ascensions/${id}`) },
     };
   } catch {
     return { title: "Spire Codex - Slay the Spire 2 Database" };

--- a/frontend/app/badges/layout.tsx
+++ b/frontend/app/badges/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { buildLanguageAlternates } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Slay the Spire 2 (STS2) Badges - Run-End Awards | Spire Codex",
@@ -9,7 +10,7 @@ export const metadata: Metadata = {
     description:
       "All run-end badges in Slay the Spire 2 — see every badge, what it requires, and which are multiplayer-only.",
   },
-  alternates: { canonical: "/badges" },
+  alternates: { canonical: "/badges", languages: buildLanguageAlternates("/badges") },
 };
 
 export default function BadgesLayout({

--- a/frontend/app/cards/[id]/page.tsx
+++ b/frontend/app/cards/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import CardDetail from "./CardDetail";
-import { stripTags, stripTagsFlat } from "@/lib/seo";
+import { stripTags, stripTagsFlat, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         images: card.image_url ? [{ url: `${API_PUBLIC}${card.image_url}` }] : [],
       },
       twitter: { card: "summary_large_image" },
-      alternates: { canonical: `/cards/${id}` },
+      alternates: { canonical: `/cards/${id}`, languages: buildLanguageAlternates(`/cards/${id}`) },
     };
   } catch {
     return { title: "Spire Codex - Slay the Spire 2 Database" };

--- a/frontend/app/cards/browse/[slug]/page.tsx
+++ b/frontend/app/cards/browse/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { buildLanguageAlternates } from "@/lib/seo";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import type { Card } from "@/lib/api";
@@ -34,7 +35,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       description,
     },
     twitter: { card: "summary_large_image" },
-    alternates: { canonical: `/cards/browse/${slug}` },
+    alternates: { canonical: `/cards/browse/${slug}`, languages: buildLanguageAlternates(`/cards/browse/${slug}`) },
   };
 }
 

--- a/frontend/app/cards/layout.tsx
+++ b/frontend/app/cards/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { buildLanguageAlternates } from "@/lib/seo";
 import { api } from "@/lib/api";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -16,7 +17,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: "Slay the Spire 2 (STS2) Cards - Complete Card List | Spire Codex",
       description: `Browse all ${count} Slay the Spire 2 (STS2) cards. Filter by character, type, rarity, and keywords.`,
     },
-    alternates: { canonical: "/cards" },
+    alternates: { canonical: "/cards", languages: buildLanguageAlternates("/cards") },
   };
 }
 

--- a/frontend/app/components/EntityProse.tsx
+++ b/frontend/app/components/EntityProse.tsx
@@ -4,15 +4,25 @@ import { useLanguage } from "@/app/contexts/LanguageContext";
 import type { Relic, Potion, Power } from "@/lib/api";
 
 /**
- * Programmatic prose block sat at the bottom of each entity's Overview
- * tab. Uses already-localized fields (name, rarity, pool, etc.) from
- * the per-language API response so the page reads naturally in any
- * language without separate translations of fixed boilerplate.
+ * Programmatic prose block at the bottom of each entity's Overview
+ * tab. The prose is English-only — every locale used to render the
+ * SAME English boilerplate text on top of localized chrome, which
+ * Google's algorithm reads as duplicate content across translations
+ * and dumps the localized variants into "Crawled - currently not
+ * indexed" (~7,000 pages affected).
  *
- * The point is purely SEO weight: these pages used to be ~130 visible
- * words (image + 1-2 sentence description). Adding 60-100 words of
- * factual contextual prose — strictly derived from existing data — is
- * the simplest way to push them past Google's "thin content" floor.
+ * Behavior now:
+ * - English: full prose (60-100 words of factual contextual content
+ *   to push the page past Google's "thin content" floor)
+ * - Non-English: a single sentence built ENTIRELY from already-
+ *   localized API fields (name, rarity, pool — translated server-
+ *   side per language). No English connective text. This ensures
+ *   each locale's page body is genuinely different from the others
+ *   while still adding minimal SEO weight beyond the bare description.
+ *
+ * Long-term, full localized prose templates would be ideal — but
+ * those require professional translation of ~30 sentence patterns
+ * × 14 languages. Until then, this asymmetry preserves indexation.
  *
  * Three discriminated variants below; each entity detail page picks
  * the one that matches its data shape.
@@ -25,17 +35,22 @@ type Props = RelicProseProps | PotionProseProps | PowerProseProps;
 
 export default function EntityProse(props: Props) {
   const { lang } = useLanguage();
-  const intro = " ";
+  const isEnglish = lang === "eng";
 
   if (props.kind === "relic") {
     const r = props.relic;
     const name = r.name;
     const rarity = r.rarity;
     const pool = r.pool || "shared";
+
+    if (!isEnglish) {
+      // Non-English: single sentence using ONLY localized API fields.
+      // No English connective text → no duplicate-content signal.
+      return <Prose sentences={[`${name} · ${rarity} · ${pool}`]} />;
+    }
+
     const sentences: string[] = [];
-    sentences.push(
-      `${name} is a ${rarity} in the ${pool} relic pool.`
-    );
+    sentences.push(`${name} is a ${rarity} in the ${pool} relic pool.`);
     if (r.merchant_price?.min && r.merchant_price?.max) {
       sentences.push(
         `It can be purchased from the merchant for ${r.merchant_price.min}–${r.merchant_price.max} gold (typical range; exact prices use the standard ±15% banker's-rounded variance).`
@@ -48,7 +63,7 @@ export default function EntityProse(props: Props) {
     sentences.push(
       `Like every relic in Slay the Spire 2, ${name} can also appear as a card-reward replacement under specific conditions and is preserved across combats unless removed by an event.`
     );
-    return <Prose lang={lang} sentences={sentences} />;
+    return <Prose sentences={sentences} />;
   }
 
   if (props.kind === "potion") {
@@ -56,6 +71,11 @@ export default function EntityProse(props: Props) {
     const name = p.name;
     const rarity = p.rarity;
     const pool = (p as Potion & { pool?: string | null }).pool;
+
+    if (!isEnglish) {
+      return <Prose sentences={[`${name} · ${rarity}${pool ? ` · ${pool}` : ""}`]} />;
+    }
+
     const sentences: string[] = [];
     sentences.push(`${name} is a ${rarity} potion${pool ? ` in the ${pool} pool` : ""}.`);
     sentences.push(
@@ -64,7 +84,7 @@ export default function EntityProse(props: Props) {
     sentences.push(
       `${name} can be saved between combats and used at any point during your turn. Effects trigger immediately and the potion is consumed.`
     );
-    return <Prose lang={lang} sentences={sentences} />;
+    return <Prose sentences={sentences} />;
   }
 
   // power
@@ -72,10 +92,13 @@ export default function EntityProse(props: Props) {
   const name = pw.name;
   const type = pw.type || "Buff";
   const stack = pw.stack_type || "Counter";
+
+  if (!isEnglish) {
+    return <Prose sentences={[`${name} · ${type} · ${stack}`]} />;
+  }
+
   const sentences: string[] = [];
-  sentences.push(
-    `${name} is a ${type.toLowerCase()} power that stacks as ${stack}.`
-  );
+  sentences.push(`${name} is a ${type.toLowerCase()} power that stacks as ${stack}.`);
   if (type === "Buff") {
     sentences.push(
       `Buffs are positive effects on the recipient — applying ${name} to a player or ally improves their position; applying it to an enemy strengthens that enemy.`
@@ -98,10 +121,10 @@ export default function EntityProse(props: Props) {
       `${name} is not directly applied by any cards in the player's pool — it appears via enemy moves, relics, or events.`
     );
   }
-  return <Prose lang={lang} sentences={sentences} />;
+  return <Prose sentences={sentences} />;
 }
 
-function Prose({ lang: _lang, sentences }: { lang: string; sentences: string[] }) {
+function Prose({ sentences }: { sentences: string[] }) {
   return (
     <section className="mt-6 pt-5 border-t border-[var(--border-subtle)] text-sm leading-relaxed text-[var(--text-secondary)] space-y-2">
       {sentences.map((s, i) => (

--- a/frontend/app/enchantments/[id]/page.tsx
+++ b/frontend/app/enchantments/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import EnchantmentDetail from "./EnchantmentDetail";
-import { stripTags } from "@/lib/seo";
+import { stripTags, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 
@@ -27,7 +27,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         images: enchantment.image_url ? [{ url: `${API_PUBLIC}${enchantment.image_url}` }] : [],
       },
       twitter: { card: "summary_large_image" },
-      alternates: { canonical: `/enchantments/${id}` },
+      alternates: { canonical: `/enchantments/${id}`, languages: buildLanguageAlternates(`/enchantments/${id}`) },
     };
   } catch {
     return { title: "Spire Codex - Slay the Spire 2 Database" };

--- a/frontend/app/encounters/layout.tsx
+++ b/frontend/app/encounters/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { buildLanguageAlternates } from "@/lib/seo";
 import { api } from "@/lib/api";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -16,7 +17,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: "Slay the Spire 2 (STS2) Encounters - All Combat Encounters | Spire Codex",
       description: `Slay the Spire 2 (STS2) encounters — browse all ${count} combat encounters including normal fights, elites, and bosses.`,
     },
-    alternates: { canonical: "/encounters" },
+    alternates: { canonical: "/encounters", languages: buildLanguageAlternates("/encounters") },
   };
 }
 

--- a/frontend/app/events/layout.tsx
+++ b/frontend/app/events/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { buildLanguageAlternates } from "@/lib/seo";
 import { api } from "@/lib/api";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -16,7 +17,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: "Slay the Spire 2 (STS2) Events - All In-Game Events | Spire Codex",
       description: `Slay the Spire 2 (STS2) events — browse all ${count} shrine events, Ancient encounters, and story events with choices, dialogue, and outcomes.`,
     },
-    alternates: { canonical: "/events" },
+    alternates: { canonical: "/events", languages: buildLanguageAlternates("/events") },
   };
 }
 

--- a/frontend/app/guides/[slug]/page.tsx
+++ b/frontend/app/guides/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import type { Guide } from "@/lib/api";
-import { SITE_URL, SITE_NAME, stripTags } from "@/lib/seo";
+import { SITE_URL, SITE_NAME, stripTags, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd } from "@/lib/jsonld";
 import GuideDetail from "./GuideDetail";

--- a/frontend/app/guides/layout.tsx
+++ b/frontend/app/guides/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { buildLanguageAlternates } from "@/lib/seo";
 import { SITE_URL, SITE_NAME } from "@/lib/seo";
 
 export const metadata: Metadata = {

--- a/frontend/app/keywords/layout.tsx
+++ b/frontend/app/keywords/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { buildLanguageAlternates } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Slay the Spire 2 (STS2) Keywords - All Card Keywords | Spire Codex",
@@ -9,7 +10,7 @@ export const metadata: Metadata = {
     description:
       "Browse all card keywords in Slay the Spire 2 (STS2) — Exhaust, Ethereal, Innate, Retain, Sly, Eternal, and more.",
   },
-  alternates: { canonical: "/keywords" },
+  alternates: { canonical: "/keywords", languages: buildLanguageAlternates("/keywords") },
 };
 
 export default function KeywordsLayout({

--- a/frontend/app/leaderboards/scoring/page.tsx
+++ b/frontend/app/leaderboards/scoring/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { SITE_URL, SITE_NAME } from "@/lib/seo";
+import { SITE_URL, SITE_NAME, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
 import ScoreBadge from "@/app/components/ScoreBadge";
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   title: `Slay the Spire 2 (STS2) Codex Score - How Tier Ratings Work | ${SITE_NAME}`,
   description:
     "How the Codex Score rates every Slay the Spire 2 card, relic, and potion. Bayesian-shrunk win-rate formula, tier bands (S through F), and methodology behind the community-meta ratings.",
-  alternates: { canonical: `${SITE_URL}/leaderboards/scoring` },
+  alternates: { canonical: `${SITE_URL}/leaderboards/scoring`, languages: buildLanguageAlternates(`/leaderboards/scoring`) },
   openGraph: {
     title: `Codex Score Methodology | ${SITE_NAME}`,
     description:

--- a/frontend/app/mechanics/[slug]/page.tsx
+++ b/frontend/app/mechanics/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { SITE_URL, SITE_NAME } from "@/lib/seo";
+import { SITE_URL, SITE_NAME, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildDetailPageJsonLd } from "@/lib/jsonld";
 import Link from "next/link";

--- a/frontend/app/mechanics/page.tsx
+++ b/frontend/app/mechanics/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { SITE_URL, SITE_NAME } from "@/lib/seo";
+import { SITE_URL, SITE_NAME, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 import Link from "next/link";

--- a/frontend/app/merchant/layout.tsx
+++ b/frontend/app/merchant/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { buildLanguageAlternates } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Slay the Spire 2 (STS2) Merchant Guide - Shop Prices & Fake Merchant | Spire Codex",
@@ -9,7 +10,7 @@ export const metadata: Metadata = {
     description:
       "Complete merchant price guide for Slay the Spire 2. Card, relic, and potion costs by rarity. Fake Merchant relic effects.",
   },
-  alternates: { canonical: "/merchant" },
+  alternates: { canonical: "/merchant", languages: buildLanguageAlternates("/merchant") },
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/frontend/app/modifiers/[id]/page.tsx
+++ b/frontend/app/modifiers/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import ModifierDetail from "./ModifierDetail";
-import { stripTags } from "@/lib/seo";
+import { stripTags, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         description: metaDesc,
       },
       twitter: { card: "summary_large_image" },
-      alternates: { canonical: `/modifiers/${id}` },
+      alternates: { canonical: `/modifiers/${id}`, languages: buildLanguageAlternates(`/modifiers/${id}`) },
     };
   } catch {
     return { title: "Spire Codex - Slay the Spire 2 Database" };

--- a/frontend/app/monsters/layout.tsx
+++ b/frontend/app/monsters/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { buildLanguageAlternates } from "@/lib/seo";
 import { api } from "@/lib/api";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -16,7 +17,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: "Slay the Spire 2 (STS2) Monsters - Complete Monster List | Spire Codex",
       description: `Slay the Spire 2 (STS2) monsters — browse all ${count} normals, elites, and bosses. View HP, moves, and ascension scaling.`,
     },
-    alternates: { canonical: "/monsters" },
+    alternates: { canonical: "/monsters", languages: buildLanguageAlternates("/monsters") },
   };
 }
 

--- a/frontend/app/news/page.tsx
+++ b/frontend/app/news/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
-import { SITE_URL, SITE_NAME } from "@/lib/seo";
+import { SITE_URL, SITE_NAME, buildLanguageAlternates} from "@/lib/seo";
 import type { NewsArticle, NewsListResponse } from "@/lib/api";
 import { newsExcerpt, formatNewsDate, newsSlugForArticle } from "@/lib/steam-news";
 

--- a/frontend/app/orbs/[id]/page.tsx
+++ b/frontend/app/orbs/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import OrbDetail from "./OrbDetail";
-import { stripTags } from "@/lib/seo";
+import { stripTags, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         description: metaDesc,
       },
       twitter: { card: "summary_large_image" },
-      alternates: { canonical: `/orbs/${id}` },
+      alternates: { canonical: `/orbs/${id}`, languages: buildLanguageAlternates(`/orbs/${id}`) },
     };
   } catch {
     return { title: "Spire Codex - Slay the Spire 2 Database" };

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -10,7 +10,7 @@ import HomeFAQ from "./components/HomeFAQ";
 import JsonLd from "./components/JsonLd";
 import SearchTrigger from "./components/SearchTrigger";
 import { buildWebSiteJsonLd, buildVideoGameJsonLd } from "@/lib/jsonld";
-import { SITE_NAME, IS_BETA } from "@/lib/seo";
+import { SITE_NAME, IS_BETA, buildLanguageAlternates } from "@/lib/seo";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -26,6 +26,7 @@ export const metadata: Metadata = {
   twitter: { card: "summary_large_image", title, description },
   alternates: {
     canonical: "/",
+    languages: buildLanguageAlternates("/"),
   },
 };
 

--- a/frontend/app/potions/[id]/page.tsx
+++ b/frontend/app/potions/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import PotionDetail from "./PotionDetail";
-import { stripTags } from "@/lib/seo";
+import { stripTags, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 
@@ -27,7 +27,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         images: potion.image_url ? [{ url: `${API_PUBLIC}${potion.image_url}` }] : [],
       },
       twitter: { card: "summary_large_image" },
-      alternates: { canonical: `/potions/${id}` },
+      alternates: { canonical: `/potions/${id}`, languages: buildLanguageAlternates(`/potions/${id}`) },
     };
   } catch {
     return { title: "Spire Codex - Slay the Spire 2 Database" };

--- a/frontend/app/potions/layout.tsx
+++ b/frontend/app/potions/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { buildLanguageAlternates } from "@/lib/seo";
 import { api } from "@/lib/api";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -16,7 +17,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: "Slay the Spire 2 (STS2) Potions - Complete Potion List | Spire Codex",
       description: `Browse all ${count} Slay the Spire 2 (STS2) potions. Filter by rarity and character pool.`,
     },
-    alternates: { canonical: "/potions" },
+    alternates: { canonical: "/potions", languages: buildLanguageAlternates("/potions") },
   };
 }
 

--- a/frontend/app/powers/[id]/page.tsx
+++ b/frontend/app/powers/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import PowerDetail from "./PowerDetail";
-import { stripTags } from "@/lib/seo";
+import { stripTags, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 
@@ -27,7 +27,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         images: power.image_url ? [{ url: `${API_PUBLIC}${power.image_url}` }] : [],
       },
       twitter: { card: "summary_large_image" },
-      alternates: { canonical: `/powers/${id}` },
+      alternates: { canonical: `/powers/${id}`, languages: buildLanguageAlternates(`/powers/${id}`) },
     };
   } catch {
     return { title: "Spire Codex - Slay the Spire 2 Database" };

--- a/frontend/app/powers/layout.tsx
+++ b/frontend/app/powers/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { buildLanguageAlternates } from "@/lib/seo";
 import { api } from "@/lib/api";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -16,7 +17,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: "Slay the Spire 2 (STS2) Powers - Complete Power List | Spire Codex",
       description: `Browse all ${count} Slay the Spire 2 (STS2) powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior.`,
     },
-    alternates: { canonical: "/powers" },
+    alternates: { canonical: "/powers", languages: buildLanguageAlternates("/powers") },
   };
 }
 

--- a/frontend/app/relics/[id]/page.tsx
+++ b/frontend/app/relics/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import RelicDetail from "./RelicDetail";
-import { stripTags } from "@/lib/seo";
+import { stripTags, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 
@@ -27,7 +27,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         images: relic.image_url ? [{ url: `${API_PUBLIC}${relic.image_url}` }] : [],
       },
       twitter: { card: "summary_large_image" },
-      alternates: { canonical: `/relics/${id}` },
+      alternates: { canonical: `/relics/${id}`, languages: buildLanguageAlternates(`/relics/${id}`) },
     };
   } catch {
     return { title: "Spire Codex - Slay the Spire 2 Database" };

--- a/frontend/app/relics/layout.tsx
+++ b/frontend/app/relics/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { buildLanguageAlternates } from "@/lib/seo";
 import { api } from "@/lib/api";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -16,7 +17,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: "Slay the Spire 2 (STS2) Relics - Complete Relic List | Spire Codex",
       description: `Browse all ${count} Slay the Spire 2 (STS2) relics. Filter by rarity and character pool. View relic effects and images.`,
     },
-    alternates: { canonical: "/relics" },
+    alternates: { canonical: "/relics", languages: buildLanguageAlternates("/relics") },
   };
 }
 

--- a/frontend/app/tier-list/cards/page.tsx
+++ b/frontend/app/tier-list/cards/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { SITE_URL, SITE_NAME } from "@/lib/seo";
+import { SITE_URL, SITE_NAME, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 import TierList, { type TierEntity } from "@/app/components/TierList";
@@ -49,7 +49,7 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
   return {
     title,
     description,
-    alternates: { canonical: `${SITE_URL}${path}` },
+    alternates: { canonical: `${SITE_URL}${path}`, languages: buildLanguageAlternates(`${path}`) },
     openGraph: {
       title,
       description,

--- a/frontend/app/tier-list/page.tsx
+++ b/frontend/app/tier-list/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { SITE_URL, SITE_NAME } from "@/lib/seo";
+import { SITE_URL, SITE_NAME, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import ScoreBadge from "@/app/components/ScoreBadge";
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
   title: `STS2 Tier List - Slay the Spire 2 Cards, Relics & Potions Ranked | ${SITE_NAME}`,
   description:
     "STS2 / Slay the Spire 2 tier list ranking every card, relic, and potion S through F. Codex Score from community win rates. Updated daily after every patch.",
-  alternates: { canonical: `${SITE_URL}/tier-list` },
+  alternates: { canonical: `${SITE_URL}/tier-list`, languages: buildLanguageAlternates(`/tier-list`) },
   openGraph: {
     title: `STS2 Tier List | ${SITE_NAME}`,
     description: "Every Slay the Spire 2 card, relic, and potion ranked S → F based on community win-rate data.",

--- a/frontend/app/tier-list/potions/page.tsx
+++ b/frontend/app/tier-list/potions/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { SITE_URL, SITE_NAME } from "@/lib/seo";
+import { SITE_URL, SITE_NAME, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 import TierList, { type TierEntity } from "@/app/components/TierList";

--- a/frontend/app/tier-list/relics/page.tsx
+++ b/frontend/app/tier-list/relics/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { SITE_URL, SITE_NAME } from "@/lib/seo";
+import { SITE_URL, SITE_NAME, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 import TierList, { type TierEntity } from "@/app/components/TierList";
@@ -47,7 +47,7 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
   return {
     title,
     description,
-    alternates: { canonical: `${SITE_URL}${path}` },
+    alternates: { canonical: `${SITE_URL}${path}`, languages: buildLanguageAlternates(`${path}`) },
     openGraph: { title, description, url: `${SITE_URL}${path}`, siteName: SITE_NAME, type: "website" },
   };
 }

--- a/frontend/app/unlocks/page.tsx
+++ b/frontend/app/unlocks/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
+import { buildLanguageAlternates } from "@/lib/seo";
 import UnlocksClient from "./UnlocksClient";
 
 export const metadata: Metadata = {
   title: "Slay the Spire 2 (STS2) Unlocks - All Unlockable Cards, Relics & Potions | Spire Codex",
   description:
     "Complete list of all unlockable content in Slay the Spire 2 — 60 cards, 45 relics, 21 potions, and 4 characters unlocked through timeline progression.",
-  alternates: { canonical: "/unlocks" },
+  alternates: { canonical: "/unlocks", languages: buildLanguageAlternates("/unlocks") },
 };
 
 export default function Page() {

--- a/frontend/lib/seo.ts
+++ b/frontend/lib/seo.ts
@@ -1,8 +1,37 @@
+import { SUPPORTED_LANGS, LANG_HREFLANG } from "./languages";
+
 export const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL || "https://spire-codex.com";
 export const IS_BETA = SITE_URL.includes("beta.");
 export const SITE_NAME = IS_BETA ? "Spire Codex (Beta)" : "Spire Codex";
 export const DEFAULT_OG_IMAGE = `${SITE_URL}/og-image.png`;
+
+/**
+ * Build the `alternates.languages` map for a given English-side path,
+ * pointing to every supported locale variant + `x-default`.
+ *
+ * Bidirectional hreflang is the indexation signal Google uses to
+ * disambiguate translated copies — without it, Google sees /cards and
+ * /jpn/cards as competing for the same query and picks ONE to index,
+ * dumping the rest into "Crawled - currently not indexed". With it,
+ * each locale variant indexes on its own and gets served to its
+ * matching audience.
+ *
+ * Pass the bare path with no /[lang]/ prefix (e.g. "/cards", "/relics"
+ * or "/cards/strike"). Returns a Record<hreflang, fullURL> ready to
+ * spread into Next.js `alternates.languages`.
+ */
+export function buildLanguageAlternates(path: string): Record<string, string> {
+  const trimmed = path.startsWith("/") ? path : `/${path}`;
+  const map: Record<string, string> = {
+    en: `${SITE_URL}${trimmed}`,
+    "x-default": `${SITE_URL}${trimmed}`,
+  };
+  for (const code of SUPPORTED_LANGS) {
+    map[LANG_HREFLANG[code]] = `${SITE_URL}/${code}${trimmed}`;
+  }
+  return map;
+}
 
 export function stripTags(text: string): string {
   return text


### PR DESCRIPTION
## Why
GSC reports show **7,272 pages "Crawled - currently not indexed"** + **1,772 "Duplicate without user-selected canonical"**. Most are localized pages (`/jpn/cards/strike`, `/deu/relics/sozu` etc.) that Google decided are duplicate-y of their English counterparts and refused to index.

Diagnosed two specific signal problems hidden under the symptom:

## Fix 1 — Bidirectional hreflang
Localized pages declare hreflang to all 13 sibling locales + English. **English-side pages never declared their localized variants.** Without the back-link, Google sees `/cards` and `/jpn/cards` as competing pages and picks ONE to index — dumping the rest into "Crawled, not indexed."

New helper `buildLanguageAlternates(path)` in `lib/seo.ts` returns the full `alternates.languages` map. Threaded through every English-side surface:

- **11 list-page layouts** (cards / relics / potions / monsters / powers / events / encounters / keywords / badges / guides / merchant)
- **18 detail-page generators** (every entity type's `[id]/page.tsx` + mechanics + tier-list + browse + news)
- **Home page**
- **4 tier-list pages**

## Fix 2 — Locale-aware EntityProse
`EntityProse` shipped 60-100 words of **identical English boilerplate** at the bottom of every entity Overview, on top of localized chrome. Google's near-duplicate detection ate it.

Now:
- **English** renders full prose as before
- **Non-English** renders a single sentence built ENTIRELY from already-localized API fields (`name · rarity · pool`). No English connectives. Each locale is genuinely different.

Long-term: professionally translate `~30 sentence patterns × 14 languages`. Until then, asymmetric rendering preserves indexation without shipping duplicate text.

## What should improve in GSC (~weeks, not days)
- ✅ `1,772 Duplicate without user-selected canonical` — bidirectional hreflang gives Google the canonical assignment for each locale
- ✅ `7,272 Crawled - currently not indexed` — localized pages now have distinct hreflang AND distinct content
- ✅ `122 Google chose different canonical` — same mechanism

## What this **won't** fix
- 879 hard 404s — separate audit needed (sitemap stale entries, removed paths)
- 988 Discovered-not-crawled — crawl budget recovery is gradual; smaller sitemap would help but is its own discussion