### PR TITLE
Fix single-target cards rendering as AoE (TargetType:choose)

### DIFF
--- a/backend/app/parsers/card_parser.py
+++ b/backend/app/parsers/card_parser.py
@@ -380,8 +380,9 @@ def parse_single_card(
     # Character color from pool
     color = card_pools.get(class_name, "unknown")
 
-    # Add card type to vars temporarily so choose() conditionals can resolve
-    resolve_vars = {**all_vars, "CardType": card_type}
+    # Add card type and target temporarily so choose() conditionals can
+    # resolve ({CardType:...} on Mad Science, {TargetType:...} on Shiv).
+    resolve_vars = {**all_vars, "CardType": card_type, "TargetType": target}
     desc_rendered = shared_resolve_description(description, resolve_vars)
 
     upgrade_description = None

--- a/backend/app/parsers/description_resolver.py
+++ b/backend/app/parsers/description_resolver.py
@@ -74,7 +74,13 @@ def resolve_description(
                         result = branches[idx]
                         break
             if result is None and branches:
-                result = branches[0]  # fallback to first only if no match found
+                if len(branches) > len(options):
+                    # "{Var:choose(A):x|y}" carries a trailing else-branch:
+                    # an unlisted value (SHIV's AnyEnemy vs choose(AllEnemies))
+                    # renders that, not the first option's text.
+                    result = branches[len(options)]
+                else:
+                    result = branches[0]  # no else-branch: first as fallback
             text = text[:start] + (result or "") + text[i:]
         return text
 

--- a/data-beta/v0.102.0/deu/cards.json
+++ b/data-beta/v0.102.0/deu/cards.json
@@ -12279,7 +12279,7 @@
   {
     "id": "SHIV",
     "name": "Messer",
-    "description": "Füge ALLEN Gegnern 4 Schaden zu.",
+    "description": "Füge 4 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|} {Damage:diff()} Schaden zu.",
     "cost": 0,
     "is_x_cost": null,
@@ -12313,7 +12313,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Füge ALLEN Gegnern 6 Schaden zu.",
+    "upgrade_description": "Füge 6 Schaden zu.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.102.0/eng/cards.json
+++ b/data-beta/v0.102.0/eng/cards.json
@@ -18856,7 +18856,7 @@
   {
     "id": "SHIV",
     "name": "Shiv",
-    "description": "Deal 4 damage to ALL enemies.",
+    "description": "Deal 4 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -18890,7 +18890,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Deal 6 damage to ALL enemies.",
+    "upgrade_description": "Deal 6 damage.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.102.0/esp/cards.json
+++ b/data-beta/v0.102.0/esp/cards.json
@@ -16103,7 +16103,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Infliges 4 de daño a TODOS los enemigos.",
+    "description": "Infliges 4 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16137,7 +16137,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliges 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Infliges 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.102.0/fra/cards.json
+++ b/data-beta/v0.102.0/fra/cards.json
@@ -20719,7 +20719,7 @@
   {
     "id": "SHIV",
     "name": "Surin",
-    "description": "Infligez 4 dégâts à TOUS les ennemis.",
+    "description": "Infligez 4 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -20753,7 +20753,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infligez 6 dégâts à TOUS les ennemis.",
+    "upgrade_description": "Infligez 6 dégâts.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.102.0/ita/cards.json
+++ b/data-beta/v0.102.0/ita/cards.json
@@ -16467,7 +16467,7 @@
   {
     "id": "SHIV",
     "name": "Pugnale",
-    "description": "Infliggi 4 di danno a TUTTI i nemici.",
+    "description": "Infliggi 4 di danno.",
     "description_raw": "Infliggi {Damage:diff()} di danno{TargetType:choose(AllEnemies): a TUTTI i nemici|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16501,7 +16501,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliggi 6 di danno a TUTTI i nemici.",
+    "upgrade_description": "Infliggi 6 di danno.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.102.0/kor/cards.json
+++ b/data-beta/v0.102.0/kor/cards.json
@@ -4480,7 +4480,7 @@
   {
     "id": "SHIV",
     "name": "단도",
-    "description": "모든 적에게 피해를 4 줍니다.",
+    "description": "피해를 4 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()} 줍니다.",
     "cost": 0,
     "is_x_cost": null,
@@ -4514,7 +4514,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "모든 적에게 피해를 6 줍니다.",
+    "upgrade_description": "피해를 6 줍니다.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.102.0/ptb/cards.json
+++ b/data-beta/v0.102.0/ptb/cards.json
@@ -14002,7 +14002,7 @@
   {
     "id": "SHIV",
     "name": "Lâmina",
-    "description": "Cause 4 de dano a TODOS os inimigos.",
+    "description": "Cause 4 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -14036,7 +14036,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Cause 6 de dano a TODOS os inimigos.",
+    "upgrade_description": "Cause 6 de dano.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.102.0/rus/cards.json
+++ b/data-beta/v0.102.0/rus/cards.json
@@ -6326,7 +6326,7 @@
   {
     "id": "SHIV",
     "name": "Заточка",
-    "description": "Наносит 4 урона ВСЕМ врагам.",
+    "description": "Наносит 4 урона.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -6360,7 +6360,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Наносит 6 урона ВСЕМ врагам.",
+    "upgrade_description": "Наносит 6 урона.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.102.0/spa/cards.json
+++ b/data-beta/v0.102.0/spa/cards.json
@@ -15914,7 +15914,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Inflige 4 de daño a TODOS los enemigos.",
+    "description": "Inflige 4 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -15948,7 +15948,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Inflige 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Inflige 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.102.0/zhs/cards.json
+++ b/data-beta/v0.102.0/zhs/cards.json
@@ -6626,7 +6626,7 @@
   {
     "id": "SHIV",
     "name": "小刀",
-    "description": "对所有敌人造成4点伤害。",
+    "description": "造成4点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害。",
     "cost": 0,
     "is_x_cost": null,
@@ -6660,7 +6660,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "对所有敌人造成6点伤害。",
+    "upgrade_description": "造成6点伤害。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.0/deu/cards.json
+++ b/data-beta/v0.103.0/deu/cards.json
@@ -12279,7 +12279,7 @@
   {
     "id": "SHIV",
     "name": "Messer",
-    "description": "Füge ALLEN Gegnern 4 Schaden zu.",
+    "description": "Füge 4 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|} {Damage:diff()} Schaden zu.",
     "cost": 0,
     "is_x_cost": null,
@@ -12313,7 +12313,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Füge ALLEN Gegnern 6 Schaden zu.",
+    "upgrade_description": "Füge 6 Schaden zu.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.0/eng/cards.json
+++ b/data-beta/v0.103.0/eng/cards.json
@@ -18844,7 +18844,7 @@
   {
     "id": "SHIV",
     "name": "Shiv",
-    "description": "Deal 4 damage to ALL enemies.",
+    "description": "Deal 4 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -18878,7 +18878,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Deal 6 damage to ALL enemies.",
+    "upgrade_description": "Deal 6 damage.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.0/esp/cards.json
+++ b/data-beta/v0.103.0/esp/cards.json
@@ -16056,7 +16056,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Infliges 4 de daño a TODOS los enemigos.",
+    "description": "Infliges 4 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16090,7 +16090,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliges 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Infliges 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.0/fra/cards.json
+++ b/data-beta/v0.103.0/fra/cards.json
@@ -20707,7 +20707,7 @@
   {
     "id": "SHIV",
     "name": "Surin",
-    "description": "Infligez 4 dégâts à TOUS les ennemis.",
+    "description": "Infligez 4 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -20741,7 +20741,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infligez 6 dégâts à TOUS les ennemis.",
+    "upgrade_description": "Infligez 6 dégâts.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.0/ita/cards.json
+++ b/data-beta/v0.103.0/ita/cards.json
@@ -16455,7 +16455,7 @@
   {
     "id": "SHIV",
     "name": "Pugnale",
-    "description": "Infliggi 4 di danno  a TUTTI i nemici.",
+    "description": "Infliggi 4 di danno .",
     "description_raw": "Infliggi {Damage:diff()} di danno {TargetType:choose(AllEnemies): a TUTTI i nemici|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16489,7 +16489,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliggi 6 di danno  a TUTTI i nemici.",
+    "upgrade_description": "Infliggi 6 di danno .",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.0/jpn/cards.json
+++ b/data-beta/v0.103.0/jpn/cards.json
@@ -4263,7 +4263,7 @@
   {
     "id": "SHIV",
     "name": "ナイフ",
-    "description": "すべての敵に4ダメージを与える。",
+    "description": "4ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを与える。",
     "cost": 0,
     "is_x_cost": null,
@@ -4297,7 +4297,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "すべての敵に6ダメージを与える。",
+    "upgrade_description": "6ダメージを与える。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.0/kor/cards.json
+++ b/data-beta/v0.103.0/kor/cards.json
@@ -4433,7 +4433,7 @@
   {
     "id": "SHIV",
     "name": "단도",
-    "description": "모든 적에게 피해를 4 줍니다.",
+    "description": "피해를 4 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()} 줍니다.",
     "cost": 0,
     "is_x_cost": null,
@@ -4467,7 +4467,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "모든 적에게 피해를 6 줍니다.",
+    "upgrade_description": "피해를 6 줍니다.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.0/pol/cards.json
+++ b/data-beta/v0.103.0/pol/cards.json
@@ -9034,7 +9034,7 @@
   {
     "id": "SHIV",
     "name": "Nóż",
-    "description": "Zadaj 4 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 4 pkt. obrażeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrażeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -9068,7 +9068,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Zadaj 6 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "upgrade_description": "Zadaj 6 pkt. obrażeń.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.0/ptb/cards.json
+++ b/data-beta/v0.103.0/ptb/cards.json
@@ -13998,7 +13998,7 @@
   {
     "id": "SHIV",
     "name": "Lâmina",
-    "description": "Cause 4 de dano a TODOS os inimigos.",
+    "description": "Cause 4 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -14032,7 +14032,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Cause 6 de dano a TODOS os inimigos.",
+    "upgrade_description": "Cause 6 de dano.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.0/rus/cards.json
+++ b/data-beta/v0.103.0/rus/cards.json
@@ -6361,7 +6361,7 @@
   {
     "id": "SHIV",
     "name": "Заточка",
-    "description": "Наносит 4 урона ВСЕМ врагам.",
+    "description": "Наносит 4 урона.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -6395,7 +6395,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Наносит 6 урона ВСЕМ врагам.",
+    "upgrade_description": "Наносит 6 урона.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.0/spa/cards.json
+++ b/data-beta/v0.103.0/spa/cards.json
@@ -15867,7 +15867,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Inflige 4 de daño a TODOS los enemigos.",
+    "description": "Inflige 4 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -15901,7 +15901,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Inflige 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Inflige 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.0/tur/cards.json
+++ b/data-beta/v0.103.0/tur/cards.json
@@ -8587,7 +8587,7 @@
   {
     "id": "SHIV",
     "name": "Kama",
-    "description": "TÜM düşmanlara 4 hasar ver.",
+    "description": "4 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):TÜM düşmanlara |}{Damage:diff()} hasar ver.",
     "cost": 0,
     "is_x_cost": null,
@@ -8621,7 +8621,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "TÜM düşmanlara 6 hasar ver.",
+    "upgrade_description": "6 hasar ver.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.0/zhs/cards.json
+++ b/data-beta/v0.103.0/zhs/cards.json
@@ -6626,7 +6626,7 @@
   {
     "id": "SHIV",
     "name": "小刀",
-    "description": "对所有敌人造成4点伤害。",
+    "description": "造成4点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害。",
     "cost": 0,
     "is_x_cost": null,
@@ -6660,7 +6660,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "对所有敌人造成6点伤害。",
+    "upgrade_description": "造成6点伤害。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.1/deu/cards.json
+++ b/data-beta/v0.103.1/deu/cards.json
@@ -12279,7 +12279,7 @@
   {
     "id": "SHIV",
     "name": "Messer",
-    "description": "Füge ALLEN Gegnern 4 Schaden zu.",
+    "description": "Füge 4 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|} {Damage:diff()} Schaden zu.",
     "cost": 0,
     "is_x_cost": null,
@@ -12313,7 +12313,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Füge ALLEN Gegnern 6 Schaden zu.",
+    "upgrade_description": "Füge 6 Schaden zu.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.1/eng/cards.json
+++ b/data-beta/v0.103.1/eng/cards.json
@@ -18844,7 +18844,7 @@
   {
     "id": "SHIV",
     "name": "Shiv",
-    "description": "Deal 4 damage to ALL enemies.",
+    "description": "Deal 4 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -18878,7 +18878,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Deal 6 damage to ALL enemies.",
+    "upgrade_description": "Deal 6 damage.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.1/esp/cards.json
+++ b/data-beta/v0.103.1/esp/cards.json
@@ -16056,7 +16056,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Infliges 4 de daño a TODOS los enemigos.",
+    "description": "Infliges 4 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16090,7 +16090,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliges 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Infliges 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.1/fra/cards.json
+++ b/data-beta/v0.103.1/fra/cards.json
@@ -20707,7 +20707,7 @@
   {
     "id": "SHIV",
     "name": "Surin",
-    "description": "Infligez 4 dégâts à TOUS les ennemis.",
+    "description": "Infligez 4 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -20741,7 +20741,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infligez 6 dégâts à TOUS les ennemis.",
+    "upgrade_description": "Infligez 6 dégâts.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.1/ita/cards.json
+++ b/data-beta/v0.103.1/ita/cards.json
@@ -16455,7 +16455,7 @@
   {
     "id": "SHIV",
     "name": "Pugnale",
-    "description": "Infliggi 4 di danno  a TUTTI i nemici.",
+    "description": "Infliggi 4 di danno .",
     "description_raw": "Infliggi {Damage:diff()} di danno {TargetType:choose(AllEnemies): a TUTTI i nemici|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16489,7 +16489,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliggi 6 di danno  a TUTTI i nemici.",
+    "upgrade_description": "Infliggi 6 di danno .",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.1/jpn/cards.json
+++ b/data-beta/v0.103.1/jpn/cards.json
@@ -4263,7 +4263,7 @@
   {
     "id": "SHIV",
     "name": "ナイフ",
-    "description": "すべての敵に4ダメージを与える。",
+    "description": "4ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを与える。",
     "cost": 0,
     "is_x_cost": null,
@@ -4297,7 +4297,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "すべての敵に6ダメージを与える。",
+    "upgrade_description": "6ダメージを与える。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.1/kor/cards.json
+++ b/data-beta/v0.103.1/kor/cards.json
@@ -4433,7 +4433,7 @@
   {
     "id": "SHIV",
     "name": "단도",
-    "description": "모든 적에게 피해를 4 줍니다.",
+    "description": "피해를 4 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()} 줍니다.",
     "cost": 0,
     "is_x_cost": null,
@@ -4467,7 +4467,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "모든 적에게 피해를 6 줍니다.",
+    "upgrade_description": "피해를 6 줍니다.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.1/pol/cards.json
+++ b/data-beta/v0.103.1/pol/cards.json
@@ -9034,7 +9034,7 @@
   {
     "id": "SHIV",
     "name": "Nóż",
-    "description": "Zadaj 4 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 4 pkt. obrażeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrażeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -9068,7 +9068,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Zadaj 6 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "upgrade_description": "Zadaj 6 pkt. obrażeń.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.1/ptb/cards.json
+++ b/data-beta/v0.103.1/ptb/cards.json
@@ -13998,7 +13998,7 @@
   {
     "id": "SHIV",
     "name": "Lâmina",
-    "description": "Cause 4 de dano a TODOS os inimigos.",
+    "description": "Cause 4 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -14032,7 +14032,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Cause 6 de dano a TODOS os inimigos.",
+    "upgrade_description": "Cause 6 de dano.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.1/rus/cards.json
+++ b/data-beta/v0.103.1/rus/cards.json
@@ -6361,7 +6361,7 @@
   {
     "id": "SHIV",
     "name": "Заточка",
-    "description": "Наносит 4 урона ВСЕМ врагам.",
+    "description": "Наносит 4 урона.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -6395,7 +6395,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Наносит 6 урона ВСЕМ врагам.",
+    "upgrade_description": "Наносит 6 урона.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.1/spa/cards.json
+++ b/data-beta/v0.103.1/spa/cards.json
@@ -15867,7 +15867,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Inflige 4 de daño a TODOS los enemigos.",
+    "description": "Inflige 4 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -15901,7 +15901,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Inflige 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Inflige 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.1/tur/cards.json
+++ b/data-beta/v0.103.1/tur/cards.json
@@ -8587,7 +8587,7 @@
   {
     "id": "SHIV",
     "name": "Kama",
-    "description": "TÜM düşmanlara 4 hasar ver.",
+    "description": "4 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):TÜM düşmanlara |}{Damage:diff()} hasar ver.",
     "cost": 0,
     "is_x_cost": null,
@@ -8621,7 +8621,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "TÜM düşmanlara 6 hasar ver.",
+    "upgrade_description": "6 hasar ver.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.1/zhs/cards.json
+++ b/data-beta/v0.103.1/zhs/cards.json
@@ -6626,7 +6626,7 @@
   {
     "id": "SHIV",
     "name": "小刀",
-    "description": "对所有敌人造成4点伤害。",
+    "description": "造成4点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害。",
     "cost": 0,
     "is_x_cost": null,
@@ -6660,7 +6660,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "对所有敌人造成6点伤害。",
+    "upgrade_description": "造成6点伤害。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.2/deu/cards.json
+++ b/data-beta/v0.103.2/deu/cards.json
@@ -11982,7 +11982,7 @@
   {
     "id": "SHIV",
     "name": "Messer",
-    "description": "Füge ALLEN Gegnern 4 Schaden zu.",
+    "description": "Füge 4 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|} {Damage:diff()} Schaden zu.",
     "cost": 0,
     "is_x_cost": null,
@@ -12015,7 +12015,7 @@
     "image_url": "/static/images/cards/shiv.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Füge ALLEN Gegnern 6 Schaden zu.",
+    "upgrade_description": "Füge 6 Schaden zu.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.2/eng/cards.json
+++ b/data-beta/v0.103.2/eng/cards.json
@@ -18391,7 +18391,7 @@
   {
     "id": "SHIV",
     "name": "Shiv",
-    "description": "Deal 4 damage to ALL enemies.",
+    "description": "Deal 4 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -18424,7 +18424,7 @@
     "image_url": "/static/images/cards/shiv.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Deal 6 damage to ALL enemies.",
+    "upgrade_description": "Deal 6 damage.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.2/esp/cards.json
+++ b/data-beta/v0.103.2/esp/cards.json
@@ -15669,7 +15669,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Infliges 4 de daño a TODOS los enemigos.",
+    "description": "Infliges 4 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -15702,7 +15702,7 @@
     "image_url": "/static/images/cards/shiv.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliges 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Infliges 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.2/fra/cards.json
+++ b/data-beta/v0.103.2/fra/cards.json
@@ -20208,7 +20208,7 @@
   {
     "id": "SHIV",
     "name": "Surin",
-    "description": "Infligez 4 dégâts à TOUS les ennemis.",
+    "description": "Infligez 4 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -20241,7 +20241,7 @@
     "image_url": "/static/images/cards/shiv.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infligez 6 dégâts à TOUS les ennemis.",
+    "upgrade_description": "Infligez 6 dégâts.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.2/ita/cards.json
+++ b/data-beta/v0.103.2/ita/cards.json
@@ -16057,7 +16057,7 @@
   {
     "id": "SHIV",
     "name": "Pugnale",
-    "description": "Infliggi 4 di danno  a TUTTI i nemici.",
+    "description": "Infliggi 4 di danno .",
     "description_raw": "Infliggi {Damage:diff()} di danno {TargetType:choose(AllEnemies): a TUTTI i nemici|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16090,7 +16090,7 @@
     "image_url": "/static/images/cards/shiv.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Infliggi 6 di danno  a TUTTI i nemici.",
+    "upgrade_description": "Infliggi 6 di danno .",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.2/jpn/cards.json
+++ b/data-beta/v0.103.2/jpn/cards.json
@@ -4158,7 +4158,7 @@
   {
     "id": "SHIV",
     "name": "ナイフ",
-    "description": "すべての敵に4ダメージを与える。",
+    "description": "4ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを与える。",
     "cost": 0,
     "is_x_cost": null,
@@ -4191,7 +4191,7 @@
     "image_url": "/static/images/cards/shiv.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "すべての敵に6ダメージを与える。",
+    "upgrade_description": "6ダメージを与える。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.2/kor/cards.json
+++ b/data-beta/v0.103.2/kor/cards.json
@@ -4327,7 +4327,7 @@
   {
     "id": "SHIV",
     "name": "단도",
-    "description": "모든 적에게 피해를 4 줍니다.",
+    "description": "피해를 4 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()} 줍니다.",
     "cost": 0,
     "is_x_cost": null,
@@ -4360,7 +4360,7 @@
     "image_url": "/static/images/cards/shiv.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "모든 적에게 피해를 6 줍니다.",
+    "upgrade_description": "피해를 6 줍니다.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.2/pol/cards.json
+++ b/data-beta/v0.103.2/pol/cards.json
@@ -8815,7 +8815,7 @@
   {
     "id": "SHIV",
     "name": "Nóż",
-    "description": "Zadaj 4 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 4 pkt. obrażeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrażeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -8848,7 +8848,7 @@
     "image_url": "/static/images/cards/shiv.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Zadaj 6 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "upgrade_description": "Zadaj 6 pkt. obrażeń.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.2/ptb/cards.json
+++ b/data-beta/v0.103.2/ptb/cards.json
@@ -13663,7 +13663,7 @@
   {
     "id": "SHIV",
     "name": "Lâmina",
-    "description": "Cause 4 de dano a TODOS os inimigos.",
+    "description": "Cause 4 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -13696,7 +13696,7 @@
     "image_url": "/static/images/cards/shiv.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Cause 6 de dano a TODOS os inimigos.",
+    "upgrade_description": "Cause 6 de dano.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.2/rus/cards.json
+++ b/data-beta/v0.103.2/rus/cards.json
@@ -6209,7 +6209,7 @@
   {
     "id": "SHIV",
     "name": "Заточка",
-    "description": "Наносит 4 урона ВСЕМ врагам.",
+    "description": "Наносит 4 урона.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -6242,7 +6242,7 @@
     "image_url": "/static/images/cards/shiv.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Наносит 6 урона ВСЕМ врагам.",
+    "upgrade_description": "Наносит 6 урона.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.2/spa/cards.json
+++ b/data-beta/v0.103.2/spa/cards.json
@@ -15485,7 +15485,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Inflige 4 de daño a TODOS los enemigos.",
+    "description": "Inflige 4 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -15518,7 +15518,7 @@
     "image_url": "/static/images/cards/shiv.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "Inflige 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Inflige 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.2/tur/cards.json
+++ b/data-beta/v0.103.2/tur/cards.json
@@ -8379,7 +8379,7 @@
   {
     "id": "SHIV",
     "name": "Kama",
-    "description": "TÜM düşmanlara 4 hasar ver.",
+    "description": "4 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):TÜM düşmanlara |}{Damage:diff()} hasar ver.",
     "cost": 0,
     "is_x_cost": null,
@@ -8412,7 +8412,7 @@
     "image_url": "/static/images/cards/shiv.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "TÜM düşmanlara 6 hasar ver.",
+    "upgrade_description": "6 hasar ver.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.103.2/zhs/cards.json
+++ b/data-beta/v0.103.2/zhs/cards.json
@@ -6465,7 +6465,7 @@
   {
     "id": "SHIV",
     "name": "小刀",
-    "description": "对所有敌人造成4点伤害。",
+    "description": "造成4点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害。",
     "cost": 0,
     "is_x_cost": null,
@@ -6498,7 +6498,7 @@
     "image_url": "/static/images/cards/shiv.webp",
     "beta_image_url": null,
     "type_variants": null,
-    "upgrade_description": "对所有敌人造成6点伤害。",
+    "upgrade_description": "造成6点伤害。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.104.0/deu/cards.json
+++ b/data-beta/v0.104.0/deu/cards.json
@@ -12234,7 +12234,7 @@
   {
     "id": "SHIV",
     "name": "Messer",
-    "description": "Füge ALLEN Gegnern 4 Schaden zu.",
+    "description": "Füge 4 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|} {Damage:diff()} Schaden zu.",
     "cost": 0,
     "is_x_cost": null,
@@ -12268,7 +12268,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Füge ALLEN Gegnern 6 Schaden zu.",
+    "upgrade_description": "Füge 6 Schaden zu.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.104.0/eng/cards.json
+++ b/data-beta/v0.104.0/eng/cards.json
@@ -18835,7 +18835,7 @@
   {
     "id": "SHIV",
     "name": "Shiv",
-    "description": "Deal 4 damage to ALL enemies.",
+    "description": "Deal 4 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -18869,7 +18869,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Deal 6 damage to ALL enemies.",
+    "upgrade_description": "Deal 6 damage.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -19695,7 +19695,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Sovereign Blade",
-    "description": "Deal 10 damage to ALL enemies.",
+    "description": "Deal 10 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}{Repeat:plural:| {} times}.{GainsBlock:cond:\nGain {CalculatedBlock:diff()} [gold]Block[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.104.0/esp/cards.json
+++ b/data-beta/v0.104.0/esp/cards.json
@@ -16097,7 +16097,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Infliges 4 de daño a TODOS los enemigos.",
+    "description": "Infliges 4 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16131,7 +16131,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliges 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Infliges 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.104.0/fra/cards.json
+++ b/data-beta/v0.104.0/fra/cards.json
@@ -12840,7 +12840,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Lame souveraine",
-    "description": "Infligez 10 dégâts à TOUS les ennemis.",
+    "description": "Infligez 10 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}{Repeat:plural:| {} fois}.{GainsBlock:cond:\nGagnez{CalculatedBlock:diff()} d'[gold]Armure[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -20705,7 +20705,7 @@
   {
     "id": "SHIV",
     "name": "Surin",
-    "description": "Infligez 4 dégâts à TOUS les ennemis.",
+    "description": "Infligez 4 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -20739,7 +20739,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infligez 6 dégâts à TOUS les ennemis.",
+    "upgrade_description": "Infligez 6 dégâts.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.104.0/ita/cards.json
+++ b/data-beta/v0.104.0/ita/cards.json
@@ -16453,7 +16453,7 @@
   {
     "id": "SHIV",
     "name": "Pugnale",
-    "description": "Infliggi 4 di danno  a TUTTI i nemici.",
+    "description": "Infliggi 4 di danno .",
     "description_raw": "Infliggi {Damage:diff()} di danno {TargetType:choose(AllEnemies): a TUTTI i nemici|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16487,7 +16487,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliggi 6 di danno  a TUTTI i nemici.",
+    "upgrade_description": "Infliggi 6 di danno .",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -20670,7 +20670,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Spada Sovrana",
-    "description": "Infliggi 10 di danno  a TUTTI i nemici.",
+    "description": "Infliggi 10 di danno .",
     "description_raw": "Infliggi {Damage:diff()} di danno {TargetType:choose(AllEnemies): a TUTTI i nemici|}{Repeat:plural:| {} volte}.{GainsBlock:cond:\nOttieni {CalculatedBlock:diff()} di [gold]Blocco[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.104.0/jpn/cards.json
+++ b/data-beta/v0.104.0/jpn/cards.json
@@ -3495,7 +3495,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "ソヴリン・ブレード",
-    "description": "すべての敵に10ダメージを与える。",
+    "description": "10ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを{Repeat:choose(1):|{}回}与える。{GainsBlock:cond:\n{CalculatedBlock:diff()}[gold]ブロック[/gold]を得る。|}",
     "cost": 2,
     "is_x_cost": null,
@@ -4263,7 +4263,7 @@
   {
     "id": "SHIV",
     "name": "ナイフ",
-    "description": "すべての敵に4ダメージを与える。",
+    "description": "4ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを与える。",
     "cost": 0,
     "is_x_cost": null,
@@ -4297,7 +4297,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "すべての敵に6ダメージを与える。",
+    "upgrade_description": "6ダメージを与える。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.104.0/kor/cards.json
+++ b/data-beta/v0.104.0/kor/cards.json
@@ -2129,7 +2129,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "군주의 칼날",
-    "description": "모든 적에게 피해를 10 줍니다.",
+    "description": "피해를 10 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()}{Repeat:choose(1):|만큼 {}번} 줍니다.{GainsBlock:cond:\n[gold]방어도[/gold]를 {CalculatedBlock:diff()} 얻습니다.|}",
     "cost": 2,
     "is_x_cost": null,
@@ -4388,7 +4388,7 @@
   {
     "id": "SHIV",
     "name": "단도",
-    "description": "모든 적에게 피해를 4 줍니다.",
+    "description": "피해를 4 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()} 줍니다.",
     "cost": 0,
     "is_x_cost": null,
@@ -4422,7 +4422,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "모든 적에게 피해를 6 줍니다.",
+    "upgrade_description": "피해를 6 줍니다.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.104.0/pol/cards.json
+++ b/data-beta/v0.104.0/pol/cards.json
@@ -8651,7 +8651,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Niebiańskie Ostrze",
-    "description": "Zadaj 10 pkt. obrazeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 10 pkt. obrazeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrazeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}{Repeat:plural:| {} razy}.{GainsBlock:cond:\nZyskaj {CalculatedBlock:diff()} pkt. [gold]Bloku[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -9199,7 +9199,7 @@
   {
     "id": "SHIV",
     "name": "Nóż",
-    "description": "Zadaj 4 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 4 pkt. obrażeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrażeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -9233,7 +9233,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Zadaj 6 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "upgrade_description": "Zadaj 6 pkt. obrażeń.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.104.0/ptb/cards.json
+++ b/data-beta/v0.104.0/ptb/cards.json
@@ -8002,7 +8002,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada Soberana",
-    "description": "Cause 10 de dano a TODOS os inimigos.",
+    "description": "Cause 10 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}{Repeat:plural:| {} vezes}.{GainsBlock:cond:\nReceba {CalculatedBlock:diff()} de [gold]Proteção[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -13996,7 +13996,7 @@
   {
     "id": "SHIV",
     "name": "Lâmina",
-    "description": "Cause 4 de dano a TODOS os inimigos.",
+    "description": "Cause 4 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -14030,7 +14030,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Cause 6 de dano a TODOS os inimigos.",
+    "upgrade_description": "Cause 6 de dano.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.104.0/rus/cards.json
+++ b/data-beta/v0.104.0/rus/cards.json
@@ -6361,7 +6361,7 @@
   {
     "id": "SHIV",
     "name": "Заточка",
-    "description": "Наносит 4 урона ВСЕМ врагам.",
+    "description": "Наносит 4 урона.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -6395,7 +6395,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Наносит 6 урона ВСЕМ врагам.",
+    "upgrade_description": "Наносит 6 урона.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -7920,7 +7920,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Клинок монарха",
-    "description": "Наносит 10 урона ВСЕМ врагамplural(ru):.",
+    "description": "Наносит 10 уронаplural(ru):.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}{Repeat:plural(ru):| {} раза| {} раз}.{GainsBlock:cond:\nДает {CalculatedBlock:diff()} [gold]защиты[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.104.0/spa/cards.json
+++ b/data-beta/v0.104.0/spa/cards.json
@@ -8388,7 +8388,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada del soberano",
-    "description": "Inflige 10 de daño a TODOS los enemigos.",
+    "description": "Inflige 10 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}{Repeat:plural:| {} veces}.{GainsBlock:cond:\nGana {CalculatedBlock:diff()} de [gold]Bloqueo[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -15908,7 +15908,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Inflige 4 de daño a TODOS los enemigos.",
+    "description": "Inflige 4 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -15942,7 +15942,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Inflige 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Inflige 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.104.0/tha/cards.json
+++ b/data-beta/v0.104.0/tha/cards.json
@@ -16847,7 +16847,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "พระแสงอาญาสิทธิ์",
-    "description": "สร้างความเสียหาย 10 ใส่ศัตรูทั้งหมด",
+    "description": "สร้างความเสียหาย 10",
     "description_raw": "สร้างความเสียหาย {Damage:diff()}{TargetType:choose(AllEnemies): ใส่ศัตรูทั้งหมด|}{Repeat:choose(1):| จำนวน {} ครั้ง}{GainsBlock:cond:\nได้รับ {CalculatedBlock:diff()} [gold]บล็อก[/gold]|}",
     "cost": 2,
     "is_x_cost": null,
@@ -17996,7 +17996,7 @@
   {
     "id": "SHIV",
     "name": "มีดสั้น",
-    "description": "สร้างความเสียหาย 4 ใส่ศัตรูทั้งหมด",
+    "description": "สร้างความเสียหาย 4",
     "description_raw": "สร้างความเสียหาย {Damage:diff()}{TargetType:choose(AllEnemies): ใส่ศัตรูทั้งหมด|}",
     "cost": 0,
     "is_x_cost": null,
@@ -18030,7 +18030,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "สร้างความเสียหาย 6 ใส่ศัตรูทั้งหมด",
+    "upgrade_description": "สร้างความเสียหาย 6",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.104.0/tur/cards.json
+++ b/data-beta/v0.104.0/tur/cards.json
@@ -4628,7 +4628,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Egemen Kılıcı",
-    "description": "Tüm düşmanlara 10 hasar ver.",
+    "description": "10 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):Tüm düşmanlara |}{Repeat:plural:|{} kez }{Damage:diff()} hasar ver.{GainsBlock:cond:\n{CalculatedBlock:diff()} [gold]Blok[/gold] elde et.|}",
     "cost": 2,
     "is_x_cost": null,
@@ -8628,7 +8628,7 @@
   {
     "id": "SHIV",
     "name": "Kama",
-    "description": "TÜM düşmanlara 4 hasar ver.",
+    "description": "4 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):TÜM düşmanlara |}{Damage:diff()} hasar ver.",
     "cost": 0,
     "is_x_cost": null,
@@ -8662,7 +8662,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "TÜM düşmanlara 6 hasar ver.",
+    "upgrade_description": "6 hasar ver.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.104.0/zhs/cards.json
+++ b/data-beta/v0.104.0/zhs/cards.json
@@ -4328,7 +4328,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "君王之剑",
-    "description": "对所有敌人造成10点伤害。",
+    "description": "造成10点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害{Repeat:choose(1):|{}次}。{GainsBlock:cond:\n获得{CalculatedBlock:diff()}点[gold]格挡[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -6626,7 +6626,7 @@
   {
     "id": "SHIV",
     "name": "小刀",
-    "description": "对所有敌人造成4点伤害。",
+    "description": "造成4点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害。",
     "cost": 0,
     "is_x_cost": null,
@@ -6660,7 +6660,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "对所有敌人造成6点伤害。",
+    "upgrade_description": "造成6点伤害。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.0/deu/cards.json
+++ b/data-beta/v0.105.0/deu/cards.json
@@ -8891,7 +8891,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Hoheitsklinge",
-    "description": "Füge ALLEN Gegnern 10 Schaden zu.",
+    "description": "Füge 10 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|}{Repeat:plural:| {} Mal} {Damage:diff()} Schaden zu.{GainsBlock:cond:\nErhalte {CalculatedBlock:diff()} [gold]Block[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -12234,7 +12234,7 @@
   {
     "id": "SHIV",
     "name": "Messer",
-    "description": "Füge ALLEN Gegnern 4 Schaden zu.",
+    "description": "Füge 4 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|} {Damage:diff()} Schaden zu.",
     "cost": 0,
     "is_x_cost": null,
@@ -12268,7 +12268,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Füge ALLEN Gegnern 6 Schaden zu.",
+    "upgrade_description": "Füge 6 Schaden zu.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.0/eng/cards.json
+++ b/data-beta/v0.105.0/eng/cards.json
@@ -18835,7 +18835,7 @@
   {
     "id": "SHIV",
     "name": "Shiv",
-    "description": "Deal 4 damage to ALL enemies.",
+    "description": "Deal 4 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -18869,7 +18869,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Deal 6 damage to ALL enemies.",
+    "upgrade_description": "Deal 6 damage.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -19695,7 +19695,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Sovereign Blade",
-    "description": "Deal 10 damage to ALL enemies.",
+    "description": "Deal 10 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}{Repeat:plural:| {} times}.{GainsBlock:cond:\nGain {CalculatedBlock:diff()} [gold]Block[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.105.0/esp/cards.json
+++ b/data-beta/v0.105.0/esp/cards.json
@@ -8802,7 +8802,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada del soberano",
-    "description": "Infliges 10 de daño a TODOS los enemigos.",
+    "description": "Infliges 10 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}{Repeat:plural:| {} veces}.{GainsBlock:cond:\nObtienes {CalculatedBlock:diff()} de [gold]bloqueo[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -16097,7 +16097,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Infliges 4 de daño a TODOS los enemigos.",
+    "description": "Infliges 4 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16131,7 +16131,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliges 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Infliges 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.0/fra/cards.json
+++ b/data-beta/v0.105.0/fra/cards.json
@@ -12840,7 +12840,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Lame souveraine",
-    "description": "Infligez 10 dégâts à TOUS les ennemis.",
+    "description": "Infligez 10 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}{Repeat:plural:| {} fois}.{GainsBlock:cond:\nGagnez {CalculatedBlock:diff()} d'[gold]Armure[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -20705,7 +20705,7 @@
   {
     "id": "SHIV",
     "name": "Surin",
-    "description": "Infligez 4 dégâts à TOUS les ennemis.",
+    "description": "Infligez 4 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -20739,7 +20739,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infligez 6 dégâts à TOUS les ennemis.",
+    "upgrade_description": "Infligez 6 dégâts.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.0/ita/cards.json
+++ b/data-beta/v0.105.0/ita/cards.json
@@ -16537,7 +16537,7 @@
   {
     "id": "SHIV",
     "name": "Pugnale",
-    "description": "Infliggi 4 di danno  a TUTTI i nemici.",
+    "description": "Infliggi 4 di danno .",
     "description_raw": "Infliggi {Damage:diff()} di danno {TargetType:choose(AllEnemies): a TUTTI i nemici|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16571,7 +16571,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliggi 6 di danno  a TUTTI i nemici.",
+    "upgrade_description": "Infliggi 6 di danno .",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -20713,7 +20713,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Spada Sovrana",
-    "description": "Infliggi 10 di danno a TUTTI i nemici.",
+    "description": "Infliggi 10 di danno.",
     "description_raw": "Infliggi {Damage:diff()} di danno{TargetType:choose(AllEnemies): a TUTTI i nemici|}{Repeat:plural:| {} volte}.{GainsBlock:cond:\nOttieni {CalculatedBlock:diff()} di [gold]Blocco[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.105.0/jpn/cards.json
+++ b/data-beta/v0.105.0/jpn/cards.json
@@ -3495,7 +3495,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "ソヴリン・ブレード",
-    "description": "すべての敵に10ダメージを与える。",
+    "description": "10ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを{Repeat:choose(1):|{}回}与える。{GainsBlock:cond:\n{CalculatedBlock:diff()}[gold]ブロック[/gold]を得る。|}",
     "cost": 2,
     "is_x_cost": null,
@@ -4263,7 +4263,7 @@
   {
     "id": "SHIV",
     "name": "ナイフ",
-    "description": "すべての敵に4ダメージを与える。",
+    "description": "4ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを与える。",
     "cost": 0,
     "is_x_cost": null,
@@ -4297,7 +4297,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "すべての敵に6ダメージを与える。",
+    "upgrade_description": "6ダメージを与える。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.0/kor/cards.json
+++ b/data-beta/v0.105.0/kor/cards.json
@@ -2129,7 +2129,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "군주의 칼날",
-    "description": "모든 적에게 피해를 10 줍니다.",
+    "description": "피해를 10 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()}{Repeat:choose(1):|만큼 {}번} 줍니다.{GainsBlock:cond:\n[gold]방어도[/gold]를 {CalculatedBlock:diff()} 얻습니다.|}",
     "cost": 2,
     "is_x_cost": null,
@@ -4388,7 +4388,7 @@
   {
     "id": "SHIV",
     "name": "단도",
-    "description": "모든 적에게 피해를 4 줍니다.",
+    "description": "피해를 4 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()} 줍니다.",
     "cost": 0,
     "is_x_cost": null,
@@ -4422,7 +4422,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "모든 적에게 피해를 6 줍니다.",
+    "upgrade_description": "피해를 6 줍니다.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.0/pol/cards.json
+++ b/data-beta/v0.105.0/pol/cards.json
@@ -8651,7 +8651,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Niebiańskie Ostrze",
-    "description": "Zadaj 10 pkt. obrazeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 10 pkt. obrazeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrazeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}{Repeat:plural:| {} razy}.{GainsBlock:cond:\nZyskaj {CalculatedBlock:diff()} pkt. [gold]Bloku[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -9199,7 +9199,7 @@
   {
     "id": "SHIV",
     "name": "Nóż",
-    "description": "Zadaj 4 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 4 pkt. obrażeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrażeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -9233,7 +9233,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Zadaj 6 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "upgrade_description": "Zadaj 6 pkt. obrażeń.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.0/ptb/cards.json
+++ b/data-beta/v0.105.0/ptb/cards.json
@@ -8045,7 +8045,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada Soberana",
-    "description": "Cause 10 de dano a TODOS os inimigos.",
+    "description": "Cause 10 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}{Repeat:plural:| {} vezes}.{GainsBlock:cond:\nReceba {CalculatedBlock:diff()} de [gold]Proteção[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -14039,7 +14039,7 @@
   {
     "id": "SHIV",
     "name": "Lâmina",
-    "description": "Cause 4 de dano a TODOS os inimigos.",
+    "description": "Cause 4 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -14073,7 +14073,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Cause 6 de dano a TODOS os inimigos.",
+    "upgrade_description": "Cause 6 de dano.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.0/rus/cards.json
+++ b/data-beta/v0.105.0/rus/cards.json
@@ -6361,7 +6361,7 @@
   {
     "id": "SHIV",
     "name": "Заточка",
-    "description": "Наносит 4 урона ВСЕМ врагам.",
+    "description": "Наносит 4 урона.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -6395,7 +6395,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Наносит 6 урона ВСЕМ врагам.",
+    "upgrade_description": "Наносит 6 урона.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -7920,7 +7920,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Клинок монарха",
-    "description": "Наносит 10 урона ВСЕМ врагамplural(ru):.",
+    "description": "Наносит 10 уронаplural(ru):.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}{Repeat:plural(ru):| {} раза| {} раз}.{GainsBlock:cond:\nДает {CalculatedBlock:diff()} [gold]защиты[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.105.0/spa/cards.json
+++ b/data-beta/v0.105.0/spa/cards.json
@@ -8388,7 +8388,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada del soberano",
-    "description": "Inflige 10 de daño a TODOS los enemigos.",
+    "description": "Inflige 10 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}{Repeat:plural:| {} veces}.{GainsBlock:cond:\nGana {CalculatedBlock:diff()} de [gold]Bloqueo[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -15908,7 +15908,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Inflige 4 de daño a TODOS los enemigos.",
+    "description": "Inflige 4 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -15942,7 +15942,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Inflige 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Inflige 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.0/tha/cards.json
+++ b/data-beta/v0.105.0/tha/cards.json
@@ -16685,7 +16685,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "พระแสงอาญาสิทธิ์",
-    "description": "สร้างความเสียหาย 10 ใส่ศัตรูทั้งหมด",
+    "description": "สร้างความเสียหาย 10",
     "description_raw": "สร้างความเสียหาย {Damage:diff()}{TargetType:choose(AllEnemies): ใส่ศัตรูทั้งหมด|}{Repeat:choose(1):| จำนวน {} ครั้ง}{GainsBlock:cond:\nได้รับ {CalculatedBlock:diff()} [gold]บล็อก[/gold]|}",
     "cost": 2,
     "is_x_cost": null,
@@ -17834,7 +17834,7 @@
   {
     "id": "SHIV",
     "name": "มีดสั้น",
-    "description": "สร้างความเสียหาย 4 ใส่ศัตรูทั้งหมด",
+    "description": "สร้างความเสียหาย 4",
     "description_raw": "สร้างความเสียหาย {Damage:diff()}{TargetType:choose(AllEnemies): ใส่ศัตรูทั้งหมด|}",
     "cost": 0,
     "is_x_cost": null,
@@ -17868,7 +17868,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "สร้างความเสียหาย 6 ใส่ศัตรูทั้งหมด",
+    "upgrade_description": "สร้างความเสียหาย 6",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.0/tur/cards.json
+++ b/data-beta/v0.105.0/tur/cards.json
@@ -4628,7 +4628,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Egemen Kılıcı",
-    "description": "Tüm düşmanlara 10 hasar ver.",
+    "description": "10 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):Tüm düşmanlara |}{Repeat:plural:|{} kez }{Damage:diff()} hasar ver.{GainsBlock:cond:\n{CalculatedBlock:diff()} [gold]Blok[/gold] elde et.|}",
     "cost": 2,
     "is_x_cost": null,
@@ -8628,7 +8628,7 @@
   {
     "id": "SHIV",
     "name": "Kama",
-    "description": "TÜM düşmanlara 4 hasar ver.",
+    "description": "4 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):TÜM düşmanlara |}{Damage:diff()} hasar ver.",
     "cost": 0,
     "is_x_cost": null,
@@ -8662,7 +8662,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "TÜM düşmanlara 6 hasar ver.",
+    "upgrade_description": "6 hasar ver.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.0/zhs/cards.json
+++ b/data-beta/v0.105.0/zhs/cards.json
@@ -4371,7 +4371,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "君王之剑",
-    "description": "对所有敌人造成10点伤害。",
+    "description": "造成10点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害{Repeat:choose(1):|{}次}。{GainsBlock:cond:\n获得{CalculatedBlock:diff()}点[gold]格挡[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -6669,7 +6669,7 @@
   {
     "id": "SHIV",
     "name": "小刀",
-    "description": "对所有敌人造成4点伤害。",
+    "description": "造成4点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害。",
     "cost": 0,
     "is_x_cost": null,
@@ -6703,7 +6703,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "对所有敌人造成6点伤害。",
+    "upgrade_description": "造成6点伤害。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.1/deu/cards.json
+++ b/data-beta/v0.105.1/deu/cards.json
@@ -8891,7 +8891,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Hoheitsklinge",
-    "description": "Füge ALLEN Gegnern 10 Schaden zu.",
+    "description": "Füge 10 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|}{Repeat:plural:| {} Mal} {Damage:diff()} Schaden zu.{GainsBlock:cond:\nErhalte {CalculatedBlock:diff()} [gold]Block[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -12234,7 +12234,7 @@
   {
     "id": "SHIV",
     "name": "Messer",
-    "description": "Füge ALLEN Gegnern 4 Schaden zu.",
+    "description": "Füge 4 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|} {Damage:diff()} Schaden zu.",
     "cost": 0,
     "is_x_cost": null,
@@ -12268,7 +12268,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Füge ALLEN Gegnern 6 Schaden zu.",
+    "upgrade_description": "Füge 6 Schaden zu.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.1/eng/cards.json
+++ b/data-beta/v0.105.1/eng/cards.json
@@ -18835,7 +18835,7 @@
   {
     "id": "SHIV",
     "name": "Shiv",
-    "description": "Deal 4 damage to ALL enemies.",
+    "description": "Deal 4 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -18869,7 +18869,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Deal 6 damage to ALL enemies.",
+    "upgrade_description": "Deal 6 damage.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -19695,7 +19695,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Sovereign Blade",
-    "description": "Deal 10 damage to ALL enemies.",
+    "description": "Deal 10 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}{Repeat:plural:| {} times}.{GainsBlock:cond:\nGain {CalculatedBlock:diff()} [gold]Block[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.105.1/esp/cards.json
+++ b/data-beta/v0.105.1/esp/cards.json
@@ -8802,7 +8802,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada del soberano",
-    "description": "Infliges 10 de daño a TODOS los enemigos.",
+    "description": "Infliges 10 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}{Repeat:plural:| {} veces}.{GainsBlock:cond:\nObtienes {CalculatedBlock:diff()} de [gold]bloqueo[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -16097,7 +16097,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Infliges 4 de daño a TODOS los enemigos.",
+    "description": "Infliges 4 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16131,7 +16131,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliges 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Infliges 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.1/fra/cards.json
+++ b/data-beta/v0.105.1/fra/cards.json
@@ -12840,7 +12840,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Lame souveraine",
-    "description": "Infligez 10 dégâts à TOUS les ennemis.",
+    "description": "Infligez 10 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}{Repeat:plural:| {} fois}.{GainsBlock:cond:\nGagnez {CalculatedBlock:diff()} d'[gold]Armure[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -20705,7 +20705,7 @@
   {
     "id": "SHIV",
     "name": "Surin",
-    "description": "Infligez 4 dégâts à TOUS les ennemis.",
+    "description": "Infligez 4 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -20739,7 +20739,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infligez 6 dégâts à TOUS les ennemis.",
+    "upgrade_description": "Infligez 6 dégâts.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.1/ita/cards.json
+++ b/data-beta/v0.105.1/ita/cards.json
@@ -16537,7 +16537,7 @@
   {
     "id": "SHIV",
     "name": "Pugnale",
-    "description": "Infliggi 4 di danno  a TUTTI i nemici.",
+    "description": "Infliggi 4 di danno .",
     "description_raw": "Infliggi {Damage:diff()} di danno {TargetType:choose(AllEnemies): a TUTTI i nemici|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16571,7 +16571,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliggi 6 di danno  a TUTTI i nemici.",
+    "upgrade_description": "Infliggi 6 di danno .",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -20713,7 +20713,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Spada Sovrana",
-    "description": "Infliggi 10 di danno a TUTTI i nemici.",
+    "description": "Infliggi 10 di danno.",
     "description_raw": "Infliggi {Damage:diff()} di danno{TargetType:choose(AllEnemies): a TUTTI i nemici|}{Repeat:plural:| {} volte}.{GainsBlock:cond:\nOttieni {CalculatedBlock:diff()} di [gold]Blocco[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.105.1/jpn/cards.json
+++ b/data-beta/v0.105.1/jpn/cards.json
@@ -3495,7 +3495,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "ソヴリン・ブレード",
-    "description": "すべての敵に10ダメージを与える。",
+    "description": "10ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを{Repeat:choose(1):|{}回}与える。{GainsBlock:cond:\n{CalculatedBlock:diff()}[gold]ブロック[/gold]を得る。|}",
     "cost": 2,
     "is_x_cost": null,
@@ -4263,7 +4263,7 @@
   {
     "id": "SHIV",
     "name": "ナイフ",
-    "description": "すべての敵に4ダメージを与える。",
+    "description": "4ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを与える。",
     "cost": 0,
     "is_x_cost": null,
@@ -4297,7 +4297,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "すべての敵に6ダメージを与える。",
+    "upgrade_description": "6ダメージを与える。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.1/kor/cards.json
+++ b/data-beta/v0.105.1/kor/cards.json
@@ -2129,7 +2129,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "군주의 칼날",
-    "description": "모든 적에게 피해를 10 줍니다.",
+    "description": "피해를 10 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()}{Repeat:choose(1):|만큼 {}번} 줍니다.{GainsBlock:cond:\n[gold]방어도[/gold]를 {CalculatedBlock:diff()} 얻습니다.|}",
     "cost": 2,
     "is_x_cost": null,
@@ -4388,7 +4388,7 @@
   {
     "id": "SHIV",
     "name": "단도",
-    "description": "모든 적에게 피해를 4 줍니다.",
+    "description": "피해를 4 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()} 줍니다.",
     "cost": 0,
     "is_x_cost": null,
@@ -4422,7 +4422,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "모든 적에게 피해를 6 줍니다.",
+    "upgrade_description": "피해를 6 줍니다.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.1/pol/cards.json
+++ b/data-beta/v0.105.1/pol/cards.json
@@ -8651,7 +8651,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Niebiańskie Ostrze",
-    "description": "Zadaj 10 pkt. obrazeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 10 pkt. obrazeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrazeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}{Repeat:plural:| {} razy}.{GainsBlock:cond:\nZyskaj {CalculatedBlock:diff()} pkt. [gold]Bloku[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -9199,7 +9199,7 @@
   {
     "id": "SHIV",
     "name": "Nóż",
-    "description": "Zadaj 4 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 4 pkt. obrażeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrażeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -9233,7 +9233,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Zadaj 6 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "upgrade_description": "Zadaj 6 pkt. obrażeń.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.1/ptb/cards.json
+++ b/data-beta/v0.105.1/ptb/cards.json
@@ -8045,7 +8045,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada Soberana",
-    "description": "Cause 10 de dano a TODOS os inimigos.",
+    "description": "Cause 10 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}{Repeat:plural:| {} vezes}.{GainsBlock:cond:\nReceba {CalculatedBlock:diff()} de [gold]Proteção[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -14039,7 +14039,7 @@
   {
     "id": "SHIV",
     "name": "Lâmina",
-    "description": "Cause 4 de dano a TODOS os inimigos.",
+    "description": "Cause 4 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -14073,7 +14073,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Cause 6 de dano a TODOS os inimigos.",
+    "upgrade_description": "Cause 6 de dano.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.1/rus/cards.json
+++ b/data-beta/v0.105.1/rus/cards.json
@@ -6361,7 +6361,7 @@
   {
     "id": "SHIV",
     "name": "Заточка",
-    "description": "Наносит 4 урона ВСЕМ врагам.",
+    "description": "Наносит 4 урона.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -6395,7 +6395,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Наносит 6 урона ВСЕМ врагам.",
+    "upgrade_description": "Наносит 6 урона.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -7920,7 +7920,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Клинок монарха",
-    "description": "Наносит 10 урона ВСЕМ врагамplural(ru):.",
+    "description": "Наносит 10 уронаplural(ru):.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}{Repeat:plural(ru):| {} раза| {} раз}.{GainsBlock:cond:\nДает {CalculatedBlock:diff()} [gold]защиты[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.105.1/spa/cards.json
+++ b/data-beta/v0.105.1/spa/cards.json
@@ -8388,7 +8388,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada del soberano",
-    "description": "Inflige 10 de daño a TODOS los enemigos.",
+    "description": "Inflige 10 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}{Repeat:plural:| {} veces}.{GainsBlock:cond:\nGana {CalculatedBlock:diff()} de [gold]Bloqueo[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -15908,7 +15908,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Inflige 4 de daño a TODOS los enemigos.",
+    "description": "Inflige 4 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -15942,7 +15942,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Inflige 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Inflige 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.1/tha/cards.json
+++ b/data-beta/v0.105.1/tha/cards.json
@@ -16685,7 +16685,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "พระแสงอาญาสิทธิ์",
-    "description": "สร้างความเสียหาย 10 ใส่ศัตรูทั้งหมด",
+    "description": "สร้างความเสียหาย 10",
     "description_raw": "สร้างความเสียหาย {Damage:diff()}{TargetType:choose(AllEnemies): ใส่ศัตรูทั้งหมด|}{Repeat:choose(1):| จำนวน {} ครั้ง}{GainsBlock:cond:\nได้รับ {CalculatedBlock:diff()} [gold]บล็อก[/gold]|}",
     "cost": 2,
     "is_x_cost": null,
@@ -17834,7 +17834,7 @@
   {
     "id": "SHIV",
     "name": "มีดสั้น",
-    "description": "สร้างความเสียหาย 4 ใส่ศัตรูทั้งหมด",
+    "description": "สร้างความเสียหาย 4",
     "description_raw": "สร้างความเสียหาย {Damage:diff()}{TargetType:choose(AllEnemies): ใส่ศัตรูทั้งหมด|}",
     "cost": 0,
     "is_x_cost": null,
@@ -17868,7 +17868,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "สร้างความเสียหาย 6 ใส่ศัตรูทั้งหมด",
+    "upgrade_description": "สร้างความเสียหาย 6",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.1/tur/cards.json
+++ b/data-beta/v0.105.1/tur/cards.json
@@ -4628,7 +4628,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Egemen Kılıcı",
-    "description": "Tüm düşmanlara 10 hasar ver.",
+    "description": "10 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):Tüm düşmanlara |}{Repeat:plural:|{} kez }{Damage:diff()} hasar ver.{GainsBlock:cond:\n{CalculatedBlock:diff()} [gold]Blok[/gold] elde et.|}",
     "cost": 2,
     "is_x_cost": null,
@@ -8628,7 +8628,7 @@
   {
     "id": "SHIV",
     "name": "Kama",
-    "description": "TÜM düşmanlara 4 hasar ver.",
+    "description": "4 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):TÜM düşmanlara |}{Damage:diff()} hasar ver.",
     "cost": 0,
     "is_x_cost": null,
@@ -8662,7 +8662,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "TÜM düşmanlara 6 hasar ver.",
+    "upgrade_description": "6 hasar ver.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.105.1/zhs/cards.json
+++ b/data-beta/v0.105.1/zhs/cards.json
@@ -4371,7 +4371,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "君王之剑",
-    "description": "对所有敌人造成10点伤害。",
+    "description": "造成10点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害{Repeat:choose(1):|{}次}。{GainsBlock:cond:\n获得{CalculatedBlock:diff()}点[gold]格挡[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -6669,7 +6669,7 @@
   {
     "id": "SHIV",
     "name": "小刀",
-    "description": "对所有敌人造成4点伤害。",
+    "description": "造成4点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害。",
     "cost": 0,
     "is_x_cost": null,
@@ -6703,7 +6703,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "对所有敌人造成6点伤害。",
+    "upgrade_description": "造成6点伤害。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.0/deu/cards.json
+++ b/data-beta/v0.106.0/deu/cards.json
@@ -8937,7 +8937,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Hoheitsklinge",
-    "description": "Füge ALLEN Gegnern 10 Schaden zu.",
+    "description": "Füge 10 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|}{Repeat:plural:| {} Mal} {Damage:diff()} Schaden zu.{GainsBlock:cond:\nErhalte {CalculatedBlock:diff()} [gold]Block[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -12280,7 +12280,7 @@
   {
     "id": "SHIV",
     "name": "Messer",
-    "description": "Füge ALLEN Gegnern 4 Schaden zu.",
+    "description": "Füge 4 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|} {Damage:diff()} Schaden zu.",
     "cost": 0,
     "is_x_cost": null,
@@ -12314,7 +12314,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Füge ALLEN Gegnern 6 Schaden zu.",
+    "upgrade_description": "Füge 6 Schaden zu.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.0/eng/cards.json
+++ b/data-beta/v0.106.0/eng/cards.json
@@ -18842,7 +18842,7 @@
   {
     "id": "SHIV",
     "name": "Shiv",
-    "description": "Deal 4 damage to ALL enemies.",
+    "description": "Deal 4 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -18876,7 +18876,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Deal 6 damage to ALL enemies.",
+    "upgrade_description": "Deal 6 damage.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -19702,7 +19702,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Sovereign Blade",
-    "description": "Deal 10 damage to ALL enemies.",
+    "description": "Deal 10 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}{Repeat:plural:| {} times}.{GainsBlock:cond:\nGain {CalculatedBlock:diff()} [gold]Block[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.106.0/esp/cards.json
+++ b/data-beta/v0.106.0/esp/cards.json
@@ -8802,7 +8802,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada del soberano",
-    "description": "Infliges 10 de daño a TODOS los enemigos.",
+    "description": "Infliges 10 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}{Repeat:plural:| {} veces}.{GainsBlock:cond:\nObtienes {CalculatedBlock:diff()} de [gold]bloqueo[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -16145,7 +16145,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Infliges 4 de daño a TODOS los enemigos.",
+    "description": "Infliges 4 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16179,7 +16179,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliges 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Infliges 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.0/fra/cards.json
+++ b/data-beta/v0.106.0/fra/cards.json
@@ -12806,7 +12806,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Lame souveraine",
-    "description": "Infligez 10 dégâts à TOUS les ennemis.",
+    "description": "Infligez 10 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}{Repeat:plural:| {} fois}.{GainsBlock:cond:\nGagnez {CalculatedBlock:diff()} d'[gold]Armure[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -20712,7 +20712,7 @@
   {
     "id": "SHIV",
     "name": "Surin",
-    "description": "Infligez 4 dégâts à TOUS les ennemis.",
+    "description": "Infligez 4 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -20746,7 +20746,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infligez 6 dégâts à TOUS les ennemis.",
+    "upgrade_description": "Infligez 6 dégâts.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.0/ita/cards.json
+++ b/data-beta/v0.106.0/ita/cards.json
@@ -16503,7 +16503,7 @@
   {
     "id": "SHIV",
     "name": "Pugnale",
-    "description": "Infliggi 4 di danno  a TUTTI i nemici.",
+    "description": "Infliggi 4 di danno .",
     "description_raw": "Infliggi {Damage:diff()} di danno {TargetType:choose(AllEnemies): a TUTTI i nemici|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16537,7 +16537,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliggi 6 di danno  a TUTTI i nemici.",
+    "upgrade_description": "Infliggi 6 di danno .",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -20720,7 +20720,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Spada Sovrana",
-    "description": "Infliggi 10 di danno a TUTTI i nemici.",
+    "description": "Infliggi 10 di danno.",
     "description_raw": "Infliggi {Damage:diff()} di danno{TargetType:choose(AllEnemies): a TUTTI i nemici|}{Repeat:plural:| {} volte}.{GainsBlock:cond:\nOttieni {CalculatedBlock:diff()} di [gold]Blocco[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.106.0/jpn/cards.json
+++ b/data-beta/v0.106.0/jpn/cards.json
@@ -3536,7 +3536,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "ソヴリン・ブレード",
-    "description": "すべての敵に10ダメージを与える。",
+    "description": "10ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを{Repeat:choose(1):|{}回}与える。{GainsBlock:cond:\n{CalculatedBlock:diff()}[gold]ブロック[/gold]を得る。|}",
     "cost": 2,
     "is_x_cost": null,
@@ -4304,7 +4304,7 @@
   {
     "id": "SHIV",
     "name": "ナイフ",
-    "description": "すべての敵に4ダメージを与える。",
+    "description": "4ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを与える。",
     "cost": 0,
     "is_x_cost": null,
@@ -4338,7 +4338,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "すべての敵に6ダメージを与える。",
+    "upgrade_description": "6ダメージを与える。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.0/kor/cards.json
+++ b/data-beta/v0.106.0/kor/cards.json
@@ -2129,7 +2129,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "군주의 칼날",
-    "description": "모든 적에게 피해를 10 줍니다.",
+    "description": "피해를 10 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()}{Repeat:choose(1):|만큼 {}번} 줍니다.{GainsBlock:cond:\n[gold]방어도[/gold]를 {CalculatedBlock:diff()} 얻습니다.|}",
     "cost": 2,
     "is_x_cost": null,
@@ -4388,7 +4388,7 @@
   {
     "id": "SHIV",
     "name": "단도",
-    "description": "모든 적에게 피해를 4 줍니다.",
+    "description": "피해를 4 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()} 줍니다.",
     "cost": 0,
     "is_x_cost": null,
@@ -4422,7 +4422,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "모든 적에게 피해를 6 줍니다.",
+    "upgrade_description": "피해를 6 줍니다.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.0/pol/cards.json
+++ b/data-beta/v0.106.0/pol/cards.json
@@ -8617,7 +8617,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Niebiańskie Ostrze",
-    "description": "Zadaj 10 pkt. obrazeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 10 pkt. obrazeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrazeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}{Repeat:plural:| {} razy}.{GainsBlock:cond:\nZyskaj {CalculatedBlock:diff()} pkt. [gold]Bloku[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -9204,7 +9204,7 @@
   {
     "id": "SHIV",
     "name": "Nóż",
-    "description": "Zadaj 4 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 4 pkt. obrażeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrażeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -9238,7 +9238,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Zadaj 6 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "upgrade_description": "Zadaj 6 pkt. obrażeń.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.0/ptb/cards.json
+++ b/data-beta/v0.106.0/ptb/cards.json
@@ -8086,7 +8086,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada Soberana",
-    "description": "Cause 10 de dano a TODOS os inimigos.",
+    "description": "Cause 10 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}{Repeat:plural:| {} vezes}.{GainsBlock:cond:\nReceba {CalculatedBlock:diff()} de [gold]Proteção[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -14085,7 +14085,7 @@
   {
     "id": "SHIV",
     "name": "Lâmina",
-    "description": "Cause 4 de dano a TODOS os inimigos.",
+    "description": "Cause 4 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -14119,7 +14119,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Cause 6 de dano a TODOS os inimigos.",
+    "upgrade_description": "Cause 6 de dano.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.0/rus/cards.json
+++ b/data-beta/v0.106.0/rus/cards.json
@@ -6322,7 +6322,7 @@
   {
     "id": "SHIV",
     "name": "Заточка",
-    "description": "Наносит 4 урона ВСЕМ врагам.",
+    "description": "Наносит 4 урона.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -6356,7 +6356,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Наносит 6 урона ВСЕМ врагам.",
+    "upgrade_description": "Наносит 6 урона.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -7922,7 +7922,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Клинок монарха",
-    "description": "Наносит 10 урона ВСЕМ врагамplural(ru):.",
+    "description": "Наносит 10 уронаplural(ru):.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}{Repeat:plural(ru):| {} раза| {} раз}.{GainsBlock:cond:\nДает {CalculatedBlock:diff()} [gold]защиты[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.106.0/spa/cards.json
+++ b/data-beta/v0.106.0/spa/cards.json
@@ -8472,7 +8472,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada del soberano",
-    "description": "Inflige 10 de daño a TODOS los enemigos.",
+    "description": "Inflige 10 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}{Repeat:plural:| {} veces}.{GainsBlock:cond:\nGana {CalculatedBlock:diff()} de [gold]Bloqueo[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -15997,7 +15997,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Inflige 4 de daño a TODOS los enemigos.",
+    "description": "Inflige 4 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16031,7 +16031,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Inflige 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Inflige 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.0/tha/cards.json
+++ b/data-beta/v0.106.0/tha/cards.json
@@ -16687,7 +16687,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "พระแสงอาญาสิทธิ์",
-    "description": "สร้างความเสียหาย 10 ใส่ศัตรูทั้งหมด",
+    "description": "สร้างความเสียหาย 10",
     "description_raw": "สร้างความเสียหาย {Damage:diff()}{TargetType:choose(AllEnemies): ใส่ศัตรูทั้งหมด|}{Repeat:choose(1):| จำนวน {} ครั้ง}{GainsBlock:cond:\nได้รับ {CalculatedBlock:diff()} [gold]บล็อก[/gold]|}",
     "cost": 2,
     "is_x_cost": null,
@@ -17836,7 +17836,7 @@
   {
     "id": "SHIV",
     "name": "มีดสั้น",
-    "description": "สร้างความเสียหาย 4 ใส่ศัตรูทั้งหมด",
+    "description": "สร้างความเสียหาย 4",
     "description_raw": "สร้างความเสียหาย {Damage:diff()}{TargetType:choose(AllEnemies): ใส่ศัตรูทั้งหมด|}",
     "cost": 0,
     "is_x_cost": null,
@@ -17870,7 +17870,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "สร้างความเสียหาย 6 ใส่ศัตรูทั้งหมด",
+    "upgrade_description": "สร้างความเสียหาย 6",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.0/tur/cards.json
+++ b/data-beta/v0.106.0/tur/cards.json
@@ -4589,7 +4589,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Egemen Kılıcı",
-    "description": "Tüm düşmanlara 10 hasar ver.",
+    "description": "10 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):Tüm düşmanlara |}{Repeat:plural:|{} kez }{Damage:diff()} hasar ver.{GainsBlock:cond:\n{CalculatedBlock:diff()} [gold]Blok[/gold] elde et.|}",
     "cost": 2,
     "is_x_cost": null,
@@ -8594,7 +8594,7 @@
   {
     "id": "SHIV",
     "name": "Kama",
-    "description": "TÜM düşmanlara 4 hasar ver.",
+    "description": "4 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):TÜM düşmanlara |}{Damage:diff()} hasar ver.",
     "cost": 0,
     "is_x_cost": null,
@@ -8628,7 +8628,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "TÜM düşmanlara 6 hasar ver.",
+    "upgrade_description": "6 hasar ver.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.0/zhs/cards.json
+++ b/data-beta/v0.106.0/zhs/cards.json
@@ -4371,7 +4371,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "君王之剑",
-    "description": "对所有敌人造成10点伤害。",
+    "description": "造成10点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害{Repeat:choose(1):|{}次}。{GainsBlock:cond:\n获得{CalculatedBlock:diff()}点[gold]格挡[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -6669,7 +6669,7 @@
   {
     "id": "SHIV",
     "name": "小刀",
-    "description": "对所有敌人造成4点伤害。",
+    "description": "造成4点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害。",
     "cost": 0,
     "is_x_cost": null,
@@ -6703,7 +6703,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "对所有敌人造成6点伤害。",
+    "upgrade_description": "造成6点伤害。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.1/deu/cards.json
+++ b/data-beta/v0.106.1/deu/cards.json
@@ -8924,7 +8924,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Hoheitsklinge",
-    "description": "Füge ALLEN Gegnern 10 Schaden zu.",
+    "description": "Füge 10 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|}{Repeat:plural:| {} Mal} {Damage:diff()} Schaden zu.{GainsBlock:cond:\nErhalte {CalculatedBlock:diff()} [gold]Block[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -12267,7 +12267,7 @@
   {
     "id": "SHIV",
     "name": "Messer",
-    "description": "Füge ALLEN Gegnern 4 Schaden zu.",
+    "description": "Füge 4 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|} {Damage:diff()} Schaden zu.",
     "cost": 0,
     "is_x_cost": null,
@@ -12301,7 +12301,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Füge ALLEN Gegnern 6 Schaden zu.",
+    "upgrade_description": "Füge 6 Schaden zu.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.1/eng/cards.json
+++ b/data-beta/v0.106.1/eng/cards.json
@@ -18821,7 +18821,7 @@
   {
     "id": "SHIV",
     "name": "Shiv",
-    "description": "Deal 4 damage to ALL enemies.",
+    "description": "Deal 4 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -18855,7 +18855,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Deal 6 damage to ALL enemies.",
+    "upgrade_description": "Deal 6 damage.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -19681,7 +19681,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Sovereign Blade",
-    "description": "Deal 10 damage to ALL enemies.",
+    "description": "Deal 10 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}{Repeat:plural:| {} times}.{GainsBlock:cond:\nGain {CalculatedBlock:diff()} [gold]Block[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.106.1/esp/cards.json
+++ b/data-beta/v0.106.1/esp/cards.json
@@ -8790,7 +8790,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada del soberano",
-    "description": "Infliges 10 de daño a TODOS los enemigos.",
+    "description": "Infliges 10 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}{Repeat:plural:| {} veces}.{GainsBlock:cond:\nObtienes {CalculatedBlock:diff()} de [gold]bloqueo[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -16121,7 +16121,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Infliges 4 de daño a TODOS los enemigos.",
+    "description": "Infliges 4 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16155,7 +16155,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliges 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Infliges 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.1/fra/cards.json
+++ b/data-beta/v0.106.1/fra/cards.json
@@ -12782,7 +12782,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Lame souveraine",
-    "description": "Infligez 10 dégâts à TOUS les ennemis.",
+    "description": "Infligez 10 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}{Repeat:plural:| {} fois}.{GainsBlock:cond:\nGagnez {CalculatedBlock:diff()} d'[gold]Armure[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -20688,7 +20688,7 @@
   {
     "id": "SHIV",
     "name": "Surin",
-    "description": "Infligez 4 dégâts à TOUS les ennemis.",
+    "description": "Infligez 4 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -20722,7 +20722,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infligez 6 dégâts à TOUS les ennemis.",
+    "upgrade_description": "Infligez 6 dégâts.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.1/ita/cards.json
+++ b/data-beta/v0.106.1/ita/cards.json
@@ -16479,7 +16479,7 @@
   {
     "id": "SHIV",
     "name": "Pugnale",
-    "description": "Infliggi 4 di danno  a TUTTI i nemici.",
+    "description": "Infliggi 4 di danno .",
     "description_raw": "Infliggi {Damage:diff()} di danno {TargetType:choose(AllEnemies): a TUTTI i nemici|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16513,7 +16513,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliggi 6 di danno  a TUTTI i nemici.",
+    "upgrade_description": "Infliggi 6 di danno .",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -20696,7 +20696,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Spada Sovrana",
-    "description": "Infliggi 10 di danno a TUTTI i nemici.",
+    "description": "Infliggi 10 di danno.",
     "description_raw": "Infliggi {Damage:diff()} di danno{TargetType:choose(AllEnemies): a TUTTI i nemici|}{Repeat:plural:| {} volte}.{GainsBlock:cond:\nOttieni {CalculatedBlock:diff()} di [gold]Blocco[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.106.1/jpn/cards.json
+++ b/data-beta/v0.106.1/jpn/cards.json
@@ -3486,7 +3486,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "ソヴリン・ブレード",
-    "description": "すべての敵に10ダメージを与える。",
+    "description": "10ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを{Repeat:choose(1):|{}回}与える。{GainsBlock:cond:\n{CalculatedBlock:diff()}[gold]ブロック[/gold]を得る。|}",
     "cost": 2,
     "is_x_cost": null,
@@ -4254,7 +4254,7 @@
   {
     "id": "SHIV",
     "name": "ナイフ",
-    "description": "すべての敵に4ダメージを与える。",
+    "description": "4ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを与える。",
     "cost": 0,
     "is_x_cost": null,
@@ -4288,7 +4288,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "すべての敵に6ダメージを与える。",
+    "upgrade_description": "6ダメージを与える。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.1/kor/cards.json
+++ b/data-beta/v0.106.1/kor/cards.json
@@ -2129,7 +2129,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "군주의 칼날",
-    "description": "모든 적에게 피해를 10 줍니다.",
+    "description": "피해를 10 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()}{Repeat:choose(1):|만큼 {}번} 줍니다.{GainsBlock:cond:\n[gold]방어도[/gold]를 {CalculatedBlock:diff()} 얻습니다.|}",
     "cost": 2,
     "is_x_cost": null,
@@ -4388,7 +4388,7 @@
   {
     "id": "SHIV",
     "name": "단도",
-    "description": "모든 적에게 피해를 4 줍니다.",
+    "description": "피해를 4 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()} 줍니다.",
     "cost": 0,
     "is_x_cost": null,
@@ -4422,7 +4422,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "모든 적에게 피해를 6 줍니다.",
+    "upgrade_description": "피해를 6 줍니다.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.1/pol/cards.json
+++ b/data-beta/v0.106.1/pol/cards.json
@@ -8604,7 +8604,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Niebiańskie Ostrze",
-    "description": "Zadaj 10 pkt. obrazeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 10 pkt. obrazeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrazeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}{Repeat:plural:| {} razy}.{GainsBlock:cond:\nZyskaj {CalculatedBlock:diff()} pkt. [gold]Bloku[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -9191,7 +9191,7 @@
   {
     "id": "SHIV",
     "name": "Nóż",
-    "description": "Zadaj 4 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 4 pkt. obrażeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrażeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -9225,7 +9225,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Zadaj 6 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "upgrade_description": "Zadaj 6 pkt. obrażeń.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.1/ptb/cards.json
+++ b/data-beta/v0.106.1/ptb/cards.json
@@ -8082,7 +8082,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada Soberana",
-    "description": "Cause 10 de dano a TODOS os inimigos.",
+    "description": "Cause 10 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}{Repeat:plural:| {} vezes}.{GainsBlock:cond:\nReceba {CalculatedBlock:diff()} de [gold]Proteção[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -14070,7 +14070,7 @@
   {
     "id": "SHIV",
     "name": "Lâmina",
-    "description": "Cause 4 de dano a TODOS os inimigos.",
+    "description": "Cause 4 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -14104,7 +14104,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Cause 6 de dano a TODOS os inimigos.",
+    "upgrade_description": "Cause 6 de dano.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.1/rus/cards.json
+++ b/data-beta/v0.106.1/rus/cards.json
@@ -6312,7 +6312,7 @@
   {
     "id": "SHIV",
     "name": "Заточка",
-    "description": "Наносит 4 урона ВСЕМ врагам.",
+    "description": "Наносит 4 урона.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -6346,7 +6346,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Наносит 6 урона ВСЕМ врагам.",
+    "upgrade_description": "Наносит 6 урона.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -7912,7 +7912,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Клинок монарха",
-    "description": "Наносит 10 урона ВСЕМ врагамplural(ru):.",
+    "description": "Наносит 10 уронаplural(ru):.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}{Repeat:plural(ru):| {} раза| {} раз}.{GainsBlock:cond:\nДает {CalculatedBlock:diff()} [gold]защиты[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.106.1/spa/cards.json
+++ b/data-beta/v0.106.1/spa/cards.json
@@ -8471,7 +8471,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada del soberano",
-    "description": "Inflige 10 de daño a TODOS los enemigos.",
+    "description": "Inflige 10 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}{Repeat:plural:| {} veces}.{GainsBlock:cond:\nGana {CalculatedBlock:diff()} de [gold]Bloqueo[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -15982,7 +15982,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Inflige 4 de daño a TODOS los enemigos.",
+    "description": "Inflige 4 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16016,7 +16016,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Inflige 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Inflige 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.1/tha/cards.json
+++ b/data-beta/v0.106.1/tha/cards.json
@@ -16676,7 +16676,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "พระแสงอาญาสิทธิ์",
-    "description": "สร้างความเสียหาย 10 ใส่ศัตรูทั้งหมด",
+    "description": "สร้างความเสียหาย 10",
     "description_raw": "สร้างความเสียหาย {Damage:diff()}{TargetType:choose(AllEnemies): ใส่ศัตรูทั้งหมด|}{Repeat:choose(1):| จำนวน {} ครั้ง}{GainsBlock:cond:\nได้รับ {CalculatedBlock:diff()} [gold]บล็อก[/gold]|}",
     "cost": 2,
     "is_x_cost": null,
@@ -17825,7 +17825,7 @@
   {
     "id": "SHIV",
     "name": "มีดสั้น",
-    "description": "สร้างความเสียหาย 4 ใส่ศัตรูทั้งหมด",
+    "description": "สร้างความเสียหาย 4",
     "description_raw": "สร้างความเสียหาย {Damage:diff()}{TargetType:choose(AllEnemies): ใส่ศัตรูทั้งหมด|}",
     "cost": 0,
     "is_x_cost": null,
@@ -17859,7 +17859,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "สร้างความเสียหาย 6 ใส่ศัตรูทั้งหมด",
+    "upgrade_description": "สร้างความเสียหาย 6",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.1/tur/cards.json
+++ b/data-beta/v0.106.1/tur/cards.json
@@ -4578,7 +4578,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Egemen Kılıcı",
-    "description": "Tüm düşmanlara 10 hasar ver.",
+    "description": "10 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):Tüm düşmanlara |}{Repeat:plural:|{} kez }{Damage:diff()} hasar ver.{GainsBlock:cond:\n{CalculatedBlock:diff()} [gold]Blok[/gold] elde et.|}",
     "cost": 2,
     "is_x_cost": null,
@@ -8580,7 +8580,7 @@
   {
     "id": "SHIV",
     "name": "Kama",
-    "description": "TÜM düşmanlara 4 hasar ver.",
+    "description": "4 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):TÜM düşmanlara |}{Damage:diff()} hasar ver.",
     "cost": 0,
     "is_x_cost": null,
@@ -8614,7 +8614,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "TÜM düşmanlara 6 hasar ver.",
+    "upgrade_description": "6 hasar ver.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.106.1/zhs/cards.json
+++ b/data-beta/v0.106.1/zhs/cards.json
@@ -4371,7 +4371,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "君王之剑",
-    "description": "对所有敌人造成10点伤害。",
+    "description": "造成10点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害{Repeat:choose(1):|{}次}。{GainsBlock:cond:\n获得{CalculatedBlock:diff()}点[gold]格挡[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -6669,7 +6669,7 @@
   {
     "id": "SHIV",
     "name": "小刀",
-    "description": "对所有敌人造成4点伤害。",
+    "description": "造成4点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害。",
     "cost": 0,
     "is_x_cost": null,
@@ -6703,7 +6703,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "对所有敌人造成6点伤害。",
+    "upgrade_description": "造成6点伤害。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.107.0/deu/cards.json
+++ b/data-beta/v0.107.0/deu/cards.json
@@ -8937,7 +8937,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Hoheitsklinge",
-    "description": "Füge ALLEN Gegnern 10 Schaden zu.",
+    "description": "Füge 10 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|}{Repeat:plural:| {} Mal} {Damage:diff()} Schaden zu.{GainsBlock:cond:\nErhalte {CalculatedBlock:diff()} [gold]Block[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -12280,7 +12280,7 @@
   {
     "id": "SHIV",
     "name": "Messer",
-    "description": "Füge ALLEN Gegnern 4 Schaden zu.",
+    "description": "Füge 4 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|} {Damage:diff()} Schaden zu.",
     "cost": 0,
     "is_x_cost": null,
@@ -12314,7 +12314,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Füge ALLEN Gegnern 6 Schaden zu.",
+    "upgrade_description": "Füge 6 Schaden zu.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.107.0/eng/cards.json
+++ b/data-beta/v0.107.0/eng/cards.json
@@ -18845,7 +18845,7 @@
   {
     "id": "SHIV",
     "name": "Shiv",
-    "description": "Deal 4 damage to ALL enemies.",
+    "description": "Deal 4 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -18879,7 +18879,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Deal 6 damage to ALL enemies.",
+    "upgrade_description": "Deal 6 damage.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -19705,7 +19705,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Sovereign Blade",
-    "description": "Deal 10 damage to ALL enemies.",
+    "description": "Deal 10 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}{Repeat:plural:| {} times}.{GainsBlock:cond:\nGain {CalculatedBlock:diff()} [gold]Block[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.107.0/esp/cards.json
+++ b/data-beta/v0.107.0/esp/cards.json
@@ -8802,7 +8802,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada del soberano",
-    "description": "Infliges 10 de daño a TODOS los enemigos.",
+    "description": "Infliges 10 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}{Repeat:plural:| {} veces}.{GainsBlock:cond:\nObtienes {CalculatedBlock:diff()} de [gold]bloqueo[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -16145,7 +16145,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Infliges 4 de daño a TODOS los enemigos.",
+    "description": "Infliges 4 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16179,7 +16179,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliges 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Infliges 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.107.0/fra/cards.json
+++ b/data-beta/v0.107.0/fra/cards.json
@@ -12806,7 +12806,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Lame souveraine",
-    "description": "Infligez 10 dégâts à TOUS les ennemis.",
+    "description": "Infligez 10 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}{Repeat:plural:| {} fois}.{GainsBlock:cond:\nGagnez {CalculatedBlock:diff()} d'[gold]Armure[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -20715,7 +20715,7 @@
   {
     "id": "SHIV",
     "name": "Surin",
-    "description": "Infligez 4 dégâts à TOUS les ennemis.",
+    "description": "Infligez 4 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -20749,7 +20749,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infligez 6 dégâts à TOUS les ennemis.",
+    "upgrade_description": "Infligez 6 dégâts.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.107.0/ita/cards.json
+++ b/data-beta/v0.107.0/ita/cards.json
@@ -16506,7 +16506,7 @@
   {
     "id": "SHIV",
     "name": "Pugnale",
-    "description": "Infliggi 4 di danno  a TUTTI i nemici.",
+    "description": "Infliggi 4 di danno .",
     "description_raw": "Infliggi {Damage:diff()} di danno {TargetType:choose(AllEnemies): a TUTTI i nemici|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16540,7 +16540,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliggi 6 di danno  a TUTTI i nemici.",
+    "upgrade_description": "Infliggi 6 di danno .",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -20723,7 +20723,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Spada Sovrana",
-    "description": "Infliggi 10 di danno a TUTTI i nemici.",
+    "description": "Infliggi 10 di danno.",
     "description_raw": "Infliggi {Damage:diff()} di danno{TargetType:choose(AllEnemies): a TUTTI i nemici|}{Repeat:plural:| {} volte}.{GainsBlock:cond:\nOttieni {CalculatedBlock:diff()} di [gold]Blocco[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.107.0/jpn/cards.json
+++ b/data-beta/v0.107.0/jpn/cards.json
@@ -3495,7 +3495,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "ソヴリン・ブレード",
-    "description": "すべての敵に10ダメージを与える。",
+    "description": "10ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを{Repeat:choose(1):|{}回}与える。{GainsBlock:cond:\n{CalculatedBlock:diff()}[gold]ブロック[/gold]を得る。|}",
     "cost": 2,
     "is_x_cost": null,
@@ -4263,7 +4263,7 @@
   {
     "id": "SHIV",
     "name": "ナイフ",
-    "description": "すべての敵に4ダメージを与える。",
+    "description": "4ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを与える。",
     "cost": 0,
     "is_x_cost": null,
@@ -4297,7 +4297,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "すべての敵に6ダメージを与える。",
+    "upgrade_description": "6ダメージを与える。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.107.0/kor/cards.json
+++ b/data-beta/v0.107.0/kor/cards.json
@@ -2129,7 +2129,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "군주의 칼날",
-    "description": "모든 적에게 피해를 10 줍니다.",
+    "description": "피해를 10 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()}{Repeat:choose(1):|만큼 {}번} 줍니다.{GainsBlock:cond:\n[gold]방어도[/gold]를 {CalculatedBlock:diff()} 얻습니다.|}",
     "cost": 2,
     "is_x_cost": null,
@@ -4388,7 +4388,7 @@
   {
     "id": "SHIV",
     "name": "단도",
-    "description": "모든 적에게 피해를 4 줍니다.",
+    "description": "피해를 4 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()} 줍니다.",
     "cost": 0,
     "is_x_cost": null,
@@ -4422,7 +4422,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "모든 적에게 피해를 6 줍니다.",
+    "upgrade_description": "피해를 6 줍니다.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.107.0/pol/cards.json
+++ b/data-beta/v0.107.0/pol/cards.json
@@ -8617,7 +8617,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Niebiańskie Ostrze",
-    "description": "Zadaj 10 pkt. obrazeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 10 pkt. obrazeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrazeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}{Repeat:plural:| {} razy}.{GainsBlock:cond:\nZyskaj {CalculatedBlock:diff()} pkt. [gold]Bloku[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -9204,7 +9204,7 @@
   {
     "id": "SHIV",
     "name": "Nóż",
-    "description": "Zadaj 4 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 4 pkt. obrażeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrażeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -9238,7 +9238,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Zadaj 6 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "upgrade_description": "Zadaj 6 pkt. obrażeń.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.107.0/ptb/cards.json
+++ b/data-beta/v0.107.0/ptb/cards.json
@@ -8086,7 +8086,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada Soberana",
-    "description": "Cause 10 de dano a TODOS os inimigos.",
+    "description": "Cause 10 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}{Repeat:plural:| {} vezes}.{GainsBlock:cond:\nReceba {CalculatedBlock:diff()} de [gold]Proteção[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -14085,7 +14085,7 @@
   {
     "id": "SHIV",
     "name": "Lâmina",
-    "description": "Cause 4 de dano a TODOS os inimigos.",
+    "description": "Cause 4 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -14119,7 +14119,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Cause 6 de dano a TODOS os inimigos.",
+    "upgrade_description": "Cause 6 de dano.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.107.0/rus/cards.json
+++ b/data-beta/v0.107.0/rus/cards.json
@@ -6325,7 +6325,7 @@
   {
     "id": "SHIV",
     "name": "Заточка",
-    "description": "Наносит 4 урона ВСЕМ врагам.",
+    "description": "Наносит 4 урона.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -6359,7 +6359,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Наносит 6 урона ВСЕМ врагам.",
+    "upgrade_description": "Наносит 6 урона.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [
@@ -7925,7 +7925,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Клинок монарха",
-    "description": "Наносит 10 урона ВСЕМ врагамplural(ru):.",
+    "description": "Наносит 10 уронаplural(ru):.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}{Repeat:plural(ru):| {} раза| {} раз}.{GainsBlock:cond:\nДает {CalculatedBlock:diff()} [gold]защиты[/gold].|}",
     "cost": 2,
     "is_x_cost": null,

--- a/data-beta/v0.107.0/spa/cards.json
+++ b/data-beta/v0.107.0/spa/cards.json
@@ -8472,7 +8472,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Espada del soberano",
-    "description": "Inflige 10 de daño a TODOS los enemigos.",
+    "description": "Inflige 10 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}{Repeat:plural:| {} veces}.{GainsBlock:cond:\nGana {CalculatedBlock:diff()} de [gold]Bloqueo[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -15997,7 +15997,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Inflige 4 de daño a TODOS los enemigos.",
+    "description": "Inflige 4 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16031,7 +16031,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Inflige 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Inflige 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.107.0/tha/cards.json
+++ b/data-beta/v0.107.0/tha/cards.json
@@ -16687,7 +16687,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "พระแสงอาญาสิทธิ์",
-    "description": "สร้างความเสียหาย 10 ใส่ศัตรูทั้งหมด",
+    "description": "สร้างความเสียหาย 10",
     "description_raw": "สร้างความเสียหาย {Damage:diff()}{TargetType:choose(AllEnemies): ใส่ศัตรูทั้งหมด|}{Repeat:choose(1):| จำนวน {} ครั้ง}{GainsBlock:cond:\nได้รับ {CalculatedBlock:diff()} [gold]บล็อก[/gold]|}",
     "cost": 2,
     "is_x_cost": null,
@@ -17836,7 +17836,7 @@
   {
     "id": "SHIV",
     "name": "มีดสั้น",
-    "description": "สร้างความเสียหาย 4 ใส่ศัตรูทั้งหมด",
+    "description": "สร้างความเสียหาย 4",
     "description_raw": "สร้างความเสียหาย {Damage:diff()}{TargetType:choose(AllEnemies): ใส่ศัตรูทั้งหมด|}",
     "cost": 0,
     "is_x_cost": null,
@@ -17870,7 +17870,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "สร้างความเสียหาย 6 ใส่ศัตรูทั้งหมด",
+    "upgrade_description": "สร้างความเสียหาย 6",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.107.0/tur/cards.json
+++ b/data-beta/v0.107.0/tur/cards.json
@@ -4589,7 +4589,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "Egemen Kılıcı",
-    "description": "Tüm düşmanlara 10 hasar ver.",
+    "description": "10 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):Tüm düşmanlara |}{Repeat:plural:|{} kez }{Damage:diff()} hasar ver.{GainsBlock:cond:\n{CalculatedBlock:diff()} [gold]Blok[/gold] elde et.|}",
     "cost": 2,
     "is_x_cost": null,
@@ -8594,7 +8594,7 @@
   {
     "id": "SHIV",
     "name": "Kama",
-    "description": "TÜM düşmanlara 4 hasar ver.",
+    "description": "4 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):TÜM düşmanlara |}{Damage:diff()} hasar ver.",
     "cost": 0,
     "is_x_cost": null,
@@ -8628,7 +8628,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "TÜM düşmanlara 6 hasar ver.",
+    "upgrade_description": "6 hasar ver.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data-beta/v0.107.0/zhs/cards.json
+++ b/data-beta/v0.107.0/zhs/cards.json
@@ -4407,7 +4407,7 @@
   {
     "id": "SOVEREIGN_BLADE",
     "name": "君王之剑",
-    "description": "对所有敌人造成10点伤害。",
+    "description": "造成10点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害{Repeat:choose(1):|{}次}。{GainsBlock:cond:\n获得{CalculatedBlock:diff()}点[gold]格挡[/gold].|}",
     "cost": 2,
     "is_x_cost": null,
@@ -6705,7 +6705,7 @@
   {
     "id": "SHIV",
     "name": "小刀",
-    "description": "对所有敌人造成4点伤害。",
+    "description": "造成4点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害。",
     "cost": 0,
     "is_x_cost": null,
@@ -6739,7 +6739,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "对所有敌人造成6点伤害。",
+    "upgrade_description": "造成6点伤害。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data/deu/cards.json
+++ b/data/deu/cards.json
@@ -12279,7 +12279,7 @@
   {
     "id": "SHIV",
     "name": "Messer",
-    "description": "Füge ALLEN Gegnern 4 Schaden zu.",
+    "description": "Füge 4 Schaden zu.",
     "description_raw": "Füge{TargetType:choose(AllEnemies): ALLEN Gegnern|} {Damage:diff()} Schaden zu.",
     "cost": 0,
     "is_x_cost": null,
@@ -12313,7 +12313,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Füge ALLEN Gegnern 6 Schaden zu.",
+    "upgrade_description": "Füge 6 Schaden zu.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data/eng/cards.json
+++ b/data/eng/cards.json
@@ -18844,7 +18844,7 @@
   {
     "id": "SHIV",
     "name": "Shiv",
-    "description": "Deal 4 damage to ALL enemies.",
+    "description": "Deal 4 damage.",
     "description_raw": "Deal {Damage:diff()} damage{TargetType:choose(AllEnemies): to ALL enemies|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -18878,7 +18878,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Deal 6 damage to ALL enemies.",
+    "upgrade_description": "Deal 6 damage.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data/esp/cards.json
+++ b/data/esp/cards.json
@@ -16056,7 +16056,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Infliges 4 de daño a TODOS los enemigos.",
+    "description": "Infliges 4 de daño.",
     "description_raw": "Infliges {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16090,7 +16090,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliges 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Infliges 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data/fra/cards.json
+++ b/data/fra/cards.json
@@ -20707,7 +20707,7 @@
   {
     "id": "SHIV",
     "name": "Surin",
-    "description": "Infligez 4 dégâts à TOUS les ennemis.",
+    "description": "Infligez 4 dégâts.",
     "description_raw": "Infligez {Damage:diff()} dégâts{TargetType:choose(AllEnemies): à TOUS les ennemis|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -20741,7 +20741,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infligez 6 dégâts à TOUS les ennemis.",
+    "upgrade_description": "Infligez 6 dégâts.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data/ita/cards.json
+++ b/data/ita/cards.json
@@ -16455,7 +16455,7 @@
   {
     "id": "SHIV",
     "name": "Pugnale",
-    "description": "Infliggi 4 di danno  a TUTTI i nemici.",
+    "description": "Infliggi 4 di danno .",
     "description_raw": "Infliggi {Damage:diff()} di danno {TargetType:choose(AllEnemies): a TUTTI i nemici|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -16489,7 +16489,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Infliggi 6 di danno  a TUTTI i nemici.",
+    "upgrade_description": "Infliggi 6 di danno .",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data/jpn/cards.json
+++ b/data/jpn/cards.json
@@ -4263,7 +4263,7 @@
   {
     "id": "SHIV",
     "name": "ナイフ",
-    "description": "すべての敵に4ダメージを与える。",
+    "description": "4ダメージを与える。",
     "description_raw": "{TargetType:choose(AllEnemies):すべての敵に|}{Damage:diff()}ダメージを与える。",
     "cost": 0,
     "is_x_cost": null,
@@ -4297,7 +4297,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "すべての敵に6ダメージを与える。",
+    "upgrade_description": "6ダメージを与える。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data/kor/cards.json
+++ b/data/kor/cards.json
@@ -4433,7 +4433,7 @@
   {
     "id": "SHIV",
     "name": "단도",
-    "description": "모든 적에게 피해를 4 줍니다.",
+    "description": "피해를 4 줍니다.",
     "description_raw": "{TargetType:choose(AllEnemies):모든 적에게 |}피해를 {Damage:diff()} 줍니다.",
     "cost": 0,
     "is_x_cost": null,
@@ -4467,7 +4467,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "모든 적에게 피해를 6 줍니다.",
+    "upgrade_description": "피해를 6 줍니다.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data/pol/cards.json
+++ b/data/pol/cards.json
@@ -9034,7 +9034,7 @@
   {
     "id": "SHIV",
     "name": "Nóż",
-    "description": "Zadaj 4 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "description": "Zadaj 4 pkt. obrażeń.",
     "description_raw": "Zadaj {Damage:diff()} pkt. obrażeń{TargetType:choose(AllEnemies): WSZYSTKIM przeciwnikom|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -9068,7 +9068,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Zadaj 6 pkt. obrażeń WSZYSTKIM przeciwnikom.",
+    "upgrade_description": "Zadaj 6 pkt. obrażeń.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data/ptb/cards.json
+++ b/data/ptb/cards.json
@@ -13998,7 +13998,7 @@
   {
     "id": "SHIV",
     "name": "Lâmina",
-    "description": "Cause 4 de dano a TODOS os inimigos.",
+    "description": "Cause 4 de dano.",
     "description_raw": "Cause {Damage:diff()} de dano{TargetType:choose(AllEnemies): a TODOS os inimigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -14032,7 +14032,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Cause 6 de dano a TODOS os inimigos.",
+    "upgrade_description": "Cause 6 de dano.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data/rus/cards.json
+++ b/data/rus/cards.json
@@ -6361,7 +6361,7 @@
   {
     "id": "SHIV",
     "name": "Заточка",
-    "description": "Наносит 4 урона ВСЕМ врагам.",
+    "description": "Наносит 4 урона.",
     "description_raw": "Наносит {Damage:diff()} урона{TargetType:choose(AllEnemies): ВСЕМ врагам|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -6395,7 +6395,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Наносит 6 урона ВСЕМ врагам.",
+    "upgrade_description": "Наносит 6 урона.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data/spa/cards.json
+++ b/data/spa/cards.json
@@ -15867,7 +15867,7 @@
   {
     "id": "SHIV",
     "name": "Navaja",
-    "description": "Inflige 4 de daño a TODOS los enemigos.",
+    "description": "Inflige 4 de daño.",
     "description_raw": "Inflige {Damage:diff()} de daño{TargetType:choose(AllEnemies): a TODOS los enemigos|}.",
     "cost": 0,
     "is_x_cost": null,
@@ -15901,7 +15901,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "Inflige 6 de daño a TODOS los enemigos.",
+    "upgrade_description": "Inflige 6 de daño.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data/tur/cards.json
+++ b/data/tur/cards.json
@@ -8587,7 +8587,7 @@
   {
     "id": "SHIV",
     "name": "Kama",
-    "description": "TÜM düşmanlara 4 hasar ver.",
+    "description": "4 hasar ver.",
     "description_raw": "{TargetType:choose(AllEnemies):TÜM düşmanlara |}{Damage:diff()} hasar ver.",
     "cost": 0,
     "is_x_cost": null,
@@ -8621,7 +8621,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "TÜM düşmanlara 6 hasar ver.",
+    "upgrade_description": "6 hasar ver.",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [

--- a/data/zhs/cards.json
+++ b/data/zhs/cards.json
@@ -6626,7 +6626,7 @@
   {
     "id": "SHIV",
     "name": "小刀",
-    "description": "对所有敌人造成4点伤害。",
+    "description": "造成4点伤害。",
     "description_raw": "{TargetType:choose(AllEnemies):对所有敌人|}造成{Damage:diff()}点伤害。",
     "cost": 0,
     "is_x_cost": null,
@@ -6660,7 +6660,7 @@
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,
-    "upgrade_description": "对所有敌人造成6点伤害。",
+    "upgrade_description": "造成6点伤害。",
     "type_key": "Attack",
     "rarity_key": "Token",
     "keywords_key": [


### PR DESCRIPTION
## What

Shiv is single-target (`target: AnyEnemy`, 4 damage) but its description rendered as "Deal 4 damage to ALL enemies." in every language. Same template bug hit beta's Sovereign Blade.

## Why

Two compounding bugs in the description pipeline:

1. `card_parser.py` passed `CardType` into the resolver for choose() conditionals but never `TargetType`, so `{TargetType:choose(AllEnemies): to ALL enemies|}` could never match anything.
2. The resolver's no-match fallback always picked the **first** branch. In SmartFormat, `{Var:choose(A):x|y}` has a trailing else-branch: an unlisted value should render `y`. The resolver now uses the extra branch as the else case, and keeps the legacy first-branch fallback only when there is no else-branch (so Mad Science's 3-option/3-branch template behaves exactly as before).

## Data

Since descriptions are rendered at parse time into the shipped JSON, I re-rendered the affected cards from `description_raw` with the fixed resolver: Shiv's description and upgrade description in 13 languages (Thai has no translation), plus Sovereign Blade in the beta versions that have it. 148 files, all surgical 2-4 line diffs. Verified the JSON writer round-trips the existing file format byte for byte, so nothing else moved.

## Testing

- Resolver unit checks: AnyEnemy renders the else-branch, AllEnemies still matches, missing var takes the else-branch when one exists, Mad Science's CardType template unchanged including its no-var fallback.
- zhs output now matches the exact expected string from the issue.
- ruff format/check clean.

Fixes #419