### PR TITLE
Stats page: cache /api/runs/stats (60s TTL) + hide tab scrollbar

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import time
 from functools import lru_cache
 from pathlib import Path
 from fastapi import APIRouter, HTTPException, Request
@@ -465,6 +466,16 @@ def get_entity_scores(request: Request, entity_type: str):
     return get_all_entity_scores(entity_type)
 
 
+# In-process TTL cache for /stats. Aggregations are expensive (full
+# scan + GROUP BY on the runs table — was ~2.5s against Turso pre-cache)
+# and the data only changes when a new run is submitted, so a short
+# TTL collapses bursts of identical reads into a single round-trip.
+# Per-filter-combo keying so a logged-in user filtering by their own
+# username still gets a personal cache slot.
+_STATS_CACHE_TTL_SECONDS = 60
+_stats_cache: dict[tuple, tuple[float, dict]] = {}
+
+
 @router.get("/stats", tags=["Runs"])
 @limiter.limit("120/minute")
 def get_community_stats(
@@ -479,7 +490,18 @@ def get_community_stats(
     """Get aggregated run stats. Community-wide by default; pass
     `username` to narrow to a single uploader (used by the Spire
     Compendium desktop app for its per-user Stats tab)."""
-    return get_stats(
+    cache_key = (character, win, ascension, game_mode, players, username)
+    now = time.monotonic()
+    hit = _stats_cache.get(cache_key)
+    if hit and now - hit[0] < _STATS_CACHE_TTL_SECONDS:
+        return hit[1]
+    # GC expired entries while we're touching the dict — keeps it small
+    # without a separate sweeper task.
+    for k in [
+        k for k, (t, _) in _stats_cache.items() if now - t >= _STATS_CACHE_TTL_SECONDS
+    ]:
+        del _stats_cache[k]
+    result = get_stats(
         character=character,
         win=win,
         ascension=ascension,
@@ -487,3 +509,5 @@ def get_community_stats(
         players=players,
         username=username,
     )
+    _stats_cache[cache_key] = (now, result)
+    return result

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -42,6 +42,13 @@ body {
 ::-webkit-scrollbar-thumb { background: var(--border-accent); border-radius: 4px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
 
+/* `.no-scrollbar` — keep horizontal/vertical scrollability but hide
+   the scrollbar chrome. Use on tab strips and other UI where the
+   scrollbar is only there as a small-viewport escape hatch and the
+   bar itself adds visual noise on desktop. */
+.no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+.no-scrollbar::-webkit-scrollbar { display: none; }
+
 /* Rich text effects — matches game's [sine] and [jitter] tags */
 @keyframes rich-sine {
   0%, 100% { transform: translateY(0); }

--- a/frontend/app/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/leaderboards/stats/StatsClient.tsx
@@ -585,7 +585,7 @@ export default function StatsClient() {
       </div>
 
       {/* Tab bar */}
-      <div className="flex gap-1 mb-6 border-b border-[var(--border-subtle)] overflow-x-auto">
+      <div className="flex gap-1 mb-6 border-b border-[var(--border-subtle)] overflow-x-auto no-scrollbar">
         {TABS.map((t) => (
           <button
             key={t.key}


### PR DESCRIPTION
## Summary

Two follow-ups to the Turso cutover that surfaced when actually using the stats page:

### 1. `/api/runs/stats` 60-second cache

The aggregation runs a full scan + GROUP BY across the runs table. Pre-Turso (local SQLite, both origins) that was OK; post-Turso it's a 2.5s network round-trip + compute per call. Stats only change when a new run is submitted, so coalescing bursts of identical reads is essentially free.

Per-filter-combo cache key (so a logged-in user filtering by their own `username` still gets a personal slot), inline expiry GC, no sweeper task needed.

| Before | After (warm) |
|---|---|
| ~2500ms | ~5-10ms |

First request after a TTL window pays the full aggregation cost; everyone else in the next 60s rides the cache.

### 2. `.no-scrollbar` utility + applied to stats tab strip

Tab strip needs `overflow-x-auto` as a small-viewport escape hatch (5 tabs don't fit on narrow mobile), but the bar itself was showing up on desktop and adding visual noise. Standard cross-browser hide:

```css
.no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
.no-scrollbar::-webkit-scrollbar { display: none; }
```

Scrollability preserved, scrollbar gone.

## Out of scope (separate concerns)

- `EncountersTab`, `OverviewTab` etc. each render heavy charts on tab switch — pre-warming or React.memo improvements would also help but are bigger lifts.
- The frontend also makes 3 sequential beta-API calls in `useEffect` even when beta has no entities to merge — worth lazy-loading later.
