### PR TITLE
Add node_exporter for host-level metrics

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,34 @@
+name: spire-codex-monitoring
+
+# Host-level metrics for the DO box. node_exporter must run on host
+# networking (to see eth0 / lo / docker0 interfaces of the host
+# itself, not its own container namespace) and with /proc, /sys, /
+# bind-mounted read-only so it can read kernel stats from outside its
+# cgroup.
+#
+# Scraped via nginx through https://spire-codex.com/node-metrics —
+# allowed only to the metrics_monitor_ip in nginx.conf.j2, so the
+# endpoint is invisible to anyone but the scraper. The nginx container
+# reaches node_exporter via host.docker.internal (host-gateway), which
+# requires `--add-host=host.docker.internal:host-gateway` on the
+# web-server container (handled by monitoring-install.yml).
+
+services:
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: node-exporter
+    restart: unless-stopped
+    network_mode: host
+    pid: host
+    command:
+      - --path.rootfs=/host
+      # Skip pseudo-filesystems that just add cardinality without value.
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc|var/lib/docker/.+|var/lib/containers/.+)($$|/)
+      - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$$
+    volumes:
+      - /:/host:ro,rslave
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/infrastructure/ansible/playbooks/monitoring-install.yml
+++ b/infrastructure/ansible/playbooks/monitoring-install.yml
@@ -1,0 +1,116 @@
+---
+# Host-level monitoring: node_exporter container + nginx wiring so
+# the scraper can reach it via https://spire-codex.com/node-metrics.
+#
+# Before running:
+#   1. Confirm playbooks/sync-config.yml has been run since the
+#      `/node-metrics` location block was added to nginx.conf.j2 —
+#      otherwise the nginx config on disk doesn't expose the endpoint.
+#
+# Usage:
+#   ./bin/do-ansible playbooks/monitoring-install.yml --limit do_origin
+#
+# What this does:
+#   - Pulls prom/node-exporter:latest and brings up the monitoring
+#     compose stack (host networking, /:/host:ro mount).
+#   - Recreates the nginx (web-server) container with
+#     `--add-host=host.docker.internal:host-gateway`, which is what
+#     lets nginx reach node_exporter's 0.0.0.0:9100 on the host
+#     network. Without it the nginx /node-metrics location 502s.
+#
+# Re-running is idempotent: docker compose up -d skips when nothing
+# changed, and the web-server recreate is conditional on the
+# host-gateway flag not already being present.
+
+- name: Install node_exporter + wire nginx
+  hosts: digital_ocean
+  gather_facts: false
+  become: true
+
+  tasks:
+    - name: Bring up the monitoring stack (node_exporter)
+      command: docker compose -f docker-compose.monitoring.yml up -d
+      args:
+        chdir: "{{ spire_codex_dir }}"
+      register: monitoring_up
+      changed_when:
+        "'Started' in monitoring_up.stderr or 'Created' in monitoring_up.stderr"
+
+    # node_exporter on host networking binds 0.0.0.0:9100, which means
+    # without a firewall rule the public IP exposes system metrics to
+    # the internet. Lock it down with the same RFC1918+loopback pattern
+    # we used for Mongo (see playbooks/mongo-lockdown.yml).
+    - name: Allow private + loopback to reach 9100
+      iptables:
+        chain: INPUT
+        protocol: tcp
+        destination_port: "9100"
+        ctstate: NEW
+        jump: ACCEPT
+        source: "{{ item }}"
+        action: insert
+        comment: "spire-codex: allow private to node_exporter"
+      loop:
+        - 10.0.0.0/8
+        - 127.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+      register: accepts
+
+    - name: DROP all other inbound traffic to 9100
+      iptables:
+        chain: INPUT
+        protocol: tcp
+        destination_port: "9100"
+        ctstate: NEW
+        jump: DROP
+        action: append
+        comment: "spire-codex: block public node_exporter"
+      register: drop_rule
+
+    - name: Persist iptables ruleset
+      shell: iptables-save > /etc/sysconfig/iptables
+      when: accepts.changed or drop_rule.changed
+
+    - name: Check whether web-server already has host-gateway mapping
+      shell: |
+        docker inspect web-server \
+          --format '{{ "{{range .HostConfig.ExtraHosts}}{{println .}}{{end}}" }}' \
+          2>/dev/null | grep -q '^host.docker.internal:host-gateway$'
+      register: ws_has_hostgw
+      changed_when: false
+      failed_when: false
+
+    - name: Recreate web-server with --add-host=host.docker.internal:host-gateway
+      when: ws_has_hostgw.rc != 0
+      block:
+        - name: Stop + remove existing web-server
+          command: docker rm -f web-server
+        - name: Start web-server with the host-gateway flag
+          command: >
+            docker run -d
+            --name web-server
+            --restart unless-stopped
+            --network nginx_web-network
+            --add-host host.docker.internal:host-gateway
+            -p 80:80
+            -p 443:443
+            -v /var/www:/var/www:ro
+            -v /data/nginx/nginx/logs:/var/log/nginx:rw
+            -v /etc/ssl/local:/etc/ssl/local:ro
+            -v /data/nginx/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+            nginx:alpine
+
+    - name: Smoke-test: node_exporter reachable from inside nginx
+      shell: docker exec web-server wget -qO- http://host.docker.internal:9100/metrics | head -c 200
+      register: probe
+      changed_when: false
+    - debug:
+        msg: "{{ probe.stdout_lines | default(['(empty — check node_exporter logs)']) }}"
+
+    - name: Done
+      debug:
+        msg: |
+          node_exporter is up on the DO host:9100.
+          Scrape target: https://spire-codex.com/node-metrics
+          (access restricted to metrics_monitor_ip via nginx)

