### PR TITLE
Add Discord and Patreon buttons to mobile drawer

### DIFF
--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -534,6 +534,30 @@ export default function Navbar() {
                     </div>
                   );
                 })}
+
+                {/* Discord + Patreon quick links */}
+                <div className="border-t border-[var(--border-subtle)] flex gap-2 p-3">
+                  <a
+                    href="https://discord.gg/xMsTBeh"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex-1 flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg bg-[var(--bg-card)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                  >
+                    <DiscordIcon className="w-5 h-5" />
+                    Discord
+                  </a>
+                  <a
+                    href="https://www.patreon.com/cw/SpireCodex"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex-1 flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg bg-[var(--bg-card)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                  >
+                    <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M14.82 2.41c3.96 0 7.18 3.24 7.18 7.21 0 3.96-3.22 7.18-7.18 7.18-3.97 0-7.21-3.22-7.21-7.18 0-3.97 3.24-7.21 7.21-7.21M2 21.6h3.5V2.41H2V21.6z" />
+                    </svg>
+                    Patreon
+                  </a>
+                </div>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Discord and Patreon buttons at the bottom of the mobile navigation drawer for quick access