### PR TITLE
nginx: alias Compendium's misrouted character-icon URLs

### DIFF
--- a/infrastructure/ansible/templates/nginx.conf.j2
+++ b/infrastructure/ansible/templates/nginx.conf.j2
@@ -126,6 +126,21 @@ http {
           proxy_set_header Host $host;
       }
 
+      # Rewrite character-icon requests that the Spire Compendium
+      # desktop app sends to the wrong directory. The Tauri app's
+      # frontend asks for /static/images/relics/{character}.webp
+      # (e.g. .../ironclad.webp, .../regent.webp) when it means the
+      # character icon, which actually lives at
+      # /static/images/characters/character_icon_{character}.webp.
+      # ~38 404s/day from this pattern before; this serves the
+      # correct file silently while the Compendium gets fixed
+      # upstream. Regex is anchored to the exact 5 character names —
+      # we don't want to start aliasing arbitrary relic names that
+      # happen to share their slug with non-relic assets.
+      location ~ ^/static/images/relics/(ironclad|silent|defect|necrobinder|regent)\.(webp|png)$ {
+          rewrite ^/static/images/relics/(.+)\.(.+)$ /static/images/characters/character_icon_$1.$2 last;
+      }
+
       location /static/ {
           proxy_pass http://spire-codex-backend:8000;
           proxy_http_version 1.1;


### PR DESCRIPTION
## Summary

The Spire Compendium desktop app (Tauri webview using next/image through Vercel image optimization) requests character icons from the wrong path. It asks for:

```
/static/images/relics/{character}.webp
```

When the actual icon lives at:

```
/static/images/characters/character_icon_{character}.webp
```

That's ~38 404s/day in the API errors metric, plus broken icon renders in the Compendium UI.

## Fix

nginx rewrite, anchored to the five known character slugs (ironclad / silent / defect / necrobinder / regent) so we don't start aliasing arbitrary relic-shaped URLs into the characters directory:

```nginx
location ~ ^/static/images/relics/(ironclad|silent|defect|necrobinder|regent)\.(webp|png)$ {
    rewrite ... /static/images/characters/character_icon_$1.$2 last;
}
```

Internal rewrite (not 302) — single request, no client roundtrip.

## Deploy

```bash
./bin/do-ansible playbooks/sync-config.yml --limit do_origin
```

nginx template gets re-rendered and the web-server container reloaded via the playbook's handler.

## Long-term

The Compendium itself should construct the right URL. This is the defensive fix that closes the 404 gap immediately.