### PR TITLE
Fix profile run linking and /cards page rendering

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -384,7 +384,12 @@ async def upload_runs(request: Request, files: list[UploadFile] = File(...)):
         # Submit the run
         from ..services.runs_db import submit_run
 
-        submit_result = submit_run(data, username=user.get("username"))
+        submit_result = submit_run(
+            data,
+            username=user.get("username"),
+            steam_id=user.get("steam_id"),
+            discord_id=user.get("discord_id"),
+        )
         if submit_result.get("error"):
             if submit_result.get("duplicate"):
                 run_hash = submit_result.get("run_hash", "")

--- a/backend/app/routers/auth_discord.py
+++ b/backend/app/routers/auth_discord.py
@@ -166,6 +166,28 @@ async def callback(request: Request):
             discord_id=discord_id,
         )
 
+        # Link any runs submitted under this Discord ID — or under the
+        # account's linked Steam ID — before sign-in, so they show on the
+        # profile without a manual .run upload.
+        if os.environ.get("MONGO_URL", "").strip():
+            try:
+                from ..services.runs_db_mongo import backfill_user_runs
+
+                linked = backfill_user_runs(
+                    user["_id"],
+                    steam_id=user.get("steam_id"),
+                    discord_id=discord_id,
+                    username=user.get("username"),
+                )
+                if linked:
+                    logger.info(
+                        "discord-auth linked %d run(s) to user=%s",
+                        linked,
+                        user["_id"],
+                    )
+            except Exception as exc:
+                logger.warning("discord-auth run backfill failed: %s", exc)
+
         needs_email = not user.get("email") and not email
         redirect_path = "/settings" if needs_email else "/settings?linked=discord"
         response = RedirectResponse(f"{base}{redirect_path}")

--- a/backend/app/routers/auth_steam.py
+++ b/backend/app/routers/auth_steam.py
@@ -197,6 +197,28 @@ async def callback(request: Request) -> HTMLResponse:
         user_id = user["_id"]
         token = create_token(user_id=user["_id"], steam_id=steamid)
         needs_email = not user.get("email")
+
+        # Link any runs the overlay / Compendium submitted under this Steam
+        # ID before the account existed (or before a prior sign-in). Also
+        # matches the account's linked discord_id so either identity surfaces
+        # the same runs. This is what makes runs appear on the profile
+        # without a manual .run upload.
+        if os.environ.get("MONGO_URL", "").strip():
+            try:
+                from ..services.runs_db_mongo import backfill_user_runs
+
+                linked = backfill_user_runs(
+                    user_id,
+                    steam_id=steamid,
+                    discord_id=user.get("discord_id"),
+                    username=user.get("username"),
+                )
+                if linked:
+                    logger.info(
+                        "steam-auth linked %d run(s) to user=%s", linked, user_id
+                    )
+            except Exception as exc:
+                logger.warning("steam-auth run backfill failed: %s", exc)
     except Exception as exc:
         logger.warning("steam-auth user creation failed: %s", exc)
         # Non-fatal: auth still succeeded, just no persistent user yet

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -50,8 +50,17 @@ def _load_run_blob(run_hash: str) -> str | None:
 
 @router.post("", tags=["Runs"])
 @limiter.limit("3000/hour")
