### PR TITLE
Fix OAuth sign-in failing across multiple workers

### DIFF
--- a/backend/app/routers/auth_discord.py
+++ b/backend/app/routers/auth_discord.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
-import secrets
-import time
+import urllib.parse
 
 import httpx
 from fastapi import APIRouter, Request
@@ -18,6 +17,7 @@ from fastapi.responses import RedirectResponse
 from slowapi import Limiter
 
 from ..dependencies import client_ip
+from ..services.auth_jwt import create_oauth_state, verify_oauth_state
 
 logger = logging.getLogger("spire-codex.auth")
 
@@ -28,10 +28,6 @@ _DISCORD_API = "https://discord.com/api/v10"
 _DISCORD_AUTHORIZE = "https://discord.com/api/oauth2/authorize"
 _DISCORD_TOKEN = "https://discord.com/api/oauth2/token"
 
-_STATE_TTL = 300
-_MAX_STATES = 5000
-_states: dict[str, float] = {}
-
 
 def _get_discord_config() -> tuple[str, str]:
     client_id = os.environ.get("DISCORD_CLIENT_ID", "").strip()
@@ -39,13 +35,6 @@ def _get_discord_config() -> tuple[str, str]:
     if not client_id or not client_secret:
         raise RuntimeError("DISCORD_CLIENT_ID and DISCORD_CLIENT_SECRET are required")
     return client_id, client_secret
-
-
-def _purge_states() -> None:
-    cutoff = time.time() - _STATE_TTL
-    stale = [s for s, t in _states.items() if t < cutoff]
-    for s in stale:
-        _states.pop(s, None)
 
 
 def _frontend_url(request: Request) -> str:
@@ -61,13 +50,7 @@ def _frontend_url(request: Request) -> str:
 async def start(request: Request):
     client_id, _ = _get_discord_config()
 
-    _purge_states()
-    if len(_states) >= _MAX_STATES:
-        oldest_key = min(_states, key=_states.get)
-        _states.pop(oldest_key, None)
-
-    state = secrets.token_urlsafe(32)
-    _states[state] = time.time()
+    state = create_oauth_state()
 
     base = _frontend_url(request)
     redirect_uri = f"{base}/api/auth/discord/callback"
@@ -80,7 +63,7 @@ async def start(request: Request):
         "state": state,
         "prompt": "consent",
     }
-    url = f"{_DISCORD_AUTHORIZE}?{'&'.join(f'{k}={v}' for k, v in params.items())}"
+    url = f"{_DISCORD_AUTHORIZE}?{urllib.parse.urlencode(params)}"
     return RedirectResponse(url)
 
 
@@ -91,18 +74,16 @@ async def callback(request: Request):
     error = request.query_params.get("error")
     if error:
         logger.info("discord-auth denied: %s", error)
-        return RedirectResponse(f"{base}/login?error=cancelled")
+        return RedirectResponse(f"{base}/profile?error=cancelled")
 
     code = request.query_params.get("code")
     state = request.query_params.get("state")
 
     if not code or not state:
-        return RedirectResponse(f"{base}/login?error=invalid_response")
+        return RedirectResponse(f"{base}/profile?error=invalid_response")
 
-    _purge_states()
-    if state not in _states:
-        return RedirectResponse(f"{base}/login?error=invalid_session")
-    _states.pop(state, None)
+    if not verify_oauth_state(state):
+        return RedirectResponse(f"{base}/profile?error=invalid_session")
 
     client_id, client_secret = _get_discord_config()
     redirect_uri = f"{base}/api/auth/discord/callback"
@@ -123,15 +104,15 @@ async def callback(request: Request):
             )
         if token_resp.status_code != 200:
             logger.warning("discord token exchange failed: %s", token_resp.text[:200])
-            return RedirectResponse(f"{base}/login?error=discord_failed")
+            return RedirectResponse(f"{base}/profile?error=discord_failed")
 
         token_data = token_resp.json()
         access_token = token_data.get("access_token")
         if not access_token:
-            return RedirectResponse(f"{base}/login?error=discord_failed")
+            return RedirectResponse(f"{base}/profile?error=discord_failed")
     except Exception as exc:
         logger.warning("discord token exchange error: %s", exc)
