### PR TITLE
Fix 500 on Steam callback (naive/aware datetime subtraction)

### DIFF
--- a/backend/app/services/auth_session_store.py
+++ b/backend/app/services/auth_session_store.py
@@ -108,6 +108,11 @@ def get_session(sid: str) -> dict | None:
             return None
         created = doc.get("created_at")
         if isinstance(created, datetime):
+            # pymongo returns naive (UTC) datetimes by default; make it
+            # tz-aware before subtracting from an aware now, otherwise
+            # "can't subtract offset-naive and offset-aware datetimes".
+            if created.tzinfo is None:
+                created = created.replace(tzinfo=timezone.utc)
             age = (datetime.now(timezone.utc) - created).total_seconds()
             if age > SESSION_TTL_SECONDS:
                 _coll().delete_one({"_id": sid})


### PR DESCRIPTION
## Symptom

Every Steam sign-in callback returns 500 Internal Server Error (`GET /api/auth/steam/callback?...` → 500). Started once sessions moved into the Mongo-backed store.

## Root cause

`auth_session_store.get_session` computed session age with:

```python
age = (datetime.now(timezone.utc) - created).total_seconds()
```

`datetime.now(timezone.utc)` is tz-aware, but pymongo (default client, no `tz_aware=True`) returns `created_at` as a **naive** datetime. Subtracting naive from aware raises `TypeError: can't subtract offset-naive and offset-aware datetimes`, which is unhandled in the callback. The in-memory store path stored aware datetimes, so it never surfaced until sessions were Mongo-backed.

## Fix

Normalize the stored datetime to UTC-aware before subtracting. One-line guard, no behavior change otherwise.