### PR TITLE
Release prep: CDN URL + auth env for prod/beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
             NEXT_PUBLIC_API_URL=
             NEXT_PUBLIC_SITE_URL=https://spire-codex.com
             NEXT_PUBLIC_UMAMI_WEBSITE_ID=${{ secrets.UMAMI_WEBSITE_ID }}
+            NEXT_PUBLIC_CDN_URL=https://cdn.spire-codex.com
           tags: |
             ptrlrd/spire-codex-frontend:latest
             ptrlrd/spire-codex-frontend:${{ github.sha }}
@@ -162,6 +163,7 @@ jobs:
             NEXT_PUBLIC_API_URL=
             NEXT_PUBLIC_SITE_URL=https://beta.spire-codex.com
             NEXT_PUBLIC_UMAMI_WEBSITE_ID=${{ secrets.UMAMI_BETA_WEBSITE_ID }}
+            NEXT_PUBLIC_CDN_URL=https://cdn.spire-codex.com
           tags: |
             ptrlrd/spire-codex-frontend:beta
             ptrlrd/spire-codex-frontend:beta-${{ github.sha }}


### PR DESCRIPTION
## Summary
Prep prod and beta for the 1.1.3 promotion:
- Add `NEXT_PUBLIC_CDN_URL` to the stable and beta frontend builds (without it, prod/beta request /static/images/*.webp from a backend that no longer ships webp, breaking images)
- Wire the user-accounts auth env vars (`JWT_SECRET`, `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `FRONTEND_URL`, `SPIRE_CODEX_PUBLIC_BASE`, `ENVIRONMENT`) into the prod and beta backend `environment:` blocks; values already live in the host .env
- Beta intentionally omits `MONGO_URL` so it keeps its read-only data-beta backend (add it later if beta accounts are wanted)

Must merge to staging before promoting staging → main.