### PR TITLE
Filter home page character stats to official characters

### DIFF
--- a/backend/app/services/runs_db.py
+++ b/backend/app/services/runs_db.py
@@ -13,11 +13,10 @@ import hashlib
 import json
 import os
 import sqlite3
-
-OFFICIAL_CHARACTERS = {"IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"}
-
 from contextlib import contextmanager
 from pathlib import Path
+
+OFFICIAL_CHARACTERS = {"IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"}
 
 # Use DATA_DIR env var (Docker) or fall back to project data/
 _data_dir = Path(

--- a/backend/app/services/runs_db.py
+++ b/backend/app/services/runs_db.py
@@ -13,6 +13,9 @@ import hashlib
 import json
 import os
 import sqlite3
+
+OFFICIAL_CHARACTERS = {"IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"}
+
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -770,6 +773,7 @@ def get_stats(
                     else 0,
                 }
                 for r in char_stats
+                if r["character"] in OFFICIAL_CHARACTERS
             ],
             "ascensions": [
                 {

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -37,9 +37,6 @@ import json
 import os
 import time
 from contextlib import contextmanager
-
-OFFICIAL_CHARACTERS = {"IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"}
-
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -48,6 +45,8 @@ from pymongo import ASCENDING, DESCENDING, MongoClient
 from pymongo.errors import DuplicateKeyError
 
 from ..metrics import db_operations, db_operation_duration
+
+OFFICIAL_CHARACTERS = {"IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"}
 
 
 @contextmanager

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -37,6 +37,9 @@ import json
 import os
 import time
 from contextlib import contextmanager
+
+OFFICIAL_CHARACTERS = {"IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"}
+
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -943,6 +946,7 @@ def get_stats(
                 else 0,
             }
             for r in char_stats
+            if r["_id"] in OFFICIAL_CHARACTERS
         ],
         "ascensions": [
             {


### PR DESCRIPTION
## Summary
- Modded characters (e.g. Komeijikoishi-koishi_character, Hina) were appearing in the CHARACTER WIN RATES section on the home page
- Added `OFFICIAL_CHARACTERS` allowlist (`IRONCLAD`, `SILENT`, `DEFECT`, `NECROBINDER`, `REGENT`) to the Mongo stats code path
- Top-level aggregate stats (total runs, wins, win rate) still count all submissions including modded runs
- Materialized view cache will pick up the filter on the next refresh cycle (~60s after deploy)