### PR TITLE
Global search covers the whole site

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from slowapi.middleware import SlowAPIMiddleware
 
 from .routers import (
     cards,
+    search,
     characters,
     relics,
     monsters,
@@ -469,6 +470,7 @@ Instrumentator(
 ).instrument(app).expose(app, endpoint="/metrics", include_in_schema=False)
 
 app.include_router(cards.router)
+app.include_router(search.router)
 app.include_router(characters.router)
 app.include_router(relics.router)
 app.include_router(monsters.router)

--- a/backend/app/routers/search.py
+++ b/backend/app/routers/search.py
@@ -1,0 +1,214 @@
+"""Unified site search: one query across everything searchable.
+
+Powers the global cmd-K modal. Previously the modal fired one request per
+entity type (10 per keystroke) and still missed half the site: keywords,
+reference entries (orbs/afflictions/intents/modifiers/achievements/badges),
+the 27 mechanics pages, guides, and news. This endpoint searches all of it
+in one in-memory pass over the lru-cached game data, with light relevance
+ranking, and returns a few results per category.
+
+Ranking per item name: exact (100) > prefix (80) > word-start (60) >
+substring (40) > match in a secondary field like the description (20).
+Ties break alphabetically. Categories cap at a handful of rows so the
+payload stays small enough for per-keystroke use.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from ..dependencies import get_lang
+from ..services import data_service, mechanics_pages
+
+router = APIRouter(prefix="/api/search", tags=["Search"])
+
+_MAX_PER_CATEGORY = 5
+_MIN_QUERY_LEN = 2
+
+
+def _score_name(name: str, q: str) -> int:
+    n = name.lower()
+    if n == q:
+        return 100
+    if n.startswith(q):
+        return 80
+    if any(word.startswith(q) for word in n.split()):
+        return 60
+    if q in n:
+        return 40
+    return 0
+
+
+def _search_rows(
+    rows: Iterable[dict],
+    q: str,
+    *,
+    name_field: str = "name",
+    extra_fields: tuple[str, ...] = (),
+    limit: int = _MAX_PER_CATEGORY,
+) -> list[tuple[int, dict]]:
+    """Score `rows` against `q`; best `limit` matches as (score, row)."""
+    scored: list[tuple[int, str, dict]] = []
+    for row in rows:
+        name = str(row.get(name_field) or "")
+        if not name:
+            continue
+        score = _score_name(name, q)
+        if score == 0:
+            for field in extra_fields:
+                value = row.get(field)
+                haystack = (
+                    " ".join(str(v) for v in value)
+                    if isinstance(value, list)
+                    else str(value or "")
+                )
+                if q in haystack.lower():
+                    score = 20
+                    break
+        if score:
+            scored.append((score, name.lower(), row))
+    scored.sort(key=lambda t: (-t[0], t[1]))
+    return [(s, row) for s, _, row in scored[:limit]]
+
+
+def _item(name: str, path: str, subtitle: str = "") -> dict[str, str]:
+    return {"name": name, "path": path, "subtitle": subtitle}
+
+
+def _entity_subtitle(row: dict, fields: tuple[str, ...]) -> str:
+    return " · ".join(str(row[f]) for f in fields if row.get(f))
+
+
+# (label, loader name, detail path prefix, subtitle fields, extra search fields)
+_ENTITY_CATEGORIES: list[tuple[str, str, str, tuple[str, ...], tuple[str, ...]]] = [
+    ("Characters", "load_characters", "/characters", (), ()),
+    ("Cards", "load_cards", "/cards", ("color", "type", "rarity"), ("description",)),
+    ("Relics", "load_relics", "/relics", ("rarity", "pool"), ("description",)),
+    ("Monsters", "load_monsters", "/monsters", ("type",), ()),
+    ("Potions", "load_potions", "/potions", ("rarity",), ("description",)),
+    ("Powers", "load_powers", "/powers", ("type", "stack_type"), ("description",)),
+    ("Enchantments", "load_enchantments", "/enchantments", (), ("description",)),
+    ("Events", "load_events", "/events", ("type",), ("description",)),
+    ("Encounters", "load_encounters", "/encounters", ("room_type",), ()),
+    ("Keywords", "load_keywords", "/keywords", (), ("description",)),
+]
+
+# Reference-style data without individual detail pages: searched together
+# under one category, each kind linking to the page that renders it.
+_REFERENCE_SOURCES: list[tuple[str, str, str]] = [
+    ("load_orbs", "Orb", "/reference"),
+    ("load_afflictions", "Affliction", "/reference"),
+    ("load_intents", "Intent", "/reference"),
+    ("load_modifiers", "Modifier", "/modifiers"),
+    ("load_achievements", "Achievement", "/unlocks"),
+    ("load_badges", "Badge", "/badges"),
+]
+
+
+@router.get("", tags=["Search"])
+def global_search(
+    request: Request,
+    q: str = Query(..., min_length=1, max_length=80),
+    lang: str = Depends(get_lang),
+) -> dict[str, Any]:
+    """Search every entity type, reference entry, mechanics page, guide,
+    and news article in one pass. Returns up to a few items per category;
+    empty categories are omitted."""
+    query = q.strip().lower()
+    if len(query) < _MIN_QUERY_LEN:
+        return {"query": q, "categories": []}
+
+    categories: list[dict[str, Any]] = []
+
+    def add(label: str, items: list[dict[str, str]]) -> None:
+        if items:
+            categories.append({"label": label, "items": items})
+
+    # Game entities with detail pages.
+    for label, loader_name, prefix, subtitle_fields, extra in _ENTITY_CATEGORIES:
+        loader: Callable = getattr(data_service, loader_name)
+        try:
+            rows = loader(lang)
+        except Exception:
+            continue
+        items = [
+            _item(
+                str(row.get("name")),
+                f"{prefix}/{str(row.get('id', '')).lower()}",
+                _entity_subtitle(row, subtitle_fields),
+            )
+            for _, row in _search_rows(rows, query, extra_fields=extra)
+        ]
+        add(label, items)
+
+    # Reference entries (orbs, afflictions, intents, modifiers, achievements,
+    # badges): one merged category, re-ranked across kinds.
+    ref_scored: list[tuple[int, str, dict[str, str]]] = []
+    for loader_name, kind, path in _REFERENCE_SOURCES:
+        loader = getattr(data_service, loader_name)
+        try:
+            rows = loader(lang)
+        except Exception:
+            continue
+        for score, row in _search_rows(
+            rows, query, extra_fields=("description",), limit=_MAX_PER_CATEGORY
+        ):
+            name = str(row.get("name"))
+            ref_scored.append((score, name.lower(), _item(name, path, kind)))
+    ref_scored.sort(key=lambda t: (-t[0], t[1]))
+    add("Reference", [item for _, _, item in ref_scored[:_MAX_PER_CATEGORY]])
+
+    # Mechanics pages (English-only markdown docs).
+    try:
+        sections = mechanics_pages.list_sections()
+    except Exception:
+        sections = []
+    add(
+        "Mechanics",
+        [
+            _item(
+                str(row.get("title")),
+                f"/mechanics/{row.get('slug')}",
+                str(row.get("category") or ""),
+            )
+            for _, row in _search_rows(
+                sections, query, name_field="title", extra_fields=("description",)
+            )
+        ],
+    )
+
+    # Community guides.
+    try:
+        guides = data_service.load_guides()
+    except Exception:
+        guides = []
+    add(
+        "Guides",
+        [
+            _item(
+                str(row.get("title")),
+                f"/guides/{row.get('slug')}",
+                str(row.get("category") or ""),
+            )
+            for _, row in _search_rows(
+                guides, query, name_field="title", extra_fields=("summary", "tags")
+            )
+        ],
+    )
+
+    # News (titles only; the archive page has full-text search).
+    try:
+        news = data_service.load_news_index()
+    except Exception:
+        news = []
+    add(
+        "News",
+        [
+            _item(str(row.get("title")), f"/news/{row.get('gid')}", "News")
+            for _, row in _search_rows(news, query, name_field="title", limit=3)
+        ],
+    )
+
+    return {"query": q, "categories": categories}

--- a/contributing/CLAUDE.md
+++ b/contributing/CLAUDE.md
@@ -191,6 +191,7 @@ spire-codex/
 - `GET /api/keywords` / `GET /api/orbs` / `GET /api/afflictions` / `GET /api/intents`
 - `GET /api/modifiers` / `GET /api/achievements`
 - `GET /api/names/{entity_type}/{entity_id}` — Cross-language name lookup
+- `GET /api/search?q=&lang=`: Unified site search (entities, reference entries, mechanics pages, guides, news) powering the global cmd-K modal
 - `GET /api/exports/{lang}` — ZIP download of all entity JSON for a language
 - `GET /api/history/{entity_type}/{entity_id}` — Per-entity version history
 - `GET /api/changelogs` / `GET /api/changelogs/{tag}` — Version changelogs

--- a/frontend/app/components/GlobalSearch.tsx
+++ b/frontend/app/components/GlobalSearch.tsx
@@ -9,96 +9,22 @@ import { imageUrl } from "@/lib/image-url";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
-interface SearchResult {
-  id: string;
+// One row in the results list. Entity/page/guide/etc. rows come from the
+// unified /api/search endpoint, which provides the path and subtitle
+// server-side; image rows come from /api/images/search and open externally
+// with a thumbnail preview.
+interface SearchItem {
   name: string;
-  [key: string]: unknown;
+  path: string;
+  subtitle?: string;
+  thumb?: string;
+  external?: boolean;
 }
 
-interface CategoryConfig {
+interface SearchSection {
   label: string;
-  endpoint: string;
-  linkFn: (item: SearchResult) => string;
-  subtitleFn?: (item: SearchResult) => string;
-  /** Absolute thumbnail URL, when present, the row renders it as a small preview. */
-  thumbFn?: (item: SearchResult) => string;
-  /** When true, activating the result opens it in a new tab instead of routing. */
-  openExternal?: boolean;
+  items: SearchItem[];
 }
-
-const CATEGORIES: CategoryConfig[] = [
-  {
-    label: "Characters",
-    endpoint: "/api/characters",
-    linkFn: (item) => `/characters/${item.id.toLowerCase()}`,
-    subtitleFn: (item) => (item.color ? String(item.color) : ""),
-  },
-  {
-    label: "Cards",
-    endpoint: "/api/cards",
-    linkFn: (item) => `/cards/${item.id.toLowerCase()}`,
-    subtitleFn: (item) => {
-      const parts: string[] = [];
-      if (item.color) parts.push(String(item.color));
-      if (item.type) parts.push(String(item.type));
-      if (item.rarity) parts.push(String(item.rarity));
-      return parts.join(" \u00b7 ");
-    },
-  },
-  {
-    label: "Relics",
-    endpoint: "/api/relics",
-    linkFn: (item) => `/relics/${item.id.toLowerCase()}`,
-    subtitleFn: (item) => (item.rarity ? String(item.rarity) : ""),
-  },
-  {
-    label: "Monsters",
-    endpoint: "/api/monsters",
-    linkFn: (item) => `/monsters/${item.id.toLowerCase()}`,
-    subtitleFn: (item) => (item.type ? String(item.type) : ""),
-  },
-  {
-    label: "Potions",
-    endpoint: "/api/potions",
-    linkFn: (item) => `/potions/${item.id.toLowerCase()}`,
-    subtitleFn: (item) => (item.rarity ? String(item.rarity) : ""),
-  },
-  {
-    label: "Powers",
-    endpoint: "/api/powers",
-    linkFn: (item) => `/powers/${item.id.toLowerCase()}`,
-    subtitleFn: (item) => {
-      const parts: string[] = [];
-      if (item.type) parts.push(String(item.type));
-      if (item.stack_type) parts.push(String(item.stack_type));
-      return parts.join(" \u00b7 ");
-    },
-  },
-  {
-    label: "Enchantments",
-    endpoint: "/api/enchantments",
-    linkFn: (item) => `/enchantments/${item.id.toLowerCase()}`,
-  },
-  {
-    label: "Events",
-    endpoint: "/api/events",
-    linkFn: (item) => `/events/${item.id.toLowerCase()}`,
-  },
-  {
-    label: "Encounters",
-    endpoint: "/api/encounters",
-    linkFn: (item) => `/encounters/${item.id.toLowerCase()}`,
-    subtitleFn: (item) => (item.room_type ? String(item.room_type) : ""),
-  },
-  {
-    label: "Images",
-    endpoint: "/api/images/search",
-    linkFn: (item) => imageUrl(item.url as string),
-    subtitleFn: (item) => (item.category_name ? String(item.category_name) : ""),
-    thumbFn: (item) => imageUrl(item.url as string),
-    openExternal: true,
-  },
-];
 
 const PAGES = [
   { name: "Cards", path: "/cards", keywords: ["card", "deck", "attack", "skill", "power"] },
@@ -117,6 +43,16 @@ const PAGES = [
   { name: "Compare Characters", path: "/compare", keywords: ["compare", "comparison", "versus", "vs"] },
   { name: "Custom Mode", path: "/modifiers", keywords: ["modifier", "custom", "mode", "mutator"] },
   { name: "Runs", path: "/runs", keywords: ["run", "upload", "submit", "history", "win", "loss"] },
+  { name: "Tier List", path: "/tier-list", keywords: ["tier", "tier list", "ranking", "best", "worst", "s tier"] },
+  { name: "Card Tier List", path: "/tier-list/cards", keywords: ["tier", "card tier", "best cards"] },
+  { name: "Relic Tier List", path: "/tier-list/relics", keywords: ["tier", "relic tier", "best relics"] },
+  { name: "Potion Tier List", path: "/tier-list/potions", keywords: ["tier", "potion tier", "best potions"] },
+  { name: "Leaderboards", path: "/leaderboards", keywords: ["leaderboard", "fastest", "ascension", "ladder", "ranking"] },
+  { name: "Card Metrics", path: "/leaderboards/metrics", keywords: ["metrics", "elo", "codex elo", "pick rate", "win rate", "table"] },
+  { name: "Codex Score", path: "/leaderboards/scoring", keywords: ["score", "codex score", "scoring", "methodology", "tier bands"] },
+  { name: "Community Stats", path: "/community-stats", keywords: ["community", "stats", "statistics", "event votes", "deadliest", "records"] },
+  { name: "Submit a Run", path: "/leaderboards/submit", keywords: ["submit", "upload", "run file"] },
+  { name: "Badges", path: "/badges", keywords: ["badge", "frame", "cosmetic"] },
   { name: "Mechanics", path: "/mechanics", keywords: ["mechanic", "formula", "odds", "chance", "drop rate", "probability", "rng"] },
   { name: "Guides", path: "/guides", keywords: ["guide", "strategy", "tip", "walkthrough", "tutorial"] },
   { name: "Submit Guide", path: "/guides/submit", keywords: ["submit", "write", "contribute", "guide"] },
@@ -138,7 +74,7 @@ const MAX_PER_CATEGORY = 5;
 export default function GlobalSearch() {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<Record<string, SearchResult[]>>({});
+  const [sections, setSections] = useState<SearchSection[]>([]);
   const [loading, setLoading] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -159,17 +95,9 @@ export default function GlobalSearch() {
     : [];
 
   // Build flat list of all visible results for keyboard navigation
-  const flatResults = [
-    ...matchedPages.map((p) => ({
-      item: { id: p.path, name: p.name } as SearchResult,
-      category: { label: "Pages", endpoint: "", linkFn: () => p.path } as CategoryConfig,
-    })),
-    ...CATEGORIES.flatMap((cat) =>
-      (results[cat.label] ?? []).slice(0, MAX_PER_CATEGORY).map((item) => ({
-        item,
-        category: cat,
-      }))
-    ),
+  const flatResults: SearchItem[] = [
+    ...matchedPages.map((p) => ({ name: p.name, path: p.path })),
+    ...sections.flatMap((s) => s.items),
   ];
 
   // Open on "." key when not in an input
@@ -194,15 +122,17 @@ export default function GlobalSearch() {
       setTimeout(() => inputRef.current?.focus(), 0);
     } else {
       setQuery("");
-      setResults({});
+      setSections([]);
       setSelectedIndex(0);
     }
   }, [open]);
 
-  // Debounced search
+  // Debounced search: ONE request to the unified /api/search endpoint
+  // (everything with a page) plus one to the image search (thumbnails,
+  // opens externally) instead of the old one-request-per-entity-type fan.
   useEffect(() => {
     if (!query.trim()) {
-      setResults({});
+      setSections([]);
       setLoading(false);
       return;
     }
@@ -214,25 +144,36 @@ export default function GlobalSearch() {
       abortRef.current = controller;
 
       const encoded = encodeURIComponent(query.trim());
-      Promise.all(
-        CATEGORIES.map((cat) =>
-          fetch(buildApiUrl(`${API}${cat.endpoint}?search=${encoded}&lang=${lang}`), {
-            signal: controller.signal,
-          })
-            .then((r) => (r.ok ? r.json() : []))
-            .then((data: SearchResult[]) => ({
-              label: cat.label,
-              items: data.slice(0, MAX_PER_CATEGORY),
-            }))
-            .catch(() => ({ label: cat.label, items: [] as SearchResult[] }))
-        )
-      ).then((all) => {
+      Promise.all([
+        fetch(buildApiUrl(`${API}/api/search?q=${encoded}&lang=${lang}`), {
+          signal: controller.signal,
+        })
+          .then((r) => (r.ok ? r.json() : { categories: [] }))
+          .catch(() => ({ categories: [] })),
+        fetch(buildApiUrl(`${API}/api/images/search?search=${encoded}`), {
+          signal: controller.signal,
+        })
+          .then((r) => (r.ok ? r.json() : []))
+          .catch(() => []),
+      ]).then(([unified, images]) => {
         if (controller.signal.aborted) return;
-        const grouped: Record<string, SearchResult[]> = {};
-        for (const { label, items } of all) {
-          if (items.length > 0) grouped[label] = items;
-        }
-        setResults(grouped);
+        const next: SearchSection[] = (unified.categories ?? []).map(
+          (c: { label: string; items: SearchItem[] }) => ({
+            label: c.label,
+            items: c.items.slice(0, MAX_PER_CATEGORY),
+          })
+        );
+        const imageItems: SearchItem[] = (images as Record<string, unknown>[])
+          .slice(0, MAX_PER_CATEGORY)
+          .map((im) => ({
+            name: String(im.name ?? ""),
+            path: imageUrl(im.url as string),
+            subtitle: im.category_name ? String(im.category_name) : "",
+            thumb: imageUrl(im.url as string),
+            external: true,
+          }));
+        if (imageItems.length > 0) next.push({ label: "Images", items: imageItems });
+        setSections(next);
         setSelectedIndex(0);
         setLoading(false);
       });
@@ -243,13 +184,12 @@ export default function GlobalSearch() {
 
   // Navigate to result
   const navigate = useCallback(
-    (cat: CategoryConfig, item: SearchResult) => {
+    (item: SearchItem) => {
       setOpen(false);
-      const href = cat.linkFn(item);
-      if (cat.openExternal) {
-        window.open(href, "_blank", "noopener,noreferrer");
+      if (item.external) {
+        window.open(item.path, "_blank", "noopener,noreferrer");
       } else {
-        router.push(href);
+        router.push(item.path);
       }
     },
     [router]
@@ -275,7 +215,7 @@ export default function GlobalSearch() {
       if (e.key === "Enter" && flatResults.length > 0) {
         e.preventDefault();
         const selected = flatResults[selectedIndex];
-        if (selected) navigate(selected.category, selected.item);
+        if (selected) navigate(selected);
         return;
       }
     },
@@ -286,7 +226,7 @@ export default function GlobalSearch() {
 
   const totalResults =
     matchedPages.length +
-    Object.values(results).reduce((sum, arr) => sum + arr.length, 0);
+    sections.reduce((sum, s) => sum + s.items.length, 0);
 
   return (
     <div
@@ -383,34 +323,32 @@ export default function GlobalSearch() {
 
           {(() => {
             let runningIndex = matchedPages.length;
-            return CATEGORIES.map((cat) => {
-              const items = results[cat.label];
-              if (!items || items.length === 0) return null;
+            return sections.map((section) => {
+              if (section.items.length === 0) return null;
               const startIndex = runningIndex;
-              runningIndex += items.length;
+              runningIndex += section.items.length;
               return (
-                <div key={cat.label} className="py-2">
+                <div key={section.label} className="py-2">
                   <div className="px-4 py-1 text-xs uppercase tracking-wider text-[var(--text-muted)] font-medium">
-                    {cat.label}
+                    {section.label}
                   </div>
-                  {items.map((item, i) => {
+                  {section.items.map((item, i) => {
                     const globalIdx = startIndex + i;
                     const isSelected = globalIdx === selectedIndex;
-                    const thumb = cat.thumbFn?.(item);
                     return (
                       <button
-                        key={item.id}
+                        key={`${item.path}:${item.name}`}
                         className={`w-full text-left px-4 py-2 flex items-center gap-3 cursor-pointer transition-colors ${
                           isSelected
                             ? "bg-[var(--bg-card-hover)]"
                             : "hover:bg-[var(--bg-card-hover)]"
                         }`}
-                        onClick={() => navigate(cat, item)}
+                        onClick={() => navigate(item)}
                         onMouseEnter={() => setSelectedIndex(globalIdx)}
                       >
-                        {thumb && (
+                        {item.thumb && (
                           <img
-                            src={thumb}
+                            src={item.thumb}
                             alt=""
                             className="w-8 h-8 object-contain shrink-0 rounded bg-[var(--bg-primary)]"
                             crossOrigin="anonymous"
@@ -420,12 +358,12 @@ export default function GlobalSearch() {
                         <span className="text-sm text-[var(--text-primary)] truncate">
                           {item.name}
                         </span>
-                        {cat.subtitleFn && cat.subtitleFn(item) && (
+                        {item.subtitle && (
                           <span className="text-xs text-[var(--text-muted)] truncate shrink-0">
-                            {cat.subtitleFn(item)}
+                            {item.subtitle}
                           </span>
                         )}
-                        {cat.openExternal && (
+                        {item.external && (
                           <span className="ml-auto text-[10px] text-[var(--text-muted)] shrink-0">↗</span>
                         )}
                       </button>

--- a/frontend/app/components/GlobalSearch.tsx
+++ b/frontend/app/components/GlobalSearch.tsx
@@ -26,47 +26,72 @@ interface SearchSection {
   items: SearchItem[];
 }
 
+// The route inventory is GENERATED from the App Router file tree by
+// scripts/generate-site-pages.mjs (predev/prebuild hooks), so new pages
+// show up in search automatically. This map only adds nicer display
+// names and keyword synonyms on top; entries here are optional and
+// nothing breaks when a page ships without one.
+import sitePages from "@/lib/site-pages.json";
+
+const PAGE_OVERRIDES: Record<string, { name?: string; keywords?: string[] }> = {
+  "/cards": { keywords: ["card", "deck", "attack", "skill", "power"] },
+  "/cards/browse": { name: "Card Browse", keywords: ["browse", "filter", "matrix"] },
+  "/characters": { keywords: ["character", "class", "hero", "ironclad", "silent", "defect", "necrobinder", "regent"] },
+  "/relics": { keywords: ["relic", "artifact"] },
+  "/monsters": { keywords: ["monster", "enemy", "boss", "bestiary"] },
+  "/potions": { keywords: ["potion", "flask"] },
+  "/powers": { keywords: ["power", "buff", "debuff", "status"] },
+  "/enchantments": { keywords: ["enchantment", "enchant"] },
+  "/encounters": { keywords: ["encounter", "fight", "combat"] },
+  "/events": { keywords: ["event"] },
+  "/merchant": { keywords: ["merchant", "shop", "store", "buy", "sell", "price", "gold", "removal"] },
+  "/ancients": { keywords: ["ancient", "neow", "darv", "orobas", "pael", "tezcatara", "vakuu", "nonupeipe", "tanx", "offering"] },
+  "/unlocks": { keywords: ["unlock", "unlockable", "progression", "epoch", "achievement"] },
+  "/keywords": { keywords: ["keyword", "exhaust", "ethereal", "innate", "retain", "sly", "eternal", "unplayable"] },
+  "/compare": { name: "Compare Characters", keywords: ["compare", "comparison", "versus", "vs"] },
+  "/modifiers": { name: "Custom Mode", keywords: ["modifier", "custom", "mode", "mutator"] },
+  "/runs": { keywords: ["run", "upload", "submit", "history", "win", "loss"] },
+  "/tier-list": { keywords: ["tier", "tier list", "ranking", "best", "worst", "s tier"] },
+  "/tier-list/cards": { name: "Card Tier List", keywords: ["tier", "best cards"] },
+  "/tier-list/relics": { name: "Relic Tier List", keywords: ["tier", "best relics", "act"] },
+  "/tier-list/potions": { name: "Potion Tier List", keywords: ["tier", "best potions"] },
+  "/tier-list-maker": { name: "Tier List Maker", keywords: ["tier", "maker", "builder", "custom tier"] },
+  "/leaderboards": { keywords: ["leaderboard", "fastest", "ascension", "ladder", "ranking"] },
+  "/leaderboards/metrics": { name: "Card Metrics", keywords: ["metrics", "elo", "codex elo", "pick rate", "win rate", "table"] },
+  "/leaderboards/scoring": { name: "Codex Score", keywords: ["score", "codex score", "scoring", "methodology", "tier bands"] },
+  "/leaderboards/stats": { name: "Run Stats", keywords: ["stats", "win rate", "pick rate"] },
+  "/leaderboards/encounters": { name: "Encounter Stats", keywords: ["encounter", "deadliest", "stats"] },
+  "/leaderboards/submit": { name: "Submit a Run", keywords: ["submit", "upload", "run file"] },
+  "/community-stats": { keywords: ["community", "stats", "statistics", "event votes", "deadliest", "records"] },
+  "/badges": { keywords: ["badge", "frame", "cosmetic"] },
+  "/mechanics": { keywords: ["mechanic", "formula", "odds", "chance", "drop rate", "probability", "rng"] },
+  "/guides": { keywords: ["guide", "strategy", "tip", "walkthrough", "tutorial"] },
+  "/guides/submit": { name: "Submit Guide", keywords: ["submit", "write", "contribute"] },
+  "/timeline": { keywords: ["timeline", "epoch", "era", "story", "lore"] },
+  "/reference": { keywords: ["reference", "intent", "orb", "affliction", "modifier", "achievement", "ascension", "act"] },
+  "/images": { keywords: ["image", "sprite", "asset", "art", "download"] },
+  "/developers": { keywords: ["developer", "api", "widget", "tooltip", "export", "data"] },
+  "/showcase": { keywords: ["showcase", "community", "project", "built with"] },
+  "/changelog": { keywords: ["changelog", "patch", "update", "version", "what changed"] },
+  "/about": { keywords: ["about", "info", "credits"] },
+  "/news": { keywords: ["news", "patch", "patch notes", "announcement", "update", "steam", "press"] },
+  "/knowledge-demon": { name: "Knowledge Demon", keywords: ["discord bot", "bot"] },
+  "/overlay": { keywords: ["overlay", "overwolf", "in-game", "companion", "app"] },
+};
+
+// Entries that aren't App Router pages (external links).
+const EXTRA_PAGES = [
+  { name: "Discord", path: "https://discord.gg/xMsTBeh", keywords: ["discord", "chat", "community"], external: true },
+];
+
 const PAGES = [
-  { name: "Cards", path: "/cards", keywords: ["card", "deck", "attack", "skill", "power"] },
-  { name: "Characters", path: "/characters", keywords: ["character", "class", "hero", "ironclad", "silent", "defect", "necrobinder", "regent"] },
-  { name: "Relics", path: "/relics", keywords: ["relic", "artifact"] },
-  { name: "Monsters", path: "/monsters", keywords: ["monster", "enemy", "boss", "bestiary"] },
-  { name: "Potions", path: "/potions", keywords: ["potion", "flask"] },
-  { name: "Powers", path: "/powers", keywords: ["power", "buff", "debuff", "status"] },
-  { name: "Enchantments", path: "/enchantments", keywords: ["enchantment", "enchant"] },
-  { name: "Encounters", path: "/encounters", keywords: ["encounter", "fight", "combat"] },
-  { name: "Events", path: "/events", keywords: ["event"] },
-  { name: "Merchant", path: "/merchant", keywords: ["merchant", "shop", "store", "buy", "sell", "price", "gold", "removal"] },
-  { name: "Ancients", path: "/ancients", keywords: ["ancient", "neow", "darv", "orobas", "pael", "tezcatara", "vakuu", "nonupeipe", "tanx", "offering"] },
-  { name: "Unlocks", path: "/unlocks", keywords: ["unlock", "unlockable", "progression", "epoch"] },
-  { name: "Keywords", path: "/keywords", keywords: ["keyword", "exhaust", "ethereal", "innate", "retain", "sly", "eternal", "unplayable"] },
-  { name: "Compare Characters", path: "/compare", keywords: ["compare", "comparison", "versus", "vs"] },
-  { name: "Custom Mode", path: "/modifiers", keywords: ["modifier", "custom", "mode", "mutator"] },
-  { name: "Runs", path: "/runs", keywords: ["run", "upload", "submit", "history", "win", "loss"] },
-  { name: "Tier List", path: "/tier-list", keywords: ["tier", "tier list", "ranking", "best", "worst", "s tier"] },
-  { name: "Card Tier List", path: "/tier-list/cards", keywords: ["tier", "card tier", "best cards"] },
-  { name: "Relic Tier List", path: "/tier-list/relics", keywords: ["tier", "relic tier", "best relics"] },
-  { name: "Potion Tier List", path: "/tier-list/potions", keywords: ["tier", "potion tier", "best potions"] },
-  { name: "Leaderboards", path: "/leaderboards", keywords: ["leaderboard", "fastest", "ascension", "ladder", "ranking"] },
-  { name: "Card Metrics", path: "/leaderboards/metrics", keywords: ["metrics", "elo", "codex elo", "pick rate", "win rate", "table"] },
-  { name: "Codex Score", path: "/leaderboards/scoring", keywords: ["score", "codex score", "scoring", "methodology", "tier bands"] },
-  { name: "Community Stats", path: "/community-stats", keywords: ["community", "stats", "statistics", "event votes", "deadliest", "records"] },
-  { name: "Submit a Run", path: "/leaderboards/submit", keywords: ["submit", "upload", "run file"] },
-  { name: "Badges", path: "/badges", keywords: ["badge", "frame", "cosmetic"] },
-  { name: "Mechanics", path: "/mechanics", keywords: ["mechanic", "formula", "odds", "chance", "drop rate", "probability", "rng"] },
-  { name: "Guides", path: "/guides", keywords: ["guide", "strategy", "tip", "walkthrough", "tutorial"] },
-  { name: "Submit Guide", path: "/guides/submit", keywords: ["submit", "write", "contribute", "guide"] },
-  { name: "Meta", path: "/meta", keywords: ["meta", "stats", "statistics", "community", "win rate", "pick rate"] },
-  { name: "Timeline", path: "/timeline", keywords: ["timeline", "epoch", "era", "story", "lore"] },
-  { name: "Reference", path: "/reference", keywords: ["reference", "intent", "orb", "affliction", "modifier", "achievement", "ascension", "act"] },
-  { name: "Images", path: "/images", keywords: ["image", "sprite", "asset", "art", "download"] },
-  { name: "Developers", path: "/developers", keywords: ["developer", "api", "widget", "tooltip", "export", "data"] },
-  { name: "Showcase", path: "/showcase", keywords: ["showcase", "community", "project", "built with"] },
-  { name: "Changelog", path: "/changelog", keywords: ["changelog", "patch", "update", "version", "what changed"] },
-  { name: "About", path: "/about", keywords: ["about", "info", "credits"] },
-  { name: "Discord", path: "https://discord.gg/xMsTBeh", keywords: ["discord", "chat", "community"] },
-  { name: "Card Browse", path: "/cards/browse", keywords: ["browse", "filter", "matrix"] },
-  { name: "News", path: "/news", keywords: ["news", "patch", "patch notes", "announcement", "update", "steam", "press"] },
+  ...(sitePages as { path: string; name: string; keywords: string[] }[]).map((p) => ({
+    name: PAGE_OVERRIDES[p.path]?.name ?? p.name,
+    path: p.path,
+    keywords: [...p.keywords, ...(PAGE_OVERRIDES[p.path]?.keywords ?? [])],
+    external: false,
+  })),
+  ...EXTRA_PAGES,
 ];
 
 const MAX_PER_CATEGORY = 5;
@@ -96,7 +121,7 @@ export default function GlobalSearch() {
 
   // Build flat list of all visible results for keyboard navigation
   const flatResults: SearchItem[] = [
-    ...matchedPages.map((p) => ({ name: p.name, path: p.path })),
+    ...matchedPages.map((p) => ({ name: p.name, path: p.path, external: p.external })),
     ...sections.flatMap((s) => s.items),
   ];
 
@@ -300,10 +325,7 @@ export default function GlobalSearch() {
                         ? "bg-[var(--bg-card-hover)]"
                         : "hover:bg-[var(--bg-card-hover)]"
                     }`}
-                    onClick={() => {
-                      setOpen(false);
-                      router.push(p.path);
-                    }}
+                    onClick={() => navigate({ name: p.name, path: p.path, external: p.external })}
                     onMouseEnter={() => setSelectedIndex(i)}
                   >
                     <svg className="w-4 h-4 text-[var(--text-muted)] shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/app/developers/page.tsx
+++ b/frontend/app/developers/page.tsx
@@ -231,6 +231,7 @@ export default function DevelopersPage() {
                 { method: "GET", path: "/api/unlocks", desc: "Unlockable entities grouped by type with epoch context" },
                 { method: "GET", path: "/api/history/{entity_type}/{entity_id}", desc: "Per-entity version history from changelogs" },
                 { method: "GET", path: "/api/names/{entity_type}/{entity_id}", desc: "Cross-language name lookup for an entity" },
+                { method: "GET", path: "/api/search", desc: "Unified site search across entities, reference entries, mechanics, guides, and news (q, lang)" },
                 { method: "GET", path: "/api/changelogs", desc: "All changelogs" },
                 { method: "GET", path: "/api/changelogs/recent-additions", desc: "Newest entities surfaced for the homepage band" },
                 { method: "GET", path: "/api/changelogs/{tag}", desc: "Single changelog by tag (e.g. v1.0.20)" },

--- a/frontend/lib/site-pages.json
+++ b/frontend/lib/site-pages.json
@@ -1,0 +1,349 @@
+[
+  {
+    "path": "/about",
+    "name": "About",
+    "keywords": [
+      "about"
+    ]
+  },
+  {
+    "path": "/ancients",
+    "name": "Ancients",
+    "keywords": [
+      "ancients"
+    ]
+  },
+  {
+    "path": "/badges",
+    "name": "Badges",
+    "keywords": [
+      "badges"
+    ]
+  },
+  {
+    "path": "/cards",
+    "name": "Cards",
+    "keywords": [
+      "cards"
+    ]
+  },
+  {
+    "path": "/cards/browse",
+    "name": "Cards · Browse",
+    "keywords": [
+      "cards",
+      "browse"
+    ]
+  },
+  {
+    "path": "/changelog",
+    "name": "Changelog",
+    "keywords": [
+      "changelog"
+    ]
+  },
+  {
+    "path": "/characters",
+    "name": "Characters",
+    "keywords": [
+      "characters"
+    ]
+  },
+  {
+    "path": "/community-stats",
+    "name": "Community Stats",
+    "keywords": [
+      "community",
+      "stats"
+    ]
+  },
+  {
+    "path": "/compare",
+    "name": "Compare",
+    "keywords": [
+      "compare"
+    ]
+  },
+  {
+    "path": "/developers",
+    "name": "Developers",
+    "keywords": [
+      "developers"
+    ]
+  },
+  {
+    "path": "/enchantments",
+    "name": "Enchantments",
+    "keywords": [
+      "enchantments"
+    ]
+  },
+  {
+    "path": "/encounters",
+    "name": "Encounters",
+    "keywords": [
+      "encounters"
+    ]
+  },
+  {
+    "path": "/events",
+    "name": "Events",
+    "keywords": [
+      "events"
+    ]
+  },
+  {
+    "path": "/guides",
+    "name": "Guides",
+    "keywords": [
+      "guides"
+    ]
+  },
+  {
+    "path": "/guides/submit",
+    "name": "Guides · Submit",
+    "keywords": [
+      "guides",
+      "submit"
+    ]
+  },
+  {
+    "path": "/images",
+    "name": "Images",
+    "keywords": [
+      "images"
+    ]
+  },
+  {
+    "path": "/keywords",
+    "name": "Keywords",
+    "keywords": [
+      "keywords"
+    ]
+  },
+  {
+    "path": "/knowledge-demon",
+    "name": "Knowledge Demon",
+    "keywords": [
+      "knowledge",
+      "demon"
+    ]
+  },
+  {
+    "path": "/leaderboards",
+    "name": "Leaderboards",
+    "keywords": [
+      "leaderboards"
+    ]
+  },
+  {
+    "path": "/leaderboards/encounters",
+    "name": "Leaderboards · Encounters",
+    "keywords": [
+      "leaderboards",
+      "encounters"
+    ]
+  },
+  {
+    "path": "/leaderboards/metrics",
+    "name": "Leaderboards · Metrics",
+    "keywords": [
+      "leaderboards",
+      "metrics"
+    ]
+  },
+  {
+    "path": "/leaderboards/scoring",
+    "name": "Leaderboards · Scoring",
+    "keywords": [
+      "leaderboards",
+      "scoring"
+    ]
+  },
+  {
+    "path": "/leaderboards/stats",
+    "name": "Leaderboards · Stats",
+    "keywords": [
+      "leaderboards",
+      "stats"
+    ]
+  },
+  {
+    "path": "/leaderboards/submit",
+    "name": "Leaderboards · Submit",
+    "keywords": [
+      "leaderboards",
+      "submit"
+    ]
+  },
+  {
+    "path": "/mechanics",
+    "name": "Mechanics",
+    "keywords": [
+      "mechanics"
+    ]
+  },
+  {
+    "path": "/merchant",
+    "name": "Merchant",
+    "keywords": [
+      "merchant"
+    ]
+  },
+  {
+    "path": "/modifiers",
+    "name": "Modifiers",
+    "keywords": [
+      "modifiers"
+    ]
+  },
+  {
+    "path": "/monsters",
+    "name": "Monsters",
+    "keywords": [
+      "monsters"
+    ]
+  },
+  {
+    "path": "/news",
+    "name": "News",
+    "keywords": [
+      "news"
+    ]
+  },
+  {
+    "path": "/overlay",
+    "name": "Overlay",
+    "keywords": [
+      "overlay"
+    ]
+  },
+  {
+    "path": "/potions",
+    "name": "Potions",
+    "keywords": [
+      "potions"
+    ]
+  },
+  {
+    "path": "/powers",
+    "name": "Powers",
+    "keywords": [
+      "powers"
+    ]
+  },
+  {
+    "path": "/privacy",
+    "name": "Privacy",
+    "keywords": [
+      "privacy"
+    ]
+  },
+  {
+    "path": "/profile",
+    "name": "Profile",
+    "keywords": [
+      "profile"
+    ]
+  },
+  {
+    "path": "/reference",
+    "name": "Reference",
+    "keywords": [
+      "reference"
+    ]
+  },
+  {
+    "path": "/relics",
+    "name": "Relics",
+    "keywords": [
+      "relics"
+    ]
+  },
+  {
+    "path": "/runs",
+    "name": "Runs",
+    "keywords": [
+      "runs"
+    ]
+  },
+  {
+    "path": "/settings",
+    "name": "Settings",
+    "keywords": [
+      "settings"
+    ]
+  },
+  {
+    "path": "/showcase",
+    "name": "Showcase",
+    "keywords": [
+      "showcase"
+    ]
+  },
+  {
+    "path": "/terms",
+    "name": "Terms",
+    "keywords": [
+      "terms"
+    ]
+  },
+  {
+    "path": "/tier-list",
+    "name": "Tier List",
+    "keywords": [
+      "tier",
+      "list"
+    ]
+  },
+  {
+    "path": "/tier-list-maker",
+    "name": "Tier List Maker",
+    "keywords": [
+      "tier",
+      "list",
+      "maker"
+    ]
+  },
+  {
+    "path": "/tier-list/cards",
+    "name": "Tier List · Cards",
+    "keywords": [
+      "tier",
+      "list",
+      "cards"
+    ]
+  },
+  {
+    "path": "/tier-list/potions",
+    "name": "Tier List · Potions",
+    "keywords": [
+      "tier",
+      "list",
+      "potions"
+    ]
+  },
+  {
+    "path": "/tier-list/relics",
+    "name": "Tier List · Relics",
+    "keywords": [
+      "tier",
+      "list",
+      "relics"
+    ]
+  },
+  {
+    "path": "/timeline",
+    "name": "Timeline",
+    "keywords": [
+      "timeline"
+    ]
+  },
+  {
+    "path": "/unlocks",
+    "name": "Unlocks",
+    "keywords": [
+      "unlocks"
+    ]
+  }
+]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "node scripts/generate-site-pages.mjs",
     "dev": "next dev",
+    "prebuild": "node scripts/generate-site-pages.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/frontend/scripts/generate-site-pages.mjs
+++ b/frontend/scripts/generate-site-pages.mjs
@@ -1,0 +1,54 @@
+// Generates lib/site-pages.json from the App Router file tree, so the
+// global search's "Pages" category can never go stale: every static
+// app/**/page.tsx IS a page, and new ones appear in search automatically
+// on the next build. Curated display names and keyword synonyms live in
+// PAGE_OVERRIDES inside GlobalSearch.tsx; this file only owns the route
+// inventory. Runs via the predev/prebuild npm hooks.
+import { readdirSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FRONTEND = join(dirname(fileURLToPath(import.meta.url)), "..");
+const APP_DIR = join(FRONTEND, "app");
+const OUT = join(FRONTEND, "lib", "site-pages.json");
+
+// Routes that exist but don't belong in a search palette: post-action
+// landers, bare redirects, and sub-flows of another page.
+const EXCLUDE = new Set(["/thank-you", "/uninstall", "/meta", "/tier-list-maker/new"]);
+
+function walk(dir, segments = []) {
+  const routes = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      // Dynamic segments ([id], [lang], ...) and route groups aren't
+      // standalone searchable pages.
+      if (entry.name.startsWith("[") || entry.name.startsWith("(")) continue;
+      routes.push(...walk(join(dir, entry.name), [...segments, entry.name]));
+    } else if (entry.name === "page.tsx" || entry.name === "page.ts") {
+      routes.push("/" + segments.join("/"));
+    }
+  }
+  return routes;
+}
+
+function titleCase(segment) {
+  return segment
+    .split("-")
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}
+
+const pages = walk(APP_DIR)
+  .filter((path) => path !== "/" && !EXCLUDE.has(path))
+  .sort()
+  .map((path) => ({
+    path,
+    // Derived default name ("/tier-list/cards" -> "Tier List · Cards");
+    // PAGE_OVERRIDES in GlobalSearch.tsx supplies nicer names where wanted.
+    name: path.slice(1).split("/").map(titleCase).join(" · "),
+    // Path words double as baseline keywords; overrides add synonyms.
+    keywords: path.toLowerCase().split(/[/-]/).filter(Boolean),
+  }));
+
+writeFileSync(OUT, JSON.stringify(pages, null, 2) + "\n");
+console.log(`site-pages.json: ${pages.length} routes`);


### PR DESCRIPTION
The cmd-K search was missing half the site: no keywords, no reference entries (orbs, afflictions, intents, modifiers, achievements, badges), none of the 27 mechanics pages, no guides, no news, and the static pages list predated the tier lists, leaderboards, card metrics, scoring page, and community stats. It also fired ten parallel requests per keystroke, one per entity type.

## Backend
New `GET /api/search?q=&lang=` does one in-memory pass over everything searchable: the ten entity types, the merged reference entries, mechanics pages, community guides, and news titles. Light relevance ranking (exact > prefix > word-start > substring > description match), localized names via lang, a handful of results per category. Sub-ms over the lru-cached game data, so no extra caching needed.

## Frontend
The modal makes one request to /api/search plus one to the image search (thumbnails, external links) instead of ten, and renders whatever categories come back. The pages list catches up with the site: tier lists (hub + per type), leaderboards, card metrics, Codex Score, community stats, submit a run, and badges.

## Verified
Live queries against real data: "drop rate" finds the Potion Drop Rates mechanics page, "exhaust" spans cards/relics/potions/powers/enchantments/events/keywords/reference, "ironclad" surfaces the character, reference entries, mechanics, and news, and Japanese queries return localized names. App boots with the route registered; ruff and tsc clean.

Documented on /developers and in contributing/CLAUDE.md.

## Self-maintaining pages list
The "Pages" category is no longer hand-curated: `scripts/generate-site-pages.mjs` derives the route inventory from `app/**/page.tsx` on every dev/build (predev/prebuild hooks), so new pages appear in search automatically. Curated display names and keyword synonyms moved to an optional overrides map; a page that ships without one still gets a derived name and path-word keywords. This immediately surfaced four pages the hand list had already missed (`/overlay`, `/knowledge-demon`, `/tier-list-maker`, `/leaderboards/encounters`).
