### PR TITLE
no-store cache for /metrics and /health so Prometheus stops getting CF-cached snapshots

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -188,6 +188,12 @@ class CORSStaticMiddleware(BaseHTTPMiddleware):
       /api/*       s-maxage=3600           — entity data only changes on deploy
                                              (every few days). Browsers still
                                              revalidate every 5 min via max-age.
+      /metrics     no-store                 — Prometheus scrapes the public URL
+      /health      no-store                   every 30s; CF's default 4h
+                                             heuristic was freezing the scrape
+                                             on a 4h-old snapshot, making
+                                             counters appear stuck and gauges
+                                             rewind on cache refresh.
 
     Cache headers are only applied to successful GETs. Caching 4xx/5xx on
     /static would prevent recovery by simply uploading the missing file.
@@ -205,6 +211,8 @@ class CORSStaticMiddleware(BaseHTTPMiddleware):
             response.headers["Cache-Control"] = (
                 "public, max-age=86400, s-maxage=86400, stale-while-revalidate=86400"
             )
+        elif path in ("/metrics", "/health"):
+            response.headers["Cache-Control"] = "no-store"
         elif path.startswith("/api/runs/"):
             response.headers["Cache-Control"] = "public, max-age=30, s-maxage=30"
         elif path.startswith("/api/"):


### PR DESCRIPTION
## Summary

Adds `Cache-Control: no-store` to `/metrics` and `/health`. Prometheus scrapes the public URL every 30 seconds (per the cluster's `infrastructure/monitoring/release.yaml` job config) so requests go through Cloudflare. Our cache-headers middleware previously only set explicit headers for `/static`, `/qa`, and `/api*`; `/metrics` fell through and CF applied its default 4-hour heuristic. Result: scrape data was a fossilized 4h-old snapshot, counters appeared stuck, and gauges "rewound" whenever a fresh origin response landed in CF.

Same problem applies to `/health` — any uptime monitor hitting the public URL was reading a stale snapshot.

## Behavior

Both endpoints now emit `Cache-Control: no-store`, which prevents both browser and edge caching. Next Prometheus scrape after deploy will start producing live data again.

## After merge

CI builds and deploys; metrics start flowing in real-time on the next scrape interval (≤30s). No manual CF purge needed because `no-store` will override the cached entry on the next miss.

If counters still look wrong after this, the second-order question is whether the cardinality fix from PR #271 changed metric names that the Grafana dashboard still expects — happy to look at the dashboard YAML to verify.
