### PR TITLE
Add Codex Elo tier view, upgrade Elo, and honest scoring copy

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -208,6 +208,60 @@ def _excluded_card_ids() -> frozenset[str]:
     return _excluded_card_ids_cache
 
 
+_starter_card_ids_cache: frozenset[str] | None = None
+
+
+def _starter_card_ids() -> frozenset[str]:
+    """Starter card ids (rarity "Basic": STRIKE_*, DEFEND_*, BASH, ...).
+
+    These carry real character colors so _excluded_card_ids misses them, but
+    they're never reward-pickable, sit in nearly every deck, and crater on
+    exposure-time bias. Dropped from the Codex Score tier surfaces so a
+    misleading "rating" isn't implied for them. Empty if data can't be read."""
+    global _starter_card_ids_cache
+    if _starter_card_ids_cache is None:
+        try:
+            from .data_service import load_cards
+
+            _starter_card_ids_cache = frozenset(
+                c["id"]
+                for c in load_cards()
+                if c.get("id")
+                and (c.get("rarity_key") or c.get("rarity") or "").lower() == "basic"
+            )
+        except Exception:
+            logger.warning(
+                "could not load card rarities for score exclusion", exc_info=True
+            )
+            _starter_card_ids_cache = frozenset()
+    return _starter_card_ids_cache
+
+
+_upgradeable_card_ids_cache: frozenset[str] | None = None
+
+
+def _upgradeable_card_ids() -> frozenset[str]:
+    """Card ids that have an upgrade (a non-null `upgrade` block in the game
+    data). Used to keep the Upgrade Elo head-to-heads honest: only cards that
+    can actually be smithed belong in the "eligible but not chosen" pool."""
+    global _upgradeable_card_ids_cache
+    if _upgradeable_card_ids_cache is None:
+        try:
+            from .data_service import load_cards
+
+            _upgradeable_card_ids_cache = frozenset(
+                c["id"]
+                for c in load_cards()
+                if c.get("id") and c.get("upgrade")
+            )
+        except Exception:
+            logger.warning(
+                "could not load card upgrades for upgrade-elo", exc_info=True
+            )
+            _upgradeable_card_ids_cache = frozenset()
+    return _upgradeable_card_ids_cache
+
+
 def _walk_run_entities(blob: dict) -> Iterable[tuple[str, str]]:
     """Emit every (entity_type, entity_id) seen in this run.
 
@@ -285,6 +339,71 @@ def _walk_card_reward_screens(blob: dict) -> Iterable[tuple[int, list[str], list
                         skipped.append(cid)
                 if picked or skipped:
                     yield act_index, picked, skipped
+
+
+# Rest-site action recorded when a player chooses to upgrade (Smith) a card.
+_SMITH_REST_CHOICE = "SMITH"
+
+
+def _walk_rest_upgrade_choices(blob: dict) -> Iterable[tuple[list[str], list[str]]]:
+    """Emit (upgraded_ids, eligible_skipped_ids) per rest-site Smith decision.
+
+    At a rest site a player may choose SMITH and upgrade a specific card. The
+    card they upgrade is a revealed preference: it "beats" the other cards
+    that were in the deck and eligible to upgrade at that point but weren't
+    chosen. Those head-to-heads feed a Bradley-Terry "Upgrade Elo" for the
+    upgraded variants, the upgrade-decision analogue of card-reward Codex Elo
+    (which only ever covers base cards, since rewards never offer upgrades).
+
+    The eligible pool is reconstructed from the final deck via
+    `floor_added_to_deck` (cards present by this floor), minus cards already
+    smithed earlier in the run and minus non-upgradeable cards. It's
+    approximate, it ignores mid-run removals and non-Smith upgrades, but it's
+    a sound preference signal at the card-type level. ids are namespace-
+    stripped ("CARD.WISP" -> "WISP") to match the cache keys.
+    """
+    upgradeable = _upgradeable_card_ids()
+    players = blob.get("players") or []
+    solo = len(players) == 1
+    for player in players:
+        pid = player.get("id")
+        # (floor_added, card_id) for this player's final deck, upgradeable only.
+        deck_cards: list[tuple[int, str]] = []
+        for c in player.get("deck") or []:
+            stripped = _strip_prefix(c.get("id", ""))
+            if not stripped or stripped[0] != "cards":
+                continue
+            cid = stripped[1]
+            if cid in upgradeable:
+                deck_cards.append((c.get("floor_added_to_deck") or 0, cid))
+        if not deck_cards:
+            continue
+        already: set[str] = set()
+        gfloor = 0
+        for act_floors in blob.get("map_point_history") or []:
+            for floor in act_floors or []:
+                gfloor += 1
+                for ps in floor.get("player_stats") or []:
+                    # Match this player's stats; in solo runs accept all rows
+                    # so a player_id/id scheme mismatch can't drop the signal.
+                    if not solo and ps.get("player_id") != pid:
+                        continue
+                    if _SMITH_REST_CHOICE not in (ps.get("rest_site_choices") or []):
+                        continue
+                    winners = []
+                    for raw in ps.get("upgraded_cards") or []:
+                        stripped = _strip_prefix(raw)
+                        if stripped and stripped[0] == "cards":
+                            winners.append(stripped[1])
+                    if not winners:
+                        continue
+                    eligible = {
+                        cid for fa, cid in deck_cards if fa <= gfloor
+                    }
+                    losers = sorted(eligible - set(winners) - already)
+                    already.update(winners)
+                    if winners and losers:
+                        yield winners, losers
 
 
 def _compute_codex_elo(
@@ -483,6 +602,9 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
     # card id; cards only (rewards never offer relics/potions this way).
     pick_counts: dict[str, dict[str, Any]] = {}
     pair_wins: dict[tuple[str, str], int] = {}
+    # Rest-site Smith decisions → Upgrade Elo for upgraded card variants.
+    # All-runs only; the metrics table doesn't split base/upg per cohort.
+    upgrade_pair_wins: dict[tuple[str, str], int] = {}
     # Parallel lightweight accumulators, one per non-"all" cohort.
     cohort_accs: dict[str, dict[str, Any]] = {
         k: _new_cohort_acc() for k in _COHORT_KEYS
@@ -630,6 +752,16 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
             if is_win:
                 sub["wins"] += 1
 
+        # Rest-site Smith decisions: the upgraded card beats the other
+        # eligible-but-unupgraded cards in the deck. Feeds the Upgrade Elo.
+        for winners, losers in _walk_rest_upgrade_choices(blob):
+            for winner in winners:
+                for loser in losers:
+                    if winner == loser:
+                        continue
+                    key = (winner, loser)
+                    upgrade_pair_wins[key] = upgrade_pair_wins.get(key, 0) + 1
+
         # Card-reward decisions: count offers/picks per act and record the
         # picked-beats-skipped head-to-heads for the Bradley-Terry fit, for
         # the all-runs pass AND every cohort this run belongs to.
@@ -668,6 +800,19 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
         agg["off_act"] = pc["off_act"]
         agg["pick_act"] = pc["pick_act"]
         agg["elo"] = elo.get(cid)
+
+    # Upgrade Elo: fit the same Bradley-Terry solver over the Smith
+    # head-to-heads and hang it on each card's "upg" sub-aggregate, so the
+    # metrics table's "+" row carries its own preference rating instead of
+    # echoing the base card's reward Elo. Only cards that actually appear
+    # upgraded in a deck have an "upg" block to attach it to.
+    upgrade_elo = _compute_codex_elo(upgrade_pair_wins)
+    for (etype, cid), agg in new_cache.items():
+        if etype != "cards":
+            continue
+        upg = agg.get("upg")
+        if upg is not None:
+            upg["elo"] = upgrade_elo.get(cid)
 
     # Per-type baselines: pick-weighted average win rate across all
     # entities of each type. Computed once per rebuild so scoring reads
@@ -960,22 +1105,39 @@ def _compute_score(wins: int, picks: int, baseline: float) -> int | None:
 
 
 def get_all_entity_scores(entity_type: str) -> dict[str, dict[str, Any]]:
-    """All entities of one type, keyed by ID, with score + counts.
+    """All entities of one type, keyed by ID, with score + counts + elo.
 
     Drives list-page tier sorting and the (planned) tooltip-widget
     score badge — fetched once by the client and cached locally instead
     of N round-trips to /stats/{type}/{id}.
+
+    `elo` is the Codex Elo (revealed-preference rating) where it exists, else
+    null. It only exists for reward-offered cards, so starters and upgraded
+    variants are null — that's the basis for the dual Score/Elo tier view.
     """
     _maybe_rebuild()
     baseline = _type_baseline(entity_type)
