### PR TITLE
Leaderboard: single/multi + game_mode toggles, fix stats shape regressions

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -186,6 +186,8 @@ def list_runs(
     seed: str | None = None,
     sort: str | None = None,
     build_id: str | None = None,
+    players: str | None = None,
+    game_mode: str | None = None,
     page: int = 1,
     limit: int = 50,
 ):
@@ -200,6 +202,8 @@ def list_runs(
             seed=seed,
             sort=sort,
             build_id=build_id,
+            players=players,
+            game_mode=game_mode,
             page=page,
             limit=limit,
         )
@@ -225,6 +229,13 @@ def list_runs(
         if build_id:
             conditions.append("build_id = ?")
             params.append(build_id)
+        if players == "single":
+            conditions.append("player_count = 1")
+        elif players == "multi":
+            conditions.append("player_count > 1")
+        if game_mode:
+            conditions.append("game_mode = ?")
+            params.append(game_mode)
         where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
 
         # Sort options
@@ -269,14 +280,33 @@ def get_leaderboard(
     request: Request,
     category: str = "fastest",
     character: str | None = None,
+    players: str | None = None,
+    game_mode: str | None = None,
     page: int = 1,
     limit: int = 50,
 ):
-    """Leaderboard for winning runs. Categories: fastest, highest_ascension."""
+    """Leaderboard for winning runs.
+
+    Categories: `fastest`, `highest_ascension`.
+    `players`: `single` (player_count == 1) or `multi` (player_count > 1).
+    `game_mode`: `standard`, `daily`, or `custom`. Custom runs ride on
+    custom seeds so their times aren't comparable to the standard
+    ladder; the frontend defaults to `standard` and exposes mode
+    explicitly so users can opt into the other pools.
+    Single-player and multiplayer runs aren't directly comparable, so the
+    frontend reads them as disjoint pools.
+    """
     if os.environ.get("MONGO_URL", "").strip():
         from ..services.runs_db_mongo import leaderboard as _lb_mongo
 
-        return _lb_mongo(category=category, character=character, page=page, limit=limit)
+        return _lb_mongo(
+            category=category,
+            character=character,
+            players=players,
+            game_mode=game_mode,
+            page=page,
+            limit=limit,
+        )
 
     from ..services.runs_db import get_conn
 
@@ -286,6 +316,16 @@ def get_leaderboard(
         if character:
             conditions.append("character = ?")
             params.append(character.upper())
+        # SQLite fallback stores player_count from the post-Mongo era; pre-existing
+        # rows default to 1 via runs_db.py's schema, so the single filter is safe
+        # even on legacy data.
+        if players == "single":
+            conditions.append("player_count = 1")
+        elif players == "multi":
+            conditions.append("player_count > 1")
+        if game_mode:
+            conditions.append("game_mode = ?")
+            params.append(game_mode)
         where = "WHERE " + " AND ".join(conditions)
 
         if category == "highest_ascension":

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -676,8 +676,14 @@ def get_stats(
             }
             for r in relics
         ],
-        "deaths": [{"killed_by": r["_id"], "count": r["count"]} for r in deaths],
-        "potion_stats": [
+        # Frontend (StatsClient.tsx) and the SQLite path use the keys
+        # `deadliest` (entries shaped as {encounter, count}) and
+        # `top_potions` (entries with a precomputed pick_rate). The
+        # initial Mongo port introduced `deaths` + `killed_by` and
+        # `potion_stats` without pick_rate; the field-name mismatch
+        # silently rendered "0 potions" and a blank deadliest panel.
+        "deadliest": [{"encounter": r["_id"], "count": r["count"]} for r in deaths],
+        "top_potions": [
             # Merge per-potion picked/used telemetry with the
             # owned-in-deck stats so the response includes both views.
             {
@@ -689,6 +695,9 @@ def get_stats(
                     "total_runs_with", 0
                 ),
                 "win_runs": potion_owned.get(r["_id"], {}).get("win_runs", 0),
+                "pick_rate": round(r["picked"] / r["offered"] * 100, 1)
+                if r["offered"] > 0
+                else 0,
             }
             for r in potion_pu
         ],
@@ -883,6 +892,8 @@ def list_runs(
     seed: str | None = None,
     sort: str | None = None,
     build_id: str | None = None,
+    players: str | None = None,
+    game_mode: str | None = None,
     page: int = 1,
     limit: int = 50,
 ) -> dict:
@@ -902,6 +913,12 @@ def list_runs(
         q["seed"] = {"$regex": seed, "$options": "i"}
     if build_id:
         q["build_id"] = build_id
+    if players == "single":
+        q["player_count"] = 1
+    elif players == "multi":
+        q["player_count"] = {"$gt": 1}
+    if game_mode:
+        q["game_mode"] = game_mode
 
     sort_map = {
         "time_asc": [("run_time", 1)],
@@ -931,15 +948,31 @@ def list_runs(
 def leaderboard(
     category: str = "fastest",
     character: str | None = None,
+    players: str | None = None,
+    game_mode: str | None = None,
     page: int = 1,
     limit: int = 50,
 ) -> dict:
-    """Wins-only leaderboard. Mirrors the /api/runs/leaderboard SQLite path."""
+    """Wins-only leaderboard. Mirrors the /api/runs/leaderboard SQLite path.
+
+    `players` segregates single-player (player_count == 1) from
+    multiplayer (player_count > 1) so a fast 5-room MP run doesn't
+    sit alongside a fast solo speedrun in the same ladder.
+    `game_mode` further filters to standard/daily/custom — custom seeds
+    in particular invalidate speedrun comparisons, so the frontend
+    surfaces this explicitly and defaults to standard.
+    """
     coll = _get_collection()
     # ETL'd docs store win as 0/1 int; submit_run stores bool. Match both.
     q: dict[str, Any] = {"win": {"$in": [True, 1]}}
     if character:
         q["character"] = character.upper()
+    if players == "single":
+        q["player_count"] = 1
+    elif players == "multi":
+        q["player_count"] = {"$gt": 1}
+    if game_mode:
+        q["game_mode"] = game_mode
 
     if category == "highest_ascension":
         sort_clause = [("ascension", -1), ("run_time", 1)]

--- a/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
+++ b/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
@@ -17,6 +17,14 @@ function displayName(id: string): string {
   return cleanId(id).replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+// The compendium uses the in-game canonical name ("The Ironclad") on
+// detail pages, but it bloats the leaderboard rows. Strip a leading
+// English "The " for the leaderboard display only; localized names
+// from non-English locales pass through untouched.
+function stripThe(name: string): string {
+  return name.replace(/^the\s+/i, "");
+}
+
 function formatTime(s: number): string {
   const m = Math.floor(s / 60);
   const sec = s % 60;
@@ -67,10 +75,25 @@ interface BrowseRun {
 }
 
 type Tab = "fastest" | "highest_ascension" | "browse";
+type Mode = "single" | "multi";
+// `gameMode` mirrors the backend `game_mode` column. Empty string = no
+// filter (all modes). Default is "standard" since custom-seed and daily
+// runs aren't time-comparable to the canonical ladder.
+type GameMode = "" | "standard" | "daily" | "custom";
 
 function tabFromParam(value: string | null): Tab {
   if (value === "browse" || value === "highest_ascension") return value;
   return "fastest";
+}
+
+function modeFromParam(value: string | null): Mode {
+  return value === "multi" ? "multi" : "single";
+}
+
+function gameModeFromParam(value: string | null): GameMode {
+  if (value === "daily" || value === "custom" || value === "") return value;
+  if (value === "all") return "";
+  return "standard";
 }
 
 export default function LeaderboardBrowseClient() {
@@ -82,6 +105,12 @@ export default function LeaderboardBrowseClient() {
   // Recent Runs "View more →" pointing at `?tab=browse`) land on the
   // right tab. Defaults to fastest when no/invalid value supplied.
   const [tab, setTab] = useState<Tab>(() => tabFromParam(searchParams.get("tab")));
+  // Single-player vs multiplayer split. Backend tags each run document
+  // with `player_count`; the API exposes `?players=single|multi` on
+  // /api/runs/leaderboard and /api/runs/list. Default to single since
+  // most submissions today are SP.
+  const [mode, setMode] = useState<Mode>(() => modeFromParam(searchParams.get("mode")));
+  const [gameMode, setGameMode] = useState<GameMode>(() => gameModeFromParam(searchParams.get("game_mode")));
 
   // --- Leaderboard state ---
   const [lbChar, setLbChar] = useState("");
@@ -133,7 +162,7 @@ export default function LeaderboardBrowseClient() {
   }
 
   // Reset leaderboard page when filters change
-  useEffect(() => { setLbPage(1); }, [tab, lbChar]);
+  useEffect(() => { setLbPage(1); }, [tab, lbChar, mode, gameMode]);
 
   // Fetch leaderboard (only when on a leaderboard tab)
   useEffect(() => {
@@ -141,6 +170,8 @@ export default function LeaderboardBrowseClient() {
     setLbLoading(true);
     const params = new URLSearchParams();
     params.set("category", tab);
+    params.set("players", mode);
+    if (gameMode) params.set("game_mode", gameMode);
     if (lbChar) params.set("character", lbChar);
     params.set("page", String(lbPage));
     params.set("limit", "20");
@@ -162,15 +193,17 @@ export default function LeaderboardBrowseClient() {
         setLbTotalPages(0);
       })
       .finally(() => setLbLoading(false));
-  }, [tab, lbChar, lbPage]);
+  }, [tab, lbChar, lbPage, mode, gameMode]);
 
   // Reset browse page when filters change
-  useEffect(() => { setBrowsePage(1); }, [browseChar, browseWin, browseUser, browseSeed, browseBuildId, browseSort]);
+  useEffect(() => { setBrowsePage(1); }, [browseChar, browseWin, browseUser, browseSeed, browseBuildId, browseSort, mode, gameMode]);
 
   // Fetch browse runs (only when on browse tab)
   useEffect(() => {
     if (tab !== "browse") return;
     const params = new URLSearchParams();
+    params.set("players", mode);
+    if (gameMode) params.set("game_mode", gameMode);
     if (browseChar) params.set("character", browseChar);
     if (browseWin) params.set("win", browseWin);
     if (browseUser) params.set("username", browseUser);
@@ -186,7 +219,7 @@ export default function LeaderboardBrowseClient() {
         setBrowseTotalPages(data.total_pages || 0);
       })
       .catch(() => {});
-  }, [tab, browseChar, browseWin, browseUser, browseSeed, browseBuildId, browseSort, browsePage]);
+  }, [tab, browseChar, browseWin, browseUser, browseSeed, browseBuildId, browseSort, browsePage, mode, gameMode]);
 
   const TABS: { key: Tab; label: string; shortLabel: string }[] = [
     { key: "fastest", label: t("Fastest Wins", lang), shortLabel: t("Fastest", lang) },
@@ -198,7 +231,55 @@ export default function LeaderboardBrowseClient() {
 
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <h1 className="text-3xl font-bold text-[var(--accent-gold)] mb-6">{t("Leaderboards", lang)}</h1>
+      <h1 className="text-3xl font-bold text-[var(--accent-gold)] mb-4">{t("Leaderboards", lang)}</h1>
+
+      {/* Single vs Multi mode toggle — these are tracked separately in
+          the runs collection (player_count == 1 vs > 1) and a fast
+          multiplayer run isn't directly comparable to a fast solo run
+          (parallel rooms, shared encounters, etc.), so the leaderboards
+          read from disjoint pools. */}
+      <div className="flex flex-wrap items-center gap-3 mb-6">
+        <div className="inline-flex gap-1 p-1 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)]">
+          {(["single", "multi"] as Mode[]).map((m) => (
+            <button
+              key={m}
+              onClick={() => setMode(m)}
+              className={`px-4 py-1.5 text-sm font-medium rounded transition-colors ${
+                mode === m
+                  ? "bg-[var(--accent-gold)] text-[var(--bg-primary)]"
+                  : "text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+              }`}
+            >
+              {m === "single" ? t("Single Player", lang) : t("Multiplayer", lang)}
+            </button>
+          ))}
+        </div>
+
+        {/* Game-mode pill row. Default is "standard" — custom-seed and
+            daily runs aren't comparable to the canonical pool (different
+            seed pool / different rules), so we surface them as opt-in
+            ladders. Empty value = no filter (show all modes). */}
+        <div className="inline-flex gap-1 p-1 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)]">
+          {([
+            { value: "standard" as GameMode, label: t("Standard", lang) },
+            { value: "daily" as GameMode, label: t("Daily", lang) },
+            { value: "custom" as GameMode, label: t("Custom", lang) },
+            { value: "" as GameMode, label: t("All Modes", lang) },
+          ]).map(({ value, label }) => (
+            <button
+              key={value || "all"}
+              onClick={() => setGameMode(value)}
+              className={`px-3 py-1.5 text-sm font-medium rounded transition-colors ${
+                gameMode === value
+                  ? "bg-[var(--accent-gold)] text-[var(--bg-primary)]"
+                  : "text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
 
       {/* Tabs */}
       <div className="flex gap-1 mb-6 border-b border-[var(--border-subtle)]">
@@ -258,14 +339,14 @@ export default function LeaderboardBrowseClient() {
                 }
               >
                 <img
-                  src={`${API}/static/images/characters/char_select_${ch.toLowerCase()}.webp`}
+                  src={`${API}/static/images/characters/character_icon_${ch.toLowerCase()}.webp`}
                   alt=""
                   aria-hidden
                   className="w-6 h-6 object-contain flex-shrink-0"
                   loading="lazy"
                   crossOrigin="anonymous"
                 />
-                <span className="hidden sm:inline text-sm">{charName(ch)}</span>
+                <span className="hidden sm:inline text-sm">{stripThe(charName(ch))}</span>
               </button>
             ))}
           </div>
@@ -296,7 +377,7 @@ export default function LeaderboardBrowseClient() {
                       // name so the per-character accent stays consistent
                       // across locales.
                       const englishName = displayName(`CHARACTER.${entry.character}`);
-                      const localizedName = charName(entry.character);
+                      const localizedName = stripThe(charName(entry.character));
                       const charColor = CHARACTER_COLORS[englishName] || "var(--text-primary)";
                       return (
                         <tr
@@ -352,7 +433,7 @@ export default function LeaderboardBrowseClient() {
             >
               <option value="">{t("All Characters", lang)}</option>
               {CHARACTERS.map((ch) => (
-                <option key={ch} value={ch.toUpperCase()}>{charName(ch)}</option>
+                <option key={ch} value={ch.toUpperCase()}>{stripThe(charName(ch))}</option>
               ))}
             </select>
 
@@ -430,7 +511,7 @@ export default function LeaderboardBrowseClient() {
                         {r.win ? "W" : r.was_abandoned ? "A" : "L"}
                       </span>
                       <span className="text-sm text-[var(--text-primary)] truncate">
-                        {charName(r.character)}
+                        {stripThe(charName(r.character))}
                       </span>
                       <span className="text-xs text-[var(--text-muted)] shrink-0">A{r.ascension}</span>
                       {r.username && (


### PR DESCRIPTION
## Summary

Two post-Mongo-cutover regressions plus the leaderboard split you asked for.

### Stats shape regressions (Mongo cutover)

`/api/runs/stats` quietly renamed two response fields when the Mongo implementation landed:

| Frontend expects | Mongo was returning |
|---|---|
| `top_potions` (with `pick_rate`) | `potion_stats` (no `pick_rate`) |
| `deadliest` (`{encounter,count}`) | `deaths` (`{killed_by,count}`) |

Result: the Potions tab rendered "0 potions" and the Deadliest panel was empty. Renamed both back to match the original SQLite contract and the frontend.

### Leaderboard mode toggles

The Mongo `_build_match` already supported `players=single|multi` and `game_mode=…` filters but the route signatures never exposed them. With multiplayer runs storing 3 rows per game (one per player perspective), the canonical leaderboard had duplicate-looking rows like `rank 1/2/3 all 16:47 with different characters`. Custom-seed speedruns were also lumped in with the standard ladder.

- Added `?players=single|multi` + `?game_mode=standard|daily|custom` to `/api/runs/leaderboard` and `/api/runs/list`.
- Frontend gets two pill rows:
  - **Single Player | Multiplayer** (defaults to Single)
  - **Standard | Daily | Custom | All Modes** (defaults to Standard)

### Visual polish on leaderboards

- Character names render without the "The " prefix in leaderboard rows + filter chips. Detail pages keep the canonical in-game name.
- Character chips swap from the bulky `char_select_*` portraits to the lighter `character_icon_*` sprites.

## Verification (full stack local, tunneled to prod Mongo)

| Filter | total | Notes |
|---|---|---|
| `single+standard` | 1,907 | canonical ladder |
| `single+daily` | 36 | daily climb |
| `single+custom` | 44 | custom seed pool |
| `multi+standard` | ~1,102 | MP standard |
| `multi+daily` | 97 | MP daily |
| (no filter) | 1,987 single / 1,219 multi | matches pre-fix unfiltered count |

After deploy, the background `stats_summary` refresher overwrites the cached doc on next tick (60s) so the Potions tab and Deadliest panel populate automatically — no manual cache bust needed.
