### PR TITLE
Tier list maker follow-ups (stay in editor on save)

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -9,7 +9,11 @@ from fastapi import APIRouter, HTTPException, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from ..services.runs_db import submit_run, get_stats, claim_runs
-from ..services.run_entity_stats import get_all_entity_scores, get_entity_stats
+from ..services.run_entity_stats import (
+    get_all_entity_scores,
+    get_entity_stats,
+    get_top_entities_for_character,
+)
 from ..metrics import (
     run_submissions,
     run_character,
@@ -669,6 +673,26 @@ def get_entity_scores(request: Request, entity_type: str):
             detail=f"entity_type must be one of {sorted(_ENTITY_STATS_TYPES)}",
         )
     return get_all_entity_scores(entity_type)
+
+
+@router.get("/top/{entity_type}/{character}", tags=["Runs"])
+@limiter.limit("120/minute")
+def get_top_for_character(
+    request: Request, entity_type: str, character: str, limit: int = 5
+):
+    """Most-picked entities of a type for one character, ranked by picks.
+
+    Powers the "Top 5 picked" sections on character pages. Returns a
+    list of {entity_id, picks, wins, win_rate, score}; empty while the
+    snapshot is cold or the character has no runs yet.
+    """
+    if entity_type not in _ENTITY_STATS_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"entity_type must be one of {sorted(_ENTITY_STATS_TYPES)}",
+        )
+    limit = max(1, min(limit, 20))
+    return get_top_entities_for_character(entity_type, character, limit)
 
 
 # Stats reads come from the materialized `stats_summary` collection,

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -466,6 +466,41 @@ def get_all_entity_scores(entity_type: str) -> dict[str, dict[str, Any]]:
     return out
 
 
