### PR TITLE
Add a temporary /qa card-render audit page + Discord feedback hook

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -53,6 +53,7 @@ from .routers import (
     mechanics,
     auth_steam,
     uninstall,
+    qa_feedback,
 )
 from .services.data_service import get_stats, load_translation_maps, current_version
 from .dependencies import get_lang, VALID_LANGUAGES, LANGUAGE_NAMES
@@ -409,6 +410,7 @@ app.include_router(images.router)
 app.include_router(changelogs.router)
 app.include_router(feedback.router)
 app.include_router(uninstall.router)
+app.include_router(qa_feedback.router)
 app.include_router(acts.router)
 app.include_router(ascensions.router)
 app.include_router(names.router)
@@ -538,5 +540,19 @@ if _BETA_ASSETS_DIR.exists():
 STATIC_DIR = Path(__file__).resolve().parents[1] / "static"
 if STATIC_DIR.exists():
     app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+# Temporary card-render QA mount. Wires up only when the operator sets
+# QA_DIR to a real directory (typically rsync'd onto the host volume at
+# /data/qa). `html=True` makes `/qa/` serve index.html so the modal
+# review page is the entry point. Designed to be deleted after the audit
+# completes — unset QA_DIR or drop the rendered files to disable.
+QA_DIR_PATH = Path(os.environ.get("QA_DIR", ""))
+if str(QA_DIR_PATH) and QA_DIR_PATH.exists() and QA_DIR_PATH.is_dir():
+    app.mount(
+        "/qa",
+        StaticFiles(directory=str(QA_DIR_PATH), html=True),
+        name="qa",
+    )
+    logger.info("QA mount enabled at /qa → %s", QA_DIR_PATH)
 
 logger.info("Spire Codex API ready")

