### PR TITLE
Add beta-watch: automated detection of new StS2 beta builds

### DIFF
--- a/tools/beta-watch/README.md
+++ b/tools/beta-watch/README.md
@@ -1,0 +1,92 @@
+# beta-watch
+
+Automated detection + ingestion of new StS2 beta builds. A launchd job fires
+`watch.sh` every 15 minutes on Thursdays from 15:00 to 22:45 local — Mega
+Crit's typical beta-drop window. Manually trigger any time with
+`launchctl start com.spirecodex.beta-watch`. The watcher:
+
+1. Has SteamCMD sync the StS2 beta branch (no-op if up to date)
+2. Reads the buildid from `appmanifest_2868840.acf`
+3. If buildid changed, runs `process.sh`:
+   - Godot RE Tools extracts assets from the `.pck`
+   - ilspycmd decompiles `sts2.dll`
+   - Sniffs the version string from the decompiled C#
+   - Archives the `.dll` + `.pck` under `extraction/beta/archives/`
+   - Runs `parse_all.py` into `data-beta/<version>/`
+   - Runs `diff_data.py` against the previous beta to generate a changelog
+   - Re-points the `data-beta/latest` symlink
+   - Pushes a branch and opens a PR on a new branch `auto/beta-<version>`
+4. Sends a Discord webhook with the new version + PR URL
+
+The watcher is idempotent. If a tick fails partway, the next tick retries
+from scratch — `last-buildid` is only updated on full success.
+
+## One-time setup
+
+```bash
+# 1. Cache Steam Guard auth (interactive, only required once per machine)
+~/Steam/steamcmd.sh +login YOUR_USERNAME YOUR_PASSWORD
+# Enter your Steam Guard code when prompted; SteamCMD remembers the session.
+
+# 2. Opt the Steam account into the StS2 beta branch via the regular Steam
+#    GUI: StS2 → Properties → Betas → pick the beta branch from the dropdown.
+
+# 3. Populate 1Password items in the "Spire Codex" vault:
+#    - Steam item with fields: username, password
+#    - Discord Webhooks item with field: beta-watch (webhook URL)
+
+# 4. Beta branch defaults to "public-beta" (what Mega Crit uses). If they
+#    rename it, set SPIRE_BETA_BRANCH in the launchd plist's
+#    EnvironmentVariables block, or edit watch.sh's default.
+
+# 5. Install the launchd job
+./tools/beta-watch/install.sh
+```
+
+## Useful commands
+
+```bash
+# Trigger a manual run (handy for verifying credentials)
+launchctl start com.spirecodex.beta-watch
+
+# Watch the log live
+tail -f ~/.spire-codex/beta-watch/watch.log
+
+# Disable temporarily
+launchctl unload ~/Library/LaunchAgents/com.spirecodex.beta-watch.plist
+
+# Re-enable
+launchctl load ~/Library/LaunchAgents/com.spirecodex.beta-watch.plist
+
+# Force re-ingest of the current beta (clears last-seen state)
+rm ~/.spire-codex/beta-watch/last-buildid
+launchctl start com.spirecodex.beta-watch
+```
+
+## Configuration
+
+All knobs are env vars with defaults that work on the current Mac:
+
+| Var                  | Default                                        | Purpose                          |
+|----------------------|------------------------------------------------|----------------------------------|
+| `SPIRE_APP_ID`       | `2868840`                                      | Slay the Spire 2 Steam app id    |
+| `SPIRE_BETA_BRANCH`  | `public-beta`                                  | Steam beta branch name           |
+| `SPIRE_STEAMCMD`     | `$HOME/Steam/steamcmd.sh`                      | Path to SteamCMD binary          |
+| `SPIRE_STATE_DIR`    | `$HOME/.spire-codex/beta-watch`                | Where state + logs live          |
+| `SPIRE_REPO`         | `$HOME/Documents/Projects/spire-codex`         | Repo working tree                |
+
+## What gets reviewed manually
+
+The PR opened by `process.sh` is intentionally *not* auto-merged. Game
+schema changes can produce parser misfires (empty changelog files, missing
+entity types, broken descriptions), and an auto-merge would push that to
+production before anyone notices. Inspect the changelog files under
+`data-beta/<version>/changelogs/` and the diff against `data-beta/latest`
+before merging.
+
+After merge, deploy beta with:
+
+```bash
+cd infrastructure/ansible && ./bin/do-ansible playbooks/deploy.yml \
+  -e compose_file=docker-compose.beta.yml
+```

