### PR TITLE
Lazy-materialize stats-page filter combos into stats_summary

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -774,4 +774,25 @@ def get_community_stats(
         username=username,
     )
     _stats_fallback_cache[cache_key] = (now, result)
+
+    # Lazy write-through to stats_summary so subsequent requests for this
+    # combo -- on any worker -- serve from the materialized view instead
+    # of paying the 5-10s aggregation again. Hot combos still get
+    # overwritten by the periodic refresher; non-hot combos persist until
+    # something else replaces them.
+    try:
+        from ..services.runs_db_mongo import write_stats_summary
+
+        write_stats_summary(
+            result,
+            character=character,
+            win=win,
+            ascension=ascension,
+            game_mode=game_mode,
+            players=players,
+            username=username,
+        )
+    except Exception:
+        pass
+
     return result

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1258,6 +1258,42 @@ def refresh_leaderboard_summary() -> int:
     return written
 
 
+def write_stats_summary(
+    result: dict,
+    *,
+    character: str | None = None,
+    win: str | None = None,
+    ascension: str | None = None,
+    game_mode: str | None = None,
+    players: str | None = None,
+    username: str | None = None,
+) -> None:
+    """Lazy-cache a live get_stats() result in stats_summary so other
+    workers and future requests can read it without re-aggregating.
+
+    Called from the API handler after a live aggregation hit (i.e. when
+    the requested filter combo isn't in HOT_FILTER_COMBOS and therefore
+    isn't kept warm by the refresher). The next request for the same
+    combo, on any worker, gets it from the summary in a single find_one.
+
+    Best-effort: any failure is swallowed -- this is a write-through
+    cache, not a critical path.
+    """
+    try:
+        key = _filter_key(
+            character=character,
+            win=win,
+            ascension=ascension,
+            game_mode=game_mode,
+            players=players,
+            username=username,
+        )
+        doc = {**result, "_id": key, "updated_at": datetime.now(timezone.utc)}
+        _summary_coll().replace_one({"_id": key}, doc, upsert=True)
+    except Exception:
+        pass
+
+
 # ── Run listing / leaderboard / rank / versions / shared ─────────────────
 # These mirror the inline get_conn() callers in routers/runs.py that
 # previously ran raw SQL. Router dispatches here when MONGO_URL is set.


### PR DESCRIPTION
## Symptom

Users picking filters on `/leaderboards/stats` see a 5-10s spinner on practically every click. The same combo on the next click might be instant or might be slow again, seemingly at random.

## Cause

`/api/runs/stats` has a 3-tier read path:

1. `stats_summary` (materialized, sub-ms) -- only covers `HOT_FILTER_COMBOS = [{}, per-character]`.
2. Process-local TTL cache (300s) -- **per worker.** Prod runs `--workers 4`, so the hit rate on any clicked-through combo is at best 1-in-4.
3. Live aggregation in `get_stats()` -- multiple pipelines including a `$unwind` over `card_choices`. **5-10s** per call on the current `runs` size.

So any combo with `win`, `ascension`, `players`, or `username` falls past step 1, and step 2 is poor cluster-wide because the cache lives in process memory. Result: clicking filters keeps paying the 5-10s tax.

## Fix

After the live aggregation runs in `get_community_stats`, write the result back into `stats_summary` with the same `(_filter_key)` shape the refresher uses. Now every worker (and every future request) reads the same materialized doc.

- **First request for a combo:** still pays the 5-10s (one user, somewhere). Inevitable for a never-seen combo.
- **Every subsequent request for that combo, cluster-wide:** single `find_one`, ~ms.
- **HOT combos** continue to be refreshed every 60s by the existing leader-elected refresher loop, which overwrites any lazy entries with fresh aggregates.
- **Non-HOT combos** persist in `stats_summary` and get overwritten the next time the same combo is queried. If the collection grows uncomfortably (it's small per doc), follow-up: add a TTL index on `updated_at`.

## Files

- `backend/app/services/runs_db_mongo.py` -- new public `write_stats_summary()` helper.
- `backend/app/routers/runs.py` -- `get_community_stats` calls it after the live path.

No data migration; no schema change; falls through to existing behavior on any failure.