### PR TITLE
Fix duplicate-key error blocking new accounts

### DIFF
--- a/backend/app/services/users_db.py
+++ b/backend/app/services/users_db.py
@@ -4,10 +4,10 @@ Document shape:
 
     {
         "_id": ObjectId,
-        "steam_id": "76561198...",   # unique, sparse
-        "discord_id": "123456...",   # unique, sparse
+        "steam_id": "76561198...",   # unique when set (partial index)
+        "discord_id": "123456...",   # unique when set (partial index)
         "username": "SomeName",
-        "username_lower": "somename",  # unique, for case-insensitive checks
+        "username_lower": "somename",  # unique when set (partial index)
         "email": "user@example.com",
         "username_changes": [ISODate(...)],  # timestamps, max 3 per 24h
         "created_at": ISODate(...),
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta, timezone
 
 from bson import ObjectId
 from pymongo import ASCENDING, MongoClient
-from pymongo.errors import DuplicateKeyError
+from pymongo.errors import DuplicateKeyError, OperationFailure
 
 _client: MongoClient | None = None
 _coll = None
@@ -56,9 +56,38 @@ def _get_collection():
 
 
 def _ensure_indexes(coll) -> None:
-    coll.create_index([("steam_id", ASCENDING)], unique=True, sparse=True)
-    coll.create_index([("discord_id", ASCENDING)], unique=True, sparse=True)
-    coll.create_index([("username_lower", ASCENDING)], unique=True, sparse=True)
+    # These must be unique only when the field is actually set. A sparse
+    # unique index is NOT enough: sparse only skips documents where the
+    # field is absent, but both create paths write explicit nulls (a
+    # Discord-only user has steam_id=None, a Steam-only user has
+    # discord_id=None). Those nulls are indexed, so a sparse unique index
+    # lets only ONE such document exist and the second collides with
+    # E11000 dup key { steam_id: null }. A partial index keyed on
+    # $type:"string" indexes only set values, exempting null/missing.
+    _ensure_partial_unique(coll, "steam_id")
+    _ensure_partial_unique(coll, "discord_id")
+    _ensure_partial_unique(coll, "username_lower")
+
+
+def _ensure_partial_unique(coll, field: str) -> None:
+    """Create a partial unique index on `field`, migrating off the legacy
+    sparse index if present. Idempotent and safe to run from every worker."""
+    name = f"{field}_unique"
+    existing = {idx["name"] for idx in coll.list_indexes()}
+    if name in existing:
+        return
+    legacy = f"{field}_1"
+    if legacy in existing:
+        try:
+            coll.drop_index(legacy)
+        except OperationFailure:
+            pass  # another worker won the race and already dropped it
+    coll.create_index(
+        [(field, ASCENDING)],
+        name=name,
+        unique=True,
+        partialFilterExpression={field: {"$type": "string"}},
+    )
 
 
 def sanitize_username(raw: str) -> str | None:


### PR DESCRIPTION
## Symptom

New Discord sign-ins fail and land on `/profile?error=discord_failed`. Backend log:

```
discord-auth user creation failed: E11000 duplicate key error
collection: spire_codex.users index: steam_id_1 dup key: { steam_id: null }
```

Existing users sign in fine (they're found, not created); only brand-new accounts fail.

## Root cause

`users` had **sparse** unique indexes on `steam_id`, `discord_id`, `username_lower`. A sparse index only skips documents where the field is **absent** — not where it's present and `null`. Both create paths write explicit nulls (`find_or_create_by_discord` sets `steam_id: None`, `find_or_create_by_steam` sets `discord_id: None`), so those nulls *are* indexed. That allows only **one** document per field to hold null: the first Discord-only user took the `steam_id: null` slot, so every subsequent one collides. The same trap applies to `discord_id` (2nd+ Steam user) and `username_lower` (2nd+ user with no name).

## Fix

Replace the sparse unique indexes with **partial** unique indexes keyed on `partialFilterExpression: { <field>: { $type: "string" } }`, which index only set values and exempt null/missing. `_ensure_indexes` migrates off the legacy `{field}_1` sparse indexes idempotently on startup (drops the old, creates `{field}_unique`), tolerating concurrent workers.

No data cleanup needed: the partial index ignores the existing null documents, so it builds cleanly and they remain valid.