### PR TITLE
Lift per-entity stats caps to cover the full game catalog

### DIFF
--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -890,20 +890,29 @@ def get_stats(
                 }
             },
             {"$sort": {"offered": -1}},
-            {"$limit": 100},
+            {"$limit": 600},
         ]
     )
 
-    # $limit 100 caps the doc size — frontend never paginates past
-    # ~50; this keeps the materialized doc under 1MB and JSON
-    # serialization sub-100ms on the user path. (Previous 1000 cap
-    # produced an 8MB response that took 1-4s to serialize.)
+    # Per-entity stats caps. Sized to comfortably cover the full live
+    # catalog (576 cards / 293 relics / 63 potions) plus headroom for a
+    # patch's worth of new content. The earlier 100-cap was a JSON-
+    # serialization guard from when /api/runs/stats served live on every
+    # request -- a 1000-cap previously produced an 8MB response that
+    # took 1-4s to serialize. With Redis (PR #388) and the existing
+    # stats_summary materialization in front of this, the doc is
+    # serialized once per refresh cycle and served from cache for every
+    # user request, so the per-request cost no longer scales with the
+    # cap. The Discord-flagged "only 20 ancient relics visible" issue
+    # was the rarity filter slicing the already-capped top-100 -- this
+    # restores the full catalog into the stats so frontend filters can
+    # find their full set.
     cards = agg(
         [
             {"$match": match},
             *_item_stats_pipeline("deck"),
             {"$sort": {"count": -1}},
-            {"$limit": 100},
+            {"$limit": 600},
         ]
     )
     relics = agg(
@@ -911,7 +920,7 @@ def get_stats(
             {"$match": match},
             *_item_stats_pipeline("relics"),
             {"$sort": {"count": -1}},
-            {"$limit": 100},
+            {"$limit": 300},
         ]
     )
     potions_owned_list = agg(


### PR DESCRIPTION
## Why

Discord report from `Radagast` in #general today:

> *"the stats page relics have a limited number of relics show up? There are only 20 for ancient relics ... and only 100 for relics in general"*

Tracing it: `get_stats()` in `runs_db_mongo.py` limits the cards/relics/potions aggregations to `$limit: 100` each, sorted by appearance count. The frontend then filters that capped set by rarity, so the "Ancient relics" view only ever showed the ~20 ancients that ranked in the overall top-100 (not the full Ancient catalog).

## Why the cap existed

The 100-cap had a real reason in the pre-cache era: a 1000-cap previously produced an 8MB response that took **1-4s to serialize per request**, and that cost was paid on every user request via the live aggregation path. The comment in the code spells it out.

What changed: PR #385 added the `stats_summary` materialization (Mongo cache), and PR #388 puts Redis in front of that. Together they mean:

- The big aggregation runs **once per refresher cycle** (~60s), not per user request.
- The serialized doc is held in Redis (and Mongo) and handed back to every subsequent user via `find_one` / Redis `GET` -- no JSON re-serialization on the request path.

So the per-request cost no longer scales with the cap. The cap can be moved from "what fits in a 1MB sub-100ms-serialization budget" to "what covers the game with comfortable headroom."

## The new caps

| Surface | Old | New | Catalog | Headroom |
|---|---|---|---|---|
| `pick_rates` (cards seen in card-rewards) | 100 | 600 | 576 | ~24 |
| `cards` (deck-appearance stats) | 100 | 600 | 576 | ~24 |
| `relics` | 100 | 300 | 293 | ~7 |
| `potions` | 100 | 100 | 63 | ~37 (already covered, untouched) |

A patch's worth of new content lands inside the headroom; if a future major patch blows past it, this is a one-line bump.

## Doc-size impact

Per filter combo, the biggest agg (deck/cards) goes from roughly 1MB to roughly 5-6MB. With:

- `allkeys-lru` eviction on Redis,
- Mongo's 16MB single-doc ceiling well clear of 6MB,
- The materialization happening once per cycle, not per request,

the inflation is comfortably bounded and the cost is borne by the refresher worker, not the user.

## Dependency on #388

This **must ship after #388 is deployed**. If it merges before Redis is up:

- Live-aggregation fallback path (rare combos that miss `stats_summary` and `_stats_fallback_cache`) becomes the 8MB / 1-4s slow path again on every cold combo.
- That's the original problem the 100-cap was guarding against.

Suggested merge order:
1. #388 → deploy → confirm Redis is up and cache-hit ratios look healthy
2. This PR → deploy

Same image rebuild; no separate deploy step.

## What Radagast will see

After this lands and the next refresher cycle rebuilds `stats_summary`:

- General relics view: all relics that have appeared in any submitted run, up to 300 (so basically the whole game).
- Ancient relics view: all Ancient-rarity relics that have appeared in any run -- no more truncation at 20.