### PR TITLE
beta-watch: drop 1Password CLI from runtime path (Touch ID kills launchd)

### DIFF
--- a/tools/beta-watch/README.md
+++ b/tools/beta-watch/README.md
@@ -24,24 +24,34 @@ from scratch — `last-buildid` is only updated on full success.
 ## One-time setup
 
 ```bash
-# 1. Cache Steam Guard auth (interactive, only required once per machine)
-~/Steam/steamcmd.sh +login YOUR_USERNAME YOUR_PASSWORD
-# Enter your Steam Guard code when prompted; SteamCMD remembers the session.
+# 1. Cache Steam Guard auth — interactive, ONE TIME per machine.
+#    SteamCMD writes a session token to ~/Library/Application Support/Steam
+#    so future headless runs only need the username (no password).
+~/Steam/steamcmd.sh +login YOUR_USERNAME
+# Enter your password and Steam Guard code at the prompts, then type `quit`.
+# From now on, `+login YOUR_USERNAME` alone works.
 
-# 2. Opt the Steam account into the StS2 beta branch via the regular Steam
-#    GUI: StS2 → Properties → Betas → pick the beta branch from the dropdown.
+# 2. Opt the Steam account into the public-beta branch via the regular Steam
+#    GUI: StS2 → Properties → Betas → pick `public-beta` from the dropdown.
 
-# 3. Populate 1Password items in the "Spire Codex" vault:
-#    - Steam item with fields: username, password
-#    - Discord Webhooks item with field: beta-watch (webhook URL)
+# 3. Scaffold the local config file:
+./tools/beta-watch/install.sh
+# First run creates ~/.spire-codex/beta-watch/config.env (a template) and
+# exits. Edit it to set STEAM_USER and DISCORD_URL, then re-run install.sh.
 
-# 4. Beta branch defaults to "public-beta" (what Mega Crit uses). If they
-#    rename it, set SPIRE_BETA_BRANCH in the launchd plist's
-#    EnvironmentVariables block, or edit watch.sh's default.
+# 4. Generate a Discord webhook (if you want pings): in your Discord
+#    channel → Edit Channel → Integrations → Webhooks → New Webhook →
+#    Copy Webhook URL. Paste into config.env's DISCORD_URL.
 
-# 5. Install the launchd job
+# 5. Re-run install.sh — this time it loads the launchd plist.
 ./tools/beta-watch/install.sh
 ```
+
+The config file at `~/.spire-codex/beta-watch/config.env` lives outside the
+git repo, so it can't be committed by accident and `git pull` can never
+overwrite it. The earlier design used the 1Password CLI but `op` prompts
+for Touch ID when the desktop app auto-locks, which kills unattended
+launchd runs.
 
 ## Useful commands
 

--- a/tools/beta-watch/install.sh
+++ b/tools/beta-watch/install.sh
@@ -4,19 +4,19 @@
 #
 # What this does:
 #   1. chmod +x on the watcher scripts
-#   2. Copies the plist into ~/Library/LaunchAgents
-#   3. Loads it via launchctl (starts the 30-min poll)
+#   2. Scaffolds ~/.spire-codex/beta-watch/config.env (gitignored by location)
+#   3. Copies the plist into ~/Library/LaunchAgents
+#   4. Loads it via launchctl (arms the calendar schedule)
 #
 # What it does NOT do (you do these yourself, once):
 #   - Install SteamCMD (already at ~/Steam/steamcmd.sh per user)
 #   - Cache Steam Guard credentials. First time, run:
