### PR TITLE
Unify metadata title format across every page

### DIFF
--- a/frontend/app/[lang]/achievements/[id]/page.tsx
+++ b/frontend/app/[lang]/achievements/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/achievements/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Achievement Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Achievement Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const entity = await res.json();
     const desc = stripTags(entity.description || "");
     const langCode = lang as LangCode;

--- a/frontend/app/[lang]/acts/[id]/page.tsx
+++ b/frontend/app/[lang]/acts/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/acts/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Act Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Act Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const act = await res.json();
     const langCode = lang as LangCode;
     const gameName = LANG_GAME_NAME[langCode];

--- a/frontend/app/[lang]/afflictions/[id]/page.tsx
+++ b/frontend/app/[lang]/afflictions/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/afflictions/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Affliction Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Affliction Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const entity = await res.json();
     const desc = stripTags(entity.description || "");
     const langCode = lang as LangCode;

--- a/frontend/app/[lang]/ascensions/[id]/page.tsx
+++ b/frontend/app/[lang]/ascensions/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/ascensions/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Ascension Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Ascension Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const asc = await res.json();
     const desc = stripTags(asc.description);
     const langCode = lang as LangCode;

--- a/frontend/app/[lang]/badges/[id]/page.tsx
+++ b/frontend/app/[lang]/badges/[id]/page.tsx
@@ -63,7 +63,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
 
   const badge = await fetchBadge(id, lang);