+def get_top_entities_for_character(
+    entity_type: str, character: str, limit: int = 5
+) -> list[dict[str, Any]]:
+    """Most-picked entities of one type for a single character.
+
+    Scans the per-entity `by_character` breakdown and ranks by that
+    character's pick count, e.g. the cards Ironclad runs include most
+    often. Score is the same Bayesian-shrunk metric, computed from the
+    character's own wins/picks against the type baseline.
+    """
+    _maybe_rebuild()
+    char = character.upper()
+    baseline = _type_baseline(entity_type)
+    rows: list[dict[str, Any]] = []
+    for (etype, eid), agg in _cache.items():
+        if etype != entity_type:
+            continue
+        cstats = agg["by_character"].get(char)
+        if not cstats or cstats["picks"] <= 0:
+            continue
+        picks = cstats["picks"]
+        wins = cstats["wins"]
+        rows.append(
+            {
+                "entity_id": eid,
+                "picks": picks,
+                "wins": wins,
+                "win_rate": round(wins / picks * 100, 1) if picks else 0.0,
+                "score": _compute_score(wins, picks, baseline),
+            }
+        )
+    rows.sort(key=lambda r: r["picks"], reverse=True)
+    return rows[:limit]
+
+
 def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
     """Public accessor — returns the aggregate for one entity or None.
 

--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import type { Stats } from "@/lib/api";
 import { cachedFetch, getBetaVersion } from "@/lib/fetch-cache";
 import { useLanguage } from "./contexts/LanguageContext";
+import { useAuth } from "./contexts/AuthContext";
 import { t } from "@/lib/ui-translations";
 
 const LANG_CODES = new Set(["deu", "esp", "fra", "ita", "jpn", "kor", "pol", "ptb", "rus", "spa", "tha", "tur", "zhs"]);
@@ -56,6 +57,7 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
   const [stats, setStats] = useState<Stats | null>(initialStats);
   const [translations, setTranslations] = useState<Translations>(initialTranslations);
   const { lang } = useLanguage();
+  const { user, loginSteam, loginDiscord } = useAuth();
   const initialRender = useRef(true);
   const pathname = usePathname();
   const pathLang = pathname.split("/")[1];
@@ -226,6 +228,149 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
               </Link>
             );
           })}
+        </div>
+      </section>
+
+      {/* Get started: one card, a gold CTA header, then a single row of
+          the sign-in cell (signed out only) plus the 4 action tiles. */}
+      <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-12">
+        <div className="flex flex-col gap-px overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--border-subtle)]">
+          {/* Row 1: full-width CTA header, gold so it reads as subtext
+              to the SPIRE CODEX logo above. */}
+          <div className="relative overflow-hidden bg-[var(--bg-card)] px-6 py-9 text-center">
+            <div className="relative">
+              <h2 className="text-2xl font-bold tracking-tight text-[var(--accent-gold)] sm:text-3xl">
+                Get started
+              </h2>
+              <p className="mx-auto mt-2 max-w-2xl text-[var(--text-secondary)]">
+                Everything you need to climb the Spire. Track your runs, rank
+                your favorites, and join the community.
+              </p>
+            </div>
+          </div>
+          {/* Row 2: sign-in cell (signed out only) + the 4 action tiles. */}
+          <div
+            className={`relative grid grid-cols-1 gap-px bg-[var(--border-subtle)] sm:grid-cols-2 ${
+              user ? "lg:grid-cols-4" : "lg:grid-cols-5"
+            }`}
+          >
+            {!user && (
+              <div className="flex h-full flex-col items-center gap-3 bg-[var(--bg-card)] p-6 text-center">
+                <span className="text-[var(--accent-gold)]">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" className="h-9 w-9">
+                    <circle cx="12" cy="8" r="4" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4 20c0-3.6 3.6-6.5 8-6.5s8 2.9 8 6.5" />
+                  </svg>
+                </span>
+                <h3 className="font-semibold text-[var(--text-primary)]">
+                  Create an account
+                </h3>
+                <p className="text-sm text-[var(--text-secondary)]">
+                  Spire Codex keeps track of your runs and tier lists, all
+                  while not tracking you. Sign in with your Steam account or
+                  Discord.
+                </p>
+                <div className="mt-auto flex w-full gap-2 pt-2">
+                  <button
+                    onClick={loginSteam}
+                    className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[#1b2838] px-2 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#2a475e]"
+                  >
+                    <svg viewBox="0 0 24 24" fill="currentColor" className="h-4 w-4">
+                      <path d="M11.98 0C5.66 0 .48 4.88.02 11.06L6.45 13.72a3.4 3.4 0 011.92-.59l.14.01 2.86-4.14v-.06a4.54 4.54 0 119.08 0 4.54 4.54 0 01-4.54 4.54h-.1l-4.08 2.91.01.11a3.41 3.41 0 11-6.81.16L.4 14.78A12 12 0 1011.98 0zM7.54 18.21l-1.47-.61a2.56 2.56 0 004.71-.4 2.55 2.55 0 00-3.34-3.35l1.52.63a1.88 1.88 0 11-1.44 3.47v.26zm10.85-9.66a3.02 3.02 0 00-3.02-3.02 3.02 3.02 0 100 6.04 3.02 3.02 0 003.02-3.02zm-5.28-.01a2.27 2.27 0 114.54.01 2.27 2.27 0 01-4.54-.01z" />
+                    </svg>
+                    Steam
+                  </button>
+                  <button
+                    onClick={loginDiscord}
+                    className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[#5865F2] px-2 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#4752c4]"
+                  >
+                    <svg viewBox="0 0 24 24" fill="currentColor" className="h-4 w-4">
+                      <path d="M20.317 4.369a19.79 19.79 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.865-.608 1.25a18.27 18.27 0 00-5.487 0 12.6 12.6 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.058a.082.082 0 00.031.056 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 00-.041-.106 13.1 13.1 0 01-1.872-.892.077.077 0 01-.008-.128c.126-.094.252-.192.372-.291a.074.074 0 01.078-.01c3.928 1.793 8.18 1.793 12.061 0a.074.074 0 01.079.009c.12.099.246.198.373.292a.077.077 0 01-.006.127c-.598.349-1.22.645-1.873.892a.076.076 0 00-.04.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.84 19.84 0 006.002-3.03.077.077 0 00.032-.055c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.029zM8.02 15.331c-1.183 0-2.157-1.086-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.211 0 2.176 1.095 2.157 2.419 0 1.333-.955 2.419-2.157 2.419zm7.975 0c-1.183 0-2.157-1.086-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.211 0 2.176 1.095 2.157 2.419 0 1.333-.946 2.419-2.157 2.419z" />
+                    </svg>
+                    Discord
+                  </button>
+                </div>
+              </div>
+            )}
+          {[
+            {
+              title: "Download the app",
+              desc: "Download Spire Codex on Overwolf to upload your runs and get in-game help. The best Slay the Spire 2 companion app.",
+              href: "https://www.overwolf.com/app/ptrlrd-spire_codex",
+              ext: true,
+              icon: (
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" className="h-9 w-9">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v12m0 0l-4-4m4 4l4-4M4 15v4a2 2 0 002 2h12a2 2 0 002-2v-4" />
+                </svg>
+              ),
+            },
+            {
+              title: "Support on Patreon",
+              desc: "Like the project? Support us directly to unlock more features and keep the data free and as up to date as possible.",
+              href: "https://www.patreon.com/cw/SpireCodex",
+              ext: true,
+              icon: (
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" className="h-9 w-9">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 20.5l-1.45-1.32C5.4 14.5 2 11.4 2 7.6 2 5 4 3 6.5 3c1.74 0 3.41.81 4.5 2.09C12.09 3.81 13.76 3 15.5 3 18 3 20 5 20 7.6c0 3.8-3.4 6.9-8.55 11.58L12 20.5z" />
+                </svg>
+              ),
+            },
+            {
+              title: "Create a tier list",
+              desc: "Show off your favorite tier lists of cards, relics, and more, and help others master the Spire.",
+              href: "/tier-list-maker",
+              ext: false,
+              icon: (
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" className="h-9 w-9">
+                  <rect x="3" y="4.5" width="18" height="4" rx="1.2" />
+                  <rect x="3" y="10" width="18" height="4" rx="1.2" />
+                  <rect x="3" y="15.5" width="18" height="4" rx="1.2" />
+                </svg>
+              ),
+            },
+            {
+              title: "Join the Discord",
+              desc: "Get on-demand updates, share tier lists, and show off your runs in the Spire Codex Discord.",
+              href: "https://discord.gg/xMsTBeh",
+              ext: true,
+              icon: (
+                <svg viewBox="0 0 24 24" fill="currentColor" className="h-9 w-9">
+                  <path d="M20.317 4.369a19.79 19.79 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.865-.608 1.25a18.27 18.27 0 00-5.487 0 12.6 12.6 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.058a.082.082 0 00.031.056 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 00-.041-.106 13.1 13.1 0 01-1.872-.892.077.077 0 01-.008-.128c.126-.094.252-.192.372-.291a.074.074 0 01.078-.01c3.928 1.793 8.18 1.793 12.061 0a.074.074 0 01.079.009c.12.099.246.198.373.292a.077.077 0 01-.006.127c-.598.349-1.22.645-1.873.892a.076.076 0 00-.04.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.84 19.84 0 006.002-3.03.077.077 0 00.032-.055c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.029zM8.02 15.331c-1.183 0-2.157-1.086-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.211 0 2.176 1.095 2.157 2.419 0 1.333-.955 2.419-2.157 2.419zm7.975 0c-1.183 0-2.157-1.086-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.211 0 2.176 1.095 2.157 2.419 0 1.333-.946 2.419-2.157 2.419z" />
+                </svg>
+              ),
+            },
+          ].map((c) => {
+            const cls =
+              "group flex h-full flex-col items-center gap-3 bg-[var(--bg-card)] p-6 text-center transition-colors hover:bg-[var(--bg-card-hover)]";
+            const inner = (
+              <>
+                <span className="text-[var(--accent-gold)]">{c.icon}</span>
+                <h3 className="font-semibold text-[var(--text-primary)] group-hover:text-[var(--accent-gold)] transition-colors">
+                  {c.title}
+                </h3>
+                <p className="text-sm text-[var(--text-secondary)]">{c.desc}</p>
+              </>
+            );
+            return c.ext ? (
+              <a
+                key={c.title}
+                href={c.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cls}
+              >
+                {inner}
+              </a>
+            ) : (
+              <Link key={c.title} href={c.href} className={cls}>
+                {inner}
+              </Link>
+            );
+          })}
+          {/* Gold pooled at the bottom of the tiles, fading up. Painted
+              over the tiles (last child) but click-through. */}
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-[var(--accent-gold)]/12 to-transparent" />
+          </div>
         </div>
       </section>
 

--- a/frontend/app/characters/[id]/CharacterDetail.tsx
+++ b/frontend/app/characters/[id]/CharacterDetail.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import type { Character, Card, Relic } from "@/lib/api";
+import type { Character, Card, Relic, Potion } from "@/lib/api";
 import RichDescription from "@/app/components/RichDescription";
+import ScoreBadge from "@/app/components/ScoreBadge";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 
@@ -31,6 +32,76 @@ const QUOTE_LABELS: Record<string, { label: string; icon: string }> = {
   banter_dead: { label: "Last Words", icon: "skull" },
 };
 
+interface TopEntry {
+  entity_id: string;
+  picks: number;
+  wins: number;
+  win_rate: number;
+  score: number | null;
+}
+
+interface TopEntity {
+  id: string;
+  name: string;
+  image_url: string | null;
+}
+
+// One "Top 5 picked" block. Mirrors the cards page top-by-score grid so
+// the character page reads as the same family of stats.
+function TopPicks({
+  title,
+  subtitle,
+  items,
+  lookup,
+  hrefBase,
+}: {
+  title: string;
+  subtitle: string;
+  items: TopEntry[];
+  lookup: (id: string) => TopEntity | undefined;
+  hrefBase: string;
+}) {
+  const resolved = items
+    .map((it) => ({ it, ent: lookup(it.entity_id) }))
+    .filter((x): x is { it: TopEntry; ent: TopEntity } => !!x.ent);
+  if (resolved.length === 0) return null;
+  return (
+    <div className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-6 mb-6">
+      <h2 className="text-lg font-semibold text-[var(--text-primary)] mb-1">{title}</h2>
+      <p className="text-sm text-[var(--text-muted)] mb-4">{subtitle}</p>
+      <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        {resolved.map(({ it, ent }) => (
+          <li key={it.entity_id}>
+            <Link
+              href={`${hrefBase}/${ent.id.toLowerCase()}`}
+              className="block group p-3 rounded-lg border border-[var(--border-subtle)] hover:border-[var(--accent-gold)] transition-colors"
+            >
+              {ent.image_url && (
+                <img
+                  src={imageUrl(ent.image_url)}
+                  alt={`${ent.name} - Slay the Spire 2`}
+                  className="w-full h-24 object-contain mb-2"
+                  loading="lazy"
+                  crossOrigin="anonymous"
+                />
+              )}
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm font-medium group-hover:text-[var(--accent-gold)] transition-colors truncate">
+                  {ent.name}
+                </span>
+                {it.score != null && <ScoreBadge score={it.score} size="sm" />}
+              </div>
+              <div className="text-xs text-[var(--text-muted)] mt-1">
+                {it.win_rate.toFixed(1)}% win · {it.picks.toLocaleString()} picks
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 export default function CharacterDetail({ initialCharacter }: { initialCharacter?: Character | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
@@ -40,6 +111,10 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
   const [relics, setRelics] = useState<Record<string, Relic>>({});
   const [allCards, setAllCards] = useState<Card[]>([]);
   const [poolRelics, setPoolRelics] = useState<Relic[]>([]);
+  const [potions, setPotions] = useState<Record<string, Potion>>({});
+  const [topCards, setTopCards] = useState<TopEntry[]>([]);
+  const [topRelics, setTopRelics] = useState<TopEntry[]>([]);
+  const [topPotions, setTopPotions] = useState<TopEntry[]>([]);
   const [loading, setLoading] = useState(!initialCharacter);
   const [notFound, setNotFound] = useState(false);
   const [expandedAncient, setExpandedAncient] = useState<string | null>(null);
@@ -71,6 +146,50 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
       })
       .finally(() => setLoading(false));
   }, [id, lang]);
+
+  // Run-metric driven "Top 5 picked" data + the potion catalog to
+  // resolve names/images. Kept separate from the catalog fetch above so
+  // a cold stats snapshot never blocks the rest of the page.
+  useEffect(() => {
+    if (!id) return;
+    const top = (type: string) =>
+      cachedFetch<TopEntry[]>(`${API}/api/runs/top/${type}/${id}?limit=5`).catch(
+        () => [] as TopEntry[],
+      );
+    Promise.all([
+      cachedFetch<Potion[]>(`${API}/api/potions?lang=${lang}`).catch(
+        () => [] as Potion[],
+      ),
+      top("cards"),
+      top("relics"),
+      top("potions"),
+    ]).then(([potionsData, tc, tr, tp]: [Potion[], TopEntry[], TopEntry[], TopEntry[]]) => {
+      const pm: Record<string, Potion> = {};
+      for (const p of potionsData ?? []) pm[p.id] = p;
+      setPotions(pm);
+      setTopCards(tc ?? []);
+      setTopRelics(tr ?? []);
+      setTopPotions(tp ?? []);
+    });
+  }, [id, lang]);
+
+  // Catalogs are keyed by their original id casing; run-metric entity
+  // ids come back upper-cased, so index everything by lowercase id.
+  const cardByLower = useMemo(() => {
+    const m: Record<string, Card> = {};
+    for (const k in cards) m[k.toLowerCase()] = cards[k];
+    return m;
+  }, [cards]);
+  const relicByLower = useMemo(() => {
+    const m: Record<string, Relic> = {};
+    for (const k in relics) m[k.toLowerCase()] = relics[k];
+    return m;
+  }, [relics]);
+  const potionByLower = useMemo(() => {
+    const m: Record<string, Potion> = {};
+    for (const k in potions) m[k.toLowerCase()] = potions[k];
+    return m;
+  }, [potions]);
 
   if (loading) {
     return (
@@ -278,6 +397,30 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
           })}
         </div>
       </div>
+
+      {/* Top picked from community runs, ranked by how often this
+          character's runs include them. */}
+      <TopPicks
+        title={`Top cards picked by ${char.name}`}
+        subtitle="Most-included cards across community-tracked runs, with win rate and Codex Score."
+        items={topCards}
+        lookup={(eid) => cardByLower[eid.toLowerCase()]}
+        hrefBase="/cards"
+      />
+      <TopPicks
+        title={`Top relics picked by ${char.name}`}
+        subtitle="Relics that show up most often in this character's runs."
+        items={topRelics}
+        lookup={(eid) => relicByLower[eid.toLowerCase()]}
+        hrefBase="/relics"
+      />
+      <TopPicks
+        title={`Top potions picked by ${char.name}`}
+        subtitle="Potions most commonly held in this character's runs."
+        items={topPotions}
+        lookup={(eid) => potionByLower[eid.toLowerCase()]}
+        hrefBase="/potions"
+      />
 
       {/* All Character Cards */}
       {allCards.length > 0 && (

--- a/frontend/app/components/DonationBanner.tsx
+++ b/frontend/app/components/DonationBanner.tsx
@@ -132,7 +132,7 @@ const ROTATING_BANNERS: RotatingBanner[] = [
   },
 ];
 
-function KofiBanner({ onDismiss }: { onDismiss: () => void }) {
+function PatreonBanner({ onDismiss }: { onDismiss: () => void }) {
   return (
     <div className="bg-emerald-900/40 border-b border-emerald-700/30">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex items-center justify-between gap-4">
@@ -147,12 +147,12 @@ function KofiBanner({ onDismiss }: { onDismiss: () => void }) {
             &ldquo;I haven&apos;t had a visitor in a millennia! If you wish to
             support Spire Codex, consider{" "}
             <a
-              href="https://ko-fi.com/yitsy"
+              href="https://www.patreon.com/cw/SpireCodex"
               target="_blank"
               rel="noopener noreferrer"
               className="font-medium text-emerald-100 underline hover:text-white transition-colors"
             >
-              donating on Ko-Fi
+              supporting us on Patreon
             </a>
             . Servants! Fetch tea for{" "}
             <Link
@@ -242,18 +242,18 @@ function TierListBanner({ onDismiss }: { onDismiss: () => void }) {
 
 export default function DonationBanner() {
   const [banner, setBanner] = useState<
-    "none" | "tierlist" | "kofi" | "rotating"
+    "none" | "tierlist" | "patreon" | "rotating"
   >("none");
   const [rotatingIndex, setRotatingIndex] = useState(0);
 
   useEffect(() => {
     const tierlistDismissed = localStorage.getItem("tierlist-announce-dismissed");
-    const kofiDismissed = localStorage.getItem("donation-banner-dismissed");
+    const patreonDismissed = localStorage.getItem("donation-banner-dismissed");
     const rotatingDismissed = sessionStorage.getItem("community-banner-dismissed");
     if (!tierlistDismissed) {
       setBanner("tierlist");
-    } else if (!kofiDismissed) {
-      setBanner("kofi");
+    } else if (!patreonDismissed) {
+      setBanner("patreon");
     } else if (!rotatingDismissed) {
       // Pick a random banner for this session
       setRotatingIndex(Math.floor(Math.random() * ROTATING_BANNERS.length));
@@ -263,10 +263,10 @@ export default function DonationBanner() {
 
   function dismissTierlist() {
     localStorage.setItem("tierlist-announce-dismissed", "1");
-    const kofiDismissed = localStorage.getItem("donation-banner-dismissed");
+    const patreonDismissed = localStorage.getItem("donation-banner-dismissed");
     const rotatingDismissed = sessionStorage.getItem("community-banner-dismissed");
-    if (!kofiDismissed) {
-      setBanner("kofi");
+    if (!patreonDismissed) {
+      setBanner("patreon");
     } else if (!rotatingDismissed) {
       setRotatingIndex(Math.floor(Math.random() * ROTATING_BANNERS.length));
       setBanner("rotating");
@@ -275,7 +275,7 @@ export default function DonationBanner() {
     }
   }
 
-  function dismissKofi() {
+  function dismissPatreon() {
     localStorage.setItem("donation-banner-dismissed", "1");
     const rotatingDismissed = sessionStorage.getItem("community-banner-dismissed");
     if (!rotatingDismissed) {
@@ -293,7 +293,7 @@ export default function DonationBanner() {
 
   if (banner === "tierlist")
     return <TierListBanner onDismiss={dismissTierlist} />;
-  if (banner === "kofi") return <KofiBanner onDismiss={dismissKofi} />;
+  if (banner === "patreon") return <PatreonBanner onDismiss={dismissPatreon} />;
   if (banner === "rotating")
     return <AncientBanner banner={ROTATING_BANNERS[rotatingIndex]} onDismiss={dismissRotating} />;
   return null;

--- a/frontend/app/components/DonationBanner.tsx
+++ b/frontend/app/components/DonationBanner.tsx
@@ -203,14 +203,56 @@ function AncientBanner({ banner, onDismiss }: { banner: RotatingBanner; onDismis
   );
 }
 
+function TierListBanner({ onDismiss }: { onDismiss: () => void }) {
+  return (
+    <div className="bg-sky-900/40 border-b border-sky-700/30">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <img
+            src={imageUrl("/static/images/misc/ancients/tanx.webp")}
+            alt="Tanx"
+            className="w-8 h-8 object-contain flex-shrink-0 hidden sm:block"
+            crossOrigin="anonymous"
+          />
+          <p className="text-sm text-sky-200">
+            <span className="mr-2 rounded bg-sky-500 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white">
+              New
+            </span>
+            The{" "}
+            <Link
+              href="/tier-list-maker"
+              className="font-medium text-sky-100 underline hover:text-white transition-colors"
+            >
+              Tier List Maker
+            </Link>{" "}
+            is here — rank cards, relics, monsters and more, then share your list.
+          </p>
+        </div>
+        <button
+          onClick={onDismiss}
+          className="text-sky-400 hover:text-sky-200 transition-colors flex-shrink-0 text-lg leading-none"
+          aria-label="Dismiss"
+        >
+          &times;
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function DonationBanner() {
-  const [banner, setBanner] = useState<"none" | "kofi" | "rotating">("none");
+  const [banner, setBanner] = useState<
+    "none" | "tierlist" | "kofi" | "rotating"
+  >("none");
   const [rotatingIndex, setRotatingIndex] = useState(0);
 
   useEffect(() => {
+    const tierlistDismissed = localStorage.getItem("tierlist-announce-dismissed");
     const kofiDismissed = localStorage.getItem("donation-banner-dismissed");
     const rotatingDismissed = sessionStorage.getItem("community-banner-dismissed");
-    if (!kofiDismissed) {
+    if (!tierlistDismissed) {
+      setBanner("tierlist");
+    } else if (!kofiDismissed) {
       setBanner("kofi");
     } else if (!rotatingDismissed) {
       // Pick a random banner for this session
@@ -218,6 +260,20 @@ export default function DonationBanner() {
       setBanner("rotating");
     }
   }, []);
+
+  function dismissTierlist() {
+    localStorage.setItem("tierlist-announce-dismissed", "1");
+    const kofiDismissed = localStorage.getItem("donation-banner-dismissed");
+    const rotatingDismissed = sessionStorage.getItem("community-banner-dismissed");
+    if (!kofiDismissed) {
+      setBanner("kofi");
+    } else if (!rotatingDismissed) {
+      setRotatingIndex(Math.floor(Math.random() * ROTATING_BANNERS.length));
+      setBanner("rotating");
+    } else {
+      setBanner("none");
+    }
+  }
 
   function dismissKofi() {
     localStorage.setItem("donation-banner-dismissed", "1");
@@ -235,6 +291,8 @@ export default function DonationBanner() {
     setBanner("none");
   }
 
+  if (banner === "tierlist")
+    return <TierListBanner onDismiss={dismissTierlist} />;
   if (banner === "kofi") return <KofiBanner onDismiss={dismissKofi} />;
   if (banner === "rotating")
     return <AncientBanner banner={ROTATING_BANNERS[rotatingIndex]} onDismiss={dismissRotating} />;

--- a/frontend/app/components/DonationBanner.tsx
+++ b/frontend/app/components/DonationBanner.tsx
@@ -205,32 +205,31 @@ function AncientBanner({ banner, onDismiss }: { banner: RotatingBanner; onDismis
 
 function TierListBanner({ onDismiss }: { onDismiss: () => void }) {
   return (
-    <div className="bg-sky-900/40 border-b border-sky-700/30">
+    <div className="bg-green-900/40 border-b border-green-700/30">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex items-center justify-between gap-4">
         <div className="flex items-center gap-3">
           <img
-            src={imageUrl("/static/images/misc/ancients/tanx.webp")}
-            alt="Tanx"
+            src="/spire-codex-white-final.png"
+            alt="Spire Codex"
             className="w-8 h-8 object-contain flex-shrink-0 hidden sm:block"
-            crossOrigin="anonymous"
           />
-          <p className="text-sm text-sky-200">
-            <span className="mr-2 rounded bg-sky-500 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white">
+          <p className="text-sm text-green-200">
+            <span className="mr-2 rounded bg-green-500 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white">
               New
             </span>
             The{" "}
             <Link
               href="/tier-list-maker"
-              className="font-medium text-sky-100 underline hover:text-white transition-colors"
+              className="font-medium text-green-100 underline hover:text-white transition-colors"
             >
               Tier List Maker
             </Link>{" "}
-            is here — rank cards, relics, monsters and more, then share your list.
+            is here. Rank cards, relics, monsters and more, then share your list.
           </p>
         </div>
         <button
           onClick={onDismiss}
-          className="text-sky-400 hover:text-sky-200 transition-colors flex-shrink-0 text-lg leading-none"
+          className="text-green-400 hover:text-green-200 transition-colors flex-shrink-0 text-lg leading-none"
           aria-label="Dismiss"
         >
           &times;

--- a/frontend/app/tier-list-maker/TierListBuilder.tsx
+++ b/frontend/app/tier-list-maker/TierListBuilder.tsx
@@ -250,7 +250,6 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
     setSaving(true);
     setError(null);
     try {
-      const isCreate = !savedIdRef.current;
       const payload = buildPayload();
       let result: TierList;
       if (savedIdRef.current) {
@@ -260,27 +259,17 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
       }
       savedIdRef.current = result.id;
       setSavedShareId(result.share_id);
-
-      if (isCreate) {
-        // First save: render the preview now (so the OG card is ready), then
-        // land on the public /shared/ URL — that's the one people should share.
-        if (result.id) {
-          const url = await captureDataUrl(1).catch(() => null);
-          if (url) await saveTierListImage(result.id, url).catch(() => {});
-        }
-        if (result.share_id) {
-          router.push(`/tier-list-maker/shared/${result.share_id}`);
-        } else if (result.id) {
-          router.replace(`/tier-list-maker/${result.id}`);
-        }
-      } else if (result.id) {
-        // Editing an existing list: refresh the preview in the background and
-        // stay in the editor.
+      // Refresh the share/OG preview in the background — best-effort, and it
+      // doesn't interrupt editing.
+      if (result.id) {
         const id = result.id;
         captureDataUrl(1)
           .then((url) => (url ? saveTierListImage(id, url) : undefined))
           .catch(() => {});
       }
+      // Stay in the editor; canonical edit URL so reloads and later saves work.
+      // The Share box surfaces the public /shared/ link to copy.
+      if (result.id) router.replace(`/tier-list-maker/${result.id}`);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not save");
     } finally {

--- a/frontend/app/tier-list-maker/TierListBuilder.tsx
+++ b/frontend/app/tier-list-maker/TierListBuilder.tsx
@@ -101,6 +101,7 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
+  const [copied, setCopied] = useState(false);
   const [savedShareId, setSavedShareId] = useState<string | undefined>(initial?.share_id);
   const savedIdRef = useRef<string | undefined>(initial?.id);
   // The branded region (tier rows + Spire Codex header) captured on export.
@@ -428,10 +429,16 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
             className="flex-1 min-w-[200px] rounded bg-neutral-800 px-2 py-1 text-sm text-neutral-200"
           />
           <button
-            onClick={() => navigator.clipboard?.writeText(shareUrl)}
-            className="rounded bg-neutral-700 px-3 py-1 text-sm text-white hover:bg-neutral-600"
+            onClick={() => {
+              navigator.clipboard?.writeText(shareUrl);
+              setCopied(true);
+              setTimeout(() => setCopied(false), 1500);
+            }}
+            className={`rounded px-3 py-1 text-sm text-white ${
+              copied ? "bg-green-600" : "bg-neutral-700 hover:bg-neutral-600"
+            }`}
           >
-            Copy
+            {copied ? "Copied!" : "Copy"}
           </button>
         </div>
       )}


### PR DESCRIPTION
Restores the in-editor behavior after saving a tier list.

#407 merged a change that redirected you to /tier-list-maker/shared/{share_id} on save, which kicked you out of the editor mid-edit. This keeps you in the editor at /{id} (the Share box already surfaces the public /shared/ link to copy, and the shared page shows an Edit link for the owner).

More tier-list follow-ups (copy toast, announcement banner) coming on this branch.