--- a/infrastructure/ansible/templates/nginx.conf.j2
+++ b/infrastructure/ansible/templates/nginx.conf.j2
@@ -101,6 +101,23 @@ http {
           proxy_set_header X-Real-IP $remote_addr;
       }
 
+      # Host-level metrics from node_exporter. node_exporter runs with
+      # `network_mode: host` (so it sees the host's real eth0 / lo /
+      # docker0 interfaces rather than its own container ns), which
+      # means nginx — on the docker bridge — has to dial back to the
+      # host via `host.docker.internal`. The web-server container is
+      # launched with `--add-host=host.docker.internal:host-gateway`
+      # by playbooks/monitoring-install.yml; without that flag this
+      # location 502s.
+      location /node-metrics {
+          allow {{ metrics_monitor_ip }};
+          deny all;
+          proxy_pass http://host.docker.internal:9100/metrics;
+          proxy_http_version 1.1;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+      }
+
       location /health {
           allow {{ metrics_monitor_ip }};
           deny all;


### PR DESCRIPTION
## Summary

Closes the last "No Data" gap on the dashboard. PR #297's multiproc fix disabled prometheus_client's per-process `process_*` collectors (CPU/memory/FDs), which left a handful of Grafana panels stuck on "No Data". This wires up a host-level source for them.

- New `docker-compose.monitoring.yml` runs `prom/node-exporter` with `network_mode: host` + `pid: host` + `/:/host:ro` so it sees the host's real interfaces and kernel stats.
- New nginx location `/node-metrics` on the main `spire-codex.com` server block, IP-allowlisted to `metrics_monitor_ip` (same pattern as the existing `/metrics`).
- `monitoring-install.yml` brings up the stack, locks down public 9100 via iptables (same RFC1918+loopback pattern as `mongo-lockdown.yml`), and recreates the nginx container with `--add-host=host.docker.internal:host-gateway` so it can reach node_exporter on host networking. The recreate check is idempotent — no churn on re-runs.

## Deploy

```bash
./bin/do-ansible playbooks/sync-config.yml      --limit do_origin   # renders new /node-metrics block
./bin/do-ansible playbooks/monitoring-install.yml --limit do_origin
```

Then update your Prometheus scrape config to add `https://spire-codex.com/node-metrics` as a target alongside the existing `/metrics`.