### PR TITLE
Act 1/2/3 filters on the relic tier list

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -5,7 +5,7 @@ import os
 import time
 from functools import lru_cache
 from pathlib import Path
-from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi import APIRouter, HTTPException, Query, Request, Response
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from ..services.runs_db import submit_run, get_stats, claim_runs
@@ -670,22 +670,41 @@ def get_entity_run_stats(request: Request, entity_type: str, entity_id: str):
 
 @router.get("/scores/{entity_type}", tags=["Runs"])
 @limiter.limit("60/minute")
-def get_entity_scores(request: Request, entity_type: str):
+def get_entity_scores(
+    request: Request,
+    entity_type: str,
+    act: int | None = Query(
+        None,
+        ge=1,
+        le=3,
+        description=(
+            "Relics only: restrict to pickups made during this act "
+            "(3 includes later acts). Scores are graded against a per-act "
+            "baseline so survivorship into later acts doesn't inflate them."
+        ),
+    ),
+):
     """All Codex Scores for one entity type, keyed by ID.
 
     Each entry carries the 0-100 Codex Score plus picks/wins/win_rate, and
     for cards the Codex Elo (null for entities without one). Cards that are
     never a reward pick (curses, statuses, events, tokens, starters) are
-    excluded. Used by list pages to render the score column / sort by tier
-    without N round-trips to /stats/{type}/{id}. Cached at the same TTL as
-    the per-entity stats since both derive from the same walk.
+    excluded. With `act` set (relics only), stats cover only pickups made
+    during that act, graded against that act's baseline. Used by list pages
+    to render the score column / sort by tier without N round-trips to
+    /stats/{type}/{id}. Cached at the same TTL as the per-entity stats since
+    both derive from the same walk.
     """
     if entity_type not in _ENTITY_STATS_TYPES:
         raise HTTPException(
             status_code=400,
             detail=f"entity_type must be one of {sorted(_ENTITY_STATS_TYPES)}",
         )
-    return get_all_entity_scores(entity_type)
+    if act is not None and entity_type != "relics":
+        raise HTTPException(
+            status_code=400, detail="act filtering is only available for relics"
+        )
+    return get_all_entity_scores(entity_type, act=act)
 
 
 @router.get("/community-stats", tags=["Runs"])

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -136,7 +136,8 @@ SNAPSHOT_COLLECTION_NAME = "entity_stats_snapshot"
 # Mongo) clobbering the snapshot: loaders reject a mismatched version and
 # keep serving what they have, and the leader rebuilds right over it instead
 # of trusting its freshness. Version 2 = elo + base/upg + cohorts + community.
-SNAPSHOT_VERSION = 2
+# Version 3 adds per-act relic pickup splits (act_picks / act_wins).
+SNAPSHOT_VERSION = 3
 # Leader rebuilds the heavy walk at most this often.
 _SNAPSHOT_REBUILD_SECONDS = 10 * 60
 # Workers reload the snapshot from Mongo this often (cheap read).
@@ -791,6 +792,48 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
         except Exception:
             logger.warning("smith-choice walk failed for %s", run_hash, exc_info=True)
 
+        # Relic acquisition act: bucket each relic pickup into A1/A2/A3+ by
+        # comparing its global pickup floor (floor_added_to_deck) against this
+        # run's act lengths from map_point_history. Powers the act filter on
+        # the relic tier list. Acts past the third fold into the last bucket.
+        try:
+            act_floors_list = blob.get("map_point_history") or []
+            if act_floors_list:
+                bounds: list[int] = []
+                running = 0
+                for act_floors in act_floors_list:
+                    running += len(act_floors or [])
+                    bounds.append(running)
+                seen_relic_acts: set[tuple[str, int]] = set()
+                for player in blob.get("players") or []:
+                    for rel in player.get("relics") or []:
+                        fl = rel.get("floor_added_to_deck")
+                        stripped = _strip_prefix(rel.get("id", ""))
+                        if (
+                            not stripped
+                            or stripped[0] != "relics"
+                            or not isinstance(fl, (int, float))
+                            or fl < 1
+                        ):
+                            continue
+                        bucket = _ACT_BUCKETS - 1
+                        for i, bound in enumerate(bounds):
+                            if fl <= bound:
+                                bucket = min(i, _ACT_BUCKETS - 1)
+                                break
+                        seen_relic_acts.add((stripped[1], bucket))
+                for rid, bucket in seen_relic_acts:
+                    agg = new_cache.get(("relics", rid))
+                    if agg is None:
+                        continue
+                    arr_p = agg.setdefault("act_picks", [0] * _ACT_BUCKETS)
+                    arr_w = agg.setdefault("act_wins", [0] * _ACT_BUCKETS)
+                    arr_p[bucket] += 1
+                    if is_win:
+                        arr_w[bucket] += 1
+        except Exception:
+            logger.warning("relic act walk failed for %s", run_hash, exc_info=True)
+
         # Card-reward decisions: count offers/picks per act and record the
         # picked-beats-skipped head-to-heads for the Bradley-Terry fit, for
         # the all-runs pass AND every cohort this run belongs to.
