### PR TITLE
Redis-backed application cache for hot read paths

### DIFF
--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -173,3 +173,22 @@ db_operation_duration = Histogram(
     ["operation"],
     buckets=[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0],
 )
+
+# Redis-backed application cache (services.cache). The namespace label is
+# the first ":"-segment of the key (stats / leaderboard / run / etc.) so
+# we can see which read paths benefit most.
+cache_hits = Counter(
+    "spire_codex_cache_hits_total",
+    "Cache hits",
+    ["namespace"],
+)
+cache_misses = Counter(
+    "spire_codex_cache_misses_total",
+    "Cache misses (treated as a clean fallthrough to the data source)",
+    ["namespace"],
+)
+cache_errors = Counter(
+    "spire_codex_cache_errors_total",
+    "Cache transport / serialization errors (also a clean fallthrough)",
+    ["op"],  # get/set/delete/encode/decode/delete_pattern
+)

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -317,8 +317,18 @@ def get_leaderboard(
     """
     if os.environ.get("MONGO_URL", "").strip():
         from ..services.runs_db_mongo import leaderboard as _lb_mongo
+        from ..services import cache as app_cache
 
-        return _lb_mongo(
+        cache_key = (
+            f"leaderboard:cat={category}|c={character or '_'}|"
+            f"p={players or '_'}|gm={game_mode or '_'}|"
+            f"today={int(bool(today))}|page={page}|limit={limit}"
+        )
+        cached = app_cache.get_json(cache_key)
+        if cached is not None:
+            return cached
+
+        result = _lb_mongo(
             category=category,
             character=character,
             players=players,
@@ -327,6 +337,13 @@ def get_leaderboard(
             page=page,
             limit=limit,
         )
+        # Short TTL: the underlying leaderboard_summary is refreshed every
+        # 60s by the leader-elected loop, so anything stale by more than
+        # one cycle should be considered for re-fetch. Today views and
+        # paginated tails (not in summary) benefit most -- they pay the
+        # ~500ms live cost once per minute instead of every request.
+        app_cache.set_json(cache_key, result, ttl_seconds=60)
+        return result
 
     from ..services.runs_db import get_conn
 
@@ -522,6 +539,18 @@ def get_shared_run(run_hash: str, request: Request):
     """
     using_mongo = bool(os.environ.get("MONGO_URL", "").strip())
 
+    # Runs are immutable once submitted (the body never changes; the
+    # username can change but is a single short field added on top), so
+    # this is an ideal cache target. 6h TTL is generous enough that
+    # share links served from cache feel instant, short enough that a
+    # claim or username change propagates within a session.
+    from ..services import cache as app_cache
+
+    cache_key = f"run:{run_hash}"
+    cached_response = app_cache.get_json(cache_key)
+    if cached_response is not None:
+        return cached_response
+
     def _attach_username(blob: dict) -> dict:
         if using_mongo:
             from ..services.runs_db_mongo import get_username_for_hash
@@ -543,7 +572,9 @@ def get_shared_run(run_hash: str, request: Request):
 
     cached = _load_run_blob(run_hash)
     if cached is not None:
-        return _attach_username(json.loads(cached))
+        response = _attach_username(json.loads(cached))
+        app_cache.set_json(cache_key, response, ttl_seconds=21600)
+        return response
 
     # Fallback for multiplayer: find sibling player runs by seed.
     if using_mongo:
@@ -584,7 +615,9 @@ def get_shared_run(run_hash: str, request: Request):
             shutil.copy2(sib_file, run_file)
             _load_run_blob.cache_clear()
             with open(run_file, "r", encoding="utf-8") as f:
-                return _attach_username(json.load(f))
+                response = _attach_username(json.load(f))
+            app_cache.set_json(cache_key, response, ttl_seconds=21600)
+            return response
 
     raise HTTPException(status_code=404, detail="Run data not available")
 
@@ -641,7 +674,20 @@ def get_entity_scores(request: Request, entity_type: str):
             status_code=400,
             detail=f"entity_type must be one of {sorted(_ENTITY_STATS_TYPES)}",
         )
-    return get_all_entity_scores(entity_type)
+
+    # The underlying snapshot only changes when the leader-only refresher
+    # rebuilds it (~10 min cadence). Cache liberally between rebuilds --
+    # the tier-list and detail-page sort columns hit this constantly.
+    from ..services import cache as app_cache
+
+    cache_key = f"entity_scores:{entity_type}"
+    cached = app_cache.get_json(cache_key)
+    if cached is not None:
+        return cached
+
+    result = get_all_entity_scores(entity_type)
+    app_cache.set_json(cache_key, result, ttl_seconds=300)
+    return result
 
 
 # Stats reads come from the materialized `stats_summary` collection,
