### PR TITLE
Self-hosted Umami analytics on DO

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -83,6 +83,11 @@ services:
     environment:
       - API_INTERNAL_URL=http://spire-codex-backend:8000
       - NEXT_PUBLIC_SITE_URL=https://spire-codex.com
+      # Self-hosted Umami tracker. Read by app/layout.tsx at SSR time
+      # — no rebuild needed when these values change. Leaving either
+      # blank keeps the analytics script off the page entirely.
+      - UMAMI_SRC=${UMAMI_SRC:-}
+      - UMAMI_WEBSITE_ID=${UMAMI_WEBSITE_ID:-}
     networks:
       - nginx_web-network
     logging:

--- a/docker-compose.umami.yml
+++ b/docker-compose.umami.yml
@@ -1,0 +1,79 @@
+name: spire-codex-umami
+
+# Self-hosted Umami analytics — privacy-friendly page-view tracker.
+# Runs alongside the spire-codex stack on DO; nginx proxies
+# analytics.spire-codex.com → umami:3000. Postgres is on its own
+# internal network so the public-facing nginx_web-network never sees
+# it.
+#
+# First-time setup is in `infrastructure/ansible/playbooks/umami-install.yml`
+# and the manual steps (DNS record, admin password rotation, website
+# registration) are documented at the top of that playbook.
+
+services:
+  umami:
+    # The `postgresql-latest` tag is the postgres-flavored Umami image —
+    # pinned by tag rather than digest to ease minor upgrades. Umami's
+    # release cadence is monthly and breaking changes are rare.
+    image: ghcr.io/umami-software/umami:postgresql-latest
+    container_name: umami
+    restart: unless-stopped
+    depends_on:
+      umami-postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_TYPE: postgresql
+      DATABASE_URL: postgresql://umami:${UMAMI_DB_PASSWORD}@umami-postgres:5432/umami
+      APP_SECRET: ${UMAMI_APP_SECRET}
+      # Daily salt rotation on the visitor-IP hash. Combined with
+      # Umami's default of not storing raw IPs, this gives one-day
+      # anonymous visitor identity without any cookie consent banner.
+      HASH_SALT: ${UMAMI_APP_SECRET}
+      # Default 3000 inside the container; nginx_web-network DNS gives
+      # `umami:3000` to the nginx proxy.
+      PORT: 3000
+    networks:
+      - nginx_web-network
+      - umami-db
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  umami-postgres:
+    # 15 chosen for long support window; Umami is happy on 13+.
+    image: postgres:15-alpine
+    container_name: umami-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: umami
+      POSTGRES_USER: umami
+      POSTGRES_PASSWORD: ${UMAMI_DB_PASSWORD}
+    volumes:
+      - ./umami-data:/var/lib/postgresql/data
+    # Isolated network — only the umami container needs Postgres
+    # access. Keeps it off `nginx_web-network` so a misconfigured
+    # public proxy can't accidentally expose the DB.
+    networks:
+      - umami-db
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U umami -d umami"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+networks:
+  # Shared with the spire-codex compose project so nginx can reach
+  # umami:3000 by service-name DNS. Created by playbooks/nginx-install.yml.
+  nginx_web-network:
+    external: true
+  # Private to this compose project.
+  umami-db:
+    driver: bridge

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navbar from "./components/Navbar";
@@ -10,6 +11,16 @@ import { Suspense } from "react";
 import { LanguageProvider } from "./contexts/LanguageContext";
 import { BetaVersionProvider } from "./contexts/BetaVersionContext";
 import { SITE_NAME, SITE_URL } from "@/lib/seo";
