### PR TITLE
Encounter stats page + /api/runs/encounter-stats endpoint (#335)

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -419,6 +419,60 @@ def get_run_rank(request: Request, run_hash: str, category: str = "fastest"):
         return {"rank": ahead + 1, "category": category}
 
 
+@router.get("/encounter-stats", tags=["Runs"])
+@limiter.limit("60/minute")
+def get_encounter_stats_endpoint(
+    request: Request,
+    act: str | None = None,
+    room_type: str | None = None,
+    multiplayer: str | None = None,
+    page: int = 1,
+    limit: int = 50,
+):
+    """Per-encounter aggregation over submitted runs.
+
+    Query params:
+      * `act` — comma-separated list of acts to include (e.g. `1,2`).
+        Omit for all.
+      * `room_type` — comma-separated list of room types
+        (`monster,elite,boss`). Omit for all.
+      * `multiplayer` — `only` returns multiplayer-only runs,
+        `exclude` removes multiplayer runs, omit for both.
+      * `page` (default 1) + `limit` (default 50, max 200) — pagination
+        applied after aggregation, sorted by sample size descending.
+
+    Each row contains the encounter's total appearances, fatal count,
+    avg damage taken, avg turns, plus a `characters` array with the
+    same fields scoped per character. Returns `{encounters, page,
+    limit, total, has_next}`. Mongo-only (returns empty when MONGO_URL
+    is unset for local dev).
+    """
+    if not os.environ.get("MONGO_URL", "").strip():
+        return {
+            "encounters": [],
+            "page": page,
+            "limit": limit,
+            "total": 0,
+            "has_next": False,
+        }
+
+    from ..services.runs_db_mongo import get_encounter_stats as _get_encounter_stats
+
+    acts = [int(a) for a in act.split(",") if a.strip().isdigit()] if act else None
+    room_types = (
+        [r.strip().lower() for r in room_type.split(",") if r.strip()]
+        if room_type
+        else None
+    )
+    return _get_encounter_stats(
+        acts=acts,
+        room_types=room_types,
+        multiplayer=multiplayer,
+        page=page,
+        limit=limit,
+    )
+
+
 @router.get("/versions", tags=["Runs"])
 def get_run_versions(request: Request):
     """Return distinct build_id values from submitted runs."""

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -488,6 +488,197 @@ def _scalar_item_stats_pipeline(field: str) -> list[dict]:
     ]
 
 