-        return RedirectResponse(f"{base}/login?error=discord_unavailable")
+        return RedirectResponse(f"{base}/profile?error=discord_unavailable")
 
     # Fetch user info from Discord
     try:
@@ -142,19 +123,19 @@ async def callback(request: Request):
             )
         if user_resp.status_code != 200:
             logger.warning("discord user fetch failed: %s", user_resp.text[:200])
-            return RedirectResponse(f"{base}/login?error=discord_failed")
+            return RedirectResponse(f"{base}/profile?error=discord_failed")
 
         discord_user = user_resp.json()
     except Exception as exc:
         logger.warning("discord user fetch error: %s", exc)
-        return RedirectResponse(f"{base}/login?error=discord_unavailable")
+        return RedirectResponse(f"{base}/profile?error=discord_unavailable")
 
     discord_id = discord_user.get("id")
     discord_username = discord_user.get("global_name") or discord_user.get("username")
     email = discord_user.get("email")
 
     if not discord_id:
-        return RedirectResponse(f"{base}/login?error=discord_failed")
+        return RedirectResponse(f"{base}/profile?error=discord_failed")
 
     # If the user is already logged in (has a valid JWT), link Discord
     # to their existing account instead of creating a new one.
@@ -200,4 +181,4 @@ async def callback(request: Request):
         return response
     except Exception as exc:
         logger.warning("discord-auth user creation failed: %s", exc)
-        return RedirectResponse(f"{base}/login?error=discord_failed")
+        return RedirectResponse(f"{base}/profile?error=discord_failed")

--- a/backend/app/routers/auth_steam.py
+++ b/backend/app/routers/auth_steam.py
@@ -14,26 +14,20 @@ the relying party. The flow:
 3. The overlay polls `/api/auth/steam/poll/<session_id>` until status
    transitions from `pending` to `ok`, then closes the loop.
 
-Sessions are kept in-memory with a TTL — the relying-party state is
-ephemeral and any persistence belongs in the client (which writes
-steamid + persona to its settings). If the FastAPI process restarts
-mid-flow the user just retries.
-
-Single-worker assumption: the in-memory `_sessions` dict only works
-because the backend Dockerfile launches uvicorn without `--workers`,
-i.e. one process. If that ever changes, swap the store for Redis or
-SQLite — start/callback/poll requests would otherwise land on
-different workers and break the rendezvous.
+Sessions live in `auth_session_store`, which is Mongo-backed (with a TTL
+index) when MONGO_URL is set and an in-memory dict otherwise. The shared
+store matters because production runs uvicorn with `--workers N`:
+start/callback/poll can each land on a different process, so a per-worker
+dict would break the rendezvous (the callback can't find the session
+/start created, and the web flow lands on /profile signed-out). Without
+Mongo (local dev) uvicorn runs a single worker, so the dict is safe.
 """
 
 from __future__ import annotations
 
 import logging
 import re
-import secrets
-import time
 import urllib.parse
-from dataclasses import dataclass
 from typing import Optional
 
 import httpx
@@ -43,55 +37,13 @@ from pydantic import BaseModel
 from slowapi import Limiter
 
 from ..dependencies import client_ip
+from ..services import auth_session_store
+from ..services.auth_session_store import SESSION_TTL_SECONDS
 
 logger = logging.getLogger("spire-codex.auth")
 
 router = APIRouter(prefix="/api/auth/steam", tags=["Auth"])
 limiter = Limiter(key_func=client_ip)
-
-# Sessions live for 5 min — generous enough for the user to bounce off
-# Steam's login (saved password autofill, 2FA, etc.) and short enough
-# that an abandoned session expires before it's discoverable.
-SESSION_TTL_SECONDS = 300
-
-# Token-bucket of unconsumed sessions. Capping the size protects us from
-# someone hammering /start to leak memory; oldest entries eviction-style
-# drop on overflow.
-MAX_SESSIONS = 5000
-
-
-@dataclass
-class _Session:
-    created_at: float
-    steamid: Optional[str] = None
-    persona_name: Optional[str] = None
-    user_id: Optional[str] = None
-    token: Optional[str] = None
-    needs_email: bool = False
-    error: Optional[str] = None
-
-
-_sessions: dict[str, _Session] = {}
-
-
-def _purge_expired() -> None:
-    """Drop sessions older than the TTL. Cheap to run on every access."""
-    cutoff = time.time() - SESSION_TTL_SECONDS
-    stale = [sid for sid, s in _sessions.items() if s.created_at < cutoff]
-    for sid in stale:
-        _sessions.pop(sid, None)
-
-
-def _new_session() -> str:
-    _purge_expired()
-    if len(_sessions) >= MAX_SESSIONS:
-        # Drop the oldest. O(N) but only on rare overflow.
-        oldest = min(_sessions.items(), key=lambda kv: kv[1].created_at)
-        _sessions.pop(oldest[0], None)
-    sid = secrets.token_urlsafe(24)
-    _sessions[sid] = _Session(created_at=time.time())
-    return sid
-
 
 _REALM_ENV_KEY = "SPIRE_CODEX_PUBLIC_BASE"
 
@@ -122,7 +74,7 @@ async def start(request: Request) -> dict:
     The session_id is the rendezvous point — the client polls /poll with
     it, the callback writes the resolved identity into the same slot.
     """
