### PR TITLE
Fix /reference bugs: deprecated act + Aggressive intent {} leak

### DIFF
--- a/backend/app/parsers/act_parser.py
+++ b/backend/app/parsers/act_parser.py
@@ -69,6 +69,8 @@ def parse_all_acts(loc_dir: Path) -> list[dict]:
     localization = load_localization(loc_dir)
     acts = []
     for filepath in sorted(ACTS_DIR.glob("*.cs")):
+        if filepath.stem == "DeprecatedAct":
+            continue
         acts.append(parse_act(filepath, localization))
     return acts
 

--- a/backend/app/services/data_service.py
+++ b/backend/app/services/data_service.py
@@ -129,7 +129,7 @@ def load_stories(lang: str = DEFAULT_LANG) -> list[dict]:
 
 
 def load_acts(lang: str = DEFAULT_LANG) -> list[dict]:
-    return _load_json(lang, "acts")
+    return [a for a in _load_json(lang, "acts") if a.get("id") != "DEPRECATED_ACT"]
 
 
 def load_ascensions(lang: str = DEFAULT_LANG) -> list[dict]:

--- a/frontend/app/components/RichDescription.tsx
+++ b/frontend/app/components/RichDescription.tsx
@@ -257,6 +257,12 @@ const VALID_TAGS = new Set([
  * that can't be resolved statically.
  */
 function cleanTemplateVars(text: string): string {
+  // The literal {} appears inside SmartFormat plural branches as the var's
+  // value placeholder (e.g. {Repeat:plural:| [blue]{}[/blue] times}). Resolve
+  // it to the same blue "X" we use for runtime-dynamic numeric vars before the
+  // plural regex runs — otherwise its [^}]* plural capture stops at the inner
+  // closing brace and leaks the trailing literal as "{ times}" on the page.
+  text = text.replace(/\{\}/g, "[blue]X[/blue]");
   // Handle {Var:plural:singular|plural} → plural
   text = text.replace(/\{(\w+):plural:([^|}]*)\|([^}]*)\}/g, (_m, _v, _s, p) => p);
   // Handle {IsMultiplayer:A|B} → B (second option)


### PR DESCRIPTION
## Summary

Two visible bugs on the [/reference page](https://spire-codex.com/reference):

### 1. Ghost "Deprecated Act" entry
`data/{lang}/acts.json` carries a `DEPRECATED_ACT` row (0 rooms, empty arrays) that surfaces in the Acts grid as a non-clickable card with "0 bosses · 0 encounters · 0 events · 0 ancients."

- \`load_acts()\` filters it from API responses — immediate fix, no re-parse needed
- \`parse_all_acts()\` skips \`DeprecatedAct.cs\` so future re-parses produce clean JSON
- Nothing else cross-references the ID (grepped data/, backend/, frontend/)

### 2. Aggressive intent leaking \`{ times}\`
The intent description is:

\`\`\`
...damage{Repeat:plural:| [blue]{}[/blue] times}.
\`\`\`

The \`{}\` inside the plural branch is a var-value placeholder. The plural regex on \`RichDescription.tsx:261\` uses \`[^}]*\` for the plural capture, which stops at the **inner** closing brace of \`{}\` — captures \`plural = " [blue]{"\`, leaves \`[/blue] times}.\` as orphaned text, and renders **"{ times}."** on the page.

Fix: pre-substitute \`{}\` → \`[blue]X[/blue]\` before the plural regex runs. We already render \`{Damage}\` / \`{CardCount}\` as a blue X, so the placeholder collapses to the same thing.

After: *"This enemy intends to Attack for X damage X times."*