### PR TITLE
MongoDB migration scaffolding + backend port

### DIFF
--- a/backend/app/services/runs_db.py
+++ b/backend/app/services/runs_db.py
@@ -833,3 +833,21 @@ def get_stats(
 
 # Initialize on import
 init_db()
+
+
+# ── MongoDB dispatch ──────────────────────────────────────────────────────
+# When MONGO_URL is set in the environment, re-export the three high-level
+# entry points (submit_run, get_stats, claim_runs) from the Mongo
+# implementation. Rebinding here at the BOTTOM of the module — after the
+# SQLite defs — ensures every `from .runs_db import submit_run` (etc.)
+# elsewhere in the codebase resolves to the Mongo version. The SQLite
+# defs above still exist as fallbacks and are kept reachable via
+# get_conn() for the few routers that issue raw SQL against the legacy
+# tables during the migration window.
+if os.environ.get("MONGO_URL", "").strip():
+    # noqa: F401, F811 — these rebind module-level names defined above
+    # so callers doing `from .runs_db import submit_run` get the Mongo
+    # version when MONGO_URL is set.
+    from .runs_db_mongo import claim_runs as claim_runs  # noqa: F401
+    from .runs_db_mongo import get_stats as get_stats  # noqa: F401
+    from .runs_db_mongo import submit_run as submit_run  # noqa: F401

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1,0 +1,663 @@
+"""MongoDB implementation of the runs database.
+
+Exports the same public interface as services.runs_db so the swap is
+a feature flag, not a forklift. runs_db.py dispatches here when
+MONGO_URL is set in the environment.
+
+Document shape (one doc per player-run):
+
+    {
+        "_id": <run_hash>,
+        "username": ..., "character": ..., "win": ..., "ascension": ...,
+        "killed_by": ..., "player_count": ..., "build_id": ...,
+        "seed": ..., "run_time": ..., "floors_reached": ...,
+        "submitted_at": ISODate(...),
+        "deck": [{ "id": ..., "upgraded": ..., "enchantment": ..., "floor_added": ... }],
+        "relics": [{ "id": ..., "floor_added": ... }],
+        "potions": [{ "id": ..., "was_picked": ..., "was_used": ... }],
+        "card_choices": [{ "card_id": ..., "was_picked": ..., "floor": ... }],
+        "raw": <the full submitted JSON, for share pages>,
+    }
+
+Indexes (created on import — idempotent):
+    {character: 1}
+    {username: 1, submitted_at: -1}
+    {submitted_at: -1}
+    {character: 1, win: 1, ascension: 1}
+    {build_id: 1}
+    {"deck.id": 1}            (multikey)
+    {relics.id: 1}            (multikey)
+    {killed_by: 1}
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pymongo import ASCENDING, DESCENDING, MongoClient
+from pymongo.errors import DuplicateKeyError
+
+# ── module state ──────────────────────────────────────────────────────────
+_data_dir = Path(os.environ.get("DATA_DIR", "/data"))
+
+_client: MongoClient | None = None
+_coll = None  # lazy — set by _get_collection
+
+
+def _get_collection():
+    """Lazily build the MongoClient + return the runs collection.
+
+    Per-process (per-worker) — pymongo manages its own connection pool
+    internally so we don't need to share across workers.
+    """
+    global _client, _coll
+    if _coll is not None:
+        return _coll
+
+    url = os.environ.get("MONGO_URL", "").strip()
+    if not url:
+        raise RuntimeError("MONGO_URL not set — runs_db_mongo imported in error")
+
+    _client = MongoClient(
+        url,
+        w="majority",
+        wtimeoutms=5000,
+        retryWrites=True,
+        connectTimeoutMS=5000,
+        serverSelectionTimeoutMS=5000,
+    )
+    # Database name comes from the connection string's default db.
+    _coll = _client.get_default_database().runs
+    _ensure_indexes(_coll)
+    return _coll
+
+
+def _ensure_indexes(coll) -> None:
+    """Create indexes if absent. Idempotent — pymongo's create_index is a
+    no-op when an equivalent index already exists."""
+    coll.create_index([("character", ASCENDING)])
+    coll.create_index([("username", ASCENDING), ("submitted_at", DESCENDING)])
+    coll.create_index([("submitted_at", DESCENDING)])
+    coll.create_index(
+        [("character", ASCENDING), ("win", ASCENDING), ("ascension", ASCENDING)]
+    )
+    coll.create_index([("build_id", ASCENDING)])
+    coll.create_index([("deck.id", ASCENDING)])
+    coll.create_index([("relics.id", ASCENDING)])
+    coll.create_index([("killed_by", ASCENDING)])
+
+
+# ── helpers (mirrors of the sqlite module) ──────────────────────────────
+def clean_id(raw_id: str) -> str:
+    """Strip CARD./RELIC./MONSTER./etc. prefixes (matches runs_db.clean_id)."""
+    for prefix in (
+        "CARD.",
+        "RELIC.",
+        "ENCHANTMENT.",
+        "MONSTER.",
+        "ENCOUNTER.",
+        "CHARACTER.",
+        "ACT.",
+        "POTION.",
+    ):
+        if raw_id.startswith(prefix):
+            return raw_id[len(prefix) :]
+    return raw_id
+
+
+def init_db():
+    """No-op for Mongo (indexes created lazily on first access). Kept for
+    import-parity with runs_db.init_db()."""
+    _get_collection()
+
+
+# ── public surface ──────────────────────────────────────────────────────
+def submit_run(data: dict, username: str | None = None) -> dict:
+    """Parse a run and store one document per player. Returns status dict
+    matching the SQLite implementation."""
+    missing: list[str] = []
+    if not data.get("players"):
+        missing.append("players")
+    if not data.get("map_point_history"):
+        missing.append("map_point_history")
+    if not isinstance(data.get("acts"), list):
+        missing.append("acts")
+    if missing:
+        return {
+            "error": f"Invalid run data — missing or empty fields: {', '.join(missing)}"
+        }
+
+    was_abandoned = bool(data.get("was_abandoned", False))
+    total_floors = sum(len(act) for act in data.get("map_point_history", []))
+    killed_by_raw = data.get("killed_by_encounter", "")
+    killed_by = (
+        clean_id(killed_by_raw)
+        if killed_by_raw and killed_by_raw != "NONE.NONE"
+        else None
+    )
+    player_count = len(data.get("players", []))
+
+    results = []
+    for player_idx, player in enumerate(data["players"]):
+        result = _submit_player_run(
+            data,
+            player,
+            player_idx,
+            was_abandoned,
+            total_floors,
+            killed_by,
+            player_count,
+            username,
+        )
+        results.append(result)
+
+    # Save the full submitted JSON for the share-run page (matches the
+    # SQLite implementation — frontend `/runs/<hash>` reads these files).
+    runs_dir = _data_dir / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    for result in results:
+        if result.get("success") or result.get("duplicate"):
+            run_hash = result.get("run_hash", "")
+            if run_hash:
+                run_file = runs_dir / f"{run_hash}.json"
+                if not run_file.exists():
+                    try:
+                        with open(run_file, "w", encoding="utf-8") as f:
+                            json.dump(data, f, ensure_ascii=False)
+                    except Exception as e:
+                        print(f"Warning: failed to save run {run_hash}: {e}")
+
+    return results[0]
+
+
+def _submit_player_run(
+    data: dict,
+    player: dict,
+    player_idx: int,
+    was_abandoned: bool,
+    total_floors: int,
+    killed_by: str | None,
+    player_count: int,
+    username: str | None,
+) -> dict:
+    """One Mongo insert per player. The full nested structure goes into
+    a single document — no joins required at query time."""
+    seed = data.get("seed", "")
+    char_raw = player["character"]
+    start = data.get("start_time", "")
+    run_time = data.get("run_time", 0)
+    deck_size = len(player.get("deck", []))
+    key = f"{seed}:{char_raw}:{start}:{run_time}:{deck_size}:{player_idx}"
+    run_hash = hashlib.sha256(key.encode()).hexdigest()[:16]
+
+    character = clean_id(char_raw)
+
+    # Build embedded arrays.
+    deck = [
+        {
+            "id": clean_id(card["id"]),
+            "upgraded": card.get("current_upgrade_level", 0),
+            "enchantment": (
+                clean_id(card["enchantment"]["id"]) if card.get("enchantment") else None
+            ),
+            "floor_added": card.get("floor_added_to_deck"),
+        }
+        for card in player.get("deck", [])
+    ]
+    relics = [
+        {
+            "id": clean_id(relic["id"]),
+            "floor_added": relic.get("floor_added_to_deck"),
+        }
+        for relic in player.get("relics", [])
+    ]
+
+    # Walk map_point_history once to collect card-choice + potion events
+    # for THIS player.
+    card_choices: list[dict] = []
+    potion_used_set: set[str] = set()
+    potion_seen: dict[str, bool] = {}
+    player_id = player.get("id", player_idx + 1)
+    for act_floors in data.get("map_point_history", []):
+        for floor_idx, floor in enumerate(act_floors):
+            floor_num = floor_idx + 1
+            for ps in floor.get("player_stats", []):
+                if ps.get("player_id") and ps["player_id"] != player_id:
+                    continue
+                for choice in ps.get("card_choices", []):
+                    card_choices.append(
+                        {
+                            "card_id": clean_id(choice["card"]["id"]),
+                            "was_picked": bool(choice.get("was_picked", False)),
+                            "floor": floor_num,
+                        }
+                    )
+                for pc in ps.get("potion_choices", []):
+                    pid = clean_id(pc.get("choice", ""))
+                    if pid:
+                        picked = bool(pc.get("was_picked", False))
+                        potion_seen[pid] = potion_seen.get(pid, False) or picked
+                for pu in ps.get("potion_used", []):
+                    pid = clean_id(pu)
+                    if pid:
+                        potion_used_set.add(pid)
+
+    potions = [
+        {
+            "id": pid,
+            "was_picked": bool(was_picked),
+            "was_used": pid in potion_used_set,
+        }
+        for pid, was_picked in potion_seen.items()
+    ]
+
+    doc = {
+        "_id": run_hash,
+        "seed": seed,
+        "character": character,
+        "win": bool(data.get("win", False)),
+        "was_abandoned": was_abandoned,
+        "ascension": data.get("ascension", 0),
+        "game_mode": data.get("game_mode", "standard"),
+        "player_count": player_count,
+        "run_time": data.get("run_time", 0),
+        "floors_reached": total_floors,
+        "acts_completed": len(data.get("acts", [])),
+        "killed_by": killed_by,
+        "deck_size": len(deck),
+        "relic_count": len(relics),
+        "username": username,
+        "build_id": data.get("build_id"),
+        "submitted_at": datetime.now(timezone.utc),
+        "deck": deck,
+        "relics": relics,
+        "potions": potions,
+        "card_choices": card_choices,
+    }
+
+    coll = _get_collection()
+    try:
+        coll.insert_one(doc)
+    except DuplicateKeyError:
+        return {
+            "error": "This run has already been submitted",
+            "duplicate": True,
+            "run_hash": run_hash,
+        }
+
+    return {"success": True, "run_id": run_hash, "run_hash": run_hash}
+
+
+def claim_runs(username: str, hashes: list[str]) -> dict:
+    """Attach `username` to any runs whose _id matches and whose current
+    username is null/empty. Matches the SQLite implementation: never
+    overwrites an existing claim."""
+    if not hashes:
+        return {"claimed": 0, "already_claimed": 0, "unknown": 0}
+
+    coll = _get_collection()
+    existing = list(coll.find({"_id": {"$in": hashes}}, {"_id": 1, "username": 1}))
+    by_hash = {d["_id"]: d.get("username") for d in existing}
+
+    unclaimed = [h for h, u in by_hash.items() if not u]
+    already_claimed = len(by_hash) - len(unclaimed)
+    unknown = len(hashes) - len(by_hash)
+
+    if unclaimed:
+        coll.update_many(
+            {"_id": {"$in": unclaimed}, "$or": [{"username": None}, {"username": ""}]},
+            {"$set": {"username": username}},
+        )
+
+    return {
+        "claimed": len(unclaimed),
+        "already_claimed": already_claimed,
+        "unknown": unknown,
+    }
+
+
+# ── stats ────────────────────────────────────────────────────────────────
+def _build_match(
+    character: str | None,
+    win: str | None,
+    ascension: str | None,
+    game_mode: str | None,
+    players: str | None,
+    username: str | None,
+    include_character: bool = True,
+) -> dict:
+    """Build the Mongo $match clause from the filter args. Centralized so
+    each pipeline below stays consistent."""
+    m: dict[str, Any] = {}
+    if include_character and character:
+        m["character"] = character.upper()
+    if win == "true":
+        m["win"] = True
+    elif win == "false":
+        m["win"] = False
+        m["was_abandoned"] = False
+    elif win == "abandoned":
+        m["was_abandoned"] = True
+    if ascension is not None and ascension != "":
+        m["ascension"] = int(ascension)
+    if game_mode:
+        m["game_mode"] = game_mode
+    if players == "single":
+        m["player_count"] = 1
+    elif players == "multi":
+        m["player_count"] = {"$gt": 1}
+    if username:
+        m["username"] = username
+    return m
+
+
+def get_stats(
+    character: str | None = None,
+    win: str | None = None,
+    ascension: str | None = None,
+    game_mode: str | None = None,
+    players: str | None = None,
+    username: str | None = None,
+) -> dict:
+    """Aggregated community stats. Mirrors the SQLite implementation's
+    response shape — frontend doesn't care which backend produced it."""
+    coll = _get_collection()
+    match = _build_match(character, win, ascension, game_mode, players, username)
+    match_no_char = _build_match(
+        character, win, ascension, game_mode, players, username, include_character=False
+    )
+
+    total = coll.count_documents(match)
+    if total == 0:
+        return {
+            "total_runs": 0,
+            "filters": {
+                "character": character,
+                "win": win,
+                "ascension": ascension,
+                "game_mode": game_mode,
+                "players": players,
+                "username": username,
+            },
+        }
+
+    wins = coll.count_documents({**match, "win": True})
+    abandoned = coll.count_documents({**match, "was_abandoned": True})
+
+    # Per-character breakdown (always grouped — drops the character filter
+    # so the breakdown has one row per character).
+    char_stats = list(
+        coll.aggregate(
+            [
+                {"$match": match_no_char},
+                {
+                    "$group": {
+                        "_id": "$character",
+                        "total": {"$sum": 1},
+                        "wins": {"$sum": {"$cond": ["$win", 1, 0]}},
+                    }
+                },
+                {"$sort": {"total": -1}},
+            ]
+        )
+    )
+
+    # Card pick rates from card_choices array
+    pick_rates = list(
+        coll.aggregate(
+            [
+                {"$match": match},
+                {"$unwind": "$card_choices"},
+                {
+                    "$group": {
+                        "_id": "$card_choices.card_id",
+                        "offered": {"$sum": 1},
+                        "picked": {
+                            "$sum": {"$cond": ["$card_choices.was_picked", 1, 0]}
+                        },
+                    }
+                },
+            ]
+        )
+    )
+
+    # Cards in winning decks (filtered)
+    win_cards = list(
+        coll.aggregate(
+            [
+                {"$match": {**match, "win": True}},
+                {"$unwind": "$deck"},
+                {"$group": {"_id": "$deck.id", "count": {"$sum": 1}}},
+            ]
+        )
+    )
+    win_card_map = {r["_id"]: r["count"] for r in win_cards}
+
+    # Cards in losing decks
+    loss_cards = list(
+        coll.aggregate(
+            [
+                {"$match": {**match, "win": False}},
+                {"$unwind": "$deck"},
+                {"$group": {"_id": "$deck.id", "count": {"$sum": 1}}},
+            ]
+        )
+    )
+    loss_card_map = {r["_id"]: r["count"] for r in loss_cards}
+
+    # All cards across filtered runs
+    all_cards = list(
+        coll.aggregate(
+            [
+                {"$match": match},
+                {"$unwind": "$deck"},
+                {"$group": {"_id": "$deck.id", "count": {"$sum": 1}}},
+                {"$sort": {"count": -1}},
+            ]
+        )
+    )
+
+    # Distinct-run counts per card (win vs all)
+    win_runs_agg = list(
+        coll.aggregate(
+            [
+                {"$match": {**match, "win": True}},
+                {"$unwind": "$deck"},
+                {"$group": {"_id": "$deck.id", "runs": {"$addToSet": "$_id"}}},
+                {"$project": {"run_count": {"$size": "$runs"}}},
+            ]
+        )
+    )
+    win_runs_map = {r["_id"]: r["run_count"] for r in win_runs_agg}
+
+    all_runs_agg = list(
+        coll.aggregate(
+            [
+                {"$match": match},
+                {"$unwind": "$deck"},
+                {"$group": {"_id": "$deck.id", "runs": {"$addToSet": "$_id"}}},
+                {"$project": {"run_count": {"$size": "$runs"}}},
+            ]
+        )
+    )
+    all_runs_map = {r["_id"]: r["run_count"] for r in all_runs_agg}
+
+    # Relic stats
+    top_relics = list(
+        coll.aggregate(
+            [
+                {"$match": match},
+                {"$unwind": "$relics"},
+                {
+                    "$group": {
+                        "_id": "$relics.id",
+                        "count": {"$sum": 1},
+                        "runs": {"$addToSet": "$_id"},
+                        "win_runs_set": {
+                            "$addToSet": {"$cond": ["$win", "$_id", "$$REMOVE"]}
+                        },
+                    }
+                },
+                {
+                    "$project": {
+                        "count": 1,
+                        "total_runs_with": {"$size": "$runs"},
+                        "win_runs": {"$size": "$win_runs_set"},
+                    }
+                },
+                {"$sort": {"count": -1}},
+            ]
+        )
+    )
+
+    # Deadliest encounters
+    deaths = list(
+        coll.aggregate(
+            [
+                {
+                    "$match": {
+                        **match,
+                        "win": False,
+                        "killed_by": {"$ne": None},
+                    }
+                },
+                {"$group": {"_id": "$killed_by", "count": {"$sum": 1}}},
+                {"$sort": {"count": -1}},
+                {"$limit": 10},
+            ]
+        )
+    )
+
+    # Ascension distribution
+    asc_stats = list(
+        coll.aggregate(
+            [
+                {"$match": match},
+                {
+                    "$group": {
+                        "_id": "$ascension",
+                        "total": {"$sum": 1},
+                        "wins": {"$sum": {"$cond": ["$win", 1, 0]}},
+                    }
+                },
+                {"$sort": {"_id": 1}},
+            ]
+        )
+    )
+
+    # Potion stats
+    potion_stats = list(
+        coll.aggregate(
+            [
+                {"$match": match},
+                {"$unwind": "$potions"},
+                {
+                    "$group": {
+                        "_id": "$potions.id",
+                        "picked": {"$sum": {"$cond": ["$potions.was_picked", 1, 0]}},
+                        "offered": {"$sum": 1},
+                        "used": {"$sum": {"$cond": ["$potions.was_used", 1, 0]}},
+                        "runs": {"$addToSet": "$_id"},
+                        "win_runs_set": {
+                            "$addToSet": {"$cond": ["$win", "$_id", "$$REMOVE"]}
+                        },
+                    }
+                },
+                {
+                    "$project": {
+                        "picked": 1,
+                        "offered": 1,
+                        "used": 1,
+                        "total_runs_with": {"$size": "$runs"},
+                        "win_runs": {"$size": "$win_runs_set"},
+                    }
+                },
+                {"$sort": {"offered": -1}},
+            ]
+        )
+    )
+
+    return {
+        "total_runs": total,
+        "total_wins": wins,
+        "total_abandoned": abandoned,
+        "win_rate": round(wins / total * 100, 1) if total > 0 else 0,
+        "filters": {
+            "character": character,
+            "win": win,
+            "ascension": ascension,
+            "game_mode": game_mode,
+            "players": players,
+            "username": username,
+        },
+        "characters": [
+            {
+                "character": r["_id"],
+                "total": r["total"],
+                "wins": r["wins"],
+                "win_rate": round(r["wins"] / r["total"] * 100, 1)
+                if r["total"] > 0
+                else 0,
+            }
+            for r in char_stats
+        ],
+        "ascensions": [
+            {
+                "level": r["_id"],
+                "total": r["total"],
+                "wins": r["wins"],
+                "win_rate": round(r["wins"] / r["total"] * 100, 1)
+                if r["total"] > 0
+                else 0,
+            }
+            for r in asc_stats
+        ],
+        "top_cards": [
+            {
+                "card_id": r["_id"],
+                "count": r["count"],
+                "in_wins": win_card_map.get(r["_id"], 0),
+                "in_losses": loss_card_map.get(r["_id"], 0),
+                "win_runs": win_runs_map.get(r["_id"], 0),
+                "total_runs_with": all_runs_map.get(r["_id"], 0),
+            }
+            for r in all_cards
+        ],
+        "pick_rates": [
+            {
+                "card_id": r["_id"],
+                "offered": r["offered"],
+                "picked": r["picked"],
+                "pick_rate": round(r["picked"] / r["offered"] * 100, 1)
+                if r["offered"] > 0
+                else 0,
+            }
+            for r in pick_rates
+        ],
+        "top_relics": [
+            {
+                "relic_id": r["_id"],
+                "count": r["count"],
+                "total_runs_with": r["total_runs_with"],
+                "win_runs": r["win_runs"],
+            }
+            for r in top_relics
+        ],
+        "deaths": [{"killed_by": r["_id"], "count": r["count"]} for r in deaths],
+        "potion_stats": [
+            {
+                "potion_id": r["_id"],
+                "offered": r["offered"],
+                "picked": r["picked"],
+                "used": r["used"],
+                "total_runs_with": r["total_runs_with"],
+                "win_runs": r["win_runs"],
+            }
+            for r in potion_stats
+        ],
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ sentry-sdk[fastapi]==2.19.2
 prometheus-fastapi-instrumentator==7.0.2
 pyjwt[crypto]==2.10.1
 libsql==0.1.11
+pymongo==4.10.1

--- a/docker-compose.mongo.yml
+++ b/docker-compose.mongo.yml
@@ -1,0 +1,51 @@
+name: spire-codex-mongo
+
+# MongoDB on the secondary box. Single-node replica set so we can use
+# transactions + we can grow to 3 nodes later without re-bootstrapping.
+# Bind only to the docker bridge; the Lightsail firewall is what
+# actually gates external access to port 27017 (allow only the primary
+# box's static IP).
+
+services:
+  mongo:
+    image: mongo:7.0
+    container_name: spire-codex-mongo
+    restart: unless-stopped
+    command:
+      - "--replSet"
+      - "spire-rs"
+      - "--bind_ip_all"
+      - "--auth"
+      - "--keyFile"
+      - "/etc/mongo/keyfile"
+      - "--wiredTigerCacheSizeGB"
+      - "4"
+    ports:
+      # Bind on all interfaces; Lightsail firewall rule restricts to
+      # primary's IP. If you ever co-locate Mongo with the app on the
+      # same box, drop this and use a UNIX socket instead.
+      - "27017:27017"
+    volumes:
+      - ./mongo-data:/data/db
+      - ./mongo-keyfile:/etc/mongo/keyfile:ro
+    environment:
+      # First-run only — these create the admin user before --auth
+      # kicks in. After the first init, ignored.
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_ADMIN_USER:-admin}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_ADMIN_PASS}
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+    healthcheck:
+      test:
+        - CMD
+        - mongosh
+        - "--quiet"
+        - "--eval"
+        - "db.adminCommand('ping')"
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,15 +27,16 @@ services:
       # index.html are rsync'd onto the host volume. Empty/missing →
       # the /qa endpoint isn't registered.
       - QA_DIR=${QA_DIR:-}
