### PR TITLE
Hopper stolen cards stat + quest items out of most-removed

### DIFF
--- a/backend/app/services/community_stats.py
+++ b/backend/app/services/community_stats.py
@@ -74,6 +74,7 @@ def new_accumulator() -> dict[str, Any]:
         "rest": {},  # rest-site choice -> count
         "ancient": {},  # relic_id -> count (chosen from the 3-relic offer)
         "removed": {},  # card_id -> count (purged at a shop/event)
+        "stolen": {},  # card_id -> count (taken by the Thieving Hopper)
         "reward_screens": 0,
         "reward_skips": 0,
         "fastest_win": None,  # (run_time, run_hash)
@@ -136,6 +137,14 @@ def accumulate(
     # Per-floor choices.
     for act_floors in blob.get("map_point_history") or []:
         for floor in act_floors or []:
+            # The Thieving Hopper steals cards mid-fight; those show up in
+            # cards_removed on its encounter floor. Route them to "stolen" so
+            # most-removed only counts removals the player chose.
+            hopper_floor = any(
+                "THIEVING_HOPPER" in (room.get("model_id") or "")
+                for room in floor.get("rooms") or []
+                if isinstance(room, dict)
+            )
             for ps in floor.get("player_stats") or []:
                 # Event decisions: keys look like
                 # "BYRDONIS_NEST.pages.INITIAL.options.TAKE.title".
@@ -167,14 +176,14 @@ def accumulate(
                         if rid:
                             _bump(acc["ancient"], rid)
 
-                # Cards purged at a shop / event.
+                # Cards purged at a shop / event, or stolen by the Hopper.
                 for rem in ps.get("cards_removed") or []:
                     raw = rem.get("id") if isinstance(rem, dict) else rem
                     if isinstance(rem, dict) and "card" in rem:
                         raw = (rem.get("card") or {}).get("id")
                     cid = _merge_starter(_bare(raw))
                     if cid:
-                        _bump(acc["removed"], cid)
+                        _bump(acc["stolen" if hopper_floor else "removed"], cid)
 
                 # Card-reward screens: a screen with nothing picked is a skip.
                 choices = ps.get("card_choices") or []
@@ -233,6 +242,22 @@ def _name_maps() -> dict[str, dict[str, str]]:
         logger.warning("community-stats event options load failed", exc_info=True)
     out["_event_options"] = event_opts  # type: ignore[assignment]
     return out
+
+
+def _quest_card_ids() -> frozenset[str]:
+    """Quest items (Byrdonis Egg, Lantern Key, ...). They only enter and
+    leave a deck through events, so counting them as removals is noise."""
+    from . import data_service
+
+    try:
+        return frozenset(
+            c["id"]
+            for c in data_service.load_cards()
+            if c.get("id") and (c.get("color") or "").lower() == "quest"
+        )
+    except Exception:
+        logger.warning("community-stats quest card load failed", exc_info=True)
+        return frozenset()
 
 
 def _pct(part: int, whole: int) -> float:
@@ -323,6 +348,9 @@ def finalize(acc: dict[str, Any]) -> dict[str, Any]:
             return None
         return {value_key: rec[0], "run_hash": rec[1]}
 
+    quest_ids = _quest_card_ids()
+    removed = {k: v for k, v in acc["removed"].items() if k not in quest_ids}
+
     return {
         "total_runs": total_runs,
         "total_wins": total_wins,
@@ -345,7 +373,8 @@ def finalize(acc: dict[str, Any]) -> dict[str, Any]:
             for c, n in sorted(acc["rest"].items(), key=lambda kv: kv[1], reverse=True)
         ],
         "ancient_picks": _ranked(acc["ancient"], names["relics"], _TOP_N),
-        "most_removed": _ranked(acc["removed"], names["cards"], _TOP_N),
+        "most_removed": _ranked(removed, names["cards"], _TOP_N),
+        "hopper_stolen": _ranked(acc.get("stolen") or {}, names["cards"], 10),
         "reward_skip_rate": _pct(acc["reward_skips"], acc["reward_screens"]),
         "records": {
             "fastest_win": _rec(acc["fastest_win"], "run_time"),

--- a/frontend/app/community-stats/page.tsx
+++ b/frontend/app/community-stats/page.tsx
@@ -31,6 +31,7 @@ interface CommunityStats {
   rest_sites: { id: string; label: string; count: number; pct: number }[];
   ancient_picks: Ranked[];
   most_removed: Ranked[];
+  hopper_stolen?: Ranked[];
   reward_skip_rate: number;
   records: { fastest_win: Record_ | null; longest_run: Record_ | null; biggest_deck: Record_ | null };
 }
@@ -233,6 +234,12 @@ export default async function CommunityStatsPage() {
           <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Most-removed cards</h2>
           <RankBars color={GOLD} data={stats.most_removed.map((r) => ({ name: r.name, value: r.count, display: r.count.toLocaleString() }))} />
         </div>
+        {(stats.hopper_stolen?.length ?? 0) > 0 && (
+          <div>
+            <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Stolen by the Thieving Hopper</h2>
+            <RankBars color={ROSE} data={(stats.hopper_stolen ?? []).map((r) => ({ name: r.name, value: r.count, display: r.count.toLocaleString() }))} />
+          </div>
+        )}
         <div>
           <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Favorite ancient relics</h2>
           <RankBars color={GOLD} data={rankPct(stats.ancient_picks)} />


### PR DESCRIPTION
## What

Two community-stats fixes from the backlog:

- **Stolen by the Thieving Hopper (#429):** cards the Hopper takes mid-fight show up in `cards_removed` on its encounter floor. I now route those into their own bucket and render a top-10 "Stolen by the Thieving Hopper" list on /community-stats. This also means steals no longer pollute most-removed, since they were never voluntary removals.
- **Quest items out of most-removed (#428):** quest items (Byrdonis Egg, Lantern Key, Spoils Map) only enter and leave a deck through events, so I filter the quest color out of most-removed at finalize time.

## How

- `accumulate()` checks the floor's rooms for a `THIEVING_HOPPER` encounter and routes that floor's removals to a new `stolen` accumulator.
- `finalize()` drops quest-colored card ids from `removed` and emits `hopper_stolen` (top 10).
- The frontend renders the new section only when the field is present and non-empty, so an older snapshot doesn't break the page. The stat appears after the next snapshot rebuild.

## Testing

- Verified against a real production run blob (0158d867ae51e7fc) that has an actual Hopper steal (Bulwark+1 on the Act 2 hopper floor): it lands in `hopper_stolen` and not `most_removed`.
- Synthetic blob with a quest-item removal (Lantern Key) plus a starter removal: quest item excluded, Strike merged and kept, all assertions pass.
- ruff format/check clean, tsc clean.

Fixes #428, fixes #429