### PR TITLE
Community stats page, Today's Daily seed fix, enchanted card URLs, lang enum

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -65,8 +65,23 @@ LANGUAGE_NAMES = {
 DEFAULT_LANG = "eng"
 
 
-def get_lang(lang: str = Query("eng", description="Language code")) -> str:
-    """Validate and return language code, falling back to English."""
+def get_lang(
+    lang: str = Query(
+        DEFAULT_LANG,
+        description=(
+            "Language code. One of the 14 supported codes; unknown values "
+            "fall back to English."
+        ),
+        json_schema_extra={"enum": sorted(VALID_LANGUAGES)},
+    )
+) -> str:
+    """Validate and return language code, falling back to English.
+
+    `json_schema_extra` surfaces the supported codes as an enum dropdown in
+    the OpenAPI docs (/docs) without making the param strict: an unknown
+    `lang` still falls back to English rather than 422-ing, so existing API
+    consumers (the bot, overlay, and desktop app) don't break.
+    """
     return lang if lang in VALID_LANGUAGES else DEFAULT_LANG
 
 

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -11,6 +11,7 @@ from slowapi.util import get_remote_address
 from ..services.runs_db import submit_run, get_stats, claim_runs
 from ..services.run_entity_stats import (
     get_all_entity_scores,
+    get_community_stats,
     get_entity_metrics_table,
     get_entity_stats,
     get_top_entities_for_character,
@@ -286,6 +287,14 @@ def list_runs(
         if game_mode:
             conditions.append("game_mode = ?")
             params.append(game_mode)
+        if today:
+            # "Today's daily" = today's daily seed (prefixed DD_MM_YYYY), not
+            # submitted_at (upload time). Mirrors _today_daily_seed_match in the
+            # Mongo path.
+            from datetime import datetime, timezone
+
+            conditions.append("seed LIKE ?")
+            params.append(datetime.now(timezone.utc).strftime("%d_%m_%Y") + "%")
         where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
 
         # Sort options
@@ -674,6 +683,17 @@ def get_entity_scores(request: Request, entity_type: str):
             detail=f"entity_type must be one of {sorted(_ENTITY_STATS_TYPES)}",
         )
     return get_all_entity_scores(entity_type)
+
+
+@router.get("/community-stats", tags=["Runs"])
+@limiter.limit("60/minute")
+def community_stats(request: Request, response: Response):
+    """Community / fun stats for the /stats page: per-event player decision
+    breakdowns, deadliest encounters/events, headline totals by ascension and
+    character, and a few records and quirks. Built in the same walk as the
+    Codex Score cache, so this is an in-memory read."""
+    response.headers["Cache-Control"] = "public, max-age=300"
+    return get_community_stats()
 
 
 @router.get("/metrics/{entity_type}", tags=["Runs"])

--- a/backend/app/services/community_stats.py
+++ b/backend/app/services/community_stats.py
@@ -1,0 +1,328 @@
+"""Community / fun stats aggregated from run blobs.
+
+These are the light, shareable numbers (the kind Mega Crit run in their
+"Spire Stats" newsletter): per-event player decision breakdowns, what kills
+players most, headline totals, and a few records / quirks.
+
+The heavy lifting piggybacks on the single run-file walk in
+``run_entity_stats._build_cache_data`` so we never read the 100k+ run blobs
+twice. That walk calls :func:`accumulate` per run and :func:`finalize` once,
+then stashes the result in the shared Mongo snapshot. This module owns only
+the aggregation + display-name resolution; it must not import
+``run_entity_stats`` (the dependency runs the other way).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Namespaces stripped off raw ids ("CARD.WISP" -> "WISP",
+# "ENCOUNTER.AXEBOTS_NORMAL" -> "AXEBOTS_NORMAL").
+_NAMESPACES = frozenset(
+    {"CARD", "RELIC", "ENCOUNTER", "EVENT", "POTION", "ENCHANTMENT", "NONE"}
+)
+_SMITH = "SMITH"
+# How many rows to keep in each ranked list (events keeps all, they're finite).
+_TOP_N = 15
+
+
+def _bare(raw: str | None) -> str | None:
+    """Strip a leading namespace token. None for empty / NONE sentinels."""
+    if not raw:
+        return None
+    parts = raw.split(".")
+    if len(parts) > 1 and parts[0] in _NAMESPACES:
+        bare = ".".join(parts[1:])
+    else:
+        bare = raw
+    if not bare or bare.upper().startswith("NONE"):
+        return None
+    return bare
+
+
+def _prettify(raw: str) -> str:
+    """Fallback label for an id we couldn't resolve from game data:
+    "EXOSKELETONS_NORMAL" -> "Exoskeletons Normal"."""
+    return raw.replace("_", " ").title()
+
+
+def new_accumulator() -> dict[str, Any]:
+    """A fresh, mutable accumulator for one full run-file walk."""
+    return {
+        "total_runs": 0,
+        "total_wins": 0,
+        "by_ascension": {},  # asc(int) -> [runs, wins]
+        "by_character": {},  # char_id -> [runs, wins]
+        "events": {},  # event_id -> {option_id -> count}
+        "deaths_encounter": {},  # encounter_id -> count
+        "deaths_event": {},  # event_id -> count
+        "rest": {},  # rest-site choice -> count
+        "ancient": {},  # relic_id -> count (chosen from the 3-relic offer)
+        "removed": {},  # card_id -> count (purged at a shop/event)
+        "reward_screens": 0,
+        "reward_skips": 0,
+        "fastest_win": None,  # (run_time, run_hash)
+        "longest_run": None,  # (run_time, run_hash)
+        "biggest_deck": None,  # (deck_size, run_hash)
+    }
+
+
+def _bump(d: dict, key: Any, n: int = 1) -> None:
+    d[key] = d.get(key, 0) + n
+
+
+def accumulate(
+    acc: dict[str, Any],
+    blob: dict,
+    *,
+    run_hash: str,
+    is_win: bool,
+    character: str,
+    ascension: int,
+) -> None:
+    """Fold one run into the accumulator. Safe on partial/old blobs: every
+    field is read defensively so a missing key never aborts the walk."""
+    acc["total_runs"] += 1
+    if is_win:
+        acc["total_wins"] += 1
+
+    asc = acc["by_ascension"].setdefault(int(ascension or 0), [0, 0])
+    asc[0] += 1
+    if is_win:
+        asc[1] += 1
+    # Normalize "character.necrobinder" / "NECROBINDER" -> "necrobinder".
+    char_id = (character or "unknown").split(".")[-1].lower()
+    ch = acc["by_character"].setdefault(char_id, [0, 0])
+    ch[0] += 1
+    if is_win:
+        ch[1] += 1
+
+    # How you died (losses only). killed_by_* are top-level on the blob.
+    if not is_win:
+        enc = _bare(blob.get("killed_by_encounter"))
+        if enc:
+            _bump(acc["deaths_encounter"], enc)
+        kev = _bare(blob.get("killed_by_event"))
+        if kev:
+            _bump(acc["deaths_event"], kev)
+
+    # Records.
+    run_time = blob.get("run_time")
+    if isinstance(run_time, (int, float)) and run_time > 0:
+        if is_win and (
+            acc["fastest_win"] is None or run_time < acc["fastest_win"][0]
+        ):
+            acc["fastest_win"] = (int(run_time), run_hash)
+        if acc["longest_run"] is None or run_time > acc["longest_run"][0]:
+            acc["longest_run"] = (int(run_time), run_hash)
+    for player in blob.get("players") or []:
+        size = len(player.get("deck") or [])
+        if size and (acc["biggest_deck"] is None or size > acc["biggest_deck"][0]):
+            acc["biggest_deck"] = (size, run_hash)
+
+    # Per-floor choices.
+    for act_floors in blob.get("map_point_history") or []:
+        for floor in act_floors or []:
+            for ps in floor.get("player_stats") or []:
+                # Event decisions: keys look like
+                # "BYRDONIS_NEST.pages.INITIAL.options.TAKE.title".
+                for ec in ps.get("event_choices") or []:
+                    title = ec.get("title") or {}
+                    if title.get("table") != "events":
+                        continue
+                    key = title.get("key") or ""
+                    if ".options." not in key:
+                        continue
+                    event_id = key.split(".", 1)[0]
+                    option_id = key.split(".options.", 1)[1].split(".", 1)[0]
+                    if not event_id or not option_id:
+                        continue
+                    opts = acc["events"].setdefault(event_id, {})
+                    _bump(opts, option_id)
+
+                # Rest-site actions (SMITH / HEAL / HATCH / CLONE / ...).
+                for choice in ps.get("rest_site_choices") or []:
+                    if choice:
+                        _bump(acc["rest"], choice)
+
+                # 3-relic "ancient" offers: count the one chosen.
+                for offer in ps.get("ancient_choice") or []:
+                    if offer.get("was_chosen"):
+                        rid = offer.get("TextKey") or _bare(
+                            (offer.get("title") or {}).get("key")
+                        )
+                        if rid:
+                            _bump(acc["ancient"], rid)
+
+                # Cards purged at a shop / event.
+                for rem in ps.get("cards_removed") or []:
+                    raw = rem.get("id") if isinstance(rem, dict) else rem
+                    if isinstance(rem, dict) and "card" in rem:
+                        raw = (rem.get("card") or {}).get("id")
+                    cid = _bare(raw)
+                    if cid:
+                        _bump(acc["removed"], cid)
+
+                # Card-reward screens: a screen with nothing picked is a skip.
+                choices = ps.get("card_choices") or []
+                if choices:
+                    acc["reward_screens"] += 1
+                    if not any(c.get("was_picked") for c in choices):
+                        acc["reward_skips"] += 1
+
+
+# ── Finalize: resolve names + compute percentages ────────────────────────────
+
+
+def _name_maps() -> dict[str, dict[str, str]]:
+    """Build id -> display-name lookups from the game data. Each is best
+    effort; a failed load just means we fall back to a prettified id."""
+    from . import data_service
+
+    out: dict[str, dict[str, str]] = {}
+
+    def _index(loader, key="id", name="name") -> dict[str, str]:
+        try:
+            return {
+                r[key]: r.get(name) or _prettify(r[key])
+                for r in loader()
+                if r.get(key)
+            }
+        except Exception:
+            logger.warning("community-stats name load failed", exc_info=True)
+            return {}
+
+    out["events"] = _index(data_service.load_events)
+    out["encounters"] = _index(data_service.load_encounters)
+    out["relics"] = _index(data_service.load_relics)
+    out["cards"] = _index(data_service.load_cards)
+    # Characters keyed lowercase so "necrobinder" resolves "NECROBINDER".
+    out["characters"] = {k.lower(): v for k, v in _index(data_service.load_characters).items()}
+    # Per-event option id -> title ("TAKE" -> "Take the Egg").
+    event_opts: dict[str, dict[str, str]] = {}
+    try:
+        for e in data_service.load_events():
+            eid = e.get("id")
+            if not eid:
+                continue
+            labels: dict[str, str] = {}
+            for opt in e.get("options") or []:
+                if opt.get("id"):
+                    labels[opt["id"]] = opt.get("title") or _prettify(opt["id"])
+            event_opts[eid] = labels
+    except Exception:
+        logger.warning("community-stats event options load failed", exc_info=True)
+    out["_event_options"] = event_opts  # type: ignore[assignment]
+    return out
+
+
+def _pct(part: int, whole: int) -> float:
+    return round(part / whole * 100, 1) if whole else 0.0
+
+
+def _ranked(counts: dict[str, int], names: dict[str, str], limit: int) -> list[dict]:
+    total = sum(counts.values())
+    rows = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:limit]
+    return [
+        {
+            "id": cid,
+            "name": names.get(cid) or _prettify(cid),
+            "count": n,
+            "pct": _pct(n, total),
+        }
+        for cid, n in rows
+    ]
+
+
+def finalize(acc: dict[str, Any]) -> dict[str, Any]:
+    """Turn the raw accumulator into the JSON the API/page render."""
+    names = _name_maps()
+    ev_names = names["events"]
+    ev_opts = names["_event_options"]  # type: ignore[index]
+
+    total_runs = acc["total_runs"]
+    total_wins = acc["total_wins"]
+
+    by_ascension = [
+        {"ascension": a, "runs": rw[0], "wins": rw[1], "win_rate": _pct(rw[1], rw[0])}
+        for a, rw in sorted(acc["by_ascension"].items())
+    ]
+    by_character = [
+        {
+            "id": cid,
+            "name": names["characters"].get(cid) or _prettify(cid),
+            "runs": rw[0],
+            "wins": rw[1],
+            "win_rate": _pct(rw[1], rw[0]),
+            "share": _pct(rw[0], total_runs),
+        }
+        for cid, rw in sorted(
+            acc["by_character"].items(), key=lambda kv: kv[1][0], reverse=True
+        )
+    ]
+
+    # Event decisions: every event with a real multi-option split, sorted by
+    # how many players hit it. Options sorted by popularity.
+    events = []
+    for eid, opts in acc["events"].items():
+        total = sum(opts.values())
+        if total <= 0:
+            continue
+        labels = ev_opts.get(eid, {})
+        options = sorted(opts.items(), key=lambda kv: kv[1], reverse=True)
+        events.append(
+            {
+                "id": eid,
+                "name": ev_names.get(eid) or _prettify(eid),
+                "total": total,
+                "options": [
+                    {
+                        "id": oid,
+                        "label": labels.get(oid) or _prettify(oid),
+                        "count": n,
+                        "pct": _pct(n, total),
+                    }
+                    for oid, n in options
+                ],
+            }
+        )
+    events.sort(key=lambda e: e["total"], reverse=True)
+
+    def _rec(rec, value_key):
+        if not rec:
+            return None
+        return {value_key: rec[0], "run_hash": rec[1]}
+
+    return {
+        "total_runs": total_runs,
+        "total_wins": total_wins,
+        "total_losses": total_runs - total_wins,
+        "win_rate": _pct(total_wins, total_runs),
+        "by_ascension": by_ascension,
+        "by_character": by_character,
+        "events": events,
+        "deaths": {
+            "encounters": _ranked(acc["deaths_encounter"], names["encounters"], _TOP_N),
+            "events": _ranked(acc["deaths_event"], names["events"], _TOP_N),
+        },
+        "rest_sites": [
+            {"id": c, "label": _prettify(c), "count": n, "pct": _pct(n, sum(acc["rest"].values()))}
+            for c, n in sorted(acc["rest"].items(), key=lambda kv: kv[1], reverse=True)
+        ],
+        "ancient_picks": _ranked(acc["ancient"], names["relics"], _TOP_N),
+        "most_removed": _ranked(acc["removed"], names["cards"], _TOP_N),
+        "reward_skip_rate": _pct(acc["reward_skips"], acc["reward_screens"]),
+        "records": {
+            "fastest_win": _rec(acc["fastest_win"], "run_time"),
+            "longest_run": _rec(acc["longest_run"], "run_time"),
+            "biggest_deck": _rec(acc["biggest_deck"], "size"),
+        },
+    }
+
+
+def empty() -> dict[str, Any]:
+    """The shape returned before any snapshot exists."""
+    return finalize(new_accumulator())

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -154,6 +154,9 @@ _type_baselines: dict[str, float] = {}
 # (solo/2p/3p/4p/a10/daily/custom). Keyed by cohort, then entity type.
 _cohort_baselines: dict[str, dict[str, float]] = {}
 _cohort_totals: dict[str, dict[str, int]] = {}
+# Community / fun stats (event decisions, deaths, headline numbers, records).
+# Built in the same run-file walk and carried through the snapshot meta doc.
+_community_stats: dict[str, Any] = {}
 _cache_built_at: float = 0.0
 _building: bool = False
 
@@ -605,6 +608,10 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
     # Rest-site Smith decisions → Upgrade Elo for upgraded card variants.
     # All-runs only; the metrics table doesn't split base/upg per cohort.
     upgrade_pair_wins: dict[tuple[str, str], int] = {}
+    # Community / fun stats, folded in from the same blob read (no 2nd walk).
+    from . import community_stats
+
+    community_acc = community_stats.new_accumulator()
     # Parallel lightweight accumulators, one per non-"all" cohort.
     cohort_accs: dict[str, dict[str, Any]] = {
         k: _new_cohort_acc() for k in _COHORT_KEYS
@@ -685,6 +692,16 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
         except (OSError, json.JSONDecodeError) as e:
             logger.warning("skipping unreadable run %s: %s", run_hash, e)
             continue
+
+        # Community / fun stats, accumulated from the same blob.
+        community_stats.accumulate(
+            community_acc,
+            blob,
+            run_hash=run_hash,
+            is_win=is_win,
+            character=character,
+            ascension=row.get("ascension") or 0,
+        )
 
         # Dedupe per-run: a deck with 5 Strikes still only counts ONE
         # pick of "this run had Strike". We count run-level membership
@@ -859,7 +876,11 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
                 "pick_act": cagg.get("pick_act", [0] * _ACT_BUCKETS),
                 "elo": cagg.get("elo"),
             }
-    cohort_meta = {"baselines": cohort_baselines, "totals": cohort_totals}
+    cohort_meta = {
+        "baselines": cohort_baselines,
+        "totals": cohort_totals,
+        "community": community_stats.finalize(community_acc),
+    }
     return new_cache, new_totals, new_type_baselines, cohort_meta
 
 
@@ -868,13 +889,14 @@ def _apply_cache(
 ) -> None:
     """Swap freshly-built (or snapshot-loaded) data into module globals."""
     global _cache, _cache_built_at, _global_totals, _type_baselines
-    global _cohort_baselines, _cohort_totals
+    global _cohort_baselines, _cohort_totals, _community_stats
     _cache = cache
     _global_totals = totals
     _type_baselines = baselines
     cohort_meta = cohort_meta or {}
     _cohort_baselines = cohort_meta.get("baselines", {})
     _cohort_totals = cohort_meta.get("totals", {})
+    _community_stats = cohort_meta.get("community") or {}
     _cache_built_at = time.time()
 
 
@@ -953,6 +975,7 @@ def _persist_snapshot(
             "type_baselines": baselines,
             "cohort_baselines": cohort_meta.get("baselines", {}),
             "cohort_totals": cohort_meta.get("totals", {}),
+            "community": cohort_meta.get("community", {}),
             "entity_types": list(by_type.keys()),
             "built_at": now,
         },
@@ -1004,6 +1027,7 @@ def _load_snapshot() -> bool:
         {
             "baselines": meta.get("cohort_baselines", {}),
             "totals": meta.get("cohort_totals", {}),
+            "community": meta.get("community", {}),
         },
     )
     return True
@@ -1102,6 +1126,17 @@ def _compute_score(wins: int, picks: int, baseline: float) -> int | None:
     delta = shrunk - baseline
     raw = (delta / _SCORE_SCALE_RANGE + 1) * 50
     return max(0, min(100, round(raw)))
+
+
+def get_community_stats() -> dict[str, Any]:
+    """Community / fun stats (event decisions, deaths, headline numbers,
+    records). Built in the same walk as the entity cache and carried through
+    the snapshot, so this is an O(1) read. Empty shape before the first
+    snapshot exists."""
+    _maybe_rebuild()
+    from . import community_stats
+
+    return _community_stats or community_stats.empty()
 
 
 def get_all_entity_scores(entity_type: str) -> dict[str, dict[str, Any]]:

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -49,6 +49,19 @@ from ..metrics import db_operations, db_operation_duration
 OFFICIAL_CHARACTERS = {"IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"}
 
 
+def _today_daily_seed_match() -> dict:
+    """Mongo match for runs of *today's* daily seed.
+
+    Daily seeds are prefixed with the UTC date as ``DD_MM_YYYY`` (e.g.
+    ``"09_06_2026_2P"``), so "today's daily" is a seed-prefix match on the
+    current UTC date. This is the correct key, NOT ``submitted_at``: that's
+    upload time, which is often null on freshly-tracked runs and gets stamped
+    in bulk when old runs are backfilled, so a March daily uploaded today
+    would otherwise rank as "today's daily"."""
+    date = datetime.now(timezone.utc).strftime("%d_%m_%Y")
+    return {"$regex": f"^{date}"}
+
+
 @contextmanager
 def _timed_op(operation: str, collection: str = "runs"):
     """Increment db_operations + observe latency for a Mongo op.
@@ -1569,10 +1582,7 @@ def list_runs(
         elif relics_f:
             q["relics.id"] = {"$all": relics_f}
     if today:
-        today_start = datetime.now(timezone.utc).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
-        q["submitted_at"] = {"$gte": today_start}
+        q["seed"] = _today_daily_seed_match()
 
     sort_map = {
         "time_asc": [("run_time", 1)],
@@ -1682,10 +1692,7 @@ def _leaderboard_live(
     if game_mode:
         q["game_mode"] = game_mode
     if today:
-        today_start = datetime.now(timezone.utc).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
-        q["submitted_at"] = {"$gte": today_start}
+        q["seed"] = _today_daily_seed_match()
 
     if category == "highest_ascension":
         sort_clause = [("ascension", -1), ("run_time", 1)]
@@ -1776,16 +1783,11 @@ def find_sibling_hashes(run_hash: str) -> list[str]:
 @_instrument("get_daily_leaderboard")
 def get_daily_leaderboard(username: str | None = None) -> dict:
     """Today's top daily climb wins, plus the requesting user's rank."""
-    from datetime import datetime, timezone
-
     coll = _get_collection()
-    today_start = datetime.now(timezone.utc).replace(
-        hour=0, minute=0, second=0, microsecond=0
-    )
     base = {
         "win": {"$in": [True, 1]},
         "game_mode": "daily",
-        "submitted_at": {"$gte": today_start},
+        "seed": _today_daily_seed_match(),
     }
 
     top_10 = list(coll.find(base, _projection_row()).sort("run_time", 1).limit(10))
@@ -1845,10 +1847,7 @@ def get_run_rank_scoped(
     elif players == "multi":
         scope["player_count"] = {"$gt": 1}
     if today_only:
-        today_start = datetime.now(timezone.utc).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
-        scope["submitted_at"] = {"$gte": today_start}
+        scope["seed"] = _today_daily_seed_match()
 
     if category == "highest_ascension":
         ahead_q = {

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -88,6 +88,7 @@ const NAV_GROUPS: NavGroup[] = [
     label: "Stats",
     links: [
       { href: "/tier-list", label: "Tier List" },
+      { href: "/stats", label: "Community Stats" },
       { href: "/leaderboards", label: "Leaderboards" },
       { href: "/runs", label: "Browse Runs" },
       { href: "/leaderboards/submit", label: "Submit a Run" },

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -99,6 +99,7 @@ const STATIC_PAGES = [
   { path: "/leaderboards", priority: 0.7, changeFrequency: "daily" as const },
   { path: "/leaderboards/submit", priority: 0.6, changeFrequency: "monthly" as const },
   { path: "/leaderboards/stats", priority: 0.8, changeFrequency: "daily" as const },
+  { path: "/stats", priority: 0.7, changeFrequency: "daily" as const },
   { path: "/leaderboards/scoring", priority: 0.6, changeFrequency: "monthly" as const },
   // Tier list, high priority, daily changefreq because scores update
   // every 30 minutes as new runs arrive. Per-character variants are
@@ -224,6 +225,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/leaderboards",
     "/leaderboards/submit",
     "/leaderboards/stats",
+    "/stats",
     "/leaderboards/scoring",
     "/tier-list",
     "/tier-list/cards",

--- a/frontend/app/stats/charts.tsx
+++ b/frontend/app/stats/charts.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+// Client-island charts for the /stats page. The page itself stays a server
+// component (all numbers render in the HTML for SEO); these handle only the
+// visuals via Recharts, the same charting lib /meta already uses.
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  LabelList,
+  PieChart,
+  Pie,
+} from "recharts";
+
+// Theme-ish hexes (SVG attributes don't reliably take CSS vars in Recharts).
+const GOLD = "#d4a843";
+const TEXT_SECONDARY = "#a1a1aa";
+const TEXT_MUTED = "#8a8a93";
+const TRACK = "#26262b";
+
+// Per-option donut palette (matches the legend dots rendered on the page).
+export const OPTION_HEX = ["#f59e0b", "#38bdf8", "#34d399", "#fb7185"];
+
+const TOOLTIP_STYLE = {
+  background: "#15151a",
+  border: "1px solid #33333a",
+  borderRadius: 6,
+  fontSize: 12,
+  padding: "4px 8px",
+} as const;
+
+interface Datum {
+  name: string;
+  value: number;
+  display: string;
+}
+
+/** Horizontal bar chart for ranked lists and win-rate breakdowns. */
+export function RankBars({
+  data,
+  color = GOLD,
+  labelWidth = 150,
+}: {
+  data: Datum[];
+  color?: string;
+  labelWidth?: number;
+}) {
+  const height = Math.max(96, data.length * 30);
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart data={data} layout="vertical" margin={{ top: 0, right: 52, bottom: 0, left: 0 }}>
+        <XAxis type="number" hide domain={[0, "dataMax"]} />
+        <YAxis
+          type="category"
+          dataKey="name"
+          width={labelWidth}
+          tickLine={false}
+          axisLine={false}
+          tick={{ fontSize: 12, fill: TEXT_SECONDARY }}
+        />
+        <Tooltip
+          cursor={{ fill: "rgba(255,255,255,0.04)" }}
+          contentStyle={TOOLTIP_STYLE}
+          itemStyle={{ color: "#e5e5e5" }}
+          labelStyle={{ color: TEXT_MUTED }}
+          formatter={(_v, _n, p) => [(p?.payload as Datum)?.display, ""]}
+        />
+        <Bar dataKey="value" fill={color} radius={[0, 3, 3, 0]} background={{ fill: TRACK }}>
+          <LabelList dataKey="display" position="right" style={{ fontSize: 11, fill: TEXT_MUTED }} />
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+/** Fixed-size donut for one event's option split. No ResponsiveContainer, so
+ *  a wall of these doesn't spin up dozens of ResizeObservers. */
+export function EventDonut({
+  options,
+  size = 96,
+}: {
+  options: { id: string; label: string; pct: number }[];
+  size?: number;
+}) {
+  const data = options.map((o, i) => ({
+    name: o.label,
+    value: o.pct,
+    fill: OPTION_HEX[i % OPTION_HEX.length],
+  }));
+  return (
+    <div className="relative shrink-0" style={{ width: size, height: size }}>
+      <PieChart width={size} height={size}>
+        <Pie
+          data={data}
+          dataKey="value"
+          nameKey="name"
+          cx="50%"
+          cy="50%"
+          innerRadius={size * 0.3}
+          outerRadius={size * 0.48}
+          startAngle={90}
+          endAngle={-270}
+          stroke="none"
+          isAnimationActive={false}
+        >
+          {data.map((d, i) => (
+            <Cell key={i} fill={d.fill} />
+          ))}
+        </Pie>
+        <Tooltip
+          contentStyle={TOOLTIP_STYLE}
+          itemStyle={{ color: "#e5e5e5" }}
+          formatter={(v, n) => [`${v}%`, n]}
+        />
+      </PieChart>
+      <span className="absolute inset-0 flex items-center justify-center text-sm font-bold tabular-nums text-[var(--text-primary)]">
+        {options[0]?.pct}%
+      </span>
+    </div>
+  );
+}

--- a/frontend/app/stats/page.tsx
+++ b/frontend/app/stats/page.tsx
@@ -1,0 +1,252 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE, buildLanguageAlternates } from "@/lib/seo";
+import JsonLd from "@/app/components/JsonLd";
+import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
+import { RankBars, EventDonut, OPTION_HEX } from "./charts";
+
+const API_INTERNAL =
+  process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+// Community stats rebuild on the backend on the snapshot cadence; a 5min
+// HTML cache keeps this page cheap without going stale.
+export const revalidate = 300;
+
+interface Option { id: string; label: string; count: number; pct: number }
+interface EventRow { id: string; name: string; total: number; options: Option[] }
+interface Ranked { id: string; name: string; count: number; pct: number }
+interface CharRow { id: string; name: string; runs: number; wins: number; win_rate: number; share: number }
+interface AscRow { ascension: number; runs: number; wins: number; win_rate: number }
+interface Record_ { run_time?: number; size?: number; run_hash: string }
+
+interface CommunityStats {
+  total_runs: number;
+  total_wins: number;
+  total_losses: number;
+  win_rate: number;
+  by_ascension: AscRow[];
+  by_character: CharRow[];
+  events: EventRow[];
+  deaths: { encounters: Ranked[]; events: Ranked[] };
+  rest_sites: { id: string; label: string; count: number; pct: number }[];
+  ancient_picks: Ranked[];
+  most_removed: Ranked[];
+  reward_skip_rate: number;
+  records: { fastest_win: Record_ | null; longest_run: Record_ | null; biggest_deck: Record_ | null };
+}
+
+export const metadata: Metadata = {
+  title: `Community Stats - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
+  description:
+    "Fun community stats for Slay the Spire 2 (sts2): how players vote at every event, what kills runs most, win rates by ascension and character, and run records, all from community-submitted runs.",
+  alternates: { canonical: `${SITE_URL}/stats`, languages: buildLanguageAlternates("/stats") },
+  openGraph: {
+    title: `Slay the Spire 2 (sts2) Community Stats | ${SITE_NAME}`,
+    description:
+      "Player decision breakdowns, deadliest enemies, win rates, and records from community-submitted Slay the Spire 2 runs.",
+    url: `${SITE_URL}/stats`,
+    siteName: SITE_NAME,
+    type: "website",
+    images: [{ url: DEFAULT_OG_IMAGE }],
+  },
+  twitter: { card: "summary_large_image", title: `Slay the Spire 2 (sts2) Community Stats | ${SITE_NAME}` },
+};
+
+const EMERALD = "#34d399";
+const SKY = "#38bdf8";
+const ROSE = "#fb7185";
+const GOLD = "#d4a843";
+
+async function fetchStats(): Promise<CommunityStats | null> {
+  try {
+    const res = await fetch(`${API_INTERNAL}/api/runs/community-stats`, { next: { revalidate: 300 } });
+    if (!res.ok) return null;
+    return (await res.json()) as CommunityStats;
+  } catch {
+    return null;
+  }
+}
+
+function fmtTime(sec?: number): string {
+  if (!sec || sec <= 0) return "-";
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  const s = sec % 60;
+  if (h > 0) return `${h}h ${m.toString().padStart(2, "0")}m`;
+  return `${m}m ${s.toString().padStart(2, "0")}s`;
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+      <div className="text-2xl font-bold text-[var(--accent-gold)] tabular-nums">{value}</div>
+      <div className="text-xs uppercase tracking-wider text-[var(--text-muted)] mt-1">{label}</div>
+    </div>
+  );
+}
+
+function RecordCard({ label, value, hash }: { label: string; value: string; hash?: string }) {
+  const body = (
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4 h-full hover:border-[var(--border-accent)] transition-colors">
+      <div className="text-2xl font-bold text-[var(--accent-gold)] tabular-nums">{value}</div>
+      <div className="text-xs uppercase tracking-wider text-[var(--text-muted)] mt-1">{label}</div>
+      {hash && <div className="text-xs text-[var(--text-secondary)] mt-1">View run →</div>}
+    </div>
+  );
+  return hash ? <Link href={`/runs/${hash}`}>{body}</Link> : body;
+}
+
+function Empty({ jsonLd }: { jsonLd: object[] }) {
+  return (
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <JsonLd data={jsonLd} />
+      <h1 className="text-3xl font-bold mb-2"><span className="text-[var(--accent-gold)]">Community Stats</span></h1>
+      <p className="text-sm text-[var(--text-muted)]">
+        No data yet. Stats build from community-submitted runs, <Link href="/leaderboards/submit" className="text-[var(--accent-gold)] hover:underline">submit a run</Link> to seed them.
+      </p>
+    </div>
+  );
+}
+
+export default async function CommunityStatsPage() {
+  const stats = await fetchStats();
+
+  const jsonLd = [
+    buildBreadcrumbJsonLd([
+      { name: "Home", href: "/" },
+      { name: "Community Stats", href: "/stats" },
+    ]),
+    buildCollectionPageJsonLd({
+      name: "Slay the Spire 2 Community Stats",
+      description: "Player decision breakdowns, deadliest enemies, win rates, and records from community-submitted Slay the Spire 2 runs.",
+      path: "/stats",
+      items: [],
+    }),
+  ];
+
+  if (!stats || stats.total_runs === 0) return <Empty jsonLd={jsonLd} />;
+
+  const { records } = stats;
+  const rankPct = (rows: Ranked[]) => rows.map((r) => ({ name: r.name, value: r.count, display: `${r.pct}%` }));
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <JsonLd data={jsonLd} />
+
+      <h1 className="text-3xl font-bold mb-2">
+        <span className="text-[var(--accent-gold)]">Community Stats</span>
+      </h1>
+      <p className="text-sm text-[var(--text-muted)] mb-8">
+        How the community actually plays <em>Slay the Spire 2</em>, drawn from {stats.total_runs.toLocaleString()} submitted runs.
+        A naive snapshot of the data, not a verdict on what is correct.
+      </p>
+
+      {/* Headline numbers */}
+      <section className="mb-10">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <StatCard label="Runs" value={stats.total_runs.toLocaleString()} />
+          <StatCard label="Wins" value={stats.total_wins.toLocaleString()} />
+          <StatCard label="Losses" value={stats.total_losses.toLocaleString()} />
+          <StatCard label="Win rate" value={`${stats.win_rate}%`} />
+        </div>
+      </section>
+
+      {/* By character + ascension */}
+      <section className="mb-10 grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Win rate by character</h2>
+          <RankBars
+            color={EMERALD}
+            labelWidth={120}
+            data={stats.by_character.map((c) => ({ name: c.name, value: c.win_rate, display: `${c.win_rate}% · ${c.share}% played` }))}
+          />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Win rate by ascension</h2>
+          <RankBars
+            color={SKY}
+            labelWidth={48}
+            data={stats.by_ascension.map((a) => ({ name: `A${a.ascension}`, value: a.win_rate, display: `${a.win_rate}% · ${a.runs.toLocaleString()}` }))}
+          />
+        </div>
+      </section>
+
+      {/* Event decisions */}
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold text-[var(--accent-gold)] mb-1">How players vote</h2>
+        <p className="text-sm text-[var(--text-muted)] mb-4">
+          What the community chooses at every event. The closer to 50/50, the more the community is torn.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {stats.events.map((e) => (
+            <div key={e.id} className="flex items-center gap-4 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+              <EventDonut options={e.options} />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-baseline justify-between gap-2 mb-1.5">
+                  <span className="text-sm font-medium text-[var(--text-primary)] truncate" title={e.name}>{e.name}</span>
+                  <span className="text-[10px] text-[var(--text-muted)] tabular-nums shrink-0">{e.total.toLocaleString()}</span>
+                </div>
+                <ul className="space-y-0.5">
+                  {e.options.map((o, i) => (
+                    <li key={o.id} className="flex items-center gap-2 text-xs text-[var(--text-secondary)]">
+                      <span className="inline-block w-2 h-2 rounded-sm" style={{ backgroundColor: OPTION_HEX[i % OPTION_HEX.length] }} />
+                      <span className="flex-1 truncate" title={o.label}>{o.label}</span>
+                      <span className="tabular-nums text-[var(--text-muted)]">{o.pct}%</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* How you died */}
+      <section className="mb-10 grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Deadliest encounters</h2>
+          <RankBars color={ROSE} data={rankPct(stats.deaths.encounters)} />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Deadliest events</h2>
+          <RankBars color={ROSE} data={rankPct(stats.deaths.events)} />
+        </div>
+      </section>
+
+      {/* Records */}
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold text-[var(--accent-gold)] mb-4">Records</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <RecordCard label="Fastest win" value={fmtTime(records.fastest_win?.run_time)} hash={records.fastest_win?.run_hash} />
+          <RecordCard label="Longest run" value={fmtTime(records.longest_run?.run_time)} hash={records.longest_run?.run_hash} />
+          <RecordCard label="Biggest deck" value={records.biggest_deck ? `${records.biggest_deck.size} cards` : "-"} hash={records.biggest_deck?.run_hash} />
+        </div>
+      </section>
+
+      {/* Quirks */}
+      <section className="mb-10 grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Rest-site choices</h2>
+          <RankBars color={GOLD} data={stats.rest_sites.map((r) => ({ name: r.label, value: r.count, display: `${r.pct}%` }))} />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Most-removed cards</h2>
+          <RankBars color={GOLD} data={stats.most_removed.map((r) => ({ name: r.name, value: r.count, display: r.count.toLocaleString() }))} />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Favorite ancient relics</h2>
+          <RankBars color={GOLD} data={rankPct(stats.ancient_picks)} />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Card reward skip rate</h2>
+          <StatCard label="of card rewards skipped" value={`${stats.reward_skip_rate}%`} />
+        </div>
+      </section>
+
+      <p className="text-xs text-[var(--text-muted)]">
+        Built from community-submitted runs, refreshed periodically. See the{" "}
+        <Link href="/leaderboards/scoring" className="text-[var(--accent-gold)] hover:underline">scoring methodology</Link> for how the data is gathered and where it is biased.
+      </p>
+    </div>
+  );
+}

--- a/frontend/lib/image-url.ts
+++ b/frontend/lib/image-url.ts
@@ -49,6 +49,29 @@ export function fullCardUrl(
   return `${CDN_BASE}/cards-full/${seg}/${langSeg}${id.toLowerCase()}${upgraded ? "_upg" : ""}.webp`;
 }
 
+/**
+ * Full game-rendered card image with an enchantment applied, exactly as the
+ * game's NEnchantPreview draws it. Lives alongside the plain renders under an
+ * ench/<enchantment>/ subfolder:
+ *   cards-full/<channel>/ench/<ench>/<id>.webp            (English)
+ *   cards-full/<channel>/<lang>/ench/<ench>/<id>.webp     (localized)
+ * `enchantment` is the lowercase enchantment id (e.g. "sown", "sharp"). Only
+ * valid card x enchantment combinations are rendered (the export uses the
+ * game's own CanEnchant gate), so only build URLs for enchantments a card can
+ * actually take.
+ */
+export function enchantedCardUrl(
+  id: string,
+  enchantment: string,
+  upgraded = false,
+  channel: "stable" | "beta" = "stable",
+  lang = "eng"
+): string {
+  const seg = channel === "beta" ? "beta/0.107.0" : "stable";
+  const langSeg = lang !== "eng" && CARD_RENDER_LANGS.has(lang) ? `${lang}/` : "";
+  return `${CDN_BASE}/cards-full/${seg}/${langSeg}ench/${enchantment.toLowerCase()}/${id.toLowerCase()}${upgraded ? "_upg" : ""}.webp`;
+}
+
 interface OgCard {
   id: string;
   name: string;


### PR DESCRIPTION
Four changes, all in the website. Stacked on #418 (`hotfix/metrics-curse-display-filter`), so the diff here is only the new work; it'll retarget to `main` once #418 merges.

## Fix Today's Daily to use the daily seed
The daily-climb leaderboard (homepage + Overwolf) and the `/runs` `daily_today` filter keyed off `submitted_at` (UTC midnight). That's upload time, so a March daily that got bulk-uploaded today ranked as "today's daily", while genuine today runs (whose `submitted_at` is often null) were excluded. Daily seeds are prefixed with the UTC date (`DD_MM_YYYY`, e.g. `09_06_2026_2P`), so I match the seed prefix instead, via a shared `_today_daily_seed_match` helper across the runs list, leaderboard, daily-rank, and daily-climb queries, plus the SQLite fallback.

## Community stats page at /stats
Fun datasets in the spirit of Mega Crit's "Spire Stats" newsletter: per-event player decision breakdowns, deadliest encounters/events, headline totals by ascension and character, and records/quirks. A new `community_stats` module folds the aggregation into the existing single run-file walk (no second pass) and rides the snapshot. The page is server-rendered for SEO with Recharts chart islands (donuts for event votes, bars elsewhere). Adds a nav link and sitemap entry.

## enchantedCardUrl helper
Builds CDN URLs for the per-enchantment card renders at `cards-full/<channel>[/<lang>]/ench/<enchantment>/<id>.webp`, matching the render export layout. The renders themselves are already live on the CDN across all 14 languages.

## lang as an enum in the API docs
`get_lang` now lists the 14 supported language codes as an enum in the OpenAPI schema, so `/docs` shows a dropdown. It stays lenient (an unknown `lang` still resolves to English rather than 422-ing) so existing API consumers don't break.

### Notes
- Backend changes (daily-seed fix, community stats, lang enum) take effect on deploy / cache rebuild.
- The enchanted-card payload change lives in spire-compendium and is committed separately.
