### PR TITLE
Token and orb pages list what generates them

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -356,12 +356,22 @@ class Intent(BaseModel):
     image_url: str | None = None
 
 
+class EntityRef(BaseModel):
+    """Minimal cross-entity link: just enough to render a named list item."""
+
+    id: str
+    name: str
+
+
 class Orb(BaseModel):
     id: str
     name: str
     description: str
     description_raw: str | None = None
     image_url: str | None = None
+    # Cards/relics whose text Channels this orb (single-orb endpoint only).
+    channeled_by_cards: list[EntityRef] | None = None
+    channeled_by_relics: list[EntityRef] | None = None
 
 
 class Affliction(BaseModel):

--- a/backend/app/routers/cards.py
+++ b/backend/app/routers/cards.py
@@ -28,6 +28,10 @@ def get_cards(
     tag: str | None = Query(
         None, description="Filter by tag (Strike, Defend, Minion, etc.)"
     ),
+    spawns: str | None = Query(
+        None,
+        description="Only cards that create or reference this card id (e.g. SOUL lists every Soul generator)",
+    ),
     search: str | None = Query(None, description="Search by name or description"),
     lang: str = Depends(get_lang),
 ):
@@ -49,6 +53,9 @@ def get_cards(
         ]
     if tag:
         cards = [c for c in cards if c.get("tags") and tag in c["tags"]]