--- a/tools/beta-watch/com.spirecodex.beta-watch.plist
+++ b/tools/beta-watch/com.spirecodex.beta-watch.plist
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  launchd job for tools/beta-watch/watch.sh. Polls Steam every 15 min
+  on Thursdays from 15:00 to 22:45 local time — that's the window when
+  Mega Crit historically ships beta builds, so we don't burn API calls
+  the rest of the week. Manual trigger any time with:
+    launchctl start com.spirecodex.beta-watch
+
+  Drop this into ~/Library/LaunchAgents/ and `launchctl load` it
+  (install.sh does both). Logs to ~/.spire-codex/beta-watch/watch.log;
+  the StandardOutPath/StandardErrorPath below only capture early errors
+  before the script opens its own log.
+
+  StartCalendarInterval matches when ALL listed fields match. To express
+  "every 15 min in the window," each (Weekday, Hour, Minute) tuple is
+  listed explicitly. Weekday 4 = Thursday under launchd (0/7=Sunday).
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.spirecodex.beta-watch</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/peterlord/Documents/Projects/spire-codex/tools/beta-watch/watch.sh</string>
+  </array>
+
+  <key>StartCalendarInterval</key>
+  <array>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>15</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>15</integer><key>Minute</key><integer>15</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>15</integer><key>Minute</key><integer>30</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>15</integer><key>Minute</key><integer>45</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>16</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>16</integer><key>Minute</key><integer>15</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>16</integer><key>Minute</key><integer>30</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>16</integer><key>Minute</key><integer>45</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>17</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>17</integer><key>Minute</key><integer>15</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>17</integer><key>Minute</key><integer>30</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>17</integer><key>Minute</key><integer>45</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>18</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>18</integer><key>Minute</key><integer>15</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>18</integer><key>Minute</key><integer>30</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>18</integer><key>Minute</key><integer>45</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>19</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>19</integer><key>Minute</key><integer>15</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>19</integer><key>Minute</key><integer>30</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>19</integer><key>Minute</key><integer>45</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>20</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>20</integer><key>Minute</key><integer>15</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>20</integer><key>Minute</key><integer>30</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>20</integer><key>Minute</key><integer>45</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>21</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>21</integer><key>Minute</key><integer>15</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>21</integer><key>Minute</key><integer>30</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>21</integer><key>Minute</key><integer>45</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>15</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>30</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>45</integer></dict>
+  </array>
+
+  <!-- Don't run on plist load — the cadence is calendar-driven. Manual
+       trigger any time via `launchctl start com.spirecodex.beta-watch`. -->
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/peterlord/.spire-codex/beta-watch/launchd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/peterlord/.spire-codex/beta-watch/launchd.err.log</string>
+
+  <!-- Inherit the user's PATH so gh/git/python/op resolve. -->
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/Users/peterlord/.dotnet/tools</string>
+    <key>HOME</key>
+    <string>/Users/peterlord</string>
+  </dict>
+</dict>
+</plist>

--- a/tools/beta-watch/install.sh
+++ b/tools/beta-watch/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# One-time setup for the beta-watch launchd job.
+# Run from anywhere: ./tools/beta-watch/install.sh
+#
+# What this does:
+#   1. chmod +x on the watcher scripts
+#   2. Copies the plist into ~/Library/LaunchAgents
+#   3. Loads it via launchctl (starts the 30-min poll)
+#
+# What it does NOT do (you do these yourself, once):
+#   - Install SteamCMD (already at ~/Steam/steamcmd.sh per user)
+#   - Cache Steam Guard credentials. First time, run:
+#       ~/Steam/steamcmd.sh +login YOUR_USERNAME YOUR_PASSWORD
+#     and enter the Steam Guard code. SteamCMD remembers the session.
+#   - Populate 1Password items:
+#       op://Spire Codex/Steam/username
+#       op://Spire Codex/Steam/password
+#       op://Spire Codex/Discord Webhooks/beta-watch
+#   - Opt the Steam account into the StS2 beta branch once via the GUI.
+
+set -euo pipefail
+
+REPO=$(cd "$(dirname "$0")/../.." && pwd)
+WATCH_DIR="$REPO/tools/beta-watch"
+LABEL="com.spirecodex.beta-watch"
+PLIST_DST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+echo "[1/3] making scripts executable"
+chmod +x "$WATCH_DIR/watch.sh" "$WATCH_DIR/process.sh"
+
+echo "[2/3] installing launchd plist to $PLIST_DST"
+mkdir -p "$HOME/Library/LaunchAgents"
+cp "$WATCH_DIR/$LABEL.plist" "$PLIST_DST"
+
+echo "[3/3] loading launchd job"
+launchctl unload "$PLIST_DST" 2>/dev/null || true
+launchctl load "$PLIST_DST"
+
+echo ""
+echo "✓ beta-watch installed and running."
+echo "  Logs:   ~/.spire-codex/beta-watch/watch.log"
+echo "  State:  ~/.spire-codex/beta-watch/last-buildid"
+echo ""
+echo "Trigger a manual run (e.g. to verify your 1Password + Steam creds):"
+echo "  launchctl start $LABEL"
+echo ""
+echo "Disable temporarily:"
+echo "  launchctl unload $PLIST_DST"