@@ -970,6 +1013,10 @@ def _persist_snapshot(
             entry["base"] = agg["base"]
         if agg.get("upg") is not None:
             entry["upg"] = agg["upg"]
+        # Per-act pickup splits (relics only).
+        if agg.get("act_picks") is not None:
+            entry["act_picks"] = agg["act_picks"]
+            entry["act_wins"] = agg.get("act_wins") or [0] * _ACT_BUCKETS
         by_type.setdefault(etype, []).append(entry)
     now = datetime.now(timezone.utc)
     for etype, entities in by_type.items():
@@ -1042,6 +1089,9 @@ def _load_snapshot() -> bool:
                 agg["base"] = e["base"]
             if e.get("upg") is not None:
                 agg["upg"] = e["upg"]
+            if e.get("act_picks") is not None:
+                agg["act_picks"] = e["act_picks"]
+                agg["act_wins"] = e.get("act_wins") or [0] * _ACT_BUCKETS
             new_cache[(etype, e["id"])] = agg
     _apply_cache(
         new_cache,
@@ -1169,7 +1219,9 @@ def get_community_stats() -> dict[str, Any]:
     return _community_stats or community_stats.empty()
 
 
-def get_all_entity_scores(entity_type: str) -> dict[str, dict[str, Any]]:
+def get_all_entity_scores(
+    entity_type: str, act: int | None = None
+) -> dict[str, dict[str, Any]]:
     """All entities of one type, keyed by ID, with score + counts + elo.
 
     Drives list-page tier sorting and the (planned) tooltip-widget
@@ -1179,8 +1231,17 @@ def get_all_entity_scores(entity_type: str) -> dict[str, dict[str, Any]]:
     `elo` is the Codex Elo (revealed-preference rating) where it exists, else
     null. It only exists for reward-offered cards, so starters and upgraded
     variants are null — that's the basis for the dual Score/Elo tier view.
+
+    `act` (relics only, 1-3 where 3 folds in later acts) restricts the stats
+    to pickups made during that act: picks/wins/score come from the act
+    bucket, graded against a per-act baseline. Later-act pickups only happen
+    in runs that already got there, so their raw win rates are survivorship-
+    inflated; comparing act-mates against each other cancels that out.
+    Entities never picked up in that act are omitted.
     """
     _maybe_rebuild()
+    if act is not None:
+        return _entity_scores_for_act(entity_type, act)
     baseline = _type_baseline(entity_type)
     # Cards: drop non-reward colors (curse/status/event/quest/token) AND
     # starters (Basic rarity). Neither is reward-pickable, so a tier "rating"
@@ -1206,6 +1267,43 @@ def get_all_entity_scores(entity_type: str) -> dict[str, dict[str, Any]]:
             "picks": picks,
             "wins": wins,
             "win_rate": round(wins / picks * 100, 1) if picks else 0.0,
+        }
+    return out
+
+
+def _entity_scores_for_act(entity_type: str, act: int) -> dict[str, dict[str, Any]]:
+    """Scores restricted to pickups made during one act (1-based; 3 = act 3+).
+
+    Same shape as the all-acts response (`elo` stays null: Codex Elo is a
+    card-reward signal, not a relic one). The baseline is the pick-weighted
+    average win rate of every pickup in that act, so each entity is graded
+    against its act-mates rather than the global pool.
+    """
+    idx = min(max(act, 1), _ACT_BUCKETS) - 1
+    total_picks = total_wins = 0
+    for (etype, _), agg in _cache.items():
+        if etype != entity_type:
+            continue
+        act_picks = agg.get("act_picks")
+        if act_picks:
+            total_picks += act_picks[idx]
+            total_wins += (agg.get("act_wins") or [0] * _ACT_BUCKETS)[idx]
+    baseline = (total_wins / total_picks) if total_picks else _baseline_win_rate()
+    out: dict[str, dict[str, Any]] = {}
+    for (etype, eid), agg in _cache.items():
+        if etype != entity_type:
+            continue
+        act_picks = agg.get("act_picks")
+        if not act_picks or not act_picks[idx]:
+            continue
+        picks = act_picks[idx]
+        wins = (agg.get("act_wins") or [0] * _ACT_BUCKETS)[idx]
+        out[eid] = {
+            "score": _compute_score(wins, picks, baseline),
+            "elo": None,
+            "picks": picks,
+            "wins": wins,
+            "win_rate": round(wins / picks * 100, 1),
         }
     return out
 

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -131,6 +131,12 @@ _RUNS_DIR = (
 # walking the files itself — this is what stops N workers each pegging a
 # CPU rebuilding the same data. Mirrors the stats_summary pattern.
 SNAPSHOT_COLLECTION_NAME = "entity_stats_snapshot"
+# Bump whenever the snapshot shape changes (fields the readers depend on).
+# Guards against an out-of-date writer (e.g. a stale container sharing the
+# Mongo) clobbering the snapshot: loaders reject a mismatched version and
+# keep serving what they have, and the leader rebuilds right over it instead
+# of trusting its freshness. Version 2 = elo + base/upg + cohorts + community.
+SNAPSHOT_VERSION = 2
 # Leader rebuilds the heavy walk at most this often.
 _SNAPSHOT_REBUILD_SECONDS = 10 * 60
 # Workers reload the snapshot from Mongo this often (cheap read).
@@ -689,15 +695,21 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
             logger.warning("skipping unreadable run %s: %s", run_hash, e)
             continue
 
-        # Community / fun stats, accumulated from the same blob.
-        community_stats.accumulate(
-            community_acc,
-            blob,
-            run_hash=run_hash,
-            is_win=is_win,
-            character=character,
-            ascension=row.get("ascension") or 0,
-        )
+        # Community / fun stats, accumulated from the same blob. Guarded so
+        # one malformed blob can't abort the whole snapshot rebuild.
+        try:
+            community_stats.accumulate(
+                community_acc,
+                blob,
+                run_hash=run_hash,
+                is_win=is_win,
+                character=character,
+                ascension=row.get("ascension") or 0,
+            )
+        except Exception:
+            logger.warning(
+                "community-stats accumulate failed for %s", run_hash, exc_info=True
+            )
 
         # Dedupe per-run: a deck with 5 Strikes still only counts ONE
         # pick of "this run had Strike". We count run-level membership
@@ -767,13 +779,17 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
 
         # Rest-site Smith decisions: the upgraded card beats the other
         # eligible-but-unupgraded cards in the deck. Feeds the Upgrade Elo.
-        for winners, losers in _walk_rest_upgrade_choices(blob):
-            for winner in winners:
-                for loser in losers:
-                    if winner == loser:
-                        continue
-                    key = (winner, loser)
-                    upgrade_pair_wins[key] = upgrade_pair_wins.get(key, 0) + 1
+        # Guarded like the community walk: a weird blob skips, never aborts.
+        try:
+            for winners, losers in _walk_rest_upgrade_choices(blob):
+                for winner in winners:
+                    for loser in losers:
+                        if winner == loser:
+                            continue
+                        key = (winner, loser)
+                        upgrade_pair_wins[key] = upgrade_pair_wins.get(key, 0) + 1
+        except Exception:
+            logger.warning("smith-choice walk failed for %s", run_hash, exc_info=True)
 
         # Card-reward decisions: count offers/picks per act and record the
         # picked-beats-skipped head-to-heads for the Bradley-Terry fit, for
@@ -974,6 +990,7 @@ def _persist_snapshot(
             "community": cohort_meta.get("community", {}),
             "entity_types": list(by_type.keys()),
             "built_at": now,
+            "snapshot_version": SNAPSHOT_VERSION,
         },
         upsert=True,
     )
@@ -985,6 +1002,16 @@ def _load_snapshot() -> bool:
     coll = _snapshot_coll()
     meta = coll.find_one({"_id": "__meta__"})
     if not meta:
+        return False
+    if meta.get("snapshot_version") != SNAPSHOT_VERSION:
+        # Written by a different code version (e.g. a stale container sharing
+        # the Mongo). Keep whatever this worker already serves rather than
+        # regressing to a snapshot missing fields the readers depend on.
+        logger.warning(
+            "ignoring entity-stats snapshot with version %s (want %s)",
+            meta.get("snapshot_version"),
+            SNAPSHOT_VERSION,
+        )
         return False
     new_cache: dict[tuple[str, str], dict[str, Any]] = {}
     for etype in meta.get("entity_types", []):
@@ -1035,8 +1062,15 @@ def refresh_entity_stats_snapshot() -> int:
     snapshot is younger than _SNAPSHOT_REBUILD_SECONDS. Returns the
     entity count written (0 if skipped)."""
     coll = _snapshot_coll()
-    meta = coll.find_one({"_id": "__meta__"}, {"built_at": 1})
-    if meta and meta.get("built_at"):
+    meta = coll.find_one({"_id": "__meta__"}, {"built_at": 1, "snapshot_version": 1})
+    # Only honor the freshness skip for a snapshot this code version wrote.
+    # A stale writer keeps built_at young forever, which would otherwise pin
+    # the leader on an old-shape snapshot it can never replace.
+    if (
+        meta
+        and meta.get("built_at")
+        and meta.get("snapshot_version") == SNAPSHOT_VERSION
+    ):
         built = meta["built_at"]
         if built.tzinfo is None:
             built = built.replace(tzinfo=timezone.utc)

--- a/contributing/CLAUDE.md
+++ b/contributing/CLAUDE.md
@@ -198,7 +198,7 @@ spire-codex/
 - `POST /api/guides` — Guide submission (Discord webhook, rate-limited)
 - `POST /api/runs` — Run submission / `GET /api/runs/list` (filters: character, win, username, seed, build_id, sort, page, limit) / `GET /api/runs/shared/{hash}` (merges `username` from DB) / `GET /api/runs/stats`
 - `GET /api/runs/leaderboard` — ranked wins-only list (category: fastest|highest_ascension, character, page, limit)
-- `GET /api/runs/scores/{type}`: Bulk Codex Scores + Codex Elo for cards/relics/potions (Bayesian-shrunk win rate mapped 0-100 to S/A/B/C/D/F; non-reward cards + starters excluded; materialized to Mongo by a single leader)
+- `GET /api/runs/scores/{type}`: Bulk Codex Scores + Codex Elo for cards/relics/potions (Bayesian-shrunk win rate mapped 0-100 to S/A/B/C/D/F; non-reward cards + starters excluded; relics accept `?act=1|2|3` for acquisition-act views graded per-act; materialized to Mongo by a single leader)
 - `GET /api/runs/community-stats`: Fun community datasets for `/community-stats` (per-event decision splits, deadliest encounters/events, win rates by ascension/character, records; official content only)
 - `GET /api/runs/leaderboard/rank/{hash}` — rank of one winning run; `POST /api/runs/claim` — attach username to prior runs
 - `GET /api/runs/encounter-stats` — per-encounter aggregates (Mongo-only)

--- a/frontend/app/developers/page.tsx
+++ b/frontend/app/developers/page.tsx
@@ -252,7 +252,7 @@ export default function DevelopersPage() {
                 { method: "GET", path: "/api/runs/shared/{run_hash}", desc: "Single submitted run by hash (rate-limited)" },
                 { method: "GET", path: "/api/runs/stats", desc: "Aggregate community stats (filter by character, ascension, username)" },
                 { method: "GET", path: "/api/runs/community-stats", desc: "Fun community datasets: event decision splits, deadliest encounters, win rates by ascension/character, records" },
-                { method: "GET", path: "/api/runs/scores/{type}", desc: "Codex Score + Codex Elo per entity (cards/relics/potions)" },
+                { method: "GET", path: "/api/runs/scores/{type}", desc: "Codex Score + Codex Elo per entity (cards/relics/potions); relics accept ?act=1|2|3 to rank by acquisition act" },
                 { method: "GET", path: "/api/runs/metrics/{type}", desc: "Dense metrics table: Codex Score, Codex Elo, win rate, pick rate, per-act splits" },
                 { method: "GET", path: "/api/runs/versions", desc: "Distinct game build IDs that have submitted runs" },
                 { method: "POST", path: "/api/feedback", desc: "Submit feedback (Discord webhook)" },

--- a/frontend/app/tier-list/relics/page.tsx
+++ b/frontend/app/tier-list/relics/page.tsx
@@ -44,28 +44,47 @@ const RARITY_FILTERS = [
   { value: "ancient",   label: "Ancient" },
 ];
 
-function relicHref(pool?: string, rarity?: string): string {
+// Acquisition act. "3" folds in the rare later acts. Backend grades each act
+// view against a per-act baseline, so picking up a relic late (in a run that
+// already survived that far) doesn't read as the relic carrying the run.
+const ACT_FILTERS = [
+  { value: "",  label: "All acts" },
+  { value: "1", label: "Act 1" },
+  { value: "2", label: "Act 2" },
+  { value: "3", label: "Act 3" },
+];
+
+function relicHref(pool?: string, rarity?: string, act?: string): string {
   const params = new URLSearchParams();
   if (pool) params.set("pool", pool);
   if (rarity) params.set("rarity", rarity);
+  if (act) params.set("act", act);
   const qs = params.toString();
   return `/tier-list/relics${qs ? `?${qs}` : ""}`;
 }
 
+function parseAct(raw?: string): string {
+  return raw === "1" || raw === "2" || raw === "3" ? raw : "";
+}
+
 interface PageProps {
-  searchParams: Promise<{ pool?: string; rarity?: string }>;
+  searchParams: Promise<{ pool?: string; rarity?: string; act?: string }>;
 }
 
 export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
   const sp = await searchParams;
   const pool = sp.pool?.toLowerCase();
+  const act = parseAct(sp.act);
   const poolLabel = POOL_FILTERS.find((p) => p.value === pool)?.label;
-  const scope = poolLabel && pool ? `${poolLabel} Relic` : "Relic";
+  const actPrefix = act ? `Act ${act} ` : "";
+  const scope = poolLabel && pool ? `${actPrefix}${poolLabel} Relic` : `${actPrefix}Relic`;
   const title = `${scope} Tier List - Relics Ranked - Slay the Spire 2 (sts2) | ${SITE_NAME}`;
-  const description = pool
+  const description = act
+    ? `Slay the Spire 2 (sts2) relics ranked by the win rate of runs that picked them up in Act ${act}, graded against other Act ${act} pickups.`
+    : pool
     ? `${poolLabel} relic tier list for Slay the Spire 2 (sts2). Every relic in the ${pool} pool ranked S through F by community win rate.`
     : "Every Slay the Spire 2 (sts2) relic ranked S through F. Codex Score from community-submitted run win rates with Bayesian shrinkage.";
-  const path = `/tier-list/relics${pool ? `?pool=${pool}` : ""}`;
+  const path = relicHref(pool, undefined, act);
   return {
     title,
     description,
@@ -75,9 +94,9 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
   };
 }
 
-async function fetchData(pool?: string): Promise<{ relics: ApiRelic[]; scores: ScoresMap }> {
+async function fetchData(pool?: string, act?: string): Promise<{ relics: ApiRelic[]; scores: ScoresMap }> {
   const relicsUrl = `${API_INTERNAL}/api/relics${pool ? `?pool=${pool}` : ""}`;
-  const scoresUrl = `${API_INTERNAL}/api/runs/scores/relics`;
+  const scoresUrl = `${API_INTERNAL}/api/runs/scores/relics${act ? `?act=${act}` : ""}`;
   try {
     const [relicsRes, scoresRes] = await Promise.all([
       fetch(relicsUrl, { next: { revalidate: 1800 } }),
@@ -95,10 +114,14 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
   const sp = await searchParams;
   const pool = sp.pool?.toLowerCase();
   const rarity = sp.rarity?.toLowerCase();
-  const { relics, scores } = await fetchData(pool);
+  const act = parseAct(sp.act);
+  const { relics, scores } = await fetchData(pool, act);
 
   const entities: TierEntity[] = relics
     .filter((r) => !rarity || (r.rarity_key ?? "").toLowerCase() === rarity)
+    // Act views rank only relics actually picked up in that act; the rest
+    // would all pile into an Unrated row, so drop them instead.
+    .filter((r) => !act || scores[r.id.toUpperCase()] !== undefined)
     .map((r) => ({
       id: r.id,
       name: r.name,
@@ -107,8 +130,11 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
     }));
 
   const poolLabel = POOL_FILTERS.find((p) => p.value === pool)?.label;
-  const heading = poolLabel && pool ? `${poolLabel} Relic Tier List` : "Relic Tier List";
-  const path = `/tier-list/relics${pool ? `?pool=${pool}` : ""}`;
+  const actPrefix = act ? `Act ${act} ` : "";
+  const heading = poolLabel && pool
+    ? `${actPrefix}${poolLabel} Relic Tier List`
+    : `${actPrefix}Relic Tier List`;
+  const path = relicHref(pool, undefined, act);
 
   // Top-30 by score for ItemList JSON-LD, gives Google a structured
   // ranked list it can render as carousel-style rich results.
@@ -146,9 +172,20 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
         <span className="text-sm text-[var(--text-muted)]">{entities.length.toLocaleString()} relics</span>
       </div>
       <p className="text-sm text-[var(--text-muted)] mb-6">
-        Ranked by <Link href="/leaderboards/scoring" className="text-[var(--accent-gold)] hover:underline">Codex Score</Link>,
-        community win-rate data with Bayesian shrinkage so a 5-pick relic doesn&apos;t outrank a
-        500-pick one. Click any relic for full stats.
+        {act ? (
+          <>
+            Ranked by the win rate of runs that picked each relic up during Act {act},
+            Bayesian-shrunk and graded against other Act {act} pickups, so reaching a
+            later act doesn&apos;t inflate a relic by itself. Smaller samples than the
+            all-acts view. Click any relic for full stats.
+          </>
+        ) : (
+          <>
+            Ranked by <Link href="/leaderboards/scoring" className="text-[var(--accent-gold)] hover:underline">Codex Score</Link>,
+            community win-rate data with Bayesian shrinkage so a 5-pick relic doesn&apos;t outrank a
+            500-pick one. Click any relic for full stats.
+          </>
+        )}
       </p>
 
       {/* Pool (character) filter */}
@@ -158,7 +195,7 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
           return (
             <Link
               key={opt.value || "all"}
-              href={relicHref(opt.value || undefined, rarity)}
+              href={relicHref(opt.value || undefined, rarity, act)}
               className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
                 isActive
                   ? "bg-[var(--accent-gold)]/10 border-[var(--accent-gold)]/40 text-[var(--accent-gold)]"
@@ -171,16 +208,35 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
         })}
       </div>
       {/* Rarity / source filter (Neow/Starter, Shop, Event, Ancient, …) */}
-      <div className="flex flex-wrap gap-1.5 mb-6">
+      <div className="flex flex-wrap gap-1.5 mb-2">
         {RARITY_FILTERS.map((opt) => {
           const isActive = (rarity ?? "") === opt.value;
           return (
             <Link
               key={opt.value || "all-rarities"}
-              href={relicHref(pool, opt.value || undefined)}
+              href={relicHref(pool, opt.value || undefined, act)}
               className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
                 isActive
                   ? "bg-sky-500/10 border-sky-500/40 text-sky-300"
+                  : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
+              }`}
+            >
+              {opt.label}
+            </Link>
+          );
+        })}
+      </div>
+      {/* Acquisition act filter (when in the run the relic was picked up) */}
+      <div className="flex flex-wrap gap-1.5 mb-6">
+        {ACT_FILTERS.map((opt) => {
+          const isActive = act === opt.value;
+          return (
+            <Link
+              key={opt.value || "all-acts"}
+              href={relicHref(pool, rarity, opt.value || undefined)}
+              className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
+                isActive
+                  ? "bg-emerald-500/10 border-emerald-500/40 text-emerald-300"
                   : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
               }`}
             >


### PR DESCRIPTION
Adds acquisition-act filtering to /tier-list/relics, so the tier list can answer which relics actually earn their keep when picked up in a given act.

## Backend
The snapshot walk buckets every relic pickup into Act 1/2/3+ by comparing its global pickup floor (floor_added_to_deck) against the run's act lengths from map_point_history, with run-level dedupe and a per-run guard so a weird blob can't abort a rebuild. The splits ride the snapshot (version bumped to 3) and /api/runs/scores/relics accepts act=1|2|3. Act views grade each relic against a per-act baseline: later-act pickups only happen in runs that already got there, so raw win rates are survivorship-inflated, and comparing act-mates against each other cancels that out. I verified the bucketing end to end against a real run blob; the act assignments match the blob's floors exactly.

## Frontend
A third pill row (All acts / Act 1 / Act 2 / Act 3) on /tier-list/relics, combinable with the existing pool and rarity filters, each act its own indexable URL like the cards color filter. Act views rank only relics actually picked up in that act and the intro explains the per-act grading. The act param is documented on /developers and in contributing/CLAUDE.md.

## Notes
- Carries the snapshot version guard commit from #424 (this branch is based on it since it bumps the version to 3); whichever merges first, the other shrinks or becomes redundant.
- Old run blobs without relic floor data are skipped from act buckets gracefully; they still count in the all-acts view.
- Takes effect after deploy + the first snapshot rebuild.