### PR TITLE
docs: Codex Score, tier list, hreflang, title format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,8 @@ If a card description, damage value, or relic effect is wrong:
 ### Run Data / Meta
 - Run submission and stats use SQLite (`data/runs.db`, not committed)
 - Schema and queries are in `backend/app/services/runs_db.py`
-- The meta page is at `frontend/app/meta/`
+- The meta page is at `frontend/app/meta/` (redirects to `/leaderboards/stats`)
+- **Codex Score** lives in `backend/app/services/run_entity_stats.py` — Bayesian-shrunk win rate per entity → 0–100 score → S/A/B/C/D/F tier. Pre-warmed on startup. Exposed at `GET /api/runs/scores/{type}` (`cards`/`relics`/`potions`) and surfaced via the `ScoreBadge`/`EntityRunStats`/`TierList` components. Methodology page at `/leaderboards/scoring`.
 
 ### Game Mechanics
 - Static content pages at `frontend/app/mechanics/`

--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ spire-codex/
 | Knowledge Demon | `/knowledge-demon` | Info page for the Discord bot — slash commands, moderation features, install CTA |
 | News | `/news` | Mirrored Steam announcements feed; canonical links back to Steam so it's additive, not duplicative |
 | News article | `/news/[gid]` | Single Steam announcement with sanitized BBCode body and `NewsArticle` JSON-LD |
+| Tier List | `/tier-list` | Codex Score tier-list hub (S → F tiers) for cards / relics / potions |
+| Tier List Detail | `/tier-list/[type]` | Visual S/A/B/C/D/F rows for one entity type, sourced from `/api/runs/scores/{type}` |
+| Scoring | `/leaderboards/scoring` | Codex Score methodology page — Bayesian shrinkage, prior weight, scale range, tier cutoffs |
 
 ## API Endpoints
 
@@ -256,10 +259,14 @@ All data endpoints accept an optional `?lang=` query parameter (default: `eng`).
 | `POST /api/guides` | Submit guide (proxied to Discord) | — |
 | `POST /api/runs` | Submit a run (.run file JSON) | `username` |
 | `GET /api/runs/list` | List submitted runs | `character`, `win`, `username`, `seed`, `build_id`, `sort`, `page`, `limit` |
-| `GET /api/runs/shared/{hash}` | Full run data by hash | — |
+| `GET /api/runs/shared/{hash}` | Full run data by hash (merges `username` from DB) | — |
 | `GET /api/runs/stats` | Aggregated community stats | `character`, `win`, `ascension`, `game_mode`, `players` |
 | `GET /api/runs/leaderboard` | Ranked wins-only leaderboard | `category` (`fastest`, `highest_ascension`), `character`, `page`, `limit` |
+| `GET /api/runs/scores/{type}` | Codex Score (Bayesian-shrunk win-rate score + S/A/B/C/D/F tier) per entity | `type` = `cards`/`relics`/`potions` |
 | `GET /api/runs/versions` | Distinct game versions across submitted runs | — |
+| `GET /api/news` | Steam announcements + community news (locally archived) | `feed_type`, `feedname`, `tag`, `since`, `search`, `limit`, `offset` |
+| `GET /api/news/{gid}` | Single news article (raw HTML/BBCode body) | — |
+| `GET /api/merchant/config` | Auto-extracted merchant pricing config | — |
 | `POST /api/feedback` | Submit feedback (proxied to Discord) | — |
 | `GET /api/versions` | Available data versions (beta multi-version) | — |
 
@@ -666,12 +673,13 @@ Examples: `v1.0.0` = initial release, `v1.0.1` = our bug fixes, `v1.1.0` = first
 
 ## SEO
 
-- **Structured data (JSON-LD)**: WebSite + VideoGame (home), CollectionPage + ItemList (list pages), Article + BreadcrumbList + FAQPage (detail pages), SoftwareApplication (developers)
-- **Title format**: `"Slay the Spire 2 [Topic] - [Descriptor] | Spire Codex"` — standardized across all pages
-- **Sitemap**: Flat XML at `/sitemap.xml` with `force-dynamic` (renders server-side, not build-time). ~20,000+ URLs including entity detail pages, browse matrix pages, and i18n detail pages for all entity types
-- **International SEO**: `/{lang}/` routes for 13 non-English languages with hreflang alternates
-- **Programmatic SEO**: 41 card browse pages at `/cards/browse/` (rare-attacks, ironclad-skills, etc.)
-- **Internal linking**: Powers ↔ cards, encounters → monsters, card keywords → keyword hub pages, monster moves → power pages (with tooltips), act pages → encounters/events, every reference entity clickable
+- **Structured data (JSON-LD)**: WebSite + VideoGame (home), CollectionPage + ItemList (list pages), Article + BreadcrumbList + FAQPage (detail pages), SoftwareApplication (developers), NewsArticle (news/[gid])
+- **Title format**: `"Slay the Spire 2 (sts2) {Page Title} | Spire Codex"` — standardized across all pages. Runs use `"{username} - {char} - Ascension {N} {win/loss} - Slay the Spire 2 (sts2) | Spire Codex"`. "(sts2)" inline so cross-locale `sts2 tier list` / `sts2 card list` queries match.
+- **Sitemap**: Flat XML at `/sitemap.xml` with `force-dynamic` (renders server-side, not build-time). ~20,000+ URLs including entity detail pages, browse matrix pages, tier-list pages, scoring methodology, runs/[hash] detail, and i18n mirrors for all entity types
+- **International SEO**: `/{lang}/` routes for 13 non-English languages with **bidirectional** hreflang alternates — English root pages also emit alternates for every locale + `x-default` via `buildLanguageAlternates(path)` in `lib/seo.ts` (fixes the GSC "Crawled - not indexed" duplicate-content cluster where Google was treating localized pages as duplicates without back-references)
+- **Programmatic SEO**: 41 card browse pages at `/cards/browse/` (rare-attacks, ironclad-skills, etc.) + 3 tier-list pages (`/tier-list/{cards,relics,potions}`)
+- **Locale-aware EntityProse**: Detail pages render a short locale-specific paragraph instead of identical English bodies in every locale
+- **Internal linking**: Powers ↔ cards, encounters → monsters, card keywords → keyword hub pages, monster moves → power pages (with tooltips), act pages → encounters/events, tier-list rows → entity detail Stats tab
 - **Open Graph & Twitter Cards**: Per-entity OG images, `summary_large_image` Twitter cards
 - **Canonical URLs**: Every page declares a canonical URL
 
