### PR TITLE
Note that default-odds sources can return multiple rares

### DIFF
--- a/data/mechanics_pages/card-rarity.md
+++ b/data/mechanics_pages/card-rarity.md
@@ -124,6 +124,8 @@ Brain Leech specifically (answers the "which effect" question):
 
 Both options use default odds. Neither touches the pity offset.
 
+**These sources can give multiple rares.** Because every card rolls on its own and the pity offset is never involved, there's nothing stopping two (or more) rares from showing up. Combat rewards can't really do this: a rolled rare resets the offset, which drops the next slot's rare chance to ~0%. Default-odds sources have no such limit. Kaleidoscope is the clearest example: it hands out two 3-card rewards, each card an independent {{constants.card_rarity_odds.RegularRareOdds.base | pct}} rare roll, so a rare in each reward is uncommon (about 1 in 130) but completely normal.
+
 ### 2. Uniform across the whole pool
 
 Used by: the All Star modifier (and any source that grants a random card with no rarity restriction).


### PR DESCRIPTION
## What

Adds a short, plain note to the Card Rarity Odds page making it explicit that default-odds sources can return more than one rare.

## Why

Came from a report of a rare in both Kaleidoscope card rewards, which looked like it should be impossible. It is not. Checked Kaleidoscope against the game code: on pickup it hands out two 3-card rewards, and every card rolls its rarity independently at default odds (`RollWithBaseOdds`, ~3% rare) with no pity offset. So multiple rares are by design, a rare in both rewards lands around 1 in 130.

Combat rewards behave differently because a rolled rare resets the offset and floors the next slot's rare chance to ~0%. The page already listed Kaleidoscope under default odds but never spelled out that this removes the one-rare-per-reward limit, so the note closes that gap.