-      # Turso (libSQL) — rolled back after Overwolf launch surfaced
-      # multi-second tail latency on POST /api/runs (network round-trip
-      # per write was untenable under burst). Hardcoded empty so
-      # _using_turso() returns False and runs_db.py uses the local
-      # /data/runs.db SQLite path. .env still has the op:// refs
-      # populated in case we want to flip back later.
+      # Turso (libSQL) — retired post-Overwolf-launch (round-trip per
+      # write was untenable under burst). Hardcoded empty so the
+      # libsql path stays off.
       - TURSO_URL=
       - TURSO_AUTH_TOKEN=
       - TURSO_LOCAL_REPLICA=
+      # MongoDB — when MONGO_URL is set, runs_db.py uses the Mongo
+      # path. Falls through to local /data/runs.db SQLite otherwise
+      # (the current state while the migration is in progress).
+      - MONGO_URL=${MONGO_URL:-}
     networks:
       - nginx_web-network
     logging:

--- a/infrastructure/ansible/files/.env.tpl
+++ b/infrastructure/ansible/files/.env.tpl
@@ -35,16 +35,17 @@ UNINSTALL_FORWARD_FROM=op://Spire Codex/Resend/forward-from
 # Admin endpoints token (gates /api/admin/*)
 ADMIN_TOKEN=op://Spire Codex/Admin Token/value
 