-#       ~/Steam/steamcmd.sh +login YOUR_USERNAME YOUR_PASSWORD
-#     and enter the Steam Guard code. SteamCMD remembers the session.
-#   - Populate 1Password items:
-#       op://Spire Codex/Steam/username
-#       op://Spire Codex/Steam/password
-#       op://Spire Codex/Discord Webhooks/beta-watch
-#   - Opt the Steam account into the StS2 beta branch once via the GUI.
+#       ~/Steam/steamcmd.sh +login YOUR_USERNAME
+#     enter password + Steam Guard code, then `quit`. SteamCMD caches the
+#     session token, so the watcher only needs the username going forward.
+#   - Edit ~/.spire-codex/beta-watch/config.env to fill in STEAM_USER and
+#     (optional) DISCORD_URL — install.sh scaffolds it empty.
+#   - Opt the Steam account into the StS2 public-beta branch once via the GUI.
 
 set -euo pipefail
 
@@ -24,24 +24,59 @@ REPO=$(cd "$(dirname "$0")/../.." && pwd)
 WATCH_DIR="$REPO/tools/beta-watch"
 LABEL="com.spirecodex.beta-watch"
 PLIST_DST="$HOME/Library/LaunchAgents/$LABEL.plist"
+STATE_DIR="$HOME/.spire-codex/beta-watch"
+CONFIG="$STATE_DIR/config.env"
 
-echo "[1/3] making scripts executable"
+echo "[1/4] making scripts executable"
 chmod +x "$WATCH_DIR/watch.sh" "$WATCH_DIR/process.sh"
 
-echo "[2/3] installing launchd plist to $PLIST_DST"
+echo "[2/4] scaffolding config at $CONFIG (skipped if it already exists)"
+mkdir -p "$STATE_DIR"
+if [ ! -f "$CONFIG" ]; then
+  cat > "$CONFIG" <<'TEMPLATE'
+# Beta-watch credentials. NEVER commit this file — it lives outside the
+# git repo on purpose. Edit the two values below, then save.
+
+# Your Steam username (NOT email). SteamCMD must already have a cached
+# session for this account (run: ~/Steam/steamcmd.sh +login THIS_USER
+# interactively once, enter your password + Steam Guard code, then quit).
+STEAM_USER=""
+
+# Discord webhook URL where new-beta pings get posted. Leave empty to
+# disable Discord notifications entirely (the pipeline still opens a PR).
+# Generate one in your Discord server: channel → Edit → Integrations →
+# Webhooks → New Webhook → Copy Webhook URL.
+DISCORD_URL=""
+TEMPLATE
+  echo "    → created template. EDIT IT NOW and re-run install.sh to load the plist."
+  chmod 600 "$CONFIG"
+  exit 0
+fi
+
+# Validate the config has at least STEAM_USER set so we fail loud here
+# instead of letting launchd produce a confusing exit-2 on first fire.
+# shellcheck source=/dev/null
+source "$CONFIG"
+if [ -z "${STEAM_USER:-}" ]; then
+  echo "    → $CONFIG exists but STEAM_USER is empty. Fill it in and re-run."
+  exit 1
+fi
+
+echo "[3/4] installing launchd plist to $PLIST_DST"
 mkdir -p "$HOME/Library/LaunchAgents"
 cp "$WATCH_DIR/$LABEL.plist" "$PLIST_DST"
 
-echo "[3/3] loading launchd job"
+echo "[4/4] loading launchd job"
 launchctl unload "$PLIST_DST" 2>/dev/null || true
 launchctl load "$PLIST_DST"
 
 echo ""
 echo "✓ beta-watch installed and running."
-echo "  Logs:   ~/.spire-codex/beta-watch/watch.log"
-echo "  State:  ~/.spire-codex/beta-watch/last-buildid"
+echo "  Config: $CONFIG"
+echo "  Logs:   $STATE_DIR/watch.log"
+echo "  State:  $STATE_DIR/last-buildid"
 echo ""
-echo "Trigger a manual run (e.g. to verify your 1Password + Steam creds):"
+echo "Trigger a manual run (e.g. to verify your Steam creds):"
 echo "  launchctl start $LABEL"
 echo ""
 echo "Disable temporarily:"