+    if spawns:
+        want = spawns.strip().upper()
+        cards = [c for c in cards if want in (c.get("spawns_cards") or [])]
     if search:
         cards = [
             c

--- a/backend/app/routers/orbs.py
+++ b/backend/app/routers/orbs.py
@@ -1,11 +1,43 @@
 """Orb API endpoints."""
 
+import re
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 from ..models.schemas import Orb
-from ..services.data_service import load_orbs
+from ..services.data_service import load_cards, load_orbs, load_relics
 from ..dependencies import get_lang
 
 router = APIRouter(prefix="/api/orbs", tags=["Orbs"])
+
+
+def _channelers(orb_id: str, lang: str) -> tuple[list[dict], list[dict]]:
+    """Cards and relics whose text Channels this orb. There is no structured
+    orb link in the game data, so matching runs on the English catalog
+    ("Channel ... Frost"), which is structurally identical across languages;
+    display names come from the requested language."""
+    eng_orb = next((o for o in load_orbs("eng") if o["id"] == orb_id), None)
+    if not eng_orb or not eng_orb.get("name"):
+        return [], []
+    channel = re.compile(r"\bChannel")
+    orb_name = re.compile(r"\b" + re.escape(eng_orb["name"]) + r"\b")
+
+    def _hits(loader) -> list[dict]:
+        eng_items = loader("eng")
+        ids = [
+            i["id"]
+            for i in eng_items
+            if channel.search(i.get("description") or "")
+            and orb_name.search(i.get("description") or "")
+        ]
+        if not ids:
+            return []
+        local = {i["id"]: i for i in (eng_items if lang == "eng" else loader(lang))}
+        return [
+            {"id": iid, "name": (local.get(iid) or {}).get("name") or iid}
+            for iid in ids
+        ]
+
+    return _hits(load_cards), _hits(load_relics)
 
 
 @router.get("", response_model=list[Orb])
@@ -18,5 +50,9 @@ def get_orb(request: Request, orb_id: str, lang: str = Depends(get_lang)):
     orbs = load_orbs(lang)
     for orb in orbs:
         if orb["id"] == orb_id.upper():
-            return orb
+            out = dict(orb)
+            cards, relics = _channelers(out["id"], lang)
+            out["channeled_by_cards"] = cards
+            out["channeled_by_relics"] = relics
+            return out
     raise HTTPException(status_code=404, detail=f"Orb '{orb_id}' not found")

--- a/frontend/app/components/RelatedCards.tsx
+++ b/frontend/app/components/RelatedCards.tsx
@@ -26,7 +26,9 @@ interface RelatedGroup {
 export default function RelatedCards({ currentId, keywords, tags, color }: RelatedCardsProps) {
   const { lang } = useLanguage();
   const lp = useLangPrefix();
-  const [groups, setGroups] = useState<RelatedGroup[]>([]);
+  // null while loading so a card with no relations at all renders nothing
+  // instead of a permanent "Loading" stub.
+  const [groups, setGroups] = useState<RelatedGroup[] | null>(null);
 
   // Fetch on mount (not on toggle) so the related-card <Link>s sit in
   // the rendered DOM at first paint. Googlebot doesn't click toggles,
@@ -36,6 +38,18 @@ export default function RelatedCards({ currentId, keywords, tags, color }: Relat
   // outbound crawl paths.
   useEffect(() => {
     const fetches: Promise<RelatedGroup>[] = [];
+
+    // Cards that create or reference this one (spawns_cards reverse lookup),
+    // so token pages like Soul lead with their generators. Fetched first so
+    // the group renders above the keyword/tag groups.
+    fetches.push(
+      cachedFetch<Card[]>(`${API}/api/cards?spawns=${encodeURIComponent(currentId.toUpperCase())}&lang=${lang}`).then(
+        (cards) => ({
+          label: "Created or used by",
+          cards: cards.filter((c) => c.id !== currentId.toUpperCase()).slice(0, 12),
+        })
+      )
+    );
 
     if (keywords?.length) {
       for (const kw of keywords) {
@@ -68,7 +82,7 @@ export default function RelatedCards({ currentId, keywords, tags, color }: Relat
     );
   }, [currentId, keywords, tags, color, lang]);
 
-  if (!keywords?.length && !tags?.length) return null;
+  if (groups !== null && groups.length === 0) return null;
 
   return (
     <details className="mt-6 group" open>
@@ -87,7 +101,7 @@ export default function RelatedCards({ currentId, keywords, tags, color }: Relat
         </svg>
         {t("Related Cards", lang)}
       </summary>
-      {groups.length > 0 ? (
+      {groups && groups.length > 0 ? (
         <div className="mt-3 space-y-4">
           {groups.map((group) => (
             <div key={group.label}>

--- a/frontend/app/developers/page.tsx
+++ b/frontend/app/developers/page.tsx
@@ -178,7 +178,7 @@ export default function DevelopersPage() {
             {
               category: "Entities",
               endpoints: [
-                { method: "GET", path: "/api/cards", desc: "All cards (filter: color, type, rarity, keyword, tag, search)" },
+                { method: "GET", path: "/api/cards", desc: "All cards (filter: color, type, rarity, keyword, tag, spawns, search)" },
                 { method: "GET", path: "/api/cards/{id}", desc: "Single card" },
                 { method: "GET", path: "/api/characters", desc: "All characters" },
                 { method: "GET", path: "/api/characters/{id}", desc: "Single character" },

--- a/frontend/app/orbs/[id]/OrbDetail.tsx
+++ b/frontend/app/orbs/[id]/OrbDetail.tsx
@@ -80,6 +80,31 @@ export default function OrbDetail({ initialOrb }: { initialOrb?: Orb | null } = 
           <RichDescription text={orb.description} />
         </div>
 
+        {[
+          { label: `Cards that Channel ${orb.name}`, items: orb.channeled_by_cards, route: "cards" },
+          { label: `Relics that Channel ${orb.name}`, items: orb.channeled_by_relics, route: "relics" },
+        ].map(({ label, items, route }) =>
+          items && items.length > 0 ? (
+            <div key={route} className="mt-5">
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-2">
+                {label}
+              </h2>
+              <ul className="space-y-1">
+                {items.map((it) => (
+                  <li key={it.id}>
+                    <Link
+                      href={`${lp}/${route}/${it.id.toLowerCase()}`}
+                      className="text-sm text-[var(--text-secondary)] hover:text-[var(--accent-gold)] transition-colors"
+                    >
+                      {it.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null
+        )}
+
         <div className="mt-6">
           <LocalizedNames entityType="orbs" entityId={id} />
           <EntityHistory entityType="orbs" entityId={id} />

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -339,6 +339,9 @@ export interface Orb {
   description: string;
   description_raw: string | null;
   image_url: string | null;
+  // Cards/relics whose text Channels this orb (single-orb endpoint only).
+  channeled_by_cards?: { id: string; name: string }[] | null;
+  channeled_by_relics?: { id: string; name: string }[] | null;
 }
 
 export interface Affliction {


### PR DESCRIPTION
## What

Two long-standing asks:

- **#273:** /cards/soul (and every other token) now leads its Related Cards section with "Created or used by", the cards that add or interact with that token. Soul shows its 10 Necrobinder generators, Shiv shows its 12, and so on for the 15 spawned card targets.
- **#386:** orb pages now list the cards and relics that Channel that orb (e.g. Lightning: Ball Lightning, Lightning Rod, Rainbow, Storm, Tempest, Voltaic, Zap, plus Cracked Core and Infused Core), each linked.

## How

- `/api/cards?spawns=SOUL` filters on the parser's existing `spawns_cards` field (built from the game's own card-creation and hover-tip references in the decompiled source), so no new data extraction was needed.
- Orbs have no structured link in the game data, so the single-orb endpoint matches "Channel" + the orb's name against the English card/relic catalogs (structure is identical across languages) and resolves display names from the requested language. The localized pages get localized names for free.
- RelatedCards also stops rendering a permanent "Loading" stub for cards with no relations at all.

## Testing

- SOUL generators return exactly the 10 expected cards; `lightning_orb` returns 7 cards + 2 relics; `frost_orb?lang=jpn` returns Japanese names.
- ruff and tsc clean.

Fixes #273, fixes #386