### PR TITLE
Profile stats, leaderboard URL sharing, navbar updates

### DIFF
--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -194,28 +194,6 @@ export default function Navbar() {
             </span>
           </Link>
 
-          <div className="hidden lg:flex items-center gap-2 ml-2">
-            <a
-              href="https://discord.gg/xMsTBeh"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-              aria-label="Discord"
-            >
-              <DiscordIcon className="w-5 h-5" />
-            </a>
-            <a
-              href="https://www.patreon.com/cw/SpireCodex"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-              aria-label="Patreon"
-            >
-              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M14.82 2.41c3.96 0 7.18 3.24 7.18 7.21 0 3.96-3.22 7.18-7.18 7.18-3.97 0-7.21-3.22-7.21-7.18 0-3.97 3.24-7.21 7.21-7.21M2 21.6h3.5V2.41H2V21.6z" />
-              </svg>
-            </a>
-          </div>
 
           {/* Desktop nav — lg+ only. Single-row mega-menu pattern: each
               group button opens a multi-column panel below the row. Pure
@@ -323,6 +301,26 @@ export default function Navbar() {
                 with the current view filtered out. Colour reflects
                 which site you're on (gold = main, emerald = beta). */}
             <SiteSwitcher />
+            <a
+              href="https://discord.gg/xMsTBeh"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hidden sm:flex text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+              aria-label="Discord"
+            >
+              <DiscordIcon className="w-5 h-5" />
+            </a>
+            <a
+              href="https://www.patreon.com/cw/SpireCodex"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hidden sm:flex text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+              aria-label="Patreon"
+            >
+              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M14.82 2.41c3.96 0 7.18 3.24 7.18 7.21 0 3.96-3.22 7.18-7.18 7.18-3.97 0-7.21-3.22-7.21-7.18 0-3.97 3.24-7.21 7.21-7.21M2 21.6h3.5V2.41H2V21.6z" />
+              </svg>
+            </a>
             <LanguageSelector />
 
             {/* Icon search — visible on mobile (below md) AND at lg+

--- a/frontend/app/components/ProfileStats.tsx
+++ b/frontend/app/components/ProfileStats.tsx
@@ -213,7 +213,7 @@ export default function ProfileStats({
 
   const tabs: { key: Tab; label: string }[] = [
     { key: "overview", label: "Overview" },
-    { key: "runs", label: `My Runs${runsTotal > 0 ? ` (${runsTotal})` : ""}` },
+    { key: "runs", label: "Runs" },
     { key: "cards", label: "Cards" },
     { key: "relics", label: "Relics" },
     { key: "potions", label: "Potions" },


### PR DESCRIPTION
## Summary
- Profile: Stats first with tabs (Overview, Runs, Cards, Relics, Potions), competitive comparison, personal bests with ranks
- Leaderboard: Shareable URLs, "Today" filter for daily climbs, version sort fix
- Navbar: Merge Contact into About, Discord/Patreon icons next to version switcher, white logo on mobile
- Discord icon replaced with official symbol SVG
- Exclude starter cards/relics from top lists
- Username limit increased to 32 characters