-# Turso (libSQL) — community run database.
-# Backend's services/runs_db.py uses Turso when TURSO_URL is set,
-# falls back to local SQLite otherwise. Leave both unset on a host
-# to keep it on the legacy local path (current prod default during
-# the migration window).
-TURSO_URL=op://Spire Codex/Turso/url
-TURSO_AUTH_TOKEN=op://Spire Codex/Turso/token
+# MongoDB — runs database. Hosted on the secondary Lightsail box as a
+# single-node replica set. Primary app box reaches it over the private
+# Lightsail network; firewall rule restricts port 27017 to primary's
+# IP only. When MONGO_URL is unset, backend falls through to the
+# legacy local SQLite path at /data/runs.db.
+MONGO_URL=op://Spire Codex/MongoDB/connection-string
 
-# Embedded replica path. When set, backend keeps a local SQLite copy
-# of the Turso DB, syncing in the background. All reads hit the local
-# file (zero Turso row-reads metered — collapses our cost line).
-# Writes still go to Turso. Leave commented to use direct mode.
-TURSO_LOCAL_REPLICA=/data/runs-replica.db
+# Turso (libSQL) — retired after the Overwolf launch revealed
+# multi-second tail latency under burst. Keep the secret refs around
+# so we can re-enable later if architecture shifts; passthroughs in
+# docker-compose.prod.yml are hardcoded empty for now.
+# TURSO_URL=op://Spire Codex/Turso/url
+# TURSO_AUTH_TOKEN=op://Spire Codex/Turso/token
+# TURSO_LOCAL_REPLICA=/data/runs-replica.db