+@_instrument("get_encounter_stats")
+def get_encounter_stats(
+    acts: list[int] | None = None,
+    room_types: list[str] | None = None,
+    multiplayer: str | None = None,
+    page: int = 1,
+    limit: int = 50,
+) -> dict:
+    """Per-encounter aggregation over submitted runs.
+
+    Walks each run's `map_point_history` (array of acts → array of rooms),
+    yields one entry per combat room, and groups by encounter id with a
+    per-character breakdown.
+
+    Filters:
+      * `acts` — restrict to specific act numbers (1, 2, 3). None = all.
+      * `room_types` — restrict to "monster" / "elite" / "boss". None = all.
+      * `multiplayer` — "only" / "exclude" / None (no filter). Multiplayer
+        detection uses `player_count > 1` since the run docs are one per
+        player and `player_count` is denormalized at submit time.
+
+    Pagination is applied AFTER grouping (we always compute all
+    encounters then slice), since the total ordering by sample size is
+    what determines the page contents.
+
+    Each returned row carries enough numbers to populate the listing's
+    primary columns (total runs that encountered it, fatal count, avg
+    damage, avg turns) plus a `characters` map shaped
+    `{IRONCLAD: {total, fatal, ...}, SILENT: {...}, ...}` for the
+    expanded per-character sub-table.
+
+    Fatal detection: a run "died here" when the run's `killed_by` field
+    matches the encounter id. This is an approximation — the same enemy
+    type can appear earlier in the same run and we'd attribute the death
+    to all instances. PR #266's extract logic narrows this to the *last*
+    matching room; we settle for the simpler heuristic here since the
+    distinction only matters for repeat enemy IDs in long runs (rare).
+    """
+    coll = _get_collection()
+
+    # Build the pre-unwind run-level match. Keep this as cheap as possible
+    # — we burn an unwind per room afterward, so any filter that can be
+    # applied to the run as a whole saves multiplicative downstream cost.
+    run_match: dict = {}
+    if multiplayer == "only":
+        run_match["player_count"] = {"$gt": 1}
+    elif multiplayer == "exclude":
+        run_match["player_count"] = {"$lte": 1}
+
+    room_match: dict = {
+        "map_point_history.room_type": {"$in": ["monster", "elite", "boss"]}
+    }
+    if room_types:
+        room_match["map_point_history.room_type"] = {"$in": room_types}
+
+    # `act_idx` is 0-based from $unwind's includeArrayIndex. We expose
+    # `act` as 1-based in the response since that's what /api/acts uses.
+    act_match: dict = {}
+    if acts:
+        act_match["act_idx"] = {"$in": [a - 1 for a in acts]}
+
+    # Fatal detection: a room is "fatal" if its model_id matches the
+    # run's killed_by AND the run did not win. `$cond` keeps this in the
+    # aggregation rather than a post-pass.
+    pipeline: list[dict] = [
+        {"$match": run_match} if run_match else {"$match": {}},
+        {
+            "$project": {
+                "character": 1,
+                "killed_by": 1,
+                "win": 1,
+                "map_point_history": 1,
+            }
+        },
+        {"$unwind": {"path": "$map_point_history", "includeArrayIndex": "act_idx"}},
+    ]
+    if act_match:
+        pipeline.append({"$match": act_match})
+    pipeline.extend(
+        [
+            {"$unwind": "$map_point_history"},
+            {"$match": room_match},
+            {
+                "$group": {
+                    "_id": {
+                        "encounter": "$map_point_history.model_id",
+                        "act": {"$add": ["$act_idx", 1]},
+                        "room_type": "$map_point_history.room_type",
+                        "character": "$character",
+                    },
+                    "total": {"$sum": 1},
+                    "fatal": {
+                        "$sum": {
+                            "$cond": [
+                                {
+                                    "$and": [
+                                        {
+                                            "$eq": [
+                                                "$map_point_history.model_id",
+                                                "$killed_by",
+                                            ]
+                                        },
+                                        {"$in": ["$win", [False, 0]]},
+                                    ]
+                                },
+                                1,
+                                0,
+                            ],
+                        }
+                    },
+                    "total_damage": {
+                        "$sum": {"$ifNull": ["$map_point_history.damage_taken", 0]}
+                    },
+                    "total_turns": {
+                        "$sum": {"$ifNull": ["$map_point_history.turns_taken", 0]}
+                    },
+                }
+            },
+            # Collapse the per-character buckets up into per-encounter rows
+            # so the page-size limit applies to encounters, not (encounter,
+            # character) pairs. Each encounter carries a `characters` map.
+            {
+                "$group": {
+                    "_id": {
+                        "encounter": "$_id.encounter",
+                        "act": "$_id.act",
+                        "room_type": "$_id.room_type",
+                    },
+                    "total": {"$sum": "$total"},
+                    "fatal": {"$sum": "$fatal"},
+                    "total_damage": {"$sum": "$total_damage"},
+                    "total_turns": {"$sum": "$total_turns"},
+                    "characters": {
+                        "$push": {
+                            "character": "$_id.character",
+                            "total": "$total",
+                            "fatal": "$fatal",
+                            "total_damage": "$total_damage",
+                            "total_turns": "$total_turns",
+                        }
+                    },
+                }
+            },
+            {"$sort": {"total": -1}},
+        ]
+    )
+
+    rows = list(coll.aggregate(pipeline, allowDiskUse=True))
+
+    page = max(page, 1)
+    limit = max(min(limit, 200), 1)
+    total_encounters = len(rows)
+    start = (page - 1) * limit
+    sliced = rows[start : start + limit]
+
+    def _shape_row(r: dict) -> dict:
+        n = r["total"] or 0
+        return {
+            "encounter_id": r["_id"]["encounter"],
+            "act": r["_id"]["act"],
+            "room_type": r["_id"]["room_type"],
+            "total": n,
+            "fatal": r["fatal"],
+            "avg_damage": round(r["total_damage"] / n, 1) if n else 0,
+            "avg_turns": round(r["total_turns"] / n, 2) if n else 0,
+            "characters": [
+                {
+                    "character": c["character"],
+                    "total": c["total"],
+                    "fatal": c["fatal"],
+                    "avg_damage": round(c["total_damage"] / c["total"], 1)
+                    if c["total"]
+                    else 0,
+                    "avg_turns": round(c["total_turns"] / c["total"], 2)
+                    if c["total"]
+                    else 0,
+                }
+                for c in sorted(r["characters"], key=lambda x: -(x["total"] or 0))
+                if c["character"]
+            ],
+        }
+
+    return {
+        "encounters": [_shape_row(r) for r in sliced],
+        "page": page,
+        "limit": limit,
+        "total": total_encounters,
+        "has_next": start + limit < total_encounters,
+    }
+
+
 @_instrument("get_stats")
 def get_stats(
     character: str | None = None,

--- a/contributing/API_REFERENCE.md
+++ b/contributing/API_REFERENCE.md
@@ -66,6 +66,7 @@ All data endpoints accept `?lang=` (default: `eng`). Rate limited to 60 req/min 
 | `GET /api/runs/shared/{hash}` | GET | Retrieve a shared run by hash. Response merges `username` from `runs.db` so the shared-run page can render "by {username}" without a second round trip. |
 | `GET /api/runs/leaderboard` | GET | Ranked wins-only leaderboard. Filters: `category` (`fastest`, `highest_ascension`), `character`, `page`, `limit` |
 | `GET /api/runs/scores/{type}` | GET | Codex Score per entity. `type` ∈ `cards` / `relics` / `potions`. Returns `{ id, score (0–100), tier (S/A/B/C/D/F), wins, losses, n }[]`. Bayesian-shrunk win rate; pre-warmed on FastAPI startup. See `services/run_entity_stats.py` and `/leaderboards/scoring` for the formula. |
+| `GET /api/runs/encounter-stats` | GET | Per-encounter aggregation. Query params: `act` (comma-separated 1/2/3), `room_type` (comma-separated monster/elite/boss), `multiplayer` (`only`/`exclude`), `page`, `limit` (max 200, default 50). Returns `{ encounters: [{ encounter_id, act, room_type, total, fatal, avg_damage, avg_turns, characters: [{ character, total, fatal, avg_damage, avg_turns }] }], page, limit, total, has_next }`. Mongo-only; returns empty when no Mongo backend is configured. |
 | `GET /api/runs/versions` | GET | Distinct `build_id` values across submitted runs — powers the version filter dropdown |
 
 ## Utility

--- a/frontend/app/[lang]/leaderboards/encounters/page.tsx
+++ b/frontend/app/[lang]/leaderboards/encounters/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next";
+import JsonLd from "@/app/components/JsonLd";
+import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
+import EncounterStatsClient from "@/app/leaderboards/encounters/EncounterStatsClient";
+import {
+  isValidLang,
+  LANG_GAME_NAME,
+  LANG_NAMES,
+  LANG_HREFLANG,
+  SUPPORTED_LANGS,
+  type LangCode,
+} from "@/lib/languages";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { t } from "@/lib/ui-translations";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}): Promise<Metadata> {
+  const { lang } = await params;
+  if (!isValidLang(lang)) return {};
+
+  const langCode = lang as LangCode;
+  const gameName = LANG_GAME_NAME[langCode];
+  const nativeName = LANG_NAMES[langCode];
+  const title = `${gameName} ${t("Encounter Stats", lang)} | Spire Codex (${nativeName})`;
+  const description = t("encounter_stats_tagline", lang);
+
+  const languages: Record<string, string> = {
+    en: `${SITE_URL}/leaderboards/encounters`,
+    "x-default": `${SITE_URL}/leaderboards/encounters`,
+  };
+  for (const code of SUPPORTED_LANGS) {
+    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/leaderboards/encounters`;
+  }
+
+  return {
+    title,
+    description,
+    openGraph: {
+      type: "website",
+      siteName: SITE_NAME,
+      url: `${SITE_URL}/${lang}/leaderboards/encounters`,
+      title,
+      description,
+      locale: LANG_HREFLANG[langCode],
+      images: [{ url: DEFAULT_OG_IMAGE }],
+    },
+    twitter: { card: "summary_large_image", title, description },
+    alternates: { canonical: `/${lang}/leaderboards/encounters`, languages },
+  };
+}
+
+export default async function LangEncounterStatsPage({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}) {
+  const { lang } = await params;
+  if (!isValidLang(lang)) return null;
+  const langCode = lang as LangCode;
+  const gameName = LANG_GAME_NAME[langCode];
+  const jsonLd = [
+    buildBreadcrumbJsonLd([
+      { name: t("Home", lang), href: `/${lang}` },
+      { name: t("Leaderboards", lang), href: `/${lang}/leaderboards` },
+      { name: t("Encounters", lang), href: `/${lang}/leaderboards/encounters` },
+    ]),
+    buildCollectionPageJsonLd({
+      name: `${gameName} ${t("Encounter Stats", lang)}`,
+      description: t("encounter_stats_tagline", lang),
+      path: `/${lang}/leaderboards/encounters`,
+      inLanguage: LANG_HREFLANG[langCode],
+    }),
+  ];
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+      <EncounterStatsClient />
+    </>
+  );
+}

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -69,6 +69,7 @@ const NAV_GROUPS: NavGroup[] = [
       { href: "/leaderboards", label: "Leaderboards" },
       { href: "/leaderboards/submit", label: "Submit a Run" },
       { href: "/leaderboards/stats", label: "Stats" },
+      { href: "/leaderboards/encounters", label: "Encounters" },
       { href: "/leaderboards/scoring", label: "Scoring" },
     ],
   },

--- a/frontend/app/leaderboards/encounters/EncounterStatsClient.tsx
+++ b/frontend/app/leaderboards/encounters/EncounterStatsClient.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useLanguage } from "@/app/contexts/LanguageContext";
+import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { cachedFetch } from "@/lib/fetch-cache";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+interface CharacterStat {
+  character: string;
+  total: number;
+  fatal: number;
+  avg_damage: number;
+  avg_turns: number;
+}
+
+interface EncounterRow {
+  encounter_id: string;
+  act: number;
+  room_type: string;
+  total: number;
+  fatal: number;
+  avg_damage: number;
+  avg_turns: number;
+  characters: CharacterStat[];
+}
+
+interface EncounterResponse {
+  encounters: EncounterRow[];
+  page: number;
+  limit: number;
+  total: number;
+  has_next: boolean;
+}
+
+interface EncounterMeta {
+  id: string;
+  name: string;
+}
+
+const ROOM_TYPES = ["monster", "elite", "boss"] as const;
+const ACTS = [1, 2, 3] as const;
+
+function toggle<T>(set: Set<T>, value: T): Set<T> {
+  const next = new Set(set);
+  if (next.has(value)) next.delete(value);
+  else next.add(value);
+  return next;
+}
+
+function displayName(id: string): string {
+  // Fallback when we don't have an encounters lookup hit — humanize the
+  // upper-snake-case id. Matches the convention other stats tables use.
+  return id
+    .split("_")
+    .map((s) => s.charAt(0) + s.slice(1).toLowerCase())
+    .join(" ");
+}
+
+export default function EncounterStatsClient() {
+  const { lang } = useLanguage();
+  const lp = useLangPrefix();
+
+  const [acts, setActs] = useState<Set<number>>(new Set());
+  const [roomTypes, setRoomTypes] = useState<Set<string>>(new Set());
+  const [multiplayer, setMultiplayer] = useState<"any" | "only" | "exclude">("any");
+  const [page, setPage] = useState(1);
+
+  const [data, setData] = useState<EncounterResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  // Encounter metadata lookup — populates display names for the IDs the
+  // aggregator returns. /api/encounters carries name + room_type already,
+  // so a single fetch + map lets us avoid a per-row API hit.
+  const [meta, setMeta] = useState<Record<string, EncounterMeta>>({});
+  useEffect(() => {
+    cachedFetch<EncounterMeta[]>(`${API}/api/encounters?lang=${lang}`)
+      .then((arr) => {
+        const m: Record<string, EncounterMeta> = {};
+        for (const e of arr || []) m[e.id] = e;
+        setMeta(m);
+      })
+      .catch(() => setMeta({}));
+  }, [lang]);
+
+  // Refetch when filters or page change. Aggregation is server-side; the
+  // backend computes all encounters and slices for the current page.
+  useEffect(() => {
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (acts.size) params.set("act", Array.from(acts).join(","));
+    if (roomTypes.size) params.set("room_type", Array.from(roomTypes).join(","));
+    if (multiplayer !== "any") params.set("multiplayer", multiplayer);
+    params.set("page", String(page));
+    params.set("limit", "50");
+    fetch(`${API}/api/runs/encounter-stats?${params}`)
+      .then((r) => r.json())
+      .then((d: EncounterResponse) => setData(d))
+      .catch(() => setData({ encounters: [], page, limit: 50, total: 0, has_next: false }))
+      .finally(() => setLoading(false));
+  }, [acts, roomTypes, multiplayer, page]);
+
+  // Reset to page 1 whenever the filter set changes — paging through a
+  // previous query's results after a filter change would be confusing.
+  useEffect(() => {
+    setPage(1);
+  }, [acts, roomTypes, multiplayer]);
+
+  const totalPages = useMemo(() => {
+    if (!data) return 1;
+    return Math.max(1, Math.ceil(data.total / data.limit));
+  }, [data]);
+
+  function toggleExpanded(id: string) {
+    setExpanded((prev) => toggle(prev, id));
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <h1 className="text-3xl font-bold mb-2">
+        <span className="text-[var(--accent-gold)]">Encounter</span>{" "}
+        <span className="text-[var(--text-primary)]">Stats</span>
+      </h1>
+      <p className="text-sm text-[var(--text-muted)] mb-6">
+        Fatal counts, average damage taken, and average turns for every Slay the Spire 2 encounter across submitted community runs. Click any row to expand the per-character breakdown.
+      </p>
+
+      {/* Filters */}
+      <div className="bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded-lg p-4 mb-6 space-y-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-[var(--text-muted)] w-20">Act:</span>
+          {ACTS.map((a) => {
+            const active = acts.has(a);
+            return (
+              <button
+                key={a}
+                onClick={() => setActs((prev) => toggle(prev, a))}
+                className={`px-3 py-1 rounded-md text-sm border transition-colors ${
+                  active
+                    ? "border-[var(--accent-gold)] text-[var(--accent-gold)] bg-[var(--accent-gold)]/10"
+                    : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50"
+                }`}
+              >
+                Act {a}
+              </button>
+            );
+          })}
+          {acts.size > 0 && (
+            <button
+              onClick={() => setActs(new Set())}
+              className="px-2 py-1 text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+            >
+              clear
+            </button>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-[var(--text-muted)] w-20">Type:</span>
+          {ROOM_TYPES.map((t) => {
+            const active = roomTypes.has(t);
+            return (
+              <button
+                key={t}
+                onClick={() => setRoomTypes((prev) => toggle(prev, t))}
+                className={`px-3 py-1 rounded-md text-sm border capitalize transition-colors ${
+                  active
+                    ? "border-[var(--accent-gold)] text-[var(--accent-gold)] bg-[var(--accent-gold)]/10"
+                    : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50"
+                }`}
+              >
+                {t}
+              </button>
+            );
+          })}
+          {roomTypes.size > 0 && (
+            <button
+              onClick={() => setRoomTypes(new Set())}
+              className="px-2 py-1 text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+            >
+              clear
+            </button>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-[var(--text-muted)] w-20">Players:</span>
+          {(["any", "exclude", "only"] as const).map((m) => {
+            const labels = { any: "All", exclude: "Solo only", only: "Multiplayer only" };
+            const active = multiplayer === m;
+            return (
+              <button
+                key={m}
+                onClick={() => setMultiplayer(m)}
+                className={`px-3 py-1 rounded-md text-sm border transition-colors ${
+                  active
+                    ? "border-[var(--accent-gold)] text-[var(--accent-gold)] bg-[var(--accent-gold)]/10"
+                    : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50"
+                }`}
+              >
+                {labels[m]}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="text-center py-12 text-[var(--text-muted)]">Loading…</div>
+      ) : !data || data.encounters.length === 0 ? (
+        <div className="text-center py-12 text-[var(--text-muted)]">
+          No encounters match the current filters.
+        </div>
+      ) : (
+        <>
+          <div className="bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded-lg overflow-hidden">
+            <div className="grid grid-cols-12 gap-2 px-4 py-2 text-xs uppercase tracking-wider text-[var(--text-muted)] border-b border-[var(--border-subtle)]">
+              <div className="col-span-5">Encounter</div>
+              <div className="col-span-2 text-right">Runs</div>
+              <div className="col-span-2 text-right">Fatal</div>
+              <div className="col-span-2 text-right">Avg Dmg</div>
+              <div className="col-span-1 text-right">Avg Turns</div>
+            </div>
+
+            {data.encounters.map((row) => {
+              const m = meta[row.encounter_id];
+              const name = m?.name || displayName(row.encounter_id);
+              const isOpen = expanded.has(row.encounter_id);
+              const fatalPct = row.total ? ((row.fatal / row.total) * 100).toFixed(1) : "0";
+              return (
+                <div
+                  key={`${row.encounter_id}-${row.act}-${row.room_type}`}
+                  className="border-b border-[var(--border-subtle)] last:border-0"
+                >
+                  <button
+                    onClick={() => toggleExpanded(row.encounter_id)}
+                    className="w-full grid grid-cols-12 gap-2 px-4 py-3 items-center text-sm hover:bg-[var(--bg-card-hover)] transition-colors text-left"
+                  >
+                    <div className="col-span-5 flex items-center gap-2">
+                      <span
+                        className={`inline-block w-3 text-[var(--text-muted)] text-xs transition-transform ${isOpen ? "rotate-90" : ""}`}
+                      >
+                        &gt;
+                      </span>
+                      <Link
+                        href={`${lp}/encounters/${row.encounter_id.toLowerCase()}`}
+                        className="font-semibold hover:text-[var(--accent-gold)]"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {name}
+                      </Link>
+                      <span className="text-xs text-[var(--text-muted)] capitalize">
+                        · Act {row.act} · {row.room_type}
+                      </span>
+                    </div>
+                    <div className="col-span-2 text-right tabular-nums">{row.total.toLocaleString()}</div>
+                    <div className="col-span-2 text-right tabular-nums">
+                      {row.fatal.toLocaleString()}
+                      <span className="text-xs text-[var(--text-muted)] ml-1">({fatalPct}%)</span>
+                    </div>
+                    <div className="col-span-2 text-right tabular-nums">{row.avg_damage.toFixed(1)}</div>
+                    <div className="col-span-1 text-right tabular-nums">{row.avg_turns.toFixed(2)}</div>
+                  </button>
+
+                  {isOpen && (
+                    <div className="px-4 pb-3 pt-1 bg-[var(--bg-primary)]">
+                      {row.characters.length === 0 ? (
+                        <div className="text-xs text-[var(--text-muted)] py-2">
+                          No per-character breakdown available.
+                        </div>
+                      ) : (
+                        <div className="grid grid-cols-12 gap-2 text-xs">
+                          <div className="col-span-5 text-[var(--text-muted)] pb-1 border-b border-[var(--border-subtle)]">
+                            Character
+                          </div>
+                          <div className="col-span-2 text-right text-[var(--text-muted)] pb-1 border-b border-[var(--border-subtle)]">
+                            Runs
+                          </div>
+                          <div className="col-span-2 text-right text-[var(--text-muted)] pb-1 border-b border-[var(--border-subtle)]">
+                            Fatal
+                          </div>
+                          <div className="col-span-2 text-right text-[var(--text-muted)] pb-1 border-b border-[var(--border-subtle)]">
+                            Avg Dmg
+                          </div>
+                          <div className="col-span-1 text-right text-[var(--text-muted)] pb-1 border-b border-[var(--border-subtle)]">
+                            Avg Turns
+                          </div>
+                          {row.characters.map((c) => (
+                            <div className="contents" key={c.character}>
+                              <div className="col-span-5 pt-2 capitalize">
+                                {c.character.toLowerCase()}
+                              </div>
+                              <div className="col-span-2 pt-2 text-right tabular-nums">
+                                {c.total.toLocaleString()}
+                              </div>
+                              <div className="col-span-2 pt-2 text-right tabular-nums">
+                                {c.fatal}
+                                <span className="text-[var(--text-muted)] ml-1">
+                                  ({c.total ? ((c.fatal / c.total) * 100).toFixed(1) : "0"}%)
+                                </span>
+                              </div>
+                              <div className="col-span-2 pt-2 text-right tabular-nums">
+                                {c.avg_damage.toFixed(1)}
+                              </div>
+                              <div className="col-span-1 pt-2 text-right tabular-nums">
+                                {c.avg_turns.toFixed(2)}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-6">
+              <button
+                onClick={() => setPage(Math.max(1, page - 1))}
+                disabled={page <= 1}
+                className="px-3 py-1.5 text-sm rounded-md border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50 disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                ← Prev
+              </button>
+              <span className="text-sm text-[var(--text-muted)] tabular-nums">
+                Page {page} of {totalPages} ({data.total.toLocaleString()} encounters)
+              </span>
+              <button
+                onClick={() => setPage(page + 1)}
+                disabled={!data.has_next}
+                className="px-3 py-1.5 text-sm rounded-md border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50 disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                Next →
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/leaderboards/encounters/page.tsx
+++ b/frontend/app/leaderboards/encounters/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+import JsonLd from "@/app/components/JsonLd";
+import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
+import EncounterStatsClient from "./EncounterStatsClient";
+
+export const dynamic = "force-dynamic";
+
+const title = "Encounter Stats - Slay the Spire 2 (sts2) | Spire Codex";
+const description =
+  "Per-encounter Slay the Spire 2 stats — fatal counts, average damage, average turns, and a per-character breakdown for every monster, elite, and boss. Live aggregation from submitted community runs.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: {
+    canonical: "/leaderboards/encounters",
+    languages: buildLanguageAlternates("/leaderboards/encounters"),
+  },
+  openGraph: {
+    type: "website",
+    siteName: SITE_NAME,
+    url: `${SITE_URL}/leaderboards/encounters`,
+    title,
+    description,
+    images: [{ url: DEFAULT_OG_IMAGE }],
+  },
+  twitter: { card: "summary_large_image", title, description },
+};
+
+export default function EncountersStatsPage() {
+  const jsonLd = [
+    buildBreadcrumbJsonLd([
+      { name: "Home", href: "/" },
+      { name: "Leaderboards", href: "/leaderboards" },
+      { name: "Encounters", href: "/leaderboards/encounters" },
+    ]),
+    buildCollectionPageJsonLd({
+      name: "Slay the Spire 2 Encounter Stats",
+      description:
+        "Per-encounter aggregation: fatal counts, average damage taken, average turn count, and per-character breakdown for every monster, elite, and boss.",
+      path: "/leaderboards/encounters",
+    }),
+  ];
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+      <EncounterStatsClient />
+    </>
+  );
+}


### PR DESCRIPTION
Closes #335.

New paginated per-encounter view of submitted runs at `/leaderboards/encounters`, with public API at `/api/runs/encounter-stats` for third-party tools.

## Filters

- **Act** — 1 / 2 / 3 (multi-select)
- **Type** — monster / elite / boss (multi-select)
- **Players** — All / Solo only / Multiplayer only

## Columns

Top-level row: encounter name (linked to its detail page) · Act · room type · Runs (sample size) · Fatal count + % · Avg damage taken · Avg turns. Click any row to expand a per-character sub-table with the same columns scoped per character.

Pagination: 50 per page with prev/next + total count.

## API

```
GET /api/runs/encounter-stats?act=1,2&room_type=elite,boss&multiplayer=only&page=1&limit=50
```

Returns `{encounters: [{encounter_id, act, room_type, total, fatal, avg_damage, avg_turns, characters: [{character, total, fatal, avg_damage, avg_turns}]}], page, limit, total, has_next}`.

## Backend

`get_encounter_stats()` in `runs_db_mongo.py` walks each run's `map_point_history` (acts → rooms), unwinds twice, groups by (encounter_id, act, room_type, character) for the per-character breakdown, then collapses up so the page-limit applies to encounters rather than (encounter, character) pairs. Currently live-aggregates per request — likely OK for now, but worth materializing into `stats_summary` (alongside the global stats refresher) if traffic warrants. Left as a follow-up so this can ship.

Fatal detection: a room counts as fatal when its `model_id` matches the run's `killed_by` and `win` is falsy. PR #266's extractor refines this to the *last* matching room — the simpler heuristic here misattributes for runs that hit the same enemy type twice and died on the second instance (rare).

## Nav + docs

- "Encounters" added to the Stats nav dropdown between Stats and Scoring
- `contributing/API_REFERENCE.md` updated with the new endpoint

## Open follow-ups (not in this PR)

- Materialize into `stats_summary` so the response is sub-ms
- Add win-rate, %-HP-lost, encounter frequency, ascension banding (the bonus stats from #335)
- Per-monster (not just per-encounter) breakdown using the `run_encounter_monsters` join data from #266 once that lands