### PR TITLE
Stop every worker walking all run files at startup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -148,6 +148,19 @@ app.add_middleware(SlowAPIMiddleware)
 def _warm_run_entity_stats() -> None:
     if IS_BETA_BACKEND:
         return
+    # On the Mongo path, skip the local walk entirely: the leader refresher
+    # builds ONE shared snapshot and every worker loads it. This pre-warm
+    # predates that design, and with 4 workers it meant five concurrent
+    # 216k-file walks on every deploy, which thrashed small boxes into
+    # near-hour warmups. Only the SQLite path still needs a local build.
+    if os.environ.get("MONGO_URL", "").strip():
+        try:
+            from .routers.runs import start_stats_refresher
+
+            start_stats_refresher()
+        except Exception:
+            pass
+        return
     import threading
 
     from .services.run_entity_stats import _build_cache


### PR DESCRIPTION
One commit that missed the #426 merge window. The startup pre-warm predates the shared snapshot: with 4 uvicorn workers it launched four full 216k-file walks per deploy on top of the leader refresher's own walk, five concurrent walks that thrash the 4 vCPU box into near-hour warmups while every snapshot-backed endpoint serves empty (tonight's blank pages). On the Mongo path workers now skip the local build and load the leader's snapshot when it lands, so a deploy costs one walk, and deploys that don't bump SNAPSHOT_VERSION have no empty window at all. The SQLite dev path keeps the local pre-warm.