### PR TITLE
Act filter pills for monsters in the tier list maker

### DIFF
--- a/frontend/app/tier-list-maker/api.ts
+++ b/frontend/app/tier-list-maker/api.ts
@@ -15,6 +15,20 @@ interface RawEntity {
   pool?: string;
   // Cards/relics/potions carry a clean rarity key (Common, Rare, Ancient, …).
   rarity_key?: string;
+  // Monsters carry their encounters, each tagged with the act it appears in.
+  encounters?: { act?: string | null }[];
+}
+
+/** Tray group for a monster: the act of its first encounter that has one
+ * ("Act 1 - Overgrowth" -> "act1-overgrowth"), or "other" for event/special
+ * monsters with no act of their own (the Architect, battle friends, ...). */
+function monsterActGroup(encounters?: { act?: string | null }[]): string {
+  for (const enc of encounters ?? []) {
+    if (enc.act) {
+      return enc.act.toLowerCase().replace(/\s*-\s*/g, "-").replace(/\s+/g, "");
+    }
+  }
+  return "other";
 }
 
 /** Map every ancient relic to the single ancient that offers it, e.g.
@@ -84,7 +98,9 @@ export async function fetchEntities(type: EntityType): Promise<TierEntity[]> {
       group:
         type === "relics"
           ? ancientMap[e.id.toUpperCase()] ?? e.pool ?? undefined
-          : e.color ?? undefined,
+          : type === "monsters"
+            ? monsterActGroup(e.encounters)
+            : e.color ?? undefined,
       // "None" is the API's placeholder for the odd un-raritied entry; treat
       // it as no rarity so it doesn't pollute the rarity dropdown.
       rarity: e.rarity_key && e.rarity_key !== "None" ? e.rarity_key : undefined,

--- a/frontend/app/tier-list-maker/types.ts
+++ b/frontend/app/tier-list-maker/types.ts
@@ -119,10 +119,23 @@ export const RELIC_GROUPS: { value: string; label: string }[] = [
   { value: "vakuu", label: "Vakuu" },
 ];
 
-/** Tray filter groups per entity type (only cards + relics have them today). */
+/** Monster tray filter groups: the act each monster appears in, taken from
+ * its encounter list (the two constructs that show up in more than one act
+ * group under their first). "Event and Special" catches monsters with no act
+ * of their own (the Architect, battle friends, ...). */
+export const MONSTER_GROUPS: { value: string; label: string }[] = [
+  { value: "act1-overgrowth", label: "Act 1 Overgrowth" },
+  { value: "act1-underdocks", label: "Act 1 Underdocks" },
+  { value: "act2-hive", label: "Act 2 Hive" },
+  { value: "act3-glory", label: "Act 3 Glory" },
+  { value: "other", label: "Event and Special" },
+];
+
+/** Tray filter groups per entity type (cards, relics, and monsters today). */
 export const GROUPS_BY_TYPE: Partial<Record<EntityType, { value: string; label: string }[]>> = {
   cards: CARD_GROUPS,
   relics: RELIC_GROUPS,
+  monsters: MONSTER_GROUPS,
 };
 
 export interface Tier {


### PR DESCRIPTION
## What

The monster tier list maker showed all 115 monsters as one flat tray, so finding the monsters for a specific act meant scrolling past everything else. The tray now has the same filter pills cards and relics already have, grouped by act:

- Act 1 Overgrowth, Act 1 Underdocks, Act 2 Hive, Act 3 Glory
- Event and Special for the 18 act-less monsters (the Architect, battle friends, Osty, ...)

## How

Each monster's group comes from the act of its first encounter in the monster data the API already returns. The two constructs that appear in more than one act (Cubex and Punch Construct) group under their first act. No backend changes; this reuses the existing `GROUPS_BY_TYPE` pill machinery in the builder.

## Testing

- tsc clean.
- Verified the act slugs against live /api/monsters data: 29 Overgrowth, 22 Underdocks, 25 Hive, 23 Glory, 18 special.

Fixes #427