-async def submit_run_endpoint(request: Request, username: str | None = None):
+async def submit_run_endpoint(
+    request: Request,
+    username: str | None = None,
+    steam_id: str | None = None,
+    discord_id: str | None = None,
+):
     """Submit a run for community stats. Paste the .run file JSON content. Optional ?username= param.
+
+    Pass ?steam_id=<SteamID64> (the overlay / Compendium send the signed-in
+    player's Steam ID) and/or ?discord_id=<id> to tag the run with its owner
+    so it links to their account on sign-in without a manual claim.
 
     Rate limit: 3000/hour (~50/min sustained, with room for burst). The
     earlier 600/hour ceiling was sized for "a few hundred backlog runs
@@ -93,7 +102,25 @@ async def submit_run_endpoint(request: Request, username: str | None = None):
         sanitized = re.sub(r"[^a-zA-Z0-9_\- ]", "", username.strip())[:32].strip()
         clean_username = sanitized or None
 
-    result = submit_run(data, username=clean_username)
+    # Sanitize steam_id / discord_id — both are digits only (SteamID64 and
+    # Discord snowflake). Drop anything else so a malformed value can't
+    # widen the linkage query.
+    clean_steam_id = None
+    if steam_id:
+        digits = "".join(ch for ch in steam_id if ch.isdigit())
+        clean_steam_id = digits or None
+
+    clean_discord_id = None
+    if discord_id:
+        digits = "".join(ch for ch in discord_id if ch.isdigit())
+        clean_discord_id = digits or None
+
+    result = submit_run(
+        data,
+        username=clean_username,
+        steam_id=clean_steam_id,
+        discord_id=clean_discord_id,
+    )
     if result.get("error"):
         if result.get("duplicate"):
             run_submissions.labels(status="duplicate").inc()

--- a/backend/app/services/runs_db.py
+++ b/backend/app/services/runs_db.py
@@ -259,8 +259,17 @@ def clean_id(raw_id: str) -> str:
     return raw_id
 
 
-def submit_run(data: dict, username: str | None = None) -> dict:
-    """Parse and store a run. Returns status dict."""
+def submit_run(
+    data: dict,
+    username: str | None = None,
+    steam_id: str | None = None,
+    discord_id: str | None = None,
+) -> dict:
+    """Parse and store a run. Returns status dict.
+
+    ``steam_id`` / ``discord_id`` are accepted for signature parity with the
+    Mongo implementation (the production path). The SQLite fallback doesn't
+    track per-account run ownership, so they're ignored here."""
     # Validate structure. Errors call out the specific field so failed
     # batch uploads (issue #151) can be triaged without re-running with
     # a debugger — previously every rejection collapsed to the same

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -143,6 +143,9 @@ def _ensure_indexes(coll) -> None:
     coll.create_index([("relics.id", ASCENDING)])
     coll.create_index([("killed_by", ASCENDING)])
     coll.create_index([("user_id", ASCENDING), ("submitted_at", DESCENDING)])