-  if (!badge) return { title: "Badge Not Found - Spire Codex" };
+  if (!badge) return { title: "Badge Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
 
   const desc = stripTags(badge.description);
   const langCode = lang as LangCode;

--- a/frontend/app/[lang]/cards/[id]/page.tsx
+++ b/frontend/app/[lang]/cards/[id]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/cards/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Card Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Card Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const card = await res.json();
     const langCode = lang as LangCode;
     const gameName = LANG_GAME_NAME[langCode];

--- a/frontend/app/[lang]/characters/[id]/page.tsx
+++ b/frontend/app/[lang]/characters/[id]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/characters/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Character Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Character Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const entity = await res.json();
     const desc = stripTags(entity.description || "");
     const langCode = lang as LangCode;

--- a/frontend/app/[lang]/compare/[pair]/page.tsx
+++ b/frontend/app/[lang]/compare/[pair]/page.tsx
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { lang, pair } = await params;
   if (!isValidLang(lang)) return {};
   const parsed = parsePair(pair);
-  if (!parsed) return { title: "Comparison Not Found - Spire Codex" };
+  if (!parsed) return { title: "Comparison Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
 
   const langCode = lang as LangCode;
   const gameName = LANG_GAME_NAME[langCode];

--- a/frontend/app/[lang]/enchantments/[id]/page.tsx
+++ b/frontend/app/[lang]/enchantments/[id]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/enchantments/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Enchantment Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Enchantment Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const entity = await res.json();
     const desc = stripTags(entity.description || "");
     const langCode = lang as LangCode;

--- a/frontend/app/[lang]/encounters/[id]/page.tsx
+++ b/frontend/app/[lang]/encounters/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/encounters/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Encounter Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Encounter Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const entity = await res.json();
     const langCode = lang as LangCode;
     const gameName = LANG_GAME_NAME[langCode];

--- a/frontend/app/[lang]/events/[id]/page.tsx
+++ b/frontend/app/[lang]/events/[id]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/events/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Event Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Event Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const entity = await res.json();
     const desc = stripTags(entity.description || "");
     const langCode = lang as LangCode;

--- a/frontend/app/[lang]/intents/[id]/page.tsx
+++ b/frontend/app/[lang]/intents/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/intents/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Intent Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Intent Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const entity = await res.json();
     const desc = stripTags(entity.description || "");
     const langCode = lang as LangCode;

--- a/frontend/app/[lang]/keywords/[id]/page.tsx
+++ b/frontend/app/[lang]/keywords/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/keywords/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Keyword Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Keyword Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const kw = await res.json();
     const desc = stripTags(kw.description);
     const langCode = lang as LangCode;

--- a/frontend/app/[lang]/modifiers/[id]/page.tsx
+++ b/frontend/app/[lang]/modifiers/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/modifiers/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Modifier Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Modifier Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const entity = await res.json();
     const desc = stripTags(entity.description || "");
     const langCode = lang as LangCode;

--- a/frontend/app/[lang]/monsters/[id]/page.tsx
+++ b/frontend/app/[lang]/monsters/[id]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/monsters/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Monster Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Monster Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const entity = await res.json();
     const desc = stripTags(entity.description || "");
     const langCode = lang as LangCode;

--- a/frontend/app/[lang]/orbs/[id]/page.tsx
+++ b/frontend/app/[lang]/orbs/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/orbs/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Orb Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Orb Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const entity = await res.json();
     const desc = stripTags(entity.description || "");
     const langCode = lang as LangCode;

--- a/frontend/app/[lang]/potions/[id]/page.tsx
+++ b/frontend/app/[lang]/potions/[id]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/potions/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Potion Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Potion Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const entity = await res.json();
     const desc = stripTags(entity.description || "");
     const langCode = lang as LangCode;

--- a/frontend/app/[lang]/powers/[id]/page.tsx
+++ b/frontend/app/[lang]/powers/[id]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/powers/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Power Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Power Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const entity = await res.json();
     const desc = stripTags(entity.description || "");
     const langCode = lang as LangCode;

--- a/frontend/app/[lang]/relics/[id]/page.tsx
+++ b/frontend/app/[lang]/relics/[id]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!isValidLang(lang)) return {};
   try {
     const res = await fetch(`${API_INTERNAL}/api/relics/${id}?lang=${lang}`);
-    if (!res.ok) return { title: "Relic Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Relic Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const entity = await res.json();
     const desc = stripTags(entity.description || "");
     const langCode = lang as LangCode;

--- a/frontend/app/[lang]/runs/[hash]/page.tsx
+++ b/frontend/app/[lang]/runs/[hash]/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   try {
     const res = await fetch(`${API_INTERNAL}/api/runs/shared/${hash}`);
-    if (!res.ok) return { title: "Run Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Run Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const run = await res.json();
     const char = run.players?.[0]?.character?.replace("CHARACTER.", "") || "";
     const resultKey = run.win

--- a/frontend/app/about/layout.tsx
+++ b/frontend/app/about/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Database - About | Spire Codex",
+  title: "Database - About - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "About Spire Codex — a community-built database for Slay the Spire 2. Learn about the data pipeline, tech stack, and how the site works.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Database - About | Spire Codex",
+    title: "Database - About - Slay the Spire 2 (sts2) | Spire Codex",
     description:
       "About Spire Codex — a community-built database for Slay the Spire 2.",
   },

--- a/frontend/app/achievements/[id]/page.tsx
+++ b/frontend/app/achievements/[id]/page.tsx
@@ -12,10 +12,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/achievements/${id}`);
-    if (!res.ok) return { title: "Achievement Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Achievement Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const achievement = await res.json();
     const desc = stripTags(achievement.description || "");
-    const title = `Slay the Spire 2 (STS2) Achievement - ${achievement.name} | Spire Codex`;
+    const title = `Achievement - ${achievement.name} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `${achievement.name} is an achievement in Slay the Spire 2: ${desc}`;
     return {
       title,
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/achievements/${id}`, languages: buildLanguageAlternates(`/achievements/${id}`) },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/acts/[id]/page.tsx
+++ b/frontend/app/acts/[id]/page.tsx
@@ -14,9 +14,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/acts/${id}`);
-    if (!res.ok) return { title: "Act Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Act Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const act = await res.json();
-    const title = `Slay the Spire 2 (STS2) Act - ${act.name} | Spire Codex`;
+    const title = `Act - ${act.name} - Slay the Spire 2 (sts2) | Spire Codex`;
     const desc = `${act.name} in Slay the Spire 2: ${act.num_rooms || "?"} rooms, ${act.bosses.length} bosses, ${act.encounters.length} encounters, ${act.events.length} events.`;
     return {
       title,
@@ -26,7 +26,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/acts/${id}`, languages: buildLanguageAlternates(`/acts/${id}`) },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/afflictions/[id]/page.tsx
+++ b/frontend/app/afflictions/[id]/page.tsx
@@ -12,10 +12,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/afflictions/${id}`);
-    if (!res.ok) return { title: "Affliction Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Affliction Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const affliction = await res.json();
     const desc = stripTags(affliction.description || "");
-    const title = `Slay the Spire 2 (STS2) Affliction - ${affliction.name} | Spire Codex`;
+    const title = `Affliction - ${affliction.name} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `${affliction.name} is an affliction in Slay the Spire 2: ${desc}`;
     return {
       title,
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/afflictions/${id}`, languages: buildLanguageAlternates(`/afflictions/${id}`) },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/ancients/page.tsx
+++ b/frontend/app/ancients/page.tsx
@@ -4,7 +4,7 @@ import AncientsClient from "./AncientsClient";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Ancient Relic Pools - All Ancient Offerings | Spire Codex",
+  title: "Ancient Relic Pools - All Ancient Offerings - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "Complete relic pool data for all 8 Ancients in Slay the Spire 2: Neow, Tezcatara, Pael, Orobas, Darv, Nonupeipe, Tanx, and Vakuu. See every relic they can offer and the conditions.",
 };

--- a/frontend/app/ascensions/[id]/page.tsx
+++ b/frontend/app/ascensions/[id]/page.tsx
@@ -14,10 +14,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/ascensions/${id}`);
-    if (!res.ok) return { title: "Ascension Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Ascension Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const asc = await res.json();
     const desc = stripTags(asc.description);
-    const title = `Slay the Spire 2 (STS2) Ascension - Level ${asc.level} - ${asc.name} | Spire Codex`;
+    const title = `Ascension - Level ${asc.level} - ${asc.name} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `Ascension ${asc.level} (${asc.name}) in Slay the Spire 2: ${desc}`;
     return {
       title,
@@ -27,7 +27,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/ascensions/${id}`, languages: buildLanguageAlternates(`/ascensions/${id}`) },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/badges/[id]/page.tsx
+++ b/frontend/app/badges/[id]/page.tsx
@@ -58,11 +58,11 @@ async function fetchBadge(id: string): Promise<Badge | null> {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   const badge = await fetchBadge(id);
-  if (!badge) return { title: "Badge Not Found - Spire Codex" };
+  if (!badge) return { title: "Badge Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
 
   const desc = stripTags(badge.description);
   const subtype = badge.tiered ? "Tiered" : "Badge";
-  const title = `Slay the Spire 2 (STS2) Badge - ${badge.name} - ${subtype} | Spire Codex`;
+  const title = `Badge - ${badge.name} - ${subtype} - Slay the Spire 2 (sts2) | Spire Codex`;
   const metaDesc = `${badge.name} run-end badge in Slay the Spire 2: ${desc}`;
   return {
     title,

--- a/frontend/app/badges/layout.tsx
+++ b/frontend/app/badges/layout.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from "next";
 import { buildLanguageAlternates } from "@/lib/seo";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Badges - Run-End Awards | Spire Codex",
+  title: "Badges - Run-End Awards - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "All run-end badges in Slay the Spire 2 — Big Deck, Perfect, Speedy, KaChing, and more. Bronze, Silver, and Gold tiers. Awarded on the Game Over screen.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Badges - Run-End Awards | Spire Codex",
+    title: "Badges - Run-End Awards - Slay the Spire 2 (sts2) | Spire Codex",
     description:
       "All run-end badges in Slay the Spire 2 — see every badge, what it requires, and which are multiplayer-only.",
   },

--- a/frontend/app/badges/page.tsx
+++ b/frontend/app/badges/page.tsx
@@ -44,7 +44,7 @@ export default async function BadgesPage() {
     buildCollectionPageJsonLd({
       name: "Slay the Spire 2 Badges",
       description:
-        "All run-end badges in Slay the Spire 2 (STS2) — Bronze, Silver, and Gold tier mini-achievements awarded on the Game Over screen.",
+        "All run-end badges in Slay the Spire 2 (sts2) — Bronze, Silver, and Gold tier mini-achievements awarded on the Game Over screen.",
       path: "/badges",
       items: badges.map((b) => ({
         name: b.name,
@@ -57,7 +57,7 @@ export default async function BadgesPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Badges</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (sts2) Badges</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Run-end badges are mini-achievements awarded on the Game Over screen.

--- a/frontend/app/cards/[id]/page.tsx
+++ b/frontend/app/cards/[id]/page.tsx
@@ -13,11 +13,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/cards/${id}`);
-    if (!res.ok) return { title: "Card Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Card Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const card = await res.json();
     const desc = stripTags(card.description || "");
     const color = (card.color || "").replace(/^\w/, (c: string) => c.toUpperCase());
-    const title = `Slay the Spire 2 (STS2) Card - ${card.name} - ${card.rarity} ${card.type} | Spire Codex`;
+    const title = `Card - ${card.name} - ${card.rarity} ${card.type} - Slay the Spire 2 (sts2) | Spire Codex`;
     const descFlat = stripTagsFlat(card.description || "");
     const keywords = card.keywords?.length ? ` ${card.keywords.join(". ")}.` : "";
     const metaDesc = `${card.name} is a ${card.cost ?? "X"} cost ${card.rarity} ${card.type} used by ${color}.\n${descFlat}${keywords}`;
@@ -33,7 +33,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/cards/${id}`, languages: buildLanguageAlternates(`/cards/${id}`) },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/cards/browse/[slug]/page.tsx
+++ b/frontend/app/cards/browse/[slug]/page.tsx
@@ -21,17 +21,17 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
   const entry = SLUG_MAP[slug];
   if (!entry) {
-    return { title: "Not Found - Spire Codex" };
+    return { title: "Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 
-  const title = `Slay the Spire 2 (STS2) ${entry.label} - Browse Cards | Spire Codex`;
+  const title = `${entry.label} - Browse Cards - Slay the Spire 2 (sts2) | Spire Codex`;
   const description = entry.description;
 
   return {
     title,
     description,
     openGraph: {
-      title: `Slay the Spire 2 (STS2) ${entry.label} | Spire Codex`,
+      title: `${entry.label} - Slay the Spire 2 (sts2) | Spire Codex`,
       description,
     },
     twitter: { card: "summary_large_image" },

--- a/frontend/app/cards/browse/layout.tsx
+++ b/frontend/app/cards/browse/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Cards - Browse by Category | Spire Codex",
+  title: "Cards - Browse by Category - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "Browse Slay the Spire 2 cards by type, rarity, character, and keyword. Find all Attack, Skill, and Power cards across Ironclad, Silent, Defect, Necrobinder, and Regent.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Cards - Browse by Category | Spire Codex",
+    title: "Cards - Browse by Category - Slay the Spire 2 (sts2) | Spire Codex",
     description:
       "Browse Slay the Spire 2 cards by type, rarity, character, and keyword.",
   },

--- a/frontend/app/cards/layout.tsx
+++ b/frontend/app/cards/layout.tsx
@@ -11,11 +11,11 @@ export async function generateMetadata(): Promise<Metadata> {
     // Fall back to the baseline count if the API is unreachable at build time.
   }
   return {
-    title: "Slay the Spire 2 (STS2) Cards - Complete Card List | Spire Codex",
-    description: `Browse all ${count} Slay the Spire 2 (STS2) cards. Filter by character (Ironclad, Silent, Defect, Necrobinder, Regent), type, rarity, and keywords. View card art, stats, upgrades, and related cards.`,
+    title: "Cards - Complete Card List - Slay the Spire 2 (sts2) | Spire Codex",
+    description: `Browse all ${count} Slay the Spire 2 (sts2) cards. Filter by character (Ironclad, Silent, Defect, Necrobinder, Regent), type, rarity, and keywords. View card art, stats, upgrades, and related cards.`,
     openGraph: {
-      title: "Slay the Spire 2 (STS2) Cards - Complete Card List | Spire Codex",
-      description: `Browse all ${count} Slay the Spire 2 (STS2) cards. Filter by character, type, rarity, and keywords.`,
+      title: "Cards - Complete Card List - Slay the Spire 2 (sts2) | Spire Codex",
+      description: `Browse all ${count} Slay the Spire 2 (sts2) cards. Filter by character, type, rarity, and keywords.`,
     },
     alternates: { canonical: "/cards", languages: buildLanguageAlternates("/cards") },
   };

--- a/frontend/app/cards/page.tsx
+++ b/frontend/app/cards/page.tsx
@@ -31,7 +31,7 @@ export default async function CardsPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Cards</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (sts2) Cards</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every card across Ironclad, Silent, Defect, Necrobinder, and Regent. Filter by character, type, rarity, and keywords.

--- a/frontend/app/changelog/layout.tsx
+++ b/frontend/app/changelog/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Changelog - Update History | Spire Codex",
+  title: "Changelog - Update History - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "Slay the Spire 2 update history and Spire Codex changelog. Track game patches, balance changes, and new content additions.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Changelog - Update History | Spire Codex",
+    title: "Changelog - Update History - Slay the Spire 2 (sts2) | Spire Codex",
     description:
       "Slay the Spire 2 update history and Spire Codex changelog. Track patches, balance changes, and new content.",
   },

--- a/frontend/app/characters/[id]/page.tsx
+++ b/frontend/app/characters/[id]/page.tsx
@@ -13,10 +13,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/characters/${id}`);
-    if (!res.ok) return { title: "Character Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Character Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const char = await res.json();
     const desc = stripTags(char.description || "");
-    const title = `Slay the Spire 2 (STS2) Character - ${char.name} | Spire Codex`;
+    const title = `Character - ${char.name} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `${char.name} is a playable character in Slay the Spire 2. ${char.starting_hp ? `${char.starting_hp} HP, ${char.max_energy} Energy.` : ""} ${desc}`;
     return {
       title,
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/characters/${id}` },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/characters/layout.tsx
+++ b/frontend/app/characters/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Characters - All Playable Characters | Spire Codex",
+  title: "Characters - All Playable Characters - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "Slay the Spire 2 characters — Ironclad, Silent, Defect, Necrobinder, and Regent. View starting decks, relics, HP, gold, energy stats, and NPC dialogues for every character.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Characters - All Playable Characters | Spire Codex",
+    title: "Characters - All Playable Characters - Slay the Spire 2 (sts2) | Spire Codex",
     description:
       "Slay the Spire 2 characters — Ironclad, Silent, Defect, Necrobinder, and Regent. Starting decks, relics, stats, and more.",
   },

--- a/frontend/app/characters/page.tsx
+++ b/frontend/app/characters/page.tsx
@@ -29,7 +29,7 @@ export default async function CharactersPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Characters</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (sts2) Characters</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         All playable characters in Slay the Spire 2 — view starting decks, relics, HP, gold, energy, and more.

--- a/frontend/app/compare/[pair]/page.tsx
+++ b/frontend/app/compare/[pair]/page.tsx
@@ -42,18 +42,18 @@ type Props = { params: Promise<{ pair: string }> };
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { pair } = await params;
   const parsed = parsePair(pair);
-  if (!parsed) return { title: "Comparison Not Found - Spire Codex" };
+  if (!parsed) return { title: "Comparison Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
 
   const nameA = CHAR_NAMES[parsed.a];
   const nameB = CHAR_NAMES[parsed.b];
-  const title = `Slay the Spire 2 (STS2) ${nameA} vs ${nameB} - Character Comparison | Spire Codex`;
+  const title = `${nameA} vs ${nameB} - Character Comparison - Slay the Spire 2 (sts2) | Spire Codex`;
   const description = `Compare ${nameA} and ${nameB} in Slay the Spire 2. Side-by-side stats, card pool breakdowns by type and rarity, keyword distributions, and starting decks.`;
 
   return {
     title,
     description,
     openGraph: {
-      title: `Slay the Spire 2 (STS2) ${nameA} vs ${nameB} - Character Comparison | Spire Codex`,
+      title: `${nameA} vs ${nameB} - Character Comparison - Slay the Spire 2 (sts2) | Spire Codex`,
       description,
     },
     twitter: { card: "summary_large_image" },

--- a/frontend/app/compare/layout.tsx
+++ b/frontend/app/compare/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Character Comparisons - Side by Side | Spire Codex",
+  title: "Character Comparisons - Side by Side - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "Compare Slay the Spire 2 characters side by side. View stat differences, card pool breakdowns, keyword distributions, and starting decks for Ironclad, Silent, Defect, Necrobinder, and Regent.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Character Comparisons - Side by Side | Spire Codex",
+    title: "Character Comparisons - Side by Side - Slay the Spire 2 (sts2) | Spire Codex",
     description:
       "Compare Slay the Spire 2 characters side by side. Stats, card pools, keywords, and starting decks.",
   },

--- a/frontend/app/compare/page.tsx
+++ b/frontend/app/compare/page.tsx
@@ -49,7 +49,7 @@ export default function ComparePage() {
     buildCollectionPageJsonLd({
       name: "Slay the Spire 2 Character Comparisons",
       description:
-        "Compare all Slay the Spire 2 (STS2) characters side by side. Stats, card pools, keywords, and starting decks.",
+        "Compare all Slay the Spire 2 (sts2) characters side by side. Stats, card pools, keywords, and starting decks.",
       path: "/compare",
       items: pairs.map((p) => ({
         name: `${p.a.name} vs ${p.b.name}`,

--- a/frontend/app/developers/page.tsx
+++ b/frontend/app/developers/page.tsx
@@ -7,13 +7,13 @@ import TinyCard, { TINY_CARD_POOL_COLOR, TINY_CARD_BANNER_COLOR } from "@/app/co
 const API_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://spire-codex.com";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Developer API & Tooltip Widget | Spire Codex",
+  title: "Developer API & Tooltip Widget - Slay the Spire 2 (sts2) | Spire Codex",
   description:
-    "Integrate Slay the Spire 2 (STS2) game data into your projects. Public REST API with 22+ endpoints, embeddable tooltip widget, and multi-language support.",
+    "Integrate Slay the Spire 2 (sts2) game data into your projects. Public REST API with 22+ endpoints, embeddable tooltip widget, and multi-language support.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Developer API & Tooltip Widget | Spire Codex",
+    title: "Developer API & Tooltip Widget - Slay the Spire 2 (sts2) | Spire Codex",
     description:
-      "Public REST API and embeddable tooltip widget for Slay the Spire 2 (STS2) game data.",
+      "Public REST API and embeddable tooltip widget for Slay the Spire 2 (sts2) game data.",
   },
   alternates: { canonical: "/developers" },
 };

--- a/frontend/app/enchantments/[id]/page.tsx
+++ b/frontend/app/enchantments/[id]/page.tsx
@@ -13,10 +13,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/enchantments/${id}`);
-    if (!res.ok) return { title: "Enchantment Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Enchantment Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const enchantment = await res.json();
     const desc = stripTags(enchantment.description || "");
-    const title = `Slay the Spire 2 (STS2) Enchantment - ${enchantment.name} | Spire Codex`;
+    const title = `Enchantment - ${enchantment.name} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `${enchantment.name} is an enchantment in Slay the Spire 2: ${desc}`;
     return {
       title,
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/enchantments/${id}`, languages: buildLanguageAlternates(`/enchantments/${id}`) },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/enchantments/layout.tsx
+++ b/frontend/app/enchantments/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Enchantments - Complete Enchantment List | Spire Codex",
+  title: "Enchantments - Complete Enchantment List - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "Browse all Slay the Spire 2 enchantments. View enchantment effects, card type restrictions, stackability, and extra card text for Attack, Skill, and Power enchantments.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Enchantments - Complete Enchantment List | Spire Codex",
+    title: "Enchantments - Complete Enchantment List - Slay the Spire 2 (sts2) | Spire Codex",
     description:
       "Browse all Slay the Spire 2 enchantments. View effects, card type restrictions, and stackability.",
   },

--- a/frontend/app/enchantments/page.tsx
+++ b/frontend/app/enchantments/page.tsx
@@ -30,7 +30,7 @@ export default async function EnchantmentsPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Enchantments</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (sts2) Enchantments</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every enchantment in Slay the Spire 2. Filter by card type and view effects, stackability, and extra card text.

--- a/frontend/app/encounters/[id]/page.tsx
+++ b/frontend/app/encounters/[id]/page.tsx
@@ -13,9 +13,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/encounters/${id}`);
-    if (!res.ok) return { title: "Encounter Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Encounter Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const encounter = await res.json();
-    const title = `Slay the Spire 2 (STS2) Encounter - ${encounter.name} - ${encounter.room_type} | Spire Codex`;
+    const title = `Encounter - ${encounter.name} - ${encounter.room_type} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = encounter.monsters?.length
       ? `${encounter.name} is a ${encounter.room_type} encounter in Slay the Spire 2 featuring ${encounter.monsters.map((m: { name: string }) => m.name).join(", ")}.`
       : `${encounter.name} is a ${encounter.room_type} encounter in Slay the Spire 2.`;
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/encounters/${id}` },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/encounters/layout.tsx
+++ b/frontend/app/encounters/layout.tsx
@@ -11,11 +11,11 @@ export async function generateMetadata(): Promise<Metadata> {
     // Fall back to the baseline count if the API is unreachable at build time.
   }
   return {
-    title: "Slay the Spire 2 (STS2) Encounters - All Combat Encounters | Spire Codex",
-    description: `Slay the Spire 2 (STS2) encounters — browse all ${count} combat encounters including normal fights, elites, and bosses. View monster compositions, act assignments, and room types.`,
+    title: "Encounters - All Combat Encounters - Slay the Spire 2 (sts2) | Spire Codex",
+    description: `Slay the Spire 2 (sts2) encounters — browse all ${count} combat encounters including normal fights, elites, and bosses. View monster compositions, act assignments, and room types.`,
     openGraph: {
-      title: "Slay the Spire 2 (STS2) Encounters - All Combat Encounters | Spire Codex",
-      description: `Slay the Spire 2 (STS2) encounters — browse all ${count} combat encounters including normal fights, elites, and bosses.`,
+      title: "Encounters - All Combat Encounters - Slay the Spire 2 (sts2) | Spire Codex",
+      description: `Slay the Spire 2 (sts2) encounters — browse all ${count} combat encounters including normal fights, elites, and bosses.`,
     },
     alternates: { canonical: "/encounters", languages: buildLanguageAlternates("/encounters") },
   };

--- a/frontend/app/encounters/page.tsx
+++ b/frontend/app/encounters/page.tsx
@@ -30,7 +30,7 @@ export default async function EncountersPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Encounters</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (sts2) Encounters</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every combat encounter in Slay the Spire 2. Filter by room type (Monster, Elite, Boss) and act to find specific fights and monster compositions.

--- a/frontend/app/events/[id]/page.tsx
+++ b/frontend/app/events/[id]/page.tsx
@@ -13,10 +13,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/events/${id}`);
-    if (!res.ok) return { title: "Event Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Event Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const event = await res.json();
     const desc = stripTags(event.description || "");
-    const title = `Slay the Spire 2 (STS2) Event - ${event.name} - ${event.type} | Spire Codex`;
+    const title = `Event - ${event.name} - ${event.type} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `${event.name} is a ${event.type} event in Slay the Spire 2${event.act ? ` (${event.act})` : ""}: ${desc}`;
     return {
       title,
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/events/${id}` },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/events/layout.tsx
+++ b/frontend/app/events/layout.tsx
@@ -11,11 +11,11 @@ export async function generateMetadata(): Promise<Metadata> {
     // Fall back to the baseline count if the API is unreachable at build time.
   }
   return {
-    title: "Slay the Spire 2 (STS2) Events - All In-Game Events | Spire Codex",
-    description: `Slay the Spire 2 (STS2) events — browse all ${count} shrine events, Ancient encounters, and story events. View choices, dialogue, relic offerings, and outcomes for every event.`,
+    title: "Events - All In-Game Events - Slay the Spire 2 (sts2) | Spire Codex",
+    description: `Slay the Spire 2 (sts2) events — browse all ${count} shrine events, Ancient encounters, and story events. View choices, dialogue, relic offerings, and outcomes for every event.`,
     openGraph: {
-      title: "Slay the Spire 2 (STS2) Events - All In-Game Events | Spire Codex",
-      description: `Slay the Spire 2 (STS2) events — browse all ${count} shrine events, Ancient encounters, and story events with choices, dialogue, and outcomes.`,
+      title: "Events - All In-Game Events - Slay the Spire 2 (sts2) | Spire Codex",
+      description: `Slay the Spire 2 (sts2) events — browse all ${count} shrine events, Ancient encounters, and story events with choices, dialogue, and outcomes.`,
     },
     alternates: { canonical: "/events", languages: buildLanguageAlternates("/events") },
   };

--- a/frontend/app/events/page.tsx
+++ b/frontend/app/events/page.tsx
@@ -31,7 +31,7 @@ export default async function EventsPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Events</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (sts2) Events</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every Slay the Spire 2 event including shrine events, Ancient encounters, and story events. View choices, dialogue, and outcomes.

--- a/frontend/app/guides/[slug]/page.tsx
+++ b/frontend/app/guides/[slug]/page.tsx
@@ -11,7 +11,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   const { slug } = await params;
   try {
     const res = await fetch(`${API}/api/guides/${slug}`, { next: { revalidate: 300 } });
-    if (!res.ok) return { title: `Guide Not Found | ${SITE_NAME}` };
+    if (!res.ok) return { title: `Guide Not Found - Slay the Spire 2 (sts2) | ${SITE_NAME}` };
     const guide: Guide = await res.json();
     const title = `${guide.title} - Slay the Spire 2 Guide | ${SITE_NAME}`;
     const description = stripTags(guide.summary);
@@ -23,7 +23,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
       twitter: { card: "summary", title, description },
     };
   } catch {
-    return { title: `Guide | ${SITE_NAME}` };
+    return { title: `Guide - Slay the Spire 2 (sts2) | ${SITE_NAME}` };
   }
 }
 

--- a/frontend/app/guides/layout.tsx
+++ b/frontend/app/guides/layout.tsx
@@ -3,12 +3,12 @@ import { buildLanguageAlternates } from "@/lib/seo";
 import { SITE_URL, SITE_NAME } from "@/lib/seo";
 
 export const metadata: Metadata = {
-  title: `Slay the Spire 2 (STS2) Guides - Strategy & Tips | ${SITE_NAME}`,
+  title: `Guides - Strategy & Tips - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
   description:
     "Community strategy guides for Slay the Spire 2. Character guides, boss strategies, deck building tips, and more from experienced players.",
   alternates: { canonical: `${SITE_URL}/guides` },
   openGraph: {
-    title: `Slay the Spire 2 (STS2) Guides - Strategy & Tips | ${SITE_NAME}`,
+    title: `Guides - Strategy & Tips - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
     description:
       "Community strategy guides for Slay the Spire 2. Character guides, boss strategies, deck building tips, and more.",
     url: `${SITE_URL}/guides`,

--- a/frontend/app/guides/page.tsx
+++ b/frontend/app/guides/page.tsx
@@ -32,7 +32,7 @@ export default async function GuidesPage() {
       <JsonLd data={jsonLd} />
       <div className="flex items-start justify-between mb-2">
         <h1 className="text-3xl font-bold">
-          <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Guides</span>
+          <span className="text-[var(--accent-gold)]">Slay the Spire 2 (sts2) Guides</span>
         </h1>
         <Link
           href="/guides/submit"

--- a/frontend/app/images/layout.tsx
+++ b/frontend/app/images/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Images - Game Art & Assets | Spire Codex",
+  title: "Images - Game Art & Assets - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "Browse and download Slay the Spire 2 game assets — card portraits, relic icons, monster sprites, character art, and more.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Images - Game Art & Assets | Spire Codex",
+    title: "Images - Game Art & Assets - Slay the Spire 2 (sts2) | Spire Codex",
     description:
       "Browse and download Slay the Spire 2 game assets — card portraits, relic icons, monster sprites, and more.",
   },

--- a/frontend/app/intents/[id]/page.tsx
+++ b/frontend/app/intents/[id]/page.tsx
@@ -12,10 +12,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/intents/${id}`);
-    if (!res.ok) return { title: "Intent Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Intent Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const intent = await res.json();
     const desc = stripTags(intent.description || "");
-    const title = `Slay the Spire 2 (STS2) Intent - ${intent.name} | Spire Codex`;
+    const title = `Intent - ${intent.name} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `${intent.name} is a monster intent in Slay the Spire 2: ${desc}`;
     return {
       title,
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/intents/${id}` },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/keywords/[id]/page.tsx
+++ b/frontend/app/keywords/[id]/page.tsx
@@ -27,13 +27,13 @@ async function fetchKeywordOrGlossary(id: string) {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   const result = await fetchKeywordOrGlossary(id);
-  if (!result) return { title: "Term Not Found - Spire Codex" };
+  if (!result) return { title: "Term Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
 
   const { type, data } = result;
   const desc = stripTags(data.description);
 
   if (type === "keyword") {
-    const title = `Slay the Spire 2 (STS2) Keyword - ${data.name} | Spire Codex`;
+    const title = `Keyword - ${data.name} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `${data.name} is a card keyword in Slay the Spire 2: ${desc}`;
     return {
       title,
@@ -47,7 +47,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
   }
 
-  const title = `Slay the Spire 2 (STS2) Term - ${data.name} | Spire Codex`;
+  const title = `Term - ${data.name} - Slay the Spire 2 (sts2) | Spire Codex`;
   const metaDesc = `${data.name} is a game term in Slay the Spire 2: ${desc}`;
   return {
     title,

--- a/frontend/app/keywords/layout.tsx
+++ b/frontend/app/keywords/layout.tsx
@@ -2,13 +2,13 @@ import type { Metadata } from "next";
 import { buildLanguageAlternates } from "@/lib/seo";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Keywords - All Card Keywords | Spire Codex",
+  title: "Keywords - All Card Keywords - Slay the Spire 2 (sts2) | Spire Codex",
   description:
-    "Browse all card keywords in Slay the Spire 2 (STS2) — Exhaust, Ethereal, Innate, Retain, Sly, Eternal, and more. See every card with each keyword.",
+    "Browse all card keywords in Slay the Spire 2 (sts2) — Exhaust, Ethereal, Innate, Retain, Sly, Eternal, and more. See every card with each keyword.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Keywords - All Card Keywords | Spire Codex",
+    title: "Keywords - All Card Keywords - Slay the Spire 2 (sts2) | Spire Codex",
     description:
-      "Browse all card keywords in Slay the Spire 2 (STS2) — Exhaust, Ethereal, Innate, Retain, Sly, Eternal, and more.",
+      "Browse all card keywords in Slay the Spire 2 (sts2) — Exhaust, Ethereal, Innate, Retain, Sly, Eternal, and more.",
   },
   alternates: { canonical: "/keywords", languages: buildLanguageAlternates("/keywords") },
 };

--- a/frontend/app/knowledge-demon/layout.tsx
+++ b/frontend/app/knowledge-demon/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Discord Bot - Knowledge Demon | Spire Codex",
+  title: "Discord Bot - Knowledge Demon - Slay the Spire 2 (sts2) | Spire Codex",
   description:
-    "Knowledge Demon is a Discord bot for Slay the Spire 2 (STS2) communities, with slash commands for cards, relics, monsters, potions, characters, events, plus moderation tools and news feeds. Powered by the Spire Codex API.",
+    "Knowledge Demon is a Discord bot for Slay the Spire 2 (sts2) communities, with slash commands for cards, relics, monsters, potions, characters, events, plus moderation tools and news feeds. Powered by the Spire Codex API.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Discord Bot - Knowledge Demon | Spire Codex",
+    title: "Discord Bot - Knowledge Demon - Slay the Spire 2 (sts2) | Spire Codex",
     description:
       "Discord bot for Slay the Spire 2 communities. Card, relic, monster, and potion lookups plus moderation tools.",
   },

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -22,7 +22,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
-  title: `${SITE_NAME} - Slay the Spire 2 Database`,
+  title: `Database - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
   description:
     "A comprehensive database for Slay the Spire 2 — browse cards, relics, characters, monsters, and potions.",
   icons: {

--- a/frontend/app/leaderboards/page.tsx
+++ b/frontend/app/leaderboards/page.tsx
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 export const metadata: Metadata = {
   title: "Leaderboards - Slay the Spire 2 | Spire Codex",
   description:
-    "Browse community-submitted Slay the Spire 2 (STS2) runs. Filter by character, ascension level, and outcome. View leaderboards and detailed run breakdowns.",
+    "Browse community-submitted Slay the Spire 2 (sts2) runs. Filter by character, ascension level, and outcome. View leaderboards and detailed run breakdowns.",
 };
 
 export default function ToolsPage() {

--- a/frontend/app/leaderboards/scoring/page.tsx
+++ b/frontend/app/leaderboards/scoring/page.tsx
@@ -6,12 +6,12 @@ import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
 import ScoreBadge from "@/app/components/ScoreBadge";
 
 export const metadata: Metadata = {
-  title: `Slay the Spire 2 (STS2) Codex Score - How Tier Ratings Work | ${SITE_NAME}`,
+  title: `Codex Score - How Tier Ratings Work - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
   description:
     "How the Codex Score rates every Slay the Spire 2 card, relic, and potion. Bayesian-shrunk win-rate formula, tier bands (S through F), and methodology behind the community-meta ratings.",
   alternates: { canonical: `${SITE_URL}/leaderboards/scoring`, languages: buildLanguageAlternates(`/leaderboards/scoring`) },
   openGraph: {
-    title: `Codex Score Methodology | ${SITE_NAME}`,
+    title: `Codex Score Methodology - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
     description:
       "How we compute the 0-100 community-meta score on every card / relic / potion. Bayesian shrinkage, tier bands, formula breakdown.",
     url: `${SITE_URL}/leaderboards/scoring`,

--- a/frontend/app/mechanics/[slug]/page.tsx
+++ b/frontend/app/mechanics/[slug]/page.tsx
@@ -40,7 +40,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   const section = await fetchSection(slug);
-  if (!section) return { title: `Not Found | ${SITE_NAME}` };
+  if (!section) return { title: `Not Found - Slay the Spire 2 (sts2) | ${SITE_NAME}` };
   const title = `${section.title} - Slay the Spire 2 | ${SITE_NAME}`;
   return {
     title,

--- a/frontend/app/mechanics/page.tsx
+++ b/frontend/app/mechanics/page.tsx
@@ -18,12 +18,12 @@ export interface MechanicSectionMeta {
 }
 
 export const metadata: Metadata = {
-  title: `Slay the Spire 2 (STS2) Game Mechanics - Drop Rates, Combat & Map Data | ${SITE_NAME}`,
+  title: `Game Mechanics - Drop Rates, Combat & Map Data - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
   description:
     "Complete game mechanics for Slay the Spire 2. Card rarity odds, relic distribution, potion chances, gold rewards, map generation, combat formulas, secrets, and more — all extracted from the game's source code.",
   alternates: { canonical: `${SITE_URL}/mechanics` },
   openGraph: {
-    title: `Slay the Spire 2 (STS2) Game Mechanics | ${SITE_NAME}`,
+    title: `Game Mechanics - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
     description: "Every drop rate, reward chance, and game formula extracted from the source code.",
     url: `${SITE_URL}/mechanics`,
     siteName: SITE_NAME,

--- a/frontend/app/merchant/layout.tsx
+++ b/frontend/app/merchant/layout.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from "next";
 import { buildLanguageAlternates } from "@/lib/seo";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Merchant Guide - Shop Prices & Fake Merchant | Spire Codex",
+  title: "Merchant Guide - Shop Prices & Fake Merchant - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "Complete Slay the Spire 2 merchant guide. Card, relic, and potion prices by rarity. Card removal costs. Fake Merchant relics and their effects. All values extracted from game source.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Merchant Guide - Shop Prices & Fake Merchant | Spire Codex",
+    title: "Merchant Guide - Shop Prices & Fake Merchant - Slay the Spire 2 (sts2) | Spire Codex",
     description:
       "Complete merchant price guide for Slay the Spire 2. Card, relic, and potion costs by rarity. Fake Merchant relic effects.",
   },

--- a/frontend/app/merchant/page.tsx
+++ b/frontend/app/merchant/page.tsx
@@ -121,7 +121,7 @@ export default async function MerchantPage() {
   const jsonLd = [
     ...buildDetailPageJsonLd({
       name: "Merchant Guide",
-      description: "Complete Slay the Spire 2 (STS2) merchant price guide with card, relic, and potion costs, card removal pricing, and Fake Merchant relic details.",
+      description: "Complete Slay the Spire 2 (sts2) merchant price guide with card, relic, and potion costs, card removal pricing, and Fake Merchant relic details.",
       path: "/merchant",
       category: "Guide",
       breadcrumbs: [

--- a/frontend/app/modifiers/[id]/page.tsx
+++ b/frontend/app/modifiers/[id]/page.tsx
@@ -12,10 +12,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/modifiers/${id}`);
-    if (!res.ok) return { title: "Modifier Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Modifier Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const modifier = await res.json();
     const desc = stripTags(modifier.description || "");
-    const title = `Slay the Spire 2 (STS2) Modifier - ${modifier.name} | Spire Codex`;
+    const title = `Modifier - ${modifier.name} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `${modifier.name} is a run modifier in Slay the Spire 2: ${desc}`;
     return {
       title,
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/modifiers/${id}`, languages: buildLanguageAlternates(`/modifiers/${id}`) },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/modifiers/page.tsx
+++ b/frontend/app/modifiers/page.tsx
@@ -4,7 +4,7 @@ import ModifiersClient from "./ModifiersClient";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Custom Mode Modifiers - All Modifiers | Spire Codex",
+  title: "Custom Mode Modifiers - All Modifiers - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "All 16 custom mode modifiers in Slay the Spire 2. See effects, deck replacement rules, Neow interactions, and gameplay impacts for Draft, Sealed Deck, Insanity, and more.",
 };

--- a/frontend/app/monsters/[id]/page.tsx
+++ b/frontend/app/monsters/[id]/page.tsx
@@ -12,11 +12,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/monsters/${id}`);
-    if (!res.ok) return { title: "Monster Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Monster Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const monster = await res.json();
     const hpText = monster.min_hp ? `${monster.min_hp}${monster.max_hp && monster.max_hp !== monster.min_hp ? `\u2013${monster.max_hp}` : ""} HP` : "";
     const desc = `${monster.type} monster${hpText ? ` \u00b7 ${hpText}` : ""}`;
-    const title = `Slay the Spire 2 (STS2) Monster - ${monster.name} - ${monster.type} | Spire Codex`;
+    const title = `Monster - ${monster.name} - ${monster.type} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `${monster.name} is a ${monster.type} monster in Slay the Spire 2. ${hpText ? `${hpText}.` : ""} ${monster.moves ? `${monster.moves.length} moves.` : ""}`;
     return {
       title,
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/monsters/${id}` },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/monsters/layout.tsx
+++ b/frontend/app/monsters/layout.tsx
@@ -11,11 +11,11 @@ export async function generateMetadata(): Promise<Metadata> {
     // Fall back to the baseline count if the API is unreachable at build time.
   }
   return {
-    title: "Slay the Spire 2 (STS2) Monsters - Complete Monster List | Spire Codex",
-    description: `Slay the Spire 2 (STS2) monsters — browse all ${count} normals, elites, and bosses. View HP values, moves, damage stats, and ascension scaling.`,
+    title: "Monsters - Complete Monster List - Slay the Spire 2 (sts2) | Spire Codex",
+    description: `Slay the Spire 2 (sts2) monsters — browse all ${count} normals, elites, and bosses. View HP values, moves, damage stats, and ascension scaling.`,
     openGraph: {
-      title: "Slay the Spire 2 (STS2) Monsters - Complete Monster List | Spire Codex",
-      description: `Slay the Spire 2 (STS2) monsters — browse all ${count} normals, elites, and bosses. View HP, moves, and ascension scaling.`,
+      title: "Monsters - Complete Monster List - Slay the Spire 2 (sts2) | Spire Codex",
+      description: `Slay the Spire 2 (sts2) monsters — browse all ${count} normals, elites, and bosses. View HP, moves, and ascension scaling.`,
     },
     alternates: { canonical: "/monsters", languages: buildLanguageAlternates("/monsters") },
   };

--- a/frontend/app/monsters/page.tsx
+++ b/frontend/app/monsters/page.tsx
@@ -31,7 +31,7 @@ export default async function MonstersPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Monsters</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (sts2) Monsters</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every monster in Slay the Spire 2 — normals, elites, and bosses. View HP values, moves, damage stats, and ascension scaling.

--- a/frontend/app/news/[...slug]/page.tsx
+++ b/frontend/app/news/[...slug]/page.tsx
@@ -60,9 +60,9 @@ export async function generateMetadata({
   const { slug } = await params;
   const joined = joinSlug(slug);
   const gid = gidFromSlug(joined);
-  if (!gid) return { title: `Slay the Spire 2 (STS2) News - Not Found | ${SITE_NAME}` };
+  if (!gid) return { title: `News - Not Found - Slay the Spire 2 (sts2) | ${SITE_NAME}` };
   const article = await fetchItem(gid);
-  if (!article) return { title: `Slay the Spire 2 (STS2) News - Not Found | ${SITE_NAME}` };
+  if (!article) return { title: `News - Not Found - Slay the Spire 2 (sts2) | ${SITE_NAME}` };
   // Lead the meta description with Spire Codex framing so search snippets
   // identify the page as our archive of the Steam announcement, not just
   // the raw article body.

--- a/frontend/app/news/page.tsx
+++ b/frontend/app/news/page.tsx
@@ -18,14 +18,14 @@ export const revalidate = 1800;
 // format used across the rest of the site (see /changelog, /cards, /relics, etc.).
 // The visible page tagline below is separate marketing copy.
 export const metadata: Metadata = {
-  title: `Slay the Spire 2 (STS2) News - Patch Notes & Announcements | ${SITE_NAME}`,
+  title: `News - Patch Notes & Announcements - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
   description:
-    "Slay the Spire 2 (STS2) patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
+    "Slay the Spire 2 (sts2) patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
   alternates: { canonical: `${SITE_URL}/news` },
   openGraph: {
-    title: `Slay the Spire 2 (STS2) News - Patch Notes & Announcements | ${SITE_NAME}`,
+    title: `News - Patch Notes & Announcements - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
     description:
-      "Slay the Spire 2 (STS2) patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
+      "Slay the Spire 2 (sts2) patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
     url: `${SITE_URL}/news`,
     siteName: SITE_NAME,
     type: "website",

--- a/frontend/app/orbs/[id]/page.tsx
+++ b/frontend/app/orbs/[id]/page.tsx
@@ -12,10 +12,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/orbs/${id}`);
-    if (!res.ok) return { title: "Orb Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Orb Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const orb = await res.json();
     const desc = stripTags(orb.description || "");
-    const title = `Slay the Spire 2 (STS2) Orb - ${orb.name} | Spire Codex`;
+    const title = `Orb - ${orb.name} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `${orb.name} is an orb in Slay the Spire 2: ${desc}`;
     return {
       title,
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/orbs/${id}`, languages: buildLanguageAlternates(`/orbs/${id}`) },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -14,10 +14,10 @@ import { SITE_NAME, IS_BETA, buildLanguageAlternates } from "@/lib/seo";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
-const title = `${SITE_NAME} - Slay the Spire 2 (STS2) ${IS_BETA ? "Beta " : ""}Database, Wiki & Guide`;
+const title = `${IS_BETA ? "Beta " : ""}Database, Wiki & Guide - Slay the Spire 2 (sts2) | ${SITE_NAME}`;
 const description = IS_BETA
-  ? "Beta preview of upcoming Slay the Spire 2 (STS2) content. Browse new cards, relics, characters, monsters, potions, events, powers, and more."
-  : "The complete Slay the Spire 2 (STS2) database. Browse all cards, relics, characters, monsters, potions, events, powers, and more. Filter by character, rarity, and type.";
+  ? "Beta preview of upcoming Slay the Spire 2 (sts2) content. Browse new cards, relics, characters, monsters, potions, events, powers, and more."
+  : "The complete Slay the Spire 2 (sts2) database. Browse all cards, relics, characters, monsters, potions, events, powers, and more. Filter by character, rarity, and type.";
 
 export const metadata: Metadata = {
   title,

--- a/frontend/app/potions/[id]/page.tsx
+++ b/frontend/app/potions/[id]/page.tsx
@@ -13,10 +13,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/potions/${id}`);
-    if (!res.ok) return { title: "Potion Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Potion Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const potion = await res.json();
     const desc = stripTags(potion.description || "");
-    const title = `Slay the Spire 2 (STS2) Potion - ${potion.name} - ${potion.rarity} | Spire Codex`;
+    const title = `Potion - ${potion.name} - ${potion.rarity} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `${potion.name} is a ${potion.rarity} potion in Slay the Spire 2: ${desc}`;
     return {
       title,
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/potions/${id}`, languages: buildLanguageAlternates(`/potions/${id}`) },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/potions/layout.tsx
+++ b/frontend/app/potions/layout.tsx
@@ -11,11 +11,11 @@ export async function generateMetadata(): Promise<Metadata> {
     // Fall back to the baseline count if the API is unreachable at build time.
   }
   return {
-    title: "Slay the Spire 2 (STS2) Potions - Complete Potion List | Spire Codex",
-    description: `Browse all ${count} Slay the Spire 2 (STS2) potions. Filter by rarity (Common, Uncommon, Rare) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View potion effects and descriptions.`,
+    title: "Potions - Complete Potion List - Slay the Spire 2 (sts2) | Spire Codex",
+    description: `Browse all ${count} Slay the Spire 2 (sts2) potions. Filter by rarity (Common, Uncommon, Rare) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View potion effects and descriptions.`,
     openGraph: {
-      title: "Slay the Spire 2 (STS2) Potions - Complete Potion List | Spire Codex",
-      description: `Browse all ${count} Slay the Spire 2 (STS2) potions. Filter by rarity and character pool.`,
+      title: "Potions - Complete Potion List - Slay the Spire 2 (sts2) | Spire Codex",
+      description: `Browse all ${count} Slay the Spire 2 (sts2) potions. Filter by rarity and character pool.`,
     },
     alternates: { canonical: "/potions", languages: buildLanguageAlternates("/potions") },
   };

--- a/frontend/app/potions/page.tsx
+++ b/frontend/app/potions/page.tsx
@@ -31,7 +31,7 @@ export default async function PotionsPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Potions</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (sts2) Potions</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every potion across Ironclad, Silent, Defect, Necrobinder, and Regent. Filter by rarity and character pool.

--- a/frontend/app/powers/[id]/page.tsx
+++ b/frontend/app/powers/[id]/page.tsx
@@ -13,10 +13,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/powers/${id}`);
-    if (!res.ok) return { title: "Power Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Power Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const power = await res.json();
     const desc = stripTags(power.description || "");
-    const title = `Slay the Spire 2 (STS2) Power - ${power.name} - ${power.type} | Spire Codex`;
+    const title = `Power - ${power.name} - ${power.type} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `${power.name} is a ${power.type} power in Slay the Spire 2: ${desc}`;
     return {
       title,
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/powers/${id}`, languages: buildLanguageAlternates(`/powers/${id}`) },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/powers/layout.tsx
+++ b/frontend/app/powers/layout.tsx
@@ -11,11 +11,11 @@ export async function generateMetadata(): Promise<Metadata> {
     // Fall back to the baseline count if the API is unreachable at build time.
   }
   return {
-    title: "Slay the Spire 2 (STS2) Powers - Complete Power List | Spire Codex",
-    description: `Browse all ${count} Slay the Spire 2 (STS2) powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior. View descriptions, icons, and details for every power.`,
+    title: "Powers - Complete Power List - Slay the Spire 2 (sts2) | Spire Codex",
+    description: `Browse all ${count} Slay the Spire 2 (sts2) powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior. View descriptions, icons, and details for every power.`,
     openGraph: {
-      title: "Slay the Spire 2 (STS2) Powers - Complete Power List | Spire Codex",
-      description: `Browse all ${count} Slay the Spire 2 (STS2) powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior.`,
+      title: "Powers - Complete Power List - Slay the Spire 2 (sts2) | Spire Codex",
+      description: `Browse all ${count} Slay the Spire 2 (sts2) powers — buffs, debuffs, and neutral effects. Filter by type and stack behavior.`,
     },
     alternates: { canonical: "/powers", languages: buildLanguageAlternates("/powers") },
   };

--- a/frontend/app/powers/page.tsx
+++ b/frontend/app/powers/page.tsx
@@ -30,7 +30,7 @@ export default async function PowersPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Powers</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (sts2) Powers</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every power in Slay the Spire 2 — buffs, debuffs, and neutral effects. Filter by type and stack behavior.

--- a/frontend/app/relics/[id]/page.tsx
+++ b/frontend/app/relics/[id]/page.tsx
@@ -13,10 +13,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/relics/${id}`);
-    if (!res.ok) return { title: "Relic Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Relic Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const relic = await res.json();
     const desc = stripTags(relic.description || "");
-    const title = `Slay the Spire 2 (STS2) Relic - ${relic.name} - ${relic.rarity} | Spire Codex`;
+    const title = `Relic - ${relic.name} - ${relic.rarity} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `${relic.name} is a ${relic.rarity} relic in Slay the Spire 2: ${desc}`;
     return {
       title,
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/relics/${id}`, languages: buildLanguageAlternates(`/relics/${id}`) },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/relics/layout.tsx
+++ b/frontend/app/relics/layout.tsx
@@ -11,11 +11,11 @@ export async function generateMetadata(): Promise<Metadata> {
     // Fall back to the baseline count if the API is unreachable at build time.
   }
   return {
-    title: "Slay the Spire 2 (STS2) Relics - Complete Relic List | Spire Codex",
-    description: `Browse all ${count} Slay the Spire 2 (STS2) relics. Filter by rarity (Common, Uncommon, Rare, Shop, Event, Ancient) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View relic effects, flavor text, and images.`,
+    title: "Relics - Complete Relic List - Slay the Spire 2 (sts2) | Spire Codex",
+    description: `Browse all ${count} Slay the Spire 2 (sts2) relics. Filter by rarity (Common, Uncommon, Rare, Shop, Event, Ancient) and character pool (Ironclad, Silent, Defect, Necrobinder, Regent). View relic effects, flavor text, and images.`,
     openGraph: {
-      title: "Slay the Spire 2 (STS2) Relics - Complete Relic List | Spire Codex",
-      description: `Browse all ${count} Slay the Spire 2 (STS2) relics. Filter by rarity and character pool. View relic effects and images.`,
+      title: "Relics - Complete Relic List - Slay the Spire 2 (sts2) | Spire Codex",
+      description: `Browse all ${count} Slay the Spire 2 (sts2) relics. Filter by rarity and character pool. View relic effects and images.`,
     },
     alternates: { canonical: "/relics", languages: buildLanguageAlternates("/relics") },
   };

--- a/frontend/app/relics/page.tsx
+++ b/frontend/app/relics/page.tsx
@@ -31,7 +31,7 @@ export default async function RelicsPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Relics</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (sts2) Relics</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Browse every relic across Ironclad, Silent, Defect, Necrobinder, and Regent. Filter by rarity and character pool.

--- a/frontend/app/runs/[hash]/page.tsx
+++ b/frontend/app/runs/[hash]/page.tsx
@@ -11,16 +11,22 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { hash } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/runs/shared/${hash}`);
-    if (!res.ok) return { title: "Run Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Run Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const run = await res.json();
-    const char = run.players?.[0]?.character?.replace("CHARACTER.", "") || "Unknown";
-    const result = run.win ? "Victory" : run.was_abandoned ? "Abandoned" : "Defeat";
+    const rawChar = run.players?.[0]?.character?.replace("CHARACTER.", "") || "Unknown";
+    // Title-case the enum-style value ("NECROBINDER" → "Necrobinder").
+    const char = rawChar.charAt(0) + rawChar.slice(1).toLowerCase();
+    const result = run.win ? "win" : run.was_abandoned ? "abandoned" : "loss";
+    const username = run.username?.trim() || "Anonymous";
+    const ascension = run.ascension ?? 0;
+    // Title format requested by user:
+    //   "{username} - {character} - Ascension N win/loss - Slay the Spire 2 (sts2) | Spire Codex"
     return {
-      title: `${char} ${result} - Run Viewer | Spire Codex`,
-      description: `${result} with ${char} at Ascension ${run.ascension || 0}. ${run.players?.[0]?.deck?.length || 0} cards, ${run.players?.[0]?.relics?.length || 0} relics.`,
+      title: `${username} - ${char} - Ascension ${ascension} ${result} - Slay the Spire 2 (sts2) | Spire Codex`,
+      description: `${username}'s ${result === "win" ? "victorious" : result} ${char} run at Ascension ${ascension}. ${run.players?.[0]?.deck?.length || 0} cards, ${run.players?.[0]?.relics?.length || 0} relics.`,
     };
   } catch {
-    return { title: "Run Viewer - Spire Codex" };
+    return { title: "Run Viewer - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/showcase/layout.tsx
+++ b/frontend/app/showcase/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Community Showcase - Projects & Tools | Spire Codex",
+  title: "Community Showcase - Projects & Tools - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "Discover community projects and tools built with the Spire Codex API. Explore bots, widgets, apps, and more for Slay the Spire 2.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Community Showcase - Projects & Tools | Spire Codex",
+    title: "Community Showcase - Projects & Tools - Slay the Spire 2 (sts2) | Spire Codex",
     description:
       "Discover community projects and tools built with the Spire Codex API.",
   },

--- a/frontend/app/thank-you/layout.tsx
+++ b/frontend/app/thank-you/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Database - Thank You | Spire Codex",
+  title: "Database - Thank You - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "Thank you to the Spire Codex community — Ko-fi supporters, contributors, and everyone who's helped report bugs, share the site, and make this project what it is.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Database - Thank You | Spire Codex",
+    title: "Database - Thank You - Slay the Spire 2 (sts2) | Spire Codex",
     description:
       "Thank you to the Spire Codex community of supporters and contributors.",
   },

--- a/frontend/app/tier-list/cards/page.tsx
+++ b/frontend/app/tier-list/cards/page.tsx
@@ -41,10 +41,10 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
   const scope = charLabel && color ? `${charLabel} Cards` : "Cards";
   // Title leads with STS2 abbreviation + full game name to capture both
   // query phrasings ("sts2 tier list" vs "slay the spire 2 tier list").
-  const title = `STS2 ${scope} Tier List - Slay the Spire 2 Cards Ranked | ${SITE_NAME}`;
+  const title = `${scope} Tier List - Cards Ranked - Slay the Spire 2 (sts2) | ${SITE_NAME}`;
   const description = color
-    ? `${charLabel} card tier list for Slay the Spire 2 (STS2). Every ${charLabel?.toLowerCase()} card ranked S through F based on community win-rate data.`
-    : "Every Slay the Spire 2 (STS2) card ranked S through F. Tier list driven by Codex Score — community-submitted run win rates with Bayesian shrinkage.";
+    ? `${charLabel} card tier list for Slay the Spire 2 (sts2). Every ${charLabel?.toLowerCase()} card ranked S through F based on community win-rate data.`
+    : "Every Slay the Spire 2 (sts2) card ranked S through F. Tier list driven by Codex Score — community-submitted run win rates with Bayesian shrinkage.";
   const path = `/tier-list/cards${color ? `?color=${color}` : ""}`;
   return {
     title,
@@ -116,7 +116,7 @@ export default async function CardsTierListPage({ searchParams }: PageProps) {
     ]),
     buildCollectionPageJsonLd({
       name: heading,
-      description: `Slay the Spire 2 (STS2) ${heading.toLowerCase()} ranked by Codex Score from community-submitted run win rates.`,
+      description: `Slay the Spire 2 (sts2) ${heading.toLowerCase()} ranked by Codex Score from community-submitted run win rates.`,
       path,
       items: rankedItems,
     }),

--- a/frontend/app/tier-list/page.tsx
+++ b/frontend/app/tier-list/page.tsx
@@ -15,12 +15,12 @@ export const metadata: Metadata = {
   // match either query phrasing — the actual SERPs we're targeting use
   // both. Order chosen so the abbreviation lands inside the truncation
   // window on mobile (Google trims at ~60 chars on phones).
-  title: `STS2 Tier List - Slay the Spire 2 Cards, Relics & Potions Ranked | ${SITE_NAME}`,
+  title: `Tier List - Cards, Relics & Potions Ranked - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
   description:
-    "STS2 / Slay the Spire 2 tier list ranking every card, relic, and potion S through F. Codex Score from community win rates. Updated daily after every patch.",
+    "Slay the Spire 2 (sts2) tier list ranking every card, relic, and potion S through F. Codex Score from community win rates. Updated daily after every patch.",
   alternates: { canonical: `${SITE_URL}/tier-list`, languages: buildLanguageAlternates(`/tier-list`) },
   openGraph: {
-    title: `STS2 Tier List | ${SITE_NAME}`,
+    title: `Tier List - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
     description: "Every Slay the Spire 2 card, relic, and potion ranked S → F based on community win-rate data.",
     url: `${SITE_URL}/tier-list`,
     siteName: SITE_NAME,
@@ -176,7 +176,7 @@ export default async function TierListIndex() {
       <JsonLd data={jsonLd} />
 
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Tier List</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (sts2) Tier List</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-2">
         Updated <time dateTime={new Date().toISOString()}>{updatedDate}</time> · Scores rebuild every 30 minutes.

--- a/frontend/app/tier-list/potions/page.tsx
+++ b/frontend/app/tier-list/potions/page.tsx
@@ -21,12 +21,12 @@ interface ScoresMap {
 }
 
 export const metadata: Metadata = {
-  title: `STS2 Potion Tier List - All 63 Slay the Spire 2 Potions Ranked | ${SITE_NAME}`,
+  title: `Potion Tier List - All 63 Potions Ranked - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
   description:
-    "Every Slay the Spire 2 (STS2) potion ranked S through F by community win rate. Codex Score with Bayesian shrinkage. Updated every 30 minutes.",
+    "Every Slay the Spire 2 (sts2) potion ranked S through F by community win rate. Codex Score with Bayesian shrinkage. Updated every 30 minutes.",
   alternates: { canonical: `${SITE_URL}/tier-list/potions` },
   openGraph: {
-    title: `STS2 Potion Tier List | ${SITE_NAME}`,
+    title: `Potion Tier List - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
     description: "Every Slay the Spire 2 potion ranked S through F by community win-rate data.",
     url: `${SITE_URL}/tier-list/potions`,
     siteName: SITE_NAME,
@@ -77,7 +77,7 @@ export default async function PotionsTierListPage() {
     ]),
     buildCollectionPageJsonLd({
       name: "Potion Tier List",
-      description: "Every Slay the Spire 2 (STS2) potion ranked by Codex Score from community-submitted run win rates.",
+      description: "Every Slay the Spire 2 (sts2) potion ranked by Codex Score from community-submitted run win rates.",
       path: "/tier-list/potions",
       items: rankedItems,
     }),

--- a/frontend/app/tier-list/relics/page.tsx
+++ b/frontend/app/tier-list/relics/page.tsx
@@ -39,10 +39,10 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
   const pool = sp.pool?.toLowerCase();
   const poolLabel = POOL_FILTERS.find((p) => p.value === pool)?.label;
   const scope = poolLabel && pool ? `${poolLabel} Relic` : "Relic";
-  const title = `STS2 ${scope} Tier List - Slay the Spire 2 Relics Ranked | ${SITE_NAME}`;
+  const title = `${scope} Tier List - Relics Ranked - Slay the Spire 2 (sts2) | ${SITE_NAME}`;
   const description = pool
-    ? `${poolLabel} relic tier list for Slay the Spire 2 (STS2). Every relic in the ${pool} pool ranked S through F by community win rate.`
-    : "Every Slay the Spire 2 (STS2) relic ranked S through F. Codex Score from community-submitted run win rates with Bayesian shrinkage.";
+    ? `${poolLabel} relic tier list for Slay the Spire 2 (sts2). Every relic in the ${pool} pool ranked S through F by community win rate.`
+    : "Every Slay the Spire 2 (sts2) relic ranked S through F. Codex Score from community-submitted run win rates with Bayesian shrinkage.";
   const path = `/tier-list/relics${pool ? `?pool=${pool}` : ""}`;
   return {
     title,
@@ -103,7 +103,7 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
     ]),
     buildCollectionPageJsonLd({
       name: heading,
-      description: `Slay the Spire 2 (STS2) ${heading.toLowerCase()} ranked by Codex Score from community-submitted run win rates.`,
+      description: `Slay the Spire 2 (sts2) ${heading.toLowerCase()} ranked by Codex Score from community-submitted run win rates.`,
       path,
       items: rankedItems,
     }),

--- a/frontend/app/timeline/[id]/page.tsx
+++ b/frontend/app/timeline/[id]/page.tsx
@@ -14,10 +14,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const res = await fetch(`${API_INTERNAL}/api/epochs/${id}`);
-    if (!res.ok) return { title: "Epoch Not Found - Spire Codex" };
+    if (!res.ok) return { title: "Epoch Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const epoch = await res.json();
     const desc = stripTags(epoch.description || "");
-    const title = `Slay the Spire 2 (STS2) Timeline - ${epoch.title} | Spire Codex`;
+    const title = `Timeline - ${epoch.title} - Slay the Spire 2 (sts2) | Spire Codex`;
     const metaDesc = `${epoch.title} is a timeline epoch in Slay the Spire 2: ${desc.slice(0, 150)}`;
     return {
       title,
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       alternates: { canonical: `/timeline/${id}` },
     };
   } catch {
-    return { title: "Spire Codex - Slay the Spire 2 Database" };
+    return { title: "Database - Slay the Spire 2 (sts2) | Spire Codex" };
   }
 }
 

--- a/frontend/app/timeline/layout.tsx
+++ b/frontend/app/timeline/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Timeline - Epochs & Unlocks | Spire Codex",
+  title: "Timeline - Epochs & Unlocks - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "Slay the Spire 2 timeline covering all epochs, eras, and story arcs. Track unlockable cards, relics, and potions across every story progression path.",
   openGraph: {
-    title: "Slay the Spire 2 (STS2) Timeline - Epochs & Unlocks | Spire Codex",
+    title: "Timeline - Epochs & Unlocks - Slay the Spire 2 (sts2) | Spire Codex",
     description:
       "Slay the Spire 2 timeline covering all epochs, eras, and story arcs. Track unlockable cards, relics, and potions across every story progression path.",
   },

--- a/frontend/app/timeline/page.tsx
+++ b/frontend/app/timeline/page.tsx
@@ -46,7 +46,7 @@ export default async function TimelinePage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (STS2) Timeline</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2 (sts2) Timeline</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
         Explore the full Slay the Spire 2 timeline across every epoch, story arc, and era. Track story progression, unlockable cards, relics, and potions.

--- a/frontend/app/unlocks/page.tsx
+++ b/frontend/app/unlocks/page.tsx
@@ -3,7 +3,7 @@ import { buildLanguageAlternates } from "@/lib/seo";
 import UnlocksClient from "./UnlocksClient";
 
 export const metadata: Metadata = {
-  title: "Slay the Spire 2 (STS2) Unlocks - All Unlockable Cards, Relics & Potions | Spire Codex",
+  title: "Unlocks - All Unlockable Cards, Relics & Potions - Slay the Spire 2 (sts2) | Spire Codex",
   description:
     "Complete list of all unlockable content in Slay the Spire 2 — 60 cards, 45 relics, 21 potions, and 4 characters unlocked through timeline progression.",
   alternates: { canonical: "/unlocks", languages: buildLanguageAlternates("/unlocks") },


### PR DESCRIPTION
## Spec
Every page now follows the same pattern:

```
{page title} - Slay the Spire 2 (sts2) | Spire Codex
```

Run-detail pages additionally encode username + character + ascension + result:

```
{username} - {Character} - Ascension N win/loss - Slay the Spire 2 (sts2) | Spire Codex
```

## Why
Title format had drifted across sweeps:
- `"Slay the Spire 2 (STS2) X - Y | Spire Codex"` (string-literal list pages)
- `Slay the Spire 2 (STS2) Card - X - Y` (detail page generators)
- `STS2 Tier List - Slay the Spire 2 Y` (tier-list pages)
- `${SITE_NAME} - Slay the Spire 2 (STS2) ...` (home page)
- `Run Viewer | Spire Codex` (runs)
- `X Not Found - Spire Codex` / `Spire Codex - Slay the Spire 2 Database` (404 fallbacks)

This sweep normalizes everything.

## What changed
- **54 files** with primary-title regex rewrites (content moves to the front, brand to the back)
- **30 files** with `(STS2)` → `(sts2)` normalization across descriptions + OG titles + JSON-LD
- **45 files** with error-fallback title rewrites
- **Home page**: manually fixed (had a unique `${SITE_NAME} - Slay the Spire 2 (STS2) ...` pattern)
- **Runs detail** (`app/runs/[hash]/page.tsx`): rewrote `generateMetadata` to emit the username/character/ascension/result format

## Why content-first not brand-first
Mobile SERPs truncate around 60 chars. Putting the unique page-specific content first means more of it stays visible before the brand suffix gets cut off. Desktop SERPs show the full brand at the end where it still does its recognition job.

## Sample after-format
| Page | Title |
|---|---|
| Home | `Database, Wiki & Guide - Slay the Spire 2 (sts2) \| Spire Codex` |
| /cards | `Cards - Complete Card List - Slay the Spire 2 (sts2) \| Spire Codex` |
| /cards/strike | `Card - Strike - Common Attack - Slay the Spire 2 (sts2) \| Spire Codex` |
| /tier-list | `Tier List - Cards, Relics & Potions Ranked - Slay the Spire 2 (sts2) \| Spire Codex` |
| /runs/abc123 | `Megatron - Necrobinder - Ascension 5 win - Slay the Spire 2 (sts2) \| Spire Codex` |
| /leaderboards/scoring | `Codex Score - How Tier Ratings Work - Slay the Spire 2 (sts2) \| Spire Codex` |
| Card Not Found | `Card Not Found - Slay the Spire 2 (sts2) \| Spire Codex` |