### PR TITLE
Redis-backed application cache for hot read paths

### DIFF
--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -173,3 +173,25 @@ db_operation_duration = Histogram(
     ["operation"],
     buckets=[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0],
 )
+
+# ── Application cache (Redis) ────────────────────────────────
+# Labeled by key namespace (the part before the first ":"), e.g. stats,
+# leaderboard, run, entity_scores. Errors cover Redis being unreachable or
+# slow; the cache layer is fail-safe so an error is a miss, never a 500.
+cache_hits = Counter(
+    "spire_codex_cache_hits_total",
+    "Application cache hits",
+    ["namespace"],
+)
+
+cache_misses = Counter(
+    "spire_codex_cache_misses_total",
+    "Application cache misses",
+    ["namespace"],
+)
+
+cache_errors = Counter(
+    "spire_codex_cache_errors_total",
+    "Application cache errors (treated as misses)",
+    ["namespace", "operation"],
+)

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -218,6 +218,7 @@ async def claim_runs_endpoint(request: Request):
 @limiter.limit("120/minute")
 def list_runs(
     request: Request,
+    response: Response,
     character: str | None = None,
     win: str | None = None,
     username: str | None = None,
@@ -237,10 +238,44 @@ def list_runs(
     limit: int = 50,
 ):
     """List submitted runs with optional filters, sorting, and pagination."""
+    # Browser/edge caching: new runs arrive constantly, but 30s of staleness
+    # on a browse page is invisible and lets Cloudflare absorb repeat hits.
+    response.headers["Cache-Control"] = "public, max-age=30"
+    # Redis layer (60s TTL): the default landing view and any repeated or
+    # shared search serve from cache; the long tail of unique filter combos
+    # falls through to Mongo, which the bounded counts + indexes keep fast.
+    cache_key = (
+        "runs_list:"
+        + ":".join(
+            str(v if v is not None else "")
+            for v in (
+                character,
+                win,
+                username,
+                seed,
+                sort,
+                build_id,
+                build_ids,
+                players,
+                game_mode,
+                ascension,
+                ascension_min,
+                ascension_max,
+                card,
+                relic,
+                int(today),
+                page,
+                limit,
+            )
+        )
+    )
+    cached = app_cache.get_json(cache_key)
+    if cached is not None:
+        return cached
     if os.environ.get("MONGO_URL", "").strip():
         from ..services.runs_db_mongo import list_runs as _list_runs_mongo
 
-        return _list_runs_mongo(
+        result = _list_runs_mongo(
             character=character,
             win=win,
             username=username,
@@ -259,6 +294,8 @@ def list_runs(
             page=page,
             limit=limit,
         )
+        app_cache.set_json(cache_key, result, ttl_seconds=60)
+        return result
 
     from ..services.runs_db import get_conn
 

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException, Query, Request, Response
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from ..services.runs_db import submit_run, get_stats, claim_runs
+from ..services import cache as app_cache
 from ..services.run_entity_stats import (
     get_all_entity_scores,
     get_community_stats as get_community_fun_stats,
@@ -356,10 +357,20 @@ def get_leaderboard(
     Single-player and multiplayer runs aren't directly comparable, so the
     frontend reads them as disjoint pools.
     """
+    # Redis layer (60s TTL, matching the refresher cycle): one cluster-wide
+    # copy per filter combination instead of per-worker recomputation. Misses
+    # fall straight through to the existing data paths.
+    cache_key = (
+        f"leaderboard:{category}:{(character or '').upper()}:{players or ''}:"
+        f"{game_mode or ''}:{int(today)}:{page}:{limit}"
+    )
+    cached = app_cache.get_json(cache_key)
+    if cached is not None:
+        return cached
     if os.environ.get("MONGO_URL", "").strip():
         from ..services.runs_db_mongo import leaderboard as _lb_mongo
 
-        return _lb_mongo(
+        result = _lb_mongo(
             category=category,
             character=character,
             players=players,
@@ -368,6 +379,8 @@ def get_leaderboard(
             page=page,
             limit=limit,
         )
+        app_cache.set_json(cache_key, result, ttl_seconds=60)
+        return result
 
     from ..services.runs_db import get_conn
 
@@ -412,7 +425,7 @@ def get_leaderboard(
             query_params,
         ).fetchall()
 
-        return {
+        result = {
             "runs": [dict(r) for r in rows],
             "total": total,
             "page": max(page, 1),
@@ -420,6 +433,8 @@ def get_leaderboard(
             "total_pages": (total + per_page - 1) // per_page,
             "category": category,
         }
+        app_cache.set_json(cache_key, result, ttl_seconds=60)
+        return result
 
 
 @router.get("/leaderboard/rank/{run_hash}", tags=["Runs"])
@@ -563,6 +578,14 @@ def get_shared_run(run_hash: str, request: Request):
     """
     using_mongo = bool(os.environ.get("MONGO_URL", "").strip())
 
+    # Redis layer (15min TTL): runs are immutable so this is safe to serve
+    # straight from cache; the short TTL absorbs share-link bursts without
+    # every viewed run squatting in memory forever. 404s are never cached.
+    redis_key = f"run:{run_hash}"
+    redis_cached = app_cache.get_json(redis_key)
+    if redis_cached is not None:
+        return redis_cached
+
     def _attach_username(blob: dict) -> dict:
         if using_mongo:
             from ..services.runs_db_mongo import get_username_for_hash
@@ -584,7 +607,9 @@ def get_shared_run(run_hash: str, request: Request):
 
     cached = _load_run_blob(run_hash)
     if cached is not None:
-        return _attach_username(json.loads(cached))
+        result = _attach_username(json.loads(cached))
+        app_cache.set_json(redis_key, result, ttl_seconds=15 * 60)
+        return result
 
     # Fallback for multiplayer: find sibling player runs by seed.
     if using_mongo:
@@ -625,7 +650,9 @@ def get_shared_run(run_hash: str, request: Request):
             shutil.copy2(sib_file, run_file)
             _load_run_blob.cache_clear()
             with open(run_file, "r", encoding="utf-8") as f:
-                return _attach_username(json.load(f))
+                result = _attach_username(json.load(f))
+            app_cache.set_json(redis_key, result, ttl_seconds=15 * 60)
+            return result
 
     raise HTTPException(status_code=404, detail="Run data not available")
 
@@ -704,7 +731,16 @@ def get_entity_scores(
         raise HTTPException(
             status_code=400, detail="act filtering is only available for relics"
         )
-    return get_all_entity_scores(entity_type, act=act)
+    # Redis layer (5min TTL): hit constantly by tier-list pages and detail
+    # sort columns. Key carries every response-shaping param; extend it if
+    # the endpoint grows new ones (e.g. per-character scoring).
+    cache_key = f"entity_scores:{entity_type}:{act or 'all'}"
+    cached = app_cache.get_json(cache_key)
+    if cached is not None:
+        return cached
+    result = get_all_entity_scores(entity_type, act=act)
+    app_cache.set_json(cache_key, result, ttl_seconds=5 * 60)
+    return result
 
 
 @router.get("/community-stats", tags=["Runs"])
@@ -853,11 +889,23 @@ def get_community_stats(
     `username` to narrow to a single uploader.
 
     Read path:
+      0. Redis (60s TTL, cluster-wide).
       1. Try the materialized stats_summary collection (sub-ms).
       2. If the filter combo isn't in the hot list / hasn't been
          materialized yet, fall through to a process-local TTL cache.
       3. On cache miss, run the live aggregation (slow, ~5-10s).
     """
+    # 0. Redis layer: one cluster-wide copy per filter combo, refreshed on
+    # the same cadence as the refresher cycle. Misses fall through to the
+    # existing chain unchanged.
+    redis_key = (
+        f"stats:{character or ''}:{win or ''}:{ascension or ''}:"
+        f"{game_mode or ''}:{players or ''}:{username or ''}"
+    )
+    redis_cached = app_cache.get_json(redis_key)
+    if redis_cached is not None:
+        return redis_cached
+
     # 1. Materialized view path
     try:
         from ..services.runs_db_mongo import read_stats_summary
@@ -871,6 +919,7 @@ def get_community_stats(
             username=username,
         )
         if materialized is not None:
+            app_cache.set_json(redis_key, materialized, ttl_seconds=60)
             return materialized
     except Exception:
         # Not on the Mongo path (SQLite fallback) — keep going.
@@ -899,6 +948,7 @@ def get_community_stats(
         username=username,
     )
     _stats_fallback_cache[cache_key] = (now, result)
+    app_cache.set_json(redis_key, result, ttl_seconds=60)
 
     # Lazy write-through to stats_summary so subsequent requests for this
     # combo -- on any worker -- serve from the materialized view instead

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -244,29 +244,26 @@ def list_runs(
     # Redis layer (60s TTL): the default landing view and any repeated or
     # shared search serve from cache; the long tail of unique filter combos
     # falls through to Mongo, which the bounded counts + indexes keep fast.
-    cache_key = (
-        "runs_list:"
-        + ":".join(
-            str(v if v is not None else "")
-            for v in (
-                character,
-                win,
-                username,
-                seed,
-                sort,
-                build_id,
-                build_ids,
-                players,
-                game_mode,
-                ascension,
-                ascension_min,
-                ascension_max,
-                card,
-                relic,
-                int(today),
-                page,
-                limit,
-            )
+    cache_key = "runs_list:" + ":".join(
+        str(v if v is not None else "")
+        for v in (
+            character,
+            win,
+            username,
+            seed,
+            sort,
+            build_id,
+            build_ids,
+            players,
+            game_mode,
+            ascension,
+            ascension_min,
+            ascension_max,
+            card,
+            relic,
+            int(today),
+            page,
+            limit,
         )
     )
     cached = app_cache.get_json(cache_key)
@@ -375,6 +372,7 @@ def list_runs(
 @limiter.limit("120/minute")
 def get_leaderboard(
     request: Request,
+    response: Response,
     category: str = "fastest",
     character: str | None = None,
     players: str | None = None,
@@ -394,6 +392,9 @@ def get_leaderboard(
     Single-player and multiplayer runs aren't directly comparable, so the
     frontend reads them as disjoint pools.
     """
+    # Edge/browser caching: 30s of ladder staleness is invisible and lets
+    # Cloudflare absorb repeat hits now that the frontend stopped cache-busting.
+    response.headers["Cache-Control"] = "public, max-age=30"
     # Redis layer (60s TTL, matching the refresher cycle): one cluster-wide
     # copy per filter combination instead of per-worker recomputation. Misses
     # fall straight through to the existing data paths.

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -5,7 +5,7 @@ import os
 import time
 from functools import lru_cache
 from pathlib import Path
-from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi import APIRouter, HTTPException, Query, Request, Response
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from ..services.runs_db import submit_run, get_stats, claim_runs
@@ -670,22 +670,41 @@ def get_entity_run_stats(request: Request, entity_type: str, entity_id: str):
 
 @router.get("/scores/{entity_type}", tags=["Runs"])
 @limiter.limit("60/minute")
-def get_entity_scores(request: Request, entity_type: str):
+def get_entity_scores(
+    request: Request,
+    entity_type: str,
+    act: int | None = Query(
+        None,
+        ge=1,
+        le=3,
+        description=(
+            "Relics only: restrict to pickups made during this act "
+            "(3 includes later acts). Scores are graded against a per-act "
+            "baseline so survivorship into later acts doesn't inflate them."
+        ),
+    ),
+):
     """All Codex Scores for one entity type, keyed by ID.
 
     Each entry carries the 0-100 Codex Score plus picks/wins/win_rate, and
     for cards the Codex Elo (null for entities without one). Cards that are
     never a reward pick (curses, statuses, events, tokens, starters) are
-    excluded. Used by list pages to render the score column / sort by tier
-    without N round-trips to /stats/{type}/{id}. Cached at the same TTL as
-    the per-entity stats since both derive from the same walk.
+    excluded. With `act` set (relics only), stats cover only pickups made
+    during that act, graded against that act's baseline. Used by list pages
+    to render the score column / sort by tier without N round-trips to
+    /stats/{type}/{id}. Cached at the same TTL as the per-entity stats since
+    both derive from the same walk.
     """
     if entity_type not in _ENTITY_STATS_TYPES:
         raise HTTPException(
             status_code=400,
             detail=f"entity_type must be one of {sorted(_ENTITY_STATS_TYPES)}",
         )
-    return get_all_entity_scores(entity_type)
+    if act is not None and entity_type != "relics":
+        raise HTTPException(
+            status_code=400, detail="act filtering is only available for relics"
+        )
+    return get_all_entity_scores(entity_type, act=act)
 
 
 @router.get("/community-stats", tags=["Runs"])

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -360,9 +360,14 @@ def get_leaderboard(
     # Redis layer (60s TTL, matching the refresher cycle): one cluster-wide
     # copy per filter combination instead of per-worker recomputation. Misses
     # fall straight through to the existing data paths.
-    cache_key = (
-        f"leaderboard:{category}:{(character or '').upper()}:{players or ''}:"
-        f"{game_mode or ''}:{int(today)}:{page}:{limit}"
+    cache_key = app_cache.leaderboard_key(
+        category=category,
+        character=character,
+        players=players,
+        game_mode=game_mode,
+        today=today,
+        page=page,
+        limit=limit,
     )
     cached = app_cache.get_json(cache_key)
     if cached is not None:
@@ -734,7 +739,7 @@ def get_entity_scores(
     # Redis layer (5min TTL): hit constantly by tier-list pages and detail
     # sort columns. Key carries every response-shaping param; extend it if
     # the endpoint grows new ones (e.g. per-character scoring).
-    cache_key = f"entity_scores:{entity_type}:{act or 'all'}"
+    cache_key = app_cache.entity_scores_key(entity_type, act=act)
     cached = app_cache.get_json(cache_key)
     if cached is not None:
         return cached
@@ -866,6 +871,26 @@ def start_stats_refresher() -> None:
                         refresh_entity_stats_snapshot()
                     except Exception:
                         pass
+                    # Proactive warm of the entity-scores cache (in-memory
+                    # reads, cheap every cycle) so tier pages serve straight
+                    # from Redis cluster-wide instead of recomputing per
+                    # worker. Includes the per-act relic views.
+                    try:
+                        if app_cache.enabled():
+                            for etype in ("cards", "relics", "potions"):
+                                app_cache.set_json(
+                                    app_cache.entity_scores_key(etype),
+                                    get_all_entity_scores(etype),
+                                    ttl_seconds=app_cache.WARM_TTL_SECONDS,
+                                )
+                            for warm_act in (1, 2, 3):
+                                app_cache.set_json(
+                                    app_cache.entity_scores_key("relics", act=warm_act),
+                                    get_all_entity_scores("relics", act=warm_act),
+                                    ttl_seconds=app_cache.WARM_TTL_SECONDS,
+                                )
+                    except Exception:
+                        pass
             except Exception:
                 # SQLite path or transient failure — sleep and retry.
                 pass
@@ -898,9 +923,13 @@ def get_community_stats(
     # 0. Redis layer: one cluster-wide copy per filter combo, refreshed on
     # the same cadence as the refresher cycle. Misses fall through to the
     # existing chain unchanged.
-    redis_key = (
-        f"stats:{character or ''}:{win or ''}:{ascension or ''}:"
-        f"{game_mode or ''}:{players or ''}:{username or ''}"
+    redis_key = app_cache.stats_key(
+        character=character,
+        win=win,
+        ascension=ascension,
+        game_mode=game_mode,
+        players=players,
+        username=username,
     )
     redis_cached = app_cache.get_json(redis_key)
     if redis_cached is not None:

--- a/backend/app/services/cache.py
+++ b/backend/app/services/cache.py
@@ -1,0 +1,141 @@
+"""Fail-safe Redis application cache.
+
+A thin JSON get/set layer in front of the hot read endpoints (issue #388).
+The cache is always an optimization, never load-bearing:
+
+- `REDIS_URL` unset -> every call no-ops without importing redis at all,
+  so bare-metal dev keeps working with zero new dependencies in play.
+- Redis down, slow, or throwing -> `get_json` returns None (a miss) and
+  writes no-op. Socket timeouts are short (250ms) so a *hung* Redis
+  degrades exactly like a *down* one instead of adding latency.
+- Values are JSON: everything cached here is already a JSON-serializable
+  API response.
+
+Keys are namespaced as "<namespace>:<rest>" (e.g. "run:<hash>",
+"entity_scores:relics:act2"); the namespace becomes the Prometheus label on
+the hit/miss/error counters.
+
+Connections are per-process (uvicorn workers each hold one client), pooled
+by redis-py internally.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+from ..metrics import cache_errors, cache_hits, cache_misses
+
+logger = logging.getLogger(__name__)
+
+_REDIS_URL = os.environ.get("REDIS_URL", "").strip()
+# Short enough that a wedged Redis costs ~250ms once per call site, not
+# request-queue pileups. redis-py raises TimeoutError, which we treat as
+# any other error: count it and miss.
+_SOCKET_TIMEOUT_SECONDS = 0.25
+
+_client: Any = None
+_client_init_failed = False
+
+
+def _namespace(key: str) -> str:
+    return key.split(":", 1)[0]
+
+
+def _get_client() -> Any:
+    """Lazy per-process client; None when disabled or construction failed."""
+    global _client, _client_init_failed
+    if not _REDIS_URL or _client_init_failed:
+        return None
+    if _client is None:
+        try:
+            import redis
+
+            _client = redis.Redis.from_url(
+                _REDIS_URL,
+                socket_timeout=_SOCKET_TIMEOUT_SECONDS,
+                socket_connect_timeout=_SOCKET_TIMEOUT_SECONDS,
+                decode_responses=True,
+            )
+        except Exception:
+            # Bad URL or redis-py missing: disable for this process rather
+            # than retrying (and logging) on every request.
+            logger.warning(
+                "app cache disabled: redis client init failed", exc_info=True
+            )
+            _client_init_failed = True
+            return None
+    return _client
+
+
+def enabled() -> bool:
+    """True when a cache backend is configured (not necessarily reachable)."""
+    return bool(_REDIS_URL) and not _client_init_failed
+
+
+def get_json(key: str) -> Any:
+    """Cached value for `key`, or None on miss/disabled/error."""
+    client = _get_client()
+    if client is None:
+        return None
+    ns = _namespace(key)
+    try:
+        raw = client.get(key)
+    except Exception:
+        cache_errors.labels(namespace=ns, operation="get").inc()
+        return None
+    if raw is None:
+        cache_misses.labels(namespace=ns).inc()
+        return None
+    try:
+        value = json.loads(raw)
+    except ValueError:
+        cache_errors.labels(namespace=ns, operation="decode").inc()
+        return None
+    cache_hits.labels(namespace=ns).inc()
+    return value
+
+
+def set_json(key: str, value: Any, ttl_seconds: int) -> None:
+    """Store `value` under `key` for `ttl_seconds`. No-ops on any failure."""
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        client.set(key, json.dumps(value), ex=ttl_seconds)
+    except Exception:
+        cache_errors.labels(namespace=_namespace(key), operation="set").inc()
+
+
+def delete(key: str) -> None:
+    """Drop one key. No-ops on any failure."""
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        client.delete(key)
+    except Exception:
+        cache_errors.labels(namespace=_namespace(key), operation="delete").inc()
+
+
+def delete_pattern(pattern: str) -> int:
+    """Drop every key matching a glob pattern (SCAN-based, non-blocking).
+
+    For deploy-time invalidation of long-TTL namespaces, e.g.
+    delete_pattern("entity_scores:*"). Returns keys deleted (0 on failure).
+    """
+    client = _get_client()
+    if client is None:
+        return 0
+    deleted = 0
+    try:
+        for batch_key in client.scan_iter(match=pattern, count=500):
+            client.delete(batch_key)
+            deleted += 1
+    except Exception:
+        cache_errors.labels(
+            namespace=_namespace(pattern), operation="delete_pattern"
+        ).inc()
+    return deleted

--- a/backend/app/services/cache.py
+++ b/backend/app/services/cache.py
@@ -39,9 +39,53 @@ _SOCKET_TIMEOUT_SECONDS = 0.25
 _client: Any = None
 _client_init_failed = False
 
+# TTL for keys the leader refresher pre-warms every cycle (60s). Generous on
+# purpose: it's a safety net against a dead refresher, not the freshness
+# mechanism. Each cycle overwrites the key with fresh data, so users
+# normally never see a miss OR data older than one cycle.
+WARM_TTL_SECONDS = 15 * 60
+
 
 def _namespace(key: str) -> str:
     return key.split(":", 1)[0]
+
+
+# ── Key builders ─────────────────────────────────────────────────────────
+# Shared by the read routes (lazy fill on miss) and the leader refresher
+# (proactive warm every cycle) so the two can never drift apart.
+
+
+def stats_key(
+    character: str | None = None,
+    win: str | None = None,
+    ascension: str | None = None,
+    game_mode: str | None = None,
+    players: str | None = None,
+    username: str | None = None,
+) -> str:
+    return (
+        f"stats:{character or ''}:{win or ''}:{ascension or ''}:"
+        f"{game_mode or ''}:{players or ''}:{username or ''}"
+    )
+
+
+def leaderboard_key(
+    category: str = "fastest",
+    character: str | None = None,
+    players: str | None = None,
+    game_mode: str | None = None,
+    today: bool = False,
+    page: int = 1,
+    limit: int = 50,
+) -> str:
+    return (
+        f"leaderboard:{category}:{(character or '').upper()}:{players or ''}:"
+        f"{game_mode or ''}:{int(today)}:{page}:{limit}"
+    )
+
+
+def entity_scores_key(entity_type: str, act: int | None = None) -> str:
+    return f"entity_scores:{entity_type}:{act or 'all'}"
 
 
 def _get_client() -> Any:

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -136,7 +136,8 @@ SNAPSHOT_COLLECTION_NAME = "entity_stats_snapshot"
 # Mongo) clobbering the snapshot: loaders reject a mismatched version and
 # keep serving what they have, and the leader rebuilds right over it instead
 # of trusting its freshness. Version 2 = elo + base/upg + cohorts + community.
-SNAPSHOT_VERSION = 2
+# Version 3 adds per-act relic pickup splits (act_picks / act_wins).
+SNAPSHOT_VERSION = 3
 # Leader rebuilds the heavy walk at most this often.
 _SNAPSHOT_REBUILD_SECONDS = 10 * 60
 # Workers reload the snapshot from Mongo this often (cheap read).
@@ -791,6 +792,48 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
         except Exception:
             logger.warning("smith-choice walk failed for %s", run_hash, exc_info=True)
 
+        # Relic acquisition act: bucket each relic pickup into A1/A2/A3+ by
+        # comparing its global pickup floor (floor_added_to_deck) against this
+        # run's act lengths from map_point_history. Powers the act filter on
+        # the relic tier list. Acts past the third fold into the last bucket.
+        try:
+            act_floors_list = blob.get("map_point_history") or []
+            if act_floors_list:
+                bounds: list[int] = []
+                running = 0
+                for act_floors in act_floors_list:
+                    running += len(act_floors or [])
+                    bounds.append(running)
+                seen_relic_acts: set[tuple[str, int]] = set()
+                for player in blob.get("players") or []:
+                    for rel in player.get("relics") or []:
+                        fl = rel.get("floor_added_to_deck")
+                        stripped = _strip_prefix(rel.get("id", ""))
+                        if (
+                            not stripped
+                            or stripped[0] != "relics"
+                            or not isinstance(fl, (int, float))
+                            or fl < 1
+                        ):
+                            continue
+                        bucket = _ACT_BUCKETS - 1
+                        for i, bound in enumerate(bounds):
+                            if fl <= bound:
+                                bucket = min(i, _ACT_BUCKETS - 1)
+                                break
+                        seen_relic_acts.add((stripped[1], bucket))
+                for rid, bucket in seen_relic_acts:
+                    agg = new_cache.get(("relics", rid))
+                    if agg is None:
+                        continue
+                    arr_p = agg.setdefault("act_picks", [0] * _ACT_BUCKETS)
+                    arr_w = agg.setdefault("act_wins", [0] * _ACT_BUCKETS)
+                    arr_p[bucket] += 1
+                    if is_win:
+                        arr_w[bucket] += 1
+        except Exception:
+            logger.warning("relic act walk failed for %s", run_hash, exc_info=True)
+
         # Card-reward decisions: count offers/picks per act and record the
         # picked-beats-skipped head-to-heads for the Bradley-Terry fit, for
         # the all-runs pass AND every cohort this run belongs to.
@@ -970,6 +1013,10 @@ def _persist_snapshot(
             entry["base"] = agg["base"]
         if agg.get("upg") is not None:
             entry["upg"] = agg["upg"]
+        # Per-act pickup splits (relics only).
+        if agg.get("act_picks") is not None:
+            entry["act_picks"] = agg["act_picks"]
+            entry["act_wins"] = agg.get("act_wins") or [0] * _ACT_BUCKETS
         by_type.setdefault(etype, []).append(entry)
     now = datetime.now(timezone.utc)
     for etype, entities in by_type.items():
@@ -1042,6 +1089,9 @@ def _load_snapshot() -> bool:
                 agg["base"] = e["base"]
             if e.get("upg") is not None:
                 agg["upg"] = e["upg"]
+            if e.get("act_picks") is not None:
+                agg["act_picks"] = e["act_picks"]
+                agg["act_wins"] = e.get("act_wins") or [0] * _ACT_BUCKETS
             new_cache[(etype, e["id"])] = agg
     _apply_cache(
         new_cache,
@@ -1169,7 +1219,9 @@ def get_community_stats() -> dict[str, Any]:
     return _community_stats or community_stats.empty()
 
 
-def get_all_entity_scores(entity_type: str) -> dict[str, dict[str, Any]]:
+def get_all_entity_scores(
+    entity_type: str, act: int | None = None
+) -> dict[str, dict[str, Any]]:
     """All entities of one type, keyed by ID, with score + counts + elo.
 
     Drives list-page tier sorting and the (planned) tooltip-widget
@@ -1179,8 +1231,17 @@ def get_all_entity_scores(entity_type: str) -> dict[str, dict[str, Any]]:
     `elo` is the Codex Elo (revealed-preference rating) where it exists, else
     null. It only exists for reward-offered cards, so starters and upgraded
     variants are null — that's the basis for the dual Score/Elo tier view.
+
+    `act` (relics only, 1-3 where 3 folds in later acts) restricts the stats
+    to pickups made during that act: picks/wins/score come from the act
+    bucket, graded against a per-act baseline. Later-act pickups only happen
+    in runs that already got there, so their raw win rates are survivorship-
+    inflated; comparing act-mates against each other cancels that out.
+    Entities never picked up in that act are omitted.
     """
     _maybe_rebuild()
+    if act is not None:
+        return _entity_scores_for_act(entity_type, act)
     baseline = _type_baseline(entity_type)
     # Cards: drop non-reward colors (curse/status/event/quest/token) AND
     # starters (Basic rarity). Neither is reward-pickable, so a tier "rating"
@@ -1206,6 +1267,43 @@ def get_all_entity_scores(entity_type: str) -> dict[str, dict[str, Any]]:
             "picks": picks,
             "wins": wins,
             "win_rate": round(wins / picks * 100, 1) if picks else 0.0,
+        }
+    return out
+
+
+def _entity_scores_for_act(entity_type: str, act: int) -> dict[str, dict[str, Any]]:
+    """Scores restricted to pickups made during one act (1-based; 3 = act 3+).
+
+    Same shape as the all-acts response (`elo` stays null: Codex Elo is a
+    card-reward signal, not a relic one). The baseline is the pick-weighted
+    average win rate of every pickup in that act, so each entity is graded
+    against its act-mates rather than the global pool.
+    """
+    idx = min(max(act, 1), _ACT_BUCKETS) - 1
+    total_picks = total_wins = 0
+    for (etype, _), agg in _cache.items():
+        if etype != entity_type:
+            continue
+        act_picks = agg.get("act_picks")
+        if act_picks:
+            total_picks += act_picks[idx]
+            total_wins += (agg.get("act_wins") or [0] * _ACT_BUCKETS)[idx]
+    baseline = (total_wins / total_picks) if total_picks else _baseline_win_rate()
+    out: dict[str, dict[str, Any]] = {}
+    for (etype, eid), agg in _cache.items():
+        if etype != entity_type:
+            continue
+        act_picks = agg.get("act_picks")
+        if not act_picks or not act_picks[idx]:
+            continue
+        picks = act_picks[idx]
+        wins = (agg.get("act_wins") or [0] * _ACT_BUCKETS)[idx]
+        out[eid] = {
+            "score": _compute_score(wins, picks, baseline),
+            "elo": None,
+            "picks": picks,
+            "wins": wins,
+            "win_rate": round(wins / picks * 100, 1),
         }
     return out
 

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -131,6 +131,12 @@ _RUNS_DIR = (
 # walking the files itself — this is what stops N workers each pegging a
 # CPU rebuilding the same data. Mirrors the stats_summary pattern.
 SNAPSHOT_COLLECTION_NAME = "entity_stats_snapshot"
+# Bump whenever the snapshot shape changes (fields the readers depend on).
+# Guards against an out-of-date writer (e.g. a stale container sharing the
+# Mongo) clobbering the snapshot: loaders reject a mismatched version and
+# keep serving what they have, and the leader rebuilds right over it instead
+# of trusting its freshness. Version 2 = elo + base/upg + cohorts + community.
+SNAPSHOT_VERSION = 2
 # Leader rebuilds the heavy walk at most this often.
 _SNAPSHOT_REBUILD_SECONDS = 10 * 60
 # Workers reload the snapshot from Mongo this often (cheap read).
@@ -689,15 +695,21 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
             logger.warning("skipping unreadable run %s: %s", run_hash, e)
             continue
 
-        # Community / fun stats, accumulated from the same blob.
-        community_stats.accumulate(
-            community_acc,
-            blob,
-            run_hash=run_hash,
-            is_win=is_win,
-            character=character,
-            ascension=row.get("ascension") or 0,
-        )
+        # Community / fun stats, accumulated from the same blob. Guarded so
+        # one malformed blob can't abort the whole snapshot rebuild.
+        try:
+            community_stats.accumulate(
+                community_acc,
+                blob,
+                run_hash=run_hash,
+                is_win=is_win,
+                character=character,
+                ascension=row.get("ascension") or 0,
+            )
+        except Exception:
+            logger.warning(
+                "community-stats accumulate failed for %s", run_hash, exc_info=True
+            )
 
         # Dedupe per-run: a deck with 5 Strikes still only counts ONE
         # pick of "this run had Strike". We count run-level membership
@@ -767,13 +779,17 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
 
         # Rest-site Smith decisions: the upgraded card beats the other
         # eligible-but-unupgraded cards in the deck. Feeds the Upgrade Elo.
-        for winners, losers in _walk_rest_upgrade_choices(blob):
-            for winner in winners:
-                for loser in losers:
-                    if winner == loser:
-                        continue
-                    key = (winner, loser)
-                    upgrade_pair_wins[key] = upgrade_pair_wins.get(key, 0) + 1
+        # Guarded like the community walk: a weird blob skips, never aborts.
+        try:
+            for winners, losers in _walk_rest_upgrade_choices(blob):
+                for winner in winners:
+                    for loser in losers:
+                        if winner == loser:
+                            continue
+                        key = (winner, loser)
+                        upgrade_pair_wins[key] = upgrade_pair_wins.get(key, 0) + 1
+        except Exception:
+            logger.warning("smith-choice walk failed for %s", run_hash, exc_info=True)
 
         # Card-reward decisions: count offers/picks per act and record the
         # picked-beats-skipped head-to-heads for the Bradley-Terry fit, for
@@ -974,6 +990,7 @@ def _persist_snapshot(
             "community": cohort_meta.get("community", {}),
             "entity_types": list(by_type.keys()),
             "built_at": now,
+            "snapshot_version": SNAPSHOT_VERSION,
         },
         upsert=True,
     )
@@ -985,6 +1002,16 @@ def _load_snapshot() -> bool:
     coll = _snapshot_coll()
     meta = coll.find_one({"_id": "__meta__"})
     if not meta:
+        return False
+    if meta.get("snapshot_version") != SNAPSHOT_VERSION:
+        # Written by a different code version (e.g. a stale container sharing
+        # the Mongo). Keep whatever this worker already serves rather than
+        # regressing to a snapshot missing fields the readers depend on.
+        logger.warning(
+            "ignoring entity-stats snapshot with version %s (want %s)",
+            meta.get("snapshot_version"),
+            SNAPSHOT_VERSION,
+        )
         return False
     new_cache: dict[tuple[str, str], dict[str, Any]] = {}
     for etype in meta.get("entity_types", []):
@@ -1035,8 +1062,15 @@ def refresh_entity_stats_snapshot() -> int:
     snapshot is younger than _SNAPSHOT_REBUILD_SECONDS. Returns the
     entity count written (0 if skipped)."""
     coll = _snapshot_coll()
-    meta = coll.find_one({"_id": "__meta__"}, {"built_at": 1})
-    if meta and meta.get("built_at"):
+    meta = coll.find_one({"_id": "__meta__"}, {"built_at": 1, "snapshot_version": 1})
+    # Only honor the freshness skip for a snapshot this code version wrote.
+    # A stale writer keeps built_at young forever, which would otherwise pin
+    # the leader on an old-shape snapshot it can never replace.
+    if (
+        meta
+        and meta.get("built_at")
+        and meta.get("snapshot_version") == SNAPSHOT_VERSION
+    ):
         built = meta["built_at"]
         if built.tzinfo is None:
             built = built.replace(tzinfo=timezone.utc)

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -163,6 +163,45 @@ def _ensure_indexes(coll) -> None:
     coll.create_index([("ascension", DESCENDING), ("run_time", ASCENDING)])
     coll.create_index([("character", ASCENDING), ("submitted_at", DESCENDING)])
     coll.create_index([("character", ASCENDING), ("run_time", ASCENDING)])
+    # /api/runs/leaderboard real traffic: the frontend always sends
+    # players=single and game_mode=standard, so the ladders need compounds
+    # with those equality fields ahead of the sort key.
+    coll.create_index(
+        [
+            ("win", ASCENDING),
+            ("game_mode", ASCENDING),
+            ("player_count", ASCENDING),
+            ("run_time", ASCENDING),
+        ]
+    )
+    coll.create_index(
+        [
+            ("win", ASCENDING),
+            ("game_mode", ASCENDING),
+            ("player_count", ASCENDING),
+            ("ascension", DESCENDING),
+            ("run_time", ASCENDING),
+        ]
+    )
+    coll.create_index(
+        [
+            ("win", ASCENDING),
+            ("game_mode", ASCENDING),
+            ("character", ASCENDING),
+            ("player_count", ASCENDING),
+            ("run_time", ASCENDING),
+        ]
+    )
+    coll.create_index(
+        [
+            ("win", ASCENDING),
+            ("game_mode", ASCENDING),
+            ("character", ASCENDING),
+            ("player_count", ASCENDING),
+            ("ascension", DESCENDING),
+            ("run_time", ASCENDING),
+        ]
+    )
     coll.create_index([("user_id", ASCENDING), ("submitted_at", DESCENDING)])
     # Backfill query on sign-in matches runs by submitter steam_id / discord_id.
     coll.create_index([("steam_id", ASCENDING)])
@@ -1261,11 +1300,14 @@ def _leaderboard_summary_coll():
 def _leaderboard_key(
     category: str = "fastest",
     character: str | None = None,
+    players: str | None = None,
+    game_mode: str | None = None,
 ) -> str:
     """Composite cache key for leaderboard_summary docs. Mirrors the
-    HOT_LEADERBOARD_COMBOS shape -- only (category, character) so the
-    common per-character ladder is O(1)."""
-    return f"{category}|{character or '_'}"
+    HOT_LEADERBOARD_COMBOS shape: (category, character, players,
+    game_mode), covering both the bare API default and the combo the
+    frontend actually sends (players=single, game_mode=standard)."""
+    return f"{category}|{character or '_'}|{players or '_'}|{game_mode or '_'}"
 
 
 def _lease_coll():
@@ -1342,12 +1384,13 @@ HOT_FILTER_COMBOS: list[dict] = [
 # query, which the new sort indexes already keep at ~500ms.
 _LEADERBOARD_CATEGORIES = ("fastest", "highest_ascension")
 _LEADERBOARD_CHARACTERS = ("IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT")
+# Two variants per (category, character): the bare API default, and the
+# players=single + game_mode=standard combo the frontend always sends.
 HOT_LEADERBOARD_COMBOS: list[dict] = [
-    {"category": cat} for cat in _LEADERBOARD_CATEGORIES
-] + [
-    {"category": cat, "character": ch}
+    {"category": cat, "character": ch, "players": pl, "game_mode": gm}
     for cat in _LEADERBOARD_CATEGORIES
-    for ch in _LEADERBOARD_CHARACTERS
+    for ch in (None, *_LEADERBOARD_CHARACTERS)
+    for (pl, gm) in ((None, None), ("single", "standard"))
 ]
 
 
@@ -1426,30 +1469,47 @@ def refresh_leaderboard_summary() -> int:
     written = 0
     for combo in HOT_LEADERBOARD_COMBOS:
         try:
+            category = combo.get("category", "fastest")
+            character = combo.get("character")
+            players = combo.get("players")
+            game_mode = combo.get("game_mode")
             result = _leaderboard_live(
-                category=combo.get("category", "fastest"),
-                character=combo.get("character"),
-                players=None,
-                game_mode=None,
+                category=category,
+                character=character,
+                players=players,
+                game_mode=game_mode,
                 today=False,
                 page=1,
                 limit=50,
             )
             key = _leaderboard_key(
-                category=combo.get("category", "fastest"),
-                character=combo.get("character"),
+                category=category,
+                character=character,
+                players=players,
+                game_mode=game_mode,
             )
             doc = {**result, "_id": key, "updated_at": datetime.now(timezone.utc)}
             summary.replace_one({"_id": key}, doc, upsert=True)
-            # Proactive warm, mirroring refresh_stats_summary above.
-            app_cache.set_json(
-                app_cache.leaderboard_key(
-                    category=combo.get("category", "fastest"),
-                    character=combo.get("character"),
-                ),
-                result,
-                ttl_seconds=app_cache.WARM_TTL_SECONDS,
-            )
+            # Proactive Redis warm with route-shaped keys: once for the API
+            # default page size and once sliced to the frontend's 20.
+            for warm_limit in (50, 20):
+                sliced = {
+                    **result,
+                    "runs": result["runs"][:warm_limit],
+                    "per_page": warm_limit,
+                    "total_pages": (result["total"] + warm_limit - 1) // warm_limit,
+                }
+                app_cache.set_json(
+                    app_cache.leaderboard_key(
+                        category=category,
+                        character=character,
+                        players=players,
+                        game_mode=game_mode,
+                        limit=warm_limit,
+                    ),
+                    sliced,
+                    ttl_seconds=app_cache.WARM_TTL_SECONDS,
+                )
             written += 1
         except Exception:
             pass
@@ -1667,21 +1727,25 @@ def leaderboard(
          directly. The new sort indexes keep this at ~500ms even when the
          summary doesn't cover the combo.
     """
-    # Fast path: serve from the materialized summary if this is the
-    # default ladder view and the combo is one we materialize.
-    if (
-        not today
-        and page == 1
-        and limit == 50
-        and players is None
-        and game_mode is None
-    ):
+    # Fast path: serve from the materialized summary when the combo is one
+    # we materialize (find_one misses otherwise and we fall to live). Docs
+    # store 50 rows, so any page-1 request up to that size can be sliced.
+    if not today and page == 1 and limit <= 50:
         try:
-            key = _leaderboard_key(category=category, character=character)
+            key = _leaderboard_key(
+                category=category,
+                character=character,
+                players=players,
+                game_mode=game_mode,
+            )
             doc = _leaderboard_summary_coll().find_one({"_id": key})
             if doc:
                 doc.pop("_id", None)
                 doc.pop("updated_at", None)
+                if limit < 50:
+                    doc["runs"] = doc.get("runs", [])[:limit]
+                    doc["per_page"] = limit
+                    doc["total_pages"] = (doc.get("total", 0) + limit - 1) // limit
                 return doc
         except Exception:
             pass

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -45,6 +45,7 @@ from pymongo import ASCENDING, DESCENDING, MongoClient
 from pymongo.errors import DuplicateKeyError
 
 from ..metrics import db_operations, db_operation_duration
+from . import cache as app_cache
 
 OFFICIAL_CHARACTERS = {"IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"}
 
@@ -1394,6 +1395,14 @@ def refresh_stats_summary() -> int:
             key = _filter_key(**filters)
             doc = {**result, "_id": key, "updated_at": datetime.now(timezone.utc)}
             summary.replace_one({"_id": key}, doc, upsert=True)
+            # Proactive warm: write the fresh result straight into Redis so
+            # readers hit the cache instead of Mongo. Refreshed every cycle;
+            # the long TTL is only a safety net if this loop dies.
+            app_cache.set_json(
+                app_cache.stats_key(**filters),
+                result,
+                ttl_seconds=app_cache.WARM_TTL_SECONDS,
+            )
             written += 1
         except Exception:
             # Best-effort; if one filter combo fails, keep going.
@@ -1425,6 +1434,15 @@ def refresh_leaderboard_summary() -> int:
             )
             doc = {**result, "_id": key, "updated_at": datetime.now(timezone.utc)}
             summary.replace_one({"_id": key}, doc, upsert=True)
+            # Proactive warm, mirroring refresh_stats_summary above.
+            app_cache.set_json(
+                app_cache.leaderboard_key(
+                    category=combo.get("category", "fastest"),
+                    character=combo.get("character"),
+                ),
+                result,
+                ttl_seconds=app_cache.WARM_TTL_SECONDS,
+            )
             written += 1
         except Exception:
             pass

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -156,6 +156,13 @@ def _ensure_indexes(coll) -> None:
     coll.create_index([("deck.id", ASCENDING)])
     coll.create_index([("relics.id", ASCENDING)])
     coll.create_index([("killed_by", ASCENDING)])
+    # /api/runs/list hot shapes: filter+sort compounds so Mongo never
+    # in-memory-sorts a 40k-doc subset, plus seed for anchored prefix search.
+    coll.create_index([("seed", ASCENDING)])
+    coll.create_index([("run_time", ASCENDING)])
+    coll.create_index([("ascension", DESCENDING), ("run_time", ASCENDING)])
+    coll.create_index([("character", ASCENDING), ("submitted_at", DESCENDING)])
+    coll.create_index([("character", ASCENDING), ("run_time", ASCENDING)])
     coll.create_index([("user_id", ASCENDING), ("submitted_at", DESCENDING)])
     # Backfill query on sign-in matches runs by submitter steam_id / discord_id.
     coll.create_index([("steam_id", ASCENDING)])
@@ -1563,7 +1570,12 @@ def list_runs(
     if username:
         q["username"] = {"$regex": username, "$options": "i"}
     if seed:
-        q["seed"] = {"$regex": seed, "$options": "i"}
+        # Anchored prefix, case-sensitive: uses the seed index instead of
+        # scanning every document. Daily seeds are date-prefixed so the
+        # common "find today's daily" search stays a prefix match.
+        import re as _re
+
+        q["seed"] = {"$regex": "^" + _re.escape(seed)}
     if build_ids:
         q["build_id"] = {"$in": [b for b in build_ids.split(",") if b]}
     elif build_id:
@@ -1610,7 +1622,14 @@ def list_runs(
     }
     sort_clause = sort_map.get(sort or "date", [("submitted_at", -1)])
 
-    total = coll.count_documents(q)
+    # Counting was the hidden cost: count_documents({}) walks all 216k+
+    # heavyweight docs (~8s). Unfiltered uses the instant metadata count;
+    # filtered counts stop at 10k, which caps pagination far beyond what
+    # anyone pages through anyway.
+    if q:
+        total = coll.count_documents(q, limit=10_000)
+    else:
+        total = coll.estimated_document_count()
     per_page = min(limit, 100)
     offset = (max(page, 1) - 1) * per_page
     cursor = (
@@ -1717,7 +1736,14 @@ def _leaderboard_live(
     else:
         sort_clause = [("run_time", 1)]
 
-    total = coll.count_documents(q)
+    # Counting was the hidden cost: count_documents({}) walks all 216k+
+    # heavyweight docs (~8s). Unfiltered uses the instant metadata count;
+    # filtered counts stop at 10k, which caps pagination far beyond what
+    # anyone pages through anyway.
+    if q:
+        total = coll.count_documents(q, limit=10_000)
+    else:
+        total = coll.estimated_document_count()
     per_page = min(limit, 100)
     offset = (max(page, 1) - 1) * per_page
     cursor = (

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ libsql==0.1.11
 pymongo==4.10.1
 python-multipart==0.0.20
 boto3>=1.34,<2
+redis==5.2.1

--- a/contributing/CLAUDE.md
+++ b/contributing/CLAUDE.md
@@ -198,7 +198,7 @@ spire-codex/
 - `POST /api/guides` — Guide submission (Discord webhook, rate-limited)
 - `POST /api/runs` — Run submission / `GET /api/runs/list` (filters: character, win, username, seed, build_id, sort, page, limit) / `GET /api/runs/shared/{hash}` (merges `username` from DB) / `GET /api/runs/stats`
 - `GET /api/runs/leaderboard` — ranked wins-only list (category: fastest|highest_ascension, character, page, limit)
-- `GET /api/runs/scores/{type}`: Bulk Codex Scores + Codex Elo for cards/relics/potions (Bayesian-shrunk win rate mapped 0-100 to S/A/B/C/D/F; non-reward cards + starters excluded; materialized to Mongo by a single leader)
+- `GET /api/runs/scores/{type}`: Bulk Codex Scores + Codex Elo for cards/relics/potions (Bayesian-shrunk win rate mapped 0-100 to S/A/B/C/D/F; non-reward cards + starters excluded; relics accept `?act=1|2|3` for acquisition-act views graded per-act; materialized to Mongo by a single leader)
 - `GET /api/runs/community-stats`: Fun community datasets for `/community-stats` (per-event decision splits, deadliest encounters/events, win rates by ascension/character, records; official content only)
 - `GET /api/runs/leaderboard/rank/{hash}` — rank of one winning run; `POST /api/runs/claim` — attach username to prior runs
 - `GET /api/runs/encounter-stats` — per-encounter aggregates (Mongo-only)

--- a/docker-compose.beta.yml
+++ b/docker-compose.beta.yml
@@ -40,6 +40,26 @@ services:
       - FRONTEND_URL=${FRONTEND_URL:-https://beta.spire-codex.com}
       - SPIRE_CODEX_PUBLIC_BASE=${SPIRE_CODEX_PUBLIC_BASE:-https://beta.spire-codex.com}
       - ENVIRONMENT=${ENVIRONMENT:-production}
+      # Application cache (issue #388). Container name, not the "redis"
+      # service alias: prod and beta share the external nginx_web-network,
+      # so a bare alias would be ambiguous between the two stacks.
+      - REDIS_URL=${REDIS_URL:-redis://spire-codex-beta-redis:6379/0}
+    depends_on:
+      - redis
+    networks:
+      - nginx_web-network
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  redis:
+    image: redis:7-alpine
+    container_name: spire-codex-beta-redis
+    # Cache only: LRU eviction, no persistence; rebuildable on miss.
+    command: redis-server --maxmemory 128mb --maxmemory-policy allkeys-lru --appendonly no --save ""
+    restart: unless-stopped
     networks:
       - nginx_web-network
     logging:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -102,7 +102,7 @@ services:
     # Cache only: hard memory cap with LRU eviction, no persistence (no AOF,
     # no RDB snapshots). Everything in here is rebuildable from Mongo / the
     # run files on a miss, so losing it on restart costs one warmup, not data.
-    command: redis-server --maxmemory 512mb --maxmemory-policy allkeys-lru --appendonly no --save ""
+    command: redis-server --maxmemory 2gb --maxmemory-policy allkeys-lru --appendonly no --save ""
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -58,6 +58,12 @@ services:
       # path. Falls through to local /data/runs.db SQLite otherwise
       # (the current state while the migration is in progress).
       - MONGO_URL=${MONGO_URL:-}
+      # Application cache (issue #388). Fail-safe: unset or unreachable ->
+      # cache calls no-op and the existing data paths run unchanged. Uses the
+      # container name (not the service alias) because prod and beta share
+      # the external nginx_web-network and a bare "redis" alias would be
+      # ambiguous between the two stacks.
+      - REDIS_URL=${REDIS_URL:-redis://spire-codex-redis:6379/0}
       # User accounts (Steam/Discord OAuth + JWT sessions). Values live
       # in the host .env; passed through so the auth endpoints work.
       - JWT_SECRET=${JWT_SECRET:-}
@@ -78,6 +84,31 @@ services:
       # to node_exporter (`node_cpu_*`, `node_memory_*`) or cAdvisor
       # (`container_cpu_*`, `container_memory_*`).
       - PROMETHEUS_MULTIPROC_DIR=/tmp/prom_multiproc
+    # Ordering only (no health condition): the backend must boot fine with
+    # Redis down, since the cache layer is fail-safe by design.
+    depends_on:
+      - redis
+    networks:
+      - nginx_web-network
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  redis:
+    image: redis:7-alpine
+    container_name: spire-codex-redis
+    # Cache only: hard memory cap with LRU eviction, no persistence (no AOF,
+    # no RDB snapshots). Everything in here is rebuildable from Mongo / the
+    # run files on a miss, so losing it on restart costs one warmup, not data.
+    command: redis-server --maxmemory 512mb --maxmemory-policy allkeys-lru --appendonly no --save ""
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
     networks:
       - nginx_web-network
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,22 @@ services:
       - GITHUB_APP_INSTALLATION_ID=${GITHUB_APP_INSTALLATION_ID:-}
       - GITHUB_APP_REPO=${GITHUB_APP_REPO:-}
       - GITHUB_APP_PRIVATE_KEY_PATH=${GITHUB_APP_PRIVATE_KEY_PATH:-/secrets/knowledge-demon.private-key.pem}
+      # Application cache (issue #388). Unset -> every cache call no-ops and
+      # the existing data paths run unchanged.
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
+    depends_on:
+      - redis
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  redis:
+    image: redis:7-alpine
+    # Cache only: hard memory cap with LRU eviction, no persistence.
+    # Everything in here is rebuildable from Mongo / the run files on miss.
+    command: redis-server --maxmemory 128mb --maxmemory-policy allkeys-lru --appendonly no --save ""
     logging:
       driver: json-file
       options:

--- a/frontend/app/developers/page.tsx
+++ b/frontend/app/developers/page.tsx
@@ -252,7 +252,7 @@ export default function DevelopersPage() {
                 { method: "GET", path: "/api/runs/shared/{run_hash}", desc: "Single submitted run by hash (rate-limited)" },
                 { method: "GET", path: "/api/runs/stats", desc: "Aggregate community stats (filter by character, ascension, username)" },
                 { method: "GET", path: "/api/runs/community-stats", desc: "Fun community datasets: event decision splits, deadliest encounters, win rates by ascension/character, records" },
-                { method: "GET", path: "/api/runs/scores/{type}", desc: "Codex Score + Codex Elo per entity (cards/relics/potions)" },
+                { method: "GET", path: "/api/runs/scores/{type}", desc: "Codex Score + Codex Elo per entity (cards/relics/potions); relics accept ?act=1|2|3 to rank by acquisition act" },
                 { method: "GET", path: "/api/runs/metrics/{type}", desc: "Dense metrics table: Codex Score, Codex Elo, win rate, pick rate, per-act splits" },
                 { method: "GET", path: "/api/runs/versions", desc: "Distinct game build IDs that have submitted runs" },
                 { method: "POST", path: "/api/feedback", desc: "Submit feedback (Discord webhook)" },

--- a/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
+++ b/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
@@ -204,7 +204,7 @@ export default function LeaderboardBrowseClient() {
     if (lbChar) params.set("character", lbChar);
     params.set("page", String(lbPage));
     params.set("limit", "20");
-    fetch(`${API}/api/runs/leaderboard?${params}&_t=${Date.now()}`)
+    fetch(`${API}/api/runs/leaderboard?${params}`)
       .then((r) => (r.ok ? r.json() : { runs: [], total: 0, total_pages: 0 }))
       .then((data) => {
         // Backend returns the rows under `runs`; rank is computed client-side
@@ -245,7 +245,7 @@ export default function LeaderboardBrowseClient() {
     if (browseBuildId) params.set("build_id", browseBuildId);
     if (browseSort) params.set("sort", browseSort);
     params.set("page", String(browsePage));
-    fetch(`${API}/api/runs/list?${params}&_t=${Date.now()}`)
+    fetch(`${API}/api/runs/list?${params}`)
       .then((r) => (r.ok ? r.json() : { runs: [], total: 0, total_pages: 0 }))
       .then((data) => {
         setRunList(data.runs || []);

--- a/frontend/app/runs/BrowseRunsClient.tsx
+++ b/frontend/app/runs/BrowseRunsClient.tsx
@@ -263,7 +263,9 @@ export default function BrowseRunsClient() {
     }
     params.set("sort", sort);
     params.set("page", String(page));
-    fetch(`${API}/api/runs/list?${params}&_t=${Date.now()}`)
+    // No cache-buster: the API sends Cache-Control max-age=30, so the edge
+    // and browser absorb repeat hits; new runs appear within seconds anyway.
+    fetch(`${API}/api/runs/list?${params}`)
       .then((r) => (r.ok ? r.json() : { runs: [], total: 0, total_pages: 0 }))
       .then((data) => {
         setRuns(data.runs || []);

--- a/frontend/app/runs/RunsClient.tsx
+++ b/frontend/app/runs/RunsClient.tsx
@@ -438,7 +438,9 @@ export default function RunsClient() {
     if (browseWin) params.set("win", browseWin);
     if (browseUser) params.set("username", browseUser);
     params.set("page", String(browsePage));
-    fetch(`${API}/api/runs/list?${params}&_t=${Date.now()}`)
+    // No cache-buster: the API sends Cache-Control max-age=30, so the edge
+    // and browser absorb repeat hits; new runs appear within seconds anyway.
+    fetch(`${API}/api/runs/list?${params}`)
       .then((r) => r.ok ? r.json() : { runs: [], total: 0, total_pages: 0 })
       .then((data) => {
         setRunList(data.runs || []);

--- a/frontend/app/tier-list/relics/page.tsx
+++ b/frontend/app/tier-list/relics/page.tsx
@@ -44,28 +44,47 @@ const RARITY_FILTERS = [
   { value: "ancient",   label: "Ancient" },
 ];
 
-function relicHref(pool?: string, rarity?: string): string {
+// Acquisition act. "3" folds in the rare later acts. Backend grades each act
+// view against a per-act baseline, so picking up a relic late (in a run that
+// already survived that far) doesn't read as the relic carrying the run.
+const ACT_FILTERS = [
+  { value: "",  label: "All acts" },
+  { value: "1", label: "Act 1" },
+  { value: "2", label: "Act 2" },
+  { value: "3", label: "Act 3" },
+];
+
+function relicHref(pool?: string, rarity?: string, act?: string): string {
   const params = new URLSearchParams();
   if (pool) params.set("pool", pool);
   if (rarity) params.set("rarity", rarity);
+  if (act) params.set("act", act);
   const qs = params.toString();
   return `/tier-list/relics${qs ? `?${qs}` : ""}`;
 }
 
+function parseAct(raw?: string): string {
+  return raw === "1" || raw === "2" || raw === "3" ? raw : "";
+}
+
 interface PageProps {
-  searchParams: Promise<{ pool?: string; rarity?: string }>;
+  searchParams: Promise<{ pool?: string; rarity?: string; act?: string }>;
 }
 
 export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
   const sp = await searchParams;
   const pool = sp.pool?.toLowerCase();
+  const act = parseAct(sp.act);
   const poolLabel = POOL_FILTERS.find((p) => p.value === pool)?.label;
-  const scope = poolLabel && pool ? `${poolLabel} Relic` : "Relic";
+  const actPrefix = act ? `Act ${act} ` : "";
+  const scope = poolLabel && pool ? `${actPrefix}${poolLabel} Relic` : `${actPrefix}Relic`;
   const title = `${scope} Tier List - Relics Ranked - Slay the Spire 2 (sts2) | ${SITE_NAME}`;
-  const description = pool
+  const description = act
+    ? `Slay the Spire 2 (sts2) relics ranked by the win rate of runs that picked them up in Act ${act}, graded against other Act ${act} pickups.`
+    : pool
     ? `${poolLabel} relic tier list for Slay the Spire 2 (sts2). Every relic in the ${pool} pool ranked S through F by community win rate.`
     : "Every Slay the Spire 2 (sts2) relic ranked S through F. Codex Score from community-submitted run win rates with Bayesian shrinkage.";
-  const path = `/tier-list/relics${pool ? `?pool=${pool}` : ""}`;
+  const path = relicHref(pool, undefined, act);
   return {
     title,
     description,
@@ -75,9 +94,9 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
   };
 }
 
-async function fetchData(pool?: string): Promise<{ relics: ApiRelic[]; scores: ScoresMap }> {
+async function fetchData(pool?: string, act?: string): Promise<{ relics: ApiRelic[]; scores: ScoresMap }> {
   const relicsUrl = `${API_INTERNAL}/api/relics${pool ? `?pool=${pool}` : ""}`;
-  const scoresUrl = `${API_INTERNAL}/api/runs/scores/relics`;
+  const scoresUrl = `${API_INTERNAL}/api/runs/scores/relics${act ? `?act=${act}` : ""}`;
   try {
     const [relicsRes, scoresRes] = await Promise.all([
       fetch(relicsUrl, { next: { revalidate: 1800 } }),
@@ -95,10 +114,14 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
   const sp = await searchParams;
   const pool = sp.pool?.toLowerCase();
   const rarity = sp.rarity?.toLowerCase();
-  const { relics, scores } = await fetchData(pool);
+  const act = parseAct(sp.act);
+  const { relics, scores } = await fetchData(pool, act);
 
   const entities: TierEntity[] = relics
     .filter((r) => !rarity || (r.rarity_key ?? "").toLowerCase() === rarity)
+    // Act views rank only relics actually picked up in that act; the rest
+    // would all pile into an Unrated row, so drop them instead.
+    .filter((r) => !act || scores[r.id.toUpperCase()] !== undefined)
     .map((r) => ({
       id: r.id,
       name: r.name,
@@ -107,8 +130,11 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
     }));
 
   const poolLabel = POOL_FILTERS.find((p) => p.value === pool)?.label;
-  const heading = poolLabel && pool ? `${poolLabel} Relic Tier List` : "Relic Tier List";
-  const path = `/tier-list/relics${pool ? `?pool=${pool}` : ""}`;
+  const actPrefix = act ? `Act ${act} ` : "";
+  const heading = poolLabel && pool
+    ? `${actPrefix}${poolLabel} Relic Tier List`
+    : `${actPrefix}Relic Tier List`;
+  const path = relicHref(pool, undefined, act);
 
   // Top-30 by score for ItemList JSON-LD, gives Google a structured
   // ranked list it can render as carousel-style rich results.
@@ -146,9 +172,20 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
         <span className="text-sm text-[var(--text-muted)]">{entities.length.toLocaleString()} relics</span>
       </div>
       <p className="text-sm text-[var(--text-muted)] mb-6">
-        Ranked by <Link href="/leaderboards/scoring" className="text-[var(--accent-gold)] hover:underline">Codex Score</Link>,
-        community win-rate data with Bayesian shrinkage so a 5-pick relic doesn&apos;t outrank a
-        500-pick one. Click any relic for full stats.
+        {act ? (
+          <>
+            Ranked by the win rate of runs that picked each relic up during Act {act},
+            Bayesian-shrunk and graded against other Act {act} pickups, so reaching a
+            later act doesn&apos;t inflate a relic by itself. Smaller samples than the
+            all-acts view. Click any relic for full stats.
+          </>
+        ) : (
+          <>
+            Ranked by <Link href="/leaderboards/scoring" className="text-[var(--accent-gold)] hover:underline">Codex Score</Link>,
+            community win-rate data with Bayesian shrinkage so a 5-pick relic doesn&apos;t outrank a
+            500-pick one. Click any relic for full stats.
+          </>
+        )}
       </p>
 
       {/* Pool (character) filter */}
@@ -158,7 +195,7 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
           return (
             <Link
               key={opt.value || "all"}
-              href={relicHref(opt.value || undefined, rarity)}
+              href={relicHref(opt.value || undefined, rarity, act)}
               className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
                 isActive
                   ? "bg-[var(--accent-gold)]/10 border-[var(--accent-gold)]/40 text-[var(--accent-gold)]"
@@ -171,16 +208,35 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
         })}
       </div>
       {/* Rarity / source filter (Neow/Starter, Shop, Event, Ancient, …) */}
-      <div className="flex flex-wrap gap-1.5 mb-6">
+      <div className="flex flex-wrap gap-1.5 mb-2">
         {RARITY_FILTERS.map((opt) => {
           const isActive = (rarity ?? "") === opt.value;
           return (
             <Link
               key={opt.value || "all-rarities"}
-              href={relicHref(pool, opt.value || undefined)}
+              href={relicHref(pool, opt.value || undefined, act)}
               className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
                 isActive
                   ? "bg-sky-500/10 border-sky-500/40 text-sky-300"
+                  : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
+              }`}
+            >
+              {opt.label}
+            </Link>
+          );
+        })}
+      </div>
+      {/* Acquisition act filter (when in the run the relic was picked up) */}
+      <div className="flex flex-wrap gap-1.5 mb-6">
+        {ACT_FILTERS.map((opt) => {
+          const isActive = act === opt.value;
+          return (
+            <Link
+              key={opt.value || "all-acts"}
+              href={relicHref(pool, rarity, opt.value || undefined)}
+              className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
+                isActive
+                  ? "bg-emerald-500/10 border-emerald-500/40 text-emerald-300"
                   : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
               }`}
             >


### PR DESCRIPTION
Implements #388. Run uploads went from ~9k/week to ~130k/week and every uncached read amplifies Mongo and disk load proportionally; this puts a fail-safe, cluster-wide Redis layer in front of the four hottest reads.

## Cache substrate
services/cache.py wraps redis-py with get_json / set_json / delete / delete_pattern. Every operation is fail-safe: REDIS_URL unset means every call no-ops without importing redis at all, and a down or hung Redis (250ms socket timeouts) degrades to a miss, never a 500 and never added latency pileups. Prometheus counters track hits/misses/errors per key namespace (stats, leaderboard, run, entity_scores).

## Wired endpoints
| Endpoint | TTL | Notes |
|---|---|---|
| /api/runs/stats | 60s | In front of stats_summary; cluster-wide instead of per-worker |
| /api/runs/leaderboard | 60s | Covers paginated/today combos not in leaderboard_summary |
| /api/runs/shared/{hash} | 15min | Immutable runs; short TTL so cold runs fall out of LRU; 404s never cached |
| /api/runs/scores/{type} | 5min | Key includes the act param from #425; extend the key if the endpoint grows more params |

## Infra
redis:7-alpine in dev/beta/prod compose: hard memory cap (512MB prod, 128MB dev/beta), allkeys-lru, no persistence (everything is rebuildable on miss), prod healthcheck. One deviation from the issue spec: prod and beta REDIS_URLs use container names (spire-codex-redis / spire-codex-beta-redis) instead of the bare redis service alias, because both stacks attach to the same external nginx_web-network and duplicate aliases would resolve ambiguously between them. The backend depends_on is ordering only, so it boots fine with Redis down.

## Verified
- No-op mode: REDIS_URL unset, all calls no-op, router imports clean.
- Dead Redis: get+set complete in ~60ms with errors counted, no exception.
- Round-trip, decode-error-as-miss, and SCAN-based pattern delete against a stub client.
- ruff clean, compose files YAML-validated.

## Deploy notes
- The prod compose change needs a compose up on the box to create spire-codex-redis; the backend image alone won't pick it up.
- Stacked on #424/#425 (this branch includes their commits); whichever merges first, the rest shrink.
- Next PR candidates per the issue: entity list responses, /api/auth/me, slowapi rate-limit storage.