### PR TITLE
Filter the runs browser by submitter win rate

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -222,6 +222,8 @@ def list_runs(
     character: str | None = None,
     win: str | None = None,
     username: str | None = None,
+    winrate_min: float | None = Query(None, ge=0, le=100),
+    winrate_max: float | None = Query(None, ge=0, le=100),
     seed: str | None = None,
     sort: str | None = None,
     build_id: str | None = None,
@@ -237,7 +239,12 @@ def list_runs(
     page: int = 1,
     limit: int = 50,
 ):
-    """List submitted runs with optional filters, sorting, and pagination."""
+    """List submitted runs with optional filters, sorting, and pagination.
+
+    `winrate_min` / `winrate_max` filter runs by their submitter's overall
+    win rate percentage; only users with at least 5 submitted runs qualify,
+    and anonymous runs never match.
+    """
     # Browser/edge caching: new runs arrive constantly, but 30s of staleness
     # on a browse page is invisible and lets Cloudflare absorb repeat hits.
     response.headers["Cache-Control"] = "public, max-age=30"
@@ -250,6 +257,8 @@ def list_runs(
             character,
             win,
             username,
+            winrate_min,
+            winrate_max,
             seed,
             sort,
             build_id,
@@ -276,6 +285,8 @@ def list_runs(
             character=character,
             win=win,
             username=username,
+            winrate_min=winrate_min,
+            winrate_max=winrate_max,
             seed=seed,
             sort=sort,
             build_id=build_id,
@@ -322,6 +333,16 @@ def list_runs(
         if game_mode:
             conditions.append("game_mode = ?")
             params.append(game_mode)
+        if winrate_min is not None or winrate_max is not None:
+            # Mirror the Mongo path: submitter winrate within range, with a
+            # 5-run floor so one-run wonders don't flood winrate:100.
+            conditions.append(
+                "username IN (SELECT username FROM runs WHERE username != '' "
+                "GROUP BY username HAVING COUNT(*) >= 5 "
+                "AND 100.0 * SUM(win) / COUNT(*) BETWEEN ? AND ?)"
+            )
+            params.append(winrate_min if winrate_min is not None else 0.0)
+            params.append(winrate_max if winrate_max is not None else 100.0)
         if today:
             # "Today's daily" = today's daily seed (prefixed DD_MM_YYYY), not
             # submitted_at (upload time). Mirrors _today_daily_seed_match in the

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1597,11 +1597,46 @@ def _row_to_dict(doc: dict) -> dict:
     return out
 
 
+# Submitters need at least this many runs before a winrate filter counts
+# them: without a floor, every one-run winner floods "winrate:100".
+WINRATE_MIN_RUNS = 5
+
+
+def get_user_winrates() -> dict[str, list[int]]:
+    """Per-username [total runs, wins], cached in Redis for 5 minutes.
+
+    One $group over the collection (a few hundred ms) once per TTL instead
+    of per request. Anonymous runs (no username) are excluded; abandoned
+    runs count as losses, matching the profile-page win rate.
+    """
+    cached = app_cache.get_json("user_winrates:all")
+    if cached is not None:
+        return cached
+    coll = _get_collection()
+    pipeline = [
+        {"$match": {"username": {"$nin": [None, ""]}}},
+        {
+            "$group": {
+                "_id": "$username",
+                "total": {"$sum": 1},
+                "wins": {"$sum": {"$cond": [{"$in": ["$win", [True, 1]]}, 1, 0]}},
+            }
+        },
+    ]
+    out: dict[str, list[int]] = {}
+    for row in coll.aggregate(pipeline, allowDiskUse=True):
+        out[str(row["_id"])] = [int(row["total"]), int(row["wins"])]
+    app_cache.set_json("user_winrates:all", out, ttl_seconds=300)
+    return out
+
+
 @_instrument("list_runs")
 def list_runs(
     character: str | None = None,
     win: str | None = None,
     username: str | None = None,
+    winrate_min: float | None = None,
+    winrate_max: float | None = None,
     seed: str | None = None,
     sort: str | None = None,
     build_id: str | None = None,
@@ -1629,6 +1664,32 @@ def list_runs(
         q["was_abandoned"] = {"$in": [False, 0]}
     if username:
         q["username"] = {"$regex": username, "$options": "i"}
+    if winrate_min is not None or winrate_max is not None:
+        # Filter runs by their submitter's overall win rate. The per-user
+        # map is one cached aggregation; the run query then becomes an $in
+        # over the qualifying usernames (composable with the regex above,
+        # since both live under the same field's operator object).
+        lo = winrate_min if winrate_min is not None else 0.0
+        hi = winrate_max if winrate_max is not None else 100.0
+        rates = get_user_winrates()
+        names = [
+            name
+            for name, (total, wins) in rates.items()
+            if total >= WINRATE_MIN_RUNS and lo <= (wins / total * 100) <= hi
+        ]
+        if not names:
+            return {
+                "runs": [],
+                "total": 0,
+                "page": max(page, 1),
+                "per_page": min(limit, 100),
+                "total_pages": 0,
+            }
+        user_q = q.get("username")
+        if isinstance(user_q, dict):
+            user_q["$in"] = names
+        else:
+            q["username"] = {"$in": names}
     if seed:
         # Anchored prefix, case-sensitive: uses the seed index instead of
         # scanning every document. Daily seeds are date-prefixed so the

--- a/frontend/app/developers/page.tsx
+++ b/frontend/app/developers/page.tsx
@@ -248,7 +248,7 @@ export default function DevelopersPage() {
                 { method: "POST", path: "/api/guides", desc: "Submit a guide (Discord webhook, rate-limited)" },
                 { method: "POST", path: "/api/runs", desc: "Submit a run for community stats and leaderboards" },
                 { method: "POST", path: "/api/runs/claim", desc: "Attach a username to previously-submitted runs by hash" },
-                { method: "GET", path: "/api/runs/list", desc: "Browse submitted runs with filters and pagination" },
+                { method: "GET", path: "/api/runs/list", desc: "Browse submitted runs with filters and pagination (incl. winrate_min/winrate_max by submitter win rate)" },
                 { method: "GET", path: "/api/runs/leaderboard", desc: "Run leaderboards (fastest, highest_ascension)" },
                 { method: "GET", path: "/api/runs/shared/{run_hash}", desc: "Single submitted run by hash (rate-limited)" },
                 { method: "GET", path: "/api/runs/stats", desc: "Aggregate community stats (filter by character, ascension, username)" },

--- a/frontend/app/runs/BrowseRunsClient.tsx
+++ b/frontend/app/runs/BrowseRunsClient.tsx
@@ -73,7 +73,7 @@ type Sort = "date" | "time_asc" | "time_desc" | "ascension_desc";
 // Parse `key:value` expressions out of a free-text query.
 // Returns extracted filters and the remaining free-text (after stripping
 // recognized key:value pairs).
-type QueryKey = "user" | "seed" | "char" | "asc" | "version" | "mode" | "result" | "players" | "card" | "relic";
+type QueryKey = "user" | "seed" | "char" | "asc" | "version" | "mode" | "result" | "players" | "card" | "relic" | "winrate";
 
 function parseQuery(q: string): {
   filters: Partial<Record<QueryKey, string>>;
@@ -103,9 +103,42 @@ function parseQuery(q: string): {
     else if (["players", "p"].includes(key)) filters.players = value;
     else if (["card", "cards"].includes(key)) filters.card = appendMulti(filters.card, value);
     else if (["relic", "relics"].includes(key)) filters.relic = appendMulti(filters.relic, value);
+    else if (["winrate", "wr"].includes(key)) filters.winrate = value;
     else restTokens.push(tok);
   }
   return { filters, rest: restTokens.join(" ").trim() };
+}
+
+// "50-70" -> {min:50, max:70}; "100" -> {min:100, max:100}; "60-" / "60+" /
+// ">=60" -> {min:60}; "-40" / "<=40" -> {max:40}; ">50" excludes exactly-50
+// via a small epsilon, "<50" likewise. A trailing % is tolerated everywhere.
+// Anything non-numeric parses to {} and is ignored.
+function parseWinrate(expr: string): { min?: number; max?: number } {
+  const clamp = (n: number) => Math.min(100, Math.max(0, n));
+  const e = expr.trim().replace(/%/g, "");
+  const cmp = /^(>=|<=|>|<)\s*(\d{1,3}(?:\.\d+)?)$/.exec(e);
+  if (cmp) {
+    const v = clamp(parseFloat(cmp[2]));
+    if (cmp[1] === ">=") return { min: v };
+    if (cmp[1] === "<=") return { max: v };
+    if (cmp[1] === ">") return { min: clamp(v + 0.01) };
+    return { max: clamp(v - 0.01) };
+  }
+  const plus = /^(\d{1,3}(?:\.\d+)?)\+$/.exec(e);
+  if (plus) return { min: clamp(parseFloat(plus[1])) };
+  const range = /^(\d{1,3}(?:\.\d+)?)?\s*-\s*(\d{1,3}(?:\.\d+)?)?$/.exec(e);
+  if (range && (range[1] !== undefined || range[2] !== undefined)) {
+    const out: { min?: number; max?: number } = {};
+    if (range[1] !== undefined) out.min = clamp(parseFloat(range[1]));
+    if (range[2] !== undefined) out.max = clamp(parseFloat(range[2]));
+    return out;
+  }
+  const single = /^(\d{1,3}(?:\.\d+)?)$/.exec(e);
+  if (single) {
+    const v = clamp(parseFloat(single[1]));
+    return { min: v, max: v };
+  }
+  return {};
 }
 
 // Expand a version expression to the list of build_ids it covers.
@@ -207,6 +240,7 @@ export default function BrowseRunsClient() {
       : "");
   const effectiveCard = queryFilters.card || "";
   const effectiveRelic = queryFilters.relic || "";
+  const effectiveWinrate = queryFilters.winrate || "";
 
   // Reset page when any filter changes
   useEffect(() => {
@@ -255,6 +289,11 @@ export default function BrowseRunsClient() {
     }
     if (effectiveCard) params.set("card", effectiveCard);
     if (effectiveRelic) params.set("relic", effectiveRelic);
+    if (effectiveWinrate) {
+      const wr = parseWinrate(effectiveWinrate);
+      if (wr.min !== undefined) params.set("winrate_min", String(wr.min));
+      if (wr.max !== undefined) params.set("winrate_max", String(wr.max));
+    }
     if (effectiveGameMode === "daily_today") {
       params.set("game_mode", "daily");
       params.set("today", "true");
@@ -274,7 +313,7 @@ export default function BrowseRunsClient() {
       })
       .catch(() => {})
       .finally(() => setLoading(false));
-  }, [effectiveChar, effectiveWin, effectiveUser, effectiveSeed, effectiveBuildId, effectivePlayers, effectiveGameMode, effectiveAscension, effectiveCard, effectiveRelic, versions, sort, page]);
+  }, [effectiveChar, effectiveWin, effectiveUser, effectiveSeed, effectiveBuildId, effectivePlayers, effectiveGameMode, effectiveAscension, effectiveCard, effectiveRelic, effectiveWinrate, versions, sort, page]);
 
   function clearAll() {
     setQuery("");
@@ -322,7 +361,7 @@ export default function BrowseRunsClient() {
           className="w-full text-sm px-4 py-2.5 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]"
         />
         <p className="mt-1.5 text-[10px] text-[var(--text-tertiary)]">
-          Expressions: <code>user:name</code>, <code>char:ironclad</code>, <code>asc:10</code> or <code>asc:3-7</code>, <code>card:bash,anger</code>, <code>relic:burning_blood</code> (combine for AND), <code>version:v0.106.0</code> or <code>version:v0.104.0-v0.106.0</code>, <code>seed:abc</code>, <code>mode:daily</code>, <code>result:win</code>, <code>players:single</code>
+          Expressions: <code>user:name</code>, <code>char:ironclad</code>, <code>asc:10</code> or <code>asc:3-7</code>, <code>card:bash,anger</code>, <code>relic:burning_blood</code> (combine for AND), <code>winrate:50-70</code>, <code>winrate:&gt;50</code>, or <code>winrate:100</code> (submitter win rate, min 5 runs), <code>version:v0.106.0</code> or <code>version:v0.104.0-v0.106.0</code>, <code>seed:abc</code>, <code>mode:daily</code>, <code>result:win</code>, <code>players:single</code>
         </p>
       </div>
 


### PR DESCRIPTION
Adds the missing win-rate expression to /runs. Type winrate:50-70, winrate:>50, winrate:>=50, winrate:50+, winrate:<30, winrate:100, or open ranges like winrate:60- into the search bar (wr: works as shorthand, percent signs are tolerated, strict > and < exclude the exact boundary). It composes with every existing filter, so char:silent card:catalyst winrate:>60 works.

Backend: /api/runs/list grows winrate_min / winrate_max. The per-username win-rate map comes from one cached aggregation (Redis, 5 minute TTL) and the range becomes an indexed username $in on the runs query, so the filter adds no per-request aggregation cost. Submitters need at least 5 runs to qualify, which keeps one-run 100% wonders out of winrate:100, and anonymous runs never match. The SQLite dev path mirrors the behavior with a HAVING subquery.

Verified end to end against injected fixtures: winrate_min=90 returns only the 100% user, 50-70 returns only the 60% user, and a 2-run 100% user is excluded by the floor. Search help and /developers updated.