### PR TITLE
Docs sweep for 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,12 @@ spire-codex/
 | Guides | `/guides` | Community strategy guides with search/filter |
 | Guide Detail | `/guides/[slug]` | Full guide with markdown rendering + tooltip widget |
 | Submit Guide | `/guides/submit` | Guide submission form (Discord webhook) |
-| Leaderboards | `/leaderboards` | Three-tab browser: Fastest Wins, Highest Ascension, Browse Runs (search by seed/username, filter by character/win/loss/game version) |
-| Submit a Run | `/leaderboards/submit` | Drag-and-drop `.run` upload, JSON paste fallback, upload progress |
+| Leaderboards | `/leaderboards` | Fastest Wins and Highest Ascension ladders with single/co-op and game-mode filters (standard / daily / Today / custom). All filter state is in the URL so any view is shareable |
+| Browse Runs | `/runs` | Full run browser with an expression search bar (`user:`, `char:`, `asc:` ranges, `card:`/`relic:` multi-value AND, `version:` ranges, `mode:`, `result:`, `players:`) plus dropdown filters, sort, and shareable URLs |
+| Submit a Run | `/leaderboards/submit` | Drag-and-drop `.run` upload with Overwolf companion link, Steam/Discord sign-in to auto-associate runs, and your recent runs |
 | Stats | `/leaderboards/stats` | Ranked tables (pick rate, win rate, count) for cards, relics, potions, encounters. Filter by character / ascension / outcome |
+| Profile | `/profile` | Signed-in user's stats (top cards/relics/potions, character breakdown), personal bests, competitive comparison (today's daily leaderboard, global ranks, win rate vs community), and run management |
+| Settings | `/settings` | Account settings: username, email, linked Steam/Discord |
 | Shared Run | `/runs/[hash]` | In-game-style victory/defeat summary with clickable map-node icons, relic strip, and tiny-card grid |
 | Reference | `/reference` | All items clickable — acts, ascensions, keywords, orbs, afflictions, intents, modifiers, achievements |
 | Images | `/images` | Browsable game assets with ZIP download per category |
@@ -263,17 +266,35 @@ All data endpoints accept an optional `?lang=` query parameter (default: `eng`).
 | `GET /api/guides/{slug}` | Single guide (with markdown content) | — |
 | `POST /api/guides` | Submit guide (proxied to Discord) | — |
 | `POST /api/runs` | Submit a run (.run file JSON) | `username` |
-| `GET /api/runs/list` | List submitted runs | `character`, `win`, `username`, `seed`, `build_id`, `sort`, `page`, `limit` |
+| `GET /api/runs/list` | List/browse submitted runs | `character`, `win`, `username`, `seed`, `build_id`, `build_ids`, `players`, `game_mode`, `ascension`, `ascension_min`, `ascension_max`, `card`, `relic`, `today`, `sort`, `page`, `limit` |
 | `GET /api/runs/shared/{hash}` | Full run data by hash (merges `username` from DB) | — |
 | `GET /api/runs/stats` | Aggregated community stats | `character`, `win`, `ascension`, `game_mode`, `players` |
-| `GET /api/runs/leaderboard` | Ranked wins-only leaderboard | `category` (`fastest`, `highest_ascension`), `character`, `page`, `limit` |
+| `GET /api/runs/leaderboard` | Ranked wins-only leaderboard | `category` (`fastest`, `highest_ascension`), `character`, `players`, `game_mode`, `today`, `page`, `limit` |
+| `GET /api/runs/leaderboard/rank/{hash}` | Rank of a single winning run within its ladder | `category` |
 | `GET /api/runs/scores/{type}` | Codex Score (Bayesian-shrunk win-rate score + S/A/B/C/D/F tier) per entity | `type` = `cards`/`relics`/`potions` |
+| `GET /api/runs/encounter-stats` | Per-encounter aggregates (appearance, fatal rate, avg damage/turns) | `act`, `room_type`, `multiplayer`, `page`, `limit` |
+| `POST /api/runs/claim` | Attach a username to previously-submitted runs by hash | — |
 | `GET /api/runs/versions` | Distinct game versions across submitted runs | — |
+| `GET /api/exports/{lang}` | ZIP of all entity JSON for one language | `lang` |
 | `GET /api/news` | Steam announcements + community news (locally archived) | `feed_type`, `feedname`, `tag`, `since`, `search`, `limit`, `offset` |
 | `GET /api/news/{gid}` | Single news article (raw HTML/BBCode body) | — |
 | `GET /api/merchant/config` | Auto-extracted merchant pricing config | — |
 | `POST /api/feedback` | Submit feedback (proxied to Discord) | — |
 | `GET /api/versions` | Available data versions (beta multi-version) | — |
