### PR TITLE
Wire auth env vars into prod and beta compose

### DIFF
--- a/docker-compose.beta.yml
+++ b/docker-compose.beta.yml
@@ -24,6 +24,17 @@ services:
       - GITHUB_APP_INSTALLATION_ID=${GITHUB_APP_INSTALLATION_ID:-}
       - GITHUB_APP_REPO=${GITHUB_APP_REPO:-}
       - GITHUB_APP_PRIVATE_KEY_PATH=${GITHUB_APP_PRIVATE_KEY_PATH:-/secrets/knowledge-demon.private-key.pem}
+      # User accounts (Steam/Discord OAuth + JWT sessions). Values live
+      # in the host .env; passed through so the auth endpoints work.
+      # NOTE: sign-in also needs MONGO_URL (the user store lives in
+      # Mongo). Left off here on purpose so beta keeps its read-only
+      # data-beta backend — add MONGO_URL if beta accounts are wanted.
+      - JWT_SECRET=${JWT_SECRET:-}
+      - DISCORD_CLIENT_ID=${DISCORD_CLIENT_ID:-}
+      - DISCORD_CLIENT_SECRET=${DISCORD_CLIENT_SECRET:-}
+      - FRONTEND_URL=${FRONTEND_URL:-https://beta.spire-codex.com}
+      - SPIRE_CODEX_PUBLIC_BASE=${SPIRE_CODEX_PUBLIC_BASE:-https://beta.spire-codex.com}
+      - ENVIRONMENT=${ENVIRONMENT:-production}
     networks:
       - nginx_web-network
     logging:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,6 +53,14 @@ services:
       # path. Falls through to local /data/runs.db SQLite otherwise
       # (the current state while the migration is in progress).
       - MONGO_URL=${MONGO_URL:-}
+      # User accounts (Steam/Discord OAuth + JWT sessions). Values live
+      # in the host .env; passed through so the auth endpoints work.
+      - JWT_SECRET=${JWT_SECRET:-}
+      - DISCORD_CLIENT_ID=${DISCORD_CLIENT_ID:-}
+      - DISCORD_CLIENT_SECRET=${DISCORD_CLIENT_SECRET:-}
+      - FRONTEND_URL=${FRONTEND_URL:-https://spire-codex.com}
+      - SPIRE_CODEX_PUBLIC_BASE=${SPIRE_CODEX_PUBLIC_BASE:-https://spire-codex.com}
+      - ENVIRONMENT=${ENVIRONMENT:-production}
       # prometheus_client multiprocess mode. Set in the env (not the
       # CMD) so it's exported into every worker as a real env var
       # before prometheus_client is imported. The dir is recreated +


### PR DESCRIPTION
## Summary
- Adds the user-accounts auth env vars (JWT_SECRET, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, FRONTEND_URL, SPIRE_CODEX_PUBLIC_BASE, ENVIRONMENT) to the prod and beta backend environment blocks
- Values already exist in the host .env; this passes them through so sign-in works after the 1.1.3 promotion
- This commit was pushed to #371 after that PR merged, so it never landed; this PR carries it in
- Beta intentionally omits MONGO_URL to keep its read-only data-beta backend