@@ -728,11 +774,25 @@ def get_community_stats(
     `username` to narrow to a single uploader.
 
     Read path:
-      1. Try the materialized stats_summary collection (sub-ms).
+      0. Try Redis (sub-ms; shared across workers, no per-process cache miss).
+      1. Try the materialized stats_summary collection (~ms).
       2. If the filter combo isn't in the hot list / hasn't been
          materialized yet, fall through to a process-local TTL cache.
       3. On cache miss, run the live aggregation (slow, ~5-10s).
+    Every miss that produces a result also write-throughs to Redis so
+    the next request -- on any worker -- serves from layer 0.
     """
+    from ..services import cache as app_cache
+
+    cache_key = (
+        f"stats:c={character or '_'}|w={win or '_'}|a={ascension or '_'}|"
+        f"gm={game_mode or '_'}|p={players or '_'}|u={username or '_'}"
+    )
+
+    cached = app_cache.get_json(cache_key)
+    if cached is not None:
+        return cached
+
     # 1. Materialized view path
     try:
         from ..services.runs_db_mongo import read_stats_summary
@@ -746,6 +806,7 @@ def get_community_stats(
             username=username,
         )
         if materialized is not None:
+            app_cache.set_json(cache_key, materialized, ttl_seconds=60)
             return materialized
     except Exception:
         # Not on the Mongo path (SQLite fallback) — keep going.
@@ -794,5 +855,9 @@ def get_community_stats(
         )
     except Exception:
         pass
+
+    # Also write through to Redis so subsequent requests for the same
+    # combo, on any worker, serve from layer 0.
+    app_cache.set_json(cache_key, result, ttl_seconds=60)
 
     return result

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -540,10 +540,12 @@ def get_shared_run(run_hash: str, request: Request):
     using_mongo = bool(os.environ.get("MONGO_URL", "").strip())
 
     # Runs are immutable once submitted (the body never changes; the
-    # username can change but is a single short field added on top), so
-    # this is an ideal cache target. 6h TTL is generous enough that
-    # share links served from cache feel instant, short enough that a
-    # claim or username change propagates within a session.
+    # username can change but is a single short field added on top).
+    # 15 min TTL: long enough to absorb a Discord share-link burst onto
+    # one URL, short enough that a username claim or rename propagates
+    # quickly, and short enough that the cache footprint stays bounded
+    # as the runs collection grows (we don't want every run that's ever
+    # been viewed living in Redis forever).
     from ..services import cache as app_cache
 
     cache_key = f"run:{run_hash}"
@@ -573,7 +575,7 @@ def get_shared_run(run_hash: str, request: Request):
     cached = _load_run_blob(run_hash)
     if cached is not None:
         response = _attach_username(json.loads(cached))
-        app_cache.set_json(cache_key, response, ttl_seconds=21600)
+        app_cache.set_json(cache_key, response, ttl_seconds=900)
         return response
 
     # Fallback for multiplayer: find sibling player runs by seed.
@@ -616,7 +618,7 @@ def get_shared_run(run_hash: str, request: Request):
             _load_run_blob.cache_clear()
             with open(run_file, "r", encoding="utf-8") as f:
                 response = _attach_username(json.load(f))
-            app_cache.set_json(cache_key, response, ttl_seconds=21600)
+            app_cache.set_json(cache_key, response, ttl_seconds=900)
             return response
 
     raise HTTPException(status_code=404, detail="Run data not available")

--- a/backend/app/services/cache.py
+++ b/backend/app/services/cache.py
@@ -1,0 +1,202 @@
+"""Redis-backed application cache.
+
+A thin, fail-safe wrapper around a redis-py client. Adding a Redis layer
+lets us avoid hitting Mongo for hot read paths -- materialized stats,
+materialized leaderboards, immutable shared runs, tier-list snapshots --
+without introducing a per-worker cold-cache problem.
+
+Design goals:
+- **Fail-safe.** Redis being unavailable must never 500 an API request.
+  All reads return `None` on error; all writes are no-ops on error. The
+  caller falls back to its existing data source (Mongo / file / live
+  aggregation). The cache is an optimization, not a dependency.
+- **Lazy connection.** The client is built on first use, not at module
+  import, so dev environments without REDIS_URL set don't pay a
+  connection cost (and tests don't need a live Redis).
+- **JSON values by default.** Almost everything we cache is a dict from
+  a Mongo query or an API response, so the typed helpers
+  (`get_json` / `set_json`) handle serialization. Raw bytes are
+  available via the lower-level `get_raw` / `set_raw` when needed.
+- **Namespace convention.** Keys are colon-delimited: `stats:<filter>`,
+  `leaderboard:<filter>`, `run:<hash>`, `entity_scores:<type>`. A future
+  deploy-time `cache_clear("stats:*")` is a one-liner.
+
+The `REDIS_URL` env var controls the client (e.g. `redis://redis:6379/0`).
+When unset, every operation no-ops and the existing data path runs
+unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+try:
+    import redis
+except ImportError:  # pragma: no cover -- dev env may not have redis installed
+    redis = None  # type: ignore[assignment]
+
+from ..metrics import cache_hits, cache_misses, cache_errors
+
+_client: "redis.Redis | None" = None
+_initialized = False
+
+
+def _get_client() -> "redis.Redis | None":
+    """Lazily build the Redis client. Returns None when REDIS_URL is unset
+    or the redis package isn't available -- the caller treats that as a
+    miss and falls back to its data source."""
+    global _client, _initialized
+    if _initialized:
+        return _client
+
+    url = os.environ.get("REDIS_URL", "").strip()
+    if not url or redis is None:
+        _initialized = True
+        return None
+
+    try:
+        # Short timeouts so a slow/down Redis can't stall request handlers.
+        # decode_responses=False -- we want to keep the raw bytes so callers
+        # can choose JSON, msgpack, or pickle without re-encoding.
+        _client = redis.Redis.from_url(
+            url,
+            socket_connect_timeout=1.0,
+            socket_timeout=0.5,
+            decode_responses=False,
+            health_check_interval=30,
+        )
+    except Exception:
+        _client = None
+
+    _initialized = True
+    return _client
+
+
+# ── raw bytes API ────────────────────────────────────────────────────────
+
+
+def get_raw(key: str) -> bytes | None:
+    """Read a raw value. Returns None on miss, unavailable Redis, or any
+    transport error."""
+    client = _get_client()
+    if client is None:
+        return None
+    try:
+        val = client.get(key)
+        if val is None:
+            cache_misses.labels(namespace=_namespace(key)).inc()
+        else:
+            cache_hits.labels(namespace=_namespace(key)).inc()
+        return val
+    except Exception:
+        cache_errors.labels(op="get").inc()
+        return None
+
+
+def set_raw(key: str, value: bytes, ttl_seconds: int | None = None) -> None:
+    """Write a raw value with optional TTL. No-op on failure."""
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        if ttl_seconds is None:
+            client.set(key, value)
+        else:
+            client.setex(key, ttl_seconds, value)
+    except Exception:
+        cache_errors.labels(op="set").inc()
+
+
+# ── JSON API (the path most callers use) ─────────────────────────────────
+
+
+def get_json(key: str) -> Any | None:
+    """Read a JSON-serialized value. Returns None on miss / unavailable
+    Redis / decode error -- treat as a clean miss in any case."""
+    raw = get_raw(key)
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except Exception:
+        cache_errors.labels(op="decode").inc()
+        return None
+
+
+def set_json(key: str, value: Any, ttl_seconds: int | None = None) -> None:
+    """Write a JSON-serialized value. Best-effort: silently drops values
+    that aren't JSON-serializable (rare; the offending caller should be
+    fixed, but we don't crash the request to enforce it)."""
+    try:
+        encoded = json.dumps(value, default=str).encode("utf-8")
+    except Exception:
+        cache_errors.labels(op="encode").inc()
+        return
+    set_raw(key, encoded, ttl_seconds=ttl_seconds)
+
+
+# ── invalidation ─────────────────────────────────────────────────────────
+
+
+def delete(key: str) -> None:
+    """Drop a single key. No-op on failure."""
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        client.delete(key)
+    except Exception:
+        cache_errors.labels(op="delete").inc()
+
+
+def delete_pattern(pattern: str) -> int:
+    """Delete all keys matching a glob pattern (e.g. `stats:*`). Returns
+    count deleted, or 0 on failure. Uses SCAN to avoid the KEYS-blocks-
+    the-server footgun.
+
+    Useful at deploy time (`delete_pattern("entity_scores:*")` after a
+    new entity-scores snapshot) or when invalidating a namespace
+    intentionally.
+    """
+    client = _get_client()
+    if client is None:
+        return 0
+    try:
+        deleted = 0
+        for batch in _scan_batches(client, pattern):
+            if batch:
+                deleted += client.delete(*batch)
+        return deleted
+    except Exception:
+        cache_errors.labels(op="delete_pattern").inc()
+        return 0
+
+
+def _scan_batches(client, pattern: str, batch_size: int = 500):
+    """Yield batches of keys matching `pattern`, capped at `batch_size`
+    per yield. Lets `delete_pattern` issue bulk DELs without holding the
+    server's attention with a giant KEYS call."""
+    cursor = 0
+    batch: list[bytes] = []
+    while True:
+        cursor, keys = client.scan(cursor=cursor, match=pattern, count=batch_size)
+        batch.extend(keys)
+        if len(batch) >= batch_size:
+            yield batch
+            batch = []
+        if cursor == 0:
+            break
+    if batch:
+        yield batch
+
+
+# ── internal ─────────────────────────────────────────────────────────────
+
+
+def _namespace(key: str) -> str:
+    """First segment of a colon-delimited key, for metrics labeling.
+    `stats:eng:character=SILENT` → `stats`. Caps label cardinality."""
+    idx = key.find(":")
+    return key[:idx] if idx > 0 else key

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ pyjwt[crypto]==2.10.1
 libsql==0.1.11
 pymongo==4.10.1
 python-multipart==0.0.20
+redis==5.2.1

--- a/docker-compose.beta.yml
+++ b/docker-compose.beta.yml
@@ -35,6 +35,10 @@ services:
       - FRONTEND_URL=${FRONTEND_URL:-https://beta.spire-codex.com}
       - SPIRE_CODEX_PUBLIC_BASE=${SPIRE_CODEX_PUBLIC_BASE:-https://beta.spire-codex.com}
       - ENVIRONMENT=${ENVIRONMENT:-production}
+      # Redis cache (services.cache). Optional -- the cache is a perf
+      # layer and never load-bearing; if unset, every call falls through
+      # to its data source unchanged.
+      - REDIS_URL=${REDIS_URL:-redis://spire-codex-beta-redis:6379/0}
     networks:
       - nginx_web-network
     logging:
@@ -42,6 +46,29 @@ services:
       options:
         max-size: "10m"
         max-file: "5"
+
+  redis:
+    image: redis:7-alpine
+    container_name: spire-codex-beta-redis
+    command:
+      - redis-server
+      - --maxmemory
+      - 128mb
+      - --maxmemory-policy
+      - allkeys-lru
+      - --appendonly
+      - "no"
+      - --save
+      - ""
+    volumes:
+      - redis-data:/data
+    networks:
+      - nginx_web-network
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "3"
 
   frontend:
     image: ptrlrd/spire-codex-frontend:beta
@@ -64,3 +91,6 @@ services:
 networks:
   nginx_web-network:
     external: true
+
+volumes:
+  redis-data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,6 +53,11 @@ services:
       # path. Falls through to local /data/runs.db SQLite otherwise
       # (the current state while the migration is in progress).
       - MONGO_URL=${MONGO_URL:-}
+      # Redis cache (services.cache). When set, hot read paths
+      # (stats / leaderboard / shared run / entity scores) serve from
+      # Redis first and fall back to Mongo on miss or any Redis error
+      # -- the cache is purely an optimization, never load-bearing.
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
       # User accounts (Steam/Discord OAuth + JWT sessions). Values live
       # in the host .env; passed through so the auth endpoints work.
       - JWT_SECRET=${JWT_SECRET:-}
@@ -81,6 +86,39 @@ services:
         max-size: "10m"
         max-file: "5"
 
+  redis:
+    image: redis:7-alpine
+    container_name: spire-codex-redis
+    # 512 MB ceiling with LRU eviction -- the box has 8 GB so this is
+    # plenty of headroom for the cache namespaces (stats, leaderboard,
+    # run hashes, entity scores) without ever pressuring the rest of
+    # the stack. AOF off; the cache is rebuildable from Mongo on miss,
+    # so disk durability would just be I/O overhead for no win.
+    command:
+      - redis-server
+      - --maxmemory
+      - 512mb
+      - --maxmemory-policy
+      - allkeys-lru
+      - --appendonly
+      - "no"
+      - --save
+      - ""
+    volumes:
+      - redis-data:/data
+    networks:
+      - nginx_web-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "3"
+
   frontend:
     image: ptrlrd/spire-codex-frontend:latest
     container_name: spire-codex-frontend
@@ -102,3 +140,6 @@ services:
 networks:
   nginx_web-network:
     external: true
+
+volumes:
+  redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,36 @@ services:
       - GITHUB_APP_INSTALLATION_ID=${GITHUB_APP_INSTALLATION_ID:-}
       - GITHUB_APP_REPO=${GITHUB_APP_REPO:-}
       - GITHUB_APP_PRIVATE_KEY_PATH=${GITHUB_APP_PRIVATE_KEY_PATH:-/secrets/knowledge-demon.private-key.pem}
+      # Redis cache (services.cache). Optional in dev -- when unset, every
+      # operation no-ops and the code paths behave exactly as before.
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
+    depends_on:
+      - redis
     logging:
       driver: json-file
       options:
         max-size: "10m"
         max-file: "3"
+
+  redis:
+    image: redis:7-alpine
+    command:
+      - redis-server
+      - --maxmemory
+      - 128mb
+      - --maxmemory-policy
+      - allkeys-lru
+      - --appendonly
+      - "no"
+      - --save
+      - ""
+    ports:
+      - "6379:6379"
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "2"
 
   frontend:
     build:


### PR DESCRIPTION
Run uploads went from ~9k/week to ~130k/week. Every uncached read is amplifying Mongo load proportionally. PR #385 added a Mongo-backed lazy cache (`stats_summary`) which handles the worst-case "first user pays 5-10 s" path; this PR puts an even faster, configurable, cross-endpoint layer in front of it and the other hot reads.

## What

A fail-safe Redis layer (`services/cache.py`) plus wiring into the four hottest read paths.

### Cache substrate

- **`services/cache.py`** — lazy `redis-py` client, `get_json` / `set_json` / `delete` / `delete_pattern` (SCAN-based). Every operation is fail-safe: Redis being unavailable returns `None` on `get` and no-ops on `set`, so the caller falls back to its existing data source. The cache is always an optimization, never load-bearing.
- **`metrics.py`** — `spire_codex_cache_hits_total` / `_misses_total` / `_errors_total`, labeled by key namespace (`stats`, `leaderboard`, `run`, `entity_scores`).

### Wired in

| Endpoint | Layer 0 | TTL | Why |
|---|---|---|---|
| `/api/runs/stats` | Redis check before `stats_summary` | 60s | Matches refresher cycle; cluster-wide instead of per-worker |
| `/api/runs/leaderboard` | Redis check before `leaderboard_summary` | 60s | Same reasoning; covers today / paginated combos that aren't in `leaderboard_summary` |
| `/api/runs/shared/{hash}` | Redis check before disk | **15min** | Runs are immutable, but I don't want every viewed run squatting in cache forever as the collection grows. 15min absorbs share-link bursts on a hot URL and lets cold runs drop off the LRU |
| `/api/runs/scores/{entity_type}` | Redis check before snapshot read | 5min | Hit constantly by tier-list + detail-page sort columns |

### Infra

- `redis:7-alpine` service in `docker-compose.yml` (dev), `docker-compose.beta.yml`, `docker-compose.prod.yml`. `allkeys-lru` eviction, AOF off (rebuildable from Mongo on miss), `maxmemory` 512 MB in prod / 128 MB in beta+dev. Healthcheck in prod.
- `REDIS_URL` env var passed into the backend in each compose, with sensible defaults that point at the bundled `redis` service. When unset, every cache call no-ops -- the existing data paths run unchanged.
- `redis==5.2.1` added to `requirements.txt`.

## Operational story

- **Redis down or unreachable** → all reads miss, all writes no-op. Every endpoint still works, just at pre-PR latency. No 500s.
- **Cache cold after restart / deploy** → the existing Mongo materialization (`stats_summary`, `leaderboard_summary`, `entity_stats_snapshot`) is still warm, so first requests hit ~ms (Mongo `find_one`) rather than the live aggregation. Redis warms up naturally on traffic.
- **Memory pressure** → `allkeys-lru` evicts oldest keys; cap protects the host.

## What this unlocks for the next PR

Adding a new cache target is `app_cache.get_json(key)` / `app_cache.set_json(key, val, ttl_seconds=N)` -- no additional infrastructure. Obvious next wins:
- `/api/cards/*`, `/api/relics/*`, `/api/potions/*` list responses (high QPS, deterministic per `(entity, lang)` between deploys; could go on a multi-hour TTL with a deploy-time `delete_pattern`).
- `/api/auth/me` (one Mongo `find_one` per request becomes one Redis `GET`; cookie-keyed).
- `slowapi` rate-limit storage so limits become cluster-wide and survive worker restarts (`slowapi[redis]` + a config line).

## Compose deploy note

When this lands, the **prod compose changes (Redis service + REDIS_URL passthrough) require a `docker compose -f docker-compose.prod.yml up -d`** on the box to bring up the new `spire-codex-redis` container. The backend image alone won't pick up Redis until the compose is re-applied.