### PR TITLE
/charts: interactive run-data explorer

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -45,6 +45,7 @@ from .routers import (
     entity_history,
     ancient_pools,
     runs,
+    charts,
     glossary,
     guides,
     versions,
@@ -513,6 +514,7 @@ app.include_router(exports.router)
 app.include_router(entity_history.router)
 app.include_router(ancient_pools.router)
 app.include_router(runs.router)
+app.include_router(charts.router)
 app.include_router(glossary.router)
 app.include_router(guides.router)
 app.include_router(versions.router)

--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -360,7 +360,9 @@ def get_chart(
     request: Request,
     chart_key: str,
     players: int | None = Query(None, ge=1, le=4, description="Player count filter"),
-    ascension: int | None = Query(None, ge=0, le=20, description="Exact ascension"),
+    ascension: int | None = Query(
+        None, ge=0, le=10, description="Exact ascension (A10 is the cap)"
+    ),
     game_mode: str | None = Query(
         None, description="standard | daily | custom (omit for all)"
     ),

--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -1,0 +1,242 @@
+"""Charts API: pre-aggregated run data for the /charts explorer page.
+
+Every endpoint returns a small, ready-to-plot payload:
+{ chart, params, series: [{id, label, points: [{x, y, n?}]}], total_runs }
+
+Metadata charts aggregate the in-memory run frame per request (fast) and the
+results are cached. Blob charts (per-floor damage, encounter damage, death
+rooms) read the snapshot accumulated during the regular stats walk, or walk a
+single user's blobs on demand when `username` is set.
+"""
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from ..services import cache as app_cache
+from ..services import charts_stats as cs
+from ..services.run_entity_stats import get_charts_blob_stats
+
+router = APIRouter(prefix="/api/charts", tags=["Charts"])
+limiter = Limiter(key_func=get_remote_address)
+
+_CACHE_TTL = 300
+
+# Registry: which charts exist, how they're built, and which filters apply.
+# kind "frame" charts support every filter; "blob" charts support players and
+# username (ascension/mode splits would blow up the snapshot, so they're
+# all-ascensions by design and the UI says so).
+CHARTS: dict[str, dict] = {
+    "winrate-by-floor": {
+        "label": "Win rate by floor reached",
+        "group": "Win rates",
+        "kind": "frame",
+        "axis": {"x": "Floor reached", "y": "Eventual win %"},
+        "desc": "Of the runs that made it to floor X, how many went on to win the run.",
+    },
+    "winrate-over-time": {
+        "label": "Win rate over time",
+        "group": "Win rates",
+        "kind": "frame",
+        "axis": {"x": "Week", "y": "Win %"},
+        "desc": "Weekly community win rate from submitted runs.",
+    },
+    "winrate-by-stat": {
+        "label": "Win rate vs run stat",
+        "group": "Win rates",
+        "kind": "frame",
+        "needs": ["stat"],
+        "axis": {"x": "stat", "y": "Win %"},
+        "desc": "Win rate of runs bucketed by a run stat (deck size, relics, length, ...).",
+    },
+    "winrate-by-ascension": {
+        "label": "Win rate by ascension",
+        "group": "Win rates",
+        "kind": "frame",
+        "axis": {"x": "Ascension", "y": "Win %"},
+        "desc": "Win rate at each ascension level.",
+    },
+    "deaths-by-floor": {
+        "label": "Deaths by floor",
+        "group": "Survival",
+        "kind": "frame",
+        "axis": {"x": "Floor", "y": "% of losses"},
+        "desc": "Where losses end. Abandoned runs are excluded.",
+    },
+    "runs-over-time": {
+        "label": "Runs submitted over time",
+        "group": "Volume",
+        "kind": "frame",
+        "axis": {"x": "Week", "y": "Runs"},
+        "desc": "Weekly submission volume.",
+    },
+    "stat-histogram": {
+        "label": "Run stat distribution",
+        "group": "Distributions",
+        "kind": "frame",
+        "needs": ["stat"],
+        "axis": {"x": "stat", "y": "% of runs"},
+        "desc": "How a run stat is distributed across the filtered runs.",
+    },
+    "stat-scatter": {
+        "label": "Stat vs stat scatter",
+        "group": "Distributions",
+        "kind": "frame",
+        "needs": ["x", "y"],
+        "scatter": True,
+        "axis": {"x": "x stat", "y": "y stat"},
+        "desc": "Sampled runs plotted stat-vs-stat, colored by character.",
+    },
+    "hp-loss-by-floor": {
+        "label": "% max HP lost per fight floor",
+        "group": "Combat",
+        "kind": "blob",
+        "axis": {"x": "Floor", "y": "Avg % max HP lost"},
+        "desc": "Average share of max HP lost in combat at each floor. All ascensions and modes.",
+    },
+    "encounter-damage": {
+        "label": "Encounter damage ranking",
+        "group": "Combat",
+        "kind": "blob",
+        "bars": True,
+        "axis": {"x": "Encounter", "y": "Avg % max HP lost"},
+        "desc": "Encounters ranked by the average share of max HP they take per fight. All ascensions and modes.",
+    },
+    "deaths-by-room": {
+        "label": "Deaths by room type",
+        "group": "Survival",
+        "kind": "blob",
+        "bars": True,
+        "axis": {"x": "Room type", "y": "% of deaths"},
+        "desc": "What kind of room runs die in. All ascensions and modes.",
+    },
+}
+
+
+@router.get("/meta")
+@limiter.limit("120/minute")
+def charts_meta(request: Request):
+    """Everything the explorer UI needs to draw its controls."""
+    chars = cs._official_characters()
+    return {
+        "charts": [
+            {
+                "key": key,
+                "label": c["label"],
+                "group": c["group"],
+                "kind": c["kind"],
+                "needs": c.get("needs", []),
+                "scatter": c.get("scatter", False),
+                "bars": c.get("bars", False),
+                "axis": c["axis"],
+                "desc": c["desc"],
+            }
+            for key, c in CHARTS.items()
+        ],
+        "stats": [{"key": k, "label": v["label"]} for k, v in cs.STATS.items()],
+        "characters": [{"id": cid, "name": name} for cid, name in chars.items()],
+    }
+
+
+def _build_frame_chart(
+    key: str, rows: list[tuple], stat: str | None, x: str | None, y: str | None
+):
+    if key == "winrate-by-floor":
+        return cs.winrate_by_floor(rows)
+    if key == "winrate-over-time":
+        return cs.winrate_over_time(rows)
+    if key == "runs-over-time":
+        return cs.runs_over_time(rows)
+    if key == "deaths-by-floor":
+        return cs.deaths_by_floor(rows)
+    if key == "winrate-by-ascension":
+        return cs.winrate_by_stat(rows, "ascension")
+    if key == "winrate-by-stat":
+        return cs.winrate_by_stat(rows, stat or "deck_size")
+    if key == "stat-histogram":
+        return cs.stat_histogram(rows, stat or "floors_reached")
+    if key == "stat-scatter":
+        return cs.stat_scatter(rows, x or "floors_reached", y or "deck_size")
+    raise HTTPException(status_code=404, detail="Unknown chart")
+
+
+@router.get("/{chart_key}")
+@limiter.limit("120/minute")
+def get_chart(
+    request: Request,
+    chart_key: str,
+    players: int | None = Query(None, ge=1, le=4, description="Player count filter"),
+    ascension: int | None = Query(None, ge=0, le=20, description="Exact ascension"),
+    game_mode: str | None = Query(
+        None, description="standard | daily | custom (omit for all)"
+    ),
+    username: str | None = Query(
+        None, max_length=64, description="One submitter's runs"
+    ),
+    stat: str | None = Query(None, description="Run stat for stat-driven charts"),
+    x: str | None = Query(None, description="X stat for the scatter"),
+    y: str | None = Query(None, description="Y stat for the scatter"),
+):
+    """One pre-aggregated chart. See /api/charts/meta for the available
+    charts, their filters, and the run stats usable for stat/x/y."""
+    spec = CHARTS.get(chart_key)
+    if not spec:
+        raise HTTPException(status_code=404, detail=f"Unknown chart '{chart_key}'")
+    if game_mode and game_mode not in ("standard", "daily", "custom"):
+        raise HTTPException(status_code=400, detail="bad game_mode")
+    for name, value in (("stat", stat), ("x", x), ("y", y)):
+        if value and value not in cs.STATS:
+            raise HTTPException(status_code=400, detail=f"unknown {name} '{value}'")
+    username = (username or "").strip() or None
+
+    cache_key = (
+        f"charts:{chart_key}:{players or ''}:{ascension if ascension is not None else ''}:"
+        f"{game_mode or ''}:{(username or '').lower()}:{stat or ''}:{x or ''}:{y or ''}"
+    )
+    cached = app_cache.get_json(cache_key)
+    if cached is not None:
+        return cached
+
+    if spec["kind"] == "frame":
+        rows = cs.filter_rows(cs.get_frame(), players, ascension, game_mode, username)
+        series = _build_frame_chart(chart_key, rows, stat, x, y)
+        total = len(rows)
+    else:
+        # Blob charts: snapshot rollup, or a per-user walk when username set.
+        if ascension is not None or game_mode:
+            raise HTTPException(
+                status_code=400,
+                detail="This chart covers all ascensions and modes; drop those filters.",
+            )
+        stats = (
+            cs.build_user_blob_stats(username) if username else get_charts_blob_stats()
+        )
+        if chart_key == "hp-loss-by-floor":
+            series = cs.hp_loss_by_floor(stats, players)
+        elif chart_key == "encounter-damage":
+            series = cs.encounter_damage(stats, players)
+        elif chart_key == "deaths-by-room":
+            series = cs.deaths_by_room(stats, players)
+        else:
+            raise HTTPException(status_code=404, detail="Unknown chart")
+        total = sum(n for *_rest, n in (stats.get("hp_floor") or [[0, 0, 0, 0, 0]]))
+
+    payload = {
+        "chart": chart_key,
+        "label": spec["label"],
+        "axis": spec["axis"],
+        "desc": spec["desc"],
+        "params": {
+            "players": players,
+            "ascension": ascension,
+            "game_mode": game_mode,
+            "username": username,
+            "stat": stat,
+            "x": x,
+            "y": y,
+        },
+        "series": series,
+        "total_runs": total,
+    }
+    app_cache.set_json(cache_key, payload, _CACHE_TTL)
+    return payload

--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -3,10 +3,12 @@
 Every endpoint returns a small, ready-to-plot payload:
 { chart, params, series: [{id, label, points: [{x, y, n?}]}], total_runs }
 
-Metadata charts aggregate the in-memory run frame per request (fast) and the
-results are cached. Blob charts (per-floor damage, encounter damage, death
-rooms) read the snapshot accumulated during the regular stats walk, or walk a
-single user's blobs on demand when `username` is set.
+Metadata charts aggregate the in-memory run frame per request (fast), support
+splitting series by character / player count / outcome / ascension band, and
+the results are cached. Blob charts (per-floor curves, encounter damage,
+event outcomes, per-entity stats) read the snapshot accumulated during the
+regular stats walk, or walk a single user's blobs on demand when `username`
+is set.
 """
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -22,15 +24,21 @@ limiter = Limiter(key_func=get_remote_address)
 
 _CACHE_TTL = 300
 
+_ALL_SPLITS = ["character", "players", "outcome", "ascension"]
+# Win-rate charts can't split by outcome (a winners-only win rate is 100%).
+_RATE_SPLITS = ["character", "players", "ascension"]
+
 # Registry: which charts exist, how they're built, and which filters apply.
-# kind "frame" charts support every filter; "blob" charts support players and
-# username (ascension/mode splits would blow up the snapshot, so they're
-# all-ascensions by design and the UI says so).
+# kind "frame" charts support every filter and series splits; "blob" charts
+# support players and username (ascension/mode splits would blow up the
+# snapshot, so they're all-ascensions by design and the UI says so).
 CHARTS: dict[str, dict] = {
+    # ── Win rates (frame) ──
     "winrate-by-floor": {
         "label": "Win rate by floor reached",
         "group": "Win rates",
         "kind": "frame",
+        "splits": _RATE_SPLITS,
         "axis": {"x": "Floor reached", "y": "Eventual win %"},
         "desc": "Of the runs that made it to floor X, how many went on to win the run.",
     },
@@ -38,6 +46,7 @@ CHARTS: dict[str, dict] = {
         "label": "Win rate over time",
         "group": "Win rates",
         "kind": "frame",
+        "splits": _RATE_SPLITS,
         "axis": {"x": "Week", "y": "Win %"},
         "desc": "Weekly community win rate from submitted runs.",
     },
@@ -46,6 +55,7 @@ CHARTS: dict[str, dict] = {
         "group": "Win rates",
         "kind": "frame",
         "needs": ["stat"],
+        "splits": _RATE_SPLITS,
         "axis": {"x": "stat", "y": "Win %"},
         "desc": "Win rate of runs bucketed by a run stat (deck size, relics, length, ...).",
     },
@@ -53,40 +63,72 @@ CHARTS: dict[str, dict] = {
         "label": "Win rate by ascension",
         "group": "Win rates",
         "kind": "frame",
+        "splits": ["character", "players"],
         "axis": {"x": "Ascension", "y": "Win %"},
         "desc": "Win rate at each ascension level.",
     },
+    "hardest-dailies": {
+        "label": "Daily win rate by date",
+        "group": "Win rates",
+        "kind": "frame",
+        "daily": True,
+        "bars": True,
+        "splits": [],
+        "axis": {"x": "Daily", "y": "Win %"},
+        "desc": "Win rate of each daily climb (the seed encodes the daily's date). Low bars were the brutal ones.",
+    },
+    # ── Survival (frame + blob) ──
     "deaths-by-floor": {
         "label": "Deaths by floor",
         "group": "Survival",
         "kind": "frame",
+        "splits": ["character", "players", "ascension"],
         "axis": {"x": "Floor", "y": "% of losses"},
         "desc": "Where losses end. Abandoned runs are excluded.",
     },
-    "runs-over-time": {
-        "label": "Runs submitted over time",
-        "group": "Volume",
+    "acts-funnel": {
+        "label": "How far runs get (funnel)",
+        "group": "Survival",
         "kind": "frame",
-        "axis": {"x": "Week", "y": "Runs"},
-        "desc": "Weekly submission volume.",
+        "bars": True,
+        "splits": _RATE_SPLITS,
+        "axis": {"x": "Stage", "y": "% of runs"},
+        "desc": "Share of runs surviving each act boundary, ending in the win rate.",
     },
-    "stat-histogram": {
-        "label": "Run stat distribution",
-        "group": "Distributions",
-        "kind": "frame",
-        "needs": ["stat"],
-        "axis": {"x": "stat", "y": "% of runs"},
-        "desc": "How a run stat is distributed across the filtered runs.",
+    "deaths-by-room": {
+        "label": "Deaths by room type",
+        "group": "Survival",
+        "kind": "blob",
+        "bars": True,
+        "axis": {"x": "Room type", "y": "% of deaths"},
+        "desc": "What kind of room runs die in. All ascensions and modes.",
     },
-    "stat-scatter": {
-        "label": "Stat vs stat scatter",
-        "group": "Distributions",
-        "kind": "frame",
-        "needs": ["x", "y"],
-        "scatter": True,
-        "axis": {"x": "x stat", "y": "y stat"},
-        "desc": "Sampled runs plotted stat-vs-stat, colored by character.",
+    # ── Run curves (blob) ──
+    "hp-trajectory": {
+        "label": "HP trajectory, wins vs losses",
+        "group": "Run curves",
+        "kind": "blob",
+        "metric": "hp",
+        "axis": {"x": "Floor", "y": "Avg % of max HP"},
+        "desc": "Average health per floor for winning and losing runs. All ascensions and modes.",
     },
+    "gold-curve": {
+        "label": "Gold curve, wins vs losses",
+        "group": "Run curves",
+        "kind": "blob",
+        "metric": "gold",
+        "axis": {"x": "Floor", "y": "Avg gold held"},
+        "desc": "Average gold held per floor for winning and losing runs. All ascensions and modes.",
+    },
+    "deck-growth": {
+        "label": "Deck growth, wins vs losses",
+        "group": "Run curves",
+        "kind": "blob",
+        "metric": "deck",
+        "axis": {"x": "Floor", "y": "Avg cards added"},
+        "desc": "Average number of final-deck cards acquired by each floor (removed cards aren't counted). All ascensions and modes.",
+    },
+    # ── Combat (blob) ──
     "hp-loss-by-floor": {
         "label": "% max HP lost per fight floor",
         "group": "Combat",
@@ -99,16 +141,107 @@ CHARTS: dict[str, dict] = {
         "group": "Combat",
         "kind": "blob",
         "bars": True,
+        "horizontal": True,
         "axis": {"x": "Encounter", "y": "Avg % max HP lost"},
         "desc": "Encounters ranked by the average share of max HP they take per fight. All ascensions and modes.",
     },
-    "deaths-by-room": {
-        "label": "Deaths by room type",
-        "group": "Survival",
+    "encounter-turns": {
+        "label": "Slowest encounters (turns)",
+        "group": "Combat",
         "kind": "blob",
         "bars": True,
-        "axis": {"x": "Room type", "y": "% of deaths"},
-        "desc": "What kind of room runs die in. All ascensions and modes.",
+        "horizontal": True,
+        "axis": {"x": "Encounter", "y": "Avg turns per fight"},
+        "desc": "Encounters ranked by how many turns the fight takes. All ascensions and modes.",
+    },
+    "encounter-histogram": {
+        "label": "Encounter damage histogram",
+        "group": "Combat",
+        "kind": "blob",
+        "bars": True,
+        "needs": ["encounter"],
+        "axis": {"x": "% of max HP lost", "y": "% of fights"},
+        "desc": "Damage distribution for one encounter, in 5%-of-max-HP buckets. All ascensions and modes.",
+    },
+    # ── Strategy (blob) ──
+    "elites-vs-winrate": {
+        "label": "Elites fought vs win rate",
+        "group": "Strategy",
+        "kind": "blob",
+        "axis": {"x": "Elite fights in the run", "y": "Win %"},
+        "desc": "Do greedy elite routes pay off. All ascensions and modes.",
+    },
+    "smiths-vs-winrate": {
+        "label": "Upgrades taken vs win rate",
+        "group": "Strategy",
+        "kind": "blob",
+        "axis": {"x": "Smith choices in the run", "y": "Win %"},
+        "desc": "Win rate by how many rest sites went to upgrading. All ascensions and modes.",
+    },
+    "event-outcomes": {
+        "label": "Event choice outcomes",
+        "group": "Strategy",
+        "kind": "blob",
+        "bars": True,
+        "needs": ["event"],
+        "axis": {"x": "Option", "y": "%"},
+        "desc": "What players pick at one event, and the win rate of runs that picked each option. All ascensions and modes.",
+    },
+    # ── Cards and relics (blob) ──
+    "entity-over-time": {
+        "label": "Card / relic / potion over time",
+        "group": "Cards and relics",
+        "kind": "blob",
+        "needs": ["etype", "entity"],
+        "axis": {"x": "Week", "y": "%"},
+        "desc": "Weekly share of runs holding it, win rate with it, and the overall win rate baseline. All ascensions and modes.",
+    },
+    "entity-copies": {
+        "label": "Copies in deck vs win rate",
+        "group": "Cards and relics",
+        "kind": "blob",
+        "bars": True,
+        "needs": ["entity"],
+        "etype_fixed": "cards",
+        "axis": {"x": "Copies in final deck", "y": "Win %"},
+        "desc": "Win rate by how many copies of one card the final deck held. All ascensions and modes.",
+    },
+    "enchant-winrate": {
+        "label": "Win rate by enchantment",
+        "group": "Cards and relics",
+        "kind": "blob",
+        "bars": True,
+        "horizontal": True,
+        "axis": {"x": "Enchantment", "y": "Win % of runs holding it"},
+        "desc": "Win rate of runs whose final deck carried each enchantment. All ascensions and modes.",
+    },
+    # ── Volume / distributions (frame) ──
+    "runs-over-time": {
+        "label": "Runs submitted over time",
+        "group": "Volume",
+        "kind": "frame",
+        "splits": _ALL_SPLITS,
+        "axis": {"x": "Week", "y": "Runs"},
+        "desc": "Weekly submission volume.",
+    },
+    "stat-histogram": {
+        "label": "Run stat distribution",
+        "group": "Distributions",
+        "kind": "frame",
+        "needs": ["stat"],
+        "splits": _ALL_SPLITS,
+        "axis": {"x": "stat", "y": "% of runs"},
+        "desc": "How a run stat is distributed across the filtered runs.",
+    },
+    "stat-scatter": {
+        "label": "Stat vs stat scatter",
+        "group": "Distributions",
+        "kind": "frame",
+        "needs": ["x", "y"],
+        "scatter": True,
+        "splits": _ALL_SPLITS,
+        "axis": {"x": "x stat", "y": "y stat"},
+        "desc": "Sampled runs plotted stat-vs-stat.",
     },
 }
 
@@ -116,7 +249,8 @@ CHARTS: dict[str, dict] = {
 @router.get("/meta")
 @limiter.limit("120/minute")
 def charts_meta(request: Request):
-    """Everything the explorer UI needs to draw its controls."""
+    """Everything the explorer UI needs to draw its controls, including the
+    event list (events actually present in the data) for the outcome chart."""
     chars = cs._official_characters()
     return {
         "charts": [
@@ -126,8 +260,12 @@ def charts_meta(request: Request):
                 "group": c["group"],
                 "kind": c["kind"],
                 "needs": c.get("needs", []),
+                "splits": c.get("splits", []),
                 "scatter": c.get("scatter", False),
                 "bars": c.get("bars", False),
+                "horizontal": c.get("horizontal", False),
+                "daily": c.get("daily", False),
+                "etype_fixed": c.get("etype_fixed"),
                 "axis": c["axis"],
                 "desc": c["desc"],
             }
@@ -135,28 +273,84 @@ def charts_meta(request: Request):
         ],
         "stats": [{"key": k, "label": v["label"]} for k, v in cs.STATS.items()],
         "characters": [{"id": cid, "name": name} for cid, name in chars.items()],
+        "events": cs.event_list(get_charts_blob_stats()),
     }
 
 
 def _build_frame_chart(
-    key: str, rows: list[tuple], stat: str | None, x: str | None, y: str | None
+    key: str,
+    rows: list[tuple],
+    stat: str | None,
+    x: str | None,
+    y: str | None,
+    split: str,
 ):
     if key == "winrate-by-floor":
-        return cs.winrate_by_floor(rows)
+        return cs.winrate_by_floor(rows, split)
     if key == "winrate-over-time":
-        return cs.winrate_over_time(rows)
+        return cs.winrate_over_time(rows, split)
     if key == "runs-over-time":
-        return cs.runs_over_time(rows)
+        return cs.runs_over_time(rows, split)
     if key == "deaths-by-floor":
-        return cs.deaths_by_floor(rows)
+        return cs.deaths_by_floor(rows, split)
     if key == "winrate-by-ascension":
-        return cs.winrate_by_stat(rows, "ascension")
+        return cs.winrate_by_stat(rows, "ascension", split)
     if key == "winrate-by-stat":
-        return cs.winrate_by_stat(rows, stat or "deck_size")
+        return cs.winrate_by_stat(rows, stat or "deck_size", split)
     if key == "stat-histogram":
-        return cs.stat_histogram(rows, stat or "floors_reached")
+        return cs.stat_histogram(rows, stat or "floors_reached", split)
     if key == "stat-scatter":
-        return cs.stat_scatter(rows, x or "floors_reached", y or "deck_size")
+        return cs.stat_scatter(rows, x or "floors_reached", y or "deck_size", split)
+    if key == "acts-funnel":
+        return cs.acts_funnel(rows, split)
+    if key == "hardest-dailies":
+        return cs.hardest_dailies(rows)
+    raise HTTPException(status_code=404, detail="Unknown chart")
+
+
+def _build_blob_chart(
+    key: str,
+    stats: dict,
+    spec: dict,
+    players: int | None,
+    encounter: str | None,
+    event: str | None,
+    etype: str | None,
+    entity: str | None,
+):
+    if key in ("hp-trajectory", "gold-curve", "deck-growth"):
+        return cs.run_trajectory(stats, players, spec["metric"])
+    if key == "hp-loss-by-floor":
+        return cs.hp_loss_by_floor(stats, players)
+    if key == "encounter-damage":
+        return cs.encounter_ranking(stats, players, "damage")
+    if key == "encounter-turns":
+        return cs.encounter_ranking(stats, players, "turns")
+    if key == "encounter-histogram":
+        if not encounter:
+            raise HTTPException(status_code=400, detail="encounter required")
+        return cs.encounter_histogram(stats, players, encounter.upper())
+    if key == "deaths-by-room":
+        return cs.deaths_by_room(stats, players)
+    if key == "elites-vs-winrate":
+        return cs.elites_vs_winrate(stats, players)
+    if key == "smiths-vs-winrate":
+        return cs.smiths_vs_winrate(stats, players)
+    if key == "event-outcomes":
+        if not event:
+            raise HTTPException(status_code=400, detail="event required")
+        return cs.event_outcomes(stats, event.upper())
+    if key == "entity-over-time":
+        if not entity:
+            raise HTTPException(status_code=400, detail="entity required")
+        et = etype if etype in ("cards", "relics", "potions") else "cards"
+        return cs.entity_over_time(stats, et, entity.upper())
+    if key == "entity-copies":
+        if not entity:
+            raise HTTPException(status_code=400, detail="entity required")
+        return cs.entity_copies(stats, entity.upper())
+    if key == "enchant-winrate":
+        return cs.enchant_winrate(stats)
     raise HTTPException(status_code=404, detail="Unknown chart")
 
 
@@ -173,12 +367,19 @@ def get_chart(
     username: str | None = Query(
         None, max_length=64, description="One submitter's runs"
     ),
+    split: str | None = Query(
+        None, description="Series split: character | players | outcome | ascension"
+    ),
     stat: str | None = Query(None, description="Run stat for stat-driven charts"),
     x: str | None = Query(None, description="X stat for the scatter"),
     y: str | None = Query(None, description="Y stat for the scatter"),
+    encounter: str | None = Query(None, max_length=80, description="Encounter id"),
+    event: str | None = Query(None, max_length=80, description="Event id"),
+    etype: str | None = Query(None, description="cards | relics | potions"),
+    entity: str | None = Query(None, max_length=80, description="Entity id"),
 ):
     """One pre-aggregated chart. See /api/charts/meta for the available
-    charts, their filters, and the run stats usable for stat/x/y."""
+    charts, their filters, splits, and the run stats usable for stat/x/y."""
     spec = CHARTS.get(chart_key)
     if not spec:
         raise HTTPException(status_code=404, detail=f"Unknown chart '{chart_key}'")
@@ -187,19 +388,27 @@ def get_chart(
     for name, value in (("stat", stat), ("x", x), ("y", y)):
         if value and value not in cs.STATS:
             raise HTTPException(status_code=400, detail=f"unknown {name} '{value}'")
+    allowed_splits = spec.get("splits", [])
+    if split and split not in allowed_splits:
+        raise HTTPException(
+            status_code=400, detail=f"split must be one of {allowed_splits or 'none'}"
+        )
     username = (username or "").strip() or None
+    split = split or "character"
 
     cache_key = (
         f"charts:{chart_key}:{players or ''}:{ascension if ascension is not None else ''}:"
-        f"{game_mode or ''}:{(username or '').lower()}:{stat or ''}:{x or ''}:{y or ''}"
+        f"{game_mode or ''}:{(username or '').lower()}:{split}:{stat or ''}:{x or ''}:{y or ''}:"
+        f"{(encounter or '').lower()}:{(event or '').lower()}:{etype or ''}:{(entity or '').lower()}"
     )
     cached = app_cache.get_json(cache_key)
     if cached is not None:
         return cached
 
     if spec["kind"] == "frame":
-        rows = cs.filter_rows(cs.get_frame(), players, ascension, game_mode, username)
-        series = _build_frame_chart(chart_key, rows, stat, x, y)
+        mode = "daily" if spec.get("daily") else game_mode
+        rows = cs.filter_rows(cs.get_frame(), players, ascension, mode, username)
+        series = _build_frame_chart(chart_key, rows, stat, x, y, split)
         total = len(rows)
     else:
         # Blob charts: snapshot rollup, or a per-user walk when username set.
@@ -211,15 +420,10 @@ def get_chart(
         stats = (
             cs.build_user_blob_stats(username) if username else get_charts_blob_stats()
         )
-        if chart_key == "hp-loss-by-floor":
-            series = cs.hp_loss_by_floor(stats, players)
-        elif chart_key == "encounter-damage":
-            series = cs.encounter_damage(stats, players)
-        elif chart_key == "deaths-by-room":
-            series = cs.deaths_by_room(stats, players)
-        else:
-            raise HTTPException(status_code=404, detail="Unknown chart")
-        total = sum(n for *_rest, n in (stats.get("hp_floor") or [[0, 0, 0, 0, 0]]))
+        series = _build_blob_chart(
+            chart_key, stats, spec, players, encounter, event, etype, entity
+        )
+        total = sum(n for _wk, n, _w in stats.get("week_totals") or [])
 
     payload = {
         "chart": chart_key,
@@ -231,9 +435,14 @@ def get_chart(
             "ascension": ascension,
             "game_mode": game_mode,
             "username": username,
+            "split": split,
             "stat": stat,
             "x": x,
             "y": y,
+            "encounter": encounter,
+            "event": event,
+            "etype": etype,
+            "entity": entity,
         },
         "series": series,
         "total_runs": total,

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -1,0 +1,703 @@
+"""Aggregates behind /api/charts, the run-data explorer.
+
+Two data paths, both designed so the browser only ever receives a small,
+ready-to-plot JSON (the usual community charts sites ship every run to the
+client and aggregate there, which is why they crawl):
+
+- Metadata frame: one process-wide list of per-run scalar tuples (character,
+  win, ascension, mode, players, floors, deck size, ...) loaded from the run
+  store and refreshed lazily. Every metadata chart is a single pass over the
+  frame with the request's filters applied. 200k+ runs aggregate in well
+  under a second, and the router caches responses on top.
+- Blob stats: per-floor damage, encounter damage, and death room types need
+  the full run blobs, so they piggyback on the single snapshot walk in
+  ``run_entity_stats`` (same pattern as community_stats) and are served as
+  O(1) reads, split by character x player count. Per-user variants walk just
+  that user's blobs on demand.
+
+This module must not import run_entity_stats (the dependency runs the other
+way, like community_stats).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DATA_DIR = Path(
+    os.environ.get("DATA_DIR", Path(__file__).resolve().parents[3] / "data")
+)
+_RUNS_DIR = _DATA_DIR / "runs"
+
+# ── Frame: per-run metadata tuples ───────────────────────────────────────────
+
+# Tuple indices (kept positional to stay light at 200k+ rows).
+CHAR, WIN, ASC, MODE, PLAYERS, TIME, FLOORS, DECK, RELICS, DAY, USER, ABANDONED = range(
+    12
+)
+
+_FRAME: list[tuple] = []
+_FRAME_TS: float = 0.0
+_FRAME_TTL = 600  # seconds between store reloads
+_FRAME_LOCK = threading.Lock()
+
+# Smallest sample a single point may summarise; thinner buckets are dropped so
+# the lines don't whip around on noise.
+MIN_POINT_N = 20
+# Smallest filtered sample a per-character series needs to be drawn at all.
+MIN_SERIES_N = 30
+# Scatter sampling caps (points per series / total).
+SCATTER_PER_SERIES = 600
+
+_GAME_MODES = frozenset({"standard", "daily", "custom"})
+
+
+def _norm_char(raw: str | None) -> str:
+    """ "character.necrobinder" / "NECROBINDER" -> "NECROBINDER"."""
+    return (raw or "").split(".")[-1].upper()
+
+
+def _epoch_day(submitted: Any) -> int:
+    if submitted is None:
+        return 0
+    if hasattr(submitted, "timestamp"):
+        return int(submitted.timestamp() // 86400)
+    s = str(submitted)
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            dt = datetime.strptime(s[:19], fmt).replace(tzinfo=timezone.utc)
+            return int(dt.timestamp() // 86400)
+        except ValueError:
+            continue
+    return 0
+
+
+def _load_frame() -> list[tuple]:
+    rows: list[tuple] = []
+    if os.environ.get("MONGO_URL", "").strip():
+        from .runs_db_mongo import _get_collection
+
+        cursor = _get_collection().find(
+            {},
+            {
+                "_id": 0,
+                "character": 1,
+                "win": 1,
+                "ascension": 1,
+                "game_mode": 1,
+                "player_count": 1,
+                "run_time": 1,
+                "floors_reached": 1,
+                "deck_size": 1,
+                "relic_count": 1,
+                "submitted_at": 1,
+                "username": 1,
+                "was_abandoned": 1,
+            },
+        )
+        for d in cursor:
+            rows.append(
+                (
+                    _norm_char(d.get("character")),
+                    1 if d.get("win") else 0,
+                    int(d.get("ascension") or 0),
+                    (d.get("game_mode") or "standard").lower(),
+                    int(d.get("player_count") or 1),
+                    int(d.get("run_time") or 0),
+                    int(d.get("floors_reached") or 0),
+                    int(d.get("deck_size") or 0),
+                    int(d.get("relic_count") or 0),
+                    _epoch_day(d.get("submitted_at")),
+                    (d.get("username") or "").lower(),
+                    1 if d.get("was_abandoned") else 0,
+                )
+            )
+    else:
+        from .runs_db import get_conn
+
+        with get_conn() as conn:
+            for d in conn.execute(
+                "SELECT character, win, ascension, game_mode, player_count,"
+                " run_time, floors_reached, deck_size, relic_count,"
+                " submitted_at, username, was_abandoned FROM runs"
+            ):
+                rows.append(
+                    (
+                        _norm_char(d["character"]),
+                        1 if d["win"] else 0,
+                        int(d["ascension"] or 0),
+                        (d["game_mode"] or "standard").lower(),
+                        int(d["player_count"] or 1),
+                        int(d["run_time"] or 0),
+                        int(d["floors_reached"] or 0),
+                        int(d["deck_size"] or 0),
+                        int(d["relic_count"] or 0),
+                        _epoch_day(d["submitted_at"]),
+                        (d["username"] or "").lower(),
+                        1 if d["was_abandoned"] else 0,
+                    )
+                )
+    return rows
+
+
+def get_frame() -> list[tuple]:
+    """The metadata frame, reloading from the store at most every TTL.
+    Keeps serving the previous frame if a reload fails."""
+    global _FRAME, _FRAME_TS
+    if _FRAME and time.time() - _FRAME_TS < _FRAME_TTL:
+        return _FRAME
+    with _FRAME_LOCK:
+        if _FRAME and time.time() - _FRAME_TS < _FRAME_TTL:
+            return _FRAME
+        try:
+            rows = _load_frame()
+            if rows or not _FRAME:
+                _FRAME = rows
+            _FRAME_TS = time.time()
+        except Exception:
+            logger.warning("charts frame reload failed", exc_info=True)
+            _FRAME_TS = time.time()  # don't hammer a broken store
+    return _FRAME
+
+
+def _official_characters() -> dict[str, str]:
+    """id -> display name (without the leading "The") for official characters."""
+    from . import data_service
+
+    try:
+        out = {}
+        for c in data_service.load_characters():
+            cid = (c.get("id") or "").upper()
+            if cid:
+                name = c.get("name") or cid.title()
+                out[cid] = name.removeprefix("The ").strip()
+        return out
+    except Exception:
+        logger.warning("charts character load failed", exc_info=True)
+        return {}
+
+
+def filter_rows(
+    rows: list[tuple],
+    players: int | None,
+    ascension: int | None,
+    game_mode: str | None,
+    username: str | None,
+) -> list[tuple]:
+    u = (username or "").lower().strip()
+    out = []
+    for r in rows:
+        if players is not None and r[PLAYERS] != players:
+            continue
+        if ascension is not None and r[ASC] != ascension:
+            continue
+        if game_mode is not None and r[MODE] != game_mode:
+            continue
+        if u and r[USER] != u:
+            continue
+        out.append(r)
+    return out
+
+
+def _series_split(rows: list[tuple]) -> list[tuple[str, str, list[tuple]]]:
+    """(series_id, label, rows) per official character with enough sample,
+    plus the ALL series. Modded characters fold into ALL only."""
+    chars = _official_characters()
+    by_char: dict[str, list[tuple]] = {}
+    for r in rows:
+        by_char.setdefault(r[CHAR], []).append(r)
+    out: list[tuple[str, str, list[tuple]]] = [("ALL", "All characters", rows)]
+    for cid, name in chars.items():
+        sub = by_char.get(cid) or []
+        if len(sub) >= MIN_SERIES_N:
+            out.append((cid, name, sub))
+    return out
+
+
+# ── Metadata chart builders ──────────────────────────────────────────────────
+
+# Run stats that "vs stat" / histogram / scatter charts can use.
+# value(row) -> numeric; bucket = bucket width; max caps the axis.
+STATS: dict[str, dict[str, Any]] = {
+    "floors_reached": {
+        "label": "Floors reached",
+        "idx": FLOORS,
+        "bucket": 1,
+        "max": 60,
+    },
+    "deck_size": {"label": "Deck size", "idx": DECK, "bucket": 2, "max": 90},
+    "relic_count": {"label": "Relic count", "idx": RELICS, "bucket": 1, "max": 45},
+    "run_minutes": {
+        "label": "Run length (minutes)",
+        "idx": TIME,
+        "bucket": 5,
+        "max": 240,
+        "scale": 1 / 60,
+    },
+    "ascension": {"label": "Ascension", "idx": ASC, "bucket": 1, "max": 20},
+}
+
+
+def _stat_value(row: tuple, stat: dict) -> float:
+    v = row[stat["idx"]] * stat.get("scale", 1)
+    return v
+
+
+def winrate_by_floor(rows: list[tuple]) -> list[dict]:
+    """Of the runs that reached floor X, how many went on to win."""
+    series = []
+    for sid, label, sub in _series_split(rows):
+        max_f = min(max((r[FLOORS] for r in sub), default=0), 60)
+        total = [0] * (max_f + 1)
+        wins = [0] * (max_f + 1)
+        for r in sub:
+            f = min(r[FLOORS], 60)
+            if f >= 1:
+                total[f] += 1
+                wins[f] += r[WIN]
+        points = []
+        reach = 0
+        reach_w = 0
+        # Suffix sums: runs whose final floor is >= X reached X.
+        suffix = []
+        for f in range(max_f, 0, -1):
+            reach += total[f]
+            reach_w += wins[f]
+            suffix.append((f, reach, reach_w))
+        for f, n, w in reversed(suffix):
+            if n >= MIN_POINT_N:
+                points.append({"x": f, "y": round(w / n * 100, 1), "n": n})
+        if points:
+            series.append({"id": sid, "label": label, "points": points})
+    return series
+
+
+def deaths_by_floor(rows: list[tuple]) -> list[dict]:
+    """Where losses end. Abandoned runs are excluded, they end anywhere."""
+    series = []
+    for sid, label, sub in _series_split(rows):
+        losses = [r for r in sub if not r[WIN] and not r[ABANDONED]]
+        if len(losses) < MIN_POINT_N:
+            continue
+        counts: dict[int, int] = {}
+        for r in losses:
+            f = min(max(r[FLOORS], 1), 60)
+            counts[f] = counts.get(f, 0) + 1
+        n_total = len(losses)
+        points = [
+            {"x": f, "y": round(c / n_total * 100, 2), "n": c}
+            for f, c in sorted(counts.items())
+        ]
+        series.append({"id": sid, "label": label, "points": points, "total": n_total})
+    return series
+
+
+def winrate_over_time(rows: list[tuple]) -> list[dict]:
+    series = []
+    for sid, label, sub in _series_split(rows):
+        weeks: dict[int, list[int]] = {}
+        for r in sub:
+            if r[DAY] <= 0:
+                continue
+            wk = r[DAY] // 7
+            cell = weeks.setdefault(wk, [0, 0])
+            cell[0] += 1
+            cell[1] += r[WIN]
+        points = []
+        for wk in sorted(weeks):
+            n, w = weeks[wk]
+            if n >= 10:
+                label_date = datetime.fromtimestamp(wk * 7 * 86400, tz=timezone.utc)
+                points.append(
+                    {
+                        "x": label_date.strftime("%Y-%m-%d"),
+                        "y": round(w / n * 100, 1),
+                        "n": n,
+                    }
+                )
+        if points:
+            series.append({"id": sid, "label": label, "points": points})
+    return series
+
+
+def runs_over_time(rows: list[tuple]) -> list[dict]:
+    series = []
+    for sid, label, sub in _series_split(rows):
+        weeks: dict[int, int] = {}
+        for r in sub:
+            if r[DAY] > 0:
+                weeks[r[DAY] // 7] = weeks.get(r[DAY] // 7, 0) + 1
+        points = [
+            {
+                "x": datetime.fromtimestamp(wk * 7 * 86400, tz=timezone.utc).strftime(
+                    "%Y-%m-%d"
+                ),
+                "y": n,
+            }
+            for wk, n in sorted(weeks.items())
+        ]
+        if points:
+            series.append({"id": sid, "label": label, "points": points})
+    return series
+
+
+def winrate_by_stat(rows: list[tuple], stat_key: str) -> list[dict]:
+    stat = STATS[stat_key]
+    series = []
+    for sid, label, sub in _series_split(rows):
+        buckets: dict[int, list[int]] = {}
+        for r in sub:
+            v = _stat_value(r, stat)
+            if v < 0 or v > stat["max"]:
+                continue
+            b = int(v // stat["bucket"]) * stat["bucket"]
+            cell = buckets.setdefault(b, [0, 0])
+            cell[0] += 1
+            cell[1] += r[WIN]
+        points = [
+            {"x": b, "y": round(w / n * 100, 1), "n": n}
+            for b, (n, w) in sorted(buckets.items())
+            if n >= MIN_POINT_N
+        ]
+        if points:
+            series.append({"id": sid, "label": label, "points": points})
+    return series
+
+
+def stat_histogram(rows: list[tuple], stat_key: str) -> list[dict]:
+    stat = STATS[stat_key]
+    series = []
+    for sid, label, sub in _series_split(rows):
+        buckets: dict[int, int] = {}
+        kept = 0
+        for r in sub:
+            v = _stat_value(r, stat)
+            if v < 0 or v > stat["max"]:
+                continue
+            b = int(v // stat["bucket"]) * stat["bucket"]
+            buckets[b] = buckets.get(b, 0) + 1
+            kept += 1
+        if kept < MIN_POINT_N:
+            continue
+        points = [
+            {"x": b, "y": round(c / kept * 100, 2), "n": c}
+            for b, c in sorted(buckets.items())
+        ]
+        series.append({"id": sid, "label": label, "points": points, "total": kept})
+    return series
+
+
+def stat_scatter(rows: list[tuple], x_key: str, y_key: str) -> list[dict]:
+    sx, sy = STATS[x_key], STATS[y_key]
+    series = []
+    for sid, label, sub in _series_split(rows):
+        if sid == "ALL" and len(_official_characters()) > 0:
+            continue  # scatter is per character; an ALL blob would just overdraw
+        stride = max(1, math.ceil(len(sub) / SCATTER_PER_SERIES))
+        points = []
+        for i in range(0, len(sub), stride):
+            r = sub[i]
+            points.append(
+                {
+                    "x": round(_stat_value(r, sx), 2),
+                    "y": round(_stat_value(r, sy), 2),
+                    "win": r[WIN],
+                }
+            )
+        if points:
+            series.append(
+                {"id": sid, "label": label, "points": points, "sampled_from": len(sub)}
+            )
+    if not series:  # username filters can leave only modded/one char in ALL
+        sub = rows
+        stride = max(1, math.ceil(len(sub) / SCATTER_PER_SERIES))
+        points = [
+            {
+                "x": round(_stat_value(sub[i], sx), 2),
+                "y": round(_stat_value(sub[i], sy), 2),
+                "win": sub[i][WIN],
+            }
+            for i in range(0, len(sub), stride)
+        ]
+        if points:
+            series.append(
+                {
+                    "id": "ALL",
+                    "label": "All runs",
+                    "points": points,
+                    "sampled_from": len(sub),
+                }
+            )
+    return series
+
+
+# ── Blob stats: accumulated during the snapshot walk ─────────────────────────
+
+_COMBAT_ROOMS = frozenset({"monster", "elite", "boss"})
+_MAX_FLOOR = 60
+
+
+def new_accumulator() -> dict[str, Any]:
+    return {
+        # (char, players, floor) -> [sum_hp_pct, n]
+        "hp_floor": {},
+        # (char, players, encounter_id) -> [sum_hp_pct, n]
+        "enc_dmg": {},
+        # (char, players, room_type) -> deaths
+        "death_room": {},
+    }
+
+
+def accumulate(
+    acc: dict[str, Any],
+    blob: dict,
+    *,
+    is_win: bool,
+    character: str,
+    player_count: int,
+) -> None:
+    """Fold one run blob into the blob-stats accumulator. Defensive like the
+    community walk: missing keys skip quietly, never raise."""
+    char = _norm_char(character)
+    players = min(max(int(player_count or 1), 1), 4)
+
+    floor_idx = 0
+    last_room_type = None
+    for act_floors in blob.get("map_point_history") or []:
+        for floor in act_floors or []:
+            if not isinstance(floor, dict):
+                continue
+            floor_idx += 1
+            if floor_idx > _MAX_FLOOR:
+                break
+            rooms = floor.get("rooms") or []
+            room = rooms[0] if rooms and isinstance(rooms[0], dict) else {}
+            room_type = (room.get("room_type") or "").lower()
+            if room_type:
+                last_room_type = room_type
+            if room_type not in _COMBAT_ROOMS:
+                continue
+            model_id = room.get("model_id") or ""
+            enc = (
+                model_id.split(".", 1)[1] if model_id.startswith("ENCOUNTER.") else None
+            )
+            for ps in floor.get("player_stats") or []:
+                if not isinstance(ps, dict):
+                    continue
+                dmg = ps.get("damage_taken")
+                max_hp = ps.get("max_hp")
+                if not isinstance(dmg, (int, float)) or not isinstance(
+                    max_hp, (int, float)
+                ):
+                    continue
+                if dmg < 0 or max_hp <= 0:
+                    continue
+                pct = min(dmg / max_hp, 1.5)
+                cell = acc["hp_floor"].setdefault((char, players, floor_idx), [0.0, 0])
+                cell[0] += pct
+                cell[1] += 1
+                if enc:
+                    ecell = acc["enc_dmg"].setdefault((char, players, enc), [0.0, 0])
+                    ecell[0] += pct
+                    ecell[1] += 1
+
+    if not is_win and not blob.get("was_abandoned") and last_room_type:
+        key = (char, players, last_room_type)
+        acc["death_room"][key] = acc["death_room"].get(key, 0) + 1
+
+
+def finalize(acc: dict[str, Any]) -> dict[str, Any]:
+    """JSON-able cell lists for the snapshot. Rollups happen per request."""
+    return {
+        "version": 1,
+        "hp_floor": [
+            [c, p, f, round(s, 4), n] for (c, p, f), (s, n) in acc["hp_floor"].items()
+        ],
+        "enc_dmg": [
+            [c, p, e, round(s, 4), n] for (c, p, e), (s, n) in acc["enc_dmg"].items()
+        ],
+        "death_room": [[c, p, rt, n] for (c, p, rt), n in acc["death_room"].items()],
+    }
+
+
+def empty() -> dict[str, Any]:
+    return finalize(new_accumulator())
+
+
+# ── Blob stat rollups (snapshot cells -> chart series) ───────────────────────
+
+
+def _merge_cells(
+    cells: list[list],
+    players: int | None,
+) -> dict[str, dict[Any, list[float]]]:
+    """cells [[char, players, key, sum, n], ...] -> {char: {key: [sum, n]}},
+    keeping only the requested player count (None = all) and folding an ALL
+    pseudo-character in."""
+    out: dict[str, dict[Any, list[float]]] = {"ALL": {}}
+    chars = _official_characters()
+    for c, p, key, s, n in cells:
+        if players is not None and p != players:
+            continue
+        for bucket in ("ALL", c) if c in chars else ("ALL",):
+            slot = out.setdefault(bucket, {}).setdefault(key, [0.0, 0])
+            slot[0] += s
+            slot[1] += n
+    return out
+
+
+def hp_loss_by_floor(stats: dict[str, Any], players: int | None) -> list[dict]:
+    merged = _merge_cells(stats.get("hp_floor") or [], players)
+    chars = _official_characters()
+    series = []
+    for cid, by_floor in merged.items():
+        points = [
+            {"x": f, "y": round(s / n * 100, 1), "n": n}
+            for f, (s, n) in sorted(by_floor.items())
+            if n >= 15
+        ]
+        if points:
+            series.append(
+                {
+                    "id": cid,
+                    "label": "All characters" if cid == "ALL" else chars.get(cid, cid),
+                    "points": points,
+                }
+            )
+    return series
+
+
+def encounter_damage(
+    stats: dict[str, Any], players: int | None, top: int = 25
+) -> list[dict]:
+    """Top encounters by average % of max HP lost per player-fight."""
+    from . import data_service
+
+    merged = _merge_cells(stats.get("enc_dmg") or [], players)
+    names: dict[str, str] = {}
+    try:
+        names = {
+            e["id"]: e.get("name") or e["id"]
+            for e in data_service.load_encounters()
+            if e.get("id")
+        }
+    except Exception:
+        pass
+    rows = []
+    for enc, (s, n) in (merged.get("ALL") or {}).items():
+        if n < 30:
+            continue
+        if names and enc not in names:
+            continue  # modded encounters
+        rows.append(
+            {
+                "x": names.get(enc) or enc.replace("_", " ").title(),
+                "y": round(s / n * 100, 1),
+                "n": n,
+            }
+        )
+    rows.sort(key=lambda r: r["y"], reverse=True)
+    return [{"id": "ALL", "label": "Avg % max HP lost", "points": rows[:top]}]
+
+
+def deaths_by_room(stats: dict[str, Any], players: int | None) -> list[dict]:
+    merged = _merge_cells(
+        [[c, p, rt, 0.0, n] for c, p, rt, n in stats.get("death_room") or []], players
+    )
+    chars = _official_characters()
+    series = []
+    for cid, by_room in merged.items():
+        total = sum(n for _, n in by_room.values())
+        if total < MIN_POINT_N:
+            continue
+        points = [
+            {"x": rt.title(), "y": round(n / total * 100, 1), "n": n}
+            for rt, (_, n) in sorted(by_room.items(), key=lambda kv: -kv[1][1])
+        ]
+        series.append(
+            {
+                "id": cid,
+                "label": "All characters" if cid == "ALL" else chars.get(cid, cid),
+                "points": points,
+                "total": total,
+            }
+        )
+    return series
+
+
+# ── Per-user blob stats (on-demand walk of one user's runs) ──────────────────
+
+_USER_BLOB_CAP = 1500
+
+
+def build_user_blob_stats(username: str) -> dict[str, Any]:
+    """Accumulate blob stats from one user's runs, newest first, capped.
+    Reads the same on-disk blobs the snapshot walk uses."""
+    u = (username or "").strip()
+    if not u:
+        return empty()
+    rows: list[dict] = []
+    if os.environ.get("MONGO_URL", "").strip():
+        import re as _re
+
+        from .runs_db_mongo import _get_collection
+
+        cursor = (
+            _get_collection()
+            .find(
+                {"username": {"$regex": f"^{_re.escape(u)}$", "$options": "i"}},
+                {"_id": 1, "character": 1, "win": 1, "player_count": 1},
+            )
+            .sort("submitted_at", -1)
+            .limit(_USER_BLOB_CAP)
+        )
+        rows = [
+            {
+                "run_hash": d["_id"],
+                "character": d.get("character") or "",
+                "win": bool(d.get("win")),
+                "player_count": d.get("player_count") or 1,
+            }
+            for d in cursor
+        ]
+    else:
+        from .runs_db import get_conn
+
+        with get_conn() as conn:
+            rows = [
+                dict(r)
+                for r in conn.execute(
+                    "SELECT run_hash, character, win, player_count FROM runs"
+                    " WHERE username = ? COLLATE NOCASE"
+                    " ORDER BY id DESC LIMIT ?",
+                    (u, _USER_BLOB_CAP),
+                )
+            ]
+
+    acc = new_accumulator()
+    for row in rows:
+        path = _RUNS_DIR / f"{row['run_hash']}.json"
+        if not path.exists():
+            continue
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                blob = json.load(f)
+            accumulate(
+                acc,
+                blob,
+                is_win=bool(row["win"]),
+                character=row["character"],
+                player_count=row["player_count"],
+            )
+        except Exception:
+            continue
+    return finalize(acc)

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -264,12 +264,12 @@ def filter_rows(
 
 SPLITS = ("character", "players", "outcome", "ascension")
 
+# A10 is the ascension cap; nothing above it exists.
 _ASC_BANDS = [
     (0, 0, "A0"),
     (1, 4, "A1-A4"),
     (5, 9, "A5-A9"),
     (10, 10, "A10"),
-    (11, 99, "A11+"),
 ]
 _PLAYER_LABELS = {1: "Solo", 2: "2 Players", 3: "3 Players", 4: "4 Players"}
 
@@ -333,7 +333,7 @@ STATS: dict[str, dict[str, Any]] = {
         "max": 240,
         "scale": 1 / 60,
     },
-    "ascension": {"label": "Ascension", "idx": ASC, "bucket": 1, "max": 20},
+    "ascension": {"label": "Ascension", "idx": ASC, "bucket": 1, "max": 10},
 }
 
 

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -7,13 +7,14 @@ client and aggregate there, which is why they crawl):
 - Metadata frame: one process-wide list of per-run scalar tuples (character,
   win, ascension, mode, players, floors, deck size, ...) loaded from the run
   store and refreshed lazily. Every metadata chart is a single pass over the
-  frame with the request's filters applied. 200k+ runs aggregate in well
-  under a second, and the router caches responses on top.
-- Blob stats: per-floor damage, encounter damage, and death room types need
-  the full run blobs, so they piggyback on the single snapshot walk in
+  frame with the request's filters applied, and supports splitting the series
+  by character, player count, outcome, or ascension band. 200k+ runs
+  aggregate in well under a second, and the router caches responses on top.
+- Blob stats: anything per-floor or per-entity (damage, HP/gold/deck curves,
+  encounter histograms, event outcomes, card/relic weekly stats) needs the
+  full run blobs, so they piggyback on the single snapshot walk in
   ``run_entity_stats`` (same pattern as community_stats) and are served as
-  O(1) reads, split by character x player count. Per-user variants walk just
-  that user's blobs on demand.
+  O(1) reads. Per-user variants walk just that user's blobs on demand.
 
 This module must not import run_entity_stats (the dependency runs the other
 way, like community_stats).
@@ -41,9 +42,22 @@ _RUNS_DIR = _DATA_DIR / "runs"
 # ── Frame: per-run metadata tuples ───────────────────────────────────────────
 
 # Tuple indices (kept positional to stay light at 200k+ rows).
-CHAR, WIN, ASC, MODE, PLAYERS, TIME, FLOORS, DECK, RELICS, DAY, USER, ABANDONED = range(
-    12
-)
+(
+    CHAR,
+    WIN,
+    ASC,
+    MODE,
+    PLAYERS,
+    TIME,
+    FLOORS,
+    DECK,
+    RELICS,
+    DAY,
+    USER,
+    ABANDONED,
+    ACTS,
+    DAILY,
+) = range(14)
 
 _FRAME: list[tuple] = []
 _FRAME_TS: float = 0.0
@@ -53,17 +67,23 @@ _FRAME_LOCK = threading.Lock()
 # Smallest sample a single point may summarise; thinner buckets are dropped so
 # the lines don't whip around on noise.
 MIN_POINT_N = 20
-# Smallest filtered sample a per-character series needs to be drawn at all.
+# Smallest filtered sample a per-series split needs to be drawn at all.
 MIN_SERIES_N = 30
-# Scatter sampling caps (points per series / total).
+# Scatter sampling cap per series.
 SCATTER_PER_SERIES = 600
-
-_GAME_MODES = frozenset({"standard", "daily", "custom"})
 
 
 def _norm_char(raw: str | None) -> str:
     """ "character.necrobinder" / "NECROBINDER" -> "NECROBINDER"."""
     return (raw or "").split(".")[-1].upper()
+
+
+def _bare(raw: str | None) -> str | None:
+    """ "CARD.WISP" -> "WISP"; None for empty values."""
+    if not raw:
+        return None
+    parts = str(raw).split(".", 1)
+    return parts[1] if len(parts) > 1 else parts[0]
 
 
 def _epoch_day(submitted: Any) -> int:
@@ -79,6 +99,29 @@ def _epoch_day(submitted: Any) -> int:
         except ValueError:
             continue
     return 0
+
+
+def _week_label(week: int) -> str:
+    return datetime.fromtimestamp(week * 7 * 86400, tz=timezone.utc).strftime(
+        "%Y-%m-%d"
+    )
+
+
+def _daily_date(seed: str | None, game_mode: str) -> str:
+    """Daily seeds encode their date as DD_MM_YYYY; '' for everything else."""
+    if game_mode != "daily" or not seed:
+        return ""
+    parts = str(seed).split("_")
+    if (
+        len(parts) >= 3
+        and parts[0].isdigit()
+        and parts[1].isdigit()
+        and parts[2].isdigit()
+    ):
+        dd, mm, yyyy = parts[0], parts[1], parts[2]
+        if len(yyyy) == 4:
+            return f"{yyyy}-{mm.zfill(2)}-{dd.zfill(2)}"
+    return ""
 
 
 def _load_frame() -> list[tuple]:
@@ -102,15 +145,18 @@ def _load_frame() -> list[tuple]:
                 "submitted_at": 1,
                 "username": 1,
                 "was_abandoned": 1,
+                "acts_completed": 1,
+                "seed": 1,
             },
         )
         for d in cursor:
+            mode = (d.get("game_mode") or "standard").lower()
             rows.append(
                 (
                     _norm_char(d.get("character")),
                     1 if d.get("win") else 0,
                     int(d.get("ascension") or 0),
-                    (d.get("game_mode") or "standard").lower(),
+                    mode,
                     int(d.get("player_count") or 1),
                     int(d.get("run_time") or 0),
                     int(d.get("floors_reached") or 0),
@@ -119,6 +165,8 @@ def _load_frame() -> list[tuple]:
                     _epoch_day(d.get("submitted_at")),
                     (d.get("username") or "").lower(),
                     1 if d.get("was_abandoned") else 0,
+                    int(d.get("acts_completed") or 0),
+                    _daily_date(d.get("seed"), mode),
                 )
             )
     else:
@@ -128,14 +176,16 @@ def _load_frame() -> list[tuple]:
             for d in conn.execute(
                 "SELECT character, win, ascension, game_mode, player_count,"
                 " run_time, floors_reached, deck_size, relic_count,"
-                " submitted_at, username, was_abandoned FROM runs"
+                " submitted_at, username, was_abandoned, acts_completed, seed"
+                " FROM runs"
             ):
+                mode = (d["game_mode"] or "standard").lower()
                 rows.append(
                     (
                         _norm_char(d["character"]),
                         1 if d["win"] else 0,
                         int(d["ascension"] or 0),
-                        (d["game_mode"] or "standard").lower(),
+                        mode,
                         int(d["player_count"] or 1),
                         int(d["run_time"] or 0),
                         int(d["floors_reached"] or 0),
@@ -144,6 +194,8 @@ def _load_frame() -> list[tuple]:
                         _epoch_day(d["submitted_at"]),
                         (d["username"] or "").lower(),
                         1 if d["was_abandoned"] else 0,
+                        int(d["acts_completed"] or 0),
+                        _daily_date(d["seed"], mode),
                     )
                 )
     return rows
@@ -208,25 +260,63 @@ def filter_rows(
     return out
 
 
-def _series_split(rows: list[tuple]) -> list[tuple[str, str, list[tuple]]]:
-    """(series_id, label, rows) per official character with enough sample,
-    plus the ALL series. Modded characters fold into ALL only."""
-    chars = _official_characters()
-    by_char: dict[str, list[tuple]] = {}
-    for r in rows:
-        by_char.setdefault(r[CHAR], []).append(r)
-    out: list[tuple[str, str, list[tuple]]] = [("ALL", "All characters", rows)]
-    for cid, name in chars.items():
-        sub = by_char.get(cid) or []
-        if len(sub) >= MIN_SERIES_N:
-            out.append((cid, name, sub))
+# ── Series splitting ─────────────────────────────────────────────────────────
+
+SPLITS = ("character", "players", "outcome", "ascension")
+
+_ASC_BANDS = [
+    (0, 0, "A0"),
+    (1, 4, "A1-A4"),
+    (5, 9, "A5-A9"),
+    (10, 10, "A10"),
+    (11, 99, "A11+"),
+]
+_PLAYER_LABELS = {1: "Solo", 2: "2 Players", 3: "3 Players", 4: "4 Players"}
+
+
+def _series_split(
+    rows: list[tuple], split: str = "character"
+) -> list[tuple[str, str, list[tuple]]]:
+    """(series_id, label, rows) for the requested split, plus the ALL series.
+    Splits with too little sample are dropped; for the character split,
+    modded characters fold into ALL only."""
+    out: list[tuple[str, str, list[tuple]]] = [("ALL", "All runs", rows)]
+    if split == "players":
+        by: dict[int, list[tuple]] = {}
+        for r in rows:
+            by.setdefault(min(r[PLAYERS], 4), []).append(r)
+        for p in (1, 2, 3, 4):
+            sub = by.get(p) or []
+            if len(sub) >= MIN_SERIES_N:
+                out.append((f"P{p}", _PLAYER_LABELS[p], sub))
+    elif split == "outcome":
+        wins = [r for r in rows if r[WIN]]
+        losses = [r for r in rows if not r[WIN]]
+        if len(wins) >= MIN_SERIES_N:
+            out.append(("WIN", "Wins", wins))
+        if len(losses) >= MIN_SERIES_N:
+            out.append(("LOSS", "Losses", losses))
+    elif split == "ascension":
+        for lo, hi, label in _ASC_BANDS:
+            sub = [r for r in rows if lo <= r[ASC] <= hi]
+            if len(sub) >= MIN_SERIES_N:
+                out.append((label, label, sub))
+    else:  # character
+        chars = _official_characters()
+        by_char: dict[str, list[tuple]] = {}
+        for r in rows:
+            by_char.setdefault(r[CHAR], []).append(r)
+        out = [("ALL", "All characters", rows)]
+        for cid, name in chars.items():
+            sub = by_char.get(cid) or []
+            if len(sub) >= MIN_SERIES_N:
+                out.append((cid, name, sub))
     return out
 
 
 # ── Metadata chart builders ──────────────────────────────────────────────────
 
 # Run stats that "vs stat" / histogram / scatter charts can use.
-# value(row) -> numeric; bucket = bucket width; max caps the axis.
 STATS: dict[str, dict[str, Any]] = {
     "floors_reached": {
         "label": "Floors reached",
@@ -248,14 +338,13 @@ STATS: dict[str, dict[str, Any]] = {
 
 
 def _stat_value(row: tuple, stat: dict) -> float:
-    v = row[stat["idx"]] * stat.get("scale", 1)
-    return v
+    return row[stat["idx"]] * stat.get("scale", 1)
 
 
-def winrate_by_floor(rows: list[tuple]) -> list[dict]:
+def winrate_by_floor(rows: list[tuple], split: str) -> list[dict]:
     """Of the runs that reached floor X, how many went on to win."""
     series = []
-    for sid, label, sub in _series_split(rows):
+    for sid, label, sub in _series_split(rows, split):
         max_f = min(max((r[FLOORS] for r in sub), default=0), 60)
         total = [0] * (max_f + 1)
         wins = [0] * (max_f + 1)
@@ -267,7 +356,6 @@ def winrate_by_floor(rows: list[tuple]) -> list[dict]:
         points = []
         reach = 0
         reach_w = 0
-        # Suffix sums: runs whose final floor is >= X reached X.
         suffix = []
         for f in range(max_f, 0, -1):
             reach += total[f]
@@ -281,10 +369,10 @@ def winrate_by_floor(rows: list[tuple]) -> list[dict]:
     return series
 
 
-def deaths_by_floor(rows: list[tuple]) -> list[dict]:
+def deaths_by_floor(rows: list[tuple], split: str) -> list[dict]:
     """Where losses end. Abandoned runs are excluded, they end anywhere."""
     series = []
-    for sid, label, sub in _series_split(rows):
+    for sid, label, sub in _series_split(rows, split):
         losses = [r for r in sub if not r[WIN] and not r[ABANDONED]]
         if len(losses) < MIN_POINT_N:
             continue
@@ -301,59 +389,45 @@ def deaths_by_floor(rows: list[tuple]) -> list[dict]:
     return series
 
 
-def winrate_over_time(rows: list[tuple]) -> list[dict]:
+def winrate_over_time(rows: list[tuple], split: str) -> list[dict]:
     series = []
-    for sid, label, sub in _series_split(rows):
+    for sid, label, sub in _series_split(rows, split):
         weeks: dict[int, list[int]] = {}
         for r in sub:
             if r[DAY] <= 0:
                 continue
-            wk = r[DAY] // 7
-            cell = weeks.setdefault(wk, [0, 0])
+            cell = weeks.setdefault(r[DAY] // 7, [0, 0])
             cell[0] += 1
             cell[1] += r[WIN]
         points = []
         for wk in sorted(weeks):
             n, w = weeks[wk]
             if n >= 10:
-                label_date = datetime.fromtimestamp(wk * 7 * 86400, tz=timezone.utc)
                 points.append(
-                    {
-                        "x": label_date.strftime("%Y-%m-%d"),
-                        "y": round(w / n * 100, 1),
-                        "n": n,
-                    }
+                    {"x": _week_label(wk), "y": round(w / n * 100, 1), "n": n}
                 )
         if points:
             series.append({"id": sid, "label": label, "points": points})
     return series
 
 
-def runs_over_time(rows: list[tuple]) -> list[dict]:
+def runs_over_time(rows: list[tuple], split: str) -> list[dict]:
     series = []
-    for sid, label, sub in _series_split(rows):
+    for sid, label, sub in _series_split(rows, split):
         weeks: dict[int, int] = {}
         for r in sub:
             if r[DAY] > 0:
                 weeks[r[DAY] // 7] = weeks.get(r[DAY] // 7, 0) + 1
-        points = [
-            {
-                "x": datetime.fromtimestamp(wk * 7 * 86400, tz=timezone.utc).strftime(
-                    "%Y-%m-%d"
-                ),
-                "y": n,
-            }
-            for wk, n in sorted(weeks.items())
-        ]
+        points = [{"x": _week_label(wk), "y": n} for wk, n in sorted(weeks.items())]
         if points:
             series.append({"id": sid, "label": label, "points": points})
     return series
 
 
-def winrate_by_stat(rows: list[tuple], stat_key: str) -> list[dict]:
+def winrate_by_stat(rows: list[tuple], stat_key: str, split: str) -> list[dict]:
     stat = STATS[stat_key]
     series = []
-    for sid, label, sub in _series_split(rows):
+    for sid, label, sub in _series_split(rows, split):
         buckets: dict[int, list[int]] = {}
         for r in sub:
             v = _stat_value(r, stat)
@@ -373,10 +447,10 @@ def winrate_by_stat(rows: list[tuple], stat_key: str) -> list[dict]:
     return series
 
 
-def stat_histogram(rows: list[tuple], stat_key: str) -> list[dict]:
+def stat_histogram(rows: list[tuple], stat_key: str, split: str) -> list[dict]:
     stat = STATS[stat_key]
     series = []
-    for sid, label, sub in _series_split(rows):
+    for sid, label, sub in _series_split(rows, split):
         buckets: dict[int, int] = {}
         kept = 0
         for r in sub:
@@ -396,12 +470,13 @@ def stat_histogram(rows: list[tuple], stat_key: str) -> list[dict]:
     return series
 
 
-def stat_scatter(rows: list[tuple], x_key: str, y_key: str) -> list[dict]:
+def stat_scatter(rows: list[tuple], x_key: str, y_key: str, split: str) -> list[dict]:
     sx, sy = STATS[x_key], STATS[y_key]
+    groups = [g for g in _series_split(rows, split) if g[0] != "ALL"]
+    if not groups:
+        groups = [("ALL", "All runs", rows)]
     series = []
-    for sid, label, sub in _series_split(rows):
-        if sid == "ALL" and len(_official_characters()) > 0:
-            continue  # scatter is per character; an ALL blob would just overdraw
+    for sid, label, sub in groups:
         stride = max(1, math.ceil(len(sub) / SCATTER_PER_SERIES))
         points = []
         for i in range(0, len(sub), stride):
@@ -417,44 +492,98 @@ def stat_scatter(rows: list[tuple], x_key: str, y_key: str) -> list[dict]:
             series.append(
                 {"id": sid, "label": label, "points": points, "sampled_from": len(sub)}
             )
-    if not series:  # username filters can leave only modded/one char in ALL
-        sub = rows
-        stride = max(1, math.ceil(len(sub) / SCATTER_PER_SERIES))
-        points = [
-            {
-                "x": round(_stat_value(sub[i], sx), 2),
-                "y": round(_stat_value(sub[i], sy), 2),
-                "win": sub[i][WIN],
-            }
-            for i in range(0, len(sub), stride)
-        ]
-        if points:
-            series.append(
-                {
-                    "id": "ALL",
-                    "label": "All runs",
-                    "points": points,
-                    "sampled_from": len(sub),
-                }
-            )
     return series
+
+
+_FUNNEL_STAGES = [
+    ("Started", lambda r: True),
+    ("Reached Act 2", lambda r: r[ACTS] >= 1),
+    ("Reached Act 3", lambda r: r[ACTS] >= 2),
+    ("Won", lambda r: bool(r[WIN])),
+]
+
+
+def acts_funnel(rows: list[tuple], split: str) -> list[dict]:
+    """How far runs get: share surviving each act boundary, ending in wins."""
+    series = []
+    for sid, label, sub in _series_split(rows, split):
+        n = len(sub)
+        if n < MIN_POINT_N:
+            continue
+        points = []
+        for stage, pred in _FUNNEL_STAGES:
+            c = sum(1 for r in sub if pred(r))
+            points.append({"x": stage, "y": round(c / n * 100, 1), "n": c})
+        series.append({"id": sid, "label": label, "points": points, "total": n})
+    return series
+
+
+def hardest_dailies(rows: list[tuple], limit: int = 42) -> list[dict]:
+    """Win rate per daily date (the seed encodes the daily's date)."""
+    by_date: dict[str, list[int]] = {}
+    for r in rows:
+        if r[DAILY]:
+            cell = by_date.setdefault(r[DAILY], [0, 0])
+            cell[0] += 1
+            cell[1] += r[WIN]
+    dates = sorted(by_date)[-limit:]
+    points = [
+        {
+            "x": d,
+            "y": round(by_date[d][1] / by_date[d][0] * 100, 1),
+            "n": by_date[d][0],
+        }
+        for d in dates
+        if by_date[d][0] >= 5
+    ]
+    return (
+        [{"id": "ALL", "label": "Daily win rate", "points": points}] if points else []
+    )
 
 
 # ── Blob stats: accumulated during the snapshot walk ─────────────────────────
 
 _COMBAT_ROOMS = frozenset({"monster", "elite", "boss"})
 _MAX_FLOOR = 60
+_HIST_BUCKET = 5  # % of max HP per histogram bucket
+_HIST_CAP = 100  # damage >= 100% of max HP folds into the top bucket
+BLOB_VERSION = 2
 
 
 def new_accumulator() -> dict[str, Any]:
     return {
-        # (char, players, floor) -> [sum_hp_pct, n]
+        # (char, players, floor) -> [sum_hp_pct, n]   combat damage only
         "hp_floor": {},
-        # (char, players, encounter_id) -> [sum_hp_pct, n]
-        "enc_dmg": {},
+        # (char, players, encounter) -> [sum_dmg_pct, n_dmg, sum_turns, n_rooms]
+        "enc": {},
+        # (players, encounter, bucket) -> n            damage histogram cells
+        "enc_hist": {},
         # (char, players, room_type) -> deaths
         "death_room": {},
+        # (char, players, win, floor) -> [s_hp, n_hp, s_gold, n_gold, s_deck, n_deck]
+        "traj": {},
+        # (char, players, elites_fought) -> [n, wins]
+        "elites": {},
+        # (char, players, smith_count) -> [n, wins]
+        "smiths": {},
+        # (event, option) -> [n, wins]
+        "events": {},
+        # (etype, entity, week) -> [n, wins]
+        "entity_week": {},
+        # week -> [n, wins]                            baseline for pick rates
+        "week_totals": {},
+        # (card, copies_bucket) -> [n, wins]
+        "copies": {},
+        # enchantment -> [n, wins]
+        "ench": {},
     }
+
+
+def _bump2(d: dict, key: Any, win: bool) -> None:
+    cell = d.setdefault(key, [0, 0])
+    cell[0] += 1
+    if win:
+        cell[1] += 1
 
 
 def accumulate(
@@ -464,14 +593,18 @@ def accumulate(
     is_win: bool,
     character: str,
     player_count: int,
+    submitted: Any = None,
 ) -> None:
     """Fold one run blob into the blob-stats accumulator. Defensive like the
     community walk: missing keys skip quietly, never raise."""
     char = _norm_char(character)
     players = min(max(int(player_count or 1), 1), 4)
+    week = _epoch_day(submitted) // 7 if submitted else 0
 
     floor_idx = 0
     last_room_type = None
+    elite_count = 0
+    smith_count = 0
     for act_floors in blob.get("map_point_history") or []:
         for floor in act_floors or []:
             if not isinstance(floor, dict):
@@ -484,48 +617,177 @@ def accumulate(
             room_type = (room.get("room_type") or "").lower()
             if room_type:
                 last_room_type = room_type
-            if room_type not in _COMBAT_ROOMS:
-                continue
+            if room_type == "elite":
+                elite_count += 1
+            is_combat = room_type in _COMBAT_ROOMS
             model_id = room.get("model_id") or ""
             enc = (
                 model_id.split(".", 1)[1] if model_id.startswith("ENCOUNTER.") else None
             )
+            turns = room.get("turns_taken")
+            if is_combat and enc and isinstance(turns, (int, float)) and turns >= 0:
+                ecell = acc["enc"].setdefault((char, players, enc), [0.0, 0, 0.0, 0])
+                ecell[2] += min(turns, 200)
+                ecell[3] += 1
+
             for ps in floor.get("player_stats") or []:
                 if not isinstance(ps, dict):
                     continue
-                dmg = ps.get("damage_taken")
                 max_hp = ps.get("max_hp")
-                if not isinstance(dmg, (int, float)) or not isinstance(
-                    max_hp, (int, float)
-                ):
-                    continue
-                if dmg < 0 or max_hp <= 0:
-                    continue
-                pct = min(dmg / max_hp, 1.5)
-                cell = acc["hp_floor"].setdefault((char, players, floor_idx), [0.0, 0])
-                cell[0] += pct
-                cell[1] += 1
-                if enc:
-                    ecell = acc["enc_dmg"].setdefault((char, players, enc), [0.0, 0])
-                    ecell[0] += pct
-                    ecell[1] += 1
+                hp_ok = isinstance(max_hp, (int, float)) and max_hp > 0
+
+                # Per-floor trajectory: HP % and gold, split by outcome.
+                cur_hp = ps.get("current_hp")
+                cur_gold = ps.get("current_gold")
+                tcell = None
+                if hp_ok and isinstance(cur_hp, (int, float)) and cur_hp >= 0:
+                    tcell = acc["traj"].setdefault(
+                        (char, players, 1 if is_win else 0, floor_idx),
+                        [0.0, 0, 0.0, 0, 0.0, 0],
+                    )
+                    tcell[0] += min(cur_hp / max_hp, 1.5)
+                    tcell[1] += 1
+                if isinstance(cur_gold, (int, float)) and cur_gold >= 0:
+                    if tcell is None:
+                        tcell = acc["traj"].setdefault(
+                            (char, players, 1 if is_win else 0, floor_idx),
+                            [0.0, 0, 0.0, 0, 0.0, 0],
+                        )
+                    tcell[2] += min(cur_gold, 20000)
+                    tcell[3] += 1
+
+                # Combat damage.
+                dmg = ps.get("damage_taken")
+                if is_combat and hp_ok and isinstance(dmg, (int, float)) and dmg >= 0:
+                    pct = min(dmg / max_hp, 1.5)
+                    cell = acc["hp_floor"].setdefault(
+                        (char, players, floor_idx), [0.0, 0]
+                    )
+                    cell[0] += pct
+                    cell[1] += 1
+                    if enc:
+                        ecell = acc["enc"].setdefault(
+                            (char, players, enc), [0.0, 0, 0.0, 0]
+                        )
+                        ecell[0] += pct
+                        ecell[1] += 1
+                        bucket = min(
+                            int(pct * 100) // _HIST_BUCKET, _HIST_CAP // _HIST_BUCKET
+                        )
+                        hkey = (players, enc, bucket)
+                        acc["enc_hist"][hkey] = acc["enc_hist"].get(hkey, 0) + 1
+
+                # Rest-site smith count (per run, across all players).
+                for choice in ps.get("rest_site_choices") or []:
+                    if choice == "SMITH":
+                        smith_count += 1
+
+                # Event decisions with outcomes attached.
+                for ec in ps.get("event_choices") or []:
+                    title = (ec.get("title") or {}) if isinstance(ec, dict) else {}
+                    if title.get("table") != "events":
+                        continue
+                    key = title.get("key") or ""
+                    if ".options." not in key:
+                        continue
+                    event_id = key.split(".", 1)[0]
+                    option_id = key.split(".options.", 1)[1].split(".", 1)[0]
+                    if event_id and option_id:
+                        _bump2(acc["events"], (event_id, option_id), is_win)
+
+    total_floors = floor_idx
 
     if not is_win and not blob.get("was_abandoned") and last_room_type:
         key = (char, players, last_room_type)
         acc["death_room"][key] = acc["death_room"].get(key, 0) + 1
 
+    _bump2(acc["elites"], (char, players, min(elite_count, 12)), is_win)
+    _bump2(acc["smiths"], (char, players, min(smith_count, 15)), is_win)
+
+    # Per-entity weekly stats + copies + enchantments, from the final loadout.
+    if week > 0:
+        _bump2(acc["week_totals"], week, is_win)
+    seen_entities: set[tuple[str, str]] = set()
+    seen_ench: set[str] = set()
+    for player in blob.get("players") or []:
+        if not isinstance(player, dict):
+            continue
+        card_counts: dict[str, int] = {}
+        adds_by_floor: dict[int, int] = {}
+        for c in player.get("deck") or []:
+            if not isinstance(c, dict):
+                continue
+            cid = _bare(c.get("id"))
+            if cid:
+                card_counts[cid] = card_counts.get(cid, 0) + 1
+            fa = c.get("floor_added_to_deck")
+            if isinstance(fa, (int, float)) and 0 <= fa <= _MAX_FLOOR:
+                adds_by_floor[int(fa)] = adds_by_floor.get(int(fa), 0) + 1
+            ench = c.get("enchantment")
+            eid = _bare(ench.get("id")) if isinstance(ench, dict) else None
+            if eid:
+                seen_ench.add(eid)
+        for cid, count in card_counts.items():
+            seen_entities.add(("cards", cid))
+            _bump2(acc["copies"], (cid, min(count, 5)), is_win)
+        for rel in player.get("relics") or []:
+            rid = _bare(rel.get("id")) if isinstance(rel, dict) else _bare(rel)
+            if rid:
+                seen_entities.add(("relics", rid))
+        for pot in player.get("potions") or []:
+            pid = _bare(pot.get("id")) if isinstance(pot, dict) else _bare(pot)
+            if pid:
+                seen_entities.add(("potions", pid))
+
+        # Deck growth: cumulative cards-still-in-deck added by each floor.
+        if adds_by_floor and total_floors:
+            cum = 0
+            cum_by_floor = []
+            for f in range(0, min(total_floors, _MAX_FLOOR) + 1):
+                cum += adds_by_floor.get(f, 0)
+                cum_by_floor.append((f, cum))
+            for f, c in cum_by_floor:
+                if f == 0:
+                    continue
+                tcell = acc["traj"].setdefault(
+                    (char, players, 1 if is_win else 0, f), [0.0, 0, 0.0, 0, 0.0, 0]
+                )
+                tcell[4] += c
+                tcell[5] += 1
+
+    if week > 0:
+        for etype, eid in seen_entities:
+            _bump2(acc["entity_week"], (etype, eid, week), is_win)
+    for eid in seen_ench:
+        _bump2(acc["ench"], eid, is_win)
+
 
 def finalize(acc: dict[str, Any]) -> dict[str, Any]:
     """JSON-able cell lists for the snapshot. Rollups happen per request."""
     return {
-        "version": 1,
+        "version": BLOB_VERSION,
         "hp_floor": [
             [c, p, f, round(s, 4), n] for (c, p, f), (s, n) in acc["hp_floor"].items()
         ],
-        "enc_dmg": [
-            [c, p, e, round(s, 4), n] for (c, p, e), (s, n) in acc["enc_dmg"].items()
+        "enc": [
+            [c, p, e, round(s, 4), n, round(st, 1), nt]
+            for (c, p, e), (s, n, st, nt) in acc["enc"].items()
         ],
+        "enc_hist": [[p, e, b, n] for (p, e, b), n in acc["enc_hist"].items()],
         "death_room": [[c, p, rt, n] for (c, p, rt), n in acc["death_room"].items()],
+        "traj": [
+            [c, p, w, f, round(sh, 4), nh, round(sg, 1), ng, round(sd, 1), nd]
+            for (c, p, w, f), (sh, nh, sg, ng, sd, nd) in acc["traj"].items()
+        ],
+        "elites": [[c, p, b, n, w] for (c, p, b), (n, w) in acc["elites"].items()],
+        "smiths": [[c, p, b, n, w] for (c, p, b), (n, w) in acc["smiths"].items()],
+        "events": [[e, o, n, w] for (e, o), (n, w) in acc["events"].items()],
+        "entity_week": [
+            [t, e, wk, n, w] for (t, e, wk), (n, w) in acc["entity_week"].items()
+        ],
+        "week_totals": [[wk, n, w] for wk, (n, w) in acc["week_totals"].items()],
+        "copies": [[e, b, n, w] for (e, b), (n, w) in acc["copies"].items()],
+        "ench": [[e, n, w] for e, (n, w) in acc["ench"].items()],
     }
 
 
@@ -536,22 +798,43 @@ def empty() -> dict[str, Any]:
 # ── Blob stat rollups (snapshot cells -> chart series) ───────────────────────
 
 
+def _char_label(cid: str, chars: dict[str, str]) -> str:
+    return "All characters" if cid == "ALL" else chars.get(cid, cid.title())
+
+
+def _entity_names(etype: str) -> dict[str, str]:
+    from . import data_service
+
+    loaders = {
+        "cards": data_service.load_cards,
+        "relics": data_service.load_relics,
+        "potions": data_service.load_potions,
+    }
+    try:
+        return {
+            e["id"]: e.get("name") or e["id"] for e in loaders[etype]() if e.get("id")
+        }
+    except Exception:
+        return {}
+
+
 def _merge_cells(
-    cells: list[list],
-    players: int | None,
+    cells: list[list], players: int | None, character: str | None = None
 ) -> dict[str, dict[Any, list[float]]]:
-    """cells [[char, players, key, sum, n], ...] -> {char: {key: [sum, n]}},
-    keeping only the requested player count (None = all) and folding an ALL
-    pseudo-character in."""
+    """cells [[char, players, key, *values], ...] -> {char: {key: [..sums..]}},
+    keeping only the requested player count / character (None = all) and
+    folding an ALL pseudo-character in."""
     out: dict[str, dict[Any, list[float]]] = {"ALL": {}}
     chars = _official_characters()
-    for c, p, key, s, n in cells:
+    for c, p, key, *vals in cells:
         if players is not None and p != players:
             continue
+        if character is not None and c != character:
+            continue
         for bucket in ("ALL", c) if c in chars else ("ALL",):
-            slot = out.setdefault(bucket, {}).setdefault(key, [0.0, 0])
-            slot[0] += s
-            slot[1] += n
+            slot = out.setdefault(bucket, {}).setdefault(key, [0.0] * len(vals))
+            for i, v in enumerate(vals):
+                slot[i] += v
     return out
 
 
@@ -561,77 +844,319 @@ def hp_loss_by_floor(stats: dict[str, Any], players: int | None) -> list[dict]:
     series = []
     for cid, by_floor in merged.items():
         points = [
-            {"x": f, "y": round(s / n * 100, 1), "n": n}
+            {"x": f, "y": round(s / n * 100, 1), "n": int(n)}
             for f, (s, n) in sorted(by_floor.items())
             if n >= 15
         ]
         if points:
             series.append(
-                {
-                    "id": cid,
-                    "label": "All characters" if cid == "ALL" else chars.get(cid, cid),
-                    "points": points,
-                }
+                {"id": cid, "label": _char_label(cid, chars), "points": points}
             )
     return series
 
 
-def encounter_damage(
-    stats: dict[str, Any], players: int | None, top: int = 25
-) -> list[dict]:
-    """Top encounters by average % of max HP lost per player-fight."""
+def _encounter_names() -> dict[str, str]:
     from . import data_service
 
-    merged = _merge_cells(stats.get("enc_dmg") or [], players)
-    names: dict[str, str] = {}
     try:
-        names = {
+        return {
             e["id"]: e.get("name") or e["id"]
             for e in data_service.load_encounters()
             if e.get("id")
         }
     except Exception:
-        pass
+        return {}
+
+
+def encounter_ranking(
+    stats: dict[str, Any], players: int | None, metric: str = "damage", top: int = 25
+) -> list[dict]:
+    """Encounters ranked by avg % max HP lost per fight, or by avg turns."""
+    merged = _merge_cells(stats.get("enc") or [], players)
+    names = _encounter_names()
     rows = []
-    for enc, (s, n) in (merged.get("ALL") or {}).items():
-        if n < 30:
-            continue
+    for enc, (s, n, st, nt) in (merged.get("ALL") or {}).items():
         if names and enc not in names:
             continue  # modded encounters
-        rows.append(
-            {
-                "x": names.get(enc) or enc.replace("_", " ").title(),
-                "y": round(s / n * 100, 1),
-                "n": n,
-            }
-        )
+        if metric == "turns":
+            if nt < 30:
+                continue
+            rows.append(
+                {
+                    "x": names.get(enc) or enc.replace("_", " ").title(),
+                    "y": round(st / nt, 1),
+                    "n": int(nt),
+                }
+            )
+        else:
+            if n < 30:
+                continue
+            rows.append(
+                {
+                    "x": names.get(enc) or enc.replace("_", " ").title(),
+                    "y": round(s / n * 100, 1),
+                    "n": int(n),
+                }
+            )
     rows.sort(key=lambda r: r["y"], reverse=True)
-    return [{"id": "ALL", "label": "Avg % max HP lost", "points": rows[:top]}]
+    label = "Avg turns per fight" if metric == "turns" else "Avg % max HP lost"
+    return [{"id": "ALL", "label": label, "points": rows[:top]}]
+
+
+def encounter_histogram(
+    stats: dict[str, Any], players: int | None, encounter: str
+) -> list[dict]:
+    """Damage distribution for one encounter, in 5%-of-max-HP buckets."""
+    by_bucket: dict[int, int] = {}
+    for p, enc, b, n in stats.get("enc_hist") or []:
+        if enc != encounter:
+            continue
+        if players is not None and p != players:
+            continue
+        by_bucket[b] = by_bucket.get(b, 0) + n
+    total = sum(by_bucket.values())
+    if total < MIN_POINT_N:
+        return []
+    max_b = _HIST_CAP // _HIST_BUCKET
+    points = []
+    for b in range(0, max_b + 1):
+        n = by_bucket.get(b, 0)
+        lo = b * _HIST_BUCKET
+        label = f"{lo}-{lo + _HIST_BUCKET}%" if b < max_b else f"{_HIST_CAP}%+"
+        points.append({"x": label, "y": round(n / total * 100, 2), "n": n})
+    names = _encounter_names()
+    return [
+        {
+            "id": "ALL",
+            "label": names.get(encounter, encounter.replace("_", " ").title()),
+            "points": points,
+            "total": total,
+        }
+    ]
 
 
 def deaths_by_room(stats: dict[str, Any], players: int | None) -> list[dict]:
     merged = _merge_cells(
-        [[c, p, rt, 0.0, n] for c, p, rt, n in stats.get("death_room") or []], players
+        [[c, p, rt, n] for c, p, rt, n in stats.get("death_room") or []], players
     )
     chars = _official_characters()
     series = []
     for cid, by_room in merged.items():
-        total = sum(n for _, n in by_room.values())
+        total = sum(v[0] for v in by_room.values())
         if total < MIN_POINT_N:
             continue
         points = [
-            {"x": rt.title(), "y": round(n / total * 100, 1), "n": n}
-            for rt, (_, n) in sorted(by_room.items(), key=lambda kv: -kv[1][1])
+            {"x": rt.title(), "y": round(n / total * 100, 1), "n": int(n)}
+            for rt, (n,) in sorted(by_room.items(), key=lambda kv: -kv[1][0])
         ]
         series.append(
             {
                 "id": cid,
-                "label": "All characters" if cid == "ALL" else chars.get(cid, cid),
+                "label": _char_label(cid, chars),
                 "points": points,
                 "total": total,
             }
         )
     return series
+
+
+_TRAJ_METRICS = {
+    "hp": (0, 1, 100, "Avg % of max HP"),
+    "gold": (2, 3, 1, "Avg gold held"),
+    "deck": (4, 5, 1, "Avg cards added"),
+}
+
+
+def run_trajectory(
+    stats: dict[str, Any],
+    players: int | None,
+    metric: str,
+    character: str | None = None,
+) -> list[dict]:
+    """Per-floor average of HP %, gold, or deck size, winners vs losers."""
+    si, ni, scale, _label = _TRAJ_METRICS[metric]
+    by_outcome: dict[int, dict[int, list[float]]] = {0: {}, 1: {}}
+    chars = _official_characters()
+    for c, p, w, f, *vals in stats.get("traj") or []:
+        if players is not None and p != players:
+            continue
+        if character is not None and c != character:
+            continue
+        if character is None and chars and c not in chars:
+            continue
+        slot = by_outcome[int(w)].setdefault(f, [0.0, 0])
+        slot[0] += vals[si]
+        slot[1] += vals[ni]
+    series = []
+    for w, sid, label in ((1, "WIN", "Wins"), (0, "LOSS", "Losses")):
+        points = [
+            {"x": f, "y": round(s / n * scale, 1), "n": int(n)}
+            for f, (s, n) in sorted(by_outcome[w].items())
+            if n >= 15
+        ]
+        if points:
+            series.append({"id": sid, "label": label, "points": points})
+    return series
+
+
+def _bucket_vs_winrate(
+    cells: list[list], players: int | None, x_fmt=lambda b: b
+) -> list[dict]:
+    merged = _merge_cells(cells, players)
+    chars = _official_characters()
+    series = []
+    for cid, by_bucket in merged.items():
+        points = [
+            {"x": x_fmt(b), "y": round(w / n * 100, 1), "n": int(n)}
+            for b, (n, w) in sorted(by_bucket.items())
+            if n >= MIN_POINT_N
+        ]
+        if points:
+            series.append(
+                {"id": cid, "label": _char_label(cid, chars), "points": points}
+            )
+    return series
+
+
+def elites_vs_winrate(stats: dict[str, Any], players: int | None) -> list[dict]:
+    return _bucket_vs_winrate(stats.get("elites") or [], players)
+
+
+def smiths_vs_winrate(stats: dict[str, Any], players: int | None) -> list[dict]:
+    return _bucket_vs_winrate(stats.get("smiths") or [], players)
+
+
+def event_outcomes(stats: dict[str, Any], event_id: str) -> list[dict]:
+    """Pick share and win rate per option of one event."""
+    from . import data_service
+
+    rows = [(o, n, w) for e, o, n, w in stats.get("events") or [] if e == event_id]
+    total = sum(n for _, n, _ in rows)
+    if total < MIN_POINT_N:
+        return []
+    labels: dict[str, str] = {}
+    try:
+        for e in data_service.load_events():
+            if e.get("id") == event_id:
+                for opt in e.get("options") or []:
+                    if opt.get("id"):
+                        labels[opt["id"]] = opt.get("title") or opt["id"].title()
+    except Exception:
+        pass
+    rows.sort(key=lambda r: -r[1])
+    pick = []
+    winr = []
+    for o, n, w in rows:
+        x = labels.get(o) or o.replace("_", " ").title()
+        pick.append({"x": x, "y": round(n / total * 100, 1), "n": n})
+        if n >= MIN_POINT_N:
+            winr.append({"x": x, "y": round(w / n * 100, 1), "n": n})
+    return [
+        {"id": "PICK", "label": "Pick share %", "points": pick, "total": total},
+        {"id": "WINRATE", "label": "Win rate when picked %", "points": winr},
+    ]
+
+
+def event_list(stats: dict[str, Any]) -> list[dict]:
+    """Events present in the data with totals, for the UI's selector."""
+    from . import data_service
+
+    totals: dict[str, int] = {}
+    for e, _o, n, _w in stats.get("events") or []:
+        totals[e] = totals.get(e, 0) + n
+    names: dict[str, str] = {}
+    try:
+        names = {
+            e["id"]: e.get("name") or e["id"]
+            for e in data_service.load_events()
+            if e.get("id")
+        }
+    except Exception:
+        pass
+    out = [
+        {"id": e, "name": names.get(e) or e.replace("_", " ").title(), "n": n}
+        for e, n in totals.items()
+        if n >= MIN_POINT_N and (not names or e in names)
+    ]
+    out.sort(key=lambda r: -r["n"])
+    return out
+
+
+def entity_over_time(stats: dict[str, Any], etype: str, entity: str) -> list[dict]:
+    """Weekly pick rate and win rate for one card/relic/potion, with the
+    overall weekly win rate as the baseline."""
+    week_totals = {wk: (n, w) for wk, n, w in stats.get("week_totals") or []}
+    cells = {
+        wk: (n, w)
+        for t, e, wk, n, w in stats.get("entity_week") or []
+        if t == etype and e == entity
+    }
+    weeks = sorted(wk for wk in cells if week_totals.get(wk, (0, 0))[0] >= 25)
+    if not weeks:
+        return []
+    pick, withr, base = [], [], []
+    for wk in weeks:
+        n, w = cells[wk]
+        tn, tw = week_totals[wk]
+        label = _week_label(wk)
+        pick.append({"x": label, "y": round(n / tn * 100, 1), "n": n})
+        if n >= 10:
+            withr.append({"x": label, "y": round(w / n * 100, 1), "n": n})
+        base.append({"x": label, "y": round(tw / tn * 100, 1), "n": tn})
+    return [
+        {"id": "WITH", "label": "Win rate with it", "points": withr},
+        {"id": "BASE", "label": "Overall win rate", "points": base},
+        {"id": "PICK", "label": "% of runs holding it", "points": pick},
+    ]
+
+
+def entity_copies(stats: dict[str, Any], entity: str) -> list[dict]:
+    """Win rate by number of copies in the final deck (cards only)."""
+    rows = [(b, n, w) for e, b, n, w in stats.get("copies") or [] if e == entity]
+    points = [
+        {"x": f"{b}+" if b >= 5 else str(b), "y": round(w / n * 100, 1), "n": n}
+        for b, n, w in sorted(rows)
+        if n >= MIN_POINT_N
+    ]
+    return (
+        [{"id": "ALL", "label": "Win rate by copies", "points": points}]
+        if points
+        else []
+    )
+
+
+def enchant_winrate(stats: dict[str, Any]) -> list[dict]:
+    """Win rate of runs whose final deck holds each enchantment."""
+    from . import data_service
+
+    names: dict[str, str] = {}
+    try:
+        names = {
+            e["id"]: e.get("name") or e["id"]
+            for e in data_service.load_enchantments()
+            if e.get("id")
+        }
+    except Exception:
+        pass
+    rows = []
+    for e, n, w in stats.get("ench") or []:
+        if n < MIN_POINT_N:
+            continue
+        if names and e not in names:
+            continue
+        rows.append(
+            {
+                "x": names.get(e) or e.replace("_", " ").title(),
+                "y": round(w / n * 100, 1),
+                "n": n,
+            }
+        )
+    rows.sort(key=lambda r: -r["y"])
+    return (
+        [{"id": "ALL", "label": "Win rate with enchantment", "points": rows}]
+        if rows
+        else []
+    )
 
 
 # ── Per-user blob stats (on-demand walk of one user's runs) ──────────────────
@@ -655,7 +1180,13 @@ def build_user_blob_stats(username: str) -> dict[str, Any]:
             _get_collection()
             .find(
                 {"username": {"$regex": f"^{_re.escape(u)}$", "$options": "i"}},
-                {"_id": 1, "character": 1, "win": 1, "player_count": 1},
+                {
+                    "_id": 1,
+                    "character": 1,
+                    "win": 1,
+                    "player_count": 1,
+                    "submitted_at": 1,
+                },
             )
             .sort("submitted_at", -1)
             .limit(_USER_BLOB_CAP)
@@ -666,6 +1197,7 @@ def build_user_blob_stats(username: str) -> dict[str, Any]:
                 "character": d.get("character") or "",
                 "win": bool(d.get("win")),
                 "player_count": d.get("player_count") or 1,
+                "submitted_at": d.get("submitted_at"),
             }
             for d in cursor
         ]
@@ -676,8 +1208,8 @@ def build_user_blob_stats(username: str) -> dict[str, Any]:
             rows = [
                 dict(r)
                 for r in conn.execute(
-                    "SELECT run_hash, character, win, player_count FROM runs"
-                    " WHERE username = ? COLLATE NOCASE"
+                    "SELECT run_hash, character, win, player_count, submitted_at"
+                    " FROM runs WHERE username = ? COLLATE NOCASE"
                     " ORDER BY id DESC LIMIT ?",
                     (u, _USER_BLOB_CAP),
                 )
@@ -697,6 +1229,7 @@ def build_user_blob_stats(username: str) -> dict[str, Any]:
                 is_win=bool(row["win"]),
                 character=row["character"],
                 player_count=row["player_count"],
+                submitted=row.get("submitted_at"),
             )
         except Exception:
             continue

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -724,6 +724,7 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
                 is_win=is_win,
                 character=character,
                 player_count=row.get("player_count") or 1,
+                submitted=submitted,
             )
         except Exception:
             logger.warning(

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -164,6 +164,9 @@ _cohort_totals: dict[str, dict[str, int]] = {}
 # Community / fun stats (event decisions, deaths, headline numbers, records).
 # Built in the same run-file walk and carried through the snapshot meta doc.
 _community_stats: dict[str, Any] = {}
+# Blob-derived chart cells (per-floor damage, encounter damage, death rooms)
+# for /api/charts, accumulated in the same walk and carried the same way.
+_charts_blob_stats: dict[str, Any] = {}
 _cache_built_at: float = 0.0
 _building: bool = False
 
@@ -612,9 +615,10 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
     # All-runs only; the metrics table doesn't split base/upg per cohort.
     upgrade_pair_wins: dict[tuple[str, str], int] = {}
     # Community / fun stats, folded in from the same blob read (no 2nd walk).
-    from . import community_stats
+    from . import charts_stats, community_stats
 
     community_acc = community_stats.new_accumulator()
+    charts_acc = charts_stats.new_accumulator()
     # Parallel lightweight accumulators, one per non-"all" cohort.
     cohort_accs: dict[str, dict[str, Any]] = {
         k: _new_cohort_acc() for k in _COHORT_KEYS
@@ -710,6 +714,20 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
         except Exception:
             logger.warning(
                 "community-stats accumulate failed for %s", run_hash, exc_info=True
+            )
+
+        # Chart cells for /api/charts, same guard.
+        try:
+            charts_stats.accumulate(
+                charts_acc,
+                blob,
+                is_win=is_win,
+                character=character,
+                player_count=row.get("player_count") or 1,
+            )
+        except Exception:
+            logger.warning(
+                "charts-stats accumulate failed for %s", run_hash, exc_info=True
             )
 
         # Dedupe per-run: a deck with 5 Strikes still only counts ONE
@@ -935,6 +953,7 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
         "baselines": cohort_baselines,
         "totals": cohort_totals,
         "community": community_stats.finalize(community_acc),
+        "charts": charts_stats.finalize(charts_acc),
     }
     return new_cache, new_totals, new_type_baselines, cohort_meta
 
@@ -944,7 +963,7 @@ def _apply_cache(
 ) -> None:
     """Swap freshly-built (or snapshot-loaded) data into module globals."""
     global _cache, _cache_built_at, _global_totals, _type_baselines
-    global _cohort_baselines, _cohort_totals, _community_stats
+    global _cohort_baselines, _cohort_totals, _community_stats, _charts_blob_stats
     _cache = cache
     _global_totals = totals
     _type_baselines = baselines
@@ -952,6 +971,7 @@ def _apply_cache(
     _cohort_baselines = cohort_meta.get("baselines", {})
     _cohort_totals = cohort_meta.get("totals", {})
     _community_stats = cohort_meta.get("community") or {}
+    _charts_blob_stats = cohort_meta.get("charts") or {}
     _cache_built_at = time.time()
 
 
@@ -1035,6 +1055,7 @@ def _persist_snapshot(
             "cohort_baselines": cohort_meta.get("baselines", {}),
             "cohort_totals": cohort_meta.get("totals", {}),
             "community": cohort_meta.get("community", {}),
+            "charts": cohort_meta.get("charts", {}),
             "entity_types": list(by_type.keys()),
             "built_at": now,
             "snapshot_version": SNAPSHOT_VERSION,
@@ -1101,6 +1122,7 @@ def _load_snapshot() -> bool:
             "baselines": meta.get("cohort_baselines", {}),
             "totals": meta.get("cohort_totals", {}),
             "community": meta.get("community", {}),
+            "charts": meta.get("charts", {}),
         },
     )
     return True
@@ -1217,6 +1239,16 @@ def get_community_stats() -> dict[str, Any]:
     from . import community_stats
 
     return _community_stats or community_stats.empty()
+
+
+def get_charts_blob_stats() -> dict[str, Any]:
+    """Blob-derived chart cells for /api/charts (per-floor damage, encounter
+    damage, death rooms). Same lifecycle as the community stats: built in the
+    walk, carried through the snapshot, O(1) to read."""
+    _maybe_rebuild()
+    from . import charts_stats
+
+    return _charts_blob_stats or charts_stats.empty()
 
 
 def get_all_entity_scores(

--- a/contributing/CLAUDE.md
+++ b/contributing/CLAUDE.md
@@ -201,6 +201,7 @@ spire-codex/
 - `GET /api/runs/leaderboard` — ranked wins-only list (category: fastest|highest_ascension, character, page, limit)
 - `GET /api/runs/scores/{type}`: Bulk Codex Scores + Codex Elo for cards/relics/potions (Bayesian-shrunk win rate mapped 0-100 to S/A/B/C/D/F; non-reward cards + starters excluded; relics accept `?act=1|2|3` for acquisition-act views graded per-act; materialized to Mongo by a single leader)
 - `GET /api/runs/community-stats`: Fun community datasets for `/community-stats` (per-event decision splits, deadliest encounters/events, win rates by ascension/character, records; official content only)
+- `GET /api/charts/meta` + `GET /api/charts/{chart}`: Pre-aggregated run charts for `/charts` (win rates by floor/time/stat/ascension, run curves, encounter damage, event outcomes, per-entity weekly stats; filters: players/ascension/game_mode/username, series splits)
 - `GET /api/runs/leaderboard/rank/{hash}` — rank of one winning run; `POST /api/runs/claim` — attach username to prior runs
 - `GET /api/runs/encounter-stats` — per-encounter aggregates (Mongo-only)
 - `GET /api/runs/versions` — distinct build_ids across submitted runs

--- a/frontend/app/charts/ChartsClient.tsx
+++ b/frontend/app/charts/ChartsClient.tsx
@@ -3,7 +3,7 @@
 // The /charts explorer. All aggregation happens in the backend
 // (/api/charts/{key}); this component is controls + a Chart.js canvas.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   Chart as ChartJS,
@@ -47,6 +47,19 @@ const CHAR_VARS: Record<string, string> = {
   REGENT: "var(--color-regent)",
 };
 
+// Fixed colors for non-character series ids (splits, outcome curves, entity
+// chart roles), then a palette for anything else by series order.
+const SERIES_HEX: Record<string, string> = {
+  ALL: GOLD,
+  WIN: "#34d399",
+  LOSS: "#fb7185",
+  PICK: "#38bdf8",
+  WITH: "#34d399",
+  BASE: "#8a8a93",
+  WINRATE: "#34d399",
+};
+const PALETTE = ["#38bdf8", "#34d399", "#fb7185", "#a78bfa", "#f59e0b", "#2dd4bf", "#e879f9", "#fbbf24"];
+
 function resolveColor(color: string): string {
   if (!color.startsWith("var(")) return color;
   if (typeof window === "undefined") return GOLD;
@@ -57,8 +70,10 @@ function resolveColor(color: string): string {
   );
 }
 
-function seriesColor(id: string): string {
-  return id === "ALL" ? GOLD : resolveColor(CHAR_VARS[id] ?? GOLD);
+function seriesColor(id: string, index: number): string {
+  if (CHAR_VARS[id]) return resolveColor(CHAR_VARS[id]);
+  if (SERIES_HEX[id]) return SERIES_HEX[id];
+  return PALETTE[index % PALETTE.length];
 }
 
 const TOOLTIP_BASE = {
@@ -84,14 +99,23 @@ interface ChartSpec {
   group: string;
   kind: "frame" | "blob";
   needs: string[];
+  splits: string[];
   scatter: boolean;
   bars: boolean;
+  horizontal: boolean;
+  daily: boolean;
+  etype_fixed: string | null;
   axis: { x: string; y: string };
   desc: string;
 }
 interface StatOpt {
   key: string;
   label: string;
+}
+interface NamedOpt {
+  id: string;
+  name: string;
+  n?: number;
 }
 interface Point {
   x: number | string;
@@ -114,6 +138,12 @@ interface ChartResponse {
   series: Series[];
   total_runs: number;
 }
+interface Meta {
+  charts: ChartSpec[];
+  stats: StatOpt[];
+  characters: NamedOpt[];
+  events: NamedOpt[];
+}
 
 const PLAYER_OPTS = [
   { value: "", label: "All runs" },
@@ -127,6 +157,17 @@ const MODE_OPTS = [
   { value: "standard", label: "Standard" },
   { value: "daily", label: "Daily" },
   { value: "custom", label: "Custom" },
+];
+const SPLIT_LABELS: Record<string, string> = {
+  character: "By character",
+  players: "By player count",
+  outcome: "Wins vs losses",
+  ascension: "By ascension band",
+};
+const ETYPES = [
+  { value: "cards", label: "Card" },
+  { value: "relics", label: "Relic" },
+  { value: "potions", label: "Potion" },
 ];
 
 function Pills({
@@ -163,31 +204,38 @@ function Pills({
 }
 
 const selectCls =
-  "bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded-md px-3 py-1.5 text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]/50";
+  "bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded-md px-3 py-1.5 text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]/50 max-w-72";
 
 export default function ChartsClient() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const [meta, setMeta] = useState<{ charts: ChartSpec[]; stats: StatOpt[] } | null>(null);
+  const [meta, setMeta] = useState<Meta | null>(null);
   const [chart, setChart] = useState(searchParams.get("chart") || "winrate-by-floor");
   const [players, setPlayers] = useState(searchParams.get("players") || "");
   const [ascension, setAscension] = useState(searchParams.get("ascension") || "");
   const [gameMode, setGameMode] = useState(searchParams.get("mode") || "");
   const [usernameInput, setUsernameInput] = useState(searchParams.get("user") || "");
   const [username, setUsername] = useState(searchParams.get("user") || "");
+  const [split, setSplit] = useState(searchParams.get("split") || "character");
   const [stat, setStat] = useState(searchParams.get("stat") || "deck_size");
   const [xStat, setXStat] = useState(searchParams.get("x") || "floors_reached");
   const [yStat, setYStat] = useState(searchParams.get("y") || "deck_size");
+  const [encounter, setEncounter] = useState(searchParams.get("encounter") || "");
+  const [event, setEvent] = useState(searchParams.get("event") || "");
+  const [etype, setEtype] = useState(searchParams.get("etype") || "cards");
+  const [entity, setEntity] = useState(searchParams.get("entity") || "");
+
+  const [encounters, setEncounters] = useState<NamedOpt[]>([]);
+  const [entityLists, setEntityLists] = useState<Record<string, NamedOpt[]>>({});
 
   const [data, setData] = useState<ChartResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const spec = useMemo(
-    () => meta?.charts.find((c) => c.key === chart),
-    [meta, chart]
-  );
+  const spec = useMemo(() => meta?.charts.find((c) => c.key === chart), [meta, chart]);
+  const effEtype = spec?.etype_fixed || etype;
+  const needsEntity = spec?.needs.includes("entity") ?? false;
 
   // Debounce the username box so we don't fetch per keystroke.
   const userTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -204,6 +252,51 @@ export default function ChartsClient() {
       .catch(() => setError("Could not load chart list"));
   }, []);
 
+  // Lazy-load selector lists the first time a chart needs them.
+  useEffect(() => {
+    if (spec?.needs.includes("encounter") && encounters.length === 0) {
+      fetch(`${API}/api/encounters?lang=eng`)
+        .then((r) => r.json())
+        .then((rows: { id: string; name: string }[]) => {
+          const opts = rows
+            .map((r) => ({ id: r.id, name: r.name }))
+            .sort((a, b) => a.name.localeCompare(b.name));
+          setEncounters(opts);
+          if (!encounter && opts.length) setEncounter(opts[0].id);
+        })
+        .catch(() => {});
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [spec]);
+
+  useEffect(() => {
+    if (needsEntity && !entityLists[effEtype]) {
+      fetch(`${API}/api/${effEtype}?lang=eng`)
+        .then((r) => r.json())
+        .then((rows: { id: string; name: string }[]) => {
+          const opts = rows
+            .map((r) => ({ id: r.id, name: r.name }))
+            .sort((a, b) => a.name.localeCompare(b.name));
+          setEntityLists((m) => ({ ...m, [effEtype]: opts }));
+        })
+        .catch(() => {});
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [needsEntity, effEtype]);
+
+  // A usable default entity/event once lists exist.
+  useEffect(() => {
+    if (needsEntity && !entity && entityLists[effEtype]?.length) {
+      const list = entityLists[effEtype];
+      const bash = list.find((e) => e.id === "BASH");
+      setEntity((bash ?? list[0]).id);
+    }
+    if (spec?.needs.includes("event") && !event && meta?.events.length) {
+      setEvent(meta.events[0].id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [needsEntity, effEtype, entityLists, spec, meta]);
+
   // Keep the URL shareable.
   useEffect(() => {
     const p = new URLSearchParams();
@@ -212,27 +305,44 @@ export default function ChartsClient() {
     if (ascension) p.set("ascension", ascension);
     if (gameMode) p.set("mode", gameMode);
     if (username) p.set("user", username);
+    if (split !== "character" && spec?.splits.includes(split)) p.set("split", split);
     if (spec?.needs.includes("stat") && stat) p.set("stat", stat);
     if (spec?.needs.includes("x")) {
       p.set("x", xStat);
       p.set("y", yStat);
     }
+    if (spec?.needs.includes("encounter") && encounter) p.set("encounter", encounter);
+    if (spec?.needs.includes("event") && event) p.set("event", event);
+    if (needsEntity && entity) {
+      if (!spec?.etype_fixed) p.set("etype", etype);
+      p.set("entity", entity);
+    }
     const qs = p.toString();
     router.replace(`/charts${qs ? `?${qs}` : ""}`, { scroll: false });
-  }, [chart, players, ascension, gameMode, username, stat, xStat, yStat, spec, router]);
+  }, [chart, players, ascension, gameMode, username, split, stat, xStat, yStat, encounter, event, etype, entity, needsEntity, spec, router]);
 
   // Fetch the chart itself.
   useEffect(() => {
     if (!spec) return;
+    if (spec.needs.includes("encounter") && !encounter) return;
+    if (spec.needs.includes("event") && !event) return;
+    if (needsEntity && !entity) return;
     const p = new URLSearchParams();
     if (players) p.set("players", players);
-    if (spec.kind === "frame" && ascension) p.set("ascension", ascension);
-    if (spec.kind === "frame" && gameMode) p.set("game_mode", gameMode);
+    if (spec.kind === "frame" && !spec.daily && ascension) p.set("ascension", ascension);
+    if (spec.kind === "frame" && !spec.daily && gameMode) p.set("game_mode", gameMode);
     if (username) p.set("username", username);
+    if (spec.splits.includes(split) && split !== "character") p.set("split", split);
     if (spec.needs.includes("stat")) p.set("stat", stat);
     if (spec.needs.includes("x")) {
       p.set("x", xStat);
       p.set("y", yStat);
+    }
+    if (spec.needs.includes("encounter")) p.set("encounter", encounter);
+    if (spec.needs.includes("event")) p.set("event", event);
+    if (needsEntity) {
+      p.set("etype", effEtype);
+      p.set("entity", entity);
     }
     setLoading(true);
     setError(null);
@@ -246,8 +356,7 @@ export default function ChartsClient() {
         // Fill the generic "stat" axis placeholders with the chosen labels.
         const statLabel = (k: string) => meta?.stats.find((s) => s.key === k)?.label ?? k;
         if (spec.needs.includes("stat")) d.axis = { ...d.axis, x: statLabel(stat) };
-        if (spec.needs.includes("x"))
-          d.axis = { x: statLabel(xStat), y: statLabel(yStat) };
+        if (spec.needs.includes("x")) d.axis = { x: statLabel(xStat), y: statLabel(yStat) };
         setData(d);
         setLoading(false);
       })
@@ -258,7 +367,7 @@ export default function ChartsClient() {
         }
       });
     return () => ctrl.abort();
-  }, [spec, meta, players, ascension, gameMode, username, stat, xStat, yStat]);
+  }, [spec, meta, players, ascension, gameMode, username, split, stat, xStat, yStat, encounter, event, effEtype, entity, needsEntity]);
 
   const groups = useMemo(() => {
     const g = new Map<string, ChartSpec[]>();
@@ -268,17 +377,14 @@ export default function ChartsClient() {
     return g;
   }, [meta]);
 
+  const filtersLocked = spec?.kind === "blob" || spec?.daily;
+
   return (
     <div>
       {/* Controls */}
       <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4 mb-6 space-y-3">
         <div className="flex flex-wrap items-center gap-3">
-          <select
-            className={selectCls}
-            value={chart}
-            onChange={(e) => setChart(e.target.value)}
-            aria-label="Chart"
-          >
+          <select className={selectCls} value={chart} onChange={(e) => setChart(e.target.value)} aria-label="Chart">
             {[...groups.entries()].map(([group, charts]) => (
               <optgroup key={group} label={group}>
                 {charts.map((c) => (
@@ -291,12 +397,7 @@ export default function ChartsClient() {
           </select>
 
           {spec?.needs.includes("stat") && (
-            <select
-              className={selectCls}
-              value={stat}
-              onChange={(e) => setStat(e.target.value)}
-              aria-label="Run stat"
-            >
+            <select className={selectCls} value={stat} onChange={(e) => setStat(e.target.value)} aria-label="Run stat">
               {(meta?.stats ?? []).map((s) => (
                 <option key={s.key} value={s.key}>
                   {s.label}
@@ -306,24 +407,14 @@ export default function ChartsClient() {
           )}
           {spec?.needs.includes("x") && (
             <>
-              <select
-                className={selectCls}
-                value={xStat}
-                onChange={(e) => setXStat(e.target.value)}
-                aria-label="X stat"
-              >
+              <select className={selectCls} value={xStat} onChange={(e) => setXStat(e.target.value)} aria-label="X stat">
                 {(meta?.stats ?? []).map((s) => (
                   <option key={s.key} value={s.key}>
                     X: {s.label}
                   </option>
                 ))}
               </select>
-              <select
-                className={selectCls}
-                value={yStat}
-                onChange={(e) => setYStat(e.target.value)}
-                aria-label="Y stat"
-              >
+              <select className={selectCls} value={yStat} onChange={(e) => setYStat(e.target.value)} aria-label="Y stat">
                 {(meta?.stats ?? []).map((s) => (
                   <option key={s.key} value={s.key}>
                     Y: {s.label}
@@ -331,6 +422,67 @@ export default function ChartsClient() {
                 ))}
               </select>
             </>
+          )}
+          {spec?.needs.includes("encounter") && (
+            <select className={selectCls} value={encounter} onChange={(e) => setEncounter(e.target.value)} aria-label="Encounter">
+              {encounters.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.name}
+                </option>
+              ))}
+            </select>
+          )}
+          {spec?.needs.includes("event") && (
+            <select className={selectCls} value={event} onChange={(e) => setEvent(e.target.value)} aria-label="Event">
+              {(meta?.events ?? []).map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.name}
+                </option>
+              ))}
+            </select>
+          )}
+          {needsEntity && (
+            <>
+              {!spec?.etype_fixed && (
+                <select
+                  className={selectCls}
+                  value={etype}
+                  onChange={(e) => {
+                    setEtype(e.target.value);
+                    setEntity("");
+                  }}
+                  aria-label="Entity type"
+                >
+                  {ETYPES.map((t) => (
+                    <option key={t.value} value={t.value}>
+                      {t.label}
+                    </option>
+                  ))}
+                </select>
+              )}
+              <select className={selectCls} value={entity} onChange={(e) => setEntity(e.target.value)} aria-label="Entity">
+                {(entityLists[effEtype] ?? []).map((o) => (
+                  <option key={o.id} value={o.id}>
+                    {o.name}
+                  </option>
+                ))}
+              </select>
+            </>
+          )}
+
+          {(spec?.splits.length ?? 0) > 0 && (
+            <select
+              className={selectCls}
+              value={spec!.splits.includes(split) ? split : "character"}
+              onChange={(e) => setSplit(e.target.value)}
+              aria-label="Split series by"
+            >
+              {spec!.splits.map((s) => (
+                <option key={s} value={s}>
+                  {SPLIT_LABELS[s] ?? s}
+                </option>
+              ))}
+            </select>
           )}
 
           <input
@@ -344,19 +496,9 @@ export default function ChartsClient() {
 
         <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
           <Pills options={PLAYER_OPTS} value={players} onChange={setPlayers} />
-          <Pills
-            options={MODE_OPTS}
-            value={gameMode}
-            onChange={setGameMode}
-            disabled={spec?.kind === "blob"}
-          />
-          <div className={spec?.kind === "blob" ? "opacity-40 pointer-events-none" : ""}>
-            <select
-              className={selectCls}
-              value={ascension}
-              onChange={(e) => setAscension(e.target.value)}
-              aria-label="Ascension"
-            >
+          <Pills options={MODE_OPTS} value={gameMode} onChange={setGameMode} disabled={filtersLocked} />
+          <div className={filtersLocked ? "opacity-40 pointer-events-none" : ""}>
+            <select className={selectCls} value={ascension} onChange={(e) => setAscension(e.target.value)} aria-label="Ascension">
               <option value="">All ascensions</option>
               {Array.from({ length: 21 }, (_, i) => (
                 <option key={i} value={String(i)}>
@@ -367,8 +509,11 @@ export default function ChartsClient() {
           </div>
           {spec?.kind === "blob" && (
             <span className="text-xs text-[var(--text-muted)]">
-              Combat charts cover all ascensions and modes.
+              This chart covers all ascensions and modes.
             </span>
+          )}
+          {spec?.daily && (
+            <span className="text-xs text-[var(--text-muted)]">Daily runs only.</span>
           )}
         </div>
       </div>
@@ -403,8 +548,15 @@ export default function ChartsClient() {
 
 function ExplorerChart({ spec, data }: { spec: ChartSpec; data: ChartResponse }) {
   if (spec.scatter) return <ScatterChart data={data} />;
-  if (spec.bars) return <BarRanking data={data} />;
+  if (spec.bars) return <BarRanking data={data} horizontal={spec.horizontal} />;
   return <LineChart data={data} />;
+}
+
+function legendOpts(count: number) {
+  return {
+    display: count > 1,
+    labels: { color: TEXT_SECONDARY, boxWidth: 12, boxHeight: 12, font: { size: 12 } },
+  };
 }
 
 function baseOptions(data: ChartResponse): ChartOptions<"line"> {
@@ -414,10 +566,7 @@ function baseOptions(data: ChartResponse): ChartOptions<"line"> {
     animation: false,
     interaction: { mode: "nearest", intersect: false },
     plugins: {
-      legend: {
-        display: data.series.length > 1,
-        labels: { color: TEXT_SECONDARY, boxWidth: 12, boxHeight: 12, font: { size: 12 } },
-      },
+      legend: legendOpts(data.series.length),
       tooltip: {
         ...TOOLTIP_BASE,
         callbacks: {
@@ -445,22 +594,30 @@ function baseOptions(data: ChartResponse): ChartOptions<"line"> {
   };
 }
 
+function lineDataset(s: Series, i: number) {
+  const color = seriesColor(s.id, i);
+  return {
+    label: s.label,
+    borderColor: color,
+    backgroundColor: color,
+    borderWidth: s.id === "ALL" ? 2.5 : 1.5,
+    pointRadius: 2,
+    pointHoverRadius: 4,
+    tension: 0.3,
+    spanGaps: true,
+    borderDash: s.id === "BASE" ? [6, 4] : undefined,
+  };
+}
+
 function LineChart({ data }: { data: ChartResponse }) {
   const numericX = data.series.every((s) => s.points.every((p) => typeof p.x === "number"));
   const options = baseOptions(data);
 
   if (numericX) {
     (options.scales!.x as { type?: string }).type = "linear";
-    const datasets = data.series.map((s) => ({
-      label: s.label,
+    const datasets = data.series.map((s, i) => ({
+      ...lineDataset(s, i),
       data: s.points.map((p) => ({ x: p.x as number, y: p.y, n: p.n })),
-      borderColor: seriesColor(s.id),
-      backgroundColor: seriesColor(s.id),
-      borderWidth: s.id === "ALL" ? 2.5 : 1.5,
-      pointRadius: 2,
-      pointHoverRadius: 4,
-      tension: 0.3,
-      spanGaps: true,
     }));
     return (
       <div className="h-[460px]">
@@ -469,7 +626,7 @@ function LineChart({ data }: { data: ChartResponse }) {
     );
   }
 
-  // Category x (weeks, labels): union of labels in first-seen order.
+  // Category x (weeks, labels): union of labels, sorted.
   const labels: string[] = [];
   const seen = new Set<string>();
   for (const s of data.series) {
@@ -482,21 +639,14 @@ function LineChart({ data }: { data: ChartResponse }) {
     }
   }
   labels.sort();
-  const datasets = data.series.map((s) => {
+  const datasets = data.series.map((s, i) => {
     const byX = new Map(s.points.map((p) => [String(p.x), p]));
     return {
-      label: s.label,
+      ...lineDataset(s, i),
       data: labels.map((l) => {
         const p = byX.get(l);
         return p ? { x: l, y: p.y, n: p.n } : { x: l, y: null as number | null };
       }),
-      borderColor: seriesColor(s.id),
-      backgroundColor: seriesColor(s.id),
-      borderWidth: s.id === "ALL" ? 2.5 : 1.5,
-      pointRadius: 2,
-      pointHoverRadius: 4,
-      tension: 0.3,
-      spanGaps: true,
     };
   });
   return (
@@ -506,26 +656,30 @@ function LineChart({ data }: { data: ChartResponse }) {
   );
 }
 
-function BarRanking({ data }: { data: ChartResponse }) {
-  // Single-series ranking (encounter damage) renders horizontally with one
-  // row per category; multi-series (deaths by room) renders grouped columns.
-  const horizontal = data.series.length === 1 && data.series[0].points.length > 8;
-  if (horizontal) {
+function BarRanking({ data, horizontal }: { data: ChartResponse; horizontal: boolean }) {
+  const barTooltip = (seriesFor: (item: TooltipItem<"bar">) => Series | undefined) => ({
+    ...TOOLTIP_BASE,
+    callbacks: {
+      label: (item: TooltipItem<"bar">) => {
+        const s = seriesFor(item);
+        const p = s?.points[item.dataIndex];
+        const v = horizontal ? item.parsed.x : item.parsed.y;
+        const n = p?.n != null ? ` · ${p.n.toLocaleString()}` : "";
+        return `${item.dataset.label}: ${v}${n}`;
+      },
+    },
+  });
+
+  if (horizontal && data.series.length === 1) {
     const s = data.series[0];
     const height = Math.max(160, s.points.length * 28);
-    const labels = s.points.map((p) => String(p.x));
     return (
       <div style={{ height }}>
         <Bar
           data={{
-            labels,
+            labels: s.points.map((p) => String(p.x)),
             datasets: [
-              {
-                label: s.label,
-                data: s.points.map((p) => p.y),
-                backgroundColor: GOLD,
-                borderRadius: 4,
-              },
+              { label: s.label, data: s.points.map((p) => p.y), backgroundColor: GOLD, borderRadius: 4 },
             ],
           }}
           options={{
@@ -533,19 +687,7 @@ function BarRanking({ data }: { data: ChartResponse }) {
             responsive: true,
             maintainAspectRatio: false,
             animation: false,
-            plugins: {
-              legend: { display: false },
-              tooltip: {
-                ...TOOLTIP_BASE,
-                callbacks: {
-                  label: (item: TooltipItem<"bar">) => {
-                    const p = s.points[item.dataIndex];
-                    const n = p?.n != null ? ` · ${p.n.toLocaleString()} fights` : "";
-                    return `${item.parsed.x}% of max HP${n}`;
-                  },
-                },
-              },
-            },
+            plugins: { legend: { display: false }, tooltip: barTooltip(() => s) },
             scales: {
               x: {
                 title: { display: true, text: data.axis.y, color: TEXT_SECONDARY },
@@ -553,10 +695,7 @@ function BarRanking({ data }: { data: ChartResponse }) {
                 grid: { color: GRID },
                 beginAtZero: true,
               },
-              y: {
-                ticks: { color: TEXT_SECONDARY, font: { size: 12 }, autoSkip: false },
-                grid: { display: false },
-              },
+              y: { ticks: { color: TEXT_SECONDARY, font: { size: 12 }, autoSkip: false }, grid: { display: false } },
             },
           }}
         />
@@ -575,12 +714,12 @@ function BarRanking({ data }: { data: ChartResponse }) {
       }
     }
   }
-  const datasets = data.series.map((s) => {
+  const datasets = data.series.map((s, i) => {
     const byX = new Map(s.points.map((p) => [String(p.x), p]));
     return {
       label: s.label,
       data: labels.map((l) => byX.get(l)?.y ?? 0),
-      backgroundColor: seriesColor(s.id),
+      backgroundColor: seriesColor(s.id, i),
       borderRadius: 4,
     };
   });
@@ -593,14 +732,11 @@ function BarRanking({ data }: { data: ChartResponse }) {
           maintainAspectRatio: false,
           animation: false,
           plugins: {
-            legend: {
-              display: datasets.length > 1,
-              labels: { color: TEXT_SECONDARY, boxWidth: 12, boxHeight: 12, font: { size: 12 } },
-            },
-            tooltip: { ...TOOLTIP_BASE },
+            legend: legendOpts(datasets.length),
+            tooltip: barTooltip((item) => data.series[item.datasetIndex]),
           },
           scales: {
-            x: { ticks: { color: TEXT_SECONDARY }, grid: { display: false } },
+            x: { ticks: { color: TEXT_SECONDARY, maxRotation: 60 }, grid: { display: false } },
             y: {
               title: { display: true, text: data.axis.y, color: TEXT_SECONDARY },
               ticks: { color: TEXT_SECONDARY },
@@ -615,10 +751,10 @@ function BarRanking({ data }: { data: ChartResponse }) {
 }
 
 function ScatterChart({ data }: { data: ChartResponse }) {
-  const datasets = data.series.map((s) => ({
+  const datasets = data.series.map((s, i) => ({
     label: s.label,
     data: s.points.map((p) => ({ x: p.x as number, y: p.y })),
-    backgroundColor: seriesColor(s.id) + "b3",
+    backgroundColor: seriesColor(s.id, i) + "b3",
     pointRadius: 2.5,
     pointHoverRadius: 4,
   }));
@@ -633,10 +769,7 @@ function ScatterChart({ data }: { data: ChartResponse }) {
             maintainAspectRatio: false,
             animation: false,
             plugins: {
-              legend: {
-                display: datasets.length > 1,
-                labels: { color: TEXT_SECONDARY, boxWidth: 12, boxHeight: 12, font: { size: 12 } },
-              },
+              legend: legendOpts(datasets.length),
               tooltip: {
                 ...TOOLTIP_BASE,
                 callbacks: {

--- a/frontend/app/charts/ChartsClient.tsx
+++ b/frontend/app/charts/ChartsClient.tsx
@@ -258,7 +258,7 @@ export default function ChartsClient() {
         }
       });
     return () => ctrl.abort();
-  }, [spec, players, ascension, gameMode, username, stat, xStat, yStat]);
+  }, [spec, meta, players, ascension, gameMode, username, stat, xStat, yStat]);
 
   const groups = useMemo(() => {
     const g = new Map<string, ChartSpec[]>();
@@ -404,7 +404,7 @@ export default function ChartsClient() {
 function ExplorerChart({ spec, data }: { spec: ChartSpec; data: ChartResponse }) {
   if (spec.scatter) return <ScatterChart data={data} />;
   if (spec.bars) return <BarRanking data={data} />;
-  return <LineChart data={data} spec={spec} />;
+  return <LineChart data={data} />;
 }
 
 function baseOptions(data: ChartResponse): ChartOptions<"line"> {
@@ -445,7 +445,7 @@ function baseOptions(data: ChartResponse): ChartOptions<"line"> {
   };
 }
 
-function LineChart({ data, spec }: { data: ChartResponse; spec: ChartSpec }) {
+function LineChart({ data }: { data: ChartResponse }) {
   const numericX = data.series.every((s) => s.points.every((p) => typeof p.x === "number"));
   const options = baseOptions(data);
 

--- a/frontend/app/charts/ChartsClient.tsx
+++ b/frontend/app/charts/ChartsClient.tsx
@@ -1,0 +1,670 @@
+"use client";
+
+// The /charts explorer. All aggregation happens in the backend
+// (/api/charts/{key}); this component is controls + a Chart.js canvas.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  Chart as ChartJS,
+  LineElement,
+  PointElement,
+  BarElement,
+  ArcElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  type ChartOptions,
+  type TooltipItem,
+} from "chart.js";
+import { Line, Bar, Scatter } from "react-chartjs-2";
+
+ChartJS.register(
+  LineElement,
+  PointElement,
+  BarElement,
+  ArcElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend
+);
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+// ── Theme (matches the community-stats charts) ───────────────────────────────
+
+const GOLD = "#d4a843";
+const TEXT_SECONDARY = "#a1a1aa";
+const GRID = "rgba(255,255,255,0.06)";
+
+const CHAR_VARS: Record<string, string> = {
+  IRONCLAD: "var(--color-ironclad)",
+  SILENT: "var(--color-silent)",
+  DEFECT: "var(--color-defect)",
+  NECROBINDER: "var(--color-necrobinder)",
+  REGENT: "var(--color-regent)",
+};
+
+function resolveColor(color: string): string {
+  if (!color.startsWith("var(")) return color;
+  if (typeof window === "undefined") return GOLD;
+  return (
+    getComputedStyle(document.documentElement)
+      .getPropertyValue(color.slice(4, -1))
+      .trim() || GOLD
+  );
+}
+
+function seriesColor(id: string): string {
+  return id === "ALL" ? GOLD : resolveColor(CHAR_VARS[id] ?? GOLD);
+}
+
+const TOOLTIP_BASE = {
+  backgroundColor: "#15151a",
+  borderColor: "#33333a",
+  borderWidth: 1,
+  cornerRadius: 6,
+  padding: 8,
+  titleColor: "#e5e5e5",
+  bodyColor: TEXT_SECONDARY,
+  displayColors: true,
+  boxWidth: 8,
+  boxHeight: 8,
+  titleFont: { size: 12 },
+  bodyFont: { size: 12 },
+} as const;
+
+// ── API types ────────────────────────────────────────────────────────────────
+
+interface ChartSpec {
+  key: string;
+  label: string;
+  group: string;
+  kind: "frame" | "blob";
+  needs: string[];
+  scatter: boolean;
+  bars: boolean;
+  axis: { x: string; y: string };
+  desc: string;
+}
+interface StatOpt {
+  key: string;
+  label: string;
+}
+interface Point {
+  x: number | string;
+  y: number;
+  n?: number;
+  win?: number;
+}
+interface Series {
+  id: string;
+  label: string;
+  points: Point[];
+  total?: number;
+  sampled_from?: number;
+}
+interface ChartResponse {
+  chart: string;
+  label: string;
+  axis: { x: string; y: string };
+  desc: string;
+  series: Series[];
+  total_runs: number;
+}
+
+const PLAYER_OPTS = [
+  { value: "", label: "All runs" },
+  { value: "1", label: "Solo" },
+  { value: "2", label: "2P" },
+  { value: "3", label: "3P" },
+  { value: "4", label: "4P" },
+];
+const MODE_OPTS = [
+  { value: "", label: "All modes" },
+  { value: "standard", label: "Standard" },
+  { value: "daily", label: "Daily" },
+  { value: "custom", label: "Custom" },
+];
+
+function Pills({
+  options,
+  value,
+  onChange,
+  disabled,
+}: {
+  options: { value: string; label: string }[];
+  value: string;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className={`flex flex-wrap gap-1.5 ${disabled ? "opacity-40 pointer-events-none" : ""}`}>
+      {options.map((o) => {
+        const active = value === o.value;
+        return (
+          <button
+            key={o.value || "all"}
+            onClick={() => onChange(o.value)}
+            className={`text-xs px-3 py-1.5 rounded-md border transition-colors cursor-pointer ${
+              active
+                ? "bg-[var(--accent-gold)]/10 border-[var(--accent-gold)]/40 text-[var(--accent-gold)]"
+                : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
+            }`}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+const selectCls =
+  "bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded-md px-3 py-1.5 text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]/50";
+
+export default function ChartsClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [meta, setMeta] = useState<{ charts: ChartSpec[]; stats: StatOpt[] } | null>(null);
+  const [chart, setChart] = useState(searchParams.get("chart") || "winrate-by-floor");
+  const [players, setPlayers] = useState(searchParams.get("players") || "");
+  const [ascension, setAscension] = useState(searchParams.get("ascension") || "");
+  const [gameMode, setGameMode] = useState(searchParams.get("mode") || "");
+  const [usernameInput, setUsernameInput] = useState(searchParams.get("user") || "");
+  const [username, setUsername] = useState(searchParams.get("user") || "");
+  const [stat, setStat] = useState(searchParams.get("stat") || "deck_size");
+  const [xStat, setXStat] = useState(searchParams.get("x") || "floors_reached");
+  const [yStat, setYStat] = useState(searchParams.get("y") || "deck_size");
+
+  const [data, setData] = useState<ChartResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const spec = useMemo(
+    () => meta?.charts.find((c) => c.key === chart),
+    [meta, chart]
+  );
+
+  // Debounce the username box so we don't fetch per keystroke.
+  const userTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onUsername = (v: string) => {
+    setUsernameInput(v);
+    if (userTimer.current) clearTimeout(userTimer.current);
+    userTimer.current = setTimeout(() => setUsername(v.trim()), 500);
+  };
+
+  useEffect(() => {
+    fetch(`${API}/api/charts/meta`)
+      .then((r) => r.json())
+      .then(setMeta)
+      .catch(() => setError("Could not load chart list"));
+  }, []);
+
+  // Keep the URL shareable.
+  useEffect(() => {
+    const p = new URLSearchParams();
+    if (chart !== "winrate-by-floor") p.set("chart", chart);
+    if (players) p.set("players", players);
+    if (ascension) p.set("ascension", ascension);
+    if (gameMode) p.set("mode", gameMode);
+    if (username) p.set("user", username);
+    if (spec?.needs.includes("stat") && stat) p.set("stat", stat);
+    if (spec?.needs.includes("x")) {
+      p.set("x", xStat);
+      p.set("y", yStat);
+    }
+    const qs = p.toString();
+    router.replace(`/charts${qs ? `?${qs}` : ""}`, { scroll: false });
+  }, [chart, players, ascension, gameMode, username, stat, xStat, yStat, spec, router]);
+
+  // Fetch the chart itself.
+  useEffect(() => {
+    if (!spec) return;
+    const p = new URLSearchParams();
+    if (players) p.set("players", players);
+    if (spec.kind === "frame" && ascension) p.set("ascension", ascension);
+    if (spec.kind === "frame" && gameMode) p.set("game_mode", gameMode);
+    if (username) p.set("username", username);
+    if (spec.needs.includes("stat")) p.set("stat", stat);
+    if (spec.needs.includes("x")) {
+      p.set("x", xStat);
+      p.set("y", yStat);
+    }
+    setLoading(true);
+    setError(null);
+    const ctrl = new AbortController();
+    fetch(`${API}/api/charts/${spec.key}?${p}`, { signal: ctrl.signal })
+      .then(async (r) => {
+        if (!r.ok) throw new Error((await r.json()).detail || `HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((d: ChartResponse) => {
+        // Fill the generic "stat" axis placeholders with the chosen labels.
+        const statLabel = (k: string) => meta?.stats.find((s) => s.key === k)?.label ?? k;
+        if (spec.needs.includes("stat")) d.axis = { ...d.axis, x: statLabel(stat) };
+        if (spec.needs.includes("x"))
+          d.axis = { x: statLabel(xStat), y: statLabel(yStat) };
+        setData(d);
+        setLoading(false);
+      })
+      .catch((e) => {
+        if (e.name !== "AbortError") {
+          setError(String(e.message || e));
+          setLoading(false);
+        }
+      });
+    return () => ctrl.abort();
+  }, [spec, players, ascension, gameMode, username, stat, xStat, yStat]);
+
+  const groups = useMemo(() => {
+    const g = new Map<string, ChartSpec[]>();
+    for (const c of meta?.charts ?? []) {
+      g.set(c.group, [...(g.get(c.group) ?? []), c]);
+    }
+    return g;
+  }, [meta]);
+
+  return (
+    <div>
+      {/* Controls */}
+      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4 mb-6 space-y-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <select
+            className={selectCls}
+            value={chart}
+            onChange={(e) => setChart(e.target.value)}
+            aria-label="Chart"
+          >
+            {[...groups.entries()].map(([group, charts]) => (
+              <optgroup key={group} label={group}>
+                {charts.map((c) => (
+                  <option key={c.key} value={c.key}>
+                    {c.label}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+
+          {spec?.needs.includes("stat") && (
+            <select
+              className={selectCls}
+              value={stat}
+              onChange={(e) => setStat(e.target.value)}
+              aria-label="Run stat"
+            >
+              {(meta?.stats ?? []).map((s) => (
+                <option key={s.key} value={s.key}>
+                  {s.label}
+                </option>
+              ))}
+            </select>
+          )}
+          {spec?.needs.includes("x") && (
+            <>
+              <select
+                className={selectCls}
+                value={xStat}
+                onChange={(e) => setXStat(e.target.value)}
+                aria-label="X stat"
+              >
+                {(meta?.stats ?? []).map((s) => (
+                  <option key={s.key} value={s.key}>
+                    X: {s.label}
+                  </option>
+                ))}
+              </select>
+              <select
+                className={selectCls}
+                value={yStat}
+                onChange={(e) => setYStat(e.target.value)}
+                aria-label="Y stat"
+              >
+                {(meta?.stats ?? []).map((s) => (
+                  <option key={s.key} value={s.key}>
+                    Y: {s.label}
+                  </option>
+                ))}
+              </select>
+            </>
+          )}
+
+          <input
+            className={`${selectCls} w-44`}
+            placeholder="Username (optional)"
+            value={usernameInput}
+            onChange={(e) => onUsername(e.target.value)}
+            aria-label="Filter to one player's runs"
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          <Pills options={PLAYER_OPTS} value={players} onChange={setPlayers} />
+          <Pills
+            options={MODE_OPTS}
+            value={gameMode}
+            onChange={setGameMode}
+            disabled={spec?.kind === "blob"}
+          />
+          <div className={spec?.kind === "blob" ? "opacity-40 pointer-events-none" : ""}>
+            <select
+              className={selectCls}
+              value={ascension}
+              onChange={(e) => setAscension(e.target.value)}
+              aria-label="Ascension"
+            >
+              <option value="">All ascensions</option>
+              {Array.from({ length: 21 }, (_, i) => (
+                <option key={i} value={String(i)}>
+                  A{i}
+                </option>
+              ))}
+            </select>
+          </div>
+          {spec?.kind === "blob" && (
+            <span className="text-xs text-[var(--text-muted)]">
+              Combat charts cover all ascensions and modes.
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Chart card */}
+      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+        {error ? (
+          <p className="text-sm text-rose-400 py-12 text-center">{error}</p>
+        ) : !data || loading ? (
+          <div className="h-[420px] flex items-center justify-center text-sm text-[var(--text-muted)]">
+            Crunching runs…
+          </div>
+        ) : data.series.length === 0 ? (
+          <div className="h-[420px] flex items-center justify-center text-sm text-[var(--text-muted)]">
+            Not enough runs match these filters.
+          </div>
+        ) : (
+          <ExplorerChart spec={spec!} data={data} />
+        )}
+        {data && !loading && !error && (
+          <p className="text-xs text-[var(--text-muted)] mt-3">
+            {data.desc} Based on {data.total_runs.toLocaleString()} runs matching the filters.
+            Thin samples are hidden so lines don&apos;t whip around on noise.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+function ExplorerChart({ spec, data }: { spec: ChartSpec; data: ChartResponse }) {
+  if (spec.scatter) return <ScatterChart data={data} />;
+  if (spec.bars) return <BarRanking data={data} />;
+  return <LineChart data={data} spec={spec} />;
+}
+
+function baseOptions(data: ChartResponse): ChartOptions<"line"> {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: false,
+    interaction: { mode: "nearest", intersect: false },
+    plugins: {
+      legend: {
+        display: data.series.length > 1,
+        labels: { color: TEXT_SECONDARY, boxWidth: 12, boxHeight: 12, font: { size: 12 } },
+      },
+      tooltip: {
+        ...TOOLTIP_BASE,
+        callbacks: {
+          label: (item: TooltipItem<"line">) => {
+            const raw = item.raw as Point;
+            const n = raw?.n != null ? ` · ${raw.n.toLocaleString()} runs` : "";
+            return `${item.dataset.label}: ${item.parsed.y}${n}`;
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        title: { display: true, text: data.axis.x, color: TEXT_SECONDARY, font: { size: 12 } },
+        ticks: { color: TEXT_SECONDARY, maxTicksLimit: 20 },
+        grid: { color: GRID },
+      },
+      y: {
+        title: { display: true, text: data.axis.y, color: TEXT_SECONDARY, font: { size: 12 } },
+        ticks: { color: TEXT_SECONDARY },
+        grid: { color: GRID },
+        beginAtZero: true,
+      },
+    },
+  };
+}
+
+function LineChart({ data, spec }: { data: ChartResponse; spec: ChartSpec }) {
+  const numericX = data.series.every((s) => s.points.every((p) => typeof p.x === "number"));
+  const options = baseOptions(data);
+
+  if (numericX) {
+    (options.scales!.x as { type?: string }).type = "linear";
+    const datasets = data.series.map((s) => ({
+      label: s.label,
+      data: s.points.map((p) => ({ x: p.x as number, y: p.y, n: p.n })),
+      borderColor: seriesColor(s.id),
+      backgroundColor: seriesColor(s.id),
+      borderWidth: s.id === "ALL" ? 2.5 : 1.5,
+      pointRadius: 2,
+      pointHoverRadius: 4,
+      tension: 0.3,
+      spanGaps: true,
+    }));
+    return (
+      <div className="h-[460px]">
+        <Line data={{ datasets }} options={options} />
+      </div>
+    );
+  }
+
+  // Category x (weeks, labels): union of labels in first-seen order.
+  const labels: string[] = [];
+  const seen = new Set<string>();
+  for (const s of data.series) {
+    for (const p of s.points) {
+      const k = String(p.x);
+      if (!seen.has(k)) {
+        seen.add(k);
+        labels.push(k);
+      }
+    }
+  }
+  labels.sort();
+  const datasets = data.series.map((s) => {
+    const byX = new Map(s.points.map((p) => [String(p.x), p]));
+    return {
+      label: s.label,
+      data: labels.map((l) => {
+        const p = byX.get(l);
+        return p ? { x: l, y: p.y, n: p.n } : { x: l, y: null as number | null };
+      }),
+      borderColor: seriesColor(s.id),
+      backgroundColor: seriesColor(s.id),
+      borderWidth: s.id === "ALL" ? 2.5 : 1.5,
+      pointRadius: 2,
+      pointHoverRadius: 4,
+      tension: 0.3,
+      spanGaps: true,
+    };
+  });
+  return (
+    <div className="h-[460px]">
+      <Line data={{ labels, datasets }} options={baseOptions(data)} />
+    </div>
+  );
+}
+
+function BarRanking({ data }: { data: ChartResponse }) {
+  // Single-series ranking (encounter damage) renders horizontally with one
+  // row per category; multi-series (deaths by room) renders grouped columns.
+  const horizontal = data.series.length === 1 && data.series[0].points.length > 8;
+  if (horizontal) {
+    const s = data.series[0];
+    const height = Math.max(160, s.points.length * 28);
+    const labels = s.points.map((p) => String(p.x));
+    return (
+      <div style={{ height }}>
+        <Bar
+          data={{
+            labels,
+            datasets: [
+              {
+                label: s.label,
+                data: s.points.map((p) => p.y),
+                backgroundColor: GOLD,
+                borderRadius: 4,
+              },
+            ],
+          }}
+          options={{
+            indexAxis: "y",
+            responsive: true,
+            maintainAspectRatio: false,
+            animation: false,
+            plugins: {
+              legend: { display: false },
+              tooltip: {
+                ...TOOLTIP_BASE,
+                callbacks: {
+                  label: (item: TooltipItem<"bar">) => {
+                    const p = s.points[item.dataIndex];
+                    const n = p?.n != null ? ` · ${p.n.toLocaleString()} fights` : "";
+                    return `${item.parsed.x}% of max HP${n}`;
+                  },
+                },
+              },
+            },
+            scales: {
+              x: {
+                title: { display: true, text: data.axis.y, color: TEXT_SECONDARY },
+                ticks: { color: TEXT_SECONDARY },
+                grid: { color: GRID },
+                beginAtZero: true,
+              },
+              y: {
+                ticks: { color: TEXT_SECONDARY, font: { size: 12 }, autoSkip: false },
+                grid: { display: false },
+              },
+            },
+          }}
+        />
+      </div>
+    );
+  }
+
+  const labels: string[] = [];
+  const seen = new Set<string>();
+  for (const s of data.series) {
+    for (const p of s.points) {
+      const k = String(p.x);
+      if (!seen.has(k)) {
+        seen.add(k);
+        labels.push(k);
+      }
+    }
+  }
+  const datasets = data.series.map((s) => {
+    const byX = new Map(s.points.map((p) => [String(p.x), p]));
+    return {
+      label: s.label,
+      data: labels.map((l) => byX.get(l)?.y ?? 0),
+      backgroundColor: seriesColor(s.id),
+      borderRadius: 4,
+    };
+  });
+  return (
+    <div className="h-[420px]">
+      <Bar
+        data={{ labels, datasets }}
+        options={{
+          responsive: true,
+          maintainAspectRatio: false,
+          animation: false,
+          plugins: {
+            legend: {
+              display: datasets.length > 1,
+              labels: { color: TEXT_SECONDARY, boxWidth: 12, boxHeight: 12, font: { size: 12 } },
+            },
+            tooltip: { ...TOOLTIP_BASE },
+          },
+          scales: {
+            x: { ticks: { color: TEXT_SECONDARY }, grid: { display: false } },
+            y: {
+              title: { display: true, text: data.axis.y, color: TEXT_SECONDARY },
+              ticks: { color: TEXT_SECONDARY },
+              grid: { color: GRID },
+              beginAtZero: true,
+            },
+          },
+        }}
+      />
+    </div>
+  );
+}
+
+function ScatterChart({ data }: { data: ChartResponse }) {
+  const datasets = data.series.map((s) => ({
+    label: s.label,
+    data: s.points.map((p) => ({ x: p.x as number, y: p.y })),
+    backgroundColor: seriesColor(s.id) + "b3",
+    pointRadius: 2.5,
+    pointHoverRadius: 4,
+  }));
+  const sampled = data.series.reduce((a, s) => a + (s.sampled_from ?? s.points.length), 0);
+  return (
+    <>
+      <div className="h-[460px]">
+        <Scatter
+          data={{ datasets }}
+          options={{
+            responsive: true,
+            maintainAspectRatio: false,
+            animation: false,
+            plugins: {
+              legend: {
+                display: datasets.length > 1,
+                labels: { color: TEXT_SECONDARY, boxWidth: 12, boxHeight: 12, font: { size: 12 } },
+              },
+              tooltip: {
+                ...TOOLTIP_BASE,
+                callbacks: {
+                  label: (item: TooltipItem<"scatter">) =>
+                    `${item.dataset.label}: ${item.parsed.x}, ${item.parsed.y}`,
+                },
+              },
+            },
+            scales: {
+              x: {
+                title: { display: true, text: data.axis.x, color: TEXT_SECONDARY },
+                ticks: { color: TEXT_SECONDARY },
+                grid: { color: GRID },
+                beginAtZero: true,
+              },
+              y: {
+                title: { display: true, text: data.axis.y, color: TEXT_SECONDARY },
+                ticks: { color: TEXT_SECONDARY },
+                grid: { color: GRID },
+                beginAtZero: true,
+              },
+            },
+          }}
+        />
+      </div>
+      <p className="text-xs text-[var(--text-muted)] mt-2">
+        Sampled from {sampled.toLocaleString()} matching runs.
+      </p>
+    </>
+  );
+}

--- a/frontend/app/charts/ChartsClient.tsx
+++ b/frontend/app/charts/ChartsClient.tsx
@@ -500,7 +500,8 @@ export default function ChartsClient() {
           <div className={filtersLocked ? "opacity-40 pointer-events-none" : ""}>
             <select className={selectCls} value={ascension} onChange={(e) => setAscension(e.target.value)} aria-label="Ascension">
               <option value="">All ascensions</option>
-              {Array.from({ length: 21 }, (_, i) => (
+              {/* A10 is the cap; the game has nothing above it. */}
+              {Array.from({ length: 11 }, (_, i) => (
                 <option key={i} value={String(i)}>
                   A{i}
                 </option>

--- a/frontend/app/charts/page.tsx
+++ b/frontend/app/charts/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE, buildLanguageAlternates } from "@/lib/seo";
+import JsonLd from "@/app/components/JsonLd";
+import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import ChartsClient from "./ChartsClient";
+
+export const metadata: Metadata = {
+  title: `Run Charts - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
+  description:
+    "Interactive charts over community-submitted Slay the Spire 2 runs: win rate by floor, ascension and over time, damage per encounter, run stat distributions and scatters. Filter by player count, ascension, game mode, or a single player.",
+  alternates: { canonical: `${SITE_URL}/charts`, languages: buildLanguageAlternates("/charts") },
+  openGraph: {
+    title: `Slay the Spire 2 (sts2) Run Charts | ${SITE_NAME}`,
+    description:
+      "Dig into aggregates of community-submitted Slay the Spire 2 runs with interactive charts.",
+    url: `${SITE_URL}/charts`,
+    siteName: SITE_NAME,
+    type: "website",
+    images: [{ url: DEFAULT_OG_IMAGE }],
+  },
+  twitter: { card: "summary_large_image", title: `Slay the Spire 2 (sts2) Run Charts | ${SITE_NAME}` },
+};
+
+export default function ChartsPage() {
+  const jsonLd = [
+    buildBreadcrumbJsonLd([
+      { name: "Home", href: "/" },
+      { name: "Charts", href: "/charts" },
+    ]),
+  ];
+  return (
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <JsonLd data={jsonLd} />
+      <h1 className="text-3xl font-bold mb-2">
+        <span className="text-[var(--accent-gold)]">Run Charts</span>
+      </h1>
+      <p className="text-sm text-[var(--text-muted)] mb-6">
+        Interactive aggregates over community-submitted runs. Pick a chart, slice by player
+        count, ascension, game mode, or a single player. Aggregation happens server-side, so
+        every view is a single small request.
+      </p>
+      <Suspense fallback={<div className="text-sm text-[var(--text-muted)]">Loading…</div>}>
+        <ChartsClient />
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -89,6 +89,7 @@ const NAV_GROUPS: NavGroup[] = [
     links: [
       { href: "/tier-list", label: "Tier List" },
       { href: "/community-stats", label: "Community Stats" },
+      { href: "/charts", label: "Charts" },
       { href: "/leaderboards", label: "Leaderboards" },
       { href: "/runs", label: "Browse Runs" },
       { href: "/leaderboards/submit", label: "Submit a Run" },

--- a/frontend/app/developers/page.tsx
+++ b/frontend/app/developers/page.tsx
@@ -253,6 +253,8 @@ export default function DevelopersPage() {
                 { method: "GET", path: "/api/runs/shared/{run_hash}", desc: "Single submitted run by hash (rate-limited)" },
                 { method: "GET", path: "/api/runs/stats", desc: "Aggregate community stats (filter by character, ascension, username)" },
                 { method: "GET", path: "/api/runs/community-stats", desc: "Fun community datasets: event decision splits, deadliest encounters, win rates by ascension/character, records" },
+                { method: "GET", path: "/api/charts/meta", desc: "Chart registry for the /charts explorer: available charts, filters, splits, and run stats" },
+                { method: "GET", path: "/api/charts/{chart}", desc: "One pre-aggregated chart (filter: players, ascension, game_mode, username, split, plus per-chart params)" },
                 { method: "GET", path: "/api/runs/scores/{type}", desc: "Codex Score + Codex Elo per entity (cards/relics/potions); relics accept ?act=1|2|3 to rank by acquisition act" },
                 { method: "GET", path: "/api/runs/metrics/{type}", desc: "Dense metrics table: Codex Score, Codex Elo, win rate, pick rate, per-act splits" },
                 { method: "GET", path: "/api/runs/versions", desc: "Distinct game build IDs that have submitted runs" },

--- a/tools/startup.sh
+++ b/tools/startup.sh
@@ -23,3 +23,12 @@ else
     docker compose -f docker-compose.prod.yml down
     docker compose -f docker-compose.prod.yml up -d
 fi
+
+# Recreated containers get new IPs on the shared docker network, but nginx
+# resolves upstream hostnames once at startup, so without a reload it keeps
+# proxying to the old addresses (beta 502'd this way on 2026-06-11). Reload is
+# zero-downtime and re-resolves every upstream. Best-effort: skip quietly when
+# the web-server container isn't on this host.
+docker exec web-server nginx -s reload 2>/dev/null \
+    && echo "nginx reloaded" \
+    || echo "nginx reload skipped (web-server not running here)"


### PR DESCRIPTION
## What

A new page under Stats, /charts, that digs into aggregates of community runs with 19 interactive charts. The reference for this category of tool ships every run to the browser and aggregates client-side, which is why it crawls; here the browser only ever receives small pre-aggregated JSON, so every view is one fast request.

## Charts

- **Win rates:** by floor reached, over time (weekly), vs any run stat, by ascension, and per daily date (the seed encodes the daily's date, so brutal dailies stand out).
- **Survival:** deaths by floor, deaths by room type, and an acts funnel (share of runs surviving each act boundary).
- **Run curves:** HP trajectory, gold curve, and deck growth per floor, winners vs losses.
- **Combat:** % max HP lost per fight floor, encounter damage ranking, slowest encounters by turns, and a per-encounter damage histogram.
- **Strategy:** elites fought vs win rate, upgrades taken vs win rate, and event choice outcomes (pick share + win rate per option for any event).
- **Cards and relics:** weekly pick rate and win rate for any card/relic/potion against the overall baseline, copies-in-deck vs win rate, and win rate by enchantment.

## Filters

Player count (solo/2P/3P/4P), exact ascension (capped at A10), game mode, and a username box that works on every chart. Frame charts can also split their series by character (global character colors), player count, wins vs losses, or ascension band, validated per chart. URLs carry the full state so views are shareable.

## How

- **Metadata charts** aggregate an in-memory frame of per-run scalars (reloaded from the store every 10 minutes, ~0.15s for 4.5k rows locally, ~1s projected at 227k) with responses cached through the Redis layer for 5 minutes.
- **Blob charts** (curves, encounter stats, event outcomes, per-entity weeklies) accumulate in the existing snapshot walk exactly like community_stats: compact cells in the snapshot meta, rolled up per request, O(1) reads. Per-user blob charts walk just that user's blobs on demand (capped at 1500).
- The frontend is Chart.js on the same theme as the community-stats page.

Also includes the deploy fix from this week's beta 502: `startup.sh` now reloads nginx after compose up so recreated containers' new IPs get re-resolved (zero-downtime, best-effort).

## Stacking

Branched off #439 (Chart.js migration), which is branched off #433. Merge order: #433, #439, then this; each then shows a clean diff.

## Testing

- Ran the whole thing locally against 4,500 real production runs (sampled via the public API into the gitignored data dir): every chart endpoint exercised, all renders verified by screenshot, per-user mode verified against a 481-run submitter, ascension cap verified (A15 request returns 422).
- ruff, eslint, and tsc clean.

Blob charts populate in prod after the first post-deploy snapshot rebuild; until then they return empty series and the page says not enough runs match.