### PR TITLE
Generate WebP companions at Docker build time

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.12-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends webp && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY requirements.txt .
@@ -7,6 +9,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app/ app/
 COPY static/ static/
+
+RUN find static/images -name '*.png' -exec sh -c 'cwebp -q 95 -m 6 -quiet "$0" -o "${0%.png}.webp"' {} \;
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- Beta images kept disappearing after container recreates because WebPs were generated at runtime inside the container, not baked into the image
- Adds `cwebp` to the Docker image and runs `find/cwebp` during the build step
- All PNGs get a `.webp` companion that survives container replacements