### PR TITLE
Regenerate webp in the backend image for the Overwolf overlay

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.12-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends webp && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY requirements.txt .
@@ -7,6 +9,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app/ app/
 COPY static/ static/
+
+# Overwolf overlay fetches images from the backend, not the CDN yet, so
+# regenerate webp from the tracked PNG sources at build time. (.dockerignore
+# keeps host webp out of the build context; these are built fresh in-image.)
+RUN find static/images -name '*.png' -exec sh -c 'cwebp -q 95 -m 6 -quiet "$0" -o "${0%.png}.webp"' {} \;
 
 EXPOSE 8000
 


### PR DESCRIPTION
The Overwolf overlay fetches images directly from the backend (`/static/images/...webp`), not the CDN, so the backend image must ship webp. The earlier CDN migration removed the build-time cwebp step, leaving the image with only PNGs — overlay images 404.

Reinstate the `cwebp` step that converts the 12,803 tracked PNG sources to webp at build time. The `**/*.webp` exclusion in `.dockerignore` only filters the build context (keeps host webp out); the conversion runs fresh inside the image, so both PNG and webp are served again.