### PR TITLE
Fix UnboundLocalError on Steam sign-in callback

### DIFF
--- a/backend/app/routers/auth_steam.py
+++ b/backend/app/routers/auth_steam.py
@@ -26,6 +26,7 @@ Mongo (local dev) uvicorn runs a single worker, so the dict is safe.
 from __future__ import annotations
 
 import logging
+import os
 import re
 import urllib.parse
 from typing import Optional
@@ -56,8 +57,6 @@ def _public_base(request: Request) -> str:
     the public URL. Override via env if the deployment ever ends up
     behind a proxy that doesn't forward the headers we expect.
     """
-    import os
-
     explicit = os.environ.get(_REALM_ENV_KEY)
     if explicit:
         return explicit.rstrip("/")
@@ -129,8 +128,6 @@ async def callback(request: Request) -> HTMLResponse:
     session_id = qs.get("session", "")
     session = auth_session_store.get_session(session_id)
     if not session:
-        import os
-
         frontend = os.environ.get("FRONTEND_URL", "").strip() or _public_base(request)
         return RedirectResponse(f"{frontend}/profile")
 
@@ -246,8 +243,6 @@ async def callback(request: Request) -> HTMLResponse:
     # approach works directly; in local dev (different ports) we need
     # this token handoff.
     if token:
-        import os
-
         frontend = os.environ.get("FRONTEND_URL", "").strip() or _public_base(request)
         auth_session_store.pop_session(session_id)
         response = RedirectResponse(f"{frontend}/profile?auth=steam&token={token}")


### PR DESCRIPTION
## Symptom

Discord report this evening: "I tried signing in with Steam and got these errors in the console. I was able to sign in but had to go with Discord and then Steam."

Backend log from the failing callback:

```
2026-06-02 03:06:24 WARNING spire-codex.auth — steam-auth user creation failed:
cannot access local variable 'os' where it is not associated with a value
2026-06-02 03:06:24 INFO    spire-codex.auth — steam-auth ok session=29K1OKdw steamid=... persona=Yitsy user=...
```

The user **did** end up created and signed in (the warning is caught and execution continues), but the backfill step silently skipped, and on the first attempt the exception window seems to have eaten the popup-to-opener postMessage handoff -- which is why "Discord first, then Steam-link" was the workaround (Discord auth is a redirect flow, no popup).

## Root cause

PR #394 added this to the Steam callback's backfill block:

```python
if os.environ.get("MONGO_URL", "").strip():
    try:
        from ..services.runs_db_mongo import backfill_user_runs
        ...
```

Same function (`callback`) already had a pre-existing `import os` further down, inside the `if token:` redirect branch:

```python
if token:
    import os
    frontend = os.environ.get("FRONTEND_URL", "").strip() or _public_base(request)
```

Python's scope rule looks at every assignment in a function at compile time. A nested `import os` inside the same function makes `os` a local for the **entire** function, so my earlier `os.environ.get` reads an unbound local and throws `UnboundLocalError`.

The outer `try/except Exception` in the same block catches it (logs a warning, marks the user-creation step as "failed"), then execution continues to the redirect block where `import os` actually runs and the rest of the flow recovers. So users got signed in -- they just got an extra exception roundtrip that occasionally raced the popup messaging.

## Same trap in two more spots

`_public_base` and the "session not found" branch of `callback` each have their own function-level `import os`. They don't bug today because the import is the first `os` reference in each function's scope. But any future edit adding an `os.environ.get` above the import in either of those would hit the same `UnboundLocalError`. Disarming the trap once.

## Fix

Move `import os` to the module-level import block, drop all three function-level imports:

```diff
 import logging
+import os
 import re
 import urllib.parse
```

```diff
 def _public_base(...):
     ...
-    import os
-
     explicit = os.environ.get(_REALM_ENV_KEY)
```

(and two more removals like the above inside `callback`)

1 insertion, 6 deletions. The `import os` only had to be once anyway.