### PR TITLE
Auto-claim runs to the signed-in user on duplicate upload

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -93,7 +93,39 @@ async def submit_run_endpoint(request: Request, username: str | None = None):
         sanitized = re.sub(r"[^a-zA-Z0-9_\- ]", "", username.strip())[:32].strip()
         clean_username = sanitized or None
 
-    result = submit_run(data, username=clean_username)
+    # If the upload is coming from a signed-in session, link the run to
+    # the account. Duplicate uploads of a previously anonymous run then
+    # claim it to the account instead of being a no-op (the feature
+    # request: "Uploading duplicate runs previously unclaimed should
+    # claim them to your account").
+    user_id = None
+    try:
+        from ..services.auth_jwt import get_current_user
+
+        current_user = get_current_user(request)
+        if current_user:
+            user_id = current_user["_id"]
+            # Fall back to the account's username if the client didn't
+            # pass one. Prefer the explicit query param so the Compendium
+            # overlay can keep sending its own.
+            if not clean_username:
+                clean_username = current_user.get("username")
+    except Exception:
+        # Auth failures shouldn't block anonymous submission.
+        pass
+
+    result = submit_run(data, username=clean_username, user_id=user_id)
+    # Duplicate that we attached to the current account ("claim on
+    # re-upload"). The original run is already counted in metrics, so
+    # don't re-emit; just tell the client it was claimed.
+    if result.get("claimed"):
+        run_submissions.labels(status="claimed").inc()
+        return {
+            "success": True,
+            "duplicate": True,
+            "claimed": True,
+            "run_hash": result.get("run_hash"),
+        }
     if result.get("error"):
         if result.get("duplicate"):
             run_submissions.labels(status="duplicate").inc()
@@ -150,7 +182,22 @@ async def claim_runs_endpoint(request: Request):
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid JSON body")
 
-    raw_username = payload.get("username")
+    # If the caller is signed in, let the account drive the claim. The
+    # username field becomes optional (we fall back to the account name)
+    # and the runs are linked by user_id, which is what /profile reads.
+    user_id = None
+    account_username = None
+    try:
+        from ..services.auth_jwt import get_current_user
+
+        current_user = get_current_user(request)
+        if current_user:
+            user_id = current_user["_id"]
+            account_username = current_user.get("username")
+    except Exception:
+        pass
+
+    raw_username = payload.get("username") or account_username
     if not raw_username or not isinstance(raw_username, str):
         raise HTTPException(status_code=400, detail="username is required")
 
@@ -177,7 +224,7 @@ async def claim_runs_endpoint(request: Request):
     if not clean_hashes:
         return {"claimed": 0, "already_claimed": 0, "unknown": 0}
 
-    return claim_runs(sanitized, clean_hashes)
+    return claim_runs(sanitized, clean_hashes, user_id=user_id)
 
 
 @router.get("/list", tags=["Runs"])

--- a/backend/app/services/runs_db.py
+++ b/backend/app/services/runs_db.py
@@ -259,8 +259,17 @@ def clean_id(raw_id: str) -> str:
     return raw_id
 
 
-def submit_run(data: dict, username: str | None = None) -> dict:
-    """Parse and store a run. Returns status dict."""
+def submit_run(
+    data: dict,
+    username: str | None = None,
+    user_id: str | None = None,
+) -> dict:
+    """Parse and store a run. Returns status dict.
+
+    `user_id` is accepted for signature parity with the Mongo path but the
+    SQLite fallback is legacy and doesn't link runs to accounts.
+    """
+    _ = user_id  # accepted-but-unused on the SQLite path
     # Validate structure. Errors call out the specific field so failed
     # batch uploads (issue #151) can be triaged without re-running with
     # a debugger — previously every rejection collapsed to the same
