### PR TITLE
Throttle every endpoint: SlowAPIMiddleware + tight cap on /api/exports

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from pathlib import Path
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 
 from .routers import (
     cards,
@@ -120,6 +121,19 @@ app = FastAPI(
 
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+# Without SlowAPIMiddleware, slowapi's `default_limits` is a no-op
+# — it only applies to routes that explicitly use `@limiter.limit()`.
+# Roughly 70/85 routes (every entity GET route, exports, news, mechanics
+# pages) had no throttle at all before this middleware landed: a scraper
+# could hit /api/cards or /api/exports/{lang} in a tight loop and the
+# only resistance was the box's actual CPU and bandwidth.
+#
+# Adding the middleware applies the limiter's `default_limits` to every
+# request before it reaches the route handler. Routes that already have
+# a `@limiter.limit(...)` decorator keep their explicit limit (slowapi
+# uses the tightest applicable limit per request); the middleware just
+# closes the unthrottled-by-default gap.
+app.add_middleware(SlowAPIMiddleware)
 
 
 # Pre-warm the per-entity run-stats cache in a background thread on

--- a/backend/app/routers/exports.py
+++ b/backend/app/routers/exports.py
@@ -1,14 +1,24 @@
 import io
 import zipfile
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
+from slowapi import Limiter
 
-from ..dependencies import VALID_LANGUAGES
+from ..dependencies import VALID_LANGUAGES, client_ip
 from ..metrics import data_exports
 from ..services.data_service import DATA_DIR
 
 router = APIRouter(prefix="/api/exports", tags=["Exports"])
+
+# Per-language export builds a multi-file zip (15+ JSON files, 1-3 MB
+# compressed) on every request. CPU cost is the deflate pass — roughly
+# 20-100ms each — plus the egress bytes. Way too expensive to fall
+# under the global 300/min default. 10/hour per real IP is plenty for
+# legitimate "give me a snapshot of the eng locale" use; anything
+# higher and you're either scraping or you should be using the JSON
+# endpoints directly.
+limiter = Limiter(key_func=client_ip)
 
 ENTITY_FILES = [
     "cards",
@@ -31,7 +41,8 @@ ENTITY_FILES = [
 
 
 @router.get("/{lang}")
-def export_language(lang: str):
+@limiter.limit("10/hour")
+def export_language(lang: str, request: Request):
     if lang not in VALID_LANGUAGES:
         lang = "eng"
     buf = io.BytesIO()


### PR DESCRIPTION
## Summary

`slowapi`'s `default_limits=["300/minute"]` setting on the main `Limiter` was a no-op without `SlowAPIMiddleware` — only routes carrying an explicit `@limiter.limit(...)` decorator got throttled. The audit:

| Decorated | Unthrottled |
|---|---|
| ~15 routes (POST writes, /api/runs/* reads) | ~70 routes (every entity GET, exports, news, mechanics, etc.) |

So `/api/cards`, `/api/relics`, `/api/exports/{lang}`, etc. had zero rate limit. A scraper could hammer them as fast as the box could serve until they ran out of bandwidth.

## Changes

1. Add `SlowAPIMiddleware` — applies the limiter's `default_limits` to every request before the route runs. slowapi picks the most restrictive applicable limit per request, so routes with their own decorator keep their tighter limit unchanged.
2. Tighten `/api/exports/{lang}` from the new 300/min floor to **10/hour** — each request builds a 15-file ZIP with deflate compression (1-3 MB / 20-100ms CPU). Cheap legitimate use, expensive abuse. 10/hour covers "snapshot all 14 locales" with room to spare; anything more is scraping.

## Smoke test

```
350 sequential GET /api/cards from one IP:
  200 OK:  300
  429:      50
```

Exactly the expected split. Middleware works.

## After deploy

Every endpoint has a floor of 300/min/IP. Routes with their own `@limiter.limit(...)` keep their tighter override. The upcoming admin rate-limit dial (PR #308) lets you tune any slug on the fly without redeploying — but the floor is in place now.
