### PR TITLE
Hide /images version dropdown on beta site + extend autodeploy to beta

### DIFF
--- a/frontend/app/images/page.tsx
+++ b/frontend/app/images/page.tsx
@@ -178,11 +178,14 @@ export default function ImagesPage() {
         Browse and download game assets. Click a category to view, or download as a zip pack.
       </p>
 
-      {/* Beta version picker — only renders when the backend exposes the
-          /api/images/beta/versions endpoint AND there's at least one
-          versioned ingest on disk. Categories prefixed with "Steam Beta"
-          re-fetch when this changes. */}
-      {betaVersions.length > 0 && (
+      {/* Version picker — only renders on the main site. Beta site
+          (beta.spire-codex.com) intentionally hides the dropdown so the
+          page reflects exactly what that branch ships; cross-version
+          browsing belongs on the main site. NEXT_PUBLIC_SITE_URL is
+          baked at build time (different per Docker image), so this
+          check resolves once at module-eval, not per-request. */}
+      {betaVersions.length > 0 &&
+        !(process.env.NEXT_PUBLIC_SITE_URL || "").includes("beta.spire-codex.com") && (
         <div className="flex items-center gap-2 mb-8 text-sm">
           <label htmlFor="beta-version" className="text-[var(--text-muted)]">
             Game version:

--- a/infrastructure/ansible/files/autodeploy.sh
+++ b/infrastructure/ansible/files/autodeploy.sh
@@ -15,6 +15,7 @@ REPO="${SPIRE_REPO:-/var/www/spire-codex}"
 LOG="${SPIRE_AUTODEPLOY_LOG:-/var/log/spire-codex-autodeploy.log}"
 CF_ENV="${SPIRE_CF_ENV:-/etc/spire-codex/cf-purge.env}"
 COMPOSE_FILE="${SPIRE_COMPOSE_FILE:-docker-compose.prod.yml}"
+BETA_COMPOSE_FILE="${SPIRE_BETA_COMPOSE_FILE:-docker-compose.beta.yml}"
 
 # Self-installing log file (cron runs as root the first time, so this
 # creates a root-owned file — subsequent appends just work).
@@ -59,18 +60,30 @@ else
 fi
 
 if [ "$RECREATE" = "1" ]; then
-  # Pull + restart. `--force-recreate` ensures the container picks up
-  # the new image even if compose thinks the config is unchanged.
-  docker compose -f "$COMPOSE_FILE" pull backend frontend >> "$LOG" 2>&1
-  docker compose -f "$COMPOSE_FILE" up -d --force-recreate backend frontend >> "$LOG" 2>&1
+  # Pull + restart both stable AND beta. `--force-recreate` ensures the
+  # container picks up the new image even if compose thinks the config
+  # is unchanged. Beta runs on the same box (separate containers via
+  # docker-compose.beta.yml) so a missed beta deploy was a recurring
+  # operational gap — folding it into autodeploy closes that loop.
+  for f in "$COMPOSE_FILE" "$BETA_COMPOSE_FILE"; do
+    [ -f "$REPO/$f" ] || { log "compose file $f missing, skipping"; continue; }
+    log "  deploying $f"
+    docker compose -f "$f" pull backend frontend >> "$LOG" 2>&1
+    docker compose -f "$f" up -d --force-recreate backend frontend >> "$LOG" 2>&1
+  done
 
   # Settle. 5s is enough for FastAPI startup; longer waits don't help.
   sleep 5
 
   if docker compose -f "$COMPOSE_FILE" logs --tail 50 backend 2>/dev/null | grep -q "Spire Codex API ready"; then
-    log "✓ backend ready"
+    log "✓ stable backend ready"
   else
-    log "✗ backend did NOT log 'Spire Codex API ready' — manual check required"
+    log "✗ stable backend did NOT log 'Spire Codex API ready' — manual check required"
+  fi
+  if docker compose -f "$BETA_COMPOSE_FILE" logs --tail 50 backend 2>/dev/null | grep -q "Spire Codex API ready"; then
+    log "✓ beta backend ready"
+  else
+    log "✗ beta backend did NOT log 'Spire Codex API ready' — manual check required"
   fi
 fi
 


### PR DESCRIPTION
Two small fixes:

1. The hide-dropdown-on-beta commit slipped past PR #329's merge window; this re-lands it. The beta site now hides the version selector, matching the intent that beta is a single-branch view rather than a cross-version browser.

2. `tools/beta-watch/autodeploy.sh` now also pulls + force-recreates the beta containers when a code change is detected. Previously the hourly cron only handled stable, so beta deploys had to be done manually. (The on-box copy at `/usr/local/bin/spire-codex-autodeploy` still references the old script — needs a re-run of `install-autodeploy.yml` to pick this up next time you're at the keyboard.)