### PR TITLE
Cache /qa/* for a day so reviewers don't refetch ~1 GB per visit

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -175,6 +175,13 @@ class CORSStaticMiddleware(BaseHTTPMiddleware):
                                              re-renders are rare and handled by
                                              a manual CF purge on the affected
                                              path.
+      /qa/*        max-age=86400            — temporary card-render QA mount.
+                                             ~576 normal + ~543 upgrade PNGs at
+                                             ~1 MB each is heavy on first paint;
+                                             a day of cache makes follow-up
+                                             reviews near-instant. When new
+                                             renders are rsync'd, manually
+                                             purge /qa/* on CF.
       /api/runs/*  s-maxage=30             — user-submitted runs need to appear
                                              in lists/leaderboards within a
                                              minute, not an hour.
@@ -194,6 +201,10 @@ class CORSStaticMiddleware(BaseHTTPMiddleware):
         path = request.url.path
         if path.startswith("/static/"):
             response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+        elif path.startswith("/qa/"):
+            response.headers["Cache-Control"] = (
+                "public, max-age=86400, s-maxage=86400, stale-while-revalidate=86400"
+            )
         elif path.startswith("/api/runs/"):
             response.headers["Cache-Control"] = "public, max-age=30, s-maxage=30"
         elif path.startswith("/api/"):


### PR DESCRIPTION
## Summary

Extends the existing Cache-Control middleware to treat `/qa/*` like `/static/*` — long browser + edge cache. The temporary card-render audit page serves ~576 normal + ~543 upgrade PNGs (~1 MB each); on the default 5-min browser cache every reviewer was burning through the full bandwidth bill on each visit. A day of cache with stale-while-revalidate covers the cadence at which we actually push new renders.

## Behaviour

- `/qa/*` responses: `Cache-Control: public, max-age=86400, s-maxage=86400, stale-while-revalidate=86400`
- Headers only set on successful GETs (existing middleware contract — caching 4xx/5xx would block re-uploads from healing the directory).
- When new renders are rsync'd onto `/var/www/spire-codex/data/qa/`, manually purge `/qa/*` in the Cloudflare dashboard. The QA tool is temporary; not worth wiring an automated purge for it.

## After merge

CI builds + pushes images + SSH-deploys → backend container picks up the new middleware on restart. No env-var change, no manual touch on the host.
