### PR TITLE
Fix curse exclusion never firing in the metrics table

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -1035,7 +1035,7 @@ def get_entity_metrics_table(entity_type: str, cohort: str = "all") -> dict[str,
         }
 
     rows: list[dict[str, Any]] = []
-    excluded_cards = _excluded_card_ids() if entity_type == "card" else frozenset()
+    excluded_cards = _excluded_card_ids() if entity_type == "cards" else frozenset()
     for (etype, eid), agg in _cache.items():
         if etype != entity_type:
             continue


### PR DESCRIPTION
Follow-up to #415. The display filter guarded on `entity_type == "card"`, but the entity type is `"cards"` (plural) everywhere else in the function (and the route passes `"cards"`), so the guard was always false and `excluded_cards` stayed empty. Curses, status, event, and token cards kept showing in the table even after #415 deployed.

One-character fix: `"card"` → `"cards"`. The Elo-computation exclusion in `_walk_card_reward_screens` was already correct (it doesn't check entity_type), so only the display side was affected.

Verified with a synthetic curse (DOUBT): it's now dropped from the table while real cards stay. ruff clean.