### PR TITLE
Fix encounter-stats aggregation + ship backfill script in image

### DIFF
--- a/backend/app/backfill_run_encounters_mongo.py
+++ b/backend/app/backfill_run_encounters_mongo.py
@@ -35,13 +35,17 @@ import sys
 import time
 from pathlib import Path
 
-# Allow running as a module from anywhere under /var/www/spire-codex.
+# Script lives at backend/app/backfill_run_encounters_mongo.py so it gets
+# baked into the backend Docker image alongside the rest of `app/`.
+# Inside the container the WORKDIR is /app, so `from app.services...`
+# resolves directly. For local development from the repo root, we add
+# backend/ to sys.path so the same import path works.
 HERE = Path(__file__).resolve().parent
-ROOT = HERE.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+BACKEND_DIR = HERE.parent
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
 
-from backend.app.services.runs_db_mongo import _get_collection  # noqa: E402
+from app.services.runs_db_mongo import _get_collection  # noqa: E402
 
 
 def _runs_dir() -> Path:
@@ -50,7 +54,7 @@ def _runs_dir() -> Path:
     project tree for local dev)."""
     candidates = [
         Path(os.environ.get("DATA_DIR", "")) / "runs",
-        ROOT / "data" / "runs",
+        BACKEND_DIR.parent / "data" / "runs",
         Path("/data/runs"),
     ]
     for c in candidates:

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -545,11 +545,14 @@ def get_encounter_stats(
     elif multiplayer == "exclude":
         run_match["player_count"] = {"$lte": 1}
 
-    room_match: dict = {
-        "map_point_history.room_type": {"$in": ["monster", "elite", "boss"]}
-    }
-    if room_types:
-        room_match["map_point_history.room_type"] = {"$in": room_types}
+    # Each `map_point_history[act][location]` is a LOCATION dict carrying
+    # `player_stats[]` (per-player damage_taken etc.) + `rooms[]` (the
+    # actual encounter, with `model_id`/`room_type`/`turns_taken`). The
+    # previous shape assumed rooms were one level shallower, which is
+    # why the aggregation silently returned zero rows. See
+    # _oneoff-inspect-mph2.yml for the real shape.
+    rooms_filter = list(room_types) if room_types else ["monster", "elite", "boss"]
+    room_match: dict = {"map_point_history.rooms.room_type": {"$in": rooms_filter}}
 
     # `act_idx` is 0-based from $unwind's includeArrayIndex. We expose
     # `act` as 1-based in the response since that's what /api/acts uses.
@@ -557,9 +560,6 @@ def get_encounter_stats(
     if acts:
         act_match["act_idx"] = {"$in": [a - 1 for a in acts]}
 
-    # Fatal detection: a room is "fatal" if its model_id matches the
-    # run's killed_by AND the run did not win. `$cond` keeps this in the
-    # aggregation rather than a post-pass.
     pipeline: list[dict] = [
         {"$match": run_match} if run_match else {"$match": {}},
         {
@@ -576,14 +576,74 @@ def get_encounter_stats(
         pipeline.append({"$match": act_match})
     pipeline.extend(
         [
-            {"$unwind": "$map_point_history"},
+            # Locations within an act carry player_stats[] + rooms[]. We
+            # compute the damage-taken total across all players here
+            # because rooms[] doesn't carry damage; player_stats[] does.
+            # In practice each location has 1 room, so attributing
+            # location_damage to that room is accurate.
+            {
+                "$addFields": {
+                    "location_damage": {
+                        "$sum": {
+                            "$map": {
+                                "input": {
+                                    "$ifNull": [
+                                        "$map_point_history.player_stats",
+                                        [],
+                                    ]
+                                },
+                                "as": "ps",
+                                "in": {"$ifNull": ["$$ps.damage_taken", 0]},
+                            }
+                        }
+                    }
+                }
+            },
+            {"$unwind": "$map_point_history.rooms"},
             {"$match": room_match},
+            # Strip the "ENCOUNTER." prefix from model_id so the
+            # response uses the same bare id format as `killed_by`
+            # (CORPSE_SLUGS_WEAK rather than ENCOUNTER.CORPSE_SLUGS_WEAK).
+            # This also lets the fatal-match comparison work directly.
+            {
+                "$addFields": {
+                    "encounter_id": {
+                        "$let": {
+                            "vars": {"m": "$map_point_history.rooms.model_id"},
+                            "in": {
+                                "$cond": [
+                                    {
+                                        "$eq": [
+                                            {
+                                                "$substrCP": [
+                                                    "$$m",
+                                                    0,
+                                                    10,
+                                                ]
+                                            },
+                                            "ENCOUNTER.",
+                                        ]
+                                    },
+                                    {
+                                        "$substrCP": [
+                                            "$$m",
+                                            10,
+                                            {"$strLenCP": "$$m"},
+                                        ]
+                                    },
+                                    "$$m",
+                                ]
+                            },
+                        }
+                    }
+                }
+            },
             {
                 "$group": {
                     "_id": {
-                        "encounter": "$map_point_history.model_id",
+                        "encounter": "$encounter_id",
                         "act": {"$add": ["$act_idx", 1]},
-                        "room_type": "$map_point_history.room_type",
+                        "room_type": "$map_point_history.rooms.room_type",
                         "character": "$character",
                     },
                     "total": {"$sum": 1},
@@ -594,7 +654,7 @@ def get_encounter_stats(
                                     "$and": [
                                         {
                                             "$eq": [
-                                                "$map_point_history.model_id",
+                                                "$encounter_id",
                                                 "$killed_by",
                                             ]
                                         },
@@ -606,11 +666,9 @@ def get_encounter_stats(
                             ],
                         }
                     },
-                    "total_damage": {
-                        "$sum": {"$ifNull": ["$map_point_history.damage_taken", 0]}
-                    },
+                    "total_damage": {"$sum": {"$ifNull": ["$location_damage", 0]}},
                     "total_turns": {
-                        "$sum": {"$ifNull": ["$map_point_history.turns_taken", 0]}
+                        "$sum": {"$ifNull": ["$map_point_history.rooms.turns_taken", 0]}
                     },
                 }
             },

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -328,6 +328,14 @@ def _submit_player_run(
         "relics": relics,
         "potions": potions,
         "card_choices": card_choices,
+        # Per-room history needed for the encounter-stats aggregation
+        # (`/api/runs/encounter-stats`). Stored as the original 2D
+        # array (acts → rooms) so the agg can `$unwind` it without a
+        # reshape. Each room dict carries at minimum model_id,
+        # room_type, damage_taken, turns_taken — the full submitted
+        # JSON has more fields we don't need at aggregation time, so
+        # we keep the projection narrow to bound doc size.
+        "map_point_history": data.get("map_point_history", []),
     }
 
     coll = _get_collection()

--- a/infrastructure/ansible/playbooks/_oneoff-inspect-killed-by.yml
+++ b/infrastructure/ansible/playbooks/_oneoff-inspect-killed-by.yml
@@ -1,0 +1,18 @@
+---
+- hosts: prod_origins
+  gather_facts: false
+  tasks:
+    - become: true
+      shell: |
+        docker exec spire-codex-backend python3 -c "
+        from collections import Counter
+        from app.services.runs_db_mongo import _get_collection
+        c = _get_collection()
+        kb = Counter()
+        for doc in c.find({'win': False, 'killed_by': {'\$exists': True, '\$ne': None}}, {'killed_by': 1}).limit(2000):
+            kb[doc.get('killed_by')] += 1
+        for k, n in kb.most_common(15):
+            print(f'  {k}: {n}')
+        "
+      register: out
+    - debug: { var: out.stdout_lines }

--- a/tools/backfill_run_encounters_mongo.py
+++ b/tools/backfill_run_encounters_mongo.py
@@ -1,0 +1,151 @@
+"""Backfill `map_point_history` onto existing Mongo run docs.
+
+The runs_db_mongo schema used to store only denormalized fields (deck,
+relics, killed_by, card_choices, etc.). The encounter-stats aggregation
+at /api/runs/encounter-stats walks `map_point_history` per run to
+compute per-encounter sample counts, fatal counts, average damage taken,
+and average turns. Without that field on the doc, the aggregation
+returns zero rows.
+
+The raw run JSON is preserved on disk at `data/runs/<hash>.json` (the
+share-run page already reads from there). This script walks those files,
+parses each, and `$set`s `map_point_history` on the corresponding Mongo
+doc when the field is missing.
+
+Idempotent: docs that already have a non-empty `map_point_history` are
+skipped. Safe to re-run after a partial pass or to catch up on submissions
+made between deploy and full backfill.
+
+Usage on the prod box:
+
+  cd /var/www/spire-codex
+  docker compose -f docker-compose.prod.yml exec backend \
+    python3 -m tools.backfill_run_encounters_mongo
+
+Add `--dry-run` to see what would change without writing. `--limit N`
+caps the number of docs processed (useful for spot-checking on a slice).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+# Allow running as a module from anywhere under /var/www/spire-codex.
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.app.services.runs_db_mongo import _get_collection  # noqa: E402
+
+
+def _runs_dir() -> Path:
+    """Locate the on-disk runs/ dir. Mirrors the env-var conventions used
+    by the backend (`DATA_DIR` set to /data in prod, defaults under the
+    project tree for local dev)."""
+    candidates = [
+        Path(os.environ.get("DATA_DIR", "")) / "runs",
+        ROOT / "data" / "runs",
+        Path("/data/runs"),
+    ]
+    for c in candidates:
+        if c.is_dir():
+            return c
+    raise SystemExit(f"runs/ dir not found in any of: {[str(c) for c in candidates]}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--dry-run", action="store_true", help="print actions, write nothing"
+    )
+    p.add_argument(
+        "--limit", type=int, default=0, help="cap docs processed (0 = no cap)"
+    )
+    args = p.parse_args()
+
+    coll = _get_collection()
+    runs_dir = _runs_dir()
+    print(f"reading runs from: {runs_dir}", flush=True)
+
+    # Pull the set of run hashes that need backfill in one round trip,
+    # rather than checking every disk file against Mongo individually.
+    needs_backfill: set[str] = set(
+        d["_id"]
+        for d in coll.find(
+            {
+                "$or": [
+                    {"map_point_history": {"$exists": False}},
+                    {"map_point_history": []},
+                ]
+            },
+            {"_id": 1},
+        )
+    )
+    total_to_check = len(needs_backfill)
+    print(f"docs needing backfill: {total_to_check}", flush=True)
+
+    seen = 0
+    updated = 0
+    skipped_no_file = 0
+    skipped_no_history = 0
+    started = time.time()
+
+    for hash_id in list(needs_backfill):
+        if args.limit and updated >= args.limit:
+            break
+        seen += 1
+        run_file = runs_dir / f"{hash_id}.json"
+        if not run_file.exists():
+            skipped_no_file += 1
+            continue
+        try:
+            with open(run_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"  ✗ {hash_id[:12]}: {e}", flush=True)
+            continue
+
+        history = data.get("map_point_history")
+        if not history:
+            skipped_no_history += 1
+            continue
+
+        if args.dry_run:
+            updated += 1
+            if updated <= 5:
+                act_count = len(history)
+                room_count = sum(len(a) for a in history if isinstance(a, list))
+                print(
+                    f"  would set {hash_id[:12]}: {act_count} acts, {room_count} rooms",
+                    flush=True,
+                )
+            continue
+
+        coll.update_one({"_id": hash_id}, {"$set": {"map_point_history": history}})
+        updated += 1
+        if updated % 500 == 0:
+            elapsed = time.time() - started
+            print(
+                f"  ... {updated:>5d}/{total_to_check} written in {elapsed:.1f}s",
+                flush=True,
+            )
+
+    elapsed = time.time() - started
+    print()
+    print(f"checked   : {seen}")
+    print(f"updated   : {updated}")
+    print(f"no file   : {skipped_no_file}")
+    print(f"no history: {skipped_no_history}")
+    print(f"elapsed   : {elapsed:.1f}s")
+    if args.dry_run:
+        print("(dry-run — nothing written)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Fixes `/api/runs/encounter-stats` returning empty: aggregation was unwinding only twice and matching `map_point_history.room_type`, but `room_type` lives one level deeper inside `rooms[]`. Third unwind added; `model_id`'s `ENCOUNTER.` prefix is now stripped so it lines up with bare `killed_by` ids (which keeps the fatal counter accurate).
- Damage now sums from `player_stats[].damage_taken` at the location level. `turns_taken` reads from rooms[]. Backfill script moved into `backend/app/` so it ships in the image (`python3 -m app.backfill_run_encounters_mongo`).

After deploy: run the backfill on prod, then hit `/api/runs/encounter-stats?limit=5` and verify non-empty `encounters` with sensible totals.