+    # Backfill query on sign-in matches runs by submitter steam_id / discord_id.
+    coll.create_index([("steam_id", ASCENDING)])
+    coll.create_index([("discord_id", ASCENDING)])
     coll.create_index(
         [
             ("game_mode", ASCENDING),
@@ -204,9 +207,43 @@ def init_db():
 
 # ── public surface ──────────────────────────────────────────────────────
 @_instrument("submit_run")
-def submit_run(data: dict, username: str | None = None) -> dict:
+def submit_run(
+    data: dict,
+    username: str | None = None,
+    steam_id: str | None = None,
+    discord_id: str | None = None,
+) -> dict:
     """Parse a run and store one document per player. Returns status dict
-    matching the SQLite implementation."""
+    matching the SQLite implementation.
+
+    When ``steam_id`` / ``discord_id`` is provided (the overlay / Compendium
+    pass the signed-in player's SteamID64), the run is tagged with it and,
+    if an account already exists for that identity, linked to it immediately
+    by setting ``user_id`` + ``username`` so it shows up on the owner's
+    profile without a manual claim. Runs submitted before the account
+    existed are linked retroactively by ``backfill_user_runs`` on sign-in."""
+    # Resolve the owning account once (not per player) so a backlog upload
+    # of N runs does a single user lookup rather than N. Steam is checked
+    # first since that's what the game clients send; discord_id is here for
+    # parity so any client that knows it links the same way.
+    linked_user_id = None
+    linked_username = None
+    if steam_id or discord_id:
+        try:
+            from .users_db import get_user_by_steam_id, get_user_by_discord_id
+
+            owner = None
+            if steam_id:
+                owner = get_user_by_steam_id(steam_id)
+            if owner is None and discord_id:
+                owner = get_user_by_discord_id(discord_id)
+            if owner:
+                linked_user_id = owner["_id"]
+                linked_username = owner.get("username")
+        except Exception:
+            # Linking is best-effort; a lookup failure must not drop the run.
+            pass
+
     missing: list[str] = []
     if not data.get("players"):
         missing.append("players")
@@ -239,7 +276,10 @@ def submit_run(data: dict, username: str | None = None) -> dict:
             total_floors,
             killed_by,
             player_count,
-            username,
+            linked_username or username,
+            steam_id,
+            discord_id,
+            linked_user_id,
         )
         results.append(result)
 
@@ -271,9 +311,14 @@ def _submit_player_run(
     killed_by: str | None,
     player_count: int,
     username: str | None,
+    steam_id: str | None = None,
+    discord_id: str | None = None,
+    linked_user_id: str | None = None,
 ) -> dict:
     """One Mongo insert per player. The full nested structure goes into
     a single document — no joins required at query time."""
+    from bson import ObjectId
+
     seed = data.get("seed", "")
     char_raw = player["character"]
     start = data.get("start_time", "")
@@ -359,6 +404,13 @@ def _submit_player_run(
         "deck_size": len(deck),
         "relic_count": len(relics),
         "username": username,
+        # Submitter identity (when the client sends it). Lets a run be linked
+        # to its owner's account on sign-in even if it was submitted
+        # anonymously. user_id is set here when an account already exists for
+        # that identity; otherwise backfill_user_runs fills it in.
+        "steam_id": steam_id,
+        "discord_id": discord_id,
+        "user_id": ObjectId(linked_user_id) if linked_user_id else None,
         "build_id": data.get("build_id"),
         "submitted_at": datetime.now(timezone.utc),
         "deck": deck,
@@ -379,6 +431,29 @@ def _submit_player_run(
     try:
         coll.insert_one(doc)
     except DuplicateKeyError:
+        # The run already exists (commonly: it was submitted anonymously
+        # before the client started sending an identity). Re-submitting with
+        # a steam_id / discord_id becomes a migration path — tag the existing
+        # doc so a later sign-in can link it. Each $set is guarded on the
+        # field being null so we never reassign a run another account owns.
+        if steam_id:
+            coll.update_one(
+                {"_id": run_hash, "steam_id": None},
+                {"$set": {"steam_id": steam_id}},
+            )
+        if discord_id:
+            coll.update_one(
+                {"_id": run_hash, "discord_id": None},
+                {"$set": {"discord_id": discord_id}},
+            )
+        if linked_user_id:
+            owner_set: dict = {"user_id": ObjectId(linked_user_id)}
+            if username:
+                owner_set["username"] = username
+            coll.update_one(
+                {"_id": run_hash, "user_id": None},
+                {"$set": owner_set},
+            )
         return {
             "error": "This run has already been submitted",
             "duplicate": True,
@@ -386,6 +461,46 @@ def _submit_player_run(
         }
 
     return {"success": True, "run_id": run_hash, "run_hash": run_hash}
+
+
+@_instrument("backfill_user_runs")
+def backfill_user_runs(
+    user_id: str,
+    steam_id: str | None = None,
+    discord_id: str | None = None,
+    username: str | None = None,
+) -> int:
+    """Link previously-anonymous runs to an account on sign-in.
+
+    Sets ``user_id`` (and ``username`` when the account has one) on every
+    run tagged with this account's ``steam_id`` or ``discord_id`` that isn't
+    already owned. Passing both matters because an account can link Steam +
+    Discord — signing in either way links runs tagged with the other ID.
+    Returns the number of runs linked. Idempotent — only touches runs whose
+    ``user_id`` is still null, so re-running on every sign-in is cheap."""
+    if not user_id:
+        return 0
+
+    identity_conds: list[dict] = []
+    if steam_id:
+        identity_conds.append({"steam_id": steam_id})
+    if discord_id:
+        identity_conds.append({"discord_id": discord_id})
+    if not identity_conds:
+        return 0
+
+    from bson import ObjectId
+
+    coll = _get_collection()
+    update: dict = {"user_id": ObjectId(user_id)}
+    if username:
+        update["username"] = username
+
+    result = coll.update_many(
+        {"user_id": None, "$or": identity_conds},
+        {"$set": update},
+    )
+    return result.modified_count
 
 
 @_instrument("claim_runs")

--- a/backend/app/services/users_db.py
+++ b/backend/app/services/users_db.py
@@ -99,6 +99,33 @@ def validate_email(email: str) -> bool:
     return bool(_EMAIL_RE.match(email.strip()))
 
 
+def get_user_by_steam_id(steam_id: str) -> dict | None:
+    """Look up a user by Steam ID without creating one. Used when a run is
+    submitted with a steam_id so it can be linked to an existing account at
+    submit time. Returns the doc with a stringified _id, or None."""
+    if not steam_id:
+        return None
+    coll = _get_collection()
+    existing = coll.find_one({"steam_id": steam_id})
+    if existing:
+        existing["_id"] = str(existing["_id"])
+        return existing
+    return None
+
+
+def get_user_by_discord_id(discord_id: str) -> dict | None:
+    """Look up a user by Discord ID without creating one. Mirror of
+    get_user_by_steam_id for runs tagged with a discord_id."""
+    if not discord_id:
+        return None
+    coll = _get_collection()
+    existing = coll.find_one({"discord_id": discord_id})
+    if existing:
+        existing["_id"] = str(existing["_id"])
+        return existing
+    return None
+
+
 def find_or_create_by_steam(steam_id: str, persona_name: str | None = None) -> dict:
     coll = _get_collection()
     now = datetime.now(timezone.utc)

--- a/frontend/app/cards/CardsClient.tsx
+++ b/frontend/app/cards/CardsClient.tsx
@@ -91,6 +91,22 @@ export default function CardsClient({ initialCards }: { initialCards: Card[] }) 
     updateUrl(current);
   }, [search, color, type, rarity, keyword, sort, updateUrl]);
 
+  // Pull the discrete filters back out of the URL whenever it changes from
+  // outside this component — e.g. clicking a "Browse cards by character"
+  // card on the hub above (a same-route navigation that doesn't remount
+  // this client), or browser back/forward. Without this, the URL updated
+  // but the dropdowns and grid never reflected it. Setting state to the
+  // same value is a no-op, so our own setFilterAndUrl writes don't loop.
+  // Search is intentionally excluded: it's a typed input owned locally,
+  // and echoing the URL back into it mid-keystroke would fight the user.
+  useEffect(() => {
+    setColor(searchParams.get("color") || "");
+    setType(searchParams.get("type") || "");
+    setRarity(searchParams.get("rarity") || "");
+    setKeyword(searchParams.get("keyword") || "");
+    setSort(searchParams.get("sort") || "az");
+  }, [searchParams]);
+
   useEffect(() => {
     // Skip the first fetch if we have server data and lang is English with no filters
     if (initialRender.current) {

--- a/frontend/app/cards/page.tsx
+++ b/frontend/app/cards/page.tsx
@@ -17,6 +17,27 @@ const API =
   process.env.NEXT_PUBLIC_API_URL ||
   "http://localhost:8000";
 
+// ISR with 60s revalidation, mirroring the home page. Without a
+// page-level revalidate the build-time render (backend unreachable
+// inside the Docker builder) bakes empty data that never refreshes,
+// which is what zeroed out the card counts below. The inner fetches
+// revalidate faster (30s) so each regen pulls fresh data.
+export const revalidate = 60;
+
+// Fetch JSON with its own try/catch so a failure on one endpoint can't
+// take down the other. Previously both fetches shared one Promise.all +
+// try/catch, so a hiccup on /api/runs/scores/cards left `cards` empty
+// and rendered every count as 0.
+async function fetchJSON<T>(url: string, fallback: T): Promise<T> {
+  try {
+    const res = await fetch(url, { next: { revalidate: 30 } });
+    if (!res.ok) return fallback;
+    return (await res.json()) as T;
+  } catch {
+    return fallback;
+  }
+}
+
 // Character anchors for the "Browse cards by character" hub section.
 // Tagline is short and factual to give Google additional substring
 // matches for character-specific long-tail queries (e.g. "silent cards
@@ -44,23 +65,14 @@ export default async function CardsPage() {
   // step is required for Google to see the intro prose, the top-N
   // section, or the character breakdown -- they're all in the initial
   // response.
-  let cards: Card[] = [];
-  let scores: EntityScore[] = [];
-  try {
-    const [cardsRes, scoresRes] = await Promise.all([
-      fetch(`${API}/api/cards?lang=eng`, { next: { revalidate: 300 } }),
-      fetch(`${API}/api/runs/scores/cards`, { next: { revalidate: 300 } }),
-    ]);
-    if (cardsRes.ok) cards = await cardsRes.json();
-    if (scoresRes.ok) {
-      const raw = (await scoresRes.json()) as Record<string, EntityScore>;
-      scores = Object.values(raw);
-    }
-  } catch {
-    // Falls through to render with empty data; the page still has the
-    // intro prose + character breakdown + FAQ, which is what matters
-    // for SEO.
-  }
+  const [cards, scoresRaw] = await Promise.all([
+    fetchJSON<Card[]>(`${API}/api/cards?lang=eng`, []),
+    fetchJSON<Record<string, EntityScore>>(
+      `${API}/api/runs/scores/cards`,
+      {},
+    ),
+  ]);
+  const scores: EntityScore[] = Object.values(scoresRaw);
 
   const totalCards = cards.length;
   const cardsByCharacter = CHARACTERS.map((char) => ({


### PR DESCRIPTION
## Bug 1: profile runs blank after sign-in

`spire-codex.com/profile` was rendering an empty runs section for accounts I knew had submitted runs through the overlay or Compendium. The runs are in Mongo, but `user_id` is `null` and so is `steam_id`. They were stored fully anonymous. Sign-in lookups match by `user_id`, so they never surface.

### Root cause

Two gaps in the submit + link path:

1. `submit_run()` had no concept of submitter identity. The overlay and Compendium already know the player's SteamID64 (they just used it to sign in via Steam OpenID), but the run doc carried none of that.
2. The Steam sign-in callback created the user record but never tried to link any pre-existing runs to it.

So runs and accounts existed in parallel and never met. Even runs submitted *after* an account was created stayed anonymous unless the user manually re-uploaded them through the "Claim Runs" drop zone.

### Fix

Made the submit + link path identity-aware on **both Steam ID and Discord ID**, so an account that has linked both can see its runs from either sign-in flow.

`runs_db_mongo.py`:
- `submit_run()` accepts `steam_id` and `discord_id`, stores both on the doc.
- Resolves the owning account once at insert time (Steam first, then Discord) and sets `user_id` immediately when the account already exists. No second round-trip.
- Added indexes on `steam_id` and `discord_id`.
- `DuplicateKeyError` path now tags `steam_id` / `discord_id` / `user_id` on the existing doc when those fields are still null, so re-submitting backlog runs (e.g. Compendium re-uploading `.run` files on first launch with this change) becomes a migration path for the rows already in Mongo.
- `backfill_user_runs` is now `(user_id, steam_id=None, discord_id=None, username=None)` and matches by `$or`, so a Steam sign-in still picks up runs tagged with the account's linked Discord ID, and vice versa.

`users_db.py`: added `get_user_by_steam_id` and `get_user_by_discord_id` (lookup-only, no auto-create) used by `submit_run` to resolve the owner.

`runs.py`: `POST /api/runs` accepts `?steam_id=<SteamID64>` and `?discord_id=<id>`. Both are digit-only sanitized before being passed through so a malformed value cannot widen the linkage query.

`auth_steam.py` and `auth_discord.py`: each `/callback` runs `backfill_user_runs` with both the just-authenticated identity and the account's other linked identity from the user doc.

`auth.py`: `/api/auth/runs/upload` passes the signed-in user's `steam_id` and `discord_id` through to `submit_run`, so the website "Claim Runs" path also tags ownership.

`runs_db.py`: signature parity on the SQLite fallback. The new params are ignored there since the fallback does not track per-account ownership.

### What's still needed (separate repos, not in this PR)

The backend now accepts identity-tagged runs but the game clients are not sending the ID yet:

- **spire-overwolf** and **spire-compendium**: append `&steam_id=<SteamID64>` on their `POST /api/runs` calls.
- **spire-compendium**: re-submit local `.run` files once on startup so existing anonymous runs in Mongo hit the `DuplicateKeyError` migration path and get tagged.

Until that ships, runs already in Mongo with no `steam_id` can only be surfaced via the website "Claim Runs" drop zone.

## Bug 2: /cards shows 0 counts and character filter clicks do nothing

`spire-codex.com/cards` had two unrelated symptoms.

### Symptom 1: every count rendered as 0

The page header and every per-character box read "0 cards" even though the live API returns the full catalog (576 cards). The home page (which shows the same total) was correct, so the API was returning real data.

### Root cause

`cards/page.tsx` did its two server fetches (cards meta and per-card scores) in one `Promise.all` / `try-catch`. Any failure on `/api/runs/scores/cards` zeroed *both* fetches. The cards array got reset to empty, so the total count dropped to 0 even though the meta fetch was fine.

And the page had no `revalidate` export. The home page has had this exact bug before and self-heals via ISR (its own comment block documents the incident). Without page-level ISR, a Docker build that renders during a backend hiccup bakes the empty fallback straight into the static output.

### Fix

- Split the two server fetches into independent `fetchJSON` calls so one failing cannot zero the other.
- Added `export const revalidate = 60` to match the home page.

### Symptom 2: clicking a "Browse by character" box updates the URL but not the grid

The character filter chips on the page worked. The big "Browse by character" cards in the discovery section navigated to the same route with a `?character=...` param but the grid stayed unfiltered.

### Root cause

`cards/CardsClient.tsx` read URL filters only inside `useState` initializers. Those run once on mount. A "Browse by character" card is a same-route navigation, so the component never remounted and the filter state never updated. The URL was correct; the UI just was not reading it.

### Fix

Added an effect that re-reads the discrete filters from `searchParams` on every URL change. Search is deliberately excluded from the effect. Syncing it from the URL would fight the user's typing.