### PR TITLE
nginx: 301 legacy /static/images URLs onto the CDN

### DIFF
--- a/infrastructure/ansible/templates/nginx.conf.j2
+++ b/infrastructure/ansible/templates/nginx.conf.j2
@@ -141,6 +141,18 @@ http {
           rewrite ^/static/images/relics/(.+)\.(.+)$ /static/images/characters/character_icon_$1.$2 last;
       }
 
+      # Legacy image URLs from before the CDN cut-over. The slim backend
+      # Dockerfile stopped shipping .webp files; assets live on Cloudflare
+      # R2 at cdn.spire-codex.com/<category>/<file> now. Old links still
+      # hit this origin (browser tabs, wiki/blog embeds, outdated client
+      # versions); 301 them onto the CDN so they keep resolving. Sits
+      # AFTER the character-icon rewrite above so a Compendium request
+      # for /static/images/relics/<char>.webp gets rewritten first, then
+      # redirected from the corrected /static/images/characters/... path.
+      location ~ ^/static/images/(.+)$ {
+          return 301 https://cdn.spire-codex.com/$1;
+      }
+
       location /static/ {
           proxy_pass http://spire-codex-backend:8000;
           proxy_http_version 1.1;


### PR DESCRIPTION
## Why

Discord report this afternoon from someone who had this URL working as recently as Saturday:

```
https://spire-codex.com/static/images/cards/adrenaline.webp
```

It's a 404 now:

```
$ curl -I https://spire-codex.com/static/images/cards/adrenaline.webp
HTTP/2 404
```

The slim backend Dockerfile dropped the `.webp` files and assets moved to Cloudflare R2 at `cdn.spire-codex.com/<category>/<file>`. The in-frontend `imageUrl()` helper already rewrites canonical URLs (`/static/images/cards/adrenaline.webp` -> `https://cdn.spire-codex.com/cards/adrenaline.webp`), so fresh page loads land on the CDN, but anything still pointing at the old host path 404s: open browser tabs, wiki/blog/Discord embeds, the Compendium pinging an outdated path, anyone with an old link in a notes doc.

## What

Add a 301 at the nginx layer so legacy URLs forward to the CDN automatically:

```nginx
location ~ ^/static/images/(.+)$ {
    return 301 https://cdn.spire-codex.com/$1;
}
```

Placed AFTER the existing character-icon rewrite (the `location ~ ^/static/images/relics/(ironclad|silent|defect|necrobinder|regent)\.(webp|png)$` block that maps the Compendium's wrong path to the correct one). The rewrite uses `last;` which re-evaluates locations, so a request for `/static/images/relics/ironclad.webp` becomes `/static/images/characters/character_icon_ironclad.webp` first, *then* hits this redirect and lands on the right CDN file. Without that ordering the Compendium would get a 301 to a non-existent `cdn.spire-codex.com/relics/ironclad.webp`.

301 (rather than 308) is the conventional choice for legacy URL forwards: it caches cleanly at every layer (browser, CF edge, search engines) so the cost is a one-time hop per old URL per client.

## Scope

Only added to the main `spire-codex.com` server block. Beta serves version-pinned `/static/data-beta/<vX.Y.Z>/...` paths that don't match this pattern, and staging isn't a real ingress.

## Deploy

Needs `playbooks/sync-config.yml` (or whatever templates `nginx.conf.j2` -> `/etc/nginx/conf.d/` -> nginx reload) on the box after merge. No image rebuild.