--- a/tools/beta-watch/watch.sh
+++ b/tools/beta-watch/watch.sh
@@ -34,15 +34,24 @@ fail() { log "FATAL: $*"; exit "${2:-1}"; }
 
 log "==== beta-watch tick ===="
 
-# --- 1. Pull credentials from 1Password ---
-# Stored at:
-#   op://Spire Codex/Steam/username
-#   op://Spire Codex/Steam/password
-#   op://Spire Codex/Discord Webhooks/beta-watch  (Discord notify URL)
-if ! command -v op >/dev/null; then fail "op CLI not on PATH" 2; fi
-STEAM_USER=$(op read "op://Spire Codex/Steam/username" 2>>"$LOG") || fail "op read steam user" 2
-STEAM_PASS=$(op read "op://Spire Codex/Steam/password" 2>>"$LOG") || fail "op read steam pass" 2
-DISCORD_URL=$(op read "op://Spire Codex/Discord Webhooks/beta-watch" 2>>"$LOG" || echo "")
+# --- 1. Source credentials from a local config file ---
+# Lives at $STATE_DIR/config.env, outside the git repo — so it can't be
+# committed by accident and `git pull` can never overwrite it. The original
+# design used the 1Password CLI but `op` prompts for Touch ID when the
+# desktop app auto-locks, which kills unattended launchd runs.
+#
+# Expected vars in config.env:
+#   STEAM_USER="yourSteamUsername"
+#   DISCORD_URL="https://discord.com/api/webhooks/..."   # optional
+#
+# (No Steam password needed — SteamCMD caches a session token from the
+# one-time interactive login, see README.)
+CONFIG="$STATE_DIR/config.env"
+[ -f "$CONFIG" ] || fail "config missing: $CONFIG (see README setup step)" 2
+# shellcheck source=/dev/null
+source "$CONFIG"
+: "${STEAM_USER:?STEAM_USER not set in $CONFIG}"
+DISCORD_URL="${DISCORD_URL:-}"
 
 # --- 2. Have SteamCMD sync the beta branch ---
 # `validate` ensures partial downloads from the prior run get fixed.
@@ -52,7 +61,7 @@ DISCORD_URL=$(op read "op://Spire Codex/Discord Webhooks/beta-watch" 2>>"$LOG" |
 log "running steamcmd app_update for app $APP_ID beta=$BETA_BRANCH"
 if ! "$STEAMCMD" \
     +force_install_dir "$DOWNLOAD_DIR" \
-    +login "$STEAM_USER" "$STEAM_PASS" \
+    +login "$STEAM_USER" \
     +app_update "$APP_ID" -beta "$BETA_BRANCH" validate \
     +quit >> "$LOG" 2>&1; then
   fail "steamcmd failed (see $LOG)" 2


### PR DESCRIPTION
Original design read Steam username + Discord webhook from 1Password via `op read` at runtime. Problem: when the 1Password desktop app auto-locks, `op` prompts for Touch ID — and launchd-fired runs have no one at the keyboard to touch the sensor.

## Fix

Watcher now sources a plain-shell config file at `~/.spire-codex/beta-watch/config.env` instead:

```bash
STEAM_USER="yourUsername"
DISCORD_URL="https://discord.com/api/webhooks/..."
```

The file lives outside the repo so there's no gitignore drift and no risk of committing it. `install.sh` scaffolds an empty template on first run and only loads the launchd plist after the user fills it in (validated by checking STEAM_USER is non-empty).

## Trade-offs

- Webhook URL on disk in plaintext at `~/.spire-codex/beta-watch/config.env` (mode 600). Acceptable: anyone with that URL can post one message to the channel, easily revoked.
- Steam username on disk — already public on the user's Steam profile.
- No password ever needed because SteamCMD caches its session token from a one-time interactive login.

## Also in this PR

Also rolls in commit 464a73b4 from the previous branch that didn't make the squash merge for #322: drops STEAM_PASS from the SteamCMD invocation (cached session works without it).