### PR TITLE
/cards: fix SSR crash on score row entity_id

### DIFF
--- a/frontend/app/cards/page.tsx
+++ b/frontend/app/cards/page.tsx
@@ -50,14 +50,19 @@ const CHARACTERS: { id: string; name: string; tagline: string }[] = [
   { id: "regent", name: "Regent", tagline: "Court attendants, decree powers, prestige scaling." },
 ];
 
-interface EntityScore {
-  entity_id: string;
+// Matches the shape returned by /api/runs/scores/{entity_type}
+// (run_entity_stats.get_all_entity_scores): the response is a dict
+// keyed by entity_id, and each value carries score + raw counts +
+// already-percentaged win_rate (e.g. 50.8 means 50.8%). entity_id
+// is the key, not a field on the value, so the SSR has to thread it
+// in when flattening to an array.
+interface ScoreEntry {
   score: number | null;
-  letter: string | null;
-  pick_rate: number;
   win_rate: number;
   picks: number;
+  wins: number;
 }
+type ScoreRow = ScoreEntry & { entity_id: string };
 
 export default async function CardsPage() {
   // Fetch the catalog + Codex Scores in parallel so the server-rendered
@@ -67,12 +72,20 @@ export default async function CardsPage() {
   // response.
   const [cards, scoresRaw] = await Promise.all([
     fetchJSON<Card[]>(`${API}/api/cards?lang=eng`, []),
-    fetchJSON<Record<string, EntityScore>>(
+    fetchJSON<Record<string, ScoreEntry>>(
       `${API}/api/runs/scores/cards`,
       {},
     ),
   ]);
-  const scores: EntityScore[] = Object.values(scoresRaw);
+  // The endpoint keys the score by entity_id; carry that through onto
+  // each row so the .map below can look the card up. Previously the
+  // page did Object.values(scoresRaw) and then read s.entity_id, which
+  // threw "Cannot read properties of undefined (reading 'toLowerCase')"
+  // and crashed the SSR render, which is why every count fell back to
+  // the build-time empty prerender.
+  const scores: ScoreRow[] = Object.entries(scoresRaw).map(
+    ([entity_id, s]) => ({ ...s, entity_id }),
+  );
 
   const totalCards = cards.length;
   const cardsByCharacter = CHARACTERS.map((char) => ({
@@ -91,10 +104,11 @@ export default async function CardsPage() {
     .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
     .slice(0, 24)
     .map((s) => {
+      if (typeof s.entity_id !== "string") return null;
       const card = cardById.get(s.entity_id.toLowerCase());
       return card ? { card, score: s } : null;
     })
-    .filter((x): x is { card: Card; score: EntityScore } => x !== null)
+    .filter((x): x is { card: Card; score: ScoreRow } => x !== null)
     .slice(0, 6);
 
   const faq = [
@@ -206,8 +220,8 @@ export default async function CardsPage() {
                     )}
                   </div>
                   <div className="text-xs text-[var(--text-muted)] mt-1">
-                    {(score.win_rate * 100).toFixed(1)}% win ·{" "}
-                    {(score.pick_rate * 100).toFixed(1)}% pick
+                    {score.win_rate.toFixed(1)}% win ·{" "}
+                    {score.picks.toLocaleString()} picks
                   </div>
                 </Link>
               </li>


### PR DESCRIPTION
## Symptom

After #394 deployed with the new ISR setup, `/cards` was still rendering every character bundle as "0 cards" and the FAQ as "0 cards across the five characters". `curl -sI` showed `x-nextjs-cache: HIT` with cached empty content even past the 60s revalidate window.

The frontend container's logs surfaced the actual reason on each request:

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at Array.map
    at .next/server/chunks/ssr/[root-of-the-server]__2fb80df6._.js
```

So the SSR was crashing every render, Next.js was catching the error, and the cached fallback was the build-time empty prerender (the CI builder cannot reach the backend, so `fetchJSON` returned `[]`). Every visitor got that fallback, ISR never updated, the page looked permanently broken.

## Root cause

`cards/page.tsx` was modeling the score endpoint with the wrong shape:

```ts
interface EntityScore {
  entity_id: string;
  ...
}
...
const scores: EntityScore[] = Object.values(scoresRaw);
...
const card = cardById.get(s.entity_id.toLowerCase());
```

But `/api/runs/scores/cards` (`run_entity_stats.get_all_entity_scores`) returns a dict **keyed by entity_id** with values of shape `{score, picks, wins, win_rate}`. There is no `entity_id` field on the value. `Object.values` threw the keys away, so `s.entity_id` was `undefined` for every row and `.toLowerCase()` threw on the first iteration of the `.map`.

This was a pre-existing bug, not a regression from #394. #394 made the symptom more visible by adding ISR, since the prior `force-dynamic` would have hit the crash on every request rather than masking it behind a hot static prerender.

## Fix

- Renamed `EntityScore` to `ScoreEntry`, reshaped it to match what the endpoint actually returns. Removed `letter` and `pick_rate` from the type (the API never returned them) and added `wins` (the API does return it). Added a `ScoreRow` type that layers `entity_id` back on after flattening.
- Switched `Object.values` to `Object.entries` so `entity_id` is threaded back onto each row from the dict key.
- Added a `typeof s.entity_id !== "string"` guard before the `.toLowerCase()` lookup so any future shape drift degrades to a missing top-rated entry rather than a full-page SSR crash.

## Display fix

Once the top-rated section actually renders, two display lines were also wrong:

- `(score.win_rate * 100).toFixed(1)` produced `5080.0% win` because the API already returns `win_rate` as a percentage (50.8 means 50.8%). Fixed to display `win_rate` directly.
- `(score.pick_rate * 100).toFixed(1)` would have shown `NaN% pick` because `pick_rate` isn't in the response at all. Swapped that column for the raw `picks` count, which the API does return.

## Aftermath

After deploy, the next ISR regen should produce a real render and the cache should populate with 576 in the FAQ, 87/88 per character in the bundles, and the top-rated section should finally light up.