+    # Cards: drop non-reward colors (curse/status/event/quest/token) AND
+    # starters (Basic rarity). Neither is reward-pickable, so a tier "rating"
+    # for them misleads. This is the single source feeding the /tier-list hub,
+    # /tier-list/cards and the /cards "Highest-rated" rail, mirroring (and
+    # extending, with starters) get_entity_metrics_table's exclusion.
+    excluded = (
+        _excluded_card_ids() | _starter_card_ids()
+        if entity_type == "cards"
+        else frozenset()
+    )
     out: dict[str, dict[str, Any]] = {}
     for (etype, eid), agg in _cache.items():
         if etype != entity_type:
+            continue
+        if eid in excluded:
             continue
         picks = agg["picks"]
         wins = agg["wins"]
         out[eid] = {
             "score": _compute_score(wins, picks, baseline),
+            "elo": agg.get("elo"),
             "picks": picks,
             "wins": wins,
             "win_rate": round(wins / picks * 100, 1) if picks else 0.0,
@@ -1061,10 +1223,10 @@ def get_entity_metrics_table(entity_type: str, cohort: str = "all") -> dict[str,
                 )
             )
             continue
-        # All-runs view: split cards into base + "+" rows. Reward picks
-        # (Elo/Pick%/per-act) only exist for the base card, since reward
-        # screens never offer the upgraded version; the "+" row carries
-        # deck win rate / Codex Score only.
+        # All-runs view: split cards into base + "+" rows. Reward Pick%/per-act
+        # only exist for the base card (reward screens never offer the upgraded
+        # version). Elo differs by row: the base row carries the card-reward
+        # Codex Elo, the "+" row carries the Upgrade Elo from Smith decisions.
         if entity_type == "cards" and ("base" in agg or "upg" in agg):
             base = agg.get("base") or {"picks": 0, "wins": 0}
             rows.append(
@@ -1087,7 +1249,7 @@ def get_entity_metrics_table(entity_type: str, cohort: str = "all") -> dict[str,
                         eid,
                         upg["picks"],
                         upg["wins"],
-                        elo=None,
+                        elo=upg.get("elo"),
                         offered=0,
                         picked=0,
                         off_act=z3,

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -250,9 +250,7 @@ def _upgradeable_card_ids() -> frozenset[str]:
             from .data_service import load_cards
 
             _upgradeable_card_ids_cache = frozenset(
-                c["id"]
-                for c in load_cards()
-                if c.get("id") and c.get("upgrade")
+                c["id"] for c in load_cards() if c.get("id") and c.get("upgrade")
             )
         except Exception:
             logger.warning(
@@ -397,9 +395,7 @@ def _walk_rest_upgrade_choices(blob: dict) -> Iterable[tuple[list[str], list[str
                             winners.append(stripped[1])
                     if not winners:
                         continue
-                    eligible = {
-                        cid for fa, cid in deck_cards if fa <= gfloor
-                    }
+                    eligible = {cid for fa, cid in deck_cards if fa <= gfloor}
                     losers = sorted(eligible - set(winners) - already)
                     already.update(winners)
                     if winners and losers:

--- a/frontend/app/components/ScoreBadge.tsx
+++ b/frontend/app/components/ScoreBadge.tsx
@@ -26,8 +26,8 @@ function scoreToTier(score: number): Tier {
   if (score >= 78) return { letter: "A", label: "Strong",   className: "bg-emerald-950/40 border-emerald-700/60 text-emerald-300" };
   if (score >= 65) return { letter: "B", label: "Solid",    className: "bg-sky-950/40 border-sky-700/60 text-sky-300" };
   if (score >= 50) return { letter: "C", label: "Average",  className: "bg-zinc-800/60 border-zinc-600/60 text-zinc-300" };
-  if (score >= 35) return { letter: "D", label: "Weak",     className: "bg-orange-950/40 border-orange-700/60 text-orange-300" };
-  return { letter: "F", label: "Avoid", className: "bg-rose-950/40 border-rose-800/60 text-rose-300" };
+  if (score >= 35) return { letter: "D", label: "Below average", className: "bg-orange-950/40 border-orange-700/60 text-orange-300" };
+  return { letter: "F", label: "Underperforming", className: "bg-rose-950/40 border-rose-800/60 text-rose-300" };
 }
 
 export default function ScoreBadge({ score, size = "md", showNumber = false }: ScoreBadgeProps) {

--- a/frontend/app/components/TierList.tsx
+++ b/frontend/app/components/TierList.tsx
@@ -15,6 +15,14 @@ export interface TierEntity {
   image_url: string | null;
   /** Codex Score 0-100, or null if entity has no submitted-run data. */
   score: number | null;
+  /** Precomputed tier letter. When set, it overrides score-based banding.
+   *  Used by the Codex Elo view, which bands by percentile within the rated
+   *  pool rather than the 0-100 score scale (raw Elo has no calibrated
+   *  bands). null/undefined falls back to banding `score`. */
+  tier?: "S" | "A" | "B" | "C" | "D" | "F" | null;
+  /** Number shown on each tile and used for in-tier sorting. Defaults to
+   *  `score` when omitted (so the Elo view shows the Elo, not the score). */
+  value?: number | null;
 }
 
 interface Tier {
@@ -32,8 +40,8 @@ const TIERS: Tier[] = [
   { letter: "A", min: 78, className: "bg-emerald-950/40 border-emerald-700/60 text-emerald-300", label: "Strong" },
   { letter: "B", min: 65, className: "bg-sky-950/40 border-sky-700/60 text-sky-300",           label: "Solid" },
   { letter: "C", min: 50, className: "bg-zinc-800/60 border-zinc-600/60 text-zinc-300",        label: "Average" },
-  { letter: "D", min: 35, className: "bg-orange-950/40 border-orange-700/60 text-orange-300",  label: "Weak" },
-  { letter: "F", min: 0,  className: "bg-rose-950/40 border-rose-800/60 text-rose-300",        label: "Avoid" },
+  { letter: "D", min: 35, className: "bg-orange-950/40 border-orange-700/60 text-orange-300",  label: "Below average" },
+  { letter: "F", min: 0,  className: "bg-rose-950/40 border-rose-800/60 text-rose-300",        label: "Underperforming" },
 ];
 
 function tierForScore(score: number): Tier {
@@ -51,6 +59,8 @@ interface TierListProps {
   entities: TierEntity[];
   /** Show scoreless entities in their own row at the bottom. */
   showUnrated?: boolean;
+  /** Label for the per-tile number in the hover title (e.g. "Score", "Elo"). */
+  valueLabel?: string;
 }
 
 /**
@@ -60,29 +70,34 @@ interface TierListProps {
  * within the tier. Designed for the /tier-list/* pages but reusable
  * anywhere we want a tier-grouped display.
  */
-export default function TierList({ route, entities, showUnrated = true }: TierListProps) {
-  // Group entities by tier, scoreless go to the bottom in a separate
+export default function TierList({ route, entities, showUnrated = true, valueLabel = "Score" }: TierListProps) {
+  // Group entities by tier, the unrated go to the bottom in a separate
   // "Unrated" row so they're still discoverable but don't pollute the
-  // tier signal. Within each tier, sort by score desc, then by name
-  // for deterministic ordering at score ties.
+  // tier signal. Within each tier, sort by value desc, then by name
+  // for deterministic ordering at ties. The value is the precomputed
+  // `value` when present (the Elo view passes Elo here), else the score.
   const grouped = new Map<string, TierEntity[]>();
   const unrated: TierEntity[] = [];
+  const tileValue = (e: TierEntity) => e.value ?? e.score;
 
   for (const ent of entities) {
-    if (ent.score == null) {
+    // Prefer a precomputed tier (Elo percentile banding); fall back to
+    // banding the 0-100 score. No tier and no score → Unrated.
+    const letter =
+      ent.tier ?? (ent.score != null ? tierForScore(ent.score).letter : null);
+    if (letter == null) {
       unrated.push(ent);
       continue;
     }
-    const tier = tierForScore(ent.score);
-    const bucket = grouped.get(tier.letter) ?? [];
+    const bucket = grouped.get(letter) ?? [];
     bucket.push(ent);
-    grouped.set(tier.letter, bucket);
+    grouped.set(letter, bucket);
   }
 
   for (const bucket of grouped.values()) {
     bucket.sort((a, b) => {
-      const sa = a.score ?? 0;
-      const sb = b.score ?? 0;
+      const sa = tileValue(a) ?? 0;
+      const sb = tileValue(b) ?? 0;
       if (sb !== sa) return sb - sa;
       return a.name.localeCompare(b.name);
     });
@@ -137,7 +152,7 @@ export default function TierList({ route, entities, showUnrated = true }: TierLi
                 <Link
                   key={ent.id}
                   href={`/cards/${ent.id.toLowerCase()}`}
-                  title={ent.score != null ? `${ent.name} (Score ${ent.score})` : ent.name}
+                  title={tileValue(ent) != null ? `${ent.name} (${valueLabel} ${tileValue(ent)})` : ent.name}
                   className="group relative flex flex-col items-center gap-0.5 w-[130px] sm:w-[150px] hover:scale-[1.04] transition-transform"
                 >
                   <img
@@ -147,9 +162,9 @@ export default function TierList({ route, entities, showUnrated = true }: TierLi
                     loading="lazy"
                     crossOrigin="anonymous"
                   />
-                  {ent.score != null && (
+                  {tileValue(ent) != null && (
                     <span className="text-[9px] font-mono tabular-nums text-[var(--text-muted)]">
-                      {ent.score}
+                      {tileValue(ent)}
                     </span>
                   )}
                 </Link>
@@ -157,7 +172,7 @@ export default function TierList({ route, entities, showUnrated = true }: TierLi
                 <Link
                   key={ent.id}
                   href={`/${route}/${ent.id.toLowerCase()}`}
-                  title={ent.score != null ? `${ent.name} (Score ${ent.score})` : ent.name}
+                  title={tileValue(ent) != null ? `${ent.name} (${valueLabel} ${tileValue(ent)})` : ent.name}
                   className="group relative flex flex-col items-center gap-1 w-16 sm:w-20 p-1.5 rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] hover:border-[var(--accent-gold)]/50 transition-colors"
                 >
                   {ent.image_url ? (
@@ -176,9 +191,9 @@ export default function TierList({ route, entities, showUnrated = true }: TierLi
                   <span className="text-[10px] sm:text-[11px] text-[var(--text-secondary)] text-center leading-tight line-clamp-2 min-h-[1.5rem]">
                     {ent.name}
                   </span>
-                  {ent.score != null && (
+                  {tileValue(ent) != null && (
                     <span className="text-[9px] font-mono tabular-nums text-[var(--text-muted)]">
-                      {ent.score}
+                      {tileValue(ent)}
                     </span>
                   )}
                 </Link>

--- a/frontend/app/leaderboards/metrics/MetricsClient.tsx
+++ b/frontend/app/leaderboards/metrics/MetricsClient.tsx
@@ -83,7 +83,7 @@ interface Column {
 const COLUMNS: Column[] = [
   { key: "name", label: "Card", title: "Card name", align: "left", descFirst: false },
   { key: "score", label: "Score", title: "Codex Score (0-100, Bayesian win rate)", align: "right", descFirst: true },
-  { key: "elo", label: "Elo", title: "Codex Elo (revealed preference from card-reward picks)", align: "right", descFirst: true },
+  { key: "elo", label: "Elo", title: "Codex Elo (revealed preference). Base rows: card-reward picks. + rows: rest-site Smith upgrade choices.", align: "right", descFirst: true },
   { key: "winRate", label: "Win%", title: "Win rate of runs containing this card", align: "right", descFirst: true },
   { key: "pickRate", label: "Pick%", title: "How often this card is taken when offered", align: "right", descFirst: true },
   { key: "offered", label: "Seen", title: "Times offered in a card reward", align: "right", descFirst: true },

--- a/frontend/app/leaderboards/scoring/page.tsx
+++ b/frontend/app/leaderboards/scoring/page.tsx
@@ -42,17 +42,17 @@ const EXAMPLES: ExampleRow[] = [
   { label: "Mid-N solid", picks: 500, wins: 280, score: 68 },
   { label: "Small-N perfect", picks: 5, wins: 5, score: 65 },
   { label: "Average performer", picks: 50, wins: 25, score: 50 },
-  { label: "Small-N total loss", picks: 5, wins: 0, score: 35 },
-  { label: "High-N weak", picks: 200, wins: 60, score: 0 },
+  { label: "Small sample, no wins yet", picks: 5, wins: 0, score: 35 },
+  { label: "High sample, underperforming", picks: 200, wins: 60, score: 0 },
 ];
 
 const TIERS = [
-  { range: "90 – 100", letter: "S", label: "Top tier", note: "Genuinely elite. Out-of-distribution win rate sustained over hundreds of picks." },
-  { range: "78 – 89",  letter: "A", label: "Strong",   note: "Reliable engine pieces. Picking these is rarely a mistake." },
-  { range: "65 – 77",  letter: "B", label: "Solid",    note: "Above-average. Pick when nothing better is offered." },
-  { range: "50 – 64",  letter: "C", label: "Average",  note: "The middle of the curve. Most cards live here." },
-  { range: "35 – 49",  letter: "D", label: "Weak",     note: "Niche or filler. Skippable in most builds." },
-  { range: "0 – 34",   letter: "F", label: "Avoid",    note: "Actively pulls runs toward losses. Take only if forced." },
+  { range: "90 – 100", letter: "S", label: "Top tier",      note: "Top of the win-rate signal. An out-of-distribution win rate sustained over hundreds of picks." },
+  { range: "78 – 89",  letter: "A", label: "Strong",        note: "Wins above the baseline reliably across a large sample." },
+  { range: "65 – 77",  letter: "B", label: "Solid",         note: "Above-average win rate. A safe pick when nothing better is offered." },
+  { range: "50 – 64",  letter: "C", label: "Average",       note: "The middle of the curve. Most entities live here." },
+  { range: "35 – 49",  letter: "D", label: "Below average", note: "Below the baseline. Often niche or situational, sometimes just high-exposure (see the biases below)." },
+  { range: "0 – 34",   letter: "F", label: "Underperforming", note: "Bottom of the win-rate signal. Frequently a staple dragged down by being in nearly every run, not necessarily a bad card." },
 ];
 
 export default function ScoringPage() {
@@ -82,7 +82,7 @@ export default function ScoringPage() {
     {
       question: "What do the S, A, B, C, D, F tier grades mean?",
       answer:
-        "S (90–100) is genuinely elite. A (78–89) is reliable and strong. B (65–77) is above average. C (50–64) is average, most entities live here. D (35–49) is niche or filler. F (0–34) actively pulls runs toward losses.",
+        "S (90–100) is the top of the win-rate signal. A (78–89) wins above baseline reliably. B (65–77) is above average. C (50–64) is average, most entities live here. D (35–49) is below average, often niche or high-exposure. F (0–34) is the bottom of the signal, which can mean a genuinely weak entity or just a staple seen in nearly every run. The grade is a data signal, not a verdict.",
     },
     {
       question: "How often does the Codex Score update?",
@@ -118,11 +118,12 @@ export default function ScoringPage() {
         </div>
         <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
           Every card, relic, and potion in <em>Slay the Spire 2</em> gets a single number that
-          summarizes <strong>how strongly it pulls toward winning runs</strong>, based purely
+          summarizes <strong>how its presence correlates with winning runs</strong>, based purely
           on community-submitted run data, not opinion. <strong>50</strong> is neutral
-          (the average run wins roughly half the time at A0), <strong>100</strong> is best-in-class,
-          <strong>0</strong> is worst. The same number drives the &ldquo;Top tier&rdquo; sort on
-          every list page and the badge on every detail page.
+          (the average run wins roughly half the time at A0), <strong>100</strong> is the top of
+          the signal, <strong>0</strong> the bottom. It is a naive correlation with known biases
+          (spelled out below), not a verdict on whether a card is good. The same number drives the
+          default sort on every list page and the badge on every detail page.
         </p>
       </section>
 
@@ -227,7 +228,7 @@ score      = clamp(raw, 0, 100)            # rounded to integer`}
       </section>
 
       {/* Codex Elo */}
-      <section className="mb-10">
+      <section id="codex-elo" className="mb-10 scroll-mt-20">
         <h2 className="text-xl font-semibold text-[var(--accent-gold)] mb-4">
           Codex Elo, the other half
         </h2>
@@ -252,13 +253,22 @@ score      = clamp(raw, 0, 100)            # rounded to integer`}
           </li>
           <li>
             <strong>Cards only.</strong> Reward screens offer cards, not relics or potions, so
-            Elo exists for cards. Starter cards and cards never offered in a reward have no Elo.
+            base-card Elo exists only for cards.
+          </li>
+          <li>
+            <strong>Upgraded cards get their own Elo.</strong> Reward screens never offer an
+            upgraded card, so the base Elo can&apos;t speak for the &ldquo;+&rdquo; version.
+            Instead the upgraded variant is rated from a different revealed preference: the
+            rest-site Smith decision. When you upgrade a card, it &ldquo;beats&rdquo; the other
+            cards in your deck you could have upgraded but didn&apos;t. Fit the same Bradley-Terry
+            model over those choices and the &ldquo;+&rdquo; row gets a genuine Upgrade Elo, not a
+            copy of the base number. Starters can earn one this way too (you can Smith a Strike).
           </li>
         </ul>
         <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
           Use them together: Score says &ldquo;this wins games,&rdquo; Elo says &ldquo;players
           want this when they see it.&rdquo; Cards high on both are unambiguous; a gap between
-          them is usually a build-around or a trap. Both, side by side, live on the{" "}
+          them is usually a build-around or a situational pick. Both, side by side, live on the{" "}
           <Link href="/leaderboards/metrics" className="text-[var(--accent-gold)] hover:underline">
             Card Metrics
           </Link>{" "}
@@ -267,9 +277,29 @@ score      = clamp(raw, 0, 100)            # rounded to integer`}
       </section>
 
       {/* Limitations / disclaimers */}
-      <section className="mb-10">
+      <section id="limitations" className="mb-10 scroll-mt-20">
         <h2 className="text-xl font-semibold text-[var(--accent-gold)] mb-4">What the score is not</h2>
+        <p className="text-sm text-[var(--text-secondary)] leading-relaxed mb-4">
+          Codex Score is a naive win-rate correlation, and a correlation carries baggage. The two
+          biggest confounds below are why some obviously good cards can land low and some niche
+          ones can land high. Read a grade as a signal with caveats, not a ruling. Where a card
+          has been offered in reward screens, <Link href="#codex-elo" className="text-[var(--accent-gold)] hover:underline">Codex Elo</Link>{" "}
+          is the less-confounded counterweight, it is skill-agnostic and not exposure-weighted.
+        </p>
         <ul className="text-sm text-[var(--text-secondary)] space-y-3 list-disc pl-5">
+          <li>
+            <strong>Exposure-time / pick-frequency bias.</strong> A card that sits in the deck
+            longer, or gets picked in nearly every run (starters, commons, high-pick staples),
+            absorbs more of every loss it was present for. So heavily-used cards score low even
+            when they&apos;re fine, which is why some staples land in the bottom tiers. An F often
+            means &ldquo;high exposure,&rdquo; not &ldquo;bad card.&rdquo;
+          </li>
+          <li>
+            <strong>Survivorship bias.</strong> Late-game rares and uncommons only get offered in
+            runs that already got deep, runs that were, on average, already going well. Their win
+            rate is inflated by the run being healthy <em>before</em> the pick, so they can look
+            stronger than they are.
+          </li>
           <li>
             <strong>Not a personal recommendation.</strong> Score answers &ldquo;what wins for the
             average submitter?&rdquo; It can&apos;t see your deck, your character, your ascension,
@@ -298,6 +328,13 @@ score      = clamp(raw, 0, 100)            # rounded to integer`}
             submit right now will affect the next score rebuild, not the one in your browser.
           </li>
         </ul>
+        <p className="text-sm text-[var(--text-secondary)] leading-relaxed mt-4">
+          To cut the obvious confounds yourself, the{" "}
+          <Link href="/leaderboards/metrics" className="text-[var(--accent-gold)] hover:underline">
+            Card Metrics
+          </Link>{" "}
+          table puts Codex Elo next to Score and slices both by per-character and per-run cohorts.
+        </p>
       </section>
 
       {/* Further reading / cross-links */}

--- a/frontend/app/tier-list/cards/page.tsx
+++ b/frontend/app/tier-list/cards/page.tsx
@@ -15,11 +15,10 @@ interface ApiCard {
   id: string;
   name: string;
   image_url: string | null;
-  color: string;
 }
 
 interface ScoresMap {
-  [id: string]: { score: number | null; picks: number; wins: number; win_rate: number };
+  [id: string]: { score: number | null; elo: number | null; picks: number; wins: number; win_rate: number };
 }
 
 const COLOR_FILTERS = [
@@ -32,8 +31,56 @@ const COLOR_FILTERS = [
   { value: "colorless",   label: "Colorless" },
 ];
 
+type SortMode = "score" | "elo";
+
+// Codex Elo is tightly bunched (most cards cluster near the 1500 anchor), so
+// fixed Elo thresholds would dump almost everything into one band. Instead the
+// Elo view bands by percentile rank within the rated pool: the top slice is S,
+// and so on. Cumulative upper bounds, walked in order.
+const ELO_TIER_BANDS: { letter: "S" | "A" | "B" | "C" | "D" | "F"; maxPct: number }[] = [
+  { letter: "S", maxPct: 0.10 },
+  { letter: "A", maxPct: 0.25 },
+  { letter: "B", maxPct: 0.50 },
+  { letter: "C", maxPct: 0.75 },
+  { letter: "D", maxPct: 0.90 },
+  { letter: "F", maxPct: 1.0 },
+];
+
+interface BaseCard {
+  id: string;
+  name: string;
+  image_url: string | null;
+  score: number | null;
+  elo: number | null;
+}
+
+// Band cards by Codex Elo percentile. Only cards with an Elo are shown: Elo
+// exists solely for reward-offered base cards, so upgraded variants and
+// never-offered cards have none and are dropped from this view entirely (Elo
+// can't be fabricated for them). Rated cards are ranked desc and sliced into
+// S-F by position.
+function eloTiered(cards: BaseCard[]): TierEntity[] {
+  const rated = cards
+    .filter((c) => c.elo != null)
+    .sort((a, b) => (b.elo as number) - (a.elo as number));
+  const n = rated.length;
+  const tierAt = (idx: number): "S" | "A" | "B" | "C" | "D" | "F" => {
+    const pct = n ? idx / n : 1;
+    for (const b of ELO_TIER_BANDS) if (pct < b.maxPct) return b.letter;
+    return "F";
+  };
+  return rated.map((c, idx) => ({
+    id: c.id,
+    name: c.name,
+    image_url: c.image_url,
+    score: null,
+    tier: tierAt(idx),
+    value: c.elo,
+  }));
+}
+
 interface PageProps {
-  searchParams: Promise<{ color?: string }>;
+  searchParams: Promise<{ color?: string; sort?: string }>;
 }
 
 export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
@@ -87,28 +134,58 @@ async function fetchData(color?: string): Promise<{ cards: ApiCard[]; scores: Sc
 export default async function CardsTierListPage({ searchParams }: PageProps) {
   const sp = await searchParams;
   const color = sp.color?.toLowerCase();
+  const sort: SortMode = sp.sort === "elo" ? "elo" : "score";
   const { cards, scores } = await fetchData(color);
 
-  const entities: TierEntity[] = cards
+  const base: BaseCard[] = cards
     // mad_science is a multi-type event card with no full render; hide it.
     .filter((c) => c.id.toLowerCase() !== "mad_science")
-    .map((c) => ({
-      id: c.id,
-      name: c.name,
-      image_url: c.image_url,
-      score: scores[c.id.toUpperCase()]?.score ?? null,
-    }));
+    // The scores endpoint is the source of truth for which cards are
+    // rankable: it already drops non-reward colors (curse/status/event/quest/
+    // token) and starters (Basic rarity). Cards absent from it (excluded, or
+    // never seen in a submitted run) don't belong on the tier list.
+    .filter((c) => scores[c.id.toUpperCase()] !== undefined)
+    .map((c) => {
+      const sc = scores[c.id.toUpperCase()];
+      return {
+        id: c.id,
+        name: c.name,
+        image_url: c.image_url,
+        score: sc?.score ?? null,
+        elo: sc?.elo ?? null,
+      };
+    });
+
+  // Codex Score view bands the 0-100 score (TierList's default); Codex Elo
+  // view bands by Elo percentile (precomputed tier + Elo as the tile value).
+  const entities: TierEntity[] =
+    sort === "elo"
+      ? eloTiered(base)
+      : base.map(({ id, name, image_url, score }) => ({ id, name, image_url, score }));
 
   const charLabel = COLOR_FILTERS.find((c) => c.value === color)?.label;
   const heading = charLabel && color ? `${charLabel} Card Tier List` : "Card Tier List";
+  // Canonical path is the Codex Score view; the ?sort=elo variant shares it
+  // (set in generateMetadata) so the two don't read as duplicate content.
   const path = `/tier-list/cards${color ? `?color=${color}` : ""}`;
+  // Preserve color when switching sort, and vice versa.
+  const sortHref = (s: SortMode) => {
+    const params = new URLSearchParams();
+    if (color) params.set("color", color);
+    if (s === "elo") params.set("sort", "elo");
+    const qs = params.toString();
+    return `/tier-list/cards${qs ? `?${qs}` : ""}`;
+  };
+  const metric = sort === "elo" ? "Codex Elo" : "Codex Score";
 
-  // Top-30 by score for the ItemList JSON-LD, gives Google a structured
-  // ranked list it can render as carousel-style rich results. Capped at
-  // 30 because longer ItemLists inflate the JSON without much SEO gain.
-  const rankedItems = [...entities]
-    .filter((e) => e.score != null)
-    .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+  // Top-30 for the ItemList JSON-LD, gives Google a structured ranked list
+  // it can render as carousel-style rich results. Capped at 30 because
+  // longer ItemLists inflate the JSON without much SEO gain.
+  const rankedItems = [...base]
+    .filter((e) => (sort === "elo" ? e.elo != null : e.score != null))
+    .sort((a, b) =>
+      sort === "elo" ? (b.elo ?? 0) - (a.elo ?? 0) : (b.score ?? 0) - (a.score ?? 0),
+    )
     .slice(0, 30)
     .map((e) => ({
       name: e.name,
@@ -123,7 +200,7 @@ export default async function CardsTierListPage({ searchParams }: PageProps) {
     ]),
     buildCollectionPageJsonLd({
       name: heading,
-      description: `Slay the Spire 2 (sts2) ${heading.toLowerCase()} ranked by Codex Score from community-submitted run win rates.`,
+      description: `Slay the Spire 2 (sts2) ${heading.toLowerCase()} ranked by ${metric} from community-submitted run data.`,
       path,
       items: rankedItems,
     }),
@@ -139,20 +216,62 @@ export default async function CardsTierListPage({ searchParams }: PageProps) {
         </h1>
         <span className="text-sm text-[var(--text-muted)]">{entities.length.toLocaleString()} cards</span>
       </div>
-      <p className="text-sm text-[var(--text-muted)] mb-6">
-        Ranked by <Link href="/leaderboards/scoring" className="text-[var(--accent-gold)] hover:underline">Codex Score</Link>,
-        community-submitted run win rates, Bayesian-shrunk so low-pick cards stay near neutral.
-        Click any card for full stats.
+      <p className="text-sm text-[var(--text-muted)] mb-4">
+        {sort === "elo" ? (
+          <>
+            Ranked by <Link href="/leaderboards/scoring" className="text-[var(--accent-gold)] hover:underline">Codex Elo</Link>,
+            a revealed-preference rating from which cards players take over the ones they skip.
+            Banded by percentile, so S is the most-drafted slice. Skill-agnostic and not
+            exposure-weighted, so it dodges the biases the win-rate Score carries.
+          </>
+        ) : (
+          <>
+            Ranked by <Link href="/leaderboards/scoring" className="text-[var(--accent-gold)] hover:underline">Codex Score</Link>,
+            community-submitted run win rates, Bayesian-shrunk so low-pick cards stay near neutral.
+            It&apos;s a naive win-rate signal with{" "}
+            <Link href="/leaderboards/scoring#limitations" className="text-[var(--accent-gold)] hover:underline">known biases</Link>{" "}
+            (high-exposure staples sink, late rares float), not a verdict, switch to Codex Elo for
+            the less-confounded view. Click any card for full stats.
+          </>
+        )}
       </p>
+
+      {/* Score vs Elo view toggle. Two distinct lenses, not a blend: Score is
+          a win-rate outcome signal, Elo is a draft-preference signal, and the
+          two are near-uncorrelated, so we never collapse them to one number. */}
+      <div className="flex flex-wrap items-center gap-1.5 mb-5">
+        <span className="text-xs text-[var(--text-muted)] mr-1">Rank by</span>
+        {([
+          { value: "score", label: "Codex Score" },
+          { value: "elo", label: "Codex Elo" },
+        ] as const).map((opt) => {
+          const isActive = sort === opt.value;
+          return (
+            <Link
+              key={opt.value}
+              href={sortHref(opt.value)}
+              className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
+                isActive
+                  ? "bg-[var(--accent-gold)]/10 border-[var(--accent-gold)]/40 text-[var(--accent-gold)]"
+                  : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
+              }`}
+            >
+              {opt.label}
+            </Link>
+          );
+        })}
+      </div>
 
       {/* Character filter, anchor links so each filtered view is its
           own indexable URL (good for "ironclad tier list" SEO). */}
       <div className="flex flex-wrap gap-1.5 mb-6">
         {COLOR_FILTERS.map((opt) => {
           const isActive = (color ?? "") === opt.value;
-          const href = opt.value
-            ? `/tier-list/cards?color=${opt.value}`
-            : "/tier-list/cards";
+          const params = new URLSearchParams();
+          if (opt.value) params.set("color", opt.value);
+          if (sort === "elo") params.set("sort", "elo");
+          const qs = params.toString();
+          const href = `/tier-list/cards${qs ? `?${qs}` : ""}`;
           return (
             <Link
               key={opt.value || "all"}
@@ -169,7 +288,7 @@ export default async function CardsTierListPage({ searchParams }: PageProps) {
         })}
       </div>
 
-      <TierList route="cards" entities={entities} />
+      <TierList route="cards" entities={entities} valueLabel={sort === "elo" ? "Elo" : "Score"} />
     </div>
   );
 }

--- a/frontend/app/tier-list/page.tsx
+++ b/frontend/app/tier-list/page.tsx
@@ -358,18 +358,24 @@ export default async function TierListIndex() {
           500-pick reliable one. Scores map to letter grades:
         </p>
         <div className="text-xs text-[var(--text-muted)] space-y-1">
-          <div><strong className="text-amber-300">S (90+)</strong> · genuinely elite</div>
-          <div><strong className="text-emerald-300">A (78–89)</strong> · reliable engine pieces</div>
+          <div><strong className="text-amber-300">S (90+)</strong> · top of the win-rate signal</div>
+          <div><strong className="text-emerald-300">A (78–89)</strong> · wins above baseline reliably</div>
           <div><strong className="text-sky-300">B (65–77)</strong> · above-average</div>
           <div><strong className="text-zinc-300">C (50–64)</strong> · average</div>
-          <div><strong className="text-orange-300">D (35–49)</strong> · niche or filler</div>
-          <div><strong className="text-rose-300">F (0–34)</strong> · actively pulls toward losses</div>
+          <div><strong className="text-orange-300">D (35–49)</strong> · below average, often niche</div>
+          <div><strong className="text-rose-300">F (0–34)</strong> · bottom of the signal, often a high-exposure staple</div>
         </div>
+        <p className="text-xs text-[var(--text-muted)] leading-relaxed mt-3">
+          This is a naive win-rate signal, not a ruling. It carries known biases, heavily-used
+          staples sink even when they&apos;re fine, and late-game rares float because they only
+          show up in runs already going well. Read a low grade as &ldquo;high exposure&rdquo; as
+          often as &ldquo;weak.&rdquo;
+        </p>
         <Link
-          href="/leaderboards/scoring"
+          href="/leaderboards/scoring#limitations"
           className="inline-block mt-4 text-sm font-medium text-[var(--accent-gold)] hover:underline"
         >
-          → Full methodology
+          → How the score works and where it&apos;s biased
         </Link>
       </section>
 


### PR DESCRIPTION
## What this does

One backend exclusion replaces the per-surface card filtering, the card tier list gets a Codex Elo lens, upgraded cards get a real Elo of their own, and the scoring page is more honest about its biases.

### Backend
- Moved the non-reward (curse/status/event/quest/token) and starter (Basic) exclusion into `get_all_entity_scores`. One source now feeds the tier-list hub, `/tier-list/cards`, and the `/cards` highest-rated section, so all three drop those cards without their own filters.
- Exposed Codex Elo on `/api/runs/scores/{type}`. The field is additive, so the Discord bot and the overlay are unaffected.
- Added Upgrade Elo. Upgraded cards no longer echo the base card's Elo. I fit the same Bradley-Terry model over rest-site Smith decisions (the card a player chooses to upgrade beats the other eligible cards in the deck) and attach it to each card's upgraded aggregate, which shows on the metrics-table `+` rows.

### Frontend
- Added a "rank by Codex Score vs Codex Elo" toggle on `/tier-list/cards`. The Elo view bands by percentile within the rated pool (raw Elo is too bunched for fixed cutoffs) and hides cards with no Elo. Removed the now-redundant `isRewardCard` filters.
- Renamed the harsh tier labels: D is "Below average", F is "Underperforming". Synced across `TierList`, `ScoreBadge`, and the scoring page.
- Added exposure-time and survivorship bias caveats to the scoring methodology, leaned on Codex Elo as the less-confounded signal, and added short limitation notes on the tier-list pages.

### Notes
- The backend changes only take effect once the run cache rebuilds on deploy.
- Upgrade Elo should get a sanity check on sample sizes against real data before trusting thin-sample upgrade ratings. It uses the same `MIN_GAMES` cutoff as reward Elo.