+
+// Self-hosted Umami analytics. Read in the root layout (a Server
+// Component) at request time, so the values land in the SSR'd HTML
+// without needing to be baked into the Docker image at CI build time
+// via NEXT_PUBLIC_* build args. The frontend container reads UMAMI_*
+// from its runtime env (set in docker-compose.prod.yml). Leaving
+// either blank — the dev / local default — keeps the script off the
+// page so localhost traffic doesn't pollute stats.
+const UMAMI_SRC = process.env.UMAMI_SRC || "";
+const UMAMI_WEBSITE_ID = process.env.UMAMI_WEBSITE_ID || "";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -74,6 +85,14 @@ export default function RootLayout({
             </BetaVersionProvider>
           </Suspense>
         </LanguageProvider>
+        {UMAMI_SRC && UMAMI_WEBSITE_ID && (
+          <Script
+            src={UMAMI_SRC}
+            data-website-id={UMAMI_WEBSITE_ID}
+            strategy="afterInteractive"
+            defer
+          />
+        )}
       </body>
     </html>
   );

--- a/infrastructure/ansible/files/.env.tpl
+++ b/infrastructure/ansible/files/.env.tpl
@@ -49,3 +49,15 @@ MONGO_URL=op://Spire Codex/MongoDB/connection-string
 # TURSO_URL=op://Spire Codex/Turso/url
 # TURSO_AUTH_TOKEN=op://Spire Codex/Turso/token
 # TURSO_LOCAL_REPLICA=/data/runs-replica.db
+
+# Umami self-hosted analytics. Top two are read by the frontend
+# container at SSR time (not bundled into the client at build) so
+# changing them is a recreate-not-rebuild operation. Until the
+# website is created in the Umami UI, leave `website_id` blank in 1P
+# — the layout guards against partial config and won't emit the
+# script tag.
+# Bottom two are consumed by docker-compose.umami.yml only.
+UMAMI_SRC=https://analytics.spire-codex.com/script.js
+UMAMI_WEBSITE_ID=op://Spire Codex/Umami/website_id
+UMAMI_DB_PASSWORD=op://Spire Codex/Umami/db_password
+UMAMI_APP_SECRET=op://Spire Codex/Umami/app_secret

--- a/infrastructure/ansible/playbooks/sync-config.yml
+++ b/infrastructure/ansible/playbooks/sync-config.yml
@@ -23,6 +23,15 @@
         metrics_monitor_ip: "{{ lookup('pipe', 'op read \"op://Spire Codex/Server/IP Address\"') }}"
       no_log: true
 
+    # Admin allowlist for the Umami dashboard. Anyone outside this IP
+    # gets a 403 at nginx before Umami's login form is reachable, so a
+    # forgotten admin password / default credentials window can't be
+    # brute-forced from the open internet.
+    - name: Fetch admin IP from 1Password
+      set_fact:
+        admin_ip: "{{ lookup('pipe', 'op read \"op://Spire Codex/Peter''s Machine/ip\"') }}"
+      no_log: true
+
     - name: Ensure QA host directory exists
       become: true
       file:

--- a/infrastructure/ansible/playbooks/sync-config.yml
+++ b/infrastructure/ansible/playbooks/sync-config.yml
@@ -9,7 +9,9 @@
 # Idempotent — re-running with no changes is a no-op.
 
 - name: Sync nginx config + QA assets to all prod origins
-  hosts: prod_origins
+  # Both Lightsail prod_origins (legacy) and the DigitalOcean origin
+  # share the same nginx template. Target both via `--limit` per run.
+  hosts: prod_origins:digital_ocean
   gather_facts: false
   tasks:
     # Fetch the metrics-monitor allow-list IP from 1Password. Used by

--- a/infrastructure/ansible/playbooks/umami-install.yml
+++ b/infrastructure/ansible/playbooks/umami-install.yml
@@ -92,16 +92,17 @@
       register: up
       changed_when: "'Started' in up.stderr or 'Created' in up.stderr"
 
-    - name: Wait for Umami to be ready (HTTP 200 from nginx → umami)
-      uri:
-        url: "http://localhost/api/heartbeat"
-        headers:
-          Host: "analytics.spire-codex.com"
-        status_code: 200
+    # Bypass nginx — the dashboard allowlist would 403 a loopback hit
+    # from the DO host. Hitting the umami container directly via the
+    # docker bridge also avoids spinning until the analytics CNAME
+    # propagates.
+    - name: Wait for Umami to be ready
+      shell: docker exec web-server wget -qO- -S http://umami:3000/api/heartbeat 2>&1 | grep -q "200 OK"
       register: heartbeat
       retries: 20
       delay: 3
-      until: heartbeat.status == 200
+      until: heartbeat.rc == 0
+      changed_when: false
 
     - name: Done — next steps
       debug:

--- a/infrastructure/ansible/playbooks/umami-install.yml
+++ b/infrastructure/ansible/playbooks/umami-install.yml
@@ -1,0 +1,116 @@
+---
+# One-shot install for self-hosted Umami analytics on the DO box.
+#
+# Complete the steps below in order. Each runs in seconds; the only
+# wait is at step 5 (you log in to a web UI).
+#
+# 1. Cloudflare DNS — add CNAME `analytics` → `spire-codex.com`
+#    (proxied / orange cloud). Verify:
+#      dig +short analytics.spire-codex.com
+#    should return CF anycast IPs.
+#
+# 2. 1Password (Spire Codex vault) — create a new item "Umami" with:
+#      - `db_password`  — random 32+ chars (Postgres password)
+#      - `app_secret`   — random 64+ chars (Umami session signer +
+#                         visitor-IP hash salt)
+#      - `website_id`   — leave blank for now (filled in at step 6)
+#    Use the 1P desktop generator; symbols are fine.
+#
+# 3. Render the updated nginx config (it now has an
+#    `analytics.spire-codex.com` server block) + render .env (it
+#    references the three Umami fields above):
+#      ./bin/do-ansible playbooks/sync-config.yml      --limit do_origin
+#      ./bin/do-ansible playbooks/sync-secrets-do.yml  --limit do_origin
+#
+# 4. Run THIS playbook:
+#      ./bin/do-ansible playbooks/umami-install.yml --limit do_origin
+#    It pulls the images, brings the Umami + Postgres containers up,
+#    and waits for the /api/heartbeat endpoint to return 200.
+#
+# 5. First login (one-time) — open https://analytics.spire-codex.com:
+#      - Default creds: admin / umami.  Change the password
+#        immediately (Settings → Profile → Change Password). Store
+#        the new password in 1P under `Umami` → `admin_password`.
+#      - Websites → Add Website.  Name: spire-codex.  Domain:
+#        spire-codex.com.  Save.
+#      - Open the website, click "Tracking code" — copy the UUID from
+#        the `data-website-id` attribute. Paste into 1P → Umami →
+#        website_id.
+#
+# 6. Re-render .env (now with website_id filled in) + recreate the
+#    frontend so the tracker script starts emitting on SSR'd HTML:
+#      ./bin/do-ansible playbooks/sync-secrets-do.yml --limit do_origin
+#      ./bin/do-ansible playbooks/deploy.yml          --limit do_origin
+#
+# Re-running this playbook is idempotent — `docker compose up -d` is
+# a no-op when nothing changed.
+
+- name: Install Umami self-hosted analytics
+  hosts: digital_ocean
+  gather_facts: false
+  become: true
+
+  vars:
+    umami_dir: "{{ spire_codex_dir }}"
+    compose_file: docker-compose.umami.yml
+
+  tasks:
+    - name: Sanity-check that sync-secrets-do.yml has been run (UMAMI_* in .env)
+      shell: grep -q '^UMAMI_DB_PASSWORD=' {{ umami_dir }}/.env && grep -q '^UMAMI_APP_SECRET=' {{ umami_dir }}/.env
+      changed_when: false
+      failed_when: false
+      register: env_check
+
+    - name: Bail if UMAMI_* env vars are missing from .env
+      fail:
+        msg: |
+          UMAMI_DB_PASSWORD and/or UMAMI_APP_SECRET not present in {{ umami_dir }}/.env.
+          Run `./bin/do-ansible playbooks/sync-secrets-do.yml --limit do_origin` first.
+          That renders the .env from files/.env.tpl (which now references
+          op://Spire Codex/Umami/db_password + /app_secret).
+      when: env_check.rc != 0
+
+    - name: Ensure umami-data dir exists on host
+      file:
+        path: "{{ umami_dir }}/umami-data"
+        state: directory
+        owner: "999"
+        group: "999"
+        mode: "0700"
+
+    - name: Pull umami + postgres images
+      command: docker compose -f {{ compose_file }} pull
+      args:
+        chdir: "{{ umami_dir }}"
+      register: pull_result
+      changed_when: "'Pulled' in pull_result.stdout"
+
+    - name: Start the Umami stack
+      command: docker compose -f {{ compose_file }} up -d
+      args:
+        chdir: "{{ umami_dir }}"
+      register: up
+      changed_when: "'Started' in up.stderr or 'Created' in up.stderr"
+
+    - name: Wait for Umami to be ready (HTTP 200 from nginx → umami)
+      uri:
+        url: "http://localhost/api/heartbeat"
+        headers:
+          Host: "analytics.spire-codex.com"
+        status_code: 200
+      register: heartbeat
+      retries: 20
+      delay: 3
+      until: heartbeat.status == 200
+
+    - name: Done — next steps
+      debug:
+        msg: |
+          Umami is up on analytics.spire-codex.com.
+
+          Manual follow-up (see playbook header):
+            1. Log in (default: admin/umami) — change password immediately.
+            2. Add Website "spire-codex" (domain: spire-codex.com).
+            3. Copy the data-website-id UUID into 1P → Umami → website_id.
+            4. Run sync-secrets-do.yml + deploy.yml to load UMAMI_WEBSITE_ID
+               + UMAMI_SRC into the frontend container.

--- a/infrastructure/ansible/templates/nginx.conf.j2
+++ b/infrastructure/ansible/templates/nginx.conf.j2
@@ -267,6 +267,13 @@ server {
   # nginx_web-network. Subdomain so it's isolated from spire-codex.com
   # (and easy to lock down at the CF edge if needed).
   #
+  # The tracker endpoints (script.js + /api/send) must stay reachable
+  # by every visitor — those are the actual page-view ingest paths. The
+  # dashboard UI (everything else: /login, /websites, etc.) is gated
+  # to the admin IP via the location-level allow/deny below. The split
+  # keeps tracking working from the open internet while making the
+  # admin surface invisible to drive-by scanners.
+  #
   # First-time setup: see playbooks/umami-install.yml.
   server {
       listen 80;
@@ -276,11 +283,32 @@ server {
       # not hit this host, and tracker pings would 10x the access log.
       access_log off;
 
-      # Tracker pings include the visitor's referrer; we want Umami to
-      # see the real client IP for country/device resolution, which
-      # nginx already populated from CF-Connecting-IP via the trusted
-      # Cloudflare ranges at the http {} level.
+      # Tracker script — every visitor's browser fetches this from
+      # the SSR'd <script src=...>. Must be public.
+      location = /script.js {
+          proxy_pass http://umami:3000;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+      }
+
+      # Page-view ingest endpoint — POST'd by script.js for every nav.
+      # Must accept traffic from every visitor IP. Umami applies its
+      # own internal sender check via the website_id.
+      location = /api/send {
+          proxy_pass http://umami:3000;
+          proxy_http_version 1.1;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      }
+
+      # Everything else (dashboard UI, login, websites CRUD, etc.) is
+      # admin-only. allow/deny is applied AFTER nginx's real_ip module
+      # rewrites $remote_addr from CF-Connecting-IP, so the comparison
+      # is against the actual visitor IP (not Cloudflare's edge).
       location / {
+          allow {{ admin_ip }};
+          deny all;
           proxy_pass http://umami:3000;
           proxy_http_version 1.1;
           proxy_set_header Host $host;

--- a/infrastructure/ansible/templates/nginx.conf.j2
+++ b/infrastructure/ansible/templates/nginx.conf.j2
@@ -263,6 +263,33 @@ server {
       }
   }
 
+  # Umami self-hosted analytics. Single container at umami:3000 on
+  # nginx_web-network. Subdomain so it's isolated from spire-codex.com
+  # (and easy to lock down at the CF edge if needed).
+  #
+  # First-time setup: see playbooks/umami-install.yml.
+  server {
+      listen 80;
+      server_name analytics.spire-codex.com;
+
+      # Don't log analytics traffic — the metrics-monitor scraper does
+      # not hit this host, and tracker pings would 10x the access log.
+      access_log off;
+
+      # Tracker pings include the visitor's referrer; we want Umami to
+      # see the real client IP for country/device resolution, which
+      # nginx already populated from CF-Connecting-IP via the trusted
+      # Cloudflare ranges at the http {} level.
+      location / {
+          proxy_pass http://umami:3000;
+          proxy_http_version 1.1;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+      }
+  }
+
   server {
         listen 80 default_server;
         listen [::]:80 default_server;


### PR DESCRIPTION
## Summary

Self-hosted Umami analytics on the DO box. GA-equivalent for what we'd actually use it for, cookie-free, no consent banner needed, fully owned (survives if we ever leave Cloudflare).

## Architecture

- New compose file `docker-compose.umami.yml` — Umami + dedicated Postgres on an isolated bridge network so a misconfigured public proxy can't accidentally expose the DB.
- Umami container joins `nginx_web-network` so the existing nginx proxies `analytics.spire-codex.com` → `umami:3000`.
- New nginx server block in `nginx.conf.j2`, `access_log off` (tracker pings would 10x the log volume).
- `<Script>` tag in `frontend/app/layout.tsx`, gated by `UMAMI_SRC` + `UMAMI_WEBSITE_ID`. Read at SSR time (server-component env access), not as `NEXT_PUBLIC_*` — so updating the values is recreate-not-rebuild. Dev / uninit prod stays untracked because the layout short-circuits when either var is blank.
- HASH_SALT pinned to APP_SECRET; Umami rotates it daily, so visitor identity is anonymous + ephemeral without any cookie.
- `sync-config.yml` now targets `prod_origins:digital_ocean` so the nginx template renders on the DO box.

## Deploy runbook (in `playbooks/umami-install.yml` header)

After merge:

1. Cloudflare → add CNAME `analytics` → `spire-codex.com` (proxied / orange cloud).
2. 1Password → create item "Umami" in the Spire Codex vault with three fields: `db_password` (32+ chars), `app_secret` (64+ chars), `website_id` (blank for now).
3. `./bin/do-ansible playbooks/sync-config.yml --limit do_origin` — renders the new nginx block.
4. `./bin/do-ansible playbooks/sync-secrets-do.yml --limit do_origin` — renders .env with the new UMAMI_* refs.
5. `./bin/do-ansible playbooks/umami-install.yml --limit do_origin` — pulls images, brings up the stack, waits for `/api/heartbeat`.
6. Open `https://analytics.spire-codex.com`. Default `admin/umami` — change password immediately. Add Website "spire-codex" (domain `spire-codex.com`). Copy the `data-website-id` UUID into 1P → Umami → website_id.
7. `./bin/do-ansible playbooks/sync-secrets-do.yml --limit do_origin` — re-render .env now that website_id is set.
8. `./bin/do-ansible playbooks/deploy.yml --limit do_origin` — recreate frontend so the tracker script starts emitting.