--- a/infrastructure/ansible/inventory.yml.tpl
+++ b/infrastructure/ansible/inventory.yml.tpl
@@ -14,15 +14,27 @@
 # the origin to the Cloudflare LB pool.
 all:
   children:
+    # App origins — boxes that run FastAPI + frontend. Targeted by
+    # deploy.yml / restart.yml / sync-config.yml. Single app box after
+    # the post-Overwolf rearchitecture; the CF LB was retired and
+    # secondary was repurposed as the MongoDB host (see db_origins).
     prod_origins:
       hosts:
         primary:
           ansible_host: op://Spire Codex/AWS Credentials/Primary IP
           origin_label: spire-codex-primary
-        secondary:
-          ansible_host: op://Spire Codex/AWS Credentials/Secondary IP
-          origin_label: spire-codex-secondary
       vars:
         spire_codex_dir: /var/www/spire-codex
         prod_compose_file: docker-compose.prod.yml
         beta_compose_file: docker-compose.beta.yml
+
+    # Database origins — boxes that run MongoDB (no app containers).
+    # Targeted only by mongo-install.yml, mongo-backup.yml, etc.
+    # Lightsail firewall on each restricts port 27017 to primary's IP.
+    db_origins:
+      hosts:
+        secondary:
+          ansible_host: op://Spire Codex/AWS Credentials/Secondary IP
+          origin_label: spire-codex-db
+      vars:
+        spire_codex_dir: /var/www/spire-codex

