### PR TITLE
Fix: surface submitter username on /runs/<hash> share pages

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -308,15 +308,31 @@ def get_run_versions(request: Request):
 # against this single endpoint and pegging the worker at 100% CPU.
 @limiter.limit("60/minute")
 def get_shared_run(run_hash: str, request: Request):
-    """Retrieve a shared run by its hash."""
+    """Retrieve a shared run by its hash, merged with DB-side username.
+
+    The on-disk run JSON is the immutable client-submitted blob — it does
+    not contain the submitter's username, since users may attach a name
+    AFTER submitting via /api/runs/claim. The username lives in the
+    SQLite runs row. Without merging, /shared dropped usernames entirely
+    even though /api/runs/list happily reported them.
+    """
+    from ..services.runs_db import get_conn
+
+    def _attach_username(blob: dict) -> dict:
+        with get_conn() as conn:
+            row = conn.execute(
+                "SELECT username FROM runs WHERE run_hash = ?", (run_hash,)
+            ).fetchone()
+            if row and row["username"]:
+                blob["username"] = row["username"]
+        return blob
+
     cached = _load_run_blob(run_hash)
     if cached is not None:
-        return json.loads(cached)
+        return _attach_username(json.loads(cached))
 
     # Fallback for multiplayer: find the run in DB, get its seed/start_time,
     # then look for any sibling player's file with the same seed
-    from ..services.runs_db import get_conn
-
     with get_conn() as conn:
         row = conn.execute(
             "SELECT seed, character FROM runs WHERE run_hash = ?", (run_hash,)
@@ -340,7 +356,7 @@ def get_shared_run(run_hash: str, request: Request):
                 # on this and subsequent requests.
                 _load_run_blob.cache_clear()
                 with open(run_file, "r", encoding="utf-8") as f:
-                    return json.load(f)
+                    return _attach_username(json.load(f))
 
     raise HTTPException(status_code=404, detail="Run data not available")
 

--- a/frontend/app/runs/[hash]/RunSummary.tsx
+++ b/frontend/app/runs/[hash]/RunSummary.tsx
@@ -90,6 +90,9 @@ interface Run {
   modifiers?: string[];
   map_point_history?: MapPoint[][];
   players: Player[];
+  /** Attached server-side from the runs DB row (not in the on-disk
+   *  run JSON). Missing for anonymous submissions. */
+  username?: string;
 }
 
 const RARITY_ORDER = ["Starter", "Common", "Uncommon", "Rare", "Ancient", "Event", "Token", "Status", "Curse", "Quest"];
@@ -242,6 +245,17 @@ export default function RunSummary({ run, player, cardData, relicData, potionDat
           <IconStat icon={`${API}/static/images/ui/top_bar/top_bar_ascension.webp`} alt="Ascension" value={`A${run.ascension}`} color="var(--accent-gold)" />
         )}
         <div className="w-full sm:w-auto sm:ml-auto text-left sm:text-right text-xs text-[var(--text-muted)] leading-tight">
+          {run.username && (
+            <div className="truncate">
+              <Link
+                href={`${lp}/leaderboards?tab=browse&user=${encodeURIComponent(run.username)}`}
+                className="text-[var(--text-secondary)] hover:text-[var(--accent-gold)] hover:underline"
+                title={t("View all runs by this player", lang)}
+              >
+                {t("by", lang)} <span className="font-medium text-[var(--text-primary)]">{run.username}</span>
+              </Link>
+            </div>
+          )}
           {run.start_time && <div className="truncate">{formatDate(run.start_time)}</div>}
           {run.seed && (
             <div className="truncate">


### PR DESCRIPTION
## Bug
[https://spire-codex.com/runs/2a2e160f24946621](https://spire-codex.com/runs/2a2e160f24946621) doesn't show `LeMerkur` even though the run has a username attached in the DB.

## Root cause
Two-part:

### Backend
`/api/runs/shared/<hash>` returned the raw client-submitted run JSON straight from disk. Usernames aren't in the JSON — they're attached AFTER submission via `/api/runs/claim` and stored on the SQLite `runs` row. `/api/runs/list` joined them; `/api/runs/shared/<hash>` didn't, so share-link consumers saw no username at all.

**Fix**: merge `username` from the DB row into the response in both code paths (cached blob + multiplayer-sibling fallback). One `SELECT` per request, negligible cost.

### Frontend
`RunSummary.tsx` had no UI for username — never displayed it.

**Fix**: small `by {username}` line in the right-aligned info block, **directly above the date**, hyperlinked to the leaderboard filtered to that user's runs (so visitors can discover other runs by the same player).

## Downstream benefit
The title format from #237 already references `run.username` in `generateMetadata`. With this fix, that title now correctly renders `LeMerkur - Defect - Ascension 9 loss - Slay the Spire 2 (sts2) | Spire Codex` instead of `Anonymous - …`.