@@ -716,6 +724,8 @@ Full docs: [spire-codex.com/developers](https://spire-codex.com/developers)
 - ~~Event preconditions~~ ✅ — 25 events with IsAllowed() conditions parsed from C# source
 - ~~Multi-version beta browsing~~ ✅ — Version dropdown, all past betas preserved and browsable with changelogs
 - ~~Discord bot~~ ✅ — [Knowledge Demon](https://bot.spire-codex.com): slash commands for every entity (`/card`, `/relic`, `/monster`, `/potion`, `/character`, `/event`, `/power`, `/enchantment`, `/lookup`, `/meta`), Steam-news RSS, plus a full moderation toolkit forked from [Kernel](https://github.com/ptrlrd/kernel)
+- ~~Codex Score & Tier List~~ ✅ — Per-entity grade computed from community runs using **Bayesian shrinkage**: `shrunk = (wins + PRIOR_WEIGHT × baseline) / (n + PRIOR_WEIGHT)`, then scaled to 0–100 and mapped to S/A/B/C/D/F. Prevents tiny-sample noise (a 1-game card going 1/1 doesn't get an S — it regresses to the prior). Pre-warmed on backend startup. Surfaced as `ScoreBadge` on detail-page Stats tab, dedicated tier-list pages, and methodology page at `/leaderboards/scoring`.
+- ~~Detail-page Stats tab~~ ✅ — Score hero badge + prose summary + recent runs links via `EntityRunStats`.
 - **Deck builder** — Interactive deck theorycrafting
 - **Database backend** — Replace JSON loading with SQLite/PostgreSQL
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -187,6 +187,9 @@ spire-codex/
 | Knowledge Demon | `/knowledge-demon` | Discord 机器人介绍页 —— 斜杠命令、版务功能、加入服务器入口 |
 | 新闻 | `/news` | 镜像 Steam 公告流；canonical 链接回 Steam，作为补充而非重复 |
 | 单条新闻 | `/news/[gid]` | 单篇 Steam 公告，BBCode 内容已净化，并附 `NewsArticle` JSON-LD |
+| 梯度表 | `/tier-list` | Codex Score 梯度表入口（卡牌 / 遗物 / 药水） |
+| 梯度表详情 | `/tier-list/[type]` | 单一实体类型的 S→F 等级展示，数据来自 `/api/runs/scores/{type}` |
+| 评分说明 | `/leaderboards/scoring` | Codex Score 方法论页面 —— 贝叶斯收缩、先验权重、分级阈值 |
 
 ## API 端点
 
@@ -245,8 +248,12 @@ spire-codex/
 | `POST /api/guides` | 提交攻略（代理到 Discord） | — |
 | `POST /api/runs` | 提交一个 run（`.run` 文件 JSON） | `username` |
 | `GET /api/runs/list` | 已提交 runs 列表 | `character`, `win`, `username`, `page`, `limit` |
-| `GET /api/runs/shared/{hash}` | 通过 hash 获取完整 run 数据 | — |
+| `GET /api/runs/shared/{hash}` | 通过 hash 获取完整 run 数据（会合并数据库中的 `username`） | — |
 | `GET /api/runs/stats` | 聚合后的社区统计 | `character`, `win`, `ascension`, `game_mode`, `players` |
+| `GET /api/runs/scores/{type}` | 各实体的 Codex Score（贝叶斯收缩胜率得分 + S/A/B/C/D/F 等级） | `type` 取值 `cards`/`relics`/`potions` |
+| `GET /api/news` | Steam 公告 + 社区新闻（本地归档；超出 Steam 滑动窗口仍可访问） | `feed_type`, `feedname`, `tag`, `since`, `search`, `limit`, `offset` |
+| `GET /api/news/{gid}` | 单篇新闻文章（原始 HTML / BBCode 正文） | — |
+| `GET /api/merchant/config` | 自动提取的商人价格配置 | — |
 | `POST /api/feedback` | 提交反馈（代理到 Discord） | — |
 
 每个 IP 每分钟限流 **60 次请求**。反馈和攻略提交接口每个 IP 每分钟限制 **3–5 次**。交互式文档位于 `/docs`（Swagger UI）。
@@ -637,12 +644,13 @@ Spire Codex 使用 **`1.X.Y`** 语义化版本规则：
 
 ## SEO
 
-- **结构化数据（JSON-LD）**：首页使用 WebSite + VideoGame，列表页使用 CollectionPage + ItemList，详情页使用 Article + BreadcrumbList + FAQPage，开发者页使用 SoftwareApplication
-- **标题格式**：`"Slay the Spire 2 [Topic] - [Descriptor] | Spire Codex"` —— 全站统一
-- **站点地图**：位于 `/sitemap.xml` 的扁平 XML，使用 `force-dynamic`（服务端动态渲染，而非构建时生成）。共约 20,000+ 个 URL，包含实体详情页、浏览矩阵页以及所有实体类型的多语言详情页
-- **国际化 SEO**：为 13 种非英语语言提供 `/{lang}/` 路由，并配置 hreflang alternates
-- **程序化 SEO**：在 `/cards/browse/` 下提供 41 个卡牌浏览页面（如 rare-attacks、ironclad-skills 等）
-- **站内链接**：能力 ↔ 卡牌、遭遇 → 怪物、卡牌关键词 → 关键词中心页、怪物行动 → 能力页（带 tooltip）、章节页 → 遭遇 / 事件、所有参考实体均可点击
+- **结构化数据（JSON-LD）**：首页使用 WebSite + VideoGame，列表页使用 CollectionPage + ItemList，详情页使用 Article + BreadcrumbList + FAQPage，开发者页使用 SoftwareApplication，新闻详情页使用 NewsArticle
+- **标题格式**：`"Slay the Spire 2 (sts2) {Page Title} | Spire Codex"` —— 全站统一。共享 run 使用 `"{username} - {char} - Ascension {N} {win/loss} - Slay the Spire 2 (sts2) | Spire Codex"`。把 "(sts2)" 内联进标题，使各语言下的 `sts2 tier list` / `sts2 card list` 等查询都能命中。
+- **站点地图**：位于 `/sitemap.xml` 的扁平 XML，使用 `force-dynamic`（服务端动态渲染，而非构建时生成）。共约 20,000+ 个 URL，包含实体详情页、浏览矩阵页、梯度表页、评分方法论页、`runs/[hash]` 详情，以及所有实体类型的多语言详情页
+- **国际化 SEO**：为 13 种非英语语言提供 `/{lang}/` 路由，并配置**双向** hreflang alternates —— 英文根页面也会通过 `lib/seo.ts` 中的 `buildLanguageAlternates(path)` 输出全部 13 个语言的 alternate 以及 `x-default`（修复 GSC 中「已抓取但未编入索引」聚类问题，此前 Google 把缺少反向引用的本地化页面当作重复内容）
+- **程序化 SEO**：在 `/cards/browse/` 下提供 41 个卡牌浏览页面（如 rare-attacks、ironclad-skills 等），加上 3 个梯度表页面（`/tier-list/{cards,relics,potions}`）
+- **本地化 EntityProse**：详情页注入按语言定制的短段落，避免不同语言下相同英文正文被 GSC 当作重复内容
+- **站内链接**：能力 ↔ 卡牌、遭遇 → 怪物、卡牌关键词 → 关键词中心页、怪物行动 → 能力页（带 tooltip）、章节页 → 遭遇 / 事件、梯度表行 → 实体详情页 Stats 标签、所有参考实体均可点击
 - **Open Graph 与 Twitter Cards**：为每个实体单独生成 OG 图片，`summary_large_image` Twitter 卡片
 - **Canonical URL**：每个页面都会声明 canonical URL
 
@@ -691,6 +699,8 @@ Spire Codex 使用 **`1.X.Y`** 语义化版本规则：
 - ~~事件前置条件~~ ✅ —— 25 个事件，条件来自 C# 源码中 IsAllowed() 的解析
 - ~~Beta 多版本浏览~~ ✅ —— 版本下拉框，保留所有历史 beta，并支持查看 changelog
 - ~~Discord 机器人~~ ✅ —— [Knowledge Demon](https://bot.spire-codex.com)：每个实体都有斜杠命令（`/card`、`/relic`、`/monster`、`/potion`、`/character`、`/event`、`/power`、`/enchantment`、`/lookup`、`/meta`），支持 Steam 新闻 RSS，外加从 [Kernel](https://github.com/ptrlrd/kernel) 派生的完整版务工具集
+- ~~Codex Score 与梯度表~~ ✅ —— 基于社区 run 数据，使用**贝叶斯收缩**计算每个实体的评分：`shrunk = (wins + PRIOR_WEIGHT × baseline) / (n + PRIOR_WEIGHT)`，再缩放到 0–100 并映射到 S/A/B/C/D/F。可避免小样本噪声（一张只打过 1 局且胜的卡不会拿到 S，而是回归先验）。FastAPI 启动时预热缓存。在详情页 Stats 标签通过 `ScoreBadge` 展示，并在 `/tier-list/{cards,relics,potions}` 单独陈列，方法论页面位于 `/leaderboards/scoring`。
+- ~~详情页 Stats 标签~~ ✅ —— `EntityRunStats` 提供得分徽章 + 文字总结 + 最近 run 链接。
 - **构筑编辑器** —— 可交互式牌组理论构筑
 - **数据库后端** —— 用 SQLite / PostgreSQL 替换 JSON 加载
 

--- a/contributing/API_REFERENCE.md
+++ b/contributing/API_REFERENCE.md
@@ -63,8 +63,9 @@ All data endpoints accept `?lang=` (default: `eng`). Rate limited to 60 req/min 
 | `POST /api/runs` | POST | Submit a run. Optional `?username=` param (25 char max) |
 | `GET /api/runs/stats` | GET | Aggregated community stats. Filters: `character`, `win`, `ascension`, `game_mode`, `players` |
 | `GET /api/runs/list` | GET | Browse runs. Filters: `character`, `win`, `username`, `seed` (LIKE), `build_id`, `sort` (`date`, `time_asc`, `time_desc`, `ascension_desc`), `page`, `limit` |
-| `GET /api/runs/shared/{hash}` | GET | Retrieve a shared run by hash |
+| `GET /api/runs/shared/{hash}` | GET | Retrieve a shared run by hash. Response merges `username` from `runs.db` so the shared-run page can render "by {username}" without a second round trip. |
 | `GET /api/runs/leaderboard` | GET | Ranked wins-only leaderboard. Filters: `category` (`fastest`, `highest_ascension`), `character`, `page`, `limit` |
+| `GET /api/runs/scores/{type}` | GET | Codex Score per entity. `type` ∈ `cards` / `relics` / `potions`. Returns `{ id, score (0–100), tier (S/A/B/C/D/F), wins, losses, n }[]`. Bayesian-shrunk win rate; pre-warmed on FastAPI startup. See `services/run_entity_stats.py` and `/leaderboards/scoring` for the formula. |
 | `GET /api/runs/versions` | GET | Distinct `build_id` values across submitted runs — powers the version filter dropdown |
 
 ## Utility

--- a/contributing/ARCHITECTURE.md
+++ b/contributing/ARCHITECTURE.md
@@ -123,7 +123,7 @@ Constants:
 - `PRIOR_WEIGHT = 50` — pulls low-sample entries toward the baseline
 - `SCALE_RANGE = 0.15` — a 15-point swing in shrunk win rate is the full 0–100 scale
 
-Tier cutoffs: **S** ≥85, **A** 70–85, **B** 55–70, **C** 40–55, **D** 25–40, **F** <25.
+Tier cutoffs (from `frontend/app/components/ScoreBadge.tsx::scoreToTier`): **S** ≥90, **A** 78–89, **B** 65–77, **C** 50–64, **D** 35–49, **F** <35.
 
 `get_all_entity_scores(entity_type)` returns the full table for one type. Results are cached and pre-warmed on FastAPI startup via `_warm_run_entity_stats()` in `main.py` (background thread, so app boot isn't blocked).
 

--- a/contributing/ARCHITECTURE.md
+++ b/contributing/ARCHITECTURE.md
@@ -19,9 +19,10 @@ The game is built with Godot 4 but all logic is in a C#/.NET 8 DLL, not GDScript
 ## Backend (`backend/`)
 
 - **FastAPI** with Pydantic schemas, slowapi rate limiting, GZip compression
-- **25+ routers** in `app/routers/` — one per entity type + guides, runs, feedback
-- **Data service** loads JSON from `data/{lang}/` with LRU caching
+- **25+ routers** in `app/routers/` — one per entity type + guides, runs, feedback, news, merchant
+- **Data service** loads JSON from `data/{lang}/` with LRU caching; `VersionMiddleware` reads `?version=` and threads it through via `ContextVar`
 - **SQLite** (`data/runs.db`) for community run submissions
+- **Run entity stats service** (`app/services/run_entity_stats.py`) — computes the Codex Score (Bayesian-shrunk win rate → 0–100 → S/A/B/C/D/F tier) per card/relic/potion. Pre-warmed on FastAPI startup by `_warm_run_entity_stats()` in `main.py` so the first request isn't a cold cache.
 - **Static images** served from `backend/static/images/`
 
 ### Parsers (`backend/app/parsers/`)
@@ -66,9 +67,15 @@ Each parser reads decompiled C# source + localization JSON and outputs structure
 | `lib/api.ts` | API client + all TypeScript interfaces |
 | `lib/ui-translations.ts` | Manual UI string translations for 13 languages |
 | `lib/use-lang-prefix.ts` | Hook for language-aware URL construction |
+| `lib/seo.ts` | `buildLanguageAlternates(path)` returns the hreflang map for all 13 locales + `x-default`. Used in `generateMetadata` for both English root pages and `/{lang}/` mirrors so the alternates are bidirectional (fixes GSC duplicate-content cluster). |
+| `lib/use-entity-scores.ts` | Client hook — bulk-fetches Codex Scores per entity type via `/api/runs/scores/{type}`. |
+| `lib/steam-news.ts` | Steam HTML/BBCode → safe HTML sanitizer for `/news` (resolves `{STEAM_CLAN_IMAGE}`, BBCode → HTML, strips scripts/iframes/event handlers). |
 | `app/globals.css` | CSS variables — colors, theme |
 | `app/components/RichDescription.tsx` | BBCode tag renderer for game text |
 | `app/components/CardGrid.tsx` | Card grid with inline icons |
+| `app/components/ScoreBadge.tsx` | S/A/B/C/D/F tier pill (sm/md/lg) used on detail Stats tabs and tier-list rows. |
+| `app/components/EntityRunStats.tsx` | Detail-page Stats tab — score hero badge + prose summary + recent runs links. |
+| `app/components/TierList.tsx` | Visual S→F rows for `/tier-list/{cards,relics,potions}`. |
 | `app/contexts/LanguageContext.tsx` | i18n state from URL path |
 
 ### Color System
@@ -93,11 +100,38 @@ All endpoints accept `?lang=` (default: `eng`). Responses are GZip-compressed wi
 
 - **List endpoints**: `GET /api/cards`, `GET /api/monsters`, etc. with filters
 - **Detail endpoints**: `GET /api/cards/{id}`, `GET /api/monsters/{id}`, etc.
-- **Runs**: `POST /api/runs` (submit), `GET /api/runs/stats` (aggregated meta), `GET /api/runs/list` (browse — accepts `seed`, `build_id`, `sort` filters), `GET /api/runs/leaderboard` (ranked wins-only), `GET /api/runs/versions` (distinct game versions), `GET /api/runs/shared/{hash}` (shared run detail)
+- **Runs**: `POST /api/runs` (submit), `GET /api/runs/stats` (aggregated meta), `GET /api/runs/list` (browse — accepts `seed`, `build_id`, `sort` filters), `GET /api/runs/leaderboard` (ranked wins-only), `GET /api/runs/versions` (distinct game versions), `GET /api/runs/shared/{hash}` (shared run detail — merges `username` from `runs.db` so the shared-run page can show "by {username}"), `GET /api/runs/scores/{type}` (Codex Score per entity)
 - **Guides**: `GET /api/guides` (list with filters), `GET /api/guides/{slug}` (detail), `POST /api/guides` (Discord webhook submission)
+- **News**: `GET /api/news`, `GET /api/news/{gid}` — Steam announcement archive (`data/news/{gid}.json`, survives Steam's sliding window)
+- **Merchant config**: `GET /api/merchant/config` — auto-extracted from C# pricing constants
 - **Docs**: `http://localhost:8000/docs` (Swagger UI)
 
 Filter parameters always use English values regardless of language.
+
+## Codex Score
+
+Per-entity grade derived from community-submitted runs. Lives in `backend/app/services/run_entity_stats.py`.
+
+The raw observed win rate is unstable for small samples (a card that's only appeared in 1 game and won would otherwise rank S). To prevent this, we **shrink** the observed rate toward a baseline (the global community win rate) using a Bayesian prior:
+
+```
+shrunk_rate = (wins + PRIOR_WEIGHT × baseline) / (n + PRIOR_WEIGHT)
+score = clamp((shrunk_rate - baseline) / SCALE_RANGE × 50 + 50, 0, 100)
+```
+
+Constants:
+- `PRIOR_WEIGHT = 50` — pulls low-sample entries toward the baseline
+- `SCALE_RANGE = 0.15` — a 15-point swing in shrunk win rate is the full 0–100 scale
+
+Tier cutoffs: **S** ≥85, **A** 70–85, **B** 55–70, **C** 40–55, **D** 25–40, **F** <25.
+
+`get_all_entity_scores(entity_type)` returns the full table for one type. Results are cached and pre-warmed on FastAPI startup via `_warm_run_entity_stats()` in `main.py` (background thread, so app boot isn't blocked).
+
+Surfaces:
+- `GET /api/runs/scores/{type}` — bulk feed for tier-list pages
+- `ScoreBadge` on entity detail Stats tab (`EntityRunStats`)
+- `/tier-list/{cards,relics,potions}` — visual S→F rows
+- `/leaderboards/scoring` — methodology page (explains the formula above for end users)
 
 ## Localization
 

--- a/contributing/CLAUDE.md
+++ b/contributing/CLAUDE.md
@@ -42,9 +42,13 @@ spire-codex/
         entity_history.py    # Per-entity version history from changelogs
         changelogs.py        # Changelog API
         guides.py            # Guides (list, detail, Discord webhook submission)
-        runs.py              # Run submission + community stats + shared runs
+        runs.py              # Run submission + community stats + shared runs + Codex Score (`/api/runs/scores/{type}`)
+        news.py              # Steam news passthrough — list + detail (`/api/news`, `/api/news/{gid}`)
+        merchant.py          # Merchant pricing config (auto-extracted constants)
+        unlocks.py versions.py
         images.py feedback.py
-      services/              # data_service (loads JSON, lru_cache)
+      services/              # data_service (loads JSON, lru_cache, ContextVar version-aware loading)
+        run_entity_stats.py  # Codex Score — Bayesian-shrunk win-rate per entity, S/A/B/C/D/F tier; pre-warmed on startup
       parsers/               # C# -> JSON parsers
         card_parser.py       # Cards with DynamicVars, upgrades, compendium_order
         character_parser.py
@@ -85,9 +89,14 @@ spire-codex/
       leaderboards/page.tsx  # Three-tab browser — Fastest Wins, Highest Ascension, Browse Runs
       leaderboards/submit/   # Drag-and-drop .run upload
       leaderboards/stats/    # Ranked-table stats (cards/relics/potions/encounters pick + win rates)
-      runs/[hash]/           # Shared-run detail — in-game-style summary with TinyCard grid, clickable map nodes
+      leaderboards/scoring/  # Codex Score methodology page (Bayesian shrinkage explainer)
+      tier-list/page.tsx     # Codex Score tier-list hub (cards/relics/potions)
+      tier-list/[type]/      # Visual S→F tier rows per entity type
+      runs/[hash]/           # Shared-run detail — "by {username}" link + in-game-style summary with TinyCard grid, clickable map nodes
       runs/page.tsx          # Redirect to /leaderboards (old URL preserved)
       meta/page.tsx          # Redirect to /leaderboards/stats (old URL preserved)
+      news/page.tsx          # Steam news list (mirrored archive)
+      news/[gid]/page.tsx    # Single Steam news article — NewsArticle JSON-LD, canonical → Steam, BBCode-sanitized body
       showcase/page.tsx      # Community project gallery
       developers/page.tsx    # API docs, widget docs, data exports
       timeline/page.tsx reference/page.tsx images/page.tsx
@@ -107,15 +116,21 @@ spire-codex/
         LocalizedNames.tsx   # Collapsible cross-language name display
         EntityHistory.tsx    # Collapsible version history timeline
         RelatedCards.tsx     # Cards sharing keywords/tags
+        ScoreBadge.tsx       # S/A/B/C/D/F tier letter pill (sm/md/lg) — detail-page Stats tab + tier-list rows
+        EntityRunStats.tsx   # Detail-page Stats tab — score hero badge + prose summary + recent runs links
+        TierList.tsx         # Visual S→F tier rows for /tier-list/{cards,relics,potions}
       runs/[hash]/
         RunSummary.tsx       # In-game-style summary — stats bar + act rows + relic strip + TinyCard grid
         RunPills.tsx         # CardPill / RelicPill / PotionPill — hover tooltips with full entity info
         SharedRunClient.tsx  # Run hash loader + top-level layout
     lib/
-      api.ts                # API client + TypeScript interfaces (with compendium_order)
-      seo.ts                # stripTags, SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE
-      jsonld.ts             # JSON-LD builders (BreadcrumbList, CollectionPage, Article, WebSite, VideoGame, FAQPage, SoftwareApplication)
+      api.ts                # API client + TypeScript interfaces (with compendium_order); `getStats` + `getStatsBounded` (3s AbortSignal.timeout for `generateMetadata`)
+      seo.ts                # stripTags, SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE, `buildLanguageAlternates(path)` → hreflang map for 13 locales + x-default + English self-reference
+      jsonld.ts             # JSON-LD builders (BreadcrumbList, CollectionPage, Article, NewsArticle, WebSite, VideoGame, FAQPage, SoftwareApplication)
+      steam-news.ts         # Steam HTML/BBCode → safe HTML sanitizer for /news
+      merchant-config.ts    # Loader + helpers for /api/merchant/config with hardcoded fallback for build-time
       fetch-cache.ts        # Client-side in-memory fetch cache (5min TTL)
+      use-entity-scores.ts  # Client hook — bulk Codex Scores per entity type
       languages.ts          # i18n config — 13 language codes, hreflang mappings, native names
     public/widget/
       spire-codex-tooltip.js   # Embeddable tooltip widget — all 13 entity types
@@ -178,11 +193,17 @@ spire-codex/
 - `GET /api/changelogs` / `GET /api/changelogs/{tag}` — Version changelogs
 - `GET /api/guides?category=&difficulty=&tag=&search=` / `GET /api/guides/{slug}` — Guides
 - `POST /api/guides` — Guide submission (Discord webhook, rate-limited)
-- `POST /api/runs` — Run submission / `GET /api/runs/list` (filters: character, win, username, seed, build_id, sort, page, limit) / `GET /api/runs/shared/{hash}` / `GET /api/runs/stats`
+- `POST /api/runs` — Run submission / `GET /api/runs/list` (filters: character, win, username, seed, build_id, sort, page, limit) / `GET /api/runs/shared/{hash}` (merges `username` from DB) / `GET /api/runs/stats`
 - `GET /api/runs/leaderboard` — ranked wins-only list (category: fastest|highest_ascension, character, page, limit)
+- `GET /api/runs/scores/{type}` — Bulk Codex Scores for cards/relics/potions (Bayesian-shrunk win rate → 0–100 → S/A/B/C/D/F)
 - `GET /api/runs/versions` — distinct build_ids across submitted runs
+- `GET /api/news?feed_type=&feedname=&tag=&since=&search=&limit=&offset=` / `GET /api/news/{gid}` — Steam announcements (locally archived)
+- `GET /api/merchant/config` — Auto-extracted merchant pricing
+- `GET /api/versions` — Available data versions (beta multi-version browsing)
+- `GET /api/unlocks` — Aggregated unlockables grouped by type
 - `GET /api/languages` / `GET /api/translations`
 - All endpoints accept `?lang=` (default: eng) — 14 languages supported
+- Beta endpoints accept `?version=` for multi-version browsing
 - Docs: `http://localhost:8000/docs`
 
 ## Merchant Pricing (from decompiled C#)
@@ -205,12 +226,13 @@ spire-codex/
 ### Shop Inventory: 5 character cards (2 ATK, 2 SKL, 1 PWR) + 2 colorless (UNC, RARE) + 3 relics + 3 potions + removal
 
 ## SEO
-- **Structured data**: JSON-LD on all pages — WebSite + VideoGame (home), CollectionPage+ItemList (list pages), Article+BreadcrumbList+FAQPage (detail pages), SoftwareApplication (developers)
-- **Title format**: `"Slay the Spire 2 [Topic] - [Descriptor] | Spire Codex"` — standardized across all pages
-- **Sitemap**: Flat XML at `/sitemap.xml`, `force-dynamic` (renders server-side, not build-time). ~1,500+ URLs including browse pages and i18n landing pages
-- **International SEO**: `/{lang}/` routes for 13 non-English languages with hreflang alternates
-- **Programmatic SEO**: 41 card browse pages at `/cards/browse/` (rare-attacks, ironclad-skills, etc.)
-- **Internal linking**: Powers ↔ cards, encounters → monsters, card keywords → keyword hub pages
+- **Structured data**: JSON-LD on all pages — WebSite + VideoGame (home), CollectionPage+ItemList (list pages), Article+BreadcrumbList+FAQPage (detail pages), SoftwareApplication (developers), NewsArticle (news/[gid])
+- **Title format**: `"Slay the Spire 2 (sts2) {Page Title} | Spire Codex"` — standardized. Runs use `"{username} - {char} - Ascension {N} {win/loss} - Slay the Spire 2 (sts2) | Spire Codex"`. "(sts2)" inline so cross-locale `sts2 tier list` / `sts2 card list` queries match.
+- **Sitemap**: Flat XML at `/sitemap.xml`, `force-dynamic` (renders server-side, not build-time). ~20,000+ URLs including browse pages, tier-list pages, scoring methodology, `runs/[hash]` detail, and i18n landing pages
+- **International SEO**: `/{lang}/` routes for 13 non-English languages with **bidirectional** hreflang alternates — English root pages also emit alternates for all locales + `x-default` via `buildLanguageAlternates(path)` in `lib/seo.ts` (fixes GSC "Crawled - not indexed" duplicate-content cluster)
+- **Programmatic SEO**: 41 card browse pages at `/cards/browse/` + 3 tier-list pages
+- **Locale-aware EntityProse**: avoids cross-locale identical English bodies that GSC flagged as duplicates
+- **Internal linking**: Powers ↔ cards, encounters → monsters, card keywords → keyword hub pages, tier-list rows → entity detail Stats tab
 - **Alt text**: All images include "Slay the Spire 2 {Category}"
 
 ## Embeddable Widgets
@@ -306,7 +328,7 @@ Parallel deployment for Steam beta branch data. Uses same codebase/images but se
 
 ## Versioning
 Uses `1.X.Y` — 1=codex major, X=bumps on Mega Crit game patch, Y=our fixes/improvements.
-Current: **v1.0.20**
+Current: **v1.1.1** (X bumped on game v0.103.2 / Major Update #1; Y rolled with i18n + badges + smoke renders + changelog guard)
 
 ## Known Limitations
 - 6 monsters lack images entirely (Crusher, Doormaker, Flyconid, Ovicopter, Rocket, Decimillipede)
@@ -348,9 +370,14 @@ Current: **v1.0.20**
 - ~~Monster attack patterns~~ ✅ — cycle/random/conditional move-machine parsing from `GenerateMoveStateMachine`
 - ~~Multi-version beta browsing~~ ✅ — versioned `data-beta/vX.Y.Z/` dirs with `latest` symlink, version-aware loader
 - ~~Leaderboards + run browser revamp~~ ✅ — `/leaderboards` 3-tab page (Fastest Wins, Highest Ascension, Browse), drag-and-drop submit, ranked-table stats replacing `/meta`, filter by seed/username/character/win/version/sort
-- ~~In-game-style run summary~~ ✅ — `/runs/[hash]` mimics the end-of-run screen with map-node rows, clickable encounter/event links, tiny-card deck grid
+- ~~In-game-style run summary~~ ✅ — `/runs/[hash]` mimics the end-of-run screen with map-node rows, clickable encounter/event links, tiny-card deck grid; shows "by {username}" link
 - ~~TinyCard primitive + docs~~ ✅ — shared React component reproducing the in-game card thumbnail; live preview + recipes on `/developers`
 - ~~Search bar redesign~~ ✅ — hero search on home, middle-of-nav on other pages, icon-only on mobile
+- ~~Codex Score & Tier List~~ ✅ — Bayesian-shrunk win-rate per entity, S/A/B/C/D/F tiers, dedicated tier-list pages, methodology page at `/leaderboards/scoring`. Pre-warmed on FastAPI startup so first request isn't a cold cache.
+- ~~Detail-page Stats tab~~ ✅ — score hero badge + prose summary + recent runs via `EntityRunStats`
+- ~~Bidirectional hreflang~~ ✅ — English root pages emit alternates for 13 locales + x-default via `buildLanguageAlternates`
+- ~~News mirror~~ ✅ — `/news` mirrors Steam's announcement feed with locally archived `data/news/{gid}.json` so the archive survives Steam's sliding window
+- ~~Unified SEO title format~~ ✅ — `"Slay the Spire 2 (sts2) {Page Title} | Spire Codex"`
 - i18n refactor — migrate from manual t() calls to `next-intl` for complete translation coverage
   - Known gaps: compare graphs (keyword matching), merchant prose, about/changelog content, scattered client component strings
   - Current t() approach doesn't scale — hundreds of strings across dozens of components

--- a/contributing/CODEX.md
+++ b/contributing/CODEX.md
@@ -47,16 +47,19 @@ Spire Codex is a comprehensive database for Slay the Spire 2, built by reverse-e
 ## File Map
 
 ```
-backend/app/main.py              → App entry, router registration
-backend/app/routers/             → API endpoints (one file per entity)
-backend/app/models/schemas.py    → Pydantic models
-backend/app/services/runs_db.py  → SQLite runs database
-backend/app/parsers/             → C# → JSON parsers
-frontend/app/layout.tsx          → Root layout (navbar, footer, providers)
-frontend/app/globals.css         → CSS variables, theme
-frontend/lib/api.ts              → API client + TypeScript interfaces
-frontend/lib/ui-translations.ts  → Manual UI translations
-frontend/app/components/         → Shared components
+backend/app/main.py                       → App entry, router registration, `_warm_run_entity_stats()` startup pre-warm
+backend/app/routers/                      → API endpoints (one file per entity)
+backend/app/models/schemas.py             → Pydantic models
+backend/app/services/runs_db.py           → SQLite runs database
+backend/app/services/run_entity_stats.py  → Codex Score — Bayesian-shrunk win rate per entity, S/A/B/C/D/F tier
+backend/app/parsers/                      → C# → JSON parsers
+frontend/app/layout.tsx                   → Root layout (navbar, footer, providers)
+frontend/app/globals.css                  → CSS variables, theme
+frontend/lib/api.ts                       → API client + TypeScript interfaces
+frontend/lib/seo.ts                       → SITE_URL, SITE_NAME, `buildLanguageAlternates(path)` for bidirectional hreflang
+frontend/lib/use-entity-scores.ts         → Hook — bulk Codex Scores per type via `/api/runs/scores/{type}`
+frontend/lib/ui-translations.ts           → Manual UI translations
+frontend/app/components/                  → Shared components (incl. ScoreBadge, EntityRunStats, TierList)
 ```
 
 ## See Also

--- a/contributing/DATA_GUIDE.md
+++ b/contributing/DATA_GUIDE.md
@@ -99,14 +99,17 @@ The frontend `RichDescription` component renders these.
 - Rare: 143-158 gold (base 150)
 
 ### Relics
-- Common: 170-230 gold. Shop: 191-259. Uncommon: 213-288. Rare: 255-345.
-- Fake Merchant: all 50 gold flat
+Major Update #1 (v0.103.2) reduced every relic base by 25g:
+- Common: 149-201 (base 175). Shop: 170-230 (base 200). Uncommon: 191-259 (base 225). Rare: 234-316 (base 275).
+- Fake Merchant: all 50 gold flat (10 fakes — `IsAllowedInShops => false`)
+- Blacklisted from regular shop: The Courier, Old Coin, Lucky Fysh, Bowler Hat, Amethyst Aubergine (last three added in MU#1)
 
 ### Potions
 - Common: 48-53. Uncommon: 71-79. Rare: 95-105.
 
 ### Card Removal
 - 75 + 25 × removals used (no RNG)
+- Ascension 6+ — Inflation: 100 + 50 × removals used (replaced Gloom / 1-fewer-rest-site in Major Update #1)
 
 ## Versioning
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,6 +38,12 @@ Runs at **http://localhost:3000**. Requires the backend running on port 8000.
 | `/images` | Browsable game assets with ZIP download |
 | `/changelog` | Data diffs between game updates |
 | `/about` | Project info, live stats, pipeline visualization |
+| `/tier-list` | Codex Score tier-list hub (cards / relics / potions) |
+| `/tier-list/[type]` | S → F tier rows for one entity type, sourced from `/api/runs/scores/{type}` |
+| `/leaderboards/scoring` | Codex Score methodology — Bayesian shrinkage, prior weight, tier cutoffs |
+| `/news` | Mirrored Steam announcements feed |
+| `/news/[gid]` | Single Steam announcement — sanitized BBCode body, NewsArticle JSON-LD |
+| `/runs/[hash]` | Shared run — in-game-style summary with "by {username}" link |
 
 ## Key Components
 
@@ -48,6 +54,9 @@ Runs at **http://localhost:3000**. Requires the backend running on port 8000.
 - **`JsonLd.tsx`** — Server component rendering `<script type="application/ld+json">` blocks
 - **`Navbar.tsx`** — Navigation with search trigger
 - **`Footer.tsx`** — Footer with feedback modal
+- **`ScoreBadge.tsx`** — S/A/B/C/D/F tier pill (sm/md/lg)
+- **`EntityRunStats.tsx`** — Detail-page Stats tab — score hero badge + prose summary + recent runs links
+- **`TierList.tsx`** — Visual S→F tier rows for `/tier-list/{cards,relics,potions}`
 
 ## SEO
 
@@ -73,7 +82,11 @@ Every page includes structured data and meta tags:
 
 Sitemaps use ISR (`revalidate: 3600`) so they regenerate hourly at runtime — this is critical because the backend API isn't available during the Docker build. Entity entries include `images` for Google Image search indexing.
 
-Shared utilities in `lib/seo.ts` (stripTags, SITE_URL, SITE_NAME) and `lib/jsonld.ts` (schema builders for BreadcrumbList, CollectionPage, Article, WebSite).
+Shared utilities in `lib/seo.ts` (stripTags, SITE_URL, SITE_NAME, `buildLanguageAlternates(path)`) and `lib/jsonld.ts` (schema builders for BreadcrumbList, CollectionPage, Article, NewsArticle, WebSite).
+
+**Title format (standardized)**: `"Slay the Spire 2 (sts2) {Page Title} | Spire Codex"`. Run pages use `"{username} - {char} - Ascension {N} {win/loss} - Slay the Spire 2 (sts2) | Spire Codex"`. "(sts2)" is inline so cross-locale `sts2 tier list` / `sts2 card list` queries match.
+
+**Bidirectional hreflang**: English root pages emit alternates for all 13 locales + `x-default` via `buildLanguageAlternates(path)`. Fixes the GSC "Crawled - not indexed" cluster where Google was treating localized pages as duplicates without back-references.
 
 ## Environment Variables
 


### PR DESCRIPTION
Re-created after the 2026-05-14 12:42 UTC repo rollback closed the original #240.

Catches the docs up on the recent SEO + Codex Score work. Touches README.md, README_CN.md, CONTRIBUTING.md, contributing/{CLAUDE,ARCHITECTURE,API_REFERENCE,CODEX,DATA_GUIDE}.md, and frontend/README.md. Adds Codex Score system, tier-list pages, scoring methodology, /api/runs/scores/{type}, username merge on /api/runs/shared/{hash}, title format spec, bidirectional hreflang, EntityProse note. No code changes.