### PR TITLE
Remove webp conversion from Docker build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends webp && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 
 COPY requirements.txt .
@@ -9,8 +7,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app/ app/
 COPY static/ static/
-
-RUN find static/images -name '*.png' -exec sh -c 'cwebp -q 95 -m 6 -quiet "$0" -o "${0%.png}.webp"' {} \;
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- Images are served from the CDN now, so the backend no longer needs to convert PNGs to webp at build time
- Removes the `webp` apt package and `cwebp` conversion step from the Dockerfile
- Cuts ~17 minutes off the staging build