### PR TITLE
Serve images from Cloudflare R2 CDN

### DIFF
--- a/backend/app/parsers/parser_paths.py
+++ b/backend/app/parsers/parser_paths.py
@@ -105,13 +105,17 @@ def resolve_image_url(entity_type: str, name_stem: str) -> str | None:
         )
         if per_version_png.exists():
             if CDN_BASE_URL:
-                return f"{CDN_BASE_URL}/beta/{BETA_VERSION}/{entity_type}/{name_stem}.webp"
+                return (
+                    f"{CDN_BASE_URL}/beta/{BETA_VERSION}/{entity_type}/{name_stem}.webp"
+                )
             return f"/static/images/beta/{BETA_VERSION}/{entity_type}/{name_stem}.webp"
 
         legacy_beta_png = DATA_DIR / "images" / entity_type / f"{name_stem}.png"
         if legacy_beta_png.exists():
             if CDN_BASE_URL:
-                return f"{CDN_BASE_URL}/beta/{BETA_VERSION}/{entity_type}/{name_stem}.webp"
+                return (
+                    f"{CDN_BASE_URL}/beta/{BETA_VERSION}/{entity_type}/{name_stem}.webp"
+                )
             return f"/static/data-beta/{BETA_VERSION}/images/{entity_type}/{name_stem}.webp"
 
     stable_png = STATIC_IMAGES_DIR / entity_type / f"{name_stem}.png"

--- a/backend/app/parsers/parser_paths.py
+++ b/backend/app/parsers/parser_paths.py
@@ -42,6 +42,10 @@ else:
 # Stable canonical asset tree — fallback when no per-version asset exists.
 STATIC_IMAGES_DIR = BASE / "backend" / "static" / "images"
 