-    sid = _new_session()
+    sid = auth_session_store.create_session()
     base = _public_base(request)
     return_to = f"{base}/api/auth/steam/callback?session={sid}"
     realm = base + "/"
@@ -150,7 +102,7 @@ async def start(request: Request) -> dict:
 @limiter.limit("20/minute")
 async def redirect_to_steam(request: Request):
     """Direct browser redirect to Steam login. For mobile and popup-blocked flows."""
-    sid = _new_session()
+    sid = auth_session_store.create_session()
     base = _public_base(request)
     return_to = f"{base}/api/auth/steam/callback?session={sid}"
     realm = base + "/"
@@ -175,7 +127,7 @@ async def callback(request: Request) -> HTMLResponse:
     """Steam-OpenID return URL. Validates with Steam and stores the result."""
     qs = dict(request.query_params)
     session_id = qs.get("session", "")
-    session = _sessions.get(session_id)
+    session = auth_session_store.get_session(session_id)
     if not session:
         import os
 
@@ -185,10 +137,12 @@ async def callback(request: Request) -> HTMLResponse:
     # OpenID response can also be `cancel` if the user bailed.
     mode = qs.get("openid.mode")
     if mode == "cancel":
-        session.error = "User cancelled sign-in."
+        auth_session_store.update_session(session_id, error="User cancelled sign-in.")
         return _close_page(error="Sign-in cancelled.")
     if mode != "id_res":
-        session.error = f"Unexpected OpenID mode: {mode}"
+        auth_session_store.update_session(
+            session_id, error=f"Unexpected OpenID mode: {mode}"
+        )
         return _close_page(error="Unexpected response from Steam.")
 
     # Verify the signature by replaying the params with check_authentication.
@@ -206,46 +160,62 @@ async def callback(request: Request) -> HTMLResponse:
         )
     except Exception as exc:
         logger.warning("steam-auth verify failed: %s", exc)
-        session.error = f"Could not verify with Steam: {exc}"
+        auth_session_store.update_session(
+            session_id, error=f"Could not verify with Steam: {exc}"
+        )
         return _close_page(error="Steam verification failed. Try again.")
 
     if not verified:
-        session.error = "Steam said the response was not valid."
+        auth_session_store.update_session(
+            session_id, error="Steam said the response was not valid."
+        )
         return _close_page(error="Steam did not validate the response.")
 
     claimed_id = qs.get("openid.claimed_id", "")
     match = re.search(r"/openid/id/(\d+)$", claimed_id)
     if not match:
-        session.error = f"Unexpected claimed_id: {claimed_id}"
+        auth_session_store.update_session(
+            session_id, error=f"Unexpected claimed_id: {claimed_id}"
+        )
         return _close_page(error="Couldn't read the SteamID from Steam's response.")
 
     steamid = match.group(1)
