### PR TITLE
Rate limiter: key off real visitor IP + bump default 60→300/min

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,6 +1,32 @@
 """Shared FastAPI dependencies."""
 
-from fastapi import Query
+from fastapi import Query, Request
+from slowapi.util import get_remote_address
+
+
+def client_ip(request: Request) -> str:
+    """Resolve the real visitor IP behind Cloudflare → nginx → uvicorn.
+
+    `slowapi.get_remote_address` reads `request.client.host`, which is
+    the upstream proxy — the nginx-container's bridge address — not
+    the real visitor. Every user shares one bucket and the default
+    limit trips fleet-wide.
+
+    nginx already trusts Cloudflare's IP ranges and rewrites
+    `$remote_addr` from `CF-Connecting-IP`, then forwards it as
+    `X-Real-IP`. Prefer that, fall back to `CF-Connecting-IP` directly
+    (in case nginx is bypassed), then the first hop in
+    `X-Forwarded-For`, and finally `request.client.host` for local dev.
+    """
+    h = request.headers
+    real = h.get("x-real-ip") or h.get("cf-connecting-ip")
+    if real:
+        return real.strip()
+    xff = h.get("x-forwarded-for")
+    if xff:
+        return xff.split(",", 1)[0].strip()
+    return get_remote_address(request)
+
 
 VALID_LANGUAGES = {
     "deu",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,6 @@ from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from pathlib import Path
 from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 
 from .routers import (
@@ -56,7 +55,7 @@ from .routers import (
     qa_feedback,
 )
 from .services.data_service import get_stats, load_translation_maps, current_version
-from .dependencies import get_lang, VALID_LANGUAGES, LANGUAGE_NAMES
+from .dependencies import client_ip, get_lang, VALID_LANGUAGES, LANGUAGE_NAMES
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from .metrics import (
@@ -106,7 +105,12 @@ if SENTRY_DSN:
 # without requiring every client to set `?version=latest`.
 IS_BETA_BACKEND = os.environ.get("DISABLE_RUN_SUBMISSIONS") == "1"
 
-limiter = Limiter(key_func=get_remote_address, default_limits=["60/minute"])
+# Default 300/minute (5 rps) per *real* visitor IP — generous enough
+# for honest browsing + embedded tooltip widgets that fan out to several
+# /api/* lookups per page, low enough to choke off scraping. Endpoints
+# that want a tighter cap (guide submission, auth, feedback) declare
+# `@limiter.limit(...)` at the router level and override this default.
+limiter = Limiter(key_func=client_ip, default_limits=["300/minute"])
 
 app = FastAPI(
     title="Spire Codex API",

--- a/backend/app/routers/auth_steam.py
+++ b/backend/app/routers/auth_steam.py
@@ -41,12 +41,13 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel
 from slowapi import Limiter
-from slowapi.util import get_remote_address
+
+from ..dependencies import client_ip
 
 logger = logging.getLogger("spire-codex.auth")
 
 router = APIRouter(prefix="/api/auth/steam", tags=["Auth"])
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=client_ip)
 
 # Sessions live for 5 min — generous enough for the user to bounce off
 # Steam's login (saved password autofill, 2FA, etc.) and short enough

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -7,8 +7,8 @@ import httpx
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 from slowapi import Limiter
-from slowapi.util import get_remote_address
 
+from ..dependencies import client_ip
 from ..metrics import feedback_submissions
 from ..services import github_issues
 
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/api/feedback", tags=["Feedback"])
 
 WEBHOOK_URL = os.environ.get("FEEDBACK_WEBHOOK_URL", "")
 
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=client_ip)
 
 
 class FeedbackRequest(BaseModel):

--- a/backend/app/routers/guides.py
+++ b/backend/app/routers/guides.py
@@ -9,7 +9,8 @@ import httpx
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 from slowapi import Limiter
-from slowapi.util import get_remote_address
+
+from ..dependencies import client_ip
 from ..models.schemas import GuideSummary, Guide
 from ..services.data_service import load_guides
 from ..metrics import guide_submissions
@@ -18,7 +19,7 @@ router = APIRouter(prefix="/api/guides", tags=["Guides"])
 
 WEBHOOK_URL = os.environ.get("GUIDE_WEBHOOK_URL", "")
 
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=client_ip)
 
 
 @router.get("", response_model=list[GuideSummary])

--- a/backend/app/routers/qa_feedback.py
+++ b/backend/app/routers/qa_feedback.py
@@ -21,12 +21,13 @@ import httpx
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 from slowapi import Limiter
-from slowapi.util import get_remote_address
+
+from ..dependencies import client_ip
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/qa-feedback", tags=["Feedback"])
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=client_ip)
 
 
 class QAFeedback(BaseModel):

--- a/backend/app/routers/uninstall.py
+++ b/backend/app/routers/uninstall.py
@@ -22,12 +22,13 @@ import httpx
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 from slowapi import Limiter
-from slowapi.util import get_remote_address
+
+from ..dependencies import client_ip
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/uninstall-feedback", tags=["Feedback"])
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=client_ip)
 
 RESEND_ENDPOINT = "https://api.resend.com/emails"
 


### PR DESCRIPTION
## Summary

- slowapi's default `get_remote_address` reads `request.client.host` — the upstream proxy IP, not the visitor. With nginx in front, every real user shared a single bucket (nginx-container's bridge IP) so the `60/minute` default tripped fleet-wide once total traffic crossed ~60 req/min/worker. The dashboard shows ~1.4k 429s on `/api/runs/stats` and ~440 on `/api/runs/scores/*` since launch — all of those.
- New `client_ip` helper in `dependencies.py`: X-Real-IP (nginx already rewrites from CF-Connecting-IP via the trusted Cloudflare IP list) → CF-Connecting-IP → first hop of X-Forwarded-For → `request.client.host`. The main limiter and the five per-router limiters (feedback, guides, qa_feedback, auth_steam, uninstall) all key off it.
- Default cap bumped 60 → 300/min (5 rps) per real IP. A normal browse session can fan out to ~30–50 `/api/*` lookups per minute (detail page → multiple lookups for related cards/keywords/powers/scores) — the old cap was right at the edge of honest use. Per-router write caps stay tight: 3/min guide submission, 5/min feedback, 20/min Steam auth.
