### PR TITLE
Umami: hardcode public IDs instead of routing through env vars

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -83,11 +83,6 @@ services:
     environment:
       - API_INTERNAL_URL=http://spire-codex-backend:8000
       - NEXT_PUBLIC_SITE_URL=https://spire-codex.com
-      # Self-hosted Umami tracker. Read by app/layout.tsx at SSR time
-      # — no rebuild needed when these values change. Leaving either
-      # blank keeps the analytics script off the page entirely.
-      - UMAMI_SRC=${UMAMI_SRC:-}
-      - UMAMI_WEBSITE_ID=${UMAMI_WEBSITE_ID:-}
     networks:
       - nginx_web-network
     logging:

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -12,15 +12,20 @@ import { LanguageProvider } from "./contexts/LanguageContext";
 import { BetaVersionProvider } from "./contexts/BetaVersionContext";
 import { SITE_NAME, SITE_URL } from "@/lib/seo";
 
-// Self-hosted Umami analytics. Read in the root layout (a Server
-// Component) at request time, so the values land in the SSR'd HTML
-// without needing to be baked into the Docker image at CI build time
-// via NEXT_PUBLIC_* build args. The frontend container reads UMAMI_*
-// from its runtime env (set in docker-compose.prod.yml). Leaving
-// either blank — the dev / local default — keeps the script off the
-// page so localhost traffic doesn't pollute stats.
-const UMAMI_SRC = process.env.UMAMI_SRC || "";
-const UMAMI_WEBSITE_ID = process.env.UMAMI_WEBSITE_ID || "";
+// Self-hosted Umami analytics. Both values are public-by-design — the
+// browser fetches the script + sends the website ID on every page
+// view — so there's no secret to manage. Hardcoding them as constants
+// dodges Next.js's static-prerender trap: pages exporting
+// `force-static` (most of the site) bake the layout at Docker build
+// time, when runtime env vars aren't reachable, which silently strips
+// the script tag from every prerendered page.
+//
+// Local-dev pollution is handled at the Umami side, not here — the
+// website is configured with `spire-codex.com` as its allowed domain
+// so pings from `localhost:3000` are rejected by Umami before they
+// land in the stats.
+const UMAMI_SRC = "https://analytics.spire-codex.com/script.js";
+const UMAMI_WEBSITE_ID = "715a2b92-5064-4369-9d33-cdd1c0ea8f93";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/infrastructure/ansible/files/.env.tpl
+++ b/infrastructure/ansible/files/.env.tpl
@@ -50,14 +50,10 @@ MONGO_URL=op://Spire Codex/MongoDB/connection-string
 # TURSO_AUTH_TOKEN=op://Spire Codex/Turso/token
 # TURSO_LOCAL_REPLICA=/data/runs-replica.db
 
-# Umami self-hosted analytics. Top two are read by the frontend
-# container at SSR time (not bundled into the client at build) so
-# changing them is a recreate-not-rebuild operation. Until the
-# website is created in the Umami UI, leave `website_id` blank in 1P
-# — the layout guards against partial config and won't emit the
-# script tag.
-# Bottom two are consumed by docker-compose.umami.yml only.
-UMAMI_SRC=https://analytics.spire-codex.com/script.js
-UMAMI_WEBSITE_ID=op://Spire Codex/Umami/website_id
+# Umami self-hosted analytics. UMAMI_SRC + UMAMI_WEBSITE_ID are
+# hardcoded as public constants in frontend/app/layout.tsx (they're
+# embedded in the SSR'd HTML anyway — no secret to keep), so they
+# don't need to be threaded through here. The two below are
+# consumed by docker-compose.umami.yml only.
 UMAMI_DB_PASSWORD=op://Spire Codex/Umami/db_password
 UMAMI_APP_SECRET=op://Spire Codex/Umami/app_secret


### PR DESCRIPTION
The first cut threaded UMAMI_SRC + UMAMI_WEBSITE_ID through docker-compose env into the frontend container, where the layout Server Component read them at SSR time. That works for dynamic pages but silently no-ops for static ones: pages exporting `force-static` (most of the site) bake their layout output at Docker build time, when runtime env vars aren't reachable. The home page shipped without the tracker tag and we burned an hour chasing it.

Both values are public-by-design — the browser fetches the script URL and sends the website ID on every page view, so there's no secret to keep. Hardcoding them as constants in `layout.tsx` dodges the static-bake trap and removes the deploy-time configuration plumbing that wasn't paying for itself.

The two values that *do* need to stay in env (Postgres password and Umami app secret, both consumed only by docker-compose.umami.yml) stay where they are.