-    session.steamid = steamid
 
     # Best-effort persona name lookup. Public XML is keyless and works for
     # private profiles too — Steam still includes the display name.
     persona = await _fetch_persona_name(steamid)
-    session.persona_name = persona
 
     # Create or find user doc and issue JWT
+    user_id = None
+    token = None
+    needs_email = False
     try:
         from ..services.users_db import find_or_create_by_steam
         from ..services.auth_jwt import create_token
 
         user = find_or_create_by_steam(steamid, persona)
-        session.user_id = user["_id"]
-        session.token = create_token(user_id=user["_id"], steam_id=steamid)
-        session.needs_email = not user.get("email")
+        user_id = user["_id"]
+        token = create_token(user_id=user["_id"], steam_id=steamid)
+        needs_email = not user.get("email")
     except Exception as exc:
         logger.warning("steam-auth user creation failed: %s", exc)
         # Non-fatal: auth still succeeded, just no persistent user yet
+
+    auth_session_store.update_session(
+        session_id,
+        steamid=steamid,
+        persona_name=persona,
+        user_id=user_id,
+        token=token,
+        needs_email=needs_email,
+    )
 
     logger.info(
         "steam-auth ok session=%s steamid=%s persona=%s user=%s",
         session_id[:8],
         steamid,
         persona,
-        session.user_id,
+        user_id,
     )
 
     # Redirect to frontend with token in URL. The frontend reads
@@ -253,14 +223,12 @@ async def callback(request: Request) -> HTMLResponse:
     # on the correct origin. In production (same domain) the cookie
     # approach works directly; in local dev (different ports) we need
     # this token handoff.
-    if session.token:
+    if token:
         import os
 
         frontend = os.environ.get("FRONTEND_URL", "").strip() or _public_base(request)
-        _sessions.pop(session_id, None)
-        response = RedirectResponse(
-            f"{frontend}/profile?auth=steam&token={session.token}"
-        )
+        auth_session_store.pop_session(session_id)
+        response = RedirectResponse(f"{frontend}/profile?auth=steam&token={token}")
         response.headers["Cache-Control"] = "no-store, no-cache"
         response.headers["Pragma"] = "no-cache"
         return response
