### PR TITLE
Hotfix: drop webp build step from prod Dockerfile

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -2,3 +2,7 @@ __pycache__
 *.pyc
 .env
 scripts
+# webp is served from the CDN, not the backend image. Keep it out of
+# the build context so the image only ships PNG sources (used by the
+# /api/images gallery + ZIP downloads).
+**/*.webp

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends webp && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 
 COPY requirements.txt .
@@ -9,8 +7,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app/ app/
 COPY static/ static/
-
-RUN find static/images -name '*.png' -exec sh -c 'cwebp -q 95 -m 6 -quiet "$0" -o "${0%.png}.webp"' {} \;
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
The staging → main merge (#376) silently kept main's old `backend/Dockerfile`: both branches added the cwebp generation step via different commits, so git's 3-way merge preserved main's copy instead of staging's removal. Same thing happened to `backend/.dockerignore`.

This hotfix makes main match the intended end state:
- Remove the `webp` apt install + the `cwebp` generation `RUN` step (webp is served from the CDN now)
- Exclude `**/*.webp` from the backend build context

Result: faster prod build, smaller image, no webp bundled. Safe because prod's frontend points at the CDN.