### PR TITLE
Fix deploy.yml: env-var become_user + force git pull

### DIFF
--- a/infrastructure/ansible/playbooks/deploy.yml
+++ b/infrastructure/ansible/playbooks/deploy.yml
@@ -19,14 +19,25 @@
     # rely on changes that aren't yet on origin/main, run sync-config
     # first (or a targeted file push) — this task will overwrite local
     # divergence on the host.
+    #
+    # become_user uses the env var directly (not `{{ ansible_user }}`)
+    # because become directives are templated before the magic var is
+    # in scope. The wrapper bin/op-ansible exports SPIRE_REMOTE_USER
+    # before invoking ansible-playbook.
     - name: Pull latest main into spire-codex working tree
       become: true
-      become_user: "{{ ansible_user }}"
+      become_user: "{{ lookup('env', 'SPIRE_REMOTE_USER') }}"
       git:
         repo: https://github.com/ptrlrd/spire-codex.git
         dest: "{{ spire_codex_dir }}"
         version: main
         update: true
+        # Discard any host-local divergence — git is the source of
+        # truth, and the host should never have uncommitted edits
+        # against main. If you've been hand-editing on the box for
+        # debugging, commit those changes to a branch first, or accept
+        # that this task wipes them.
+        force: true
       register: git_pull
       changed_when: git_pull.before != git_pull.after
 


### PR DESCRIPTION
## Summary

Two small fixes that surfaced when `deploy.yml` ran for real during the Turso cutover:

### 1. `become_user` can't use `{{ ansible_user }}`

The become layer templates its directives before connection-magic vars are in scope, so `{{ ansible_user }}` came back undefined:

```
Error processing keyword 'become_user': 'ansible_user' is undefined
```

Pulling from the env var the wrapper exports is reliable at every templating stage:

```yaml
become_user: "{{ lookup('env', 'SPIRE_REMOTE_USER') }}"
```

### 2. `force: true` on the git module

Pull was bailing with `Local modifications exist in the destination (force=no)` because we'd hand-pushed a hot-fix `docker-compose.prod.yml` to the host earlier in the session.

With ansible owning the deploy path, the host should never have uncommitted edits against `main` — `force: true` makes that assumption explicit and discards any divergence. The comment in the playbook calls out the policy so future hand-edits are an obvious "you're doing it wrong" signal.

## Verification

Both fixes already proven during this session by the actual Turso cutover (`./bin/op-ansible playbooks/deploy.yml --limit secondary` and `--limit primary`, both green). PR just lands the fixes so the next deploy doesn't trip on the same two errors.
