### PR TITLE
map-generation: drop fictional "-1 rest site on A6" claim

### DIFF
--- a/data/mechanics_pages/map-generation.md
+++ b/data/mechanics_pages/map-generation.md
@@ -23,7 +23,7 @@ order: 6
 | Elites | 5 | 8 |
 | Shops | 3 | 3 |
 | Unknown (?) | 10-14 | 10-14 |
-| Rest sites | 5-7 (varies by act) | -1 on A6 |
-| Fights | Remaining slots | — |
+| Rest sites | 5-7 (varies by act) | (no change) |
+| Fights | Remaining slots | (no change) |
 
-> Unknown rooms average ~12 (Gaussian). Rest sites: 6-7 in Acts 1-2, 5-6 in Act 3 (each -1 on A6). No elites or rest sites in the first 5 rows.
+> Unknown rooms average ~12 (Gaussian, 10-14). Rest sites: 6-7 in Acts 1-2 (Overgrowth, Underdocks, Hive), 5-6 in Act 3 (Glory). Rest site count is rolled at map generation from a per-act distribution and is independent of ascension level. No elites or rest sites in the first 5 rows.


### PR DESCRIPTION
Fixes #236.

## The report

> "Ascension levels no longer affect rest site allocation."  
> [/mechanics/map-generation](https://spire-codex.com/mechanics/map-generation), reported via the feedback form.

## Verification against decompiled C#

`StandardActMap` constructs its room counts via `actModel.GetMapPointTypes(mapRng)`, which is `abstract` on `ActModel` and overridden per act. Pulled each override from `sts2.dll`:

| Act | Rest count formula | Range |
|---|---|---|
| Overgrowth | `NextGaussianInt(7, 1, 6, 7)` | 6-7 |
| Underdocks | `NextGaussianInt(7, 1, 6, 7)` | 6-7 |
| Hive | `NextGaussianInt(6, 1, 6, 7)` | 6-7 (lower mean) |
| Glory | `NextInt(5, 7)` | 5-6 (`NextInt` is `[min, max)`) |

**None of them call `AscensionHelper.HasAscension(...)` for rest count.** Compare to `MapPointTypeCounts.NumOfElites`, which does explicitly check `AscensionLevel.SwarmingElites` and scales 5 -> 8 starting at A1. If a rest-site reduction existed it would be wired the same way.

`AscensionLevel` enum in current code:

```
None, SwarmingElites, WearyTraveler, Poverty, TightBelt, AscendersBane,
Inflation, Scarcity, ToughEnemies, DeadlyEnemies, DoubleBoss
```

A6 = `Inflation` (gold prices). Nothing named like `FewerRestSites` exists.

The `-1 on A6` claim was likely STS1 carryover (STS1 *does* subtract a rest site at A6) or written against an early STS2 playtest build.

## Fix

`data/mechanics_pages/map-generation.md`:

- Table: rest-sites and fights `A1+` cells changed from `-1 on A6` / em-dash to `(no change)`.
- Prose: replaced "(each -1 on A6)" with an explicit per-act range and a one-line note that the count is independent of ascension level.

User-visible: `/mechanics/map-generation` no longer claims ascension affects rest site count. The "5-7 (varies by act)" base claim and the elite ascension-scaling (`5 → 8 on A1+`) are both correct and stay.

## Follow-up worth doing

The mechanics-pages content is hand-written markdown, not parsed from the C#. Same class of drift will happen again on the next major patch. A reasonable follow-up: extend `mechanics_constants_parser.py` to walk each `ActModel.GetMapPointTypes` override and write per-act room-distribution constants to `mechanics_constants.json`, and re-shape this page to pull the numbers from that. Out of scope here. Happy to file a separate issue.