### PR TITLE
Mark /api/auth/* as private, no-store

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -212,6 +212,16 @@ class CORSStaticMiddleware(BaseHTTPMiddleware):
                                              reviews near-instant. When new
                                              renders are rsync'd, manually
                                              purge /qa/* on CF.
+      /api/auth/*  private, no-store        — per-user authed endpoints (profile
+                                             runs, claim flow, sign-in state).
+                                             Without this they fell under the
+                                             /api/* branch below and got
+                                             s-maxage=3600, which let Cloudflare
+                                             cache one user's response and risk
+                                             serving it to another. Today CF
+                                             bypasses on cookie heuristics but
+                                             the origin should declare intent
+                                             explicitly.
       /api/runs/*  s-maxage=30             — user-submitted runs need to appear
                                              in lists/leaderboards within a
                                              minute, not an hour.
@@ -243,6 +253,8 @@ class CORSStaticMiddleware(BaseHTTPMiddleware):
             )
         elif path in ("/metrics", "/health"):
             response.headers["Cache-Control"] = "no-store"
+        elif path.startswith("/api/auth/"):
+            response.headers["Cache-Control"] = "private, no-store"
         elif path.startswith("/api/runs/"):
             response.headers["Cache-Control"] = "public, max-age=30, s-maxage=30"
         elif path.startswith("/api/"):


### PR DESCRIPTION
## Why

Tonight's "profile went from 106 runs to 3" report. The 104 runs were intact in Mongo; the bug had to be between origin and browser. Clearing CF cache fixed it.

Tracing the actual cache directive on the endpoint:

```python
# backend/app/main.py — CORSStaticMiddleware
elif path.startswith("/api/"):
    response.headers["Cache-Control"] = "public, max-age=300, s-maxage=3600"
```

`/api/auth/runs`, `/api/auth/me`, `/api/auth/stats` all fall under this branch. The origin was telling Cloudflare to cache per-user authed responses for one hour at the edge. That's how a profile request can end up serving someone else's data, or a stale snapshot of your own, from a CF PoP.

Today CF bypasses these anyway via its cookie-presence heuristic, which is why this hadn't bitten harder. But the origin shouldn't depend on a CDN heuristic to keep auth data private. Belt-and-suspenders.

## What

One branch added to `CORSStaticMiddleware.dispatch`, placed before the generic `/api/*` fallback:

```python
elif path.startswith("/api/auth/"):
    response.headers["Cache-Control"] = "private, no-store"
```

- `private` keeps the response off shared caches (CDN, intermediate proxies).
- `no-store` keeps it out of any cache, including the browser disk cache. Each profile load goes back to origin.

## What it doesn't change

- `/static/*`, `/qa/*`, `/api/runs/*` (community runs feed), `/api/*` (entity data) — all unchanged. Those are public, cacheable, and the existing TTLs are correct.
- The cookie-presence bypass that CF applies today still applies. This is additive defense, not a replacement for it.

## Deploy

Backend image rebuild + restart on the box. No frontend changes, no migration.