--- a/tools/beta-watch/process.sh
+++ b/tools/beta-watch/process.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Pipeline: takes a freshly-downloaded StS2 beta install, extracts assets,
+# decompiles the DLL, parses data, generates a changelog, commits to a
+# new branch, and opens a PR. Stateless — every input comes from env vars
+# so this can be called by watch.sh or invoked manually.
+#
+# Required env vars (passed by watch.sh):
+#   BUILDID        — Steam buildid of the new beta (used in the branch name)
+#   DOWNLOAD_DIR   — where SteamCMD wrote the install (contains the .pck/.dll)
+#   REPO           — absolute path to the spire-codex working tree
+#
+# Outputs (state files in $STATE_DIR for watch.sh to pick up):
+#   $STATE_DIR/last-pr-url   — URL of the opened PR
+#   $STATE_DIR/last-version  — game version string (e.g. v0.105.0)
+
+set -euo pipefail
+
+: "${BUILDID:?BUILDID env var required}"
+: "${DOWNLOAD_DIR:?DOWNLOAD_DIR env var required}"
+: "${REPO:?REPO env var required}"
+
+STATE_DIR="${SPIRE_STATE_DIR:-$HOME/.spire-codex/beta-watch}"
+mkdir -p "$STATE_DIR"
+
+cd "$REPO"
+
+# --- 1. Locate the game's .pck and .dll inside the SteamCMD download ---
+# On macOS the Godot project is bundled inside the .app; on Linux/Windows
+# it's a sibling file. Probe both.
+APP_DIR=$(find "$DOWNLOAD_DIR" -maxdepth 3 -name "*.app" -type d | head -1)
+if [ -n "$APP_DIR" ]; then
+  PCK=$(find "$APP_DIR/Contents/Resources" -maxdepth 2 -name "*.pck" 2>/dev/null | head -1)
+  DLL=$(find "$APP_DIR/Contents/Resources" -maxdepth 3 -name "sts2.dll" 2>/dev/null | head -1)
+else
+  PCK=$(find "$DOWNLOAD_DIR" -maxdepth 3 -name "*.pck" 2>/dev/null | head -1)
+  DLL=$(find "$DOWNLOAD_DIR" -maxdepth 5 -name "sts2.dll" 2>/dev/null | head -1)
+fi
+
+[ -f "$PCK" ] || { echo "could not locate .pck under $DOWNLOAD_DIR"; exit 1; }
+[ -f "$DLL" ] || { echo "could not locate sts2.dll under $DOWNLOAD_DIR"; exit 1; }
+echo "found pck=$PCK"
+echo "found dll=$DLL"
+
+# --- 2. Run Godot RE Tools to extract assets ---
+GDRE="/Applications/Godot RE Tools.app/Contents/MacOS/Godot RE Tools"
+[ -x "$GDRE" ] || { echo "Godot RE Tools not at $GDRE"; exit 1; }
+
+rm -rf "$REPO/extraction/beta/raw"
+mkdir -p "$REPO/extraction/beta/raw" "$REPO/extraction/beta/archives"
+"$GDRE" --headless "--recover=$PCK" "--output=$REPO/extraction/beta/raw" >/dev/null
+
+# --- 3. Decompile the DLL ---
+rm -rf "$REPO/extraction/beta/decompiled"
+mkdir -p "$REPO/extraction/beta/decompiled"
+~/.dotnet/tools/ilspycmd -p -o "$REPO/extraction/beta/decompiled" "$DLL"
+
+# --- 4. Detect the game version string ---
+# The version lives in either Project Settings or a constant in the DLL.
+# Simplest path: grep the decompiled C# for a version literal. Falls back
+# to the buildid if that pattern moves.
+VERSION=$(grep -hroE '"[vV]?[0-9]+\.[0-9]+\.[0-9]+"' \
+             "$REPO/extraction/beta/decompiled" 2>/dev/null \
+          | tr -d '"' | sort -u | head -1)
+[ -z "$VERSION" ] && VERSION="b$BUILDID"
+[[ "$VERSION" != v* ]] && VERSION="v$VERSION"
+echo "detected version: $VERSION"
+echo "$VERSION" > "$STATE_DIR/last-version"
+
+DATA_OUT="$REPO/data-beta/$VERSION"
+if [ -d "$DATA_OUT" ]; then
+  echo "data-beta/$VERSION already exists — was the buildid mismatched?"
+  exit 1
+fi
+
+# --- 5. Archive the raw .dll + .pck so we can DepotDownload this build later ---
+cp "$DLL" "$REPO/extraction/beta/archives/sts2-$VERSION.dll"
+cp "$PCK" "$REPO/extraction/beta/archives/sts2-$VERSION.pck"
+
+# --- 6. Parse all 14 languages into data-beta/$VERSION/ ---
+(cd "$REPO/backend/app/parsers" && \
+  EXTRACTION_DIR="$REPO/extraction/beta" \
+  DATA_DIR="$DATA_OUT" \
+  python3 parse_all.py)
+
+# --- 7. Diff against the previous beta to make a changelog ---
+PREV=$(ls -1d "$REPO/data-beta"/v*/ 2>/dev/null | grep -v "/$VERSION/" \
+       | sort -V | tail -1 | sed 's:/$::' | xargs -n1 basename || true)
+if [ -n "$PREV" ]; then
+  python3 "$REPO/tools/diff_data.py" \
+    "$REPO/data-beta/$PREV/eng" \
+    "$DATA_OUT/eng" \
+    --format json \
+    --output-dir "$DATA_OUT/changelogs" \
+    --game-version "$VERSION" \
+    --title "Beta $VERSION"
+fi
+
+# --- 8. Repoint the `latest` symlink ---
+(cd "$REPO/data-beta" && rm -f latest && ln -sf "$VERSION" latest)
+
+# --- 9. Branch, commit, push, open PR ---
+BRANCH="auto/beta-$VERSION"
+cd "$REPO"
+git fetch origin main --quiet
+git checkout -B "$BRANCH" origin/main
+
+git add data-beta/ extraction/beta/archives/ 2>/dev/null || true
+git commit -m "Auto: ingest beta $VERSION (buildid $BUILDID)" || {
+  echo "nothing to commit (data-beta already up to date?)"; exit 1;
+}
+git push -u origin "$BRANCH" --quiet
+
+PR_URL=$(gh pr create \
+  --title "Auto: ingest beta $VERSION" \
+  --body "Detected new Steam beta build \`$BUILDID\` and parsed it into \`data-beta/$VERSION/\`.
+
+**Source manifest:** $BUILDID
+**Game version:** $VERSION
+**Diff base:** \`$PREV\`
+
+This PR was opened by \`tools/beta-watch/watch.sh\`. Smoke-check the changelog files under \`data-beta/$VERSION/changelogs/\` before merging — a game schema change can sometimes produce empty or malformed diffs that need a parser fix first." \
+  2>&1 | tail -1)
+
+echo "$PR_URL" > "$STATE_DIR/last-pr-url"
+echo "opened $PR_URL"

--- a/tools/beta-watch/watch.sh
+++ b/tools/beta-watch/watch.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Beta-watch: poll Steam for a new StS2 beta build. On detection, run the
+# extraction + parse + diff pipeline, push a branch, open a PR, and ping
+# Discord. Idempotent — runs every 30 min via launchd, no-op when up to date.
+#
+# Setup is documented in README.md. State (last-seen buildid, logs) lives
+# at $STATE_DIR. The script must be runnable without an interactive TTY,
+# so Steam Guard credentials need to be cached (steamcmd remembers after
+# the first login — keep your credential file warm).
+#
+# Exit codes:
+#   0   No new build, or new build fully processed.
+#   2   SteamCMD failed (network, auth, Steam down).
+#   3   New build detected but extraction/parse pipeline failed.
+#   4   Pipeline succeeded but git/gh/Discord step failed.
+
+set -euo pipefail
+
+# --- Config (override via env or edit) ---
+APP_ID="${SPIRE_APP_ID:-2868840}"           # StS2
+BETA_BRANCH="${SPIRE_BETA_BRANCH:-public-beta}"  # Steam beta branch name
+STATE_DIR="${SPIRE_STATE_DIR:-$HOME/.spire-codex/beta-watch}"
+REPO="${SPIRE_REPO:-$HOME/Documents/Projects/spire-codex}"
+STEAMCMD="${SPIRE_STEAMCMD:-$HOME/Steam/steamcmd.sh}"
+DOWNLOAD_DIR="$STATE_DIR/download"
+
+mkdir -p "$STATE_DIR" "$DOWNLOAD_DIR"
+LOG="$STATE_DIR/watch.log"
+LAST_BUILDID_FILE="$STATE_DIR/last-buildid"
+
+# --- Logging helper ---
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >> "$LOG"; }
+fail() { log "FATAL: $*"; exit "${2:-1}"; }
+
+log "==== beta-watch tick ===="
+
+# --- 1. Pull credentials from 1Password ---
+# Stored at:
+#   op://Spire Codex/Steam/username
+#   op://Spire Codex/Steam/password
+#   op://Spire Codex/Discord Webhooks/beta-watch  (Discord notify URL)
+if ! command -v op >/dev/null; then fail "op CLI not on PATH" 2; fi
+STEAM_USER=$(op read "op://Spire Codex/Steam/username" 2>>"$LOG") || fail "op read steam user" 2
+STEAM_PASS=$(op read "op://Spire Codex/Steam/password" 2>>"$LOG") || fail "op read steam pass" 2
+DISCORD_URL=$(op read "op://Spire Codex/Discord Webhooks/beta-watch" 2>>"$LOG" || echo "")
+
+# --- 2. Have SteamCMD sync the beta branch ---
+# `validate` ensures partial downloads from the prior run get fixed.
+# +force_install_dir keeps the cached install isolated from the user's
+# regular Steam library, so a watcher download doesn't clobber the GUI
+# Steam playing-build.
+log "running steamcmd app_update for app $APP_ID beta=$BETA_BRANCH"
+if ! "$STEAMCMD" \
+    +force_install_dir "$DOWNLOAD_DIR" \
+    +login "$STEAM_USER" "$STEAM_PASS" \
+    +app_update "$APP_ID" -beta "$BETA_BRANCH" validate \
+    +quit >> "$LOG" 2>&1; then
+  fail "steamcmd failed (see $LOG)" 2
+fi
+
+# --- 3. Read the new buildid from appmanifest ---
+ACF="$DOWNLOAD_DIR/steamapps/appmanifest_$APP_ID.acf"
+[ -f "$ACF" ] || fail "appmanifest missing after steamcmd run: $ACF" 2
+NEW_BUILDID=$(awk -F'"' '/^[[:space:]]*"buildid"/{print $4; exit}' "$ACF")
+[ -n "$NEW_BUILDID" ] || fail "could not parse buildid from $ACF" 2
+log "current beta buildid: $NEW_BUILDID"
+
+OLD_BUILDID=""
+[ -f "$LAST_BUILDID_FILE" ] && OLD_BUILDID=$(cat "$LAST_BUILDID_FILE")
+
+if [ "$NEW_BUILDID" = "$OLD_BUILDID" ]; then
+  log "no change (still $NEW_BUILDID), exiting"
+  exit 0
+fi
+
+log "NEW BUILD: $OLD_BUILDID -> $NEW_BUILDID"
+
+# --- 4. Run the extraction + parse + changelog pipeline ---
+# Delegates to a sibling script so this watcher stays small and the
+# pipeline can be invoked manually too (e.g. you ran SteamCMD by hand
+# and just want to rebuild data-beta/).
+PIPELINE="$REPO/tools/beta-watch/process.sh"
+[ -x "$PIPELINE" ] || fail "pipeline script missing or not executable: $PIPELINE" 3
+
+if ! BUILDID="$NEW_BUILDID" \
+      DOWNLOAD_DIR="$DOWNLOAD_DIR" \
+      REPO="$REPO" \
+      "$PIPELINE" >> "$LOG" 2>&1; then
+  fail "pipeline failed (see $LOG)" 3
+fi
+
+# --- 5. Notify Discord ---
+if [ -n "$DISCORD_URL" ]; then
+  PR_URL=$(cat "$STATE_DIR/last-pr-url" 2>/dev/null || echo "(no PR opened)")
+  VERSION=$(cat "$STATE_DIR/last-version" 2>/dev/null || echo "$NEW_BUILDID")
+  MSG="**New StS2 beta detected**: \`$VERSION\` (buildid $NEW_BUILDID)\nPR: $PR_URL"
+  curl -s -X POST -H "Content-Type: application/json" \
+    -d "$(printf '{"content":"%s"}' "${MSG//\"/\\\"}")" \
+    "$DISCORD_URL" >> "$LOG" 2>&1 || log "discord notify failed (non-fatal)"
+fi
+
+# --- 6. Commit the new state only on full success ---
+echo "$NEW_BUILDID" > "$LAST_BUILDID_FILE"
+log "==== beta-watch done ===="

--- a/tools/beta-watch/watch.sh
+++ b/tools/beta-watch/watch.sh
@@ -93,9 +93,13 @@ fi
 if [ -n "$DISCORD_URL" ]; then
   PR_URL=$(cat "$STATE_DIR/last-pr-url" 2>/dev/null || echo "(no PR opened)")
   VERSION=$(cat "$STATE_DIR/last-version" 2>/dev/null || echo "$NEW_BUILDID")
-  MSG="**New StS2 beta detected**: \`$VERSION\` (buildid $NEW_BUILDID)\nPR: $PR_URL"
+  # <@99656376954916864> = peter — explicit mention so the message escalates
+  # to a phone push notification, not just a passive channel message.
+  MSG="<@99656376954916864> **New StS2 beta detected**: \`$VERSION\` (buildid $NEW_BUILDID)\nPR: $PR_URL"
+  # allowed_mentions.parse=["users"] is what actually causes Discord to ring
+  # the user — without it, the <@id> renders as text and skips the ping.
   curl -s -X POST -H "Content-Type: application/json" \
-    -d "$(printf '{"content":"%s"}' "${MSG//\"/\\\"}")" \
+    -d "$(printf '{"content":"%s","allowed_mentions":{"parse":["users"]}}' "${MSG//\"/\\\"}")" \
     "$DISCORD_URL" >> "$LOG" 2>&1 || log "discord notify failed (non-fatal)"
 fi
 


### PR DESCRIPTION
Adds `tools/beta-watch/` — a launchd-driven watcher that polls Steam for new StS2 beta builds and ingests them automatically.

## Flow

1. **launchd** fires `watch.sh` every 15 min on Thursdays from 15:00 to 22:45 local (Mega Crit's typical beta-drop window — 32 ticks/week)
2. `watch.sh` reads creds from 1Password, runs SteamCMD's `app_update` for the `public-beta` branch, and reads the new buildid from `appmanifest_2868840.acf`
3. If the buildid matches the last-seen value, exit. Otherwise delegate to `process.sh`:
   - Godot RE Tools extracts assets from the `.pck`
   - ilspycmd decompiles `sts2.dll`
   - Sniffs the version string from the decompiled C#
   - Archives the raw `.dll` + `.pck` under `extraction/beta/archives/`
   - Runs `parse_all.py` into `data-beta/<version>/`
   - Runs `diff_data.py` against the previous beta to generate a changelog
   - Re-points `data-beta/latest`
   - Pushes a branch `auto/beta-<version>` and opens a PR
4. **Discord webhook** pings on success

## Files

| File | Purpose |
|---|---|
| `watch.sh` | launchd entry — auth + SteamCMD + buildid check + delegate |
| `process.sh` | Extract + parse + diff + open PR. Callable manually too |
| `com.spirecodex.beta-watch.plist` | Thursday-only StartCalendarInterval |
| `install.sh` | One-command launchd setup |
| `README.md` | One-time setup + ops docs |

## Manual override

`launchctl start com.spirecodex.beta-watch` fires the watcher any time, ignoring the calendar window.

## What's not auto

The PR opened by `process.sh` is **not** auto-merged. Game schema changes can produce parser misfires (empty changelogs, missing entity types). Inspect `data-beta/<version>/changelogs/` and the diff against `data-beta/latest` before merging.

## One-time setup (before `./tools/beta-watch/install.sh`)

1. `~/Steam/steamcmd.sh +login YOUR_USERNAME` to cache Steam Guard
2. Opt the account into the StS2 `public-beta` branch via the Steam GUI
3. Populate 1Password items in the `Spire Codex` vault:
   - `Steam` → `username`, `password`
   - `Discord Webhooks` → `beta-watch`