### PR TITLE
Cards: add 'Event' to color filter (#311)

### DIFF
--- a/frontend/app/cards/CardsClient.tsx
+++ b/frontend/app/cards/CardsClient.tsx
@@ -26,6 +26,7 @@ const colorOptions = [
   { label: "Necrobinder", value: "necrobinder" },
   { label: "Regent", value: "regent" },
   { label: "Colorless", value: "colorless" },
+  { label: "Event", value: "event" },
   { label: "Token", value: "token" },
   { label: "Curse", value: "curse" },
 ];


### PR DESCRIPTION
Adds Event as a color filter option on /cards. 27 cards have `color: event` (Apotheosis, Apparition, Caltrops, etc.) — these come from event rewards. API already supports `?color=event`; this just surfaces it in the UI dropdown.

Per #311. Reporter preferred type filter, but Event lives in the `color` field in the data model — type is genuinely Skill/Attack/Power for these cards. Adding to color matches the data shape without synthetic mapping.

Closes #311