+
+**User accounts** (cookie/JWT session; sign in with Steam or Discord):
+
+| Endpoint | Description |
+|---|---|
+| `GET /api/auth/me` | Current signed-in user |
+| `GET /api/auth/steam/redirect` | Start Steam OpenID sign-in |
+| `GET /api/auth/discord/start` | Start Discord OAuth sign-in |
+| `POST /api/auth/logout` | Clear the session cookie |
+| `PATCH /api/auth/username` / `PATCH /api/auth/email` | Update profile fields |
+| `GET /api/auth/runs` / `POST /api/auth/runs/upload` / `DELETE /api/auth/runs/{hash}` | List, upload, and remove the user's runs |
+| `GET /api/auth/stats` | Per-user aggregated stats (profile page) |
+| `GET /api/auth/personal-bests` | Fastest solo/co-op, highest ascension, today's and all-time daily |
+| `GET /api/auth/competitive` | Today's daily leaderboard, global ranks, win rate vs community |
 
 Rate limited to **60 requests per minute** per IP. Feedback and guide submission limited to **3-5 per minute** per IP. Interactive docs at `/docs` (Swagger UI).
 
@@ -362,6 +383,25 @@ docker compose up --build
 ```
 
 Starts both services (backend on 8000, frontend on 3000).
+
+### Environment variables
+
+The core read-only API needs no configuration. The optional features below are
+enabled by env vars (set in the backend's environment or the compose file):
+
+| Variable | Used by | Notes |
+|---|---|---|
+| `MONGO_URL` | Backend | Runs database (community stats, leaderboards, accounts). When unset, the backend falls back to the legacy SQLite path (`data/runs.db`). |
+| `JWT_SECRET` | Backend | Signs user-account session tokens. |
+| `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET` | Backend | Discord OAuth sign-in. |
+| `FRONTEND_URL`, `SPIRE_CODEX_PUBLIC_BASE` | Backend | OAuth redirect / return URLs. |
+| `ENVIRONMENT` | Backend | `production` toggles secure-cookie behavior. |
+| `NEXT_PUBLIC_API_URL` | Frontend (build) | API base; empty in prod so images/data resolve same-origin. |
+| `NEXT_PUBLIC_CDN_URL` | Frontend (build) | When set (e.g. `https://cdn.spire-codex.com`), images load from the CDN instead of `/static`. |
+| `NEXT_PUBLIC_SITE_URL` | Frontend (build) | Canonical site URL for metadata. |
+
+User accounts and the CDN are off by default, so the project runs end-to-end
+without any of these.
 
 ## Update Pipeline
 
@@ -746,9 +786,13 @@ Thanks to **vesper-arch**, **terracubist**, **U77654**, **Purple Aspired Dreamin
 ## Tech Stack
 
 - **Backend**: Python, FastAPI, Pydantic, slowapi, GZip compression
+- **Runs database**: MongoDB (community stats, leaderboards, user accounts), with a materialized `stats_summary` collection and a leader-elected background refresher. Legacy SQLite path kept as an offline fallback.
+- **Accounts**: Steam OpenID + Discord OAuth, JWT session cookies
 - **Frontend**: Next.js 16 (App Router), TypeScript, Tailwind CSS, 14-language support
+- **Images/CDN**: Cloudflare R2 served via `cdn.spire-codex.com` (webp)
+- **Analytics & observability**: self-hosted Umami, Prometheus + node-exporter
 - **Spine Renderer**: Node.js, Playwright, @esotericsoftware/spine-webgl (WebGL via headless Chrome)
-- **Infrastructure**: Docker, GitHub Actions CI (self-hosted K8s runner), SSH deploy
+- **Infrastructure**: Docker, GitHub Actions CI (self-hosted runner) with registry-backed BuildKit cache, Ansible/SSH deploy
 - **Tools**: Python (update pipeline, changelog diffing, image copying)
 
 ## License

--- a/README_CN.md
+++ b/README_CN.md
@@ -121,7 +121,7 @@ spire-codex/
 │   ├── guides/                 # 带 YAML frontmatter 的 Markdown 指南文件
 │   ├── guides.json             # 解析后的指南数据
 │   ├── runs/                   # 用户提交的 run JSON 文件（按玩家 hash）
-│   └── runs.db                 # 存储 run 元数据的 SQLite 数据库
+│   └── runs.db                 # 旧版 SQLite 回退（run 元数据现已迁移至 MongoDB）
 ├── extraction/                 # 原始游戏文件（未提交）
 │   ├── raw/                    # 通过 GDRE 提取出的 Godot 项目（stable）
 │   ├── decompiled/             # ILSpy 输出（stable）
@@ -177,8 +177,13 @@ spire-codex/
 | 指南 | `/guides` | 社区策略指南，支持搜索 / 筛选 |
 | 指南详情 | `/guides/[slug]` | 完整指南，支持 Markdown 渲染和 tooltip 组件 |
 | 提交指南 | `/guides/submit` | 指南提交表单（Discord webhook） |
