### PR TITLE
SEO: collapse run-share hreflang, noindex beta

### DIFF
--- a/frontend/app/[lang]/runs/[hash]/page.tsx
+++ b/frontend/app/[lang]/runs/[hash]/page.tsx
@@ -1,122 +1,20 @@
-import type { Metadata } from "next";
-import JsonLd from "@/app/components/JsonLd";
-import { buildDetailPageJsonLd } from "@/lib/jsonld";
-import SharedRunClient from "@/app/runs/[hash]/SharedRunClient";
-import {
-  isValidLang,
-  LANG_GAME_NAME,
-  LANG_NAMES,
-  LANG_HREFLANG,
-  SUPPORTED_LANGS,
-  type LangCode,
-} from "@/lib/languages";
-import { clipMetaDescription, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
-import { t } from "@/lib/ui-translations";
+import { permanentRedirect } from "next/navigation";
+import { isValidLang } from "@/lib/languages";
 
 export const dynamic = "force-dynamic";
 
-const API_INTERNAL =
-  process.env.API_INTERNAL_URL ||
-  process.env.NEXT_PUBLIC_API_URL ||
-  "http://localhost:8000";
-
 type Props = { params: Promise<{ lang: string; hash: string }> };
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
+// Run-share pages are inherently English game data; localized variants
+// were generating thousands of duplicate URLs in GSC ("Duplicate without
+// user-selected canonical" cluster). Collapse all /<lang>/runs/<hash>
+// requests to the canonical /runs/<hash>.
+export default async function LangSharedRunRedirect({ params }: Props) {
   const { lang, hash } = await params;
-  if (!isValidLang(lang)) return {};
-
-  const langCode = lang as LangCode;
-  const gameName = LANG_GAME_NAME[langCode];
-  const nativeName = LANG_NAMES[langCode];
-
-  try {
-    const res = await fetch(`${API_INTERNAL}/api/runs/shared/${hash}`);
-    if (!res.ok) return { title: "Run Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
-    const run = await res.json();
-    const char = run.players?.[0]?.character?.replace("CHARACTER.", "") || "";
-    const resultKey = run.win
-      ? "Victory"
-      : run.was_abandoned
-        ? "Abandoned"
-        : "Defeat";
-    const result = t(resultKey, lang);
-
-    const title = `${char} ${result} — ${gameName} | Spire Codex (${nativeName})`;
-    const username = (run.username || "").trim() || "Anonymous";
-    const description = clipMetaDescription(
-      `${gameName} — ${username}'s ${char} ${result.toLowerCase()} at ${t("Ascension", lang)} ${run.ascension || 0}.`,
-    );
-
-    const languages: Record<string, string> = {
-      en: `${SITE_URL}/runs/${hash}`,
-      "x-default": `${SITE_URL}/runs/${hash}`,
-    };
-    for (const code of SUPPORTED_LANGS) {
-      languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/runs/${hash}`;
-    }
-
-    return {
-      title,
-      description,
-      openGraph: {
-        type: "article",
-        siteName: SITE_NAME,
-        url: `${SITE_URL}/${lang}/runs/${hash}`,
-        title,
-        description,
-        locale: LANG_HREFLANG[langCode],
-        images: [{ url: DEFAULT_OG_IMAGE }],
-      },
-      twitter: { card: "summary_large_image", title, description },
-      alternates: { canonical: `/${lang}/runs/${hash}`, languages },
-    };
-  } catch {
-    return { title: `Spire Codex (${nativeName})` };
+  if (!isValidLang(lang)) {
+    // Unknown locale segment: still redirect to the canonical page rather
+    // than 404, so any stale Googlebot crawls collapse cleanly.
+    permanentRedirect(`/runs/${hash}`);
   }
-}
-
-interface SharedRun {
-  win?: boolean;
-  was_abandoned?: boolean;
-  username?: string | null;
-  ascension?: number;
-  players?: { character?: string }[];
-}
-
-export default async function LangSharedRunPage({ params }: Props) {
-  const { lang, hash } = await params;
-  if (!isValidLang(lang)) return null;
-  const langCode = lang as LangCode;
-  let jsonLd: ReturnType<typeof buildDetailPageJsonLd> | null = null;
-  try {
-    const res = await fetch(`${API_INTERNAL}/api/runs/shared/${hash}`);
-    if (res.ok) {
-      const run = (await res.json()) as SharedRun;
-      const rawChar = run.players?.[0]?.character?.replace("CHARACTER.", "") || "Unknown";
-      const char = rawChar.charAt(0) + rawChar.slice(1).toLowerCase();
-      const username = run.username?.trim() || "Anonymous";
-      const ascension = run.ascension ?? 0;
-      const resultKey = run.win ? "Victory" : run.was_abandoned ? "Abandoned" : "Defeat";
-      const result = t(resultKey, lang);
-      jsonLd = buildDetailPageJsonLd({
-        name: `${username} - ${char} - ${t("Ascension", lang)} ${ascension} ${result}`,
-        description: `${username}'s ${char} run at ${t("Ascension", lang)} ${ascension} in Slay the Spire 2.`,
-        path: `/${lang}/runs/${hash}`,
-        category: "Run",
-        breadcrumbs: [
-          { name: t("Home", lang), href: `/${lang}` },
-          { name: t("Leaderboards", lang), href: `/${lang}/leaderboards` },
-          { name: `${username} - ${char}`, href: `/${lang}/runs/${hash}` },
-        ],
-        inLanguage: LANG_HREFLANG[langCode],
-      });
-    }
-  } catch {}
-  return (
-    <>
-      {jsonLd && <JsonLd data={jsonLd} />}
-      <SharedRunClient />
-    </>
-  );
+  permanentRedirect(`/runs/${hash}`);
 }

