### PR TITLE
Per-origin /metrics + /health for Prometheus host-distinct scraping

### DIFF
--- a/infrastructure/ansible/templates/nginx.conf.j2
+++ b/infrastructure/ansible/templates/nginx.conf.j2
@@ -226,6 +226,28 @@ server {
           return 200 "ok\n";
       }
 
+      # Per-origin Prometheus scrape. The main spire-codex.com block
+      # also exposes /metrics, but scraping it goes through CF LB and
+      # round-robins origins — Prometheus then can't tell them apart.
+      # Scraping origin.spire-codex.com + origin-backup.spire-codex.com
+      # gives per-host data points.
+      location /metrics {
+          allow {{ metrics_monitor_ip }};
+          deny all;
+          proxy_pass http://spire-codex-backend:8000/metrics;
+          proxy_http_version 1.1;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+      }
+
+      location /health {
+          allow {{ metrics_monitor_ip }};
+          deny all;
+          proxy_pass http://spire-codex-backend:8000/health;
+          proxy_http_version 1.1;
+          proxy_set_header Host $host;
+      }
+
       location / {
           add_header Content-Type text/html;
           add_header X-Origin "{{ origin_label }}" always;


### PR DESCRIPTION
## Summary

Add `/metrics` and `/health` location blocks inside the test-origin nginx server block so Prometheus can scrape each origin individually.

**Before:** scraping `spire-codex.com/metrics` goes through Cloudflare LB, which random-routes between primary and secondary. Same `instance` label in Prometheus, two hosts' metrics collapsed together.

**After:** scrape via the per-origin hostnames (grey-cloud DNS, direct to the bare IP):

| URL | Always hits |
|---|---|
| `http://origin.spire-codex.com/metrics` | primary |
| `http://origin-backup.spire-codex.com/metrics` | secondary |

Prometheus naturally tags by target URL → per-host data points → charts split cleanly.

## Suggested Prometheus scrape config

```yaml
scrape_configs:
  - job_name: spire-codex
    static_configs:
      - targets: ['origin.spire-codex.com:80']
        labels: { instance: primary }
      - targets: ['origin-backup.spire-codex.com:80']
        labels: { instance: secondary }
```

## Security

Same `allow {{ metrics_monitor_ip }}; deny all;` as the existing main `/metrics` block — Prometheus host IP is the only thing that gets in. Hitting `/metrics` from your laptop will return 403 (correct behavior).

## Apply

```bash
cd infrastructure/ansible
./bin/op-ansible playbooks/sync-config.yml
```

(Already deployed locally during the session that produced this PR — this PR is for git history + reviewability.)