-| Runs | `/runs` | 社区 run 浏览器，支持角色 / 胜负筛选 |
-| Meta | `/meta` | 来自用户提交 runs 的实时社区统计 |
+| 排行榜 | `/leaderboards` | 最快通关与最高进阶榜单，支持单人 / 合作与游戏模式筛选（标准 / 每日 / 今日 / 自定义）。所有筛选状态写入 URL，任意视图均可分享 |
+| 浏览 Runs | `/runs` | 完整的 run 浏览器，带表达式搜索栏（`user:`、`char:`、`asc:` 区间、`card:`/`relic:` 多值 AND、`version:` 区间、`mode:`、`result:`、`players:`），外加下拉筛选、排序与可分享 URL |
+| 提交 Run | `/leaderboards/submit` | 拖放上传 `.run`，含 Overwolf 伴侣应用链接、Steam/Discord 登录以自动关联 run，以及你最近的 runs |
+| 统计 | `/leaderboards/stats` | 卡牌 / 遗物 / 药水 / 遭遇战的排名表（选取率、胜率、计数），可按角色 / 进阶 / 结果筛选 |
+| 个人档案 | `/profile` | 登录用户的统计（常用卡牌 / 遗物 / 药水、角色分布）、个人最佳、竞技对比（今日每日榜、全球排名、对比社区胜率）及 run 管理 |
+| 设置 | `/settings` | 账户设置：用户名、邮箱、已绑定的 Steam/Discord |
+| 共享 Run | `/runs/[hash]` | 游戏内风格的胜利 / 失败总结，含可点击的地图节点图标、遗物条与迷你卡牌网格 |
 | 参考 | `/reference` | 所有条目可点击 —— 章节、进阶等级、关键词、充能球、苦难、意图、修饰器、成就 |
 | 图片 | `/images` | 可浏览的游戏素材，支持按类别下载 ZIP |
 | 更新日志 | `/changelog` | 游戏更新之间的数据差异 |
@@ -247,14 +252,33 @@ spire-codex/
 | `GET /api/guides/{slug}` | 单篇攻略（含 Markdown 内容） | — |
 | `POST /api/guides` | 提交攻略（代理到 Discord） | — |
 | `POST /api/runs` | 提交一个 run（`.run` 文件 JSON） | `username` |
-| `GET /api/runs/list` | 已提交 runs 列表 | `character`, `win`, `username`, `page`, `limit` |
+| `GET /api/runs/list` | 浏览已提交的 runs | `character`, `win`, `username`, `seed`, `build_id`, `build_ids`, `players`, `game_mode`, `ascension`, `ascension_min`, `ascension_max`, `card`, `relic`, `today`, `sort`, `page`, `limit` |
 | `GET /api/runs/shared/{hash}` | 通过 hash 获取完整 run 数据（会合并数据库中的 `username`） | — |
 | `GET /api/runs/stats` | 聚合后的社区统计 | `character`, `win`, `ascension`, `game_mode`, `players` |
+| `GET /api/runs/leaderboard` | 仅胜利的排名榜单 | `category`（`fastest`、`highest_ascension`）、`character`、`players`、`game_mode`、`today`、`page`、`limit` |
+| `GET /api/runs/leaderboard/rank/{hash}` | 单个胜利 run 在榜单中的名次 | `category` |
 | `GET /api/runs/scores/{type}` | 各实体的 Codex Score（贝叶斯收缩胜率得分 + S/A/B/C/D/F 等级） | `type` 取值 `cards`/`relics`/`potions` |
+| `GET /api/runs/encounter-stats` | 各遭遇战聚合（出现次数、致死率、平均伤害 / 回合） | `act`、`room_type`、`multiplayer`、`page`、`limit` |
+| `POST /api/runs/claim` | 通过 hash 把用户名关联到此前提交的 runs | — |
+| `GET /api/exports/{lang}` | 某语言全部实体 JSON 的 ZIP | `lang` |
 | `GET /api/news` | Steam 公告 + 社区新闻（本地归档；超出 Steam 滑动窗口仍可访问） | `feed_type`, `feedname`, `tag`, `since`, `search`, `limit`, `offset` |
 | `GET /api/news/{gid}` | 单篇新闻文章（原始 HTML / BBCode 正文） | — |
 | `GET /api/merchant/config` | 自动提取的商人价格配置 | — |
 | `POST /api/feedback` | 提交反馈（代理到 Discord） | — |
