### PR TITLE
Correct card generation facts on the rarity page

### DIFF
--- a/data/mechanics_pages/card-rarity.md
+++ b/data/mechanics_pages/card-rarity.md
@@ -61,6 +61,29 @@ After a rare resets the offset to {{constants.card_rarity_odds._baseRarityOffset
 
 So multi-rares in a single reward are functionally impossible **except in pre-A7 elite rewards**, where the second/third slot still rolls at ~5% rare chance after the first lands.
 
+### Why your uncommon odds aren't always what the table says
+
+The three rarities aren't rolled as three separate chances. The game rolls one random number and checks it against bands stacked in order: rare first, then uncommon on top of rare, then common gets whatever is left.
+
+- The rare band is `base rare% + offset`.
+- The uncommon band is a **fixed width** ({{constants.card_rarity_odds.regularUncommonOdds | pct}} in normal fights, {{constants.card_rarity_odds.eliteUncommonOdds | pct}} in elites). It always sits directly on top of the rare band.
+- Common is everything after that.
+
+The catch is what happens when `base rare% + offset` goes **negative**. In a normal fight, the offset resets to {{constants.card_rarity_odds._baseRarityOffset | pct}} and the rare base is only {{constants.card_rarity_odds.RegularRareOdds.base | pct}}, so right after a rare (or at the very start of a run) the rare band is {{constants.card_rarity_odds.RegularRareOdds.base | pct}} − 5% = −2%. Rare gets floored to 0%, but that missing 2% also eats into the **bottom of the uncommon band**. The lost slice doesn't go to uncommon, it goes to common.
+
+So at a fresh normal-fight reset the real odds are about:
+
+| Rarity | Headline (offset at 0) | Actual at reset (offset {{constants.card_rarity_odds._baseRarityOffset | pct}}) |
+|--------|----:|----:|
+| Rare | {{constants.card_rarity_odds.RegularRareOdds.base | pct}} | **0%** |
+| Uncommon | {{constants.card_rarity_odds.regularUncommonOdds | pct}} | **~35%** |
+| Common | {{constants.card_rarity_odds.regularCommonOdds.base | pct}} | **~65%** |
+
+Two takeaways:
+
+- The headline table at the top of this page is the raw odds at offset 0. You only actually see {{constants.card_rarity_odds.RegularRareOdds.base | pct}} rare / {{constants.card_rarity_odds.regularUncommonOdds | pct}} uncommon after the offset has climbed back to 0, which takes a few non-rare cards.
+- Once the rare band is 0% or higher (any positive offset, or any elite, where the rare base is high enough that the band never goes negative), the uncommon band fits fully and uncommon stays at its listed {{constants.card_rarity_odds.regularUncommonOdds | pct}}/{{constants.card_rarity_odds.eliteUncommonOdds | pct}}. Only common flexes. The uncommon dip only happens when the rare band is underwater, which in practice is normal fights right after a rare or at the start of a run.
+
 ## What doesn't update the pity counter
 
 The pity counter only moves on **combat reward** rolls (Monster, Elite, Boss rooms) and on the Sealed Deck Neow modifier (which generates 30 starting cards through the same mutating path). Several other card-creation paths read the offset but don't reset or increment it, and most don't read it at all:
@@ -78,23 +101,54 @@ Translation: a high pity offset *does* slightly improve your odds at the next sh
 
 ## When common is forbidden
 
-For sources where Common is disallowed (Lasting Candy, the shop's colorless power slot, Infested Automaton's "Study" since no character has a Common power, etc.), a rolled Common is bumped to the **next-highest** rarity (Uncommon). The Common chance does **not** get split proportionally between Uncommon and Rare. Effective weights for a non-combat source using regular-fight base odds:
+For sources where Common is disallowed (Lasting Candy, the shop's colorless power slot, Infested Automaton's "Study" since no character has a Common power, etc.), a rolled Common is bumped to the **next-highest** rarity (Uncommon). The Common chance does **not** get split proportionally between Uncommon and Rare. Effective weights for a non-combat source using default odds:
 
-- Uncommon: base Uncommon% + base Common%
+- Uncommon: everything that isn't Rare (the rolled Common share folds into Uncommon)
 - Rare: base Rare%
 
 So Infested Automaton's "Study" (which can only return Powers — no character has a Common power) effectively rolls **~97% Uncommon power, ~3% Rare power** (~98.5% / ~1.5% on A7+).
 
-## "Random card" events come in two flavors
+## How non-combat card sources roll
 
-| Mode | Used by | How it works |
-|------|---------|--------------|
-| **Default odds** | Infested Automaton, Brain Leech, Trial, Endless Conveyor, Kaleidoscope | Rolls a rarity at the regular-fight base rates ({{constants.card_rarity_odds.regularCommonOdds.base | pct}}/{{constants.card_rarity_odds.regularUncommonOdds | pct}}/{{constants.card_rarity_odds.RegularRareOdds.base | pct}} — or {{constants.card_rarity_odds.regularCommonOdds.ascended | pct}}/{{constants.card_rarity_odds.regularUncommonOdds | pct}}/{{constants.card_rarity_odds.RegularRareOdds.ascended | pct2}} on A7+), then picks a card uniformly within that rarity. |
-| **Uniform** | Room Full of Cheese, The Future of Potions, Glass Eye, Sea Glass, Scroll Boxes, All Star modifier | Picks a card uniformly across the entire valid pool — every card equally likely (Basic and Ancient excluded). |
+Card effects outside of combat rewards use one of three methods. None of them read or write the rare-card pity offset (only combat rewards and the Sealed Deck Neow option do that).
 
-Neither mode reads or writes the rare-card pity offset.
+### 1. Default odds
 
-A practical consequence: under **Default odds**, an individual common is roughly 10× more likely than an individual rare per pick (because rarity is rolled first at 60/37/3, then the specific card is picked uniformly within the rolled rarity, and there are far more commons than rares). Under **Uniform**, that imbalance disappears — each card has the same chance regardless of rarity.
+Used by: Infested Automaton, **Brain Leech (both options)**, Trial, Endless Conveyor, Kaleidoscope.
+
+Rolls a rarity at fixed base rates (no pity offset), then picks a card uniformly within that rarity. One wrinkle: the non-combat roll uses a base-odds method that checks the rare and uncommon thresholds separately instead of stacking them, so the realized split is about **63% common / 34% uncommon / 3% rare** (A7+: ~63% / ~35.5% / ~1.5%). That's a few points more common (and fewer uncommon) than the 60/37/3 you see on combat rewards, with the rare chance unchanged. An individual common is still far more likely than an individual rare, since commons heavily outnumber rares in the pool.
+
+Brain Leech specifically (answers the "which effect" question):
+- **Share Knowledge** generates **5 cards from your own character pool** (you pick 1) at default odds.
+- **Rip the Leech Off** gives a **3-card colorless reward** at default odds, after a 5 HP hit (unblockable).
+
+Both options use default odds. Neither touches the pity offset.
+
+### 2. Uniform across the whole pool
+
+Used by: the All Star modifier (and any source that grants a random card with no rarity restriction).
+
+No rarity roll at all. Every eligible card in the pool is equally likely (Basic and Ancient excluded). A specific rare is exactly as likely as a specific common here, the opposite of default odds. You still draw commons more often only because there are more of them.
+
+### 3. Fixed rarity, uniform within rarity
+
+Used by: Glass Eye, Sea Glass, **Crystal Sphere**, **Colorful Philosophers**, Room Full of Cheese, Scroll Boxes, The Future of Potions.
+
+These hand out one or more card rewards, each **locked to a specific rarity** (the rarity is fixed, not rolled), and pick uniformly among cards of that rarity. This is the bucket the "uniform" label used to lump together with #2, but the rarity here is pinned per reward:
+
+| Source | Card rewards (each is a 3-card pick unless noted) | Pool |
+|--------|------|------|
+| Glass Eye | Common, Common, Uncommon, Uncommon, Rare | your character |
+| Sea Glass | Common, Uncommon, Rare | your character |
+| Crystal Sphere | Common, Uncommon, Rare | your character |
+| Colorful Philosophers | Common, Uncommon, Rare | a chosen **other** character |
+| Room Full of Cheese | 8 cards, all Common | your character |
+| Scroll Boxes | Common, Uncommon | its card pool |
+| The Future of Potions | one per potion, fixed rarity + card type | your character |
+
+**Colorful Philosophers** offers you up to 3 of the *other* characters' colors (random which ones if you've unlocked more than 3 other pools). Pick a color and you get those three rewards (a Common, an Uncommon, and a Rare pick) drawn from that character's pool.
+
+**Crystal Sphere** buries its three card rewards (Common, Uncommon, Rare) on the dig grid alongside the relic, potions, gold, and curse. See the [Crystal Sphere Minesweeper](/mechanics/crystal-sphere) page for the full layout. Mechanically each uncovered card reward works exactly like a Glass Eye slot.
 
 ## Card Upgrade Chance
 


### PR DESCRIPTION
## What

Fixes the factual errors on the Card Rarity Odds mechanics page and adds the missing card sources. This came out of issues #254, #251, and #235.

I verified everything against the decompiled game code (`CardRarityOdds`, `CardFactory.CreateForReward`, and the event/relic model classes) rather than from memory, since the page had a few things wrong.

## Changes

- **Rewrote the "random card" section into the three behaviors that actually exist** (it claimed two):
  1. Default odds: rolls a rarity at fixed base rates with no pity offset. The non-combat path uses `RollWithBaseOdds`, which checks the rare and uncommon thresholds separately instead of stacking them, so it realizes ~63/34/3, not the 60/37/3 on combat rewards.
  2. True whole-pool uniform: every eligible card equally likely (All Star).
  3. Fixed rarity, uniform within rarity: the reward's rarity is pinned, not rolled.
- **Recategorized Glass Eye and Sea Glass.** They were listed as free uniform pulls across the whole pool. They are actually fixed-rarity per reward (Glass Eye C/C/U/U/R, Sea Glass C/U/R), uniform within each rarity.
- **Added Colorful Philosophers** (#254): pick another character's color, get a Common/Uncommon/Rare reward set from that pool.
- **Added Crystal Sphere** (#235): three card rewards on the dig grid pinned to Common/Uncommon/Rare, same mechanism as Glass Eye.
- **Clarified Brain Leech** (#251): both options use default odds and neither touches the offset. Share Knowledge is 5 from the character's own pool, Rip is a 3-card colorless reward.
- **Documented the uncommon-clipping behavior**: the rare threshold is not floored at 0 before the uncommon band stacks on it, so uncommon dips below its nominal value at a fresh regular-fight reset.

## Note for follow-up

The ~63/34/3 default-odds split looks like a latent bug in the game itself: combat's `Roll` stacks the rare and uncommon thresholds, but `RollWithBaseOdds` does not. Documented as-is for now since it is what the code does.

Closes #235
Closes #251
Closes #254