### PR TITLE
Fix /mechanics/potion-drop-rates — contradictions + wrong Elite math

### DIFF
--- a/data/mechanics_pages/potion-drop-rates.md
+++ b/data/mechanics_pages/potion-drop-rates.md
@@ -1,18 +1,26 @@
 ---
 title: Potion Drop Rates
-description: Potion drop chances from combat with adaptive pity system. Base 40% chance, capped at 50%, with elite bonus.
+description: Potion drop chances from combat with an adaptive pity system. Starts at 40%, ±10% per combat, no hard cap. Elite encounters add a 12.5% effective bonus that doesn't move pity.
 category: mechanics
 order: 3
 ---
 
 ## Combat Rewards
 
-| Encounter | Base Chance |
+| Encounter | Drop Chance |
 |-----------|------------:|
-| Normal | {{constants.potion_reward_odds._basePotionRewardOdds | pct}} |
-| Elite | ~52.5% |
+| Normal monster | pity counter (starts at {{constants.potion_reward_odds._basePotionRewardOdds | pct}}) |
+| Elite | pity counter + 12.5% bonus |
+| Boss | pity counter (same as Normal) |
+| Treasure / Shop / Event / Rest | no roll, no pity change |
 
-> **Pity system:** +10% each fight without a potion, -10% when one drops. No hard cap in the code. Elite fights add a flat +{{constants.potion_reward_odds.eliteBonus | pct}} bonus without affecting the pity counter. The adaptive counter targets {{constants.potion_reward_odds.targetOdds | pct}}.
+> **Pity counter (`PotionRewardOdds.CurrentValue`):**
+> Starts at {{constants.potion_reward_odds._basePotionRewardOdds | pct}}. After each combat the counter moves ±10% — **down 10%** if a potion drops, **up 10%** if not. There is **no hard cap** in the code (the underlying `AbstractOdds.CurrentValue` is an unclamped `float`). The constant `targetOdds = {{constants.potion_reward_odds.targetOdds | pct}}` is a design target, not an enforced ceiling.
+
+> **Elite bonus:**
+> The source constant `eliteBonus = {{constants.potion_reward_odds.eliteBonus | pct}}` is *halved* when applied to the roll: `currentValue + eliteBonus * 0.5`. So the **effective** Elite bonus is **+12.5%**, not +25%. The bonus is **freebie territory** — if your random roll lands between the bare pity counter and the bonus zone, you get the potion *and* pity still ticks up by 10% (the pity check uses the bare counter, not the post-bonus value).
+
+> **Bosses roll just like monsters.** The reward switch in `RewardsSet.GenerateRewardsForRoom` calls the same `RollForPotionAndAddTo` path for `Monster`, `Elite`, and `Boss`. Bosses don't get the Elite bonus, so they roll against the bare pity counter, and the result *does* move the counter ±10% like any other combat.
 
 ## Rarity Distribution
 

--- a/data/mechanics_pages/potion-drop-rates.md
+++ b/data/mechanics_pages/potion-drop-rates.md
@@ -22,6 +22,22 @@ order: 3
 
 > **Bosses roll just like monsters.** The reward switch in `RewardsSet.GenerateRewardsForRoom` calls the same `RollForPotionAndAddTo` path for `Monster`, `Elite`, and `Boss`. Bosses don't get the Elite bonus, so they roll against the bare pity counter, and the result *does* move the counter ±10% like any other combat.
 
+### Elite drops create hidden pity state
+
+A subtle consequence of the bonus being decoupled from the pity check: **after a potion drops from an Elite, you can't tell which direction your pity counter moved.** Walking through the three roll outcomes:
+
+| Roll lands at... | Drop? | Pity moves |
+|---|------:|------:|
+| `num < currentValue` | ✅ | **−10%** |
+| `currentValue ≤ num < currentValue + 0.125` | ✅ | **+10%** |
+| `num ≥ currentValue + 0.125` | ❌ | **+10%** |
+
+Both successful-drop cases look identical to the player — you just see a potion. But internally, the pity counter is now in one of two states 20 percentage points apart. For Normal monsters and Bosses (no bonus zone), `drop ⇒ pity went down` and `no-drop ⇒ pity went up` are clean inverses. Elites break that.
+
+The asymmetry has a real gameplay implication: **the lower your pity is going into an Elite, the more likely a drop is from the bonus zone** (because most of the bare counter is below your random roll), so **pity ticks UP despite the drop**. Counter-intuitive but mechanically correct.
+
+If you're trying to time potion drops around predictable pity movements, prefer routing through Normal/Boss fights where the signal is unambiguous.
+
 ## Rarity Distribution
 
 | Rarity | Chance |


### PR DESCRIPTION
## Bugs caught by a reader

### 1. Frontmatter contradicted the body
- Frontmatter: *"Base 40% chance, **capped at 50%**"*
- Body: *"**No hard cap** in the code."*

The body was right. Verified in `AbstractOdds.cs`:
```csharp
public abstract class AbstractOdds(float initialValue, Rng rng)
{
    public float CurrentValue { get; protected set; } = initialValue;
    public void OverrideCurrentValue(float newValue) { CurrentValue = newValue; }
}
```
Plain unclamped float. The constant `targetOdds = 0.5f` is a *design target*, not an enforced ceiling. Removed the cap claim.

### 2. Elite bonus rendered as +25% but actually +12.5%
The page pulled `eliteBonus = 0.25f` (the named constant) directly. But `PotionRewardOdds.Roll()` halves it when applied:

```csharp
return num < currentValue + num3 * 0.5f;   // num3 = 0.25 → effective +12.5%
```

The page now leads with the **effective** +12.5% and explains the halving as a footnote. The Elite chance (~52.5% from base 40 + bonus 12.5) was always correct, but the math wasn't reconcilable with the `+25%` wording shown next to it.

### 3. Missing rows for Boss + non-combat
Added explicitly:
- **Boss** rolls like Normal (no Elite bonus), and *does* move pity. Verified via `RewardsSet.cs` reward switch routing Monster/Elite/Boss through the same `RollForPotionAndAddTo` path.
- **Treasure / Shop / Event / Rest** — don't roll, don't change pity.

### 4. Clarified the Elite "freebie" zone
The bonus gives a drop *without* moving the pity counter — because the pity check uses bare `currentValue` while the drop check uses `currentValue + 0.125`. If your roll lands in that 12.5% gap, you get the potion AND your pity still ticks up by 10%. Important for build planning.