@@ -278,38 +246,38 @@ async def poll(session_id: str) -> JSONResponse:
       - `error`: explicit failure (cancelled, invalid, etc.).
       - 404: session is unknown or expired.
     """
-    _purge_expired()
-    session = _sessions.get(session_id)
+    session = auth_session_store.get_session(session_id)
     if not session:
         raise HTTPException(status_code=404, detail="session not found or expired")
 
-    if session.error:
+    if session.get("error"):
         # Returning the error and dropping the session — the client should
         # restart with /start rather than re-poll a known-bad slot.
-        msg = session.error
-        _sessions.pop(session_id, None)
+        msg = session["error"]
+        auth_session_store.pop_session(session_id)
         return JSONResponse({"status": "error", "message": msg})
 
-    if session.steamid is None:
+    if session.get("steamid") is None:
         return JSONResponse({"status": "pending"})
 
     # Identity ready. Drop the session so a third party who somehow
     # snooped the session_id can't replay-poll.
+    token = session.get("token")
     payload = {
         "status": "ok",
-        "steamid": session.steamid,
-        "persona_name": session.persona_name,
-        "user_id": session.user_id,
-        "token": session.token,
-        "needs_email": session.needs_email,
+        "steamid": session.get("steamid"),
+        "persona_name": session.get("persona_name"),
+        "user_id": session.get("user_id"),
+        "token": token,
+        "needs_email": session.get("needs_email", False),
     }
-    _sessions.pop(session_id, None)
+    auth_session_store.pop_session(session_id)
 
     response = JSONResponse(payload)
-    if session.token:
+    if token:
         from ..services.auth_jwt import set_auth_cookie
 
-        set_auth_cookie(response, session.token)
+        set_auth_cookie(response, token)
 
     return response
 

--- a/backend/app/services/auth_jwt.py
+++ b/backend/app/services/auth_jwt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import secrets
 from datetime import datetime, timedelta, timezone
 
 import jwt
@@ -13,6 +14,8 @@ _JWT_SECRET = os.environ.get("JWT_SECRET", "").strip()
 _JWT_ALGORITHM = "HS256"
 _JWT_EXPIRY_DAYS = 7
 _COOKIE_NAME = "spire_session"
+_STATE_PURPOSE = "oauth_state"
+_STATE_TTL_SECONDS = 600
 
 
 def _get_secret() -> str:
@@ -44,6 +47,33 @@ def decode_token(token: str) -> dict | None:
         return jwt.decode(token, _get_secret(), algorithms=[_JWT_ALGORITHM])
     except (jwt.ExpiredSignatureError, jwt.InvalidTokenError):
         return None
+
+
+def create_oauth_state() -> str:
+    """Signed, self-contained CSRF state for OAuth redirect flows.
+
+    Stateless on purpose: the prod backend runs multiple uvicorn workers,
+    so the /start and /callback requests can land on different processes.
+    A signed token any worker can verify avoids a shared state store.
+    """
+    now = datetime.now(timezone.utc)
+    payload = {
+        "purpose": _STATE_PURPOSE,
+        "nonce": secrets.token_urlsafe(8),
+        "iat": now,
+        "exp": now + timedelta(seconds=_STATE_TTL_SECONDS),
+    }
+    return jwt.encode(payload, _get_secret(), algorithm=_JWT_ALGORITHM)
+
+
+def verify_oauth_state(token: str) -> bool:
+    if not token:
+        return False
+    try:
+        payload = jwt.decode(token, _get_secret(), algorithms=[_JWT_ALGORITHM])
+    except (jwt.ExpiredSignatureError, jwt.InvalidTokenError):
+        return False
+    return payload.get("purpose") == _STATE_PURPOSE
 
 
 def set_auth_cookie(response: JSONResponse, token: str) -> None:

--- a/backend/app/services/auth_session_store.py
+++ b/backend/app/services/auth_session_store.py
@@ -1,0 +1,138 @@
+"""Shared store for in-flight Steam OpenID sign-in sessions.
+
+The Steam flow is a rendezvous: /start (or /redirect) mints a session id,
+Steam returns the user to /callback with that id, and the overlay polls
+/poll for the resolved identity. In production uvicorn runs with
+`--workers N`, so those three requests can each land on a different
+process. A per-process dict therefore breaks the rendezvous: the callback
+can't find the session /start created, and the web flow silently lands on
+/profile signed-out.
+
+When MONGO_URL is set we keep sessions in a Mongo collection with a TTL
+index so every worker sees the same state. Without Mongo (local dev, which
+runs a single uvicorn worker) we fall back to an in-memory dict, preserving
+the original behavior.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import time
+from datetime import datetime, timezone
+
+SESSION_TTL_SECONDS = 300
+MAX_SESSIONS = 5000  # in-memory cap only; Mongo uses a TTL index
+_COLLECTION_NAME = "steam_auth_sessions"
+
+_SESSION_FIELDS = (
+    "steamid",
+    "persona_name",
+    "user_id",
+    "token",
+    "needs_email",
+    "error",
+)
+
+
+def _use_mongo() -> bool:
+    return bool(os.environ.get("MONGO_URL", "").strip())
+
+
+def _blank_session() -> dict:
+    return {
+        "steamid": None,
+        "persona_name": None,
+        "user_id": None,
+        "token": None,
+        "needs_email": False,
+        "error": None,
+    }
+
+
+# ── Mongo-backed store ───────────────────────────────────────────────────
+_indexed = False
+
+
+def _coll():
+    global _indexed
+    from .runs_db_mongo import get_database
+
+    coll = get_database()[_COLLECTION_NAME]
+    if not _indexed:
+        # Lazily delete expired docs server-side. Mongo's TTL monitor runs
+        # ~every 60s, so a session can outlive the TTL briefly; get_session
+        # enforces the precise cutoff on read.
+        coll.create_index("created_at", expireAfterSeconds=SESSION_TTL_SECONDS)
+        _indexed = True
+    return coll
+
+
+# ── In-memory store (no Mongo / single worker) ───────────────────────────
+_mem: dict[str, dict] = {}
+
+
+def _purge_mem() -> None:
+    cutoff = time.time() - SESSION_TTL_SECONDS
+    stale = [sid for sid, s in _mem.items() if s["created_at"] < cutoff]
+    for sid in stale:
+        _mem.pop(sid, None)
+
+
+# ── Public API ───────────────────────────────────────────────────────────
+def create_session() -> str:
+    sid = secrets.token_urlsafe(24)
+    if _use_mongo():
+        doc = _blank_session()
+        doc["_id"] = sid
+        doc["created_at"] = datetime.now(timezone.utc)
+        _coll().insert_one(doc)
+        return sid
+
+    _purge_mem()
+    if len(_mem) >= MAX_SESSIONS:
+        oldest = min(_mem.items(), key=lambda kv: kv[1]["created_at"])
+        _mem.pop(oldest[0], None)
+    session = _blank_session()
+    session["created_at"] = time.time()
+    _mem[sid] = session
+    return sid
+
+
+def get_session(sid: str) -> dict | None:
+    if not sid:
+        return None
+    if _use_mongo():
+        doc = _coll().find_one({"_id": sid})
+        if not doc:
+            return None
+        created = doc.get("created_at")
+        if isinstance(created, datetime):
+            age = (datetime.now(timezone.utc) - created).total_seconds()
+            if age > SESSION_TTL_SECONDS:
+                _coll().delete_one({"_id": sid})
+                return None
+        return doc
+
+    _purge_mem()
+    return _mem.get(sid)
+
+
+def update_session(sid: str, **fields) -> None:
+    updates = {k: v for k, v in fields.items() if k in _SESSION_FIELDS}
+    if not updates:
+        return
+    if _use_mongo():
+        _coll().update_one({"_id": sid}, {"$set": updates})
+        return
+    session = _mem.get(sid)
+    if session is not None:
+        session.update(updates)
+
+
+def pop_session(sid: str) -> dict | None:
+    if not sid:
+        return None
+    if _use_mongo():
+        return _coll().find_one_and_delete({"_id": sid})
+    return _mem.pop(sid, None)

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1034,6 +1034,15 @@ def get_stats(
 # to `stats_summary`. API handlers read that single document — O(1).
 
 
+def get_database():
+    """Public handle to the default database, reusing the pooled client.
+
+    Lets other services (e.g. the Steam auth session store) share a
+    Mongo-backed collection without opening a second client.
+    """
+    return _get_collection().database
+
+
 def _summary_coll():
     return _get_collection().database[SUMMARY_COLLECTION_NAME]
 


### PR DESCRIPTION
## Why sign-in broke on prod but not staging

Production runs `uvicorn --workers 4`; staging runs 1. Both auth flows stored their in-flight OAuth state in **per-process memory**, so on prod the `/start` and `/callback` requests land on different workers and the rendezvous breaks. With one worker, start and callback always hit the same process.

- **Discord ("page not found"):** the OAuth `state` lived in a module-level `_states` dict. A callback on the wrong worker didn't find the state and redirected to `/login?error=invalid_session` — and there is no `/login` route, so Next.js rendered "page not found." Retrying eventually hit the worker holding the state.
- **Steam ("Sign in to view your profile"):** sessions lived in a `_sessions` dict. On the wrong worker the session was missing, so the callback redirected to `/profile` with no token, landing signed-out.

## Fix

- **Discord — stateless signed state:** `auth_jwt.create_oauth_state` / `verify_oauth_state` produce an HMAC-signed, self-expiring token any worker can validate. No shared storage needed. Also urlencode the authorize URL (the old manual join left a raw space in `scope` and an unencoded `redirect_uri`), and point genuine-error redirects at `/profile` instead of the nonexistent `/login`.
- **Steam — shared session store:** new `auth_session_store` keeps sessions in MongoDB with a TTL index when `MONGO_URL` is set (shared across all workers), falling back to the in-memory dict for local single-worker dev. Fixes both the web redirect flow and the overlay poll.

No new environment variables required (`JWT_SECRET` and `MONGO_URL` are already set in prod).