+
+**用户账户**（Cookie/JWT 会话；可用 Steam 或 Discord 登录）：
+
+| 端点 | 说明 |
+|---|---|
+| `GET /api/auth/me` | 当前登录用户 |
+| `GET /api/auth/steam/redirect` | 发起 Steam OpenID 登录 |
+| `GET /api/auth/discord/start` | 发起 Discord OAuth 登录 |
+| `POST /api/auth/logout` | 清除会话 Cookie |
+| `PATCH /api/auth/username` / `PATCH /api/auth/email` | 更新资料字段 |
+| `GET /api/auth/runs` / `POST /api/auth/runs/upload` / `DELETE /api/auth/runs/{hash}` | 列出、上传、删除用户的 runs |
+| `GET /api/auth/stats` | 用户聚合统计（个人档案页） |
+| `GET /api/auth/personal-bests` | 最快单人 / 合作、最高进阶、今日及历史每日 |
+| `GET /api/auth/competitive` | 今日每日榜、全球排名、对比社区胜率 |
 
 每个 IP 每分钟限流 **60 次请求**。反馈和攻略提交接口每个 IP 每分钟限制 **3–5 次**。交互式文档位于 `/docs`（Swagger UI）。
 
@@ -344,6 +368,23 @@ docker compose up --build
 ```
 
 会同时启动两个服务（后端在 8000，前端在 3000）。
+
+### 环境变量
+
+只读核心 API 无需任何配置。下列可选功能由环境变量启用（设置在后端环境或 compose 文件中）：
+
+| 变量 | 使用方 | 说明 |
+|---|---|---|
+| `MONGO_URL` | 后端 | Runs 数据库（社区统计、排行榜、账户）。未设置时回退到旧版 SQLite（`data/runs.db`）。 |
+| `JWT_SECRET` | 后端 | 签发用户账户会话令牌。 |
+| `DISCORD_CLIENT_ID`、`DISCORD_CLIENT_SECRET` | 后端 | Discord OAuth 登录。 |
+| `FRONTEND_URL`、`SPIRE_CODEX_PUBLIC_BASE` | 后端 | OAuth 跳转 / 返回 URL。 |
+| `ENVIRONMENT` | 后端 | `production` 时启用安全 Cookie。 |
+| `NEXT_PUBLIC_API_URL` | 前端（构建期） | API 基址；生产环境留空以同源解析。 |
+| `NEXT_PUBLIC_CDN_URL` | 前端（构建期） | 设置后（如 `https://cdn.spire-codex.com`）图片走 CDN 而非 `/static`。 |
+| `NEXT_PUBLIC_SITE_URL` | 前端（构建期） | 元数据用的规范站点 URL。 |
+
+用户账户与 CDN 默认关闭，因此无需上述任何变量即可端到端运行。
 
 ## 更新流水线
 
