### PR TITLE
Reduce run blob LRU cache from 2048 to 256

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -29,7 +29,7 @@ limiter = Limiter(key_func=get_remote_address)
 MAX_BODY_SIZE = 512 * 1024  # 512 KB
 
 
-@lru_cache(maxsize=2048)
+@lru_cache(maxsize=256)
 def _load_run_blob(run_hash: str) -> str | None:
     """Read a run JSON file once and serve from memory thereafter.
 


### PR DESCRIPTION
## Summary
- Backend container at 3GB/7.8GB on the droplet (90% memory pressure)
- The `_load_run_blob` LRU cache holds up to 2048 full run JSON blobs in memory
- At ~500KB per blob, that's ~1GB of cache alone
- Reduce to 256 entries (~128MB) -- still plenty for hot share links