### PR TITLE
Hide sign-in on beta

### DIFF
--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -328,8 +328,8 @@ export default function Navbar() {
               </div>
             )}
 
-          {/* User menu */}
-          {!authLoading && (
+          {/* User menu — hidden on beta (accounts are stable-only for now) */}
+          {!authLoading && !IS_BETA && (
             <div className="relative">
               <button
                 ref={userButtonRef}


### PR DESCRIPTION
## Summary
- Gate the navbar user menu behind `!IS_BETA` so the Sign In button doesn't show on beta
- Accounts are stable-only for now; beta's Discord OAuth redirect isn't registered, so the button just errored there
- Stable is unaffected

Targets main so the next beta image build picks it up.