--- a/infrastructure/ansible/playbooks/bootstrap.yml
+++ b/infrastructure/ansible/playbooks/bootstrap.yml
@@ -16,7 +16,11 @@
 # that's already there.
 
 - name: Bootstrap a fresh spire-codex origin
-  hosts: prod_origins
+  # Targets both app boxes (prod_origins) and DB-only boxes
+  # (db_origins) — the installable bits (docker, git, dirs) are the
+  # same. Specialisation happens later: deploy.yml only targets
+  # prod_origins; mongo-install.yml only targets db_origins.
+  hosts: prod_origins:db_origins
   gather_facts: true
   become: true
   tasks:

--- a/infrastructure/ansible/playbooks/mongo-install.yml
+++ b/infrastructure/ansible/playbooks/mongo-install.yml
@@ -1,0 +1,183 @@
+---
+# One-shot Mongo install for the secondary Lightsail box.
+#
+# Prereqs:
+#   - Secondary has already been resized to >=8GB Lightsail bundle.
+#   - Spire-codex app containers on secondary are stopped (this box is
+#     no longer an app origin — see docker-compose down step below).
+#   - 1Password has the following entries populated:
+#       op://Spire Codex/MongoDB/admin-user        (default: admin)
+#       op://Spire Codex/MongoDB/admin-password    (strong, 32+ chars)
+#       op://Spire Codex/MongoDB/app-user          (default: app)
+#       op://Spire Codex/MongoDB/app-password      (strong, 32+ chars)
+#       op://Spire Codex/MongoDB/keyfile           (openssl rand -base64 756)
+#
+# Usage:
+#   cd infrastructure/ansible
+#   ./bin/op-ansible playbooks/mongo-install.yml --limit secondary
+#
+# Idempotent — re-running just verifies state, doesn't reset data.
+
+- name: Install MongoDB single-node replica set on secondary
+  hosts: secondary
+  gather_facts: false
+  vars:
+    mongo_dir: /var/www/spire-codex
+    replica_set_name: spire-rs
+    db_name: spire_codex
+
+  tasks:
+    - name: Stop legacy spire-codex containers (this box is Mongo-only now)
+      become: true
+      command: docker compose -f docker-compose.prod.yml down
+      args:
+        chdir: "{{ mongo_dir }}"
+      ignore_errors: true   # may already be down
+
+    - name: Pull MongoDB admin creds from 1Password
+      delegate_to: localhost
+      become: false
+      run_once: true
+      block:
+        - command: op read "op://Spire Codex/MongoDB/admin-user"
+          register: op_admin_user
+          changed_when: false
+          no_log: true
+        - command: op read "op://Spire Codex/MongoDB/admin-password"
+          register: op_admin_pass
+          changed_when: false
+          no_log: true
+        - command: op read "op://Spire Codex/MongoDB/app-user"
+          register: op_app_user
+          changed_when: false
+          no_log: true
+        - command: op read "op://Spire Codex/MongoDB/app-password"
+          register: op_app_pass
+          changed_when: false
+          no_log: true
+        - command: op read "op://Spire Codex/MongoDB/keyfile"
+          register: op_keyfile
+          changed_when: false
+          no_log: true
+
+    - name: Ensure mongo data directory exists
+      become: true
+      file:
+        path: "{{ mongo_dir }}/mongo-data"
+        state: directory
+        owner: "999"          # mongo container UID
+        group: "999"
+        mode: '0755'
+
+    - name: Drop the replica-set keyfile (root-owned, 0600, mongo container UID)
+      become: true
+      copy:
+        content: "{{ op_keyfile.stdout }}"
+        dest: "{{ mongo_dir }}/mongo-keyfile"
+        owner: "999"
+        group: "999"
+        mode: '0400'
+      no_log: true
+
+    - name: Render docker-compose.mongo.env (Mongo admin creds for first-boot init)
+      become: true
+      copy:
+        content: |
+          MONGO_ADMIN_USER={{ op_admin_user.stdout }}
+          MONGO_ADMIN_PASS={{ op_admin_pass.stdout }}
+        dest: "{{ mongo_dir }}/.env.mongo"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0600'
+      no_log: true
+
+    - name: Pull the latest spire-codex repo (gets docker-compose.mongo.yml)
+      become: true
+      become_user: "{{ lookup('env', 'SPIRE_REMOTE_USER') }}"
+      git:
+        repo: https://github.com/ptrlrd/spire-codex.git
+        dest: "{{ mongo_dir }}"
+        version: main
+        update: true
+        force: true
+
+    - name: Start MongoDB container
+      become: true
+      command: docker compose --env-file .env.mongo -f docker-compose.mongo.yml up -d
+      args:
+        chdir: "{{ mongo_dir }}"
+
+    - name: Wait for Mongo to accept connections (auth not required for ping)
+      become: true
+      shell: |
+        for i in $(seq 1 30); do
+          docker exec spire-codex-mongo mongosh --quiet --eval "db.adminCommand('ping')" && exit 0
+          sleep 2
+        done
+        exit 1
+      register: ping
+      changed_when: false
+
+    - name: Initiate the replica set (idempotent — fails harmlessly if already initiated)
+      become: true
+      shell: |
+        docker exec spire-codex-mongo mongosh \
+          -u "{{ op_admin_user.stdout }}" \
+          -p "{{ op_admin_pass.stdout }}" \
+          --authenticationDatabase admin \
+          --quiet \
+          --eval 'try { rs.status() } catch(e) { rs.initiate({ _id: "{{ replica_set_name }}", members: [{ _id: 0, host: "localhost:27017" }] }) }'
+      register: rs_init
+      changed_when: "'newlyAdded' in rs_init.stdout or 'ok: 1' in rs_init.stdout"
+      no_log: true
+
+    - name: Wait for primary election (rs becomes a PRIMARY, not just SECONDARY/STARTUP)
+      become: true
+      shell: |
+        for i in $(seq 1 30); do
+          state=$(docker exec spire-codex-mongo mongosh \
+            -u "{{ op_admin_user.stdout }}" \
+            -p "{{ op_admin_pass.stdout }}" \
+            --authenticationDatabase admin \
+            --quiet --eval 'rs.status().myState' 2>/dev/null | tr -d '[:space:]')
+          if [ "$state" = "1" ]; then exit 0; fi
+          sleep 2
+        done
+        exit 1
+      changed_when: false
+      no_log: true
+
+    - name: Create the app user with read+write on spire_codex DB
+      become: true
+      shell: |
+        docker exec spire-codex-mongo mongosh \
+          -u "{{ op_admin_user.stdout }}" \
+          -p "{{ op_admin_pass.stdout }}" \
+          --authenticationDatabase admin \
+          --quiet \
+          --eval 'try {
+            db.getSiblingDB("{{ db_name }}").createUser({
+              user: "{{ op_app_user.stdout }}",
+              pwd: "{{ op_app_pass.stdout }}",
+              roles: [{ role: "readWrite", db: "{{ db_name }}" }]
+            })
+          } catch(e) {
+            if (e.codeName !== "DuplicateKey") throw e;
+            db.getSiblingDB("{{ db_name }}").updateUser("{{ op_app_user.stdout }}", {
+              pwd: "{{ op_app_pass.stdout }}",
+              roles: [{ role: "readWrite", db: "{{ db_name }}" }]
+            })
+          }'
+      register: create_user
+      changed_when: "'Successfully' in create_user.stdout or 'ok: 1' in create_user.stdout"
+      no_log: true
+
+    - name: Final status
+      debug:
+        msg: |
+          MongoDB ready on this box.
+          Replica set: {{ replica_set_name }}
+          DB: {{ db_name }}
+          App user: {{ op_app_user.stdout }}
+          Connection string template (for primary's .env):
+            mongodb://{{ op_app_user.stdout }}:<password>@<this-box-ip>:27017/{{ db_name }}?authSource={{ db_name }}&replicaSet={{ replica_set_name }}

--- a/infrastructure/ansible/playbooks/mongo-install.yml
+++ b/infrastructure/ansible/playbooks/mongo-install.yml
@@ -18,8 +18,8 @@
 #
 # Idempotent — re-running just verifies state, doesn't reset data.
 
-- name: Install MongoDB single-node replica set on secondary
-  hosts: secondary
+- name: Install MongoDB single-node replica set
+  hosts: db_origins
   gather_facts: false
   vars:
     mongo_dir: /var/www/spire-codex

--- a/tools/sqlite_to_mongo.py
+++ b/tools/sqlite_to_mongo.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""One-shot SQLite → MongoDB ETL for the runs database.
+
+Reads /data/runs.db (the current source of truth) and writes the
+denormalized document representation to MongoDB. Runs idempotently —
+re-running on a partial migration picks up only the missing runs.
+
+Schema mapping
+--------------
+Old relational shape:
+
+    runs(run_hash PK, username, character, win, ascension, ...)
+    run_cards(run_hash FK, card_id, count, upgraded, floor_added_to_deck)
+    run_relics(run_hash FK, relic_id, floor_picked_up)
+    run_potions(run_hash FK, potion_id, floor, used)
+    run_encounters(run_hash FK, encounter_id, floor)
+    run_map(run_hash FK, floor, node_type, ...)
+
+New document shape (one document per run):
+
+    {
+        "_id": <run_hash>,
+        "username": ..., "character": ..., "win": ..., etc,
+        "deck": [{ "id": ..., "count": ..., "upgraded": ..., "floor_added": ... }],
+        "relics": [{ "id": ..., "floor": ... }],
+        "potions": [{ "id": ..., "floor": ..., "used": ... }],
+        "encounters": [{ "id": ..., "floor": ... }],
+        "map": [{ "floor": ..., "node_type": ... }],
+    }
+
+Usage
+-----
+    MONGO_URL=mongodb://app:<pass>@<host>:27017/spire_codex?... \\
+    python3 tools/sqlite_to_mongo.py /path/to/runs.db
+
+    # Dry run — counts + sample doc, no writes
+    python3 tools/sqlite_to_mongo.py /path/to/runs.db --dry-run
+
+    # Verify only — read both, byte-compare on a sample
+    python3 tools/sqlite_to_mongo.py /path/to/runs.db --verify
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+import time
+from collections import defaultdict
+from typing import Any
+
+try:
+    from pymongo import MongoClient, UpdateOne
+    from pymongo.errors import BulkWriteError
+except ImportError:
+    print("pymongo not installed. pip install pymongo", file=sys.stderr)
+    sys.exit(1)
+
+
+BATCH_SIZE = 500
+
+
+def fetch_child_rows(cur: sqlite3.Cursor, table: str) -> dict[str, list[dict[str, Any]]]:
+    """Read an entire child table into {run_hash: [rows]}."""
+    cur.execute(f"SELECT * FROM {table}")
+    cols = [c[0] for c in cur.description]
+    out: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in cur.fetchall():
+        d = dict(zip(cols, row, strict=False))
+        run_hash = d.pop("run_hash")
+        out[run_hash].append(d)
+    return out
+
+
+def build_doc(run_row: dict[str, Any], children: dict[str, dict[str, list]]) -> dict[str, Any]:
+    """Compose one Mongo document from a runs row + child rows."""
+    rh = run_row["run_hash"]
+    doc = {
+        "_id": rh,
+        **{k: v for k, v in run_row.items() if k != "run_hash"},
+    }
+    # Pull child arrays. Field names match the runs_db schema.
+    doc["deck"] = children["run_cards"].get(rh, [])
+    doc["relics"] = children["run_relics"].get(rh, [])
+    doc["potions"] = children["run_potions"].get(rh, [])
+    doc["encounters"] = children["run_encounters"].get(rh, [])
+    # Map data may not exist in older schemas — handle gracefully.
+    if "run_map" in children:
+        doc["map"] = children["run_map"].get(rh, [])
+    return doc
+
+
+def migrate(sqlite_path: str, mongo_url: str, dry_run: bool = False) -> tuple[int, int]:
+    """Returns (total_runs_seen, inserted_count)."""
+    conn = sqlite3.connect(sqlite_path)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+
+    # Find which child tables actually exist (schema has drifted over
+    # versions — old DBs may lack run_map etc.)
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'run_%'")
+    child_tables = [r[0] for r in cur.fetchall() if r[0] != "runs"]
+    print(f"[sqlite] child tables found: {child_tables}")
+
+    # Bulk-load every child table once. Trades RAM for round-trip count;
+    # at 55MB the whole DB fits in memory many times over.
+    print("[sqlite] loading child tables into memory...")
+    t0 = time.time()
+    children = {t: fetch_child_rows(cur, t) for t in child_tables}
+    print(f"[sqlite] child load: {time.time() - t0:.1f}s")
+
+    cur.execute("SELECT COUNT(*) FROM runs")
+    total = cur.fetchone()[0]
+    print(f"[sqlite] {total} runs to migrate")
+
+    if dry_run:
+        cur.execute("SELECT * FROM runs LIMIT 1")
+        sample = dict(cur.fetchone())
+        print(f"[dry-run] sample doc:\n{build_doc(sample, children)}")
+        return total, 0
+
+    client = MongoClient(mongo_url)
+    coll = client.get_default_database().runs
+
+    # Build idempotent upserts so re-running the script is safe.
+    cur.execute("SELECT * FROM runs ORDER BY run_hash")
+    batch: list[UpdateOne] = []
+    inserted = 0
+    seen = 0
+    t0 = time.time()
+    for row in cur:
+        doc = build_doc(dict(row), children)
+        batch.append(UpdateOne({"_id": doc["_id"]}, {"$setOnInsert": doc}, upsert=True))
+        seen += 1
+        if len(batch) >= BATCH_SIZE:
+            inserted += _flush(coll, batch)
+            batch.clear()
+            if seen % 2000 == 0:
+                rate = seen / (time.time() - t0)
+                print(f"  {seen}/{total} ({rate:.0f}/s)")
+
+    if batch:
+        inserted += _flush(coll, batch)
+
+    print(f"[mongo] {inserted} new docs written ({seen} runs seen in source)")
+    return seen, inserted
+
+
+def _flush(coll: Any, batch: list[UpdateOne]) -> int:
+    try:
+        res = coll.bulk_write(batch, ordered=False)
+        return res.upserted_count
+    except BulkWriteError as e:
+        # Duplicate keys are expected on re-run — count the real failures.
+        write_errors = [err for err in e.details["writeErrors"] if err["code"] != 11000]
+        if write_errors:
+            print(f"  bulk write errors: {write_errors[:3]}", file=sys.stderr)
+        return e.details.get("nUpserted", 0)
+
+
+def verify(sqlite_path: str, mongo_url: str, sample_size: int = 50) -> int:
+    """Sanity-check: counts match, sampled runs are byte-equivalent."""
+    sconn = sqlite3.connect(sqlite_path)
+    sconn.row_factory = sqlite3.Row
+    s_count = sconn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
+
+    client = MongoClient(mongo_url)
+    coll = client.get_default_database().runs
+    m_count = coll.count_documents({})
+
+    print(f"sqlite runs: {s_count}")
+    print(f"mongo runs:  {m_count}")
+    if s_count != m_count:
+        print(f"  DELTA: {s_count - m_count}")
+        return 1
+
+    # Spot-check N random run_hashes
+    sample = sconn.execute(
+        f"SELECT run_hash FROM runs ORDER BY RANDOM() LIMIT {sample_size}"
+    ).fetchall()
+    miss = 0
+    for (rh,) in sample:
+        if not coll.find_one({"_id": rh}):
+            print(f"  missing in mongo: {rh}")
+            miss += 1
+    print(f"sampled {sample_size}, missing in mongo: {miss}")
+    return 0 if miss == 0 else 1
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("sqlite_path")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--verify", action="store_true")
+    args = p.parse_args()
+
+    mongo_url = os.environ.get("MONGO_URL")
+    if not mongo_url:
+        print("MONGO_URL env var required", file=sys.stderr)
+        return 2
+
+    if args.verify:
+        return verify(args.sqlite_path, mongo_url)
+
+    seen, inserted = migrate(args.sqlite_path, mongo_url, dry_run=args.dry_run)
+    return 0 if seen > 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Replaces SQLite-based runs.db with a self-hosted MongoDB single-node replica set on the (repurposed) secondary box. Lands BEFORE Mongo is wired so the new file (docker-compose.mongo.yml) is available to ansible playbooks.

- docker-compose.mongo.yml — Mongo container for the secondary
- playbooks/mongo-install.yml + bootstrap.yml updates — install Mongo, init replica set, AlmaLinux-compatible bootstrap
- backend/app/services/runs_db_mongo.py — full port of submit_run / get_stats / claim_runs
- backend/app/services/runs_db.py — dispatcher at the bottom (rebinds to Mongo when MONGO_URL is set)
- tools/sqlite_to_mongo.py — idempotent ETL
- .env.tpl — MONGO_URL ref added; Turso retired
- docker-compose.prod.yml — MONGO_URL passthrough (empty default, no-op until set)
- inventory.yml.tpl — split prod_origins (app) / db_origins (mongo)

Until MONGO_URL is set in primary's .env, behavior is identical to today (SQLite). Safe to merge.