@@ -479,15 +488,23 @@ def _submit_player_run(
     return {"success": True, "run_id": run_id, "run_hash": run_hash}
 
 
-def claim_runs(username: str, hashes: list[str]) -> dict:
+def claim_runs(
+    username: str,
+    hashes: list[str],
+    user_id: str | None = None,
+) -> dict:
     """Attach `username` to any run rows whose hash matches and whose
     current username is NULL/empty. Rows already claimed by any user
     (including the same one) are left untouched so this can't overwrite.
+
+    `user_id` is accepted for signature parity with the Mongo path but
+    the SQLite fallback is legacy and doesn't link runs to accounts.
 
     Returns a summary: how many rows were updated, how many hashes
     matched a row but were skipped (already claimed), and how many
     hashes didn't match any row at all.
     """
+    _ = user_id  # accepted-but-unused on the SQLite path
     if not hashes:
         return {"claimed": 0, "already_claimed": 0, "unknown": 0}
 

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -204,9 +204,18 @@ def init_db():
 
 # ── public surface ──────────────────────────────────────────────────────
 @_instrument("submit_run")
-def submit_run(data: dict, username: str | None = None) -> dict:
+def submit_run(
+    data: dict,
+    username: str | None = None,
+    user_id: str | None = None,
+) -> dict:
     """Parse a run and store one document per player. Returns status dict
-    matching the SQLite implementation."""
+    matching the SQLite implementation.
+
+    `user_id` ties the run to an authenticated account. When set, a
+    duplicate-hash upload claims an existing unclaimed run to that
+    account instead of just returning `duplicate`.
+    """
     missing: list[str] = []
     if not data.get("players"):
         missing.append("players")
@@ -240,6 +249,7 @@ def submit_run(data: dict, username: str | None = None) -> dict:
             killed_by,
             player_count,
             username,
+            user_id,
         )
         results.append(result)
 
@@ -271,6 +281,7 @@ def _submit_player_run(
     killed_by: str | None,
     player_count: int,
     username: str | None,
+    user_id: str | None = None,
 ) -> dict:
     """One Mongo insert per player. The full nested structure goes into
     a single document — no joins required at query time."""
@@ -359,6 +370,7 @@ def _submit_player_run(
         "deck_size": len(deck),
         "relic_count": len(relics),
         "username": username,
+        "user_id": user_id,
         "build_id": data.get("build_id"),
         "submitted_at": datetime.now(timezone.utc),
         "deck": deck,
@@ -378,37 +390,75 @@ def _submit_player_run(
     coll = _get_collection()
     try:
         coll.insert_one(doc)
+        return {"success": True, "run_id": run_hash, "run_hash": run_hash}
     except DuplicateKeyError:
+        # If the caller is authenticated and the existing row is unclaimed,
+        # attach the account to it instead of just reporting "duplicate".
+        # This is the website-side equivalent of the overlay's /claim flow.
+        if user_id:
+            claim_filter = {
+                "_id": run_hash,
+                "$or": [
+                    {"user_id": {"$in": [None, ""]}},
+                    {"user_id": {"$exists": False}},
+                ],
+            }
+            update_fields: dict[str, Any] = {"user_id": user_id}
+            if username:
+                update_fields["username"] = username
+            res = coll.update_one(claim_filter, {"$set": update_fields})
+            if res.modified_count:
+                return {
+                    "success": True,
+                    "duplicate": True,
+                    "claimed": True,
+                    "run_hash": run_hash,
+                }
         return {
             "error": "This run has already been submitted",
             "duplicate": True,
             "run_hash": run_hash,
         }
 
-    return {"success": True, "run_id": run_hash, "run_hash": run_hash}
-
 
 @_instrument("claim_runs")
-def claim_runs(username: str, hashes: list[str]) -> dict:
-    """Attach `username` to any runs whose _id matches and whose current
-    username is null/empty. Matches the SQLite implementation: never
-    overwrites an existing claim."""
+def claim_runs(
+    username: str,
+    hashes: list[str],
+    user_id: str | None = None,
+) -> dict:
+    """Attach `username` (and optionally `user_id`) to any runs whose _id
+    matches and whose current claim slot is empty. Never overwrites an
+    existing claim.
+
+    Two modes:
+      - Legacy (no `user_id`): matches the Compendium/overlay flow that
+        only knew a username string. "Unclaimed" means no username.
+      - Authenticated (`user_id` set): website flow after sign-in.
+        "Unclaimed" means no user_id, and we set both fields so the run
+        actually shows up on the profile page (which queries by user_id).
+    """
     if not hashes:
         return {"claimed": 0, "already_claimed": 0, "unknown": 0}
 
     coll = _get_collection()
-    existing = list(coll.find({"_id": {"$in": hashes}}, {"_id": 1, "username": 1}))
-    by_hash = {d["_id"]: d.get("username") for d in existing}
+    slot = "user_id" if user_id else "username"
+    existing = list(coll.find({"_id": {"$in": hashes}}, {"_id": 1, slot: 1}))
+    by_hash = {d["_id"]: d.get(slot) for d in existing}
 
-    unclaimed = [h for h, u in by_hash.items() if not u]
+    unclaimed = [h for h, val in by_hash.items() if not val]
     already_claimed = len(by_hash) - len(unclaimed)
     unknown = len(hashes) - len(by_hash)
 
     if unclaimed:
-        coll.update_many(
-            {"_id": {"$in": unclaimed}, "$or": [{"username": None}, {"username": ""}]},
-            {"$set": {"username": username}},
-        )
+        unclaimed_filter = {
+            "_id": {"$in": unclaimed},
+            "$or": [{slot: {"$in": [None, ""]}}, {slot: {"$exists": False}}],
+        }
+        update_fields = {"username": username}
+        if user_id:
+            update_fields["user_id"] = user_id
+        coll.update_many(unclaimed_filter, {"$set": update_fields})
 
     return {
         "claimed": len(unclaimed),


### PR DESCRIPTION
## Feature request

> *"I uploaded my runs before creating an account, and there is no way to claim them now. Uploading duplicate runs previously unclaimed should claim them to your account."* — `phelnaxgaming@gmail.com`

## Why it didn't work today

- `/api/runs/claim` exists, but it's a **client-driven** flow: the Overwolf overlay hashes the user's local `.run` files and POSTs `{username, hashes}`. The browser can't do that — it has no `.run` files.
- `POST /api/runs` didn't read the JWT cookie, so even an authenticated submission was treated as anonymous.
- `claim_runs` only wrote `username`, never `user_id`. Even if a run got claimed, it didn't show up on `/profile` (which queries by `user_id`).

## What this PR does

**`POST /api/runs`** now reads the JWT cookie. When the caller is signed in:
- New runs are inserted with `user_id` (and `username` from the account if the query param isn't supplied).
- On a duplicate-hash submission whose existing row is **unclaimed** (no `user_id`), the row is updated with the user's `user_id` and `username`, and the response carries `{success: true, duplicate: true, claimed: true, run_hash: …}` so the client can show "claimed N runs."
- Anonymous flows (overlay/Compendium with no cookie) are unchanged — auth is best-effort, never blocking.

**`POST /api/runs/claim`** also recognizes the signed-in session and writes `user_id` alongside `username`. The `username` payload field becomes optional when authenticated (falls back to the account's name). Existing Compendium/overlay calls that supply `{username, hashes}` continue to work via the legacy (username-only) code path.

**`claim_runs`** has two modes: legacy username-only (unchanged behavior for Compendium) and authenticated user_id (new, writes both fields, considers a row unclaimed iff `user_id` is empty).

## Files

- `backend/app/services/runs_db_mongo.py` — `submit_run` / `_submit_player_run` accept `user_id`; new claim-on-duplicate branch in `_submit_player_run`; `claim_runs` gains a `user_id` mode.
- `backend/app/services/runs_db.py` — SQLite dispatcher signatures accept `user_id` for parity (legacy path).
- `backend/app/routers/runs.py` — both endpoints call `get_current_user(request)` and pass `user_id` through.

## Net behavioral change

| Flow | Before | After |
|---|---|---|
| Signed-in user uploads a brand-new run | username only (no link) | `user_id` + `username` set; shows on `/profile` |
| Signed-in user re-uploads an anonymous run | `{"duplicate": true}` (silent failure) | `{"claimed": true, "duplicate": true}`; row now linked to account |
| Anonymous client uploads (Compendium, overlay) | unchanged | unchanged |
| Compendium calls `/claim` with `{username, hashes}` | unchanged | unchanged (legacy mode preserved) |
| Website calls `/claim` while signed in | needed username + ignored user_id | username optional, both fields written |

Pre-paves the verified-Steam-persona auto-claim work flagged during the `Big Boy Only Getting Bigger` reconciliation: same hook, different identity source.