### PR TITLE
Unify player-mode toggle UI between /stats and /leaderboards

### DIFF
--- a/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
+++ b/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
@@ -75,7 +75,7 @@ interface BrowseRun {
 }
 
 type Tab = "fastest" | "highest_ascension" | "browse";
-type Mode = "single" | "multi";
+type Mode = "" | "single" | "multi";
 // `gameMode` mirrors the backend `game_mode` column. Empty string = no
 // filter (all modes). Default is "standard" since custom-seed and daily
 // runs aren't time-comparable to the canonical ladder.
@@ -87,7 +87,9 @@ function tabFromParam(value: string | null): Tab {
 }
 
 function modeFromParam(value: string | null): Mode {
-  return value === "multi" ? "multi" : "single";
+  if (value === "multi") return "multi";
+  if (value === "all" || value === "") return "";
+  return "single";
 }
 
 function gameModeFromParam(value: string | null): GameMode {
@@ -170,7 +172,7 @@ export default function LeaderboardBrowseClient() {
     setLbLoading(true);
     const params = new URLSearchParams();
     params.set("category", tab);
-    params.set("players", mode);
+    if (mode) params.set("players", mode);
     if (gameMode) params.set("game_mode", gameMode);
     if (lbChar) params.set("character", lbChar);
     params.set("page", String(lbPage));
@@ -202,7 +204,7 @@ export default function LeaderboardBrowseClient() {
   useEffect(() => {
     if (tab !== "browse") return;
     const params = new URLSearchParams();
-    params.set("players", mode);
+    if (mode) params.set("players", mode);
     if (gameMode) params.set("game_mode", gameMode);
     if (browseChar) params.set("character", browseChar);
     if (browseWin) params.set("win", browseWin);
@@ -240,17 +242,21 @@ export default function LeaderboardBrowseClient() {
           read from disjoint pools. */}
       <div className="flex flex-wrap items-center gap-3 mb-6">
         <div className="inline-flex gap-1 p-1 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)]">
-          {(["single", "multi"] as Mode[]).map((m) => (
+          {([
+            { value: "" as Mode, label: t("All", lang) },
+            { value: "single" as Mode, label: t("Single Player", lang) },
+            { value: "multi" as Mode, label: t("Multiplayer", lang) },
+          ]).map(({ value, label }) => (
             <button
-              key={m}
-              onClick={() => setMode(m)}
+              key={value || "all"}
+              onClick={() => setMode(value)}
               className={`px-4 py-1.5 text-sm font-medium rounded transition-colors ${
-                mode === m
+                mode === value
                   ? "bg-[var(--accent-gold)] text-[var(--bg-primary)]"
                   : "text-[var(--text-muted)] hover:text-[var(--text-primary)]"
               }`}
             >
-              {m === "single" ? t("Single Player", lang) : t("Multiplayer", lang)}
+              {label}
             </button>
           ))}
         </div>

--- a/frontend/app/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/leaderboards/stats/StatsClient.tsx
@@ -261,6 +261,12 @@ export default function StatsClient() {
   const [character, setCharacter] = useState("");
   const [winFilter, setWinFilter] = useState("");
   const [ascension, setAscension] = useState("");
+  // Single-player vs multiplayer vs all. Empty string = all (default —
+  // stats include both pools). Matches the backend `?players=` filter
+  // on /api/runs/stats. Multiplayer runs are stored as one document
+  // per player (player_count > 1), so leaving the filter off gives
+  // the full population.
+  const [players, setPlayers] = useState<"" | "single" | "multi">("");
 
   // Tabs
   const [tab, setTab] = useState<TopTab>("overview");
@@ -341,12 +347,13 @@ export default function StatsClient() {
     if (character) params.set("character", character);
     if (winFilter) params.set("win", winFilter);
     if (ascension) params.set("ascension", ascension);
+    if (players) params.set("players", players);
     setLoading(true);
     fetch(`${API}/api/runs/stats?${params}`)
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => setStats(d))
       .finally(() => setLoading(false));
-  }, [character, winFilter, ascension]);
+  }, [character, winFilter, ascension, players]);
 
   const imgBaseFor = (id: string) => (betaIds.has(id) ? BETA_API : API);
 
@@ -539,6 +546,34 @@ export default function StatsClient() {
         </Link>{" "}
         to contribute.
       </p>
+
+      {/* Player-mode toggle — visually identical to LeaderboardBrowseClient's
+          mode pills (same wrapper, padding, colors) so the two pages
+          read as one design language. "All" is the default here
+          because aggregate stats are most useful when not artificially
+          narrowed; leaderboards default to "single" because rankings
+          across SP/MP pools aren't comparable. */}
+      <div className="flex flex-wrap items-center gap-3 mb-6">
+        <div className="inline-flex gap-1 p-1 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)]">
+          {([
+            { value: "" as const, label: t("All", lang) },
+            { value: "single" as const, label: t("Single Player", lang) },
+            { value: "multi" as const, label: t("Multiplayer", lang) },
+          ]).map(({ value, label }) => (
+            <button
+              key={value || "all"}
+              onClick={() => setPlayers(value)}
+              className={`px-4 py-1.5 text-sm font-medium rounded transition-colors ${
+                players === value
+                  ? "bg-[var(--accent-gold)] text-[var(--bg-primary)]"
+                  : "text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
 
       {/* Global filter bar */}
       <div className="flex flex-wrap gap-2 mb-5">


### PR DESCRIPTION
## Summary

Both pages now share the same three-position pill toggle (**All | Single Player | Multiplayer**) — same wrapper, padding, colors, hover states. Adding 'All' to leaderboards is purely additive (existing default of Single Player is preserved); stats gets the toggle for the first time with default 'All'.

| Page | Default | Why |
|---|---|---|
| /leaderboards | Single Player | Solo and MP speedrun times aren't comparable; blending them would confuse rankings |
| /leaderboards/stats | All | Aggregate stats are most useful when not artificially narrowed; opt into a pool by clicking |

Backend already accepts `?players=single|multi` (omit = all). Frontend change is just adding the empty-string variant to the existing `Mode` type, conditionalizing the param set, and swapping the two-option button list for a three-option one.