### PR TITLE
Keywords: force-dynamic to escape build-time prerender trap

### DIFF
--- a/frontend/app/keywords/page.tsx
+++ b/frontend/app/keywords/page.tsx
@@ -3,6 +3,17 @@ import JsonLd from "@/app/components/JsonLd";
 import RichDescription from "@/app/components/RichDescription";
 import { buildCollectionPageJsonLd } from "@/lib/jsonld";
 
+// force-dynamic so the page SSRs at runtime instead of getting baked
+// into the Docker image at build time. The build container has no
+// network path to the backend, so the build-time fetch returns empty
+// (try/catch swallows the failure) and the resulting static HTML
+// permanently shows zero Game Terms until revalidate expires. CF
+// caches the runtime-rendered HTML for the s-maxage TTL set in the
+// backend's CORSStaticMiddleware, so edge perf is unaffected.
+//
+// See feedback_frontend_build_offline_backend.md — same trap caught
+// us once already on entity detail pages.
+export const dynamic = "force-dynamic";
 export const revalidate = 3600;
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";

--- a/infrastructure/ansible/playbooks/purge-cache.yml
+++ b/infrastructure/ansible/playbooks/purge-cache.yml
@@ -18,14 +18,19 @@
     everything: false
     urls: []
   tasks:
+    # Field labels in the 1Password Cloudflare item are "API Token"
+    # and "Zone ID" (with spaces/capitals). `op read` requires the
+    # exact label — the previous snake_case path silently failed with
+    # "item does not have a field 'api_token'". Spaces have to be URL
+    # encoded as %20 when used inside the op:// scheme.
     - name: Fetch CF API token from 1Password
-      command: op read "op://Spire Codex/Cloudflare/api_token"
+      command: op read "op://Spire Codex/Cloudflare/API Token"
       register: cf_token
       changed_when: false
       no_log: true
 
     - name: Fetch CF zone ID from 1Password
-      command: op read "op://Spire Codex/Cloudflare/zone_id"
+      command: op read "op://Spire Codex/Cloudflare/Zone ID"
       register: cf_zone
       changed_when: false
       no_log: true


### PR DESCRIPTION
`/keywords` server-renders Card Keywords + Game Terms by fetching `/api/keywords` and `/api/glossary`. With only `export const revalidate = 3600` set, Next.js prerenders the page at `next build` time. Build runs inside the frontend Docker image, which has no network path to the backend (separate container, no shared compose context). The fetches throw → caught by the try/catch → both arrays default to empty → empty static HTML gets baked into the image.

After deploy, the prerendered HTML keeps serving for up to 3600s before ISR background-regen kicks in. Users see "Card Keywords" populated (the keywords array got built-time data once when the prerender happened to succeed, or got lucky in a previous build) but "Game Terms" empty.

`force-dynamic` opts the route out of build-time prerendering. The fetches happen at request time when the backend is reachable; CF still caches the response per s-maxage from CORSStaticMiddleware, so edge perf is unchanged for repeat visitors.

Also: fix `playbooks/purge-cache.yml` 1Password field names. The Cloudflare item uses "API Token" and "Zone ID" (with spaces, mixed case); the playbook referenced `api_token`/`zone_id` which silently failed. Updated both.