### PR TITLE
CI: drop setup-node npm cache (storage quota fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,16 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          # No `cache: npm` here on purpose. Self-hosted runners give
+          # us free compute, but setup-node's npm cache still uploads
+          # ~/.npm to GitHub-managed storage (Next.js + sharp + swc
+          # cross-platform binaries makes it ~350 MiB per cache, and
+          # we'd blow through the 500 MiB plan quota with one cache on
+          # main and another on a feature branch). The runner has fast
+          # internet — `npm ci` re-fetching costs ~30s vs paying for
+          # storage overage. If we ever need this back, store the
+          # cache on the runner host (persistent volume) instead of
+          # uploading it.
 
       - run: npm ci
 


### PR DESCRIPTION
## Summary

Self-hosted runners zero out compute minutes, but `actions/setup-node`'s `cache: npm` still uploads `~/.npm` to **GitHub-managed** storage on every miss. With Next.js + sharp + swc cross-platform binaries each cache is ~350 MiB; one cache on main + one on a feature branch put us at 574 MiB against the 500 MiB plan quota.

Dropped `cache: npm` — `npm ci` from the public registry on a fast runner is ~30s extra per CI run, much cheaper than paying for storage overage. Existing caches purged manually so the quota is already healthy.

If we want fast deps back in the future, the right place is a persistent volume on the runner host (`/var/cache/npm` mounted into the workspace), not GitHub storage.