@@ -701,8 +742,11 @@ Spire Codex 使用 **`1.X.Y`** 语义化版本规则：
 - ~~Discord 机器人~~ ✅ —— [Knowledge Demon](https://bot.spire-codex.com)：每个实体都有斜杠命令（`/card`、`/relic`、`/monster`、`/potion`、`/character`、`/event`、`/power`、`/enchantment`、`/lookup`、`/meta`），支持 Steam 新闻 RSS，外加从 [Kernel](https://github.com/ptrlrd/kernel) 派生的完整版务工具集
 - ~~Codex Score 与梯度表~~ ✅ —— 基于社区 run 数据，使用**贝叶斯收缩**计算每个实体的评分：`shrunk = (wins + PRIOR_WEIGHT × baseline) / (n + PRIOR_WEIGHT)`，再缩放到 0–100 并映射到 S/A/B/C/D/F。可避免小样本噪声（一张只打过 1 局且胜的卡不会拿到 S，而是回归先验）。FastAPI 启动时预热缓存。在详情页 Stats 标签通过 `ScoreBadge` 展示，并在 `/tier-list/{cards,relics,potions}` 单独陈列，方法论页面位于 `/leaderboards/scoring`。
 - ~~详情页 Stats 标签~~ ✅ —— `EntityRunStats` 提供得分徽章 + 文字总结 + 最近 run 链接。
+- ~~Runs 数据库后端~~ ✅ —— MongoDB（社区统计、排行榜、账户）；通过 leader 选举的刷新器维护物化的 `stats_summary` 与 `entity_stats_snapshot` 集合，未设置 `MONGO_URL` 时回退到 SQLite
+- ~~用户账户~~ ✅ —— Steam OpenID + Discord OAuth、JWT 会话、个人档案统计、个人最佳、竞技对比、run 关联 / 上传
+- ~~图片 CDN~~ ✅ —— Cloudflare R2，经 `cdn.spire-codex.com` 提供（webp）
 - **构筑编辑器** —— 可交互式牌组理论构筑
-- **数据库后端** —— 用 SQLite / PostgreSQL 替换 JSON 加载
+- **Patreon 账户关联** —— 为支持者解锁权益
 
 ## 致谢
 
@@ -711,9 +755,13 @@ Spire Codex 使用 **`1.X.Y`** 语义化版本规则：
 ## 技术栈
 
 - **后端**：Python、FastAPI、Pydantic、slowapi、GZip 压缩
+- **Runs 数据库**：MongoDB（社区统计、排行榜、用户账户），含物化的 `stats_summary` 集合与 leader 选举的后台刷新器；保留 SQLite 作为离线回退
+- **账户**：Steam OpenID + Discord OAuth、JWT 会话 Cookie
 - **前端**：Next.js 16（App Router）、TypeScript、Tailwind CSS、14 语言支持
+- **图片 / CDN**：Cloudflare R2，经 `cdn.spire-codex.com` 提供（webp）
+- **分析与可观测性**：自托管 Umami、Prometheus + node-exporter
 - **Spine 渲染器**：Node.js、Playwright、@esotericsoftware/spine-webgl（通过无头 Chrome 使用 WebGL）
-- **基础设施**：Docker、Forgejo CI、buildah
+- **基础设施**：Docker、GitHub Actions CI（自托管 runner，带 BuildKit 缓存）、Ansible/SSH 部署
 - **工具**：Python（更新流水线、changelog diff、图片复制）
 
 ## 免责声明

--- a/contributing/API_REFERENCE.md
+++ b/contributing/API_REFERENCE.md
@@ -60,14 +60,36 @@ All data endpoints accept `?lang=` (default: `eng`). Rate limited to 60 req/min 
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `POST /api/runs` | POST | Submit a run. Optional `?username=` param (25 char max) |
+| `POST /api/runs` | POST | Submit a run. Optional `?username=` param (32 char max) |
 | `GET /api/runs/stats` | GET | Aggregated community stats. Filters: `character`, `win`, `ascension`, `game_mode`, `players` |
-| `GET /api/runs/list` | GET | Browse runs. Filters: `character`, `win`, `username`, `seed` (LIKE), `build_id`, `sort` (`date`, `time_asc`, `time_desc`, `ascension_desc`), `page`, `limit` |
-| `GET /api/runs/shared/{hash}` | GET | Retrieve a shared run by hash. Response merges `username` from `runs.db` so the shared-run page can render "by {username}" without a second round trip. |
-| `GET /api/runs/leaderboard` | GET | Ranked wins-only leaderboard. Filters: `category` (`fastest`, `highest_ascension`), `character`, `page`, `limit` |
-| `GET /api/runs/scores/{type}` | GET | Codex Score per entity. `type` ∈ `cards` / `relics` / `potions`. Returns `{ id, score (0–100), tier (S/A/B/C/D/F), wins, losses, n }[]`. Bayesian-shrunk win rate; pre-warmed on FastAPI startup. See `services/run_entity_stats.py` and `/leaderboards/scoring` for the formula. |
+| `GET /api/runs/list` | GET | Browse runs. Filters: `character`, `win`, `username`, `seed` (LIKE), `build_id`, `build_ids` (comma list), `players` (`single`/`multi`), `game_mode`, `ascension`, `ascension_min`, `ascension_max`, `card`, `relic` (exact id; comma-separated = AND), `today`, `sort` (`date`, `time_asc`, `time_desc`, `ascension_desc`), `page`, `limit` |
+| `GET /api/runs/shared/{hash}` | GET | Retrieve a shared run by hash. Response merges `username` from the runs DB so the shared-run page can render "by {username}" without a second round trip. |
+| `GET /api/runs/leaderboard` | GET | Ranked wins-only leaderboard. Filters: `category` (`fastest`, `highest_ascension`), `character`, `players`, `game_mode`, `today`, `page`, `limit` |
+| `GET /api/runs/leaderboard/rank/{hash}` | GET | Rank of one winning run within its ladder. `category` filter. |
+| `POST /api/runs/claim` | POST | Body `{ username, hashes: [] }` — attaches a username to previously-submitted runs (only rows with a null/empty username). |
+| `GET /api/runs/scores/{type}` | GET | Codex Score per entity. `type` ∈ `cards` / `relics` / `potions`. Returns `{ id, score (0–100), tier (S/A/B/C/D/F), wins, losses, n }[]`. Bayesian-shrunk win rate graded against the per-type average, materialized to MongoDB by a single leader and read by all workers. See `services/run_entity_stats.py` and `/leaderboards/scoring`. |
 | `GET /api/runs/encounter-stats` | GET | Per-encounter aggregation. Query params: `act` (comma-separated 1/2/3), `room_type` (comma-separated monster/elite/boss), `multiplayer` (`only`/`exclude`), `page`, `limit` (max 200, default 50). Returns `{ encounters: [{ encounter_id, act, room_type, total, fatal, avg_damage, avg_turns, characters: [{ character, total, fatal, avg_damage, avg_turns }] }], page, limit, total, has_next }`. Mongo-only; returns empty when no Mongo backend is configured. |
 | `GET /api/runs/versions` | GET | Distinct `build_id` values across submitted runs — powers the version filter dropdown |
+
+## User Accounts
+
+Cookie/JWT session. Sign in with Steam (OpenID) or Discord (OAuth). Requires `MONGO_URL` + the auth env vars (`JWT_SECRET`, `DISCORD_CLIENT_ID/SECRET`, `FRONTEND_URL`, `SPIRE_CODEX_PUBLIC_BASE`).
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `GET /api/auth/me` | GET | Current user, or 401 |
+| `GET /api/auth/steam/redirect` | GET | Begin Steam OpenID flow |
+| `GET /api/auth/discord/start` | GET | Begin Discord OAuth flow |
+| `POST /api/auth/logout` | POST | Clear the session cookie |
+| `POST /api/auth/set-cookie` | POST | Exchange a token for an httpOnly cookie (cross-origin dev) |
+| `PATCH /api/auth/username` | PATCH | Update username (32 char max, 3 changes/day) |
+| `PATCH /api/auth/email` | PATCH | Update email |
+| `GET /api/auth/runs` | GET | The user's runs (paginated) |
+| `POST /api/auth/runs/upload` | POST | Multi-file `.run` upload, claimed to the user |
+| `DELETE /api/auth/runs/{hash}` | DELETE | Soft-delete one of the user's runs |
+| `GET /api/auth/stats` | GET | Per-user aggregated stats (profile page) |
+| `GET /api/auth/personal-bests` | GET | Fastest solo/co-op, highest ascension, today's + all-time daily |
+| `GET /api/auth/competitive` | GET | Today's daily leaderboard, per-best global rank, win rate vs community |
 
 ## Utility
 

--- a/contributing/ARCHITECTURE.md
+++ b/contributing/ARCHITECTURE.md
@@ -22,8 +22,9 @@ The game is built with Godot 4 but all logic is in a C#/.NET 8 DLL, not GDScript
 - **25+ routers** in `app/routers/` — one per entity type + guides, runs, feedback, news, merchant
 - **Data service** loads JSON from `data/{lang}/` with LRU caching; `VersionMiddleware` reads `?version=` and threads it through via `ContextVar`
 - **MongoDB** (self-hosted single-node replica set on the DB origin) for community run submissions. Materialized `stats_summary` collection populated by a background refresher (one worker via a Mongo TTL lease) — API handlers read the precomputed doc in sub-millisecond time. SQLite (`data/runs.db`) is kept as the offline-fallback codepath in `services/runs_db.py` when `MONGO_URL` is unset.
-- **Run entity stats service** (`app/services/run_entity_stats.py`) — computes the Codex Score (Bayesian-shrunk win rate → 0–100 → S/A/B/C/D/F tier) per card/relic/potion. Pre-warmed on FastAPI startup by `_warm_run_entity_stats()` in `main.py` so the first request isn't a cold cache.
-- **Static images** served from `backend/static/images/`
+- **Run entity stats service** (`app/services/run_entity_stats.py`) — computes the Codex Score (Bayesian-shrunk win rate, graded against the per-type average → 0–100 → S/A/B/C/D/F tier) per card/relic/potion. The heavy 100k-file walk runs in a single leader process (same stats-refresher lease) and is materialized to the `entity_stats_snapshot` collection; every worker reads that shared snapshot rather than re-walking the run files.
+- **User accounts** (`app/routers/auth.py`, `services/auth_jwt.py`, `services/users_db.py`) — Steam OpenID + Discord OAuth, JWT session cookies, profile stats, personal bests, and competitive comparison. Users + their claimed runs live in MongoDB. Needs `JWT_SECRET`, `DISCORD_CLIENT_ID/SECRET`, `FRONTEND_URL`, `SPIRE_CODEX_PUBLIC_BASE`.
+- **Static images** served from `backend/static/images/` in dev; in production they're served from a Cloudflare R2 CDN at `cdn.spire-codex.com` (webp). `resolve_image_url` emits CDN URLs when `CDN_BASE_URL` is set; the frontend rewrites `/static/images/` to `NEXT_PUBLIC_CDN_URL` at build time.
 
 ### Parsers (`backend/app/parsers/`)
 

--- a/contributing/CLAUDE.md
+++ b/contributing/CLAUDE.md
@@ -86,14 +86,16 @@ spire-codex/
       guides/page.tsx        # Community guides list with search/filter
       guides/[slug]/         # Guide detail with markdown rendering + tooltip widget
       guides/submit/         # Guide submission form → Discord webhook
-      leaderboards/page.tsx  # Three-tab browser — Fastest Wins, Highest Ascension, Browse Runs
+      leaderboards/page.tsx  # Fastest Wins + Highest Ascension ladders (single/co-op, game-mode + Today filters, shareable URLs)
       leaderboards/submit/   # Drag-and-drop .run upload
       leaderboards/stats/    # Ranked-table stats (cards/relics/potions/encounters pick + win rates)
       leaderboards/scoring/  # Codex Score methodology page (Bayesian shrinkage explainer)
       tier-list/page.tsx     # Codex Score tier-list hub (cards/relics/potions)
       tier-list/[type]/      # Visual S→F tier rows per entity type
       runs/[hash]/           # Shared-run detail — "by {username}" link + in-game-style summary with TinyCard grid, clickable map nodes
-      runs/page.tsx          # Redirect to /leaderboards (old URL preserved)
+      runs/page.tsx          # Browse Runs — expression search bar + filters + shareable URLs
+      profile/page.tsx       # Signed-in user profile — stats, personal bests, competitive comparison, run management
+      settings/page.tsx      # Account settings (username, email, linked Steam/Discord)
       meta/page.tsx          # Redirect to /leaderboards/stats (old URL preserved)
       news/page.tsx          # Steam news list (mirrored archive)
       news/[gid]/page.tsx    # Single Steam news article — NewsArticle JSON-LD, canonical → Steam, BBCode-sanitized body
@@ -152,8 +154,8 @@ spire-codex/
     changelogs/             # Version changelogs with per-entity diffs
     guides/                 # Markdown guide files with YAML frontmatter
     guides.json             # Parsed guide data
-    runs/                   # Submitted run JSON files (per player hash)
-    runs.db                 # SQLite database for run metadata
+    runs/                   # Submitted run JSON files (per player hash) — deck/relic data read by the Codex Score builder
+    runs.db                 # Legacy SQLite (fallback when MONGO_URL unset; run metadata now lives in MongoDB)
     showcase.json           # Community project gallery data
   docker-compose.yml        # Local dev
   docker-compose.prod.yml   # Production (Docker Hub images + nginx network)
@@ -195,8 +197,11 @@ spire-codex/
 - `POST /api/guides` — Guide submission (Discord webhook, rate-limited)
 - `POST /api/runs` — Run submission / `GET /api/runs/list` (filters: character, win, username, seed, build_id, sort, page, limit) / `GET /api/runs/shared/{hash}` (merges `username` from DB) / `GET /api/runs/stats`
 - `GET /api/runs/leaderboard` — ranked wins-only list (category: fastest|highest_ascension, character, page, limit)
-- `GET /api/runs/scores/{type}` — Bulk Codex Scores for cards/relics/potions (Bayesian-shrunk win rate → 0–100 → S/A/B/C/D/F)
+- `GET /api/runs/scores/{type}` — Bulk Codex Scores for cards/relics/potions (Bayesian-shrunk win rate → 0–100 → S/A/B/C/D/F; materialized to Mongo by a single leader)
+- `GET /api/runs/leaderboard/rank/{hash}` — rank of one winning run; `POST /api/runs/claim` — attach username to prior runs
+- `GET /api/runs/encounter-stats` — per-encounter aggregates (Mongo-only)
 - `GET /api/runs/versions` — distinct build_ids across submitted runs
+- `/api/auth/*` — user accounts: Steam/Discord sign-in, `me`, `runs`, `runs/upload`, `stats`, `personal-bests`, `competitive` (cookie/JWT session)
 - `GET /api/news?feed_type=&feedname=&tag=&since=&search=&limit=&offset=` / `GET /api/news/{gid}` — Steam announcements (locally archived)
 - `GET /api/merchant/config` — Auto-extracted merchant pricing
 - `GET /api/versions` — Available data versions (beta multi-version browsing)
@@ -328,7 +333,7 @@ Parallel deployment for Steam beta branch data. Uses same codebase/images but se
 
 ## Versioning
 Uses `1.X.Y` — 1=codex major, X=bumps on Mega Crit game patch, Y=our fixes/improvements.
-Current: **v1.1.1** (X bumped on game v0.103.2 / Major Update #1; Y rolled with i18n + badges + smoke renders + changelog guard)
+Current: **v1.1.3** (Y rolled with user accounts, MongoDB migration, Codex Score tier lists, Cloudflare CDN, encounter stats, the /runs browser, and self-hosted analytics)
 
 ## Known Limitations
 - 6 monsters lack images entirely (Crusher, Doormaker, Flyconid, Ovicopter, Rocket, Decimillipede)
@@ -382,7 +387,9 @@ Current: **v1.1.1** (X bumped on game v0.103.2 / Major Update #1; Y rolled with 
   - Known gaps: compare graphs (keyword matching), merchant prose, about/changelog content, scattered client component strings
   - Current t() approach doesn't scale — hundreds of strings across dozens of components
   - `next-intl` handles URL-based locale detection, server/client components, centralized message files
-- Discord bot (card lookup, patch alerts)
+- ~~Database instead of JSON files for runs~~ ✅ — MongoDB (community stats, leaderboards, accounts); materialized `stats_summary` + `entity_stats_snapshot` collections via a leader-elected refresher
+- ~~User accounts~~ ✅ — Steam OpenID + Discord OAuth, JWT sessions, profile stats, personal bests, competitive comparison, run claiming/upload
+- ~~Discord bot (card lookup)~~ ✅ — Knowledge Demon (see /knowledge-demon)
+- ~~CDN for images~~ ✅ — Cloudflare R2 at `cdn.spire-codex.com` (webp)
 - Deck builder / run simulator
-- Database (SQLite/Postgres) instead of JSON files
-- User accounts with deck/run sharing
+- Patreon-to-account linking for supporter perks

--- a/contributing/CODEX.md
+++ b/contributing/CODEX.md
@@ -8,9 +8,12 @@ Spire Codex is a comprehensive database for Slay the Spire 2, built by reverse-e
 
 ## Quick References
 
-- **Backend**: Python 3.12, FastAPI, Pydantic, SQLite
+- **Backend**: Python 3.12, FastAPI, Pydantic
+- **Runs DB**: MongoDB (community stats, leaderboards, accounts); legacy SQLite fallback when `MONGO_URL` is unset
+- **Accounts**: Steam OpenID + Discord OAuth, JWT session cookies
 - **Frontend**: Next.js 16, TypeScript, Tailwind CSS, recharts
-- **Data**: JSON files in `data/{lang}/`, 14 languages
+- **Data**: game-entity JSON files in `data/{lang}/`, 14 languages (runs live in MongoDB)
+- **Images**: Cloudflare R2 CDN (`cdn.spire-codex.com`) when `NEXT_PUBLIC_CDN_URL` is set
 - **API docs**: `http://localhost:8000/docs`
 - **Run locally**: `docker compose up --build`
 
@@ -50,8 +53,10 @@ Spire Codex is a comprehensive database for Slay the Spire 2, built by reverse-e
 backend/app/main.py                       → App entry, router registration, `_warm_run_entity_stats()` startup pre-warm
 backend/app/routers/                      → API endpoints (one file per entity)
 backend/app/models/schemas.py             → Pydantic models
-backend/app/services/runs_db.py           → SQLite runs database
-backend/app/services/run_entity_stats.py  → Codex Score — Bayesian-shrunk win rate per entity, S/A/B/C/D/F tier
+backend/app/services/runs_db.py           → Runs DB dispatcher (Mongo when MONGO_URL set, else SQLite)
+backend/app/services/runs_db_mongo.py      → MongoDB runs store + materialized stats_summary + leader-lease refresher
+backend/app/routers/auth.py                → User accounts (profile, runs, stats, personal-bests, competitive)
+backend/app/services/run_entity_stats.py  → Codex Score — Bayesian-shrunk win rate per entity, S/A/B/C/D/F tier; materialized to Mongo by a single leader
 backend/app/parsers/                      → C# → JSON parsers
 frontend/app/layout.tsx                   → Root layout (navbar, footer, providers)
 frontend/app/globals.css                  → CSS variables, theme

--- a/contributing/DATA_GUIDE.md
+++ b/contributing/DATA_GUIDE.md
@@ -48,8 +48,8 @@ data/
   guides.json   Parsed guide data
   ancient_pools.json
   showcase.json
-  runs.db       SQLite (not committed)
-  runs/         Shared run JSONs (not committed)
+  runs.db       Legacy SQLite fallback, not committed (run metadata now lives in MongoDB)
+  runs/         Submitted run JSONs, not committed (deck/relic source for Codex Score)
 ```
 
 ## Parsing Data


### PR DESCRIPTION
## Summary
Documentation pass covering everything shipped since 1.1.2.

- **README.md / README_CN.md**: add the Browse Runs (/runs), Profile, and Settings pages; correct the Leaderboards entry (mode/Today filters, shareable URLs); document the auth, encounter-stats, leaderboard/rank, claim, and exports endpoints; add an environment-variable table (MONGO_URL, JWT_SECRET, DISCORD_*, FRONTEND_URL, SPIRE_CODEX_PUBLIC_BASE, NEXT_PUBLIC_CDN_URL); refresh the tech stack (MongoDB, CDN, Umami, Prometheus, OAuth)
- **contributing/**: API_REFERENCE gets a User Accounts section and updated run-list filters; CODEX / ARCHITECTURE / CLAUDE / DATA_GUIDE updated from SQLite to MongoDB, entity-stats snapshot, user accounts, and a version bump to 1.1.3