### PR TITLE
Fix doubled 'Ancient Relic Relics' label + collapse related drawer (#276)

### DIFF
--- a/frontend/app/components/RelatedItems.tsx
+++ b/frontend/app/components/RelatedItems.tsx
@@ -86,7 +86,7 @@ export default function RelatedItems({
   }, [currentId, route, groupsKey]);
 
   return (
-    <details className="mt-6 group" open>
+    <details className="mt-6 group">
       <summary className="text-sm text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors flex items-center gap-1 cursor-pointer list-none">
         <svg
           aria-hidden

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -283,7 +283,7 @@ export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | n
               path: `/api/relics?pool=${encodeURIComponent(relic.pool)}&lang=${lang}`,
             },
             {
-              label: `${relic.rarity} relics`,
+              label: relic.rarity.endsWith("Relic") ? `${relic.rarity}s` : `${relic.rarity} Relics`,
               path: `/api/relics?rarity=${encodeURIComponent(relic.rarity)}&lang=${lang}`,
             },
           ]}


### PR DESCRIPTION
Two fixes:

1. **Doubled rarity label.** Every relic rarity already ends in 'Relic' (Ancient Relic, Common Relic, Event Relic, etc.), so the previous `${relic.rarity} relics` template produced 'Ancient Relic relics', 'Common Relic relics', etc. Now smart-pluralized: `endsWith('Relic') ? \`${rarity}s\` : \`${rarity} Relics\`` → 'Ancient Relics', 'Common Relics', 'Relics'.

2. **Drawer collapsed by default.** Related-items section now starts closed (`<details>` instead of `<details open>`). Affects relic + potion detail pages — clean default UI, click to expand and see everything.

Closes #276