### PR TITLE
Bump /api/qa-feedback rate limit to 60/min

### DIFF
--- a/backend/app/routers/qa_feedback.py
+++ b/backend/app/routers/qa_feedback.py
@@ -39,7 +39,11 @@ class QAFeedback(BaseModel):
 
 
 @router.post("")
-@limiter.limit("10/minute")
+# 60/minute lets a single reviewer hammer through a couple cards per
+# second without tripping the limiter, and gives headroom for several
+# reviewers behind one NAT/office IP. Discord's own per-webhook cap
+# (~5 / 2s) is the real ceiling above this.
+@limiter.limit("60/minute")
 async def submit_qa_feedback(request: Request, body: QAFeedback):
     webhook = os.environ.get("FEEDBACK_WEBHOOK_URL", "")
     if not webhook:


### PR DESCRIPTION
## Summary

Bumps the slowapi rate limit on `/api/qa-feedback` from `10/minute` to `60/minute`. Reviewers stepping through cards quickly — or multiple reviewers sharing a NAT — were tripping the old 10-per-minute cap and seeing intermittent "failed" toasts in the QA modal.

60/min gives ~1 sustained submission per second per IP, well above realistic review pace. Discord's own per-webhook cap (~5 per 2s globally) remains the actual ceiling above us, so this change can't accidentally weaponize the QA endpoint into a Discord-spam channel.

## Why not just disable the limit

This endpoint forwards to a Discord webhook, which is rate-limited by Discord and counts against the project's webhook quota. Keeping a per-IP limit guards against a stuck client loop. 60/min is high enough to never matter for legitimate reviewers but low enough to catch obvious abuse.

## After merge

CI builds + deploys; backend restart picks up the new decorator value.
