### PR TITLE
Relic filtering by ancient

### DIFF
--- a/backend/app/routers/relics.py
+++ b/backend/app/routers/relics.py
@@ -8,6 +8,26 @@ from ..dependencies import get_lang, matches_search
 router = APIRouter(prefix="/api/relics", tags=["Relics"])
 
 
+def _relic_ancient_map() -> dict[str, str]:
+    """relic_id -> the ancient that offers it (TANX, NEOW, ...), from the
+    ancient pool data. Each ancient relic belongs to exactly one ancient."""
+    from .ancient_pools import _load_pools
+
+    out: dict[str, str] = {}
+    for anc in _load_pools():
+        aid = anc.get("id")
+        if not aid:
+            continue
+        for pool_entry in anc.get("pools") or []:
+            for rel in pool_entry.get("relics") or []:
+                rid = rel.get("id") if isinstance(rel, dict) else rel
+                if rid:
+                    out[str(rid).upper()] = aid
+        for rid in anc.get("per_character_relics") or []:
+            out[str(rid).upper()] = aid
+    return out
+
+
 @router.get("", response_model=list[Relic])
 def get_relics(
     request: Request,
@@ -19,6 +39,10 @@ def get_relics(
         None,
         description="Filter by character pool (ironclad, silent, defect, necrobinder, regent, shared)",
     ),
+    ancient: str | None = Query(
+        None,
+        description="Filter to one ancient's relic pool (neow, tezcatara, pael, orobas, darv, nonupeipe, tanx, vakuu)",
+    ),
     search: str | None = Query(None, description="Search by name or description"),
     lang: str = Depends(get_lang),
 ):
@@ -29,11 +53,19 @@ def get_relics(
         relics = [r for r in relics if r["rarity"] == rarity_localized]
     if pool:
         relics = [r for r in relics if r["pool"].lower() == pool.lower()]
+    amap = _relic_ancient_map() if ancient or search else {}
+    if ancient:
+        want = ancient.strip().upper()
+        relics = [r for r in relics if amap.get(r["id"]) == want]
     if search:
+        # Besides the relic's own fields, let an ancient's name find its
+        # whole pool ("tanx" -> every relic Tanx offers).
+        s = search.strip().lower()
         relics = [
             r
             for r in relics
             if matches_search(r, search, ["name", "description", "rarity", "pool"])
+            or (s and amap.get(r["id"], "").lower().startswith(s))
         ]
     return relics
 

--- a/frontend/app/developers/page.tsx
+++ b/frontend/app/developers/page.tsx
@@ -182,7 +182,7 @@ export default function DevelopersPage() {
                 { method: "GET", path: "/api/cards/{id}", desc: "Single card" },
                 { method: "GET", path: "/api/characters", desc: "All characters" },
                 { method: "GET", path: "/api/characters/{id}", desc: "Single character" },
-                { method: "GET", path: "/api/relics", desc: "All relics (filter: rarity, pool, search)" },
+                { method: "GET", path: "/api/relics", desc: "All relics (filter: rarity, pool, ancient, search)" },
                 { method: "GET", path: "/api/relics/{id}", desc: "Single relic" },
                 { method: "GET", path: "/api/potions", desc: "All potions (filter: rarity, pool, search)" },
                 { method: "GET", path: "/api/potions/{id}", desc: "Single potion" },

--- a/frontend/app/relics/RelicsClient.tsx
+++ b/frontend/app/relics/RelicsClient.tsx
@@ -43,6 +43,17 @@ const poolOptions = [
   { label: "Regent", value: "regent" },
 ];
 
+const ancientOptions = [
+  { label: "Neow", value: "neow" },
+  { label: "Tezcatara", value: "tezcatara" },
+  { label: "Pael", value: "pael" },
+  { label: "Orobas", value: "orobas" },
+  { label: "Darv", value: "darv" },
+  { label: "Nonupeipe", value: "nonupeipe" },
+  { label: "Tanx", value: "tanx" },
+  { label: "Vakuu", value: "vakuu" },
+];
+
 const sortOptions = [
   { label: "Top tier", value: "score" },
   { label: "A → Z", value: "az" },
@@ -58,6 +69,7 @@ export default function RelicsClient({ initialRelics }: { initialRelics: Relic[]
   const [search, setSearch] = useState(searchParams.get("search") || "");
   const [rarity, setRarity] = useState(searchParams.get("rarity") || "");
   const [pool, setPool] = useState(searchParams.get("pool") || "");
+  const [ancient, setAncient] = useState(searchParams.get("ancient") || "");
   const [sort, setSort] = useState(searchParams.get("sort") || "az");
   const { lang } = useLanguage();
   const initialRender = useRef(true);
@@ -73,27 +85,28 @@ export default function RelicsClient({ initialRelics }: { initialRelics: Relic[]
 
   const setFilterAndUrl = useCallback((key: string, value: string, setter: (v: string) => void) => {
     setter(value);
-    const current: Record<string, string> = { search, rarity, pool, sort };
+    const current: Record<string, string> = { search, rarity, pool, ancient, sort };
     current[key] = value;
     updateUrl(current);
-  }, [search, rarity, pool, sort, updateUrl]);
+  }, [search, rarity, pool, ancient, sort, updateUrl]);
 
   useEffect(() => {
     // Skip the first fetch if we have server data and lang is English with no filters
     if (initialRender.current) {
       initialRender.current = false;
-      if (lang === "eng" && !rarity && !pool && !search && initialRelics.length > 0) {
+      if (lang === "eng" && !rarity && !pool && !ancient && !search && initialRelics.length > 0) {
         return;
       }
     }
     const params = new URLSearchParams();
     if (rarity) params.set("rarity", rarity);
     if (pool) params.set("pool", pool);
+    if (ancient) params.set("ancient", ancient);
     if (search) params.set("search", search);
     params.set("lang", lang);
     cachedFetch<Relic[]>(`${API}/api/relics?${params}`)
       .then(setRelics);
-  }, [rarity, pool, search, lang]);
+  }, [rarity, pool, ancient, search, lang]);
 
   const scores = useEntityScores("relics");
 
@@ -137,6 +150,12 @@ export default function RelicsClient({ initialRelics }: { initialRelics: Relic[]
             value: pool,
             options: poolOptions,
             onChange: (v) => setFilterAndUrl("pool", v, setPool),
+          },
+          {
+            label: "All Ancients",
+            value: ancient,
+            options: ancientOptions,
+            onChange: (v) => setFilterAndUrl("ancient", v, setAncient),
           },
         ]}
       />


### PR DESCRIPTION
## What

From #361: "put in tanx to see all tanx relics". Three pieces:

- `/api/relics` accepts an `ancient` query param (neow, tezcatara, pael, orobas, darv, nonupeipe, tanx, vakuu), resolved through the existing ancient pool data (`/api/ancient-pools` source files).
- The relic search now also matches ancient names by prefix, so just typing "tanx" in the search box returns the whole Tanx pool, which is literally what the issue asked for.
- The /relics page gets an "All Ancients" dropdown next to the rarity and pool filters, synced to the URL like the others.

## Testing

- `ancient=tanx` returns the 10 Tanx relics (Claws, Crossbow, Iron Club, Meat Cleaver, Sai, Spiked Gauntlets, Tanx's Whistle, Throwing Axe, Tri-Boomerang, War Hammer).
- `search=tanx` returns the same set (the whistle matches by name, the rest by ancient).
- 97 ancient relics map across all 8 ancients; unfiltered and pool-filtered responses unchanged.
- ruff and tsc clean.

Fixes #361