--- a/backend/app/routers/qa_feedback.py
+++ b/backend/app/routers/qa_feedback.py
@@ -1,0 +1,82 @@
+"""Temporary endpoint for the in-house card-render QA tool.
+
+The `/qa` page (mounted as static HTML when QA_DIR is set) lets reviewers
+click a card thumbnail to open a modal with the rendered image + a small
+feedback form. Submissions land here and get forwarded to the Discord
+feedback webhook as embeds — operationally cheap, lets reviewers report
+"this curse is missing the violet stroke" or "Spore Mind cost should be
+hidden" without needing GitHub access.
+
+Distinct from /api/feedback (the public, persistent feedback channel)
+because this one carries card-specific context (id + variant + image
+URL) and is expected to be wound down after the render audit completes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/qa-feedback", tags=["Feedback"])
+limiter = Limiter(key_func=get_remote_address)
+
+
+class QAFeedback(BaseModel):
+    card_id: str = Field(..., max_length=100)
+    variant: str = Field(default="normal", max_length=30)
+    feedback: str = Field(..., min_length=1, max_length=2000)
+    contact: str | None = Field(default=None, max_length=200)
+    card_name: str | None = Field(default=None, max_length=200)
+    image_url: str | None = Field(default=None, max_length=500)
+
+
+@router.post("")
+@limiter.limit("10/minute")
+async def submit_qa_feedback(request: Request, body: QAFeedback):
+    webhook = os.environ.get("FEEDBACK_WEBHOOK_URL", "")
+    if not webhook:
+        # Operator hasn't wired up the webhook yet — return an explicit
+        # 503 so the modal can show "QA not configured" instead of a
+        # silent success.
+        raise HTTPException(status_code=503, detail="QA feedback not configured")
+
+    title = f"QA: {body.card_name or body.card_id}"
+    fields = [
+        {"name": "Card ID", "value": f"`{body.card_id}`", "inline": True},
+        {"name": "Variant", "value": body.variant or "normal", "inline": True},
+    ]
+    if body.contact:
+        fields.append({"name": "Contact", "value": body.contact, "inline": False})
+
+    embed: dict = {
+        "title": title,
+        "description": body.feedback.strip(),
+        "color": 0xFFB347,  # warm orange — distinct from /api/feedback's blue/red
+        "fields": fields,
+        "footer": {"text": "Spire Codex • Card QA"},
+    }
+    if body.image_url:
+        # Discord renders this as a small thumbnail in the embed corner.
+        embed["thumbnail"] = {"url": body.image_url}
+
+    payload = {"embeds": [embed]}
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.post(webhook, json=payload)
+        if resp.status_code >= 400:
+            logger.error(
+                "QA feedback discord post failed: %s %s",
+                resp.status_code,
+                resp.text[:200],
+            )
+            raise HTTPException(status_code=502, detail="Failed to send feedback")
+
+    return {"ok": True}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,6 +19,10 @@ services:
       - GITHUB_APP_INSTALLATION_ID=${GITHUB_APP_INSTALLATION_ID:-}
       - GITHUB_APP_REPO=${GITHUB_APP_REPO:-}
       - GITHUB_APP_PRIVATE_KEY_PATH=${GITHUB_APP_PRIVATE_KEY_PATH:-/secrets/knowledge-demon.private-key.pem}
+      # Card-render QA mount. Set to /data/qa once the rendered PNGs +
+      # index.html are rsync'd onto the host volume. Empty/missing →
+      # the /qa endpoint isn't registered.
+      - QA_DIR=${QA_DIR:-}
     networks:
       - nginx_web-network
     logging:


### PR DESCRIPTION
## Summary

Stands up `spire-codex.com/qa` as a temporary card-render audit tool. Reviewers see a thumbnail grid of all 576 cards, click any one to open a modal with the rendered image + a small feedback form. Submitting forwards the card id, variant (normal or upgraded), and a thumbnail link to the existing `FEEDBACK_WEBHOOK_URL` as a Discord embed.

## What ships

- `backend/app/routers/qa_feedback.py` — new POST endpoint `/api/qa-feedback`, rate-limited 10/min/ip, sends a Discord embed with card context + thumbnail. Tagged orange (`#FFB347`) to visually distinguish from the existing `/api/feedback` blue/red embeds.
- `backend/app/main.py` — env-var-gated static mount at `/qa` that serves whatever lives under `QA_DIR` (typically `/data/qa` on the host). Auto-disables when the env var is unset or the directory doesn't exist. `html=True` makes `/qa/` serve `index.html`.
- `docker-compose.prod.yml` — passes the `QA_DIR` env var through. Empty by default → no mount registered.

## What stays out of the repo

The rendered PNGs + `index.html` are gitignored under `tools/card-renderer/output/all/`. They get rsync'd onto the host volume at deploy time, not baked into the Docker image. Same lifecycle as `data/runs/` — generated content lives on the volume, code lives in git.

## After merge

1. Set `QA_DIR=/data/qa` in the prod `.env`
2. `docker compose up -d backend` to pick up the env var
3. From your dev machine: `rsync -av tools/card-renderer/output/all/{index.html,*.png} server:/var/www/spire-codex/data/qa/`
4. Visit `https://spire-codex.com/qa/`

## To wind it down later

- Unset `QA_DIR` in `.env` + restart backend → endpoint disappears
- Delete the `/data/qa/` directory → no files to serve
- Revert this commit → router gone

Nothing else in the codebase references the mount, so cleanup is three motions.

## What's deliberately out of scope (flagged for follow-up)

- **Enchantment variants** — 576 cards × 22 enchantments ≈ 12.7K extra renders + ~8 GB on disk. Worth doing on-demand or for a subset of common enchantments, but not in this PR.
- **Per-language QA** — Currently English only. Adding `?lang=` toggle is straightforward but not urgent.
- **Auth** — Page is public. Modal carries no admin-only knobs; risk is "random visitors submit nonsense to the feedback channel" which is bounded by the rate limit. If that becomes a problem, gate behind `ADMIN_TOKEN`.
