### PR TITLE
General fixes: competitive stats, CDN, username limit, RunDropZone

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -193,6 +193,87 @@ async def user_stats(request: Request):
     return get_stats(username=username)
 
 
+@router.get("/personal-bests")
+@limiter.limit("10/minute")
+async def personal_bests(request: Request):
+    user = require_user(request)
+    username = user.get("username")
+    if not username or not os.environ.get("MONGO_URL", "").strip():
+        return {"bests": []}
+
+    from ..services.runs_db_mongo import _get_collection
+
+    coll = _get_collection()
+    base_match = {
+        "username": username,
+        "win": {"$in": [True, 1]},
+    }
+
+    results = {}
+
+    # Fastest single-player win
+    sp = coll.find_one(
+        {**base_match, "player_count": 1, "game_mode": "standard"},
+        {"_id": 1, "character": 1, "run_time": 1, "ascension": 1, "floors_reached": 1},
+        sort=[("run_time", 1)],
+    )
+    if sp:
+        results["fastest_solo"] = {
+            "run_hash": sp["_id"],
+            "character": sp["character"],
+            "run_time": sp["run_time"],
+            "ascension": sp.get("ascension", 0),
+            "floors_reached": sp.get("floors_reached", 0),
+        }
+
+    # Fastest multiplayer win
+    mp = coll.find_one(
+        {**base_match, "player_count": {"$gt": 1}, "game_mode": "standard"},
+        {"_id": 1, "character": 1, "run_time": 1, "ascension": 1, "floors_reached": 1},
+        sort=[("run_time", 1)],
+    )
+    if mp:
+        results["fastest_multi"] = {
+            "run_hash": mp["_id"],
+            "character": mp["character"],
+            "run_time": mp["run_time"],
+            "ascension": mp.get("ascension", 0),
+            "floors_reached": mp.get("floors_reached", 0),
+        }
+
+    # Highest ascension win
+    ha = coll.find_one(
+        {**base_match, "game_mode": "standard"},
+        {"_id": 1, "character": 1, "run_time": 1, "ascension": 1, "floors_reached": 1},
+        sort=[("ascension", -1), ("run_time", 1)],
+    )
+    if ha:
+        results["highest_ascension"] = {
+            "run_hash": ha["_id"],
+            "character": ha["character"],
+            "run_time": ha["run_time"],
+            "ascension": ha.get("ascension", 0),
+            "floors_reached": ha.get("floors_reached", 0),
+        }
+
+    # Best daily climb (fastest win in daily mode)
+    dc = coll.find_one(
+        {**base_match, "game_mode": "daily"},
+        {"_id": 1, "character": 1, "run_time": 1, "ascension": 1, "floors_reached": 1},
+        sort=[("run_time", 1)],
+    )
+    if dc:
+        results["fastest_daily"] = {
+            "run_hash": dc["_id"],
+            "character": dc["character"],
+            "run_time": dc["run_time"],
+            "ascension": dc.get("ascension", 0),
+            "floors_reached": dc.get("floors_reached", 0),
+        }
+
+    return results
+
+
 @router.post("/runs/upload")
 @limiter.limit("10/minute")
 async def upload_runs(request: Request, files: list[UploadFile] = File(...)):

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -256,19 +256,42 @@ async def personal_bests(request: Request):
             "floors_reached": ha.get("floors_reached", 0),
         }
 
-    # Best daily climb (fastest win in daily mode)
+    # Today's daily climb (fastest win submitted today)
+    from datetime import datetime, timezone, timedelta
+
+    now = datetime.now(timezone.utc)
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
     dc = coll.find_one(
-        {**base_match, "game_mode": "daily"},
+        {
+            **base_match,
+            "game_mode": "daily",
+            "submitted_at": {"$gte": today_start},
+        },
         {"_id": 1, "character": 1, "run_time": 1, "ascension": 1, "floors_reached": 1},
         sort=[("run_time", 1)],
     )
     if dc:
