### PR TITLE
Pin Cache-Control on /static + /api so CF stops thrashing origin

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -161,14 +161,42 @@ class VersionMiddleware(BaseHTTPMiddleware):
 
 
 class CORSStaticMiddleware(BaseHTTPMiddleware):
-    """Add CORS headers and cache headers to all responses."""
+    """Add CORS + Cache-Control headers.
+
+    Cloudflare's edge respects origin Cache-Control as authoritative. Without
+    explicit headers it falls back to a ~4h heuristic for static assets, which
+    combined with ~200 PoPs caching per-file per-region produced ~75 req/sec of
+    backend traffic just refilling /static across the planet. The split below
+    pins each path class to a TTL appropriate to how often the content can
+    actually change:
+
+      /static/*    immutable, 1y           — sprite/image filenames are stable;
+                                             re-renders are rare and handled by
+                                             a manual CF purge on the affected
+                                             path.
+      /api/runs/*  s-maxage=30             — user-submitted runs need to appear
+                                             in lists/leaderboards within a
+                                             minute, not an hour.
+      /api/*       s-maxage=3600           — entity data only changes on deploy
+                                             (every few days). Browsers still
+                                             revalidate every 5 min via max-age.
+
+    Cache headers are only applied to successful GETs. Caching 4xx/5xx on
+    /static would prevent recovery by simply uploading the missing file.
+    """
 
     async def dispatch(self, request: Request, call_next):
         response = await call_next(request)
         response.headers["Access-Control-Allow-Origin"] = "*"
-        # Cache API GET responses for 5 minutes (data changes only on redeploy)
-        if request.method == "GET" and request.url.path.startswith("/api/"):
-            response.headers["Cache-Control"] = "public, max-age=300"
+        if request.method != "GET" or response.status_code >= 400:
+            return response
+        path = request.url.path
+        if path.startswith("/static/"):
+            response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+        elif path.startswith("/api/runs/"):
+            response.headers["Cache-Control"] = "public, max-age=30, s-maxage=30"
+        elif path.startswith("/api/"):
+            response.headers["Cache-Control"] = "public, max-age=300, s-maxage=3600"
         return response
 
 


### PR DESCRIPTION
## Summary

- `/static/*` now ships `Cache-Control: public, max-age=31536000, immutable` so Cloudflare stops re-filling sprites every 4 hours per PoP — Grafana showed ~75 req/sec of pure /static refill traffic alone.
- `/api/*` bumped from `max-age=300` to `max-age=300, s-maxage=3600`, so browsers still revalidate every 5 minutes while CF holds the response at the edge for an hour.
- `/api/runs/*` gets a short `s-maxage=30` because it reflects user-submitted data — a new leaderboard entry should appear within a minute, not an hour.
- 4xx / 5xx responses skip cache headers entirely so a 404 on `/static` can be recovered by uploading the missing file rather than waiting out a year of negative caching.

## Why now

Grafana showed sustained ~254 req/sec to backend, with `/static` (75/sec) and the entity detail endpoints `/api/cards/{id}` (42/sec) + `/api/relics/{id}` (32/sec) + `/api/monsters/{id}` (15/sec) + `/api/powers/{id}` (12/sec) dominating. CF was caching `strike_ironclad.webp` (HIT) but missing on `akabeko.webp` and `architect.webp` because per-PoP fills are constant under the existing 4h TTL. With ~1.5K static files × ~200 PoPs the math works out to roughly the 75/sec we observed.

After this lands and CF cache refills with the new headers (within ~4 hours, or immediately with a manual purge), backend req/sec should drop from 254 → likely under 50, which is enough headroom that the Overwolf 15K-user surge won't OOM the box on day one.

## After-merge

- Watch the Grafana "HTTP Requests / min" stat — expect a clear stepdown once edge cache refills propagate.
- If you re-render a sprite that's already been served with `immutable`, manually purge that path via CF dashboard. Worth wiring into `tools/deploy.py` later but not blocking this change.