### PR TITLE
Fix card-grid and tooltip images bypassing the CDN

### DIFF
--- a/frontend/app/components/CardGrid.tsx
+++ b/frontend/app/components/CardGrid.tsx
@@ -73,7 +73,7 @@ function CardItem({ card }: { card: Card }) {
         return imgUrl ? (
           <div className="mb-3 -mx-4 -mt-4">
             <img
-              src={`${API_BASE}${imgUrl}`}
+              src={imageUrl(imgUrl)}
               alt={`${card.name} - Slay the Spire 2 Card`}
               className="w-full h-32 object-cover rounded-t-lg"
               loading="lazy"

--- a/frontend/app/components/RichDescription.tsx
+++ b/frontend/app/components/RichDescription.tsx
@@ -314,7 +314,7 @@ function CardHoverTip({ card, isUpgraded, children }: { card: RelatedCard; isUpg
             {card.image_url && (
               <span className="block bg-black/40">
                 <img
-                  src={`${API_BASE}${card.image_url}`}
+                  src={imageUrl(card.image_url)}
                   alt={`${displayName} - Slay the Spire 2 Card`}
                   className="w-full h-24 object-contain"
                   crossOrigin="anonymous"


### PR DESCRIPTION
## Symptom

`https://spire-codex.com/cards` renders card tiles with no images. Same for in-text card tooltips powered by `RichDescription`. Started after the slim backend Dockerfile shipped — the backend no longer carries `.webp` files, and these two components were still pointing at `spire-codex.com/static/images/...` instead of `cdn.spire-codex.com/...`.

## Root cause

`CardGrid.tsx:76` and `RichDescription.tsx:317` were constructing image sources directly as ``` `${API_BASE}${imgUrl}` ```. Both components *already imported* `imageUrl()` from `lib/image-url` and used it correctly for the small star-cost icon (`CardGrid.tsx:100`), but not for the main card art.

`imageUrl()` is the CDN-aware helper:
- When `NEXT_PUBLIC_CDN_URL` is set (prod), it rewrites `/static/images/...` → `https://cdn.spire-codex.com/...`.
- When unset (dev), falls back to `${API}${path}` — same behavior these components had before.

## Fix

Route both image sources through `imageUrl()`:

```tsx
// Before
src={`${API_BASE}${imgUrl}`}

// After
src={imageUrl(imgUrl)}
```

`crossOrigin="anonymous"` kept on both so canvas compositing elsewhere still works against the CDN.

Dev behavior is unchanged (the helper falls back to `${API}${path}` when `NEXT_PUBLIC_CDN_URL` is unset). Prod gets the CDN images back.

## Verify after deploy

```bash
# Card grid images point at cdn.spire-codex.com, not spire-codex.com/static
curl -s https://spire-codex.com/cards | grep -oE 'src="[^"]*\.webp"' | head -5
```