-        results["fastest_daily"] = {
+        results["todays_daily"] = {
             "run_hash": dc["_id"],
             "character": dc["character"],
             "run_time": dc["run_time"],
             "ascension": dc.get("ascension", 0),
             "floors_reached": dc.get("floors_reached", 0),
+        }
+
+    # All-time fastest daily climb
+    dc_all = coll.find_one(
+        {**base_match, "game_mode": "daily"},
+        {"_id": 1, "character": 1, "run_time": 1, "ascension": 1, "floors_reached": 1},
+        sort=[("run_time", 1)],
+    )
+    if dc_all:
+        results["fastest_daily"] = {
+            "run_hash": dc_all["_id"],
+            "character": dc_all["character"],
+            "run_time": dc_all["run_time"],
+            "ascension": dc_all.get("ascension", 0),
+            "floors_reached": dc_all.get("floors_reached", 0),
         }
 
     return results

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -177,6 +177,22 @@ async def delete_run(run_hash: str, request: Request):
     return {"success": True}
 
 
+@router.get("/stats")
+@limiter.limit("10/minute")
+async def user_stats(request: Request):
+    user = require_user(request)
+    username = user.get("username")
+    if not username:
+        return {"total_runs": 0}
+
+    if not os.environ.get("MONGO_URL", "").strip():
+        return {"total_runs": 0}
+
+    from ..services.runs_db_mongo import get_stats
+
+    return get_stats(username=username)
+
+
 @router.post("/runs/upload")
 @limiter.limit("10/minute")
 async def upload_runs(request: Request, files: list[UploadFile] = File(...)):

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -193,108 +193,123 @@ async def user_stats(request: Request):
     return get_stats(username=username)
 
 
-@router.get("/personal-bests")
-@limiter.limit("10/minute")
-async def personal_bests(request: Request):
-    user = require_user(request)
-    username = user.get("username")
-    if not username or not os.environ.get("MONGO_URL", "").strip():
-        return {"bests": []}
-
+def _compute_personal_bests(username: str) -> dict:
     from ..services.runs_db_mongo import _get_collection
+    from datetime import datetime, timezone
 
     coll = _get_collection()
     base_match = {
         "username": username,
         "win": {"$in": [True, 1]},
     }
-
+    proj = {
+        "_id": 1,
+        "character": 1,
+        "run_time": 1,
+        "ascension": 1,
+        "floors_reached": 1,
+    }
     results = {}
 
-    # Fastest single-player win
-    sp = coll.find_one(
-        {**base_match, "player_count": 1, "game_mode": "standard"},
-        {"_id": 1, "character": 1, "run_time": 1, "ascension": 1, "floors_reached": 1},
-        sort=[("run_time", 1)],
-    )
-    if sp:
-        results["fastest_solo"] = {
-            "run_hash": sp["_id"],
-            "character": sp["character"],
-            "run_time": sp["run_time"],
-            "ascension": sp.get("ascension", 0),
-            "floors_reached": sp.get("floors_reached", 0),
-        }
+    def _best(key, extra_match, sort):
+        doc = coll.find_one({**base_match, **extra_match}, proj, sort=sort)
+        if doc:
+            results[key] = {
+                "run_hash": doc["_id"],
+                "character": doc["character"],
+                "run_time": doc["run_time"],
+                "ascension": doc.get("ascension", 0),
+                "floors_reached": doc.get("floors_reached", 0),
+            }
 
-    # Fastest multiplayer win
-    mp = coll.find_one(
-        {**base_match, "player_count": {"$gt": 1}, "game_mode": "standard"},
-        {"_id": 1, "character": 1, "run_time": 1, "ascension": 1, "floors_reached": 1},
-        sort=[("run_time", 1)],
+    _best(
+        "fastest_solo", {"player_count": 1, "game_mode": "standard"}, [("run_time", 1)]
     )
-    if mp:
-        results["fastest_multi"] = {
-            "run_hash": mp["_id"],
-            "character": mp["character"],
-            "run_time": mp["run_time"],
-            "ascension": mp.get("ascension", 0),
-            "floors_reached": mp.get("floors_reached", 0),
-        }
-
-    # Highest ascension win
-    ha = coll.find_one(
-        {**base_match, "game_mode": "standard"},
-        {"_id": 1, "character": 1, "run_time": 1, "ascension": 1, "floors_reached": 1},
-        sort=[("ascension", -1), ("run_time", 1)],
+    _best(
+        "fastest_multi",
+        {"player_count": {"$gt": 1}, "game_mode": "standard"},
+        [("run_time", 1)],
     )
-    if ha:
-        results["highest_ascension"] = {
-            "run_hash": ha["_id"],
-            "character": ha["character"],
-            "run_time": ha["run_time"],
-            "ascension": ha.get("ascension", 0),
-            "floors_reached": ha.get("floors_reached", 0),
-        }
-
-    # Today's daily climb (fastest win submitted today)
-    from datetime import datetime, timezone, timedelta
-
-    now = datetime.now(timezone.utc)
-    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
-    dc = coll.find_one(
-        {
-            **base_match,
-            "game_mode": "daily",
-            "submitted_at": {"$gte": today_start},
-        },
-        {"_id": 1, "character": 1, "run_time": 1, "ascension": 1, "floors_reached": 1},
-        sort=[("run_time", 1)],
+    _best(
+        "highest_ascension",
+        {"game_mode": "standard"},
+        [("ascension", -1), ("run_time", 1)],
     )
-    if dc:
-        results["todays_daily"] = {
-            "run_hash": dc["_id"],
-            "character": dc["character"],
-            "run_time": dc["run_time"],
-            "ascension": dc.get("ascension", 0),
-            "floors_reached": dc.get("floors_reached", 0),
-        }
 
-    # All-time fastest daily climb
-    dc_all = coll.find_one(
-        {**base_match, "game_mode": "daily"},
-        {"_id": 1, "character": 1, "run_time": 1, "ascension": 1, "floors_reached": 1},
-        sort=[("run_time", 1)],
+    today_start = datetime.now(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
     )
-    if dc_all:
-        results["fastest_daily"] = {
-            "run_hash": dc_all["_id"],
-            "character": dc_all["character"],
-            "run_time": dc_all["run_time"],
-            "ascension": dc_all.get("ascension", 0),
-            "floors_reached": dc_all.get("floors_reached", 0),
-        }
+    _best(
+        "todays_daily",
+        {"game_mode": "daily", "submitted_at": {"$gte": today_start}},
+        [("run_time", 1)],
+    )
+    _best("fastest_daily", {"game_mode": "daily"}, [("run_time", 1)])
 
     return results
+
+
+@router.get("/personal-bests")
+@limiter.limit("10/minute")
+async def personal_bests(request: Request):
+    user = require_user(request)
+    username = user.get("username")
+    if not username or not os.environ.get("MONGO_URL", "").strip():
+        return {}
+    return _compute_personal_bests(username)
+
+
+@router.get("/competitive")
+@limiter.limit("10/minute")
+async def competitive_stats(request: Request):
+    user = require_user(request)
+    username = user.get("username")
+    if not username or not os.environ.get("MONGO_URL", "").strip():
+        return {
+            "daily_leaderboard": {"runs": [], "user_rank": None, "total_today": 0},
+            "personal_ranks": {},
+            "win_rate_comparison": [],
+        }
+
+    from ..services.runs_db_mongo import (
+        get_daily_leaderboard,
+        get_run_rank_scoped,
+        get_win_rate_comparison,
+    )
+
+    bests = _compute_personal_bests(username)
+
+    rank_configs = {
+        "fastest_solo": {
+            "category": "fastest",
+            "game_mode": "standard",
+            "players": "single",
+        },
+        "fastest_multi": {
+            "category": "fastest",
+            "game_mode": "standard",
+            "players": "multi",
+        },
+        "highest_ascension": {"category": "highest_ascension", "game_mode": "standard"},
+        "todays_daily": {
+            "category": "fastest",
+            "game_mode": "daily",
+            "today_only": True,
+        },
+        "fastest_daily": {"category": "fastest", "game_mode": "daily"},
+    }
+
+    personal_ranks = {}
+    for key, cfg in rank_configs.items():
+        best = bests.get(key)
+        if best:
+            personal_ranks[key] = get_run_rank_scoped(best["run_hash"], **cfg)
+
+    return {
+        "daily_leaderboard": get_daily_leaderboard(username),
+        "personal_ranks": personal_ranks,
+        "win_rate_comparison": get_win_rate_comparison(username),
+    }
 
 
 @router.post("/runs/upload")

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -142,6 +142,14 @@ def _ensure_indexes(coll) -> None:
     coll.create_index([("relics.id", ASCENDING)])
     coll.create_index([("killed_by", ASCENDING)])
     coll.create_index([("user_id", ASCENDING), ("submitted_at", DESCENDING)])
+    coll.create_index(
+        [
+            ("game_mode", ASCENDING),
+            ("win", ASCENDING),
+            ("submitted_at", DESCENDING),
+            ("run_time", ASCENDING),
+        ]
+    )
 
 
 # ── helpers (mirrors of the sqlite module) ──────────────────────────────
@@ -1373,6 +1381,152 @@ def find_sibling_hashes(run_hash: str) -> list[str]:
         return []
     siblings = coll.find({"seed": row["seed"], "_id": {"$ne": run_hash}}, {"_id": 1})
     return [s["_id"] for s in siblings]
+
+
+# ── Competitive / comparison queries ────────────────────────────────────
+
+
+@_instrument("get_daily_leaderboard")
+def get_daily_leaderboard(username: str | None = None) -> dict:
+    """Today's top daily climb wins, plus the requesting user's rank."""
+    from datetime import datetime, timezone
+
+    coll = _get_collection()
+    today_start = datetime.now(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    base = {
+        "win": {"$in": [True, 1]},
+        "game_mode": "daily",
+        "submitted_at": {"$gte": today_start},
+    }
+
+    top_10 = list(coll.find(base, _projection_row()).sort("run_time", 1).limit(10))
+    total = coll.count_documents(base)
+
+    runs = []
+    for r in top_10:
+        row = _row_to_dict(r)
+        row["is_current_user"] = bool(username and row.get("username") == username)
+        runs.append(row)
+
+    user_rank = None
+    if username:
+        user_run = coll.find_one(
+            {**base, "username": username},
+            {"run_time": 1},
+            sort=[("run_time", 1)],
+        )
+        if user_run:
+            user_rank = (
+                coll.count_documents(
+                    {**base, "run_time": {"$lt": user_run["run_time"]}}
+                )
+                + 1
+            )
+
+    return {"runs": runs, "user_rank": user_rank, "total_today": total}
+
+
+@_instrument("get_run_rank_scoped")
+def get_run_rank_scoped(
+    run_hash: str,
+    category: str = "fastest",
+    game_mode: str | None = None,
+    players: str | None = None,
+    today_only: bool = False,
+) -> dict:
+    """Rank of a run within a scoped leaderboard. Extends get_run_rank
+    with optional game_mode, players, and today-only filters."""
+    from datetime import datetime, timezone
+
+    coll = _get_collection()
+    row = coll.find_one(
+        {"_id": run_hash},
+        {"win": 1, "character": 1, "run_time": 1, "ascension": 1},
+    )
+    if not row or not row.get("win"):
+        return {"rank": None, "total": 0}
+
+    scope: dict[str, Any] = {"win": {"$in": [True, 1]}}
+    if not today_only:
+        scope["character"] = row["character"]
+    if game_mode:
+        scope["game_mode"] = game_mode
+    if players == "single":
+        scope["player_count"] = 1
+    elif players == "multi":
+        scope["player_count"] = {"$gt": 1}
+    if today_only:
+        today_start = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        scope["submitted_at"] = {"$gte": today_start}
+
+    if category == "highest_ascension":
+        ahead_q = {
+            **scope,
+            "$or": [
+                {"ascension": {"$gt": row.get("ascension", 0)}},
+                {
+                    "ascension": row.get("ascension", 0),
+                    "run_time": {"$lt": row.get("run_time", 0)},
+                },
+            ],
+        }
+    else:
+        ahead_q = {**scope, "run_time": {"$lt": row.get("run_time", 0)}}
+
+    ahead = coll.count_documents(ahead_q)
+    total = coll.count_documents(scope)
+    return {"rank": ahead + 1, "total": total}
+
+
+@_instrument("get_win_rate_comparison")
+def get_win_rate_comparison(username: str) -> list[dict]:
+    """Per-character win rate for the user vs community average."""
+    coll = _get_collection()
+
+    user_chars = list(
+        coll.aggregate(
+            [
+                {"$match": {"username": username}},
+                {
+                    "$group": {
+                        "_id": "$character",
+                        "total": {"$sum": 1},
+                        "wins": {"$sum": {"$cond": ["$win", 1, 0]}},
+                    }
+                },
+            ],
+            allowDiskUse=True,
+        )
+    )
+
+    summary = _summary_coll().find_one({"_id": "global"})
+    community_chars = {}
+    if summary and "characters" in summary:
+        for c in summary["characters"]:
+            community_chars[c["character"]] = c.get("win_rate", 0)
+
+    result = []
+    for uc in user_chars:
+        char = uc["_id"]
+        if char not in OFFICIAL_CHARACTERS or uc["total"] < 5:
+            continue
+        user_wr = round(uc["wins"] / uc["total"] * 100, 1) if uc["total"] > 0 else 0
+        result.append(
+            {
+                "character": char,
+                "user_win_rate": user_wr,
+                "community_win_rate": community_chars.get(char, 0),
+                "user_wins": uc["wins"],
+                "user_total": uc["total"],
+            }
+        )
+
+    result.sort(key=lambda x: x["user_total"], reverse=True)
+    return result
 
 
 # ── User run ownership ──────────────────────────────────────────────────

--- a/frontend/app/components/ProfileStats.tsx
+++ b/frontend/app/components/ProfileStats.tsx
@@ -38,6 +38,31 @@ interface PersonalBests {
   fastest_daily?: PersonalBest;
 }
 
+interface DailyLeaderboardEntry {
+  run_hash: string;
+  username: string | null;
+  character: string;
+  run_time: number;
+  ascension: number;
+  is_current_user: boolean;
+}
+
+interface CompetitiveData {
+  daily_leaderboard: {
+    runs: DailyLeaderboardEntry[];
+    user_rank: number | null;
+    total_today: number;
+  };
+  personal_ranks: Record<string, { rank: number; total: number } | null>;
+  win_rate_comparison: {
+    character: string;
+    user_win_rate: number;
+    community_win_rate: number;
+    user_wins: number;
+    user_total: number;
+  }[];
+}
+
 interface Stats {
   total_runs: number;
   total_wins?: number;
@@ -97,6 +122,7 @@ export default function ProfileStats() {
   const lp = useLangPrefix();
   const [stats, setStats] = useState<Stats | null>(null);
   const [bests, setBests] = useState<PersonalBests | null>(null);
+  const [competitive, setCompetitive] = useState<CompetitiveData | null>(null);
   const [cardData, setCardData] = useState<Record<string, EntityInfo>>({});
   const [relicData, setRelicData] = useState<Record<string, EntityInfo>>({});
   const [potionData, setPotionData] = useState<Record<string, EntityInfo>>({});
@@ -106,15 +132,17 @@ export default function ProfileStats() {
   useEffect(() => {
     async function load() {
       try {
-        const [statsRes, bestsRes, cards, relics, potions] = await Promise.all([
+        const [statsRes, bestsRes, competitiveRes, cards, relics, potions] = await Promise.all([
           fetch(`${API}/api/auth/stats`, { credentials: "include" }).then((r) => r.ok ? r.json() : null),
           fetch(`${API}/api/auth/personal-bests`, { credentials: "include" }).then((r) => r.ok ? r.json() : null),
+          fetch(`${API}/api/auth/competitive`, { credentials: "include" }).then((r) => r.ok ? r.json() : null),
           cachedFetch<EntityInfo[]>(`${API}/api/cards`),
           cachedFetch<EntityInfo[]>(`${API}/api/relics`),
           cachedFetch<EntityInfo[]>(`${API}/api/potions`),
         ]);
         if (statsRes) setStats(statsRes);
         if (bestsRes) setBests(bestsRes);
+        if (competitiveRes) setCompetitive(competitiveRes);
         const cm: Record<string, EntityInfo> = {};
         for (const c of cards) cm[c.id] = c;
         setCardData(cm);
@@ -217,51 +245,123 @@ export default function ProfileStats() {
             <div className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-4">
               <h3 className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-3">Personal Bests</h3>
               <div className="space-y-2">
-                {bests.fastest_solo && (
-                  <Link href={`${lp}/runs/${bests.fastest_solo.run_hash}`} className="flex items-center justify-between text-sm hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 py-1 transition-colors">
-                    <span className="text-[var(--text-secondary)]">Fastest Solo</span>
-                    <span className="text-[var(--text-primary)] font-medium tabular-nums">
-                      {formatTime(bests.fastest_solo.run_time)}
-                      <span className="text-[var(--text-tertiary)] ml-2 text-xs">{displayName(bests.fastest_solo.character)} A{bests.fastest_solo.ascension}</span>
+                {([
+                  ["fastest_solo", "Fastest Solo", bests.fastest_solo],
+                  ["fastest_multi", "Fastest Co-op", bests.fastest_multi],
+                  ["highest_ascension", "Highest Ascension", bests.highest_ascension],
+                  ["todays_daily", "Today’s Daily Climb", bests.todays_daily],
+                  ["fastest_daily", "Fastest Daily (All Time)", bests.fastest_daily],
+                ] as [string, string, PersonalBest | undefined][]).map(([key, label, best]) => {
+                  if (!best) return null;
+                  const rank = competitive?.personal_ranks?.[key];
+                  const isAsc = key === "highest_ascension";
+                  return (
+                    <Link key={key} href={`${lp}/runs/${best.run_hash}`} className="flex items-center justify-between text-sm hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 py-1 transition-colors">
+                      <span className="text-[var(--text-secondary)]">{label}</span>
+                      <span className="text-[var(--text-primary)] font-medium tabular-nums">
+                        {isAsc ? `A${best.ascension}` : formatTime(best.run_time)}
+                        <span className="text-[var(--text-tertiary)] ml-2 text-xs">
+                          {displayName(best.character)}
+                          {!isAsc && ` A${best.ascension}`}
+                          {isAsc && ` ${formatTime(best.run_time)}`}
+                        </span>
+                        {rank && rank.rank && (
+                          <span className="text-[var(--accent-gold)] ml-2 text-[10px]">
+                            #{rank.rank.toLocaleString()}
+                            <span className="text-[var(--text-muted)]"> of {rank.total.toLocaleString()}</span>
+                          </span>
+                        )}
+                      </span>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Today's Daily Climb Leaderboard */}
+          {competitive?.daily_leaderboard && competitive.daily_leaderboard.runs.length > 0 && (
+            <div className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-4">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">Today&apos;s Daily Climb</h3>
+                <span className="text-[10px] text-[var(--text-tertiary)]">{competitive.daily_leaderboard.total_today} runs today</span>
+              </div>
+              <div className="space-y-1">
+                {competitive.daily_leaderboard.runs.map((entry, i) => (
+                  <Link
+                    key={entry.run_hash}
+                    href={`${lp}/runs/${entry.run_hash}`}
+                    className={`flex items-center gap-3 text-sm px-2 -mx-2 py-1.5 rounded transition-colors ${
+                      entry.is_current_user
+                        ? "bg-[var(--accent-gold)]/10 hover:bg-[var(--accent-gold)]/15"
+                        : "hover:bg-[var(--bg-card-hover)]"
+                    }`}
+                  >
+                    <span className="w-5 text-right text-xs text-[var(--text-tertiary)] tabular-nums">{i + 1}</span>
+                    <span
+                      className="w-2 h-2 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: CHAR_COLORS[entry.character] || "#888" }}
+                    />
+                    <span className={`flex-1 truncate ${entry.is_current_user ? "text-[var(--accent-gold)] font-medium" : "text-[var(--text-primary)]"}`}>
+                      {entry.username || "Anonymous"}
                     </span>
+                    <span className="text-xs text-[var(--text-tertiary)] tabular-nums">{displayName(entry.character)}</span>
+                    <span className="text-xs text-[var(--text-primary)] tabular-nums font-medium">{formatTime(entry.run_time)}</span>
                   </Link>
+                ))}
+                {competitive.daily_leaderboard.user_rank && competitive.daily_leaderboard.user_rank > 10 && (
+                  <>
+                    <div className="text-center text-[var(--text-muted)] text-xs py-1">...</div>
+                    <div className="flex items-center gap-3 text-sm px-2 -mx-2 py-1.5 rounded bg-[var(--accent-gold)]/10">
+                      <span className="w-5 text-right text-xs text-[var(--text-tertiary)] tabular-nums">{competitive.daily_leaderboard.user_rank}</span>
+                      <span className="flex-1 text-[var(--accent-gold)] font-medium">You</span>
+                    </div>
+                  </>
                 )}
-                {bests.fastest_multi && (
-                  <Link href={`${lp}/runs/${bests.fastest_multi.run_hash}`} className="flex items-center justify-between text-sm hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 py-1 transition-colors">
-                    <span className="text-[var(--text-secondary)]">Fastest Co-op</span>
-                    <span className="text-[var(--text-primary)] font-medium tabular-nums">
-                      {formatTime(bests.fastest_multi.run_time)}
-                      <span className="text-[var(--text-tertiary)] ml-2 text-xs">{displayName(bests.fastest_multi.character)} A{bests.fastest_multi.ascension}</span>
-                    </span>
-                  </Link>
-                )}
-                {bests.highest_ascension && (
-                  <Link href={`${lp}/runs/${bests.highest_ascension.run_hash}`} className="flex items-center justify-between text-sm hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 py-1 transition-colors">
-                    <span className="text-[var(--text-secondary)]">Highest Ascension</span>
-                    <span className="text-[var(--text-primary)] font-medium tabular-nums">
-                      A{bests.highest_ascension.ascension}
-                      <span className="text-[var(--text-tertiary)] ml-2 text-xs">{displayName(bests.highest_ascension.character)} {formatTime(bests.highest_ascension.run_time)}</span>
-                    </span>
-                  </Link>
-                )}
-                {bests.todays_daily && (
-                  <Link href={`${lp}/runs/${bests.todays_daily.run_hash}`} className="flex items-center justify-between text-sm hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 py-1 transition-colors">
-                    <span className="text-[var(--text-secondary)]">Today&apos;s Daily Climb</span>
-                    <span className="text-[var(--text-primary)] font-medium tabular-nums">
-                      {formatTime(bests.todays_daily.run_time)}
-                      <span className="text-[var(--text-tertiary)] ml-2 text-xs">{displayName(bests.todays_daily.character)} A{bests.todays_daily.ascension}</span>
-                    </span>
-                  </Link>
-                )}
-                {bests.fastest_daily && (
-                  <Link href={`${lp}/runs/${bests.fastest_daily.run_hash}`} className="flex items-center justify-between text-sm hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 py-1 transition-colors">
-                    <span className="text-[var(--text-secondary)]">Fastest Daily (All Time)</span>
-                    <span className="text-[var(--text-primary)] font-medium tabular-nums">
-                      {formatTime(bests.fastest_daily.run_time)}
-                      <span className="text-[var(--text-tertiary)] ml-2 text-xs">{displayName(bests.fastest_daily.character)}</span>
-                    </span>
-                  </Link>
-                )}
+              </div>
+            </div>
+          )}
+
+          {/* Win Rate vs Community */}
+          {competitive?.win_rate_comparison && competitive.win_rate_comparison.length > 0 && (
+            <div className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-4">
+              <h3 className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-3">Win Rate vs Community</h3>
+              <div className="space-y-3">
+                {competitive.win_rate_comparison.map((c) => {
+                  const color = CHAR_COLORS[c.character] || "var(--text-muted)";
+                  const delta = c.user_win_rate - c.community_win_rate;
+                  const deltaColor = delta > 0 ? "text-green-400" : delta < 0 ? "text-red-400" : "text-[var(--text-muted)]";
+                  return (
+                    <div key={c.character} className="space-y-1">
+                      <div className="flex items-center justify-between text-sm">
+                        <div className="flex items-center gap-2">
+                          <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
+                          <span className="text-[var(--text-primary)]">{displayName(c.character)}</span>
+                        </div>
+                        <span className={`text-xs font-medium tabular-nums ${deltaColor}`}>
+                          {delta > 0 ? "+" : ""}{delta.toFixed(1)}%
+                        </span>
+                      </div>
+                      <div className="space-y-0.5">
+                        <div className="flex items-center gap-2">
+                          <span className="w-8 text-[10px] text-[var(--text-tertiary)]">You</span>
+                          <div className="flex-1 h-1.5 rounded-full bg-[var(--bg-primary)] overflow-hidden">
+                            <div className="h-full rounded-full" style={{ width: `${Math.min(c.user_win_rate, 100)}%`, backgroundColor: color }} />
+                          </div>
+                          <span className="w-12 text-right text-[10px] tabular-nums text-[var(--text-primary)]">{c.user_win_rate}%</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className="w-8 text-[10px] text-[var(--text-tertiary)]">Avg</span>
+                          <div className="flex-1 h-1.5 rounded-full bg-[var(--bg-primary)] overflow-hidden">
+                            <div className="h-full rounded-full opacity-40" style={{ width: `${Math.min(c.community_win_rate, 100)}%`, backgroundColor: color }} />
+                          </div>
+                          <span className="w-12 text-right text-[10px] tabular-nums text-[var(--text-tertiary)]">{c.community_win_rate}%</span>
+                        </div>
+                      </div>
+                      <p className="text-[10px] text-[var(--text-muted)]">{c.user_wins}W / {c.user_total - c.user_wins}L across {c.user_total} runs</p>
+                    </div>
+                  );
+                })}
               </div>
             </div>
           )}

--- a/frontend/app/components/ProfileStats.tsx
+++ b/frontend/app/components/ProfileStats.tsx
@@ -34,6 +34,7 @@ interface PersonalBests {
   fastest_solo?: PersonalBest;
   fastest_multi?: PersonalBest;
   highest_ascension?: PersonalBest;
+  todays_daily?: PersonalBest;
   fastest_daily?: PersonalBest;
 }
 
@@ -243,9 +244,18 @@ export default function ProfileStats() {
                     </span>
                   </Link>
                 )}
+                {bests.todays_daily && (
+                  <Link href={`${lp}/runs/${bests.todays_daily.run_hash}`} className="flex items-center justify-between text-sm hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 py-1 transition-colors">
+                    <span className="text-[var(--text-secondary)]">Today&apos;s Daily Climb</span>
+                    <span className="text-[var(--text-primary)] font-medium tabular-nums">
+                      {formatTime(bests.todays_daily.run_time)}
+                      <span className="text-[var(--text-tertiary)] ml-2 text-xs">{displayName(bests.todays_daily.character)} A{bests.todays_daily.ascension}</span>
+                    </span>
+                  </Link>
+                )}
                 {bests.fastest_daily && (
                   <Link href={`${lp}/runs/${bests.fastest_daily.run_hash}`} className="flex items-center justify-between text-sm hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 py-1 transition-colors">
-                    <span className="text-[var(--text-secondary)]">Fastest Daily Climb</span>
+                    <span className="text-[var(--text-secondary)]">Fastest Daily (All Time)</span>
                     <span className="text-[var(--text-primary)] font-medium tabular-nums">
                       {formatTime(bests.fastest_daily.run_time)}
                       <span className="text-[var(--text-tertiary)] ml-2 text-xs">{displayName(bests.fastest_daily.character)}</span>

--- a/frontend/app/components/ProfileStats.tsx
+++ b/frontend/app/components/ProfileStats.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { cachedFetch } from "@/lib/fetch-cache";
+import { imageUrl } from "@/lib/image-url";
+import { useLangPrefix } from "@/lib/use-lang-prefix";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+const CHAR_COLORS: Record<string, string> = {
+  IRONCLAD: "#d53b27",
+  SILENT: "#23935b",
+  DEFECT: "#3873a9",
+  NECROBINDER: "#bf5a85",
+  REGENT: "#f07c1e",
+};
+
+interface EntityInfo {
+  id: string;
+  name: string;
+  image_url: string | null;
+}
+
+interface Stats {
+  total_runs: number;
+  total_wins?: number;
+  total_abandoned?: number;
+  win_rate?: number;
+  characters?: { character: string; total: number; wins: number; win_rate: number }[];
+  top_cards?: { card_id: string; count: number; in_wins: number; total_runs_with: number; win_runs: number }[];
+  top_relics?: { relic_id: string; count: number; total_runs_with: number; win_runs: number }[];
+  top_potions?: { potion_id: string; offered: number; picked: number; used: number; pick_rate: number }[];
+  deadliest?: { encounter: string; count: number }[];
+}
+
+function displayName(id: string): string {
+  return id
+    .replace(/^(CARD|RELIC|ENCHANTMENT|MONSTER|ENCOUNTER|CHARACTER|ACT|POTION)\./, "")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function StatCard({ label, value, sub }: { label: string; value: string | number; sub?: string }) {
+  return (
+    <div className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-4">
+      <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider mb-1">{label}</p>
+      <p className="text-2xl font-bold text-[var(--text-primary)]">{value}</p>
+      {sub && <p className="text-xs text-[var(--text-tertiary)] mt-0.5">{sub}</p>}
+    </div>
+  );
+}
+
+function EntityRow({ name, imageSrc, stat, href }: { name: string; imageSrc: string | null; stat: string; href: string }) {
+  return (
+    <Link href={href} className="flex items-center gap-3 py-1.5 hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 transition-colors">
+      <span className="flex-shrink-0 w-8 h-8 rounded bg-[var(--bg-primary)] border border-[var(--border-subtle)] overflow-hidden flex items-center justify-center">
+        {imageSrc ? (
+          <img src={imageSrc} alt={name} className="w-full h-full object-contain p-0.5" crossOrigin="anonymous" />
+        ) : (
+          <span className="text-[9px] text-[var(--text-muted)]">—</span>
+        )}
+      </span>
+      <span className="flex-1 truncate text-sm text-[var(--text-primary)]">{name}</span>
+      <span className="text-xs text-[var(--text-tertiary)] tabular-nums">{stat}</span>
+    </Link>
+  );
+}
+
+type Tab = "overview" | "cards" | "relics" | "potions";
+
+export default function ProfileStats() {
+  const lp = useLangPrefix();
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [cardData, setCardData] = useState<Record<string, EntityInfo>>({});
+  const [relicData, setRelicData] = useState<Record<string, EntityInfo>>({});
+  const [potionData, setPotionData] = useState<Record<string, EntityInfo>>({});
+  const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState<Tab>("overview");
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [statsRes, cards, relics, potions] = await Promise.all([
+          fetch(`${API}/api/auth/stats`, { credentials: "include" }).then((r) => r.ok ? r.json() : null),
+          cachedFetch<EntityInfo[]>(`${API}/api/cards`),
+          cachedFetch<EntityInfo[]>(`${API}/api/relics`),
+          cachedFetch<EntityInfo[]>(`${API}/api/potions`),
+        ]);
+        if (statsRes) setStats(statsRes);
+        const cm: Record<string, EntityInfo> = {};
+        for (const c of cards) cm[c.id] = c;
+        setCardData(cm);
+        const rm: Record<string, EntityInfo> = {};
+        for (const r of relics) rm[r.id] = r;
+        setRelicData(rm);
+        const pm: Record<string, EntityInfo> = {};
+        for (const p of potions) pm[p.id] = p;
+        setPotionData(pm);
+      } catch {} finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="h-20 bg-[var(--bg-card)] rounded-lg animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!stats || stats.total_runs === 0) {
+    return (
+      <p className="text-sm text-[var(--text-secondary)] py-4">
+        No stats yet. Upload runs to see your personal stats here.
+      </p>
+    );
+  }
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: "overview", label: "Overview" },
+    { key: "cards", label: "Cards" },
+    { key: "relics", label: "Relics" },
+    { key: "potions", label: "Potions" },
+  ];
+
+  const topCards = (stats.top_cards || []).slice(0, 10);
+  const topRelics = (stats.top_relics || []).slice(0, 10);
+  const topPotions = (stats.top_potions || [])
+    .sort((a, b) => b.picked - a.picked)
+    .slice(0, 10);
+  const deadliest = (stats.deadliest || []).slice(0, 5);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-1 border-b border-[var(--border-subtle)]">
+        {tabs.map((tb) => (
+          <button
+            key={tb.key}
+            onClick={() => setTab(tb.key)}
+            className={`px-3 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+              tab === tb.key
+                ? "border-[var(--accent-gold)] text-[var(--accent-gold)]"
+                : "border-transparent text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+            }`}
+          >
+            {tb.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "overview" && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <StatCard label="Runs" value={stats.total_runs} />
+            <StatCard label="Wins" value={stats.total_wins ?? 0} />
+            <StatCard label="Win Rate" value={`${stats.win_rate ?? 0}%`} />
+            <StatCard label="Abandoned" value={stats.total_abandoned ?? 0} />
+          </div>
+
+          {stats.characters && stats.characters.length > 0 && (
+            <div className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-4">
+              <h3 className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-3">Characters</h3>
+              <div className="space-y-2">
+                {stats.characters.map((c) => {
+                  const color = CHAR_COLORS[c.character] || "var(--text-muted)";
+                  const pct = stats.total_runs > 0 ? (c.total / stats.total_runs) * 100 : 0;
+                  return (
+                    <div key={c.character} className="flex items-center gap-3 text-sm">
+                      <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
+                      <span className="w-24 text-[var(--text-primary)]">{displayName(c.character)}</span>
+                      <div className="flex-1 h-1.5 rounded-full bg-[var(--bg-primary)] overflow-hidden">
+                        <div className="h-full rounded-full" style={{ width: `${pct}%`, backgroundColor: color }} />
+                      </div>
+                      <span className="w-8 text-right text-xs text-[var(--text-tertiary)] tabular-nums">{c.total}</span>
+                      <span className="w-12 text-right text-xs tabular-nums" style={{ color }}>{c.win_rate}%</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {deadliest.length > 0 && (
+            <div className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-4">
+              <h3 className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-3">Deadliest Encounters</h3>
+              <div className="space-y-1.5">
+                {deadliest.map((d) => (
+                  <div key={d.encounter} className="flex items-center justify-between text-sm">
+                    <span className="text-[var(--text-primary)]">{displayName(d.encounter)}</span>
+                    <span className="text-xs text-[var(--text-tertiary)] tabular-nums">{d.count} deaths</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {tab === "cards" && (
+        <div className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-4">
+          <h3 className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-3">Most Used Cards</h3>
+          {topCards.length === 0 ? (
+            <p className="text-sm text-[var(--text-tertiary)]">No card data yet.</p>
+          ) : (
+            <div className="space-y-0.5">
+              {topCards.map((c) => {
+                const info = cardData[c.card_id];
+                return (
+                  <EntityRow
+                    key={c.card_id}
+                    name={info?.name || displayName(c.card_id)}
+                    imageSrc={info?.image_url ? imageUrl(info.image_url) : null}
+                    stat={`${c.count} copies`}
+                    href={`${lp}/cards/${c.card_id.toLowerCase()}`}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {tab === "relics" && (
+        <div className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-4">
+          <h3 className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-3">Most Used Relics</h3>
+          {topRelics.length === 0 ? (
+            <p className="text-sm text-[var(--text-tertiary)]">No relic data yet.</p>
+          ) : (
+            <div className="space-y-0.5">
+              {topRelics.map((r) => {
+                const info = relicData[r.relic_id];
+                return (
+                  <EntityRow
+                    key={r.relic_id}
+                    name={info?.name || displayName(r.relic_id)}
+                    imageSrc={info?.image_url ? imageUrl(info.image_url) : null}
+                    stat={`${r.total_runs_with} runs`}
+                    href={`${lp}/relics/${r.relic_id.toLowerCase()}`}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {tab === "potions" && (
+        <div className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-4">
+          <h3 className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-3">Most Picked Potions</h3>
+          {topPotions.length === 0 ? (
+            <p className="text-sm text-[var(--text-tertiary)]">No potion data yet.</p>
+          ) : (
+            <div className="space-y-0.5">
+              {topPotions.map((p) => {
+                const info = potionData[p.potion_id];
+                return (
+                  <EntityRow
+                    key={p.potion_id}
+                    name={info?.name || displayName(p.potion_id)}
+                    imageSrc={info?.image_url ? imageUrl(info.image_url) : null}
+                    stat={`${p.pick_rate}% pick`}
+                    href={`${lp}/potions/${p.potion_id.toLowerCase()}`}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/ProfileStats.tsx
+++ b/frontend/app/components/ProfileStats.tsx
@@ -22,6 +22,21 @@ interface EntityInfo {
   image_url: string | null;
 }
 
+interface PersonalBest {
+  run_hash: string;
+  character: string;
+  run_time: number;
+  ascension: number;
+  floors_reached: number;
+}
+
+interface PersonalBests {
+  fastest_solo?: PersonalBest;
+  fastest_multi?: PersonalBest;
+  highest_ascension?: PersonalBest;
+  fastest_daily?: PersonalBest;
+}
+
 interface Stats {
   total_runs: number;
   total_wins?: number;
@@ -32,6 +47,14 @@ interface Stats {
   top_relics?: { relic_id: string; count: number; total_runs_with: number; win_runs: number }[];
   top_potions?: { potion_id: string; offered: number; picked: number; used: number; pick_rate: number }[];
   deadliest?: { encounter: string; count: number }[];
+}
+
+function formatTime(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  return `${m}m ${s}s`;
 }
 
 function displayName(id: string): string {
@@ -72,6 +95,7 @@ type Tab = "overview" | "cards" | "relics" | "potions";
 export default function ProfileStats() {
   const lp = useLangPrefix();
   const [stats, setStats] = useState<Stats | null>(null);
+  const [bests, setBests] = useState<PersonalBests | null>(null);
   const [cardData, setCardData] = useState<Record<string, EntityInfo>>({});
   const [relicData, setRelicData] = useState<Record<string, EntityInfo>>({});
   const [potionData, setPotionData] = useState<Record<string, EntityInfo>>({});
@@ -81,13 +105,15 @@ export default function ProfileStats() {
   useEffect(() => {
     async function load() {
       try {
-        const [statsRes, cards, relics, potions] = await Promise.all([
+        const [statsRes, bestsRes, cards, relics, potions] = await Promise.all([
           fetch(`${API}/api/auth/stats`, { credentials: "include" }).then((r) => r.ok ? r.json() : null),
+          fetch(`${API}/api/auth/personal-bests`, { credentials: "include" }).then((r) => r.ok ? r.json() : null),
           cachedFetch<EntityInfo[]>(`${API}/api/cards`),
           cachedFetch<EntityInfo[]>(`${API}/api/relics`),
           cachedFetch<EntityInfo[]>(`${API}/api/potions`),
         ]);
         if (statsRes) setStats(statsRes);
+        if (bestsRes) setBests(bestsRes);
         const cm: Record<string, EntityInfo> = {};
         for (const c of cards) cm[c.id] = c;
         setCardData(cm);
@@ -182,6 +208,50 @@ export default function ProfileStats() {
                     </div>
                   );
                 })}
+              </div>
+            </div>
+          )}
+
+          {bests && Object.keys(bests).length > 0 && (
+            <div className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-4">
+              <h3 className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-3">Personal Bests</h3>
+              <div className="space-y-2">
+                {bests.fastest_solo && (
+                  <Link href={`${lp}/runs/${bests.fastest_solo.run_hash}`} className="flex items-center justify-between text-sm hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 py-1 transition-colors">
+                    <span className="text-[var(--text-secondary)]">Fastest Solo</span>
+                    <span className="text-[var(--text-primary)] font-medium tabular-nums">
+                      {formatTime(bests.fastest_solo.run_time)}
+                      <span className="text-[var(--text-tertiary)] ml-2 text-xs">{displayName(bests.fastest_solo.character)} A{bests.fastest_solo.ascension}</span>
+                    </span>
+                  </Link>
+                )}
+                {bests.fastest_multi && (
+                  <Link href={`${lp}/runs/${bests.fastest_multi.run_hash}`} className="flex items-center justify-between text-sm hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 py-1 transition-colors">
+                    <span className="text-[var(--text-secondary)]">Fastest Co-op</span>
+                    <span className="text-[var(--text-primary)] font-medium tabular-nums">
+                      {formatTime(bests.fastest_multi.run_time)}
+                      <span className="text-[var(--text-tertiary)] ml-2 text-xs">{displayName(bests.fastest_multi.character)} A{bests.fastest_multi.ascension}</span>
+                    </span>
+                  </Link>
+                )}
+                {bests.highest_ascension && (
+                  <Link href={`${lp}/runs/${bests.highest_ascension.run_hash}`} className="flex items-center justify-between text-sm hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 py-1 transition-colors">
+                    <span className="text-[var(--text-secondary)]">Highest Ascension</span>
+                    <span className="text-[var(--text-primary)] font-medium tabular-nums">
+                      A{bests.highest_ascension.ascension}
+                      <span className="text-[var(--text-tertiary)] ml-2 text-xs">{displayName(bests.highest_ascension.character)} {formatTime(bests.highest_ascension.run_time)}</span>
+                    </span>
+                  </Link>
+                )}
+                {bests.fastest_daily && (
+                  <Link href={`${lp}/runs/${bests.fastest_daily.run_hash}`} className="flex items-center justify-between text-sm hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 py-1 transition-colors">
+                    <span className="text-[var(--text-secondary)]">Fastest Daily Climb</span>
+                    <span className="text-[var(--text-primary)] font-medium tabular-nums">
+                      {formatTime(bests.fastest_daily.run_time)}
+                      <span className="text-[var(--text-tertiary)] ml-2 text-xs">{displayName(bests.fastest_daily.character)}</span>
+                    </span>
+                  </Link>
+                )}
               </div>
             </div>
           )}

--- a/frontend/app/profile/ProfileClient.tsx
+++ b/frontend/app/profile/ProfileClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useAuth } from "@/app/contexts/AuthContext";
 import { useToast } from "@/app/components/Toast";
 import RunDropZone from "@/app/components/RunDropZone";
+import ProfileStats from "@/app/components/ProfileStats";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -290,6 +291,12 @@ export default function ProfileClient() {
             )}
           </>
         )}
+      </section>
+
+      {/* Personal Stats */}
+      <section>
+        <h2 className="text-lg font-semibold text-[var(--text-primary)] mb-3">Your Stats</h2>
+        <ProfileStats />
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add Docker BuildKit layer caching to all CI builds
- Increase username limit from 25 to 32 characters (Steam name length)
- Extract RunDropZone as shared component for submit and profile pages
- Add personal stats and personal bests to profile page
- Add competitive comparison: daily leaderboard, global ranks, win rate vs community
- Revert CDN image URLs to .webp (R2 bucket now has webp files)