+# CDN base URL — when set, image URLs are absolute (e.g. https://cdn.spire-codex.com).
+# When unset, URLs are relative paths served from the backend (e.g. /static/images/...).
+CDN_BASE_URL = os.environ.get("CDN_BASE_URL", "").rstrip("/")
+
 
 def _detect_beta_version() -> str | None:
     """If DATA_DIR is `data-beta/vX.Y.Z[...]`, return that version segment.
@@ -100,14 +104,20 @@ def resolve_image_url(entity_type: str, name_stem: str) -> str | None:
             STATIC_IMAGES_DIR / "beta" / BETA_VERSION / entity_type / f"{name_stem}.png"
         )
         if per_version_png.exists():
+            if CDN_BASE_URL:
+                return f"{CDN_BASE_URL}/beta/{BETA_VERSION}/{entity_type}/{name_stem}.webp"
             return f"/static/images/beta/{BETA_VERSION}/{entity_type}/{name_stem}.webp"
 
         legacy_beta_png = DATA_DIR / "images" / entity_type / f"{name_stem}.png"
         if legacy_beta_png.exists():
+            if CDN_BASE_URL:
+                return f"{CDN_BASE_URL}/beta/{BETA_VERSION}/{entity_type}/{name_stem}.webp"
             return f"/static/data-beta/{BETA_VERSION}/images/{entity_type}/{name_stem}.webp"
 
     stable_png = STATIC_IMAGES_DIR / entity_type / f"{name_stem}.png"
     if stable_png.exists():
+        if CDN_BASE_URL:
+            return f"{CDN_BASE_URL}/{entity_type}/{name_stem}.webp"
         return f"/static/images/{entity_type}/{name_stem}.webp"
 
     return None

--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -11,6 +11,7 @@ import { t } from "@/lib/ui-translations";
 const LANG_CODES = new Set(["deu", "esp", "fra", "ita", "jpn", "kor", "pol", "ptb", "rus", "spa", "tha", "tur", "zhs"]);
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+import { imageUrl } from "@/lib/image-url";
 
 interface Translations {
   sections?: Record<string, string>;
@@ -211,7 +212,7 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
                 />
                 <div className="relative aspect-square flex items-end justify-center overflow-hidden">
                   <img
-                    src={`${API}/static/images/characters/combat_${char.id}.webp`}
+                    src={imageUrl(`/static/images/characters/combat_${char.id}.webp`)}
                     alt={`${charName} - Slay the Spire 2 Character`}
                     className="w-full h-full object-contain p-1 sm:p-2 group-hover:scale-105 transition-transform duration-300"
                     crossOrigin="anonymous"

--- a/frontend/app/[lang]/badges/[id]/page.tsx
+++ b/frontend/app/[lang]/badges/[id]/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/languages";
 import { t } from "@/lib/ui-translations";
 import type { Badge } from "@/lib/api";
+import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-dynamic";
 
@@ -92,7 +93,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title,
       description: metaDesc,
       images: badge.image_url
-        ? [{ url: `${ABSOLUTE_BASE}${badge.image_url}` }]
+        ? [{ url: imageUrl(badge.image_url) }]
         : [],
       locale: LANG_HREFLANG[langCode],
     },
@@ -118,7 +119,7 @@ export default async function LangBadgePage({ params }: Props) {
     name: badge.name,
     description: desc || `${badge.name}`,
     path: `/${lang}/badges/${id}`,
-    imageUrl: badge.image_url ? `${ABSOLUTE_BASE}${badge.image_url}` : undefined,
+    imageUrl: badge.image_url ? imageUrl(badge.image_url) : undefined,
     category: "Badge",
     breadcrumbs: [
       { name: t("Home", lang), href: `/${lang}` },
@@ -152,7 +153,7 @@ export default async function LangBadgePage({ params }: Props) {
         {badge.image_url && (
           <div className="flex justify-center mb-6">
             <img
-              src={`${STATIC_BASE}${badge.image_url}`}
+              src={imageUrl(badge.image_url)}
               alt={`${badge.name} badge`}
               className="w-24 h-24 object-contain"
             />

--- a/frontend/app/[lang]/badges/page.tsx
+++ b/frontend/app/[lang]/badges/page.tsx
@@ -17,6 +17,7 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 import type { Badge } from "@/lib/api";
+import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-dynamic";
 
@@ -190,7 +191,7 @@ function BadgeCard({ badge, lang }: { badge: Badge; lang: string }) {
     >
       {badge.image_url && (
         <img
-          src={`${STATIC_BASE}${badge.image_url}`}
+          src={imageUrl(badge.image_url)}
           alt={`${badge.name} badge`}
           className="w-14 h-14 object-contain shrink-0"
           loading="lazy"

--- a/frontend/app/[lang]/cards/[id]/page.tsx
+++ b/frontend/app/[lang]/cards/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-dynamic";
 
@@ -41,7 +42,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         title,
         description: metaDesc,
         locale: LANG_HREFLANG[langCode],
-        images: card.image_url ? [{ url: `${API_PUBLIC}${card.image_url}` }] : [],
+        images: card.image_url ? [{ url: imageUrl(card.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: metaDesc },
       alternates: { canonical: `/${lang}/cards/${id}`, languages },
@@ -65,7 +66,7 @@ export default async function Page({ params }: Props) {
       const desc = stripTags(card.description || "");
       const detailJsonLd = buildDetailPageJsonLd({
         name: card.name, description: desc || card.name, path: `/${lang}/cards/${id}`,
-        imageUrl: card.image_url ? `${API_PUBLIC}${card.image_url}` : undefined, category: "Card",
+        imageUrl: card.image_url ? imageUrl(card.image_url) : undefined, category: "Card",
         breadcrumbs: [{ name: "Home", href: `/${lang}` }, { name: "Cards", href: `/${lang}/cards` }, { name: card.name, href: `/${lang}/cards/${id}` }],
         inLanguage: LANG_HREFLANG[langCode],
       });

--- a/frontend/app/[lang]/characters/[id]/page.tsx
+++ b/frontend/app/[lang]/characters/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-dynamic";
 
@@ -37,7 +38,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         title,
         description: clipMetaDescription(`${gameName} playable character — ${name}${desc ? `: ${desc}` : ""}`),
         locale: LANG_HREFLANG[langCode],
-        images: entity.image_url ? [{ url: `${API_PUBLIC}${entity.image_url}` }] : [],
+        images: entity.image_url ? [{ url: imageUrl(entity.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: clipMetaDescription(`${gameName} playable character — ${name}${desc ? `: ${desc}` : ""}`) },
       alternates: { canonical: `/${lang}/characters/${id}`, languages },
@@ -62,7 +63,7 @@ export default async function Page({ params }: Props) {
       const name = data.name || data.title || id;
       const detailJsonLd = buildDetailPageJsonLd({
         name, description: desc || name, path: `/${lang}/characters/${id}`,
-        imageUrl: data.image_url ? `${API_PUBLIC}${data.image_url}` : undefined, category: "Character",
+        imageUrl: data.image_url ? imageUrl(data.image_url) : undefined, category: "Character",
         breadcrumbs: [{ name: "Home", href: `/${lang}` }, { name: "Characters", href: `/${lang}/characters` }, { name, href: `/${lang}/characters/${id}` }],
         inLanguage: LANG_HREFLANG[langCode],
       });

--- a/frontend/app/[lang]/enchantments/[id]/page.tsx
+++ b/frontend/app/[lang]/enchantments/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-dynamic";
 
@@ -37,7 +38,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         title,
         description: clipMetaDescription(`${gameName} card enchantment — ${name}${desc ? `: ${desc}` : ""}`),
         locale: LANG_HREFLANG[langCode],
-        images: entity.image_url ? [{ url: `${API_PUBLIC}${entity.image_url}` }] : [],
+        images: entity.image_url ? [{ url: imageUrl(entity.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: clipMetaDescription(`${gameName} card enchantment — ${name}${desc ? `: ${desc}` : ""}`) },
       alternates: { canonical: `/${lang}/enchantments/${id}`, languages },
@@ -62,7 +63,7 @@ export default async function Page({ params }: Props) {
       const name = data.name || id;
       const detailJsonLd = buildDetailPageJsonLd({
         name, description: desc || name, path: `/${lang}/enchantments/${id}`,
-        imageUrl: data.image_url ? `${API_PUBLIC}${data.image_url}` : undefined, category: "Enchantment",
+        imageUrl: data.image_url ? imageUrl(data.image_url) : undefined, category: "Enchantment",
         breadcrumbs: [{ name: "Home", href: `/${lang}` }, { name: "Enchantments", href: `/${lang}/enchantments` }, { name, href: `/${lang}/enchantments/${id}` }],
         inLanguage: LANG_HREFLANG[langCode],
       });

--- a/frontend/app/[lang]/events/[id]/page.tsx
+++ b/frontend/app/[lang]/events/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-dynamic";
 
@@ -37,7 +38,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         title,
         description: clipMetaDescription(`${gameName} event — ${name}${desc ? `: ${desc}` : ""}`),
         locale: LANG_HREFLANG[langCode],
-        images: entity.image_url ? [{ url: `${API_PUBLIC}${entity.image_url}` }] : [],
+        images: entity.image_url ? [{ url: imageUrl(entity.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: clipMetaDescription(`${gameName} event — ${name}${desc ? `: ${desc}` : ""}`) },
       alternates: { canonical: `/${lang}/events/${id}`, languages },
@@ -62,7 +63,7 @@ export default async function Page({ params }: Props) {
       const name = data.name || data.title || id;
       const detailJsonLd = buildDetailPageJsonLd({
         name, description: desc || name, path: `/${lang}/events/${id}`,
-        imageUrl: data.image_url ? `${API_PUBLIC}${data.image_url}` : undefined, category: "Event",
+        imageUrl: data.image_url ? imageUrl(data.image_url) : undefined, category: "Event",
         breadcrumbs: [{ name: "Home", href: `/${lang}` }, { name: "Events", href: `/${lang}/events` }, { name, href: `/${lang}/events/${id}` }],
         inLanguage: LANG_HREFLANG[langCode],
       });

--- a/frontend/app/[lang]/monsters/[id]/page.tsx
+++ b/frontend/app/[lang]/monsters/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-dynamic";
 
@@ -37,7 +38,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         title,
         description: clipMetaDescription(`${gameName} monster — ${name}${desc ? `: ${desc}` : ""}`),
         locale: LANG_HREFLANG[langCode],
-        images: entity.image_url ? [{ url: `${API_PUBLIC}${entity.image_url}` }] : [],
+        images: entity.image_url ? [{ url: imageUrl(entity.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: clipMetaDescription(`${gameName} monster — ${name}${desc ? `: ${desc}` : ""}`) },
       alternates: { canonical: `/${lang}/monsters/${id}`, languages },
@@ -62,7 +63,7 @@ export default async function Page({ params }: Props) {
       const name = data.name || data.title || id;
       const detailJsonLd = buildDetailPageJsonLd({
         name, description: desc || name, path: `/${lang}/monsters/${id}`,
-        imageUrl: data.image_url ? `${API_PUBLIC}${data.image_url}` : undefined, category: "Monster",
+        imageUrl: data.image_url ? imageUrl(data.image_url) : undefined, category: "Monster",
         breadcrumbs: [{ name: "Home", href: `/${lang}` }, { name: "Monsters", href: `/${lang}/monsters` }, { name, href: `/${lang}/monsters/${id}` }],
         inLanguage: LANG_HREFLANG[langCode],
       });

--- a/frontend/app/[lang]/potions/[id]/page.tsx
+++ b/frontend/app/[lang]/potions/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-dynamic";
 
@@ -37,7 +38,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         title,
         description: clipMetaDescription(`${gameName} potion — ${name}${desc ? `: ${desc}` : ""}`),
         locale: LANG_HREFLANG[langCode],
-        images: entity.image_url ? [{ url: `${API_PUBLIC}${entity.image_url}` }] : [],
+        images: entity.image_url ? [{ url: imageUrl(entity.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: clipMetaDescription(`${gameName} potion — ${name}${desc ? `: ${desc}` : ""}`) },
       alternates: { canonical: `/${lang}/potions/${id}`, languages },
@@ -62,7 +63,7 @@ export default async function Page({ params }: Props) {
       const name = data.name || data.title || id;
       const detailJsonLd = buildDetailPageJsonLd({
         name, description: desc || name, path: `/${lang}/potions/${id}`,
-        imageUrl: data.image_url ? `${API_PUBLIC}${data.image_url}` : undefined, category: "Potion",
+        imageUrl: data.image_url ? imageUrl(data.image_url) : undefined, category: "Potion",
         breadcrumbs: [{ name: "Home", href: `/${lang}` }, { name: "Potions", href: `/${lang}/potions` }, { name, href: `/${lang}/potions/${id}` }],
         inLanguage: LANG_HREFLANG[langCode],
       });

--- a/frontend/app/[lang]/powers/[id]/page.tsx
+++ b/frontend/app/[lang]/powers/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-dynamic";
 
@@ -37,7 +38,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         title,
         description: clipMetaDescription(`${gameName} power — ${name}${desc ? `: ${desc}` : ""}`),
         locale: LANG_HREFLANG[langCode],
-        images: entity.image_url ? [{ url: `${API_PUBLIC}${entity.image_url}` }] : [],
+        images: entity.image_url ? [{ url: imageUrl(entity.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: clipMetaDescription(`${gameName} power — ${name}${desc ? `: ${desc}` : ""}`) },
       alternates: { canonical: `/${lang}/powers/${id}`, languages },
@@ -62,7 +63,7 @@ export default async function Page({ params }: Props) {
       const name = data.name || data.title || id;
       const detailJsonLd = buildDetailPageJsonLd({
         name, description: desc || name, path: `/${lang}/powers/${id}`,
-        imageUrl: data.image_url ? `${API_PUBLIC}${data.image_url}` : undefined, category: "Power",
+        imageUrl: data.image_url ? imageUrl(data.image_url) : undefined, category: "Power",
         breadcrumbs: [{ name: "Home", href: `/${lang}` }, { name: "Powers", href: `/${lang}/powers` }, { name, href: `/${lang}/powers/${id}` }],
         inLanguage: LANG_HREFLANG[langCode],
       });

--- a/frontend/app/[lang]/relics/[id]/page.tsx
+++ b/frontend/app/[lang]/relics/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-dynamic";
 
@@ -37,7 +38,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         title,
         description: clipMetaDescription(`${gameName} relic — ${name}${desc ? `: ${desc}` : ""}`),
         locale: LANG_HREFLANG[langCode],
-        images: entity.image_url ? [{ url: `${API_PUBLIC}${entity.image_url}` }] : [],
+        images: entity.image_url ? [{ url: imageUrl(entity.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: clipMetaDescription(`${gameName} relic — ${name}${desc ? `: ${desc}` : ""}`) },
       alternates: { canonical: `/${lang}/relics/${id}`, languages },
@@ -62,7 +63,7 @@ export default async function Page({ params }: Props) {
       const name = data.name || data.title || id;
       const detailJsonLd = buildDetailPageJsonLd({
         name, description: desc || name, path: `/${lang}/relics/${id}`,
-        imageUrl: data.image_url ? `${API_PUBLIC}${data.image_url}` : undefined, category: "Relic",
+        imageUrl: data.image_url ? imageUrl(data.image_url) : undefined, category: "Relic",
         breadcrumbs: [{ name: "Home", href: `/${lang}` }, { name: "Relics", href: `/${lang}/relics` }, { name, href: `/${lang}/relics/${id}` }],
         inLanguage: LANG_HREFLANG[langCode],
       });

--- a/frontend/app/ancients/AncientsClient.tsx
+++ b/frontend/app/ancients/AncientsClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -73,7 +74,7 @@ function RelicPill({
       >
         {info?.image_url && (
           <img
-            src={`${API}${info.image_url}`}
+            src={imageUrl(info.image_url)}
             alt={name}
             className="w-8 h-8 object-contain"
             crossOrigin="anonymous"

--- a/frontend/app/badges/[id]/page.tsx
+++ b/frontend/app/badges/[id]/page.tsx
@@ -6,6 +6,7 @@ import RichDescription from "@/app/components/RichDescription";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates, SITE_NAME, SITE_URL } from "@/lib/seo";
 import type { Badge } from "@/lib/api";
+import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-dynamic";
 
@@ -76,7 +77,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title,
       description: metaDesc,
       images: badge.image_url
-        ? [{ url: `${ABSOLUTE_BASE}${badge.image_url}` }]
+        ? [{ url: imageUrl(badge.image_url) }]
         : [],
     },
     twitter: { card: "summary_large_image", title, description: metaDesc },
@@ -99,7 +100,7 @@ export default async function BadgePage({ params }: Props) {
     name: badge.name,
     description: desc || `${badge.name} run-end badge from Slay the Spire 2`,
     path: `/badges/${id}`,
-    imageUrl: badge.image_url ? `${ABSOLUTE_BASE}${badge.image_url}` : undefined,
+    imageUrl: badge.image_url ? imageUrl(badge.image_url) : undefined,
     category: "Badge",
     breadcrumbs: [
       { name: "Home", href: "/" },
@@ -144,7 +145,7 @@ export default async function BadgePage({ params }: Props) {
         {badge.image_url && (
           <div className="flex justify-center mb-6">
             <img
-              src={`${STATIC_BASE}${badge.image_url}`}
+              src={imageUrl(badge.image_url)}
               alt={`Slay the Spire 2 ${badge.name} badge`}
               className="w-24 h-24 object-contain"
             />

--- a/frontend/app/badges/page.tsx
+++ b/frontend/app/badges/page.tsx
@@ -6,6 +6,7 @@ import {
   buildCollectionPageJsonLd,
 } from "@/lib/jsonld";
 import type { Badge } from "@/lib/api";
+import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-dynamic";
 
@@ -128,7 +129,7 @@ function BadgeCard({ badge }: { badge: Badge }) {
     >
       {badge.image_url && (
         <img
-          src={`${STATIC_BASE}${badge.image_url}`}
+          src={imageUrl(badge.image_url)}
           alt={`Slay the Spire 2 ${badge.name} badge`}
           className="w-14 h-14 object-contain shrink-0"
           loading="lazy"

--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -13,6 +13,7 @@ import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import RelatedCards from "@/app/components/RelatedCards";
+import { imageUrl } from "@/lib/image-url";
 import EntityRunStats from "@/app/components/EntityRunStats";
 import HoverTooltip from "@/app/components/HoverTooltip";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
@@ -300,7 +301,7 @@ export default function CardDetail({ initialCard }: { initialCard?: Card | null 
         {imgUrl && (
           <div className="bg-black/40 rounded-t-2xl overflow-hidden">
             <img
-              src={`${API}${imgUrl}`}
+              src={imageUrl(imgUrl)}
               alt={`${card.name} - Slay the Spire 2 Card`}
               className="w-full object-contain max-h-80"
               crossOrigin="anonymous"
@@ -329,7 +330,7 @@ export default function CardDetail({ initialCard }: { initialCard?: Card | null 
                 <span className="inline-flex items-center gap-0.5 px-2 py-1 rounded-full bg-[var(--bg-primary)] border border-amber-700/40 text-sm font-bold text-amber-300">
                   {card.is_x_star_cost ? "X" : card.star_cost}
                   <img
-                    src={`${API}/static/images/icons/star_icon.webp`}
+                    src={imageUrl("/static/images/icons/star_icon.webp")}
                     alt="star"
                     className="w-4 h-4"
                     crossOrigin="anonymous"
@@ -516,7 +517,7 @@ export default function CardDetail({ initialCard }: { initialCard?: Card | null 
                   </h3>
                   <div className="flex items-center gap-2 text-sm">
                     <img
-                      src={`${API}/static/images/ui/rewards/reward_icon_money.webp`}
+                      src={imageUrl("/static/images/ui/rewards/reward_icon_money.webp")}
                       alt="Gold"
                       className="w-5 h-5"
                       crossOrigin="anonymous"

--- a/frontend/app/cards/[id]/page.tsx
+++ b/frontend/app/cards/[id]/page.tsx
@@ -4,6 +4,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { imageUrl } from "@/lib/image-url";
 
 // 1h on-demand ISR. force-static + revalidate forces Next.js to
 // cache even with async-params pages — without it, Next 15+ sees
@@ -44,7 +45,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         url: `${SITE_URL}/cards/${id}`,
         title,
         description: metaDesc,
-        images: card.image_url ? [{ url: `${API_PUBLIC}${card.image_url}` }] : [],
+        images: card.image_url ? [{ url: imageUrl(card.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: metaDesc },
       alternates: { canonical: `/cards/${id}`, languages: buildLanguageAlternates(`/cards/${id}`) },
@@ -70,7 +71,7 @@ export default async function Page({ params }: Props) {
         name: card.name,
         description: desc || `${card.name} card from Slay the Spire 2`,
         path: `/cards/${id}`,
-        imageUrl: card.image_url ? `${API_PUBLIC}${card.image_url}` : undefined,
+        imageUrl: card.image_url ? imageUrl(card.image_url) : undefined,
         category: "Card",
         breadcrumbs: [
           { name: "Home", href: "/" },

--- a/frontend/app/characters/CharactersClient.tsx
+++ b/frontend/app/characters/CharactersClient.tsx
@@ -9,6 +9,7 @@ import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+import { imageUrl } from "@/lib/image-url";
 
 function toUpperSnake(s: string): string {
   return s.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toUpperCase();
@@ -94,7 +95,7 @@ const [characters, setCharacters] = useState<Character[]>(initialCharacters);
                 {char.name}
               </h2>
               <img
-                src={`${API}/static/images/characters/character_icon_${char.id.toLowerCase()}.webp`}
+                src={imageUrl(`/static/images/characters/character_icon_${char.id.toLowerCase()}.webp`)}
                 alt={`${char.name} - Slay the Spire 2 Character`}
                 className="w-10 h-10 rounded-full object-cover border-2 border-[var(--border-subtle)] ml-auto flex-shrink-0"
                 loading="lazy"

--- a/frontend/app/characters/[id]/CharacterDetail.tsx
+++ b/frontend/app/characters/[id]/CharacterDetail.tsx
@@ -9,6 +9,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+import { imageUrl } from "@/lib/image-url";
 
 function toUpperSnake(s: string): string {
   return s.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toUpperCase();
@@ -153,7 +154,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
       <div className={`rounded-xl border-2 ${style.border} bg-gradient-to-br ${style.bg} to-transparent bg-[var(--bg-card)] p-6 mb-8`}>
         <div className="flex flex-col sm:flex-row items-center gap-6">
           <img
-            src={`${API}/static/images/characters/combat_${char.id.toLowerCase()}.webp`}
+            src={imageUrl(`/static/images/characters/combat_${char.id.toLowerCase()}.webp`)}
             alt={`${char.name} - Slay the Spire 2 Character`}
             className="w-48 h-48 object-contain"
             crossOrigin="anonymous"
@@ -220,7 +221,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
               >
                 {cardData?.image_url && (
                   <img
-                    src={`${API}${cardData.image_url}`}
+                    src={imageUrl(cardData.image_url)}
                     alt={`${cardData.name} - Slay the Spire 2 Card`}
                     className="w-10 h-10 object-contain"
                     crossOrigin="anonymous"
@@ -256,7 +257,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
               >
                 {relicData?.image_url && (
                   <img
-                    src={`${API}${relicData.image_url}`}
+                    src={imageUrl(relicData.image_url)}
                     alt={`${relicData.name} - Slay the Spire 2 Relic`}
                     className="w-10 h-10 object-contain"
                     crossOrigin="anonymous"
@@ -312,7 +313,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
                       >
                         {card.image_url && (
                           <img
-                            src={`${API}${card.image_url}`}
+                            src={imageUrl(card.image_url)}
                             alt={`${card.name} - Slay the Spire 2 Card`}
                             className="w-8 h-8 object-contain flex-shrink-0"
                             crossOrigin="anonymous"
@@ -361,7 +362,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
                 >
                   {relic.image_url && (
                     <img
-                      src={`${API}${relic.image_url}`}
+                      src={imageUrl(relic.image_url)}
                       alt={`${relic.name} - Slay the Spire 2 Relic`}
                       className="w-10 h-10 object-contain flex-shrink-0"
                       crossOrigin="anonymous"

--- a/frontend/app/characters/[id]/page.tsx
+++ b/frontend/app/characters/[id]/page.tsx
@@ -4,6 +4,8 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 
+import { imageUrl } from "@/lib/image-url";
+
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const API_PUBLIC = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_API_URL || "";
 
@@ -30,7 +32,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         url: `${SITE_URL}/characters/${id}`,
         title,
         description: metaDesc,
-        images: [{ url: `${API_PUBLIC}/static/images/characters/combat_${char.id.toLowerCase()}.webp` }],
+        images: [{ url: imageUrl(`/static/images/characters/combat_${char.id.toLowerCase()}.webp`) }],
       },
       twitter: { card: "summary_large_image", title, description: metaDesc },
       alternates: { canonical: `/characters/${id}`, languages: buildLanguageAlternates(`/characters/${id}`) },
@@ -53,7 +55,7 @@ export default async function Page({ params }: Props) {
         name: char.name,
         description: desc || `${char.name} from Slay the Spire 2`,
         path: `/characters/${id}`,
-        imageUrl: `${API_PUBLIC}/static/images/characters/combat_${char.id.toLowerCase()}.webp`,
+        imageUrl: imageUrl(`/static/images/characters/combat_${char.id.toLowerCase()}.webp`),
         category: "Character",
         breadcrumbs: [
           { name: "Home", href: "/" },

--- a/frontend/app/components/CardGrid.tsx
+++ b/frontend/app/components/CardGrid.tsx
@@ -8,6 +8,7 @@ import { useLangPrefix } from "@/lib/use-lang-prefix";
 import RichDescription from "./RichDescription";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+import { imageUrl } from "@/lib/image-url";
 
 const colorMap: Record<string, string> = {
   ironclad: "border-[var(--color-ironclad)]/60 hover:border-[var(--color-ironclad)]",
@@ -96,7 +97,7 @@ function CardItem({ card }: { card: Card }) {
           {(card.star_cost != null || card.is_x_star_cost) && (
             <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-[var(--bg-primary)] border border-amber-700/40 text-xs font-bold text-amber-300">
               {card.is_x_star_cost ? "X" : card.star_cost}
-              <img src={`${API_BASE}/static/images/icons/star_icon.webp`}
+              <img src={imageUrl("/static/images/icons/star_icon.webp")}
                 alt="star" className="w-3.5 h-3.5" crossOrigin="anonymous" />
             </span>
           )}

--- a/frontend/app/components/DonationBanner.tsx
+++ b/frontend/app/components/DonationBanner.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, type ReactNode } from "react";
 import Link from "next/link";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+import { imageUrl } from "@/lib/image-url";
 
 interface RotatingBanner {
   ancient: string;
@@ -137,7 +138,7 @@ function KofiBanner({ onDismiss }: { onDismiss: () => void }) {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex items-center justify-between gap-4">
         <div className="flex items-center gap-3">
           <img
-            src={`${API}/static/images/misc/ancients/nonupeipe.webp`}
+            src={imageUrl("/static/images/misc/ancients/nonupeipe.webp")}
             alt="Nonupeipe"
             className="w-8 h-8 object-contain flex-shrink-0 hidden sm:block"
             crossOrigin="anonymous"
@@ -181,7 +182,7 @@ function AncientBanner({ banner, onDismiss }: { banner: RotatingBanner; onDismis
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex items-center justify-between gap-4">
         <div className="flex items-center gap-3">
           <img
-            src={`${API}/static/images/misc/ancients/${banner.image}`}
+            src={imageUrl(`/static/images/misc/ancients/${banner.image}`)}
             alt={banner.ancient}
             className="w-8 h-8 object-contain flex-shrink-0 hidden sm:block"
             crossOrigin="anonymous"

--- a/frontend/app/components/GlobalSearch.tsx
+++ b/frontend/app/components/GlobalSearch.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useLanguage } from "../contexts/LanguageContext";
 import { buildApiUrl } from "@/lib/fetch-cache";
 import { t } from "@/lib/ui-translations";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -92,9 +93,9 @@ const CATEGORIES: CategoryConfig[] = [
   {
     label: "Images",
     endpoint: "/api/images/search",
-    linkFn: (item) => `${API}${item.url}`,
+    linkFn: (item) => imageUrl(item.url as string),
     subtitleFn: (item) => (item.category_name ? String(item.category_name) : ""),
-    thumbFn: (item) => `${API}${item.url}`,
+    thumbFn: (item) => imageUrl(item.url as string),
     openExternal: true,
   },
 ];

--- a/frontend/app/components/HomeLeaderboardSection.tsx
+++ b/frontend/app/components/HomeLeaderboardSection.tsx
@@ -19,8 +19,10 @@ const RUNS_API = IS_BETA ? "https://spire-codex.com" : API;
 // leaks into the SSR'd HTML.
 const PUBLIC_API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
+import { imageUrl } from "@/lib/image-url";
+
 function characterIcon(character: string): string {
-  return `${PUBLIC_API}/static/images/characters/character_icon_${character.toLowerCase()}.webp`;
+  return imageUrl(`/static/images/characters/character_icon_${character.toLowerCase()}.webp`);
 }
 
 const REVALIDATE = 300;

--- a/frontend/app/components/RelatedItems.tsx
+++ b/frontend/app/components/RelatedItems.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import HoverTooltip from "@/app/components/HoverTooltip";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -73,7 +74,7 @@ export default function RelatedItems({
     const upper = currentId.toUpperCase();
     Promise.all(
       groups.map(async ({ label, path, limit = 12 }) => {
-        const items = await cachedFetch<RelatedItem[]>(`${API}${path}`).catch(() => []);
+        const items = await cachedFetch<RelatedItem[]>(imageUrl(path)).catch(() => []);
         return {
           label,
           items: items

--- a/frontend/app/components/RichDescription.tsx
+++ b/frontend/app/components/RichDescription.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import Link from "next/link";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+import { imageUrl } from "@/lib/image-url";
 
 export interface RelatedCard {
   id: string;
@@ -156,14 +157,14 @@ function renderNode(
 
   if (node.isEnergy) {
     if (node.count === -1) {
-      return <span key={key}><img src={`${API_BASE}/static/images/icons/${energyIcon}_energy_icon.webp`} alt="energy" className="inline-block w-4 h-4 align-text-bottom" crossOrigin="anonymous" />X</span>;
+      return <span key={key}><img src={imageUrl(`/static/images/icons/${energyIcon}_energy_icon.webp`)} alt="energy" className="inline-block w-4 h-4 align-text-bottom" crossOrigin="anonymous" />X</span>;
     }
     const icons = [];
     for (let i = 0; i < (node.count ?? 1); i++) {
       icons.push(
         <img
           key={i}
-          src={`${API_BASE}/static/images/icons/${energyIcon}_energy_icon.webp`}
+          src={imageUrl(`/static/images/icons/${energyIcon}_energy_icon.webp`)}
           alt="energy"
           className="inline-block w-4 h-4 align-text-bottom"
           crossOrigin="anonymous"
@@ -179,7 +180,7 @@ function renderNode(
       icons.push(
         <img
           key={i}
-          src={`${API_BASE}/static/images/icons/star_icon.webp`}
+          src={imageUrl("/static/images/icons/star_icon.webp")}
           alt="star"
           className="inline-block w-4 h-4 align-text-bottom"
           crossOrigin="anonymous"

--- a/frontend/app/components/RunFileHelp.tsx
+++ b/frontend/app/components/RunFileHelp.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useLanguage } from "@/app/contexts/LanguageContext";
+import { t } from "@/lib/ui-translations";
+
+export default function RunFileHelp() {
+  const { lang } = useLanguage();
+
+  return (
+    <div className="text-left text-xs text-[var(--text-muted)] space-y-3">
+      <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+        <a
+          href="https://www.overwolf.com/app/ptrlrd-spire_codex"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center justify-center w-full sm:w-auto px-4 py-2 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-[var(--bg-primary)] hover:opacity-90 transition-opacity"
+        >
+          Download Overwolf Companion App
+        </a>
+      </div>
+
+      <div className="space-y-1.5">
+        <p className="text-[var(--text-secondary)]">
+          {t("Your .run files live here:", lang)}
+        </p>
+        <div>
+          <strong className="text-[var(--text-secondary)] block sm:inline">Windows</strong>
+          <code className="block sm:inline sm:ml-1 mt-0.5 sm:mt-0 bg-[var(--bg-primary)] px-1.5 py-0.5 rounded break-all">
+            %AppData%/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history
+          </code>
+        </div>
+        <div>
+          <strong className="text-[var(--text-secondary)] block sm:inline">macOS</strong>
+          <code className="block sm:inline sm:ml-1 mt-0.5 sm:mt-0 bg-[var(--bg-primary)] px-1.5 py-0.5 rounded break-all">
+            ~/Library/Application Support/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history
+          </code>
+        </div>
+        <div>
+          <strong className="text-[var(--text-secondary)] block sm:inline">Linux / Steam Deck</strong>
+          <code className="block sm:inline sm:ml-1 mt-0.5 sm:mt-0 bg-[var(--bg-primary)] px-1.5 py-0.5 rounded break-all">
+            ~/.local/share/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history
+          </code>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/TierList.tsx
+++ b/frontend/app/components/TierList.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { imageUrl } from "@/lib/image-url";
 
 // Use ?? not || — production sets NEXT_PUBLIC_API_URL="" intentionally
 // so URLs resolve same-origin (nginx proxies /static to the backend
@@ -139,7 +140,7 @@ export default function TierList({ route, entities, showUnrated = true }: TierLi
               >
                 {ent.image_url ? (
                   <img
-                    src={`${API_PUBLIC}${ent.image_url}`}
+                    src={imageUrl(ent.image_url)}
                     alt={ent.name}
                     className="w-12 h-12 sm:w-14 sm:h-14 object-contain"
                     loading="lazy"

--- a/frontend/app/components/TinyCard.tsx
+++ b/frontend/app/components/TinyCard.tsx
@@ -16,8 +16,9 @@ import type { CSSProperties } from "react";
  * `CardPoolModel.DeckEntryCardColor`). See /developers for the full recipe.
  */
 
-const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
-const BASE = `${API}/static/images/ui/run_history_card`;
+import { imageUrl } from "@/lib/image-url";
+
+const BASE = imageUrl("/static/images/ui/run_history_card");
 
 // CardPoolModel.DeckEntryCardColor — one per character/pool.
 export const TINY_CARD_POOL_COLOR: Record<string, string> = {

--- a/frontend/app/enchantments/EnchantmentsClient.tsx
+++ b/frontend/app/enchantments/EnchantmentsClient.tsx
@@ -9,6 +9,7 @@ import SearchFilter from "../components/SearchFilter";
 import RichDescription from "../components/RichDescription";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -93,7 +94,7 @@ export default function EnchantmentsClient({ initialEnchantments }: { initialEnc
             <div className="flex items-start gap-3 mb-2">
               {ench.image_url && (
                 <img
-                  src={`${API}${ench.image_url}`}
+                  src={imageUrl(ench.image_url)}
                   alt={`${ench.name} enchantment icon`}
                   className="w-10 h-10 object-contain flex-shrink-0"
                   loading="lazy"

--- a/frontend/app/enchantments/[id]/EnchantmentDetail.tsx
+++ b/frontend/app/enchantments/[id]/EnchantmentDetail.tsx
@@ -11,6 +11,7 @@ import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -77,7 +78,7 @@ export default function EnchantmentDetail({ initialEnchantment }: { initialEncha
         {enchantment.image_url && (
           <div className="flex justify-center mb-6">
             <img
-              src={`${API}${enchantment.image_url}`}
+              src={imageUrl(enchantment.image_url)}
               alt={`${enchantment.name} - Slay the Spire 2 Enchantment`}
               className="w-24 h-24 object-contain"
               crossOrigin="anonymous"

--- a/frontend/app/enchantments/[id]/page.tsx
+++ b/frontend/app/enchantments/[id]/page.tsx
@@ -4,6 +4,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { imageUrl } from "@/lib/image-url";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const API_PUBLIC = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_API_URL || "";
@@ -30,7 +31,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         url: `${SITE_URL}/enchantments/${id}`,
         title,
         description: metaDesc,
-        images: enchantment.image_url ? [{ url: `${API_PUBLIC}${enchantment.image_url}` }] : [],
+        images: enchantment.image_url ? [{ url: imageUrl(enchantment.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: metaDesc },
       alternates: { canonical: `/enchantments/${id}`, languages: buildLanguageAlternates(`/enchantments/${id}`) },
@@ -54,7 +55,7 @@ export default async function Page({ params }: Props) {
         name: enchantment.name,
         description: desc || `${enchantment.name} enchantment from Slay the Spire 2`,
         path: `/enchantments/${id}`,
-        imageUrl: enchantment.image_url ? `${API_PUBLIC}${enchantment.image_url}` : undefined,
+        imageUrl: enchantment.image_url ? imageUrl(enchantment.image_url) : undefined,
         category: "Enchantment",
         breadcrumbs: [
           { name: "Home", href: "/" },

--- a/frontend/app/events/EventsClient.tsx
+++ b/frontend/app/events/EventsClient.tsx
@@ -9,6 +9,7 @@ import SearchFilter from "../components/SearchFilter";
 import RichDescription from "../components/RichDescription";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -216,7 +217,7 @@ export default function EventsClient({ initialEvents }: { initialEvents: GameEve
                 <div className="flex items-start gap-3">
                   {event.image_url && (
                     <img
-                      src={`${API}${event.image_url}`}
+                      src={imageUrl(event.image_url)}
                       alt={`${event.name} - Slay the Spire 2 Event`}
                       className="w-10 h-10 object-contain flex-shrink-0"
                       crossOrigin="anonymous"
@@ -346,7 +347,7 @@ export default function EventsClient({ initialEvents }: { initialEvents: GameEve
                         >
                           {relic?.image_url && (
                             <img
-                              src={`${API}${relic.image_url}`}
+                              src={imageUrl(relic.image_url)}
                               alt={`${relic.name} - Slay the Spire 2 Relic`}
                               className="w-8 h-8 object-contain flex-shrink-0"
                               crossOrigin="anonymous"

--- a/frontend/app/events/[id]/EventDetail.tsx
+++ b/frontend/app/events/[id]/EventDetail.tsx
@@ -8,6 +8,7 @@ import RichDescription from "@/app/components/RichDescription";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import LocalizedNames from "@/app/components/LocalizedNames";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -130,7 +131,7 @@ export default function EventDetail({ initialEvent }: { initialEvent?: GameEvent
         {event.image_url && (
           <div className="flex justify-center mb-4">
             <img
-              src={`${API}${event.image_url}`}
+              src={imageUrl(event.image_url)}
               alt={`${event.name} - Slay the Spire 2 Event`}
               className="w-20 h-20 object-contain"
               crossOrigin="anonymous"
@@ -242,7 +243,7 @@ export default function EventDetail({ initialEvent }: { initialEvent?: GameEvent
                   >
                     {relic?.image_url && (
                       <img
-                        src={`${API}${relic.image_url}`}
+                        src={imageUrl(relic.image_url)}
                         alt={`${relic.name} - Slay the Spire 2 Relic`}
                         className="w-8 h-8 object-contain flex-shrink-0"
                         crossOrigin="anonymous"

--- a/frontend/app/events/[id]/page.tsx
+++ b/frontend/app/events/[id]/page.tsx
@@ -4,6 +4,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { imageUrl } from "@/lib/image-url";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const API_PUBLIC = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_API_URL || "";
@@ -30,7 +31,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         url: `${SITE_URL}/events/${id}`,
         title,
         description: metaDesc,
-        images: event.image_url ? [{ url: `${API_PUBLIC}${event.image_url}` }] : [],
+        images: event.image_url ? [{ url: imageUrl(event.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: metaDesc },
       alternates: { canonical: `/events/${id}`, languages: buildLanguageAlternates(`/events/${id}`) },
@@ -54,7 +55,7 @@ export default async function Page({ params }: Props) {
         name: event.name,
         description: desc || `${event.name} event from Slay the Spire 2`,
         path: `/events/${id}`,
-        imageUrl: event.image_url ? `${API_PUBLIC}${event.image_url}` : undefined,
+        imageUrl: event.image_url ? imageUrl(event.image_url) : undefined,
         category: "Event",
         breadcrumbs: [
           { name: "Home", href: "/" },

--- a/frontend/app/images/page.tsx
+++ b/frontend/app/images/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -261,7 +262,7 @@ export default function ImagesPage() {
                         >
                           <div className="flex items-center justify-center p-2">
                             <img
-                              src={`${API}${img.url}`}
+                              src={imageUrl(img.url)}
                               alt={img.filename.replace(/\.(png|webp|gif|jpe?g)$/i, "").replace(/_/g, " ")}
                               crossOrigin="anonymous"
                               loading="lazy"

--- a/frontend/app/intents/[id]/IntentDetail.tsx
+++ b/frontend/app/intents/[id]/IntentDetail.tsx
@@ -11,6 +11,7 @@ import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -63,7 +64,7 @@ export default function IntentDetail({ initialIntent }: { initialIntent?: Intent
         {intent.image_url && (
           <div className="flex justify-center mb-4">
             <img
-              src={`${API}${intent.image_url}`}
+              src={imageUrl(intent.image_url)}
               alt={`${intent.name} - Slay the Spire 2 Intent`}
               className="w-16 h-16 object-contain"
               crossOrigin="anonymous"

--- a/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
+++ b/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
@@ -8,6 +8,7 @@ import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+import { imageUrl } from "@/lib/image-url";
 
 function cleanId(id: string): string {
   return id.replace(/^(CHARACTER|CARD|RELIC|ENCOUNTER|EVENT|MONSTER|ACT|POTION)\./, "");
@@ -345,7 +346,7 @@ export default function LeaderboardBrowseClient() {
                 }
               >
                 <img
-                  src={`${API}/static/images/characters/character_icon_${ch.toLowerCase()}.webp`}
+                  src={imageUrl(`/static/images/characters/character_icon_${ch.toLowerCase()}.webp`)}
                   alt=""
                   aria-hidden
                   className="w-6 h-6 object-contain flex-shrink-0"

--- a/frontend/app/leaderboards/submit/SubmitRunClient.tsx
+++ b/frontend/app/leaderboards/submit/SubmitRunClient.tsx
@@ -2,21 +2,44 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { useLanguage } from "@/app/contexts/LanguageContext";
+import { useAuth } from "@/app/contexts/AuthContext";
 import { t } from "@/lib/ui-translations";
 import { IS_BETA } from "@/lib/seo";
 import RunFileHelp from "@/app/components/RunFileHelp";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
+interface Run {
+  run_hash: string;
+  character: string;
+  win: boolean;
+  was_abandoned: boolean;
+  ascension: number;
+  floors_reached: number;
+  submitted_at: string;
+}
+
+const CHARACTER_COLORS: Record<string, string> = {
+  IRONCLAD: "#d53b27",
+  SILENT: "#23935b",
+  DEFECT: "#3873a9",
+  NECROBINDER: "#bf5a85",
+  REGENT: "#f07c1e",
+};
+
 export default function SubmitRunClient() {
   const router = useRouter();
   const lp = useLangPrefix();
   const { lang } = useLanguage();
-  const [jsonInput, setJsonInput] = useState("");
+  const { user, loading: authLoading, loginSteam, loginDiscord } = useAuth();
   const [error, setError] = useState("");
   const [username, setUsername] = useState("");
+  const [runs, setRuns] = useState<Run[]>([]);
+  const [runsTotal, setRunsTotal] = useState(0);
+  const [runsLoading, setRunsLoading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState<{
     total: number;
     done: number;
@@ -176,38 +199,25 @@ export default function SubmitRunClient() {
     [username, lp, router]
   );
 
-  function parseRun() {
-    setError("");
+  const fetchRuns = useCallback(async () => {
+    setRunsLoading(true);
     try {
-      const data = JSON.parse(jsonInput);
-      if (!data.players || !data.map_point_history || !Array.isArray(data.acts)) {
-        setError(
-          t("submit_invalid_run", lang)
-        );
-        return;
+      const res = await fetch(`${API}/api/auth/runs?page=1&limit=5`, {
+        credentials: "include",
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setRuns(data.runs || []);
+        setRunsTotal(data.total || 0);
       }
-      // Submit and redirect
-      const submitUrl = username.trim()
-        ? `${API}/api/runs?username=${encodeURIComponent(username.trim())}`
-        : `${API}/api/runs`;
-      fetch(submitUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: jsonInput,
-      })
-        .then((r) => r.json().catch(() => null))
-        .then((d) => {
-          if (d?.run_hash) {
-            router.push(`${lp}/runs/${d.run_hash}`);
-          }
-        })
-        .catch(() => {});
-    } catch {
-      setError(
-        "Invalid JSON. Make sure you pasted the full contents of the .run file."
-      );
+    } catch {} finally {
+      setRunsLoading(false);
     }
-  }
+  }, []);
+
+  useEffect(() => {
+    if (user) fetchRuns();
+  }, [user, fetchRuns]);
 
   // Drag-and-drop handlers for the upload area
   const handleDragEnter = useCallback((e: React.DragEvent) => {
@@ -306,17 +316,43 @@ export default function SubmitRunClient() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">{t("Submit a Run", lang)}</span>
-      </h1>
-      <p className="text-sm text-[var(--text-muted)] mb-6">
-        {t("submit_tagline", lang)}
-      </p>
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold mb-2">
+          <span className="text-[var(--accent-gold)]">{t("Submit a Run", lang)}</span>
+        </h1>
+        <p className="text-sm text-[var(--text-muted)]">
+          {t("submit_tagline", lang)}
+        </p>
+      </div>
 
-      <div className="space-y-4">
-        {/* Username — full width on mobile, fixed-width on sm+ where the
-            sparse layout looked goofy with a 100% input. */}
+      {/* Sign in prompt */}
+      {!authLoading && !user && (
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4 sm:p-5">
+          <p className="text-sm text-[var(--text-secondary)] mb-3">
+            Sign in to automatically associate runs with your account.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={loginSteam}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-card-hover)] transition-colors"
+            >
+              <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="currentColor"><path d="M11.979 0C5.678 0 .511 4.86.022 11.037l6.432 2.658a3.387 3.387 0 0 1 1.912-.593c.064 0 .127.003.19.007l2.862-4.146v-.058a4.533 4.533 0 0 1 4.53-4.53 4.533 4.533 0 0 1 4.53 4.53 4.533 4.533 0 0 1-4.53 4.53h-.106l-4.08 2.91c0 .053.003.107.003.161a3.4 3.4 0 0 1-3.4 3.4 3.404 3.404 0 0 1-3.367-2.936L.256 15.21C1.542 20.2 6.218 24 11.979 24 18.627 24 24 18.627 24 11.979 24 5.373 18.627 0 11.979 0z"/></svg>
+              Steam
+            </button>
+            <button
+              onClick={loginDiscord}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-card-hover)] transition-colors"
+            >
+              <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/></svg>
+              Discord
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Username input (only when not signed in) */}
+      {!user && (
         <input
           type="text"
           value={username}
@@ -325,116 +361,147 @@ export default function SubmitRunClient() {
           maxLength={25}
           className="px-3 py-2 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm focus:outline-none focus:border-[var(--accent-gold)] w-full sm:w-48"
         />
+      )}
 
-        {/* File Upload with drag-and-drop. Mobile gets shorter padding
-            (p-4 instead of p-6) and the path-help is collapsed into a
-            <details> so the long save-game paths don't blow up the
-            viewport. Mobile also gets a touch-friendly button copy
-            since drag-and-drop is desktop-only. */}
-        <div
-          onDragEnter={handleDragEnter}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
-          className={`bg-[var(--bg-card)] rounded-xl p-4 sm:p-6 text-center transition-colors ${
-            isDragging
-              ? "border-2 border-solid border-[var(--accent-gold)] bg-[var(--accent-gold)]/5"
-              : "border border-dashed border-[var(--border-accent)]"
-          }`}
-        >
-          <p className="text-sm text-[var(--text-secondary)] mb-3">
-            {isDragging
-              ? t("Drop files here...", lang)
-              : (
-                <>
-                  <span className="hidden sm:inline">{t("Drag & drop .run files here, or click to select", lang)}</span>
-                  <span className="sm:hidden">{t("Tap below to choose .run files", lang)}</span>
-                </>
-              )}
+      {/* Drop zone */}
+      <div
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        onClick={() => fileInputRef.current?.click()}
+        className={`border-2 border-dashed rounded-lg p-6 sm:p-8 text-center cursor-pointer transition-colors ${
+          isDragging
+            ? "border-[var(--accent-gold)] bg-[var(--accent-gold)]/5"
+            : "border-[var(--border-subtle)] hover:border-[var(--border-accent)]"
+        }`}
+      >
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept=".run,.json"
+          className="hidden"
+          onChange={(e) => {
+            if (e.target.files) handleFileUpload(e.target.files);
+            e.target.value = "";
+          }}
+        />
+        {isDragging ? (
+          <p className="text-[var(--text-primary)] font-medium">
+            {t("Drop files here...", lang)}
           </p>
-
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-center gap-2 sm:gap-3">
-            <label className="inline-flex items-center justify-center w-full sm:w-auto px-5 py-2.5 sm:py-2 rounded-lg text-sm font-medium bg-[var(--bg-primary)] text-[var(--text-primary)] border border-[var(--border-accent)] hover:bg-[var(--bg-card-hover)] transition-colors cursor-pointer">
-              {t("Choose Files", lang)}
-              <input
-                ref={fileInputRef}
-                type="file"
-                multiple
-                accept=".run,.json"
-                className="hidden"
-                onChange={(e) =>
-                  e.target.files && handleFileUpload(e.target.files)
-                }
-              />
-            </label>
-          </div>
-
-          <div className="mt-4 pt-4 border-t border-[var(--border-subtle)]">
-            <RunFileHelp />
-          </div>
-          {uploadProgress && (
-            <div className="mt-4">
-              <div className="w-full bg-[var(--bg-primary)] rounded-full h-2 mb-2">
-                <div
-                  className="h-2 rounded-full bg-[var(--accent-gold)] transition-all"
-                  style={{
-                    width: `${(uploadProgress.done / uploadProgress.total) * 100}%`,
-                  }}
-                />
-              </div>
-              <p className="text-xs text-[var(--text-muted)]">
-                {uploadProgress.done === uploadProgress.total ? (
-                  <>
-                    {t("Done!", lang)}{" "}
-                    {uploadProgress.total -
-                      uploadProgress.dupes -
-                      uploadProgress.errors}{" "}
-                    {t("submitted", lang)}
-                    {uploadProgress.dupes > 0 && (
-                      <>, {uploadProgress.dupes} {t("duplicates skipped", lang)}</>
-                    )}
-                    {uploadProgress.errors > 0 && (
-                      <>, {uploadProgress.errors} {t("invalid", lang)}</>
-                    )}
-                  </>
-                ) : (
-                  <>
-                    {t("Processing", lang)} {uploadProgress.done} {t("of", lang)}{" "}
-                    {uploadProgress.total}...
-                  </>
-                )}
-              </p>
-            </div>
-          )}
-        </div>
-
-        {/* Or paste JSON */}
-        <div className="relative">
-          <div className="absolute inset-x-0 top-0 flex items-center justify-center -mt-2">
-            <span className="bg-[var(--bg-primary)] px-3 text-xs text-[var(--text-muted)]">
-              {t("or paste JSON", lang)}
-            </span>
-          </div>
-          <textarea
-            value={jsonInput}
-            onChange={(e) => setJsonInput(e.target.value)}
-            placeholder='{"acts":["ACT.OVERGROWTH"...],"ascension":0,...}'
-            rows={6}
-            className="w-full px-4 py-3 pt-5 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm font-mono focus:outline-none focus:border-[var(--accent-gold)] resize-none"
-          />
-          <button
-            onClick={parseRun}
-            disabled={!jsonInput.trim()}
-            className="mt-2 w-full sm:w-auto px-5 py-2.5 sm:py-2 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-[var(--bg-primary)] hover:opacity-90 transition-opacity disabled:opacity-50"
-          >
-            {t("Analyze Run", lang)}
-          </button>
-        </div>
-
-        {error && (
-          <p className="text-[var(--color-ironclad)] text-sm">{error}</p>
+        ) : (
+          <p className="text-[var(--text-primary)] font-medium">
+            Drop .run files here or click to browse
+          </p>
         )}
       </div>
+
+      {/* Upload progress */}
+      {uploadProgress && (
+        <div>
+          <div className="w-full bg-[var(--bg-primary)] rounded-full h-2 mb-2">
+            <div
+              className="h-2 rounded-full bg-[var(--accent-gold)] transition-all"
+              style={{
+                width: `${(uploadProgress.done / uploadProgress.total) * 100}%`,
+              }}
+            />
+          </div>
+          <p className="text-xs text-[var(--text-muted)]">
+            {uploadProgress.done === uploadProgress.total ? (
+              <>
+                {t("Done!", lang)}{" "}
+                {uploadProgress.total - uploadProgress.dupes - uploadProgress.errors}{" "}
+                {t("submitted", lang)}
+                {uploadProgress.dupes > 0 && (
+                  <>, {uploadProgress.dupes} {t("duplicates skipped", lang)}</>
+                )}
+                {uploadProgress.errors > 0 && (
+                  <>, {uploadProgress.errors} {t("invalid", lang)}</>
+                )}
+              </>
+            ) : (
+              <>
+                {t("Processing", lang)} {uploadProgress.done} {t("of", lang)}{" "}
+                {uploadProgress.total}...
+              </>
+            )}
+          </p>
+        </div>
+      )}
+
+      {/* OS paths + Overwolf */}
+      <RunFileHelp />
+
+      {error && (
+        <p className="text-[var(--color-ironclad)] text-sm">{error}</p>
+      )}
+
+      {/* Your Runs (signed in only) */}
+      {user && (
+        <section>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-lg font-semibold text-[var(--text-primary)]">
+              Your Runs {runsTotal > 0 && <span className="text-sm font-normal text-[var(--text-tertiary)]">({runsTotal})</span>}
+            </h2>
+            {runsTotal > 5 && (
+              <Link
+                href={`${lp}/profile`}
+                className="text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+              >
+                View all
+              </Link>
+            )}
+          </div>
+
+          {runsLoading ? (
+            <div className="space-y-2">
+              {[...Array(3)].map((_, i) => (
+                <div key={i} className="h-12 bg-[var(--bg-card)] rounded animate-pulse" />
+              ))}
+            </div>
+          ) : runs.length === 0 ? (
+            <p className="text-sm text-[var(--text-secondary)] py-4">
+              No runs yet. Upload .run files above to get started.
+            </p>
+          ) : (
+            <div className="space-y-1.5">
+              {runs.map((run) => (
+                <Link
+                  key={run.run_hash}
+                  href={`${lp}/runs/${run.run_hash}`}
+                  className="flex items-center gap-2 sm:gap-3 px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] text-sm hover:bg-[var(--bg-card-hover)] transition-colors"
+                >
+                  <span
+                    className="w-2 h-2 rounded-full shrink-0"
+                    style={{ backgroundColor: CHARACTER_COLORS[run.character] || "#888" }}
+                  />
+                  <span className="font-medium text-[var(--text-primary)] w-20 sm:w-24 truncate">
+                    {run.character}
+                  </span>
+                  <span className={`shrink-0 text-xs px-1.5 py-0.5 rounded ${
+                    run.win
+                      ? "bg-green-500/15 text-green-400"
+                      : run.was_abandoned
+                        ? "bg-yellow-500/15 text-yellow-400"
+                        : "bg-red-500/15 text-red-400"
+                  }`}>
+                    {run.win ? "W" : run.was_abandoned ? "A" : "L"}
+                  </span>
+                  <span className="text-[var(--text-tertiary)] text-xs hidden sm:inline">
+                    A{run.ascension}
+                  </span>
+                  <span className="text-[var(--text-tertiary)] text-xs hidden sm:inline">
+                    F{run.floors_reached}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          )}
+        </section>
+      )}
     </div>
   );
 }

--- a/frontend/app/leaderboards/submit/SubmitRunClient.tsx
+++ b/frontend/app/leaderboards/submit/SubmitRunClient.tsx
@@ -6,6 +6,7 @@ import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import { IS_BETA } from "@/lib/seo";
+import RunFileHelp from "@/app/components/RunFileHelp";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -353,14 +354,6 @@ export default function SubmitRunClient() {
           </p>
 
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-center gap-2 sm:gap-3">
-            <a
-              href="https://www.overwolf.com/app/ptrlrd-spire_codex"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center justify-center w-full sm:w-auto px-5 py-2.5 sm:py-2 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-[var(--bg-primary)] hover:opacity-90 transition-opacity"
-            >
-              Download Overwolf Companion App
-            </a>
             <label className="inline-flex items-center justify-center w-full sm:w-auto px-5 py-2.5 sm:py-2 rounded-lg text-sm font-medium bg-[var(--bg-primary)] text-[var(--text-primary)] border border-[var(--border-accent)] hover:bg-[var(--bg-card-hover)] transition-colors cursor-pointer">
               {t("Choose Files", lang)}
               <input
@@ -376,30 +369,8 @@ export default function SubmitRunClient() {
             </label>
           </div>
 
-          {/* File paths — kept visible (not collapsed) so users can find
-              their .run files without digging through a disclosure. */}
-          <div className="mt-4 pt-4 border-t border-[var(--border-subtle)] text-left text-xs text-[var(--text-muted)] space-y-1.5">
-            <p className="text-[var(--text-secondary)] mb-2">
-              {t("Your .run files live here:", lang)}
-            </p>
-            <div>
-              <strong className="text-[var(--text-secondary)] block sm:inline">Windows</strong>
-              <code className="block sm:inline sm:ml-1 mt-0.5 sm:mt-0 bg-[var(--bg-primary)] px-1.5 py-0.5 rounded break-all">
-                %AppData%/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history
-              </code>
-            </div>
-            <div>
-              <strong className="text-[var(--text-secondary)] block sm:inline">macOS</strong>
-              <code className="block sm:inline sm:ml-1 mt-0.5 sm:mt-0 bg-[var(--bg-primary)] px-1.5 py-0.5 rounded break-all">
-                ~/Library/Application Support/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history
-              </code>
-            </div>
-            <div>
-              <strong className="text-[var(--text-secondary)] block sm:inline">Linux / Steam Deck</strong>
-              <code className="block sm:inline sm:ml-1 mt-0.5 sm:mt-0 bg-[var(--bg-primary)] px-1.5 py-0.5 rounded break-all">
-                ~/.local/share/SlayTheSpire2/steam/&lt;steamid&gt;/profile1/saves/history
-              </code>
-            </div>
+          <div className="mt-4 pt-4 border-t border-[var(--border-subtle)]">
+            <RunFileHelp />
           </div>
           {uploadProgress && (
             <div className="mt-4">

--- a/frontend/app/monsters/MonstersClient.tsx
+++ b/frontend/app/monsters/MonstersClient.tsx
@@ -8,6 +8,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import SearchFilter from "../components/SearchFilter";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -124,7 +125,7 @@ export default function MonstersClient({ initialMonsters }: { initialMonsters: M
             {monster.image_url && (
               <div className="mb-3 -mx-4 -mt-4">
                 <img
-                  src={`${API}${monster.image_url}`}
+                  src={imageUrl(monster.image_url)}
                   alt={`${monster.name} - Slay the Spire 2 Monster`}
                   className="w-full h-40 object-contain rounded-t-lg"
                   loading="lazy"

--- a/frontend/app/monsters/[id]/MonsterDetail.tsx
+++ b/frontend/app/monsters/[id]/MonsterDetail.tsx
@@ -10,6 +10,7 @@ import { useLangPrefix } from "@/lib/use-lang-prefix";
 import RichDescription from "@/app/components/RichDescription";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -82,7 +83,7 @@ function PowerPill({
           <div className="flex items-center gap-2 mb-1.5">
             {power.image_url && (
               <img
-                src={`${API}${power.image_url}`}
+                src={imageUrl(power.image_url)}
                 alt=""
                 className="w-6 h-6 object-contain"
                 crossOrigin="anonymous"
@@ -291,7 +292,7 @@ export default function MonsterDetail({ initialMonster }: { initialMonster?: Mon
       {monster.image_url && (
         <div className="mb-6">
           <img
-            src={`${API}${betaArt && monster.beta_image_url ? monster.beta_image_url : monster.image_url}`}
+            src={imageUrl(betaArt && monster.beta_image_url ? monster.beta_image_url : monster.image_url)}
             alt={`${monster.name} - Slay the Spire 2 Monster`}
             className="mx-auto max-h-80 object-contain"
             crossOrigin="anonymous"

--- a/frontend/app/monsters/[id]/page.tsx
+++ b/frontend/app/monsters/[id]/page.tsx
@@ -3,6 +3,7 @@ import MonsterDetail from "./MonsterDetail";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { clipMetaDescription, buildLanguageAlternates, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-static";
 export const revalidate = 3600;
@@ -36,7 +37,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         url: `${SITE_URL}/monsters/${id}`,
         title,
         description: metaDesc,
-        images: monster.image_url ? [{ url: `${API_PUBLIC}${monster.image_url}` }] : [],
+        images: monster.image_url ? [{ url: imageUrl(monster.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: metaDesc },
       alternates: { canonical: `/monsters/${id}`, languages: buildLanguageAlternates(`/monsters/${id}`) },
@@ -62,7 +63,7 @@ export default async function Page({ params }: Props) {
         name: monster.name,
         description: desc,
         path: `/monsters/${id}`,
-        imageUrl: monster.image_url ? `${API_PUBLIC}${monster.image_url}` : undefined,
+        imageUrl: monster.image_url ? imageUrl(monster.image_url) : undefined,
         category: "Monster",
         breadcrumbs: [
           { name: "Home", href: "/" },

--- a/frontend/app/orbs/[id]/OrbDetail.tsx
+++ b/frontend/app/orbs/[id]/OrbDetail.tsx
@@ -11,6 +11,7 @@ import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -63,7 +64,7 @@ export default function OrbDetail({ initialOrb }: { initialOrb?: Orb | null } = 
         {orb.image_url && (
           <div className="flex justify-center mb-4">
             <img
-              src={`${API}${orb.image_url}`}
+              src={imageUrl(orb.image_url)}
               alt={`${orb.name} - Slay the Spire 2 Orb`}
               className="w-16 h-16 object-contain"
               crossOrigin="anonymous"

--- a/frontend/app/potions/PotionsClient.tsx
+++ b/frontend/app/potions/PotionsClient.tsx
@@ -10,6 +10,7 @@ import RichDescription from "../components/RichDescription";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { useEntityScores } from "@/lib/use-entity-scores";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -152,7 +153,7 @@ export default function PotionsClient({ initialPotions }: { initialPotions: Poti
                 <div className="flex gap-3">
                   {potion.image_url && (
                     <img
-                      src={`${API}${potion.image_url}`}
+                      src={imageUrl(potion.image_url)}
                       alt={`${potion.name} - Slay the Spire 2 Potion`}
                       className="w-12 h-12 object-contain flex-shrink-0"
                       loading="lazy"

--- a/frontend/app/potions/[id]/PotionDetail.tsx
+++ b/frontend/app/potions/[id]/PotionDetail.tsx
@@ -13,6 +13,7 @@ import EntityHistory from "@/app/components/EntityHistory";
 import RelatedItems from "@/app/components/RelatedItems";
 import EntityProse from "@/app/components/EntityProse";
 import EntityRunStats from "@/app/components/EntityRunStats";
+import { imageUrl } from "@/lib/image-url";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -98,7 +99,7 @@ export default function PotionDetail({ initialPotion }: { initialPotion?: Potion
         {potion.image_url && (
           <div className="flex justify-center mb-6">
             <img
-              src={`${API}${potion.image_url}`}
+              src={imageUrl(potion.image_url)}
               alt={`${potion.name} - Slay the Spire 2 Potion`}
               className="w-24 h-24 object-contain"
               crossOrigin="anonymous"
@@ -161,7 +162,7 @@ export default function PotionDetail({ initialPotion }: { initialPotion?: Potion
                 </h3>
                 <div className="flex items-center gap-2 text-sm">
                   <img
-                    src={`${API}/static/images/ui/rewards/reward_icon_money.webp`}
+                    src={imageUrl("/static/images/ui/rewards/reward_icon_money.webp")}
                     alt="Gold"
                     className="w-5 h-5"
                     crossOrigin="anonymous"

--- a/frontend/app/potions/[id]/page.tsx
+++ b/frontend/app/potions/[id]/page.tsx
@@ -4,6 +4,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { imageUrl } from "@/lib/image-url";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const API_PUBLIC = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_API_URL || "";
@@ -30,7 +31,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         url: `${SITE_URL}/potions/${id}`,
         title,
         description: metaDesc,
-        images: potion.image_url ? [{ url: `${API_PUBLIC}${potion.image_url}` }] : [],
+        images: potion.image_url ? [{ url: imageUrl(potion.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: metaDesc },
       alternates: { canonical: `/potions/${id}`, languages: buildLanguageAlternates(`/potions/${id}`) },
@@ -54,7 +55,7 @@ export default async function Page({ params }: Props) {
         name: potion.name,
         description: desc || `${potion.name} potion from Slay the Spire 2`,
         path: `/potions/${id}`,
-        imageUrl: potion.image_url ? `${API_PUBLIC}${potion.image_url}` : undefined,
+        imageUrl: potion.image_url ? imageUrl(potion.image_url) : undefined,
         category: "Potion",
         breadcrumbs: [
           { name: "Home", href: "/" },

--- a/frontend/app/powers/PowersClient.tsx
+++ b/frontend/app/powers/PowersClient.tsx
@@ -8,6 +8,7 @@ import SearchFilter from "../components/SearchFilter";
 import RichDescription from "../components/RichDescription";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -91,7 +92,7 @@ const [powers, setPowers] = useState<Power[]>(initialPowers);
                 <div className="flex items-center gap-2">
                   {power.image_url && (
                     <img
-                      src={`${API}${power.image_url}`}
+                      src={imageUrl(power.image_url)}
                       alt=""
                       className="w-8 h-8 object-contain flex-shrink-0"
                       crossOrigin="anonymous"

--- a/frontend/app/powers/[id]/PowerDetail.tsx
+++ b/frontend/app/powers/[id]/PowerDetail.tsx
@@ -11,6 +11,7 @@ import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -86,7 +87,7 @@ export default function PowerDetail({ initialPower }: { initialPower?: Power | n
         {power.image_url && (
           <div className="flex justify-center mb-6">
             <img
-              src={`${API}${power.image_url}`}
+              src={imageUrl(power.image_url)}
               alt={`${power.name} - Slay the Spire 2 Power`}
               className="w-24 h-24 object-contain"
               crossOrigin="anonymous"

--- a/frontend/app/powers/[id]/page.tsx
+++ b/frontend/app/powers/[id]/page.tsx
@@ -4,6 +4,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { imageUrl } from "@/lib/image-url";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const API_PUBLIC = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_API_URL || "";
@@ -30,7 +31,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         url: `${SITE_URL}/powers/${id}`,
         title,
         description: metaDesc,
-        images: power.image_url ? [{ url: `${API_PUBLIC}${power.image_url}` }] : [],
+        images: power.image_url ? [{ url: imageUrl(power.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: metaDesc },
       alternates: { canonical: `/powers/${id}`, languages: buildLanguageAlternates(`/powers/${id}`) },
@@ -54,7 +55,7 @@ export default async function Page({ params }: Props) {
         name: power.name,
         description: desc || `${power.name} power from Slay the Spire 2`,
         path: `/powers/${id}`,
-        imageUrl: power.image_url ? `${API_PUBLIC}${power.image_url}` : undefined,
+        imageUrl: power.image_url ? imageUrl(power.image_url) : undefined,
         category: "Power",
         breadcrumbs: [
           { name: "Home", href: "/" },

--- a/frontend/app/profile/ProfileClient.tsx
+++ b/frontend/app/profile/ProfileClient.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useAuth } from "@/app/contexts/AuthContext";
 import { useToast } from "@/app/components/Toast";
+import RunFileHelp from "@/app/components/RunFileHelp";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -193,15 +194,14 @@ export default function ProfileClient() {
           {uploading ? (
             <p className="text-[var(--text-secondary)]">Uploading...</p>
           ) : (
-            <>
-              <p className="text-[var(--text-primary)] font-medium mb-1">
-                Drop .run files here or click to browse
-              </p>
-              <p className="text-xs text-[var(--text-tertiary)]">
-                Windows: %APPDATA%/SlayTheSpire2/runs/ &middot; Mac: ~/Library/Application Support/SlayTheSpire2/runs/
-              </p>
-            </>
+            <p className="text-[var(--text-primary)] font-medium">
+              Drop .run files here or click to browse
+            </p>
           )}
+        </div>
+
+        <div className="mt-4">
+          <RunFileHelp />
         </div>
 
         {uploadResults && uploadResults.length > 0 && (

--- a/frontend/app/reference/ReferenceClient.tsx
+++ b/frontend/app/reference/ReferenceClient.tsx
@@ -16,6 +16,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import RichDescription from "../components/RichDescription";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -189,7 +190,7 @@ export default function ReferenceClient({
           <div className="flex items-start gap-3">
             {orb.image_url && (
               <img
-                src={`${API}${orb.image_url}`}
+                src={imageUrl(orb.image_url)}
                 alt={orb.name}
                 className="w-10 h-10 object-contain flex-shrink-0 mt-0.5"
                 crossOrigin="anonymous"
@@ -249,7 +250,7 @@ export default function ReferenceClient({
           <div className="flex items-start gap-3">
             {intent.image_url && (
               <img
-                src={`${API}${intent.image_url}`}
+                src={imageUrl(intent.image_url)}
                 alt={intent.name}
                 className="w-10 h-10 object-contain flex-shrink-0 mt-0.5"
                 crossOrigin="anonymous"

--- a/frontend/app/relics/RelicsClient.tsx
+++ b/frontend/app/relics/RelicsClient.tsx
@@ -10,6 +10,7 @@ import RichDescription from "../components/RichDescription";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { useEntityScores } from "@/lib/use-entity-scores";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -154,7 +155,7 @@ export default function RelicsClient({ initialRelics }: { initialRelics: Relic[]
               <div className="flex gap-3">
                 {relic.image_url && (
                   <img
-                    src={`${API}${relic.image_url}`}
+                    src={imageUrl(relic.image_url)}
                     alt={`${relic.name} - Slay the Spire 2 Relic`}
                     className="w-12 h-12 object-contain flex-shrink-0"
                     loading="lazy"

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -13,6 +13,7 @@ import EntityHistory from "@/app/components/EntityHistory";
 import RelatedItems from "@/app/components/RelatedItems";
 import EntityProse from "@/app/components/EntityProse";
 import EntityRunStats from "@/app/components/EntityRunStats";
+import { imageUrl } from "@/lib/image-url";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -100,7 +101,7 @@ export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | n
         {relic.image_url && (
           <div className="flex flex-col items-center mb-6">
             <img
-              src={`${API}${selectedVariant || relic.image_url}`}
+              src={imageUrl(selectedVariant || relic.image_url)}
               alt={`${relic.name}${selectedChar ? ` (${selectedChar})` : ""} - Slay the Spire 2 Relic`}
               className="w-24 h-24 object-contain"
               crossOrigin="anonymous"
@@ -222,7 +223,7 @@ export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | n
                 </h3>
                 <div className="flex items-center gap-2 text-sm">
                   <img
-                    src={`${API}/static/images/ui/rewards/reward_icon_money.webp`}
+                    src={imageUrl("/static/images/ui/rewards/reward_icon_money.webp")}
                     alt="Gold"
                     className="w-5 h-5"
                     crossOrigin="anonymous"

--- a/frontend/app/relics/[id]/page.tsx
+++ b/frontend/app/relics/[id]/page.tsx
@@ -4,6 +4,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { imageUrl } from "@/lib/image-url";
 
 // Relic data only changes on deploy. force-static + revalidate
 // keeps Next.js from auto-marking the page dynamic just because we
@@ -38,7 +39,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         url: `${SITE_URL}/relics/${id}`,
         title,
         description: metaDesc,
-        images: relic.image_url ? [{ url: `${API_PUBLIC}${relic.image_url}` }] : [],
+        images: relic.image_url ? [{ url: imageUrl(relic.image_url) }] : [],
       },
       twitter: { card: "summary_large_image", title, description: metaDesc },
       alternates: { canonical: `/relics/${id}`, languages: buildLanguageAlternates(`/relics/${id}`) },
@@ -64,7 +65,7 @@ export default async function Page({ params }: Props) {
         name: relic.name,
         description: desc || `${relic.name} relic from Slay the Spire 2`,
         path: `/relics/${id}`,
-        imageUrl: relic.image_url ? `${API_PUBLIC}${relic.image_url}` : undefined,
+        imageUrl: relic.image_url ? imageUrl(relic.image_url) : undefined,
         category: "Relic",
         breadcrumbs: [
           { name: "Home", href: "/" },

--- a/frontend/app/runs/RunsClient.tsx
+++ b/frontend/app/runs/RunsClient.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import { cachedFetch } from "@/lib/fetch-cache";
 import RichDescription from "../components/RichDescription";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -62,7 +63,7 @@ function CardPill({
         <div className="absolute z-50 bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 p-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] shadow-xl pointer-events-none">
           <div className="flex items-start gap-2 mb-1.5">
             {info.image_url && (
-              <img src={`${API}${info.image_url}`} alt="" className="w-10 h-10 object-cover rounded" crossOrigin="anonymous" />
+              <img src={imageUrl(info.image_url)} alt="" className="w-10 h-10 object-cover rounded" crossOrigin="anonymous" />
             )}
             <div className="min-w-0">
               <div className="font-semibold text-xs text-[var(--text-primary)] truncate">{info.name}</div>
@@ -107,7 +108,7 @@ function RelicPill({
         <div className="absolute z-50 bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 p-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] shadow-xl pointer-events-none">
           <div className="flex items-start gap-2 mb-1.5">
             {info.image_url && (
-              <img src={`${API}${info.image_url}`} alt="" className="w-8 h-8 object-contain" crossOrigin="anonymous" />
+              <img src={imageUrl(info.image_url)} alt="" className="w-8 h-8 object-contain" crossOrigin="anonymous" />
             )}
             <div className="min-w-0">
               <div className="font-semibold text-xs text-[var(--text-primary)] truncate">{info.name}</div>

--- a/frontend/app/runs/[hash]/RunPills.tsx
+++ b/frontend/app/runs/[hash]/RunPills.tsx
@@ -3,6 +3,7 @@
 import { useState, type ReactNode } from "react";
 import Link from "next/link";
 import RichDescription from "@/app/components/RichDescription";
+import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -83,7 +84,7 @@ export function CardPill({
           <div className="flex items-start gap-2 mb-1.5">
             {info.image_url && (
               <img
-                src={`${API}${info.image_url}`}
+                src={imageUrl(info.image_url)}
                 alt=""
                 className="w-10 h-10 object-cover rounded"
                 crossOrigin="anonymous"
@@ -137,7 +138,7 @@ export function RelicPill({
           <div className="flex items-start gap-2 mb-1.5">
             {info.image_url && (
               <img
-                src={`${API}${info.image_url}`}
+                src={imageUrl(info.image_url)}
                 alt=""
                 className="w-8 h-8 object-contain"
                 crossOrigin="anonymous"
@@ -186,7 +187,7 @@ export function PotionPill({
           <div className="flex items-start gap-2 mb-1.5">
             {info.image_url && (
               <img
-                src={`${API}${info.image_url}`}
+                src={imageUrl(info.image_url)}
                 alt=""
                 className="w-8 h-8 object-contain"
                 crossOrigin="anonymous"

--- a/frontend/app/runs/[hash]/RunSummary.tsx
+++ b/frontend/app/runs/[hash]/RunSummary.tsx
@@ -24,7 +24,8 @@ import {
 export type { PotionInfo };
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
-const ICON_BASE = `${API}/static/images/ui/run_history`;
+import { imageUrl } from "@/lib/image-url";
+const ICON_BASE = imageUrl("/static/images/ui/run_history");
 
 interface DeckCard {
   id: string;
@@ -200,7 +201,7 @@ export default function RunSummary({ run, player, cardData, relicData, potionDat
   const finalStats = lastPlayerStats(run);
   const totalFloors = (run.map_point_history ?? []).reduce((sum, act) => sum + act.length, 0);
   const charSlug = cleanId(player.character).toLowerCase();
-  const charIcon = `${API}/static/images/characters/character_icon_${charSlug}.webp`;
+  const charIcon = imageUrl(`/static/images/characters/character_icon_${charSlug}.webp`);
   const potionSlots = player.max_potion_slot_count ?? 3;
   const playerPotions = player.potions ?? [];
 
@@ -236,13 +237,13 @@ export default function RunSummary({ run, player, cardData, relicData, potionDat
             crossOrigin="anonymous"
           />
         </Link>
-        <IconStat icon={`${API}/static/images/ui/top_bar/top_bar_heart.webp`} alt="HP" value={`${finalStats?.current_hp ?? "?"}/${finalStats?.max_hp ?? "?"}`} color="var(--color-ironclad)" />
-        <IconStat icon={`${API}/static/images/ui/top_bar/top_bar_gold.webp`} alt="Gold" value={finalStats?.current_gold ?? "?"} color="var(--accent-gold)" />
+        <IconStat icon={imageUrl("/static/images/ui/top_bar/top_bar_heart.webp")} alt="HP" value={`${finalStats?.current_hp ?? "?"}/${finalStats?.max_hp ?? "?"}`} color="var(--color-ironclad)" />
+        <IconStat icon={imageUrl("/static/images/ui/top_bar/top_bar_gold.webp")} alt="Gold" value={finalStats?.current_gold ?? "?"} color="var(--accent-gold)" />
         <PotionSlots potions={playerPotions} total={potionSlots} potionData={potionData} lp={lp} />
-        <IconStat icon={`${API}/static/images/ui/top_bar/top_bar_map.webp`} alt="Floor" value={totalFloors} />
-        <IconStat icon={`${API}/static/images/ui/top_bar/timer_icon.webp`} alt="Time" value={formatTime(run.run_time ?? 0)} />
+        <IconStat icon={imageUrl("/static/images/ui/top_bar/top_bar_map.webp")} alt="Floor" value={totalFloors} />
+        <IconStat icon={imageUrl("/static/images/ui/top_bar/timer_icon.webp")} alt="Time" value={formatTime(run.run_time ?? 0)} />
         {(run.ascension ?? 0) > 0 && (
-          <IconStat icon={`${API}/static/images/ui/top_bar/top_bar_ascension.webp`} alt="Ascension" value={`A${run.ascension}`} color="var(--accent-gold)" />
+          <IconStat icon={imageUrl("/static/images/ui/top_bar/top_bar_ascension.webp")} alt="Ascension" value={`A${run.ascension}`} color="var(--accent-gold)" />
         )}
         <div className="w-full sm:w-auto sm:ml-auto text-left sm:text-right text-xs text-[var(--text-muted)] leading-tight">
           {run.username && (
@@ -309,7 +310,7 @@ export default function RunSummary({ run, player, cardData, relicData, potionDat
               >
                 {info?.image_url ? (
                   <img
-                    src={`${API}${info.image_url}`}
+                    src={imageUrl(info.image_url)}
                     alt={info.name}
                     className="w-full h-full object-contain p-0.5"
                     crossOrigin="anonymous"
@@ -537,7 +538,7 @@ function PotionSlots({
           >
             {info?.image_url ? (
               <img
-                src={`${API}${info.image_url}`}
+                src={imageUrl(info.image_url)}
                 alt={info.name}
                 className="w-5 h-5 object-contain"
                 crossOrigin="anonymous"

--- a/frontend/app/settings/SettingsClient.tsx
+++ b/frontend/app/settings/SettingsClient.tsx
@@ -150,7 +150,7 @@ export default function SettingsClient() {
           <button
             onClick={saveUsername}
             disabled={!usernameChanged || saving === "username" || usernameAvailable === false}
-            className="px-4 py-2 text-sm font-medium rounded-lg bg-[var(--border-accent)] text-[var(--bg-primary)] hover:opacity-90 disabled:opacity-30 transition-opacity shrink-0"
+            className="px-4 py-2 text-sm font-medium rounded-lg bg-[var(--border-accent)] text-white hover:opacity-90 disabled:opacity-30 transition-opacity shrink-0"
           >
             {saving === "username" ? "Saving..." : "Save"}
           </button>
@@ -174,7 +174,7 @@ export default function SettingsClient() {
           <button
             onClick={saveEmail}
             disabled={!emailChanged || saving === "email"}
-            className="px-4 py-2 text-sm font-medium rounded-lg bg-[var(--border-accent)] text-[var(--bg-primary)] hover:opacity-90 disabled:opacity-30 transition-opacity shrink-0"
+            className="px-4 py-2 text-sm font-medium rounded-lg bg-[var(--border-accent)] text-white hover:opacity-90 disabled:opacity-30 transition-opacity shrink-0"
           >
             {saving === "email" ? "Saving..." : "Save"}
           </button>

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 import { ALL_BROWSE_SLUGS } from "./cards/browse/slug-map";
 import { SUPPORTED_LANGS } from "@/lib/languages";
+import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-dynamic";
 
@@ -164,7 +165,7 @@ const DYNAMIC_ROUTES = [
 
 async function fetchEntities(endpoint: string): Promise<EntityWithImage[]> {
   try {
-    const res = await fetch(`${API}${endpoint}`);
+    const res = await fetch(imageUrl(endpoint));
     if (!res.ok) return [];
     return res.json();
   } catch {
@@ -264,7 +265,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       };
 
       if (entity.image_url) {
-        entry.images = [`${API_PUBLIC}${entity.image_url}`];
+        entry.images = [imageUrl(entity.image_url)];
       }
 
       return entry;

--- a/frontend/app/tier-list/page.tsx
+++ b/frontend/app/tier-list/page.tsx
@@ -4,6 +4,7 @@ import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE, buildLanguageAlternates } from "
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import ScoreBadge from "@/app/components/ScoreBadge";
+import { imageUrl } from "@/lib/image-url";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const API_PUBLIC = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -256,7 +257,7 @@ export default async function TierListIndex() {
                       >
                         {ent.image_url && (
                           <img
-                            src={`${API_PUBLIC}${ent.image_url}`}
+                            src={imageUrl(ent.image_url)}
                             alt={ent.name}
                             className="w-12 h-12 object-contain"
                             loading="lazy"

--- a/frontend/app/unlocks/UnlocksClient.tsx
+++ b/frontend/app/unlocks/UnlocksClient.tsx
@@ -8,6 +8,7 @@ import { useLangPrefix } from "@/lib/use-lang-prefix";
 import RichDescription from "@/app/components/RichDescription";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+import { imageUrl } from "@/lib/image-url";
 
 interface UnlockEntity {
   id: string;
@@ -65,7 +66,7 @@ function EntityCard({ entity, type, lp }: { entity: UnlockEntity; type: string; 
     >
       {entity.image_url && (
         <img
-          src={`${API}${entity.image_url}`}
+          src={imageUrl(entity.image_url)}
           alt={entity.name}
           className="w-8 h-8 object-contain flex-shrink-0"
           crossOrigin="anonymous"
@@ -206,7 +207,7 @@ export default function UnlocksClient() {
                 className="flex items-center gap-3 px-3 py-3 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] hover:border-[var(--accent-gold)]/50 transition-colors group"
               >
                 <img
-                  src={`${API}/static/images/characters/combat_${char.id.toLowerCase()}.webp`}
+                  src={imageUrl(`/static/images/characters/combat_${char.id.toLowerCase()}.webp`)}
                   alt={char.name}
                   className="w-12 h-12 object-contain flex-shrink-0"
                   crossOrigin="anonymous"

--- a/frontend/lib/image-url.ts
+++ b/frontend/lib/image-url.ts
@@ -1,0 +1,11 @@
+const CDN_URL = process.env.NEXT_PUBLIC_CDN_URL?.replace(/\/$/, "") || "";
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+export function imageUrl(path: string | null | undefined): string {
+  if (!path) return "";
+  if (path.startsWith("http")) return path;
+  if (CDN_URL && path.startsWith("/static/images/")) {
+    return `${CDN_URL}${path.replace("/static/images/", "/")}`;
+  }
+  return `${API}${path}`;
+}


### PR DESCRIPTION
## Summary
- Add `CDN_BASE_URL` env var to backend `resolve_image_url` for absolute CDN URLs
- Add `NEXT_PUBLIC_CDN_URL` env var and `imageUrl()` helper on the frontend
- Migrate all 47 frontend components from hardcoded `${API}/static/images/...` to `imageUrl()`
- Falls back to existing API-relative paths when env vars are unset (local dev)