### PR TITLE
Fix double-v in the v0.107.0 beta changelog

### DIFF
--- a/data-beta/v0.107.0/changelogs/v0.107.0.json
+++ b/data-beta/v0.107.0/changelogs/v0.107.0.json
@@ -1,8 +1,8 @@
 {
   "app_id": 2868840,
-  "game_version": "v0.107.0",
+  "game_version": "0.107.0",
   "build_id": "",
-  "tag": "v0.107.0",
+  "tag": "0.107.0",
   "date": "2026-06-04",
   "title": "Beta v0.107.0",
   "from_ref": "data-beta/v0.106.1/eng",

--- a/tools/beta-watch/process.sh
+++ b/tools/beta-watch/process.sh
@@ -97,7 +97,7 @@ if [ -n "$PREV" ]; then
     "$DATA_OUT/eng" \
     --format json \
     --output-dir "$DATA_OUT/changelogs" \
-    --game-version "$VERSION" \
+    --game-version "${VERSION#v}" \
     --title "Beta $VERSION"
 fi
 


### PR DESCRIPTION
The changelog page renders `v{game_version}`, so `game_version`/`tag` shouldn't include their own leading `v` (other versions use `0.x.y`). The v0.107.0 ingest passed the v-prefixed version to `--game-version`, producing `vv0.107.0` on the beta changelog.

Fixes the already-committed v0.107.0 changelog (`game_version`/`tag` -> `0.107.0`, title unchanged) and strips the `v` in `process.sh` so future ingests don't repeat it.