--- a/frontend/app/[lang]/runs/page.tsx
+++ b/frontend/app/[lang]/runs/page.tsx
@@ -1,13 +1,11 @@
-import { redirect } from "next/navigation";
-import { isValidLang } from "@/lib/languages";
-import BrowseRunsClient from "../../runs/BrowseRunsClient";
+import { permanentRedirect } from "next/navigation";
 
-export default async function LangRunsPage({
-  params,
-}: {
-  params: Promise<{ lang: string }>;
-}) {
-  const { lang } = await params;
-  if (!isValidLang(lang)) redirect("/runs");
-  return <BrowseRunsClient />;
+export const dynamic = "force-dynamic";
+
+// /<lang>/runs is a localized chrome wrapper around the same Browse Runs
+// data as /runs. Google was bucketing the 13 localized variants as
+// duplicates of the canonical English page. Collapse them with a 301 so
+// the canonical /runs absorbs all the equity.
+export default function LangRunsRedirect() {
+  permanentRedirect("/runs");
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -47,11 +47,17 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+// Belt-and-suspenders alongside the beta branch in robots.ts. Some bots
+// honor robots.txt only partially; an explicit noindex meta on every
+// beta page makes it impossible for a beta URL to enter the index.
+const IS_BETA = /beta\./i.test(SITE_URL);
+
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: `Database - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
   description:
     "Fan-built database for Slay the Spire 2 (sts2). Browse cards, relics, monsters, potions, events, powers, plus run stats and tier lists.",
+  ...(IS_BETA && { robots: { index: false, follow: false } }),
   icons: {
     icon: [
       { url: "/favicon.ico", sizes: "32x32" },

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -3,12 +3,22 @@ import type { MetadataRoute } from "next";
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://spire-codex.com";
 
 export default function robots(): MetadataRoute.Robots {
-  // GSC was logging "Crawled - currently not indexed" against thousands
-  // of /api/images/<type>/download URLs and a handful of /static/
-  // asset trees — they're either binary downloads or raw assets, not
-  // pages worth indexing. Disallow them so Googlebot stops burning
-  // crawl budget there. Real content lives under /, /<lang>/, and the
-  // sitemap is unchanged.
+  // Beta serves near-identical data to prod (different game build) and was
+  // showing up in GSC competing with the canonical prod URLs as
+  // "Duplicate without user-selected canonical." Disallow all on the
+  // beta host so Googlebot stops indexing it.
+  if (/beta\./i.test(SITE_URL)) {
+    return {
+      rules: [{ userAgent: "*", disallow: "/" }],
+    };
+  }
+
+  // Prod: GSC was logging "Crawled - currently not indexed" against
+  // thousands of /api/images/<type>/download URLs and a handful of
+  // /static/ asset trees — they're either binary downloads or raw
+  // assets, not pages worth indexing. Disallow them so Googlebot stops
+  // burning crawl budget there. Real content lives under /, /<lang>/,
+  // and the sitemap is unchanged.
   return {
     rules: [
       {

--- a/frontend/app/runs/[hash]/page.tsx
+++ b/frontend/app/runs/[hash]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd } from "@/lib/jsonld";
-import { DEFAULT_OG_IMAGE, buildLanguageAlternates, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import SharedRunClient from "./SharedRunClient";
 
 export const dynamic = "force-dynamic";
@@ -58,7 +58,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       images: [{ url: DEFAULT_OG_IMAGE }],
     },
     twitter: { card: "summary_large_image", title, description },
-    alternates: { canonical: `/runs/${hash}`, languages: buildLanguageAlternates(`/runs/${hash}`) },
+    // No hreflang alternates: a run-share page is inherently English
+    // game data (the same hash points at the same numbers regardless of
+    // locale chrome), so localized variants /<lang>/runs/<hash> read to
+    // Google as near-duplicates of the canonical /runs/<hash>. That was
+    // generating ~5,000 "Duplicate without user-selected canonical"
+    // pages in GSC. Self-canonical only.
+    alternates: { canonical: `/runs/${hash}` },
   };
 }
 


### PR DESCRIPTION
## Why

GSC currently has **8,204 pages** in the *"Duplicate without user-selected canonical"* bucket — they aren't indexed and aren't competing for any query. Sampling the URL examples showed three dominant patterns:

| Pattern | ~Share | Cause |
|---|---|---|
| `/<lang>/runs/<hash>` | ~60% | `buildLanguageAlternates` emits 13 hreflang alternates from the canonical `/runs/<hash>`, but a run-share page is inherently English game data. Google sees 13 near-duplicates per run hash and buckets them. With 130k runs growing, this is going to balloon. |
| `beta.spire-codex.com/...` | ~15% | Beta serves nearly the same data as prod, competing with the canonical URLs. Was never explicitly disindexed. |
| `www.spire-codex.com/...` | ~2% | `www` not redirecting to apex. Separate fix on the box (nginx); not in this PR. |

## This PR fixes #1 and #2

### Run-share hreflang collapse

- `runs/[hash]/page.tsx`: drop `alternates.languages`. Self-canonical only.
- `[lang]/runs/[hash]/page.tsx`: replaced with a 308 `permanentRedirect` to `/runs/<hash>`.
- `[lang]/runs/page.tsx`: 308 `permanentRedirect` to `/runs`.

The redirects collapse any URL Google has already indexed onto the canonical English page so equity transfers rather than getting folded out.

### Beta noindex

- `robots.ts`: when `NEXT_PUBLIC_SITE_URL` contains `beta.`, return `User-agent: * / Disallow: /`.
- `layout.tsx`: belt-and-suspenders — emit `robots: { index: false, follow: false }` on every beta page so any bot that ignores `robots.txt` still skips indexing.

## Expected impact

After deploy + 1-3 weeks of re-crawl, the duplicate bucket should drop by **~6,000 pages** (~5,000 from run hreflang collapse, ~1,000+ from beta disindexing). That's the largest single SEO move available without writing new content. Current ~17k impressions/day at ~3k indexed pages → potentially 30-50k/day as Google re-allocates crawl budget to unique pages and the surface area roughly doubles.

## What's still needed on the box (out of scope for this PR)

1. **nginx `www` → apex 301**: one server block, cleans up the small "www" duplicate cluster.
2. **GSC removal request** for `beta.spire-codex.com` to flush already-indexed beta URLs faster than waiting for re-crawl.

## Verification

After merge + deploy:

```bash
# robots.txt on beta should disallow everything
curl https://beta.spire-codex.com/robots.txt
# Expected: User-agent: * \n Disallow: /

# robots.txt on prod unchanged (allow /, with /api/ /static/ /_next/ /uninstall disallowed)
curl https://spire-codex.com/robots.txt

# /<lang>/runs/<hash> should 308-redirect to /runs/<hash>
curl -I https://spire-codex.com/zhs/runs/SOMEHASH
# Expected: HTTP/2 308, Location: /runs/SOMEHASH

# /runs/<hash> page source should have a single canonical and no hreflang alternates
curl -s https://spire-codex.com/runs/SOMEHASH | grep -E "canonical|hreflang"
```