### PR TITLE
Add Docker prune workflow (every 6h)

### DIFF
--- a/.github/workflows/docker-prune.yml
+++ b/.github/workflows/docker-prune.yml
@@ -1,0 +1,65 @@
+name: Docker prune
+
+# Reclaims disk on the prod host. Every CI deploy pulls a new image SHA
+# under the same `:latest` / `:beta` tag, leaving the previous SHA as a
+# dangling image — Docker never garbage-collects on its own. Over weeks
+# of deploys that's tens of GB.
+#
+# What this prunes (safe):
+#   - stopped containers
+#   - dangling images (untagged layers)
+#   - build cache older than 24h
+#   - unused networks
+#
+# What this deliberately does NOT prune:
+#   - volumes (`docker volume prune`) — would wipe runs.db, news archive,
+#     guides, every bind-mounted file. Never automate this.
+#   - `image prune -a` — would also drop base images currently not in a
+#     running container, forcing a full re-pull on next deploy.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Every 6h at :20 past — clear of news-refresh (`0 * * * *`) and
+    # runs-db-backup (`15 3 * * *`).
+    - cron: "20 */6 * * *"
+
+concurrency:
+  group: docker-prune
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    name: Prune Docker on prod host
+    runs-on: self-hosted
+    steps:
+      - name: SSH — prune
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            set -euo pipefail
+
+            echo "=== before ==="
+            docker system df
+            echo ""
+
+            # Stopped containers — left behind by `compose up -d` after
+            # an image upgrade swaps the running container.
+            docker container prune -f
+
+            # Dangling images — the main reclaim target.
+            docker image prune -f
+
+            # Build cache older than 24h. Prod doesn't normally build,
+            # but ad-hoc `compose --build` calls leave cache behind.
+            docker builder prune -af --filter "until=24h"
+
+            # Unused networks (recreated by compose on demand).
+            docker network prune -f
+
+            echo ""
+            echo "=== after ==="
+            docker system df


### PR DESCRIPTION
## Summary

Adds a scheduled GitHub Action that prunes Docker on the prod host every 6 hours. Fixes the low-disk pressure caused by every CI deploy pulling a new image SHA under the same `:latest` / `:beta` tag — Docker leaves the old SHA as a dangling image and never garbage-collects on its own.

**Schedule**: `20 */6 * * *` (00:20, 06:20, 12:20, 18:20 UTC) — clear of `news-refresh` (`0 * * * *`) and `runs-db-backup` (`15 3 * * *`).

## What it prunes (safe)

- Stopped containers — left behind by `compose up -d` after an image upgrade
- Dangling images — the main reclaim target
- Build cache older than 24h — for ad-hoc `compose --build` debug runs
- Unused networks — recreated by compose on demand

## What it deliberately does NOT prune

- **Volumes** — would wipe `runs.db`, news archive, guides. Never automate.
- **`image prune -a`** — would drop unreferenced base images (Alpine, Node, Python), forcing a full re-pull on the next deploy. Dangling-only keeps the working set warm.

## Testing

- `workflow_dispatch` trigger included so you can run it on demand from the Actions tab right after merging.
- Output includes `docker system df` before and after, so the log shows reclaimed space.
