### PR TITLE
Stats overview: Codex Elo column, dig-deeper links, honest chart building state

### DIFF
--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -407,6 +407,7 @@ def get_chart(
     if cached is not None:
         return cached
 
+    building = False
     if spec["kind"] == "frame":
         mode = "daily" if spec.get("daily") else game_mode
         rows = cs.filter_rows(cs.get_frame(), players, ascension, mode, username)
@@ -426,6 +427,11 @@ def get_chart(
             chart_key, stats, spec, players, encounter, event, etype, entity
         )
         total = sum(n for _wk, n, _w in stats.get("week_totals") or [])
+        # Blob stats land with the first snapshot rebuild after a deploy;
+        # until then the cells are missing entirely, which is different from
+        # a filter matching nothing. Surface that so the page can say so.
+        if not username and not stats.get("week_totals"):
+            building = True
 
     payload = {
         "chart": chart_key,
@@ -448,6 +454,9 @@ def get_chart(
         },
         "series": series,
         "total_runs": total,
+        "building": building,
     }
-    app_cache.set_json(cache_key, payload, _CACHE_TTL)
+    # A still-building snapshot resolves within minutes; don't pin the empty
+    # answer for the full TTL.
+    app_cache.set_json(cache_key, payload, 30 if building else _CACHE_TTL)
     return payload

--- a/frontend/app/charts/ChartsClient.tsx
+++ b/frontend/app/charts/ChartsClient.tsx
@@ -137,6 +137,7 @@ interface ChartResponse {
   desc: string;
   series: Series[];
   total_runs: number;
+  building?: boolean;
 }
 interface Meta {
   charts: ChartSpec[];
@@ -529,7 +530,9 @@ export default function ChartsClient() {
           </div>
         ) : data.series.length === 0 ? (
           <div className="h-[420px] flex items-center justify-center text-sm text-[var(--text-muted)]">
-            Not enough runs match these filters.
+            {data.building
+              ? "These stats are still building after a fresh deploy. They cover every run and land within a few minutes."
+              : "Not enough runs match these filters."}
           </div>
         ) : (
           <ExplorerChart spec={spec!} data={data} />

--- a/frontend/app/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/leaderboards/stats/StatsClient.tsx
@@ -218,7 +218,7 @@ function EntityRowPill({
 
 type TopTab = "overview" | "cards" | "relics" | "potions" | "encounters";
 
-type CardSort = "pick_rate" | "win_pct" | "count" | "name";
+type CardSort = "pick_rate" | "win_pct" | "elo" | "count" | "name";
 type RelicSort = "pick_rate" | "win_pct" | "count" | "name";
 type PotionSort = "pick_rate" | "use_rate" | "win_pct" | "count" | "name";
 type SortDir = "asc" | "desc";
@@ -261,6 +261,9 @@ export default function StatsClient() {
   const [relicData, setRelicData] = useState<Record<string, RelicInfo>>({});
   const [potionData, setPotionData] = useState<Record<string, PotionInfo>>({});
   const [betaIds, setBetaIds] = useState<Set<string>>(new Set());
+  // Codex Elo per card id, from the scores endpoint (reward-pick cards only;
+  // curses, statuses, events, tokens, and starters have none).
+  const [eloMap, setEloMap] = useState<Record<string, number | null>>({});
   const [loading, setLoading] = useState(true);
 
   // Top-level filters
@@ -325,6 +328,17 @@ export default function StatsClient() {
       const pm: Record<string, PotionInfo> = {};
       for (const p of potions) pm[p.id] = p;
       setPotionData(pm);
+
+      // Codex Elo rides along; best-effort, the column just stays empty.
+      cachedFetch<Record<string, { elo: number | null }>>(
+        `${API}/api/runs/scores/cards`
+      )
+        .then((scores) => {
+          const em: Record<string, number | null> = {};
+          for (const [id, s] of Object.entries(scores)) em[id] = s.elo;
+          setEloMap(em);
+        })
+        .catch(() => {});
 
       // Merge beta-only entities
       try {
@@ -416,10 +430,11 @@ export default function StatsClient() {
         win_runs: winRuns,
         total_runs_with: totalRunsWith,
         win_pct: winPct,
+        elo: eloMap[id] ?? null,
       };
     });
     return rows;
-  }, [stats, cardData]);
+  }, [stats, cardData, eloMap]);
 
   const cardTypes = useMemo(() => {
     const s = new Set<string>();
@@ -449,6 +464,8 @@ export default function StatsClient() {
       if (cardSort === "name") v = a.name.localeCompare(b.name);
       else if (cardSort === "pick_rate") v = a.pick_rate - b.pick_rate || a.offered - b.offered;
       else if (cardSort === "win_pct") v = a.win_pct - b.win_pct || a.win_runs - b.win_runs;
+      // Cards without an Elo (not reward picks) sink to the bottom either way.
+      else if (cardSort === "elo") v = (a.elo ?? -1e9) - (b.elo ?? -1e9);
       else if (cardSort === "count") v = a.count - b.count;
       return mul * v;
     });
@@ -577,7 +594,7 @@ export default function StatsClient() {
       <h1 className="text-3xl font-bold mb-2">
         <span className="text-[var(--accent-gold)]">{t("Stats", lang)}</span>
       </h1>
-      <p className="text-[var(--text-secondary)] mb-5">
+      <p className="text-[var(--text-secondary)] mb-3">
         {stats?.total_runs || 0} runs analyzed.{" "}
         <Link
           href={`${lp}/leaderboards/submit`}
@@ -587,6 +604,26 @@ export default function StatsClient() {
         </Link>{" "}
         to contribute.
       </p>
+
+      {/* Jumping-off points to the deeper views built on the same run data. */}
+      <div className="flex flex-wrap items-center gap-1.5 mb-6 text-xs">
+        <span className="text-[var(--text-muted)] mr-1">Dig deeper:</span>
+        {[
+          { href: "/charts", label: "Run Charts" },
+          { href: "/community-stats", label: "Community Stats" },
+          { href: "/leaderboards/metrics", label: "Card Metrics" },
+          { href: "/tier-list", label: "Tier List" },
+          { href: "/leaderboards/scoring", label: "How scoring works" },
+        ].map((l) => (
+          <Link
+            key={l.href}
+            href={l.href}
+            className="px-3 py-1.5 rounded-md border bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)] hover:text-[var(--text-primary)] transition-colors"
+          >
+            {l.label}
+          </Link>
+        ))}
+      </div>
 
       {/* Player-mode toggle, visually identical to LeaderboardBrowseClient's
           mode pills (same wrapper, padding, colors) so the two pages
@@ -900,6 +937,7 @@ interface CardRow {
   win_runs: number;
   total_runs_with: number;
   win_pct: number;
+  elo: number | null;
 }
 
 function CardsTab({
@@ -1057,6 +1095,9 @@ function CardTable({
             <SortHeader column="win_pct" current={cardSort} dir={cardDir} onClick={onCardHeader}>
               Win Rate
             </SortHeader>
+            <SortHeader column="elo" current={cardSort} dir={cardDir} onClick={onCardHeader}>
+              Codex Elo
+            </SortHeader>
             <SortHeader column="count" current={cardSort} dir={cardDir} onClick={onCardHeader}>
               Count
             </SortHeader>
@@ -1098,6 +1139,13 @@ function CardTable({
                     <span className="text-[var(--text-muted)]">—</span>
                   )}
                 </div>
+              </td>
+              <td className="py-2 text-right tabular-nums">
+                {r.elo != null ? (
+                  <span className="text-[var(--accent-gold)]">{Math.round(r.elo)}</span>
+                ) : (
+                  <span className="text-[var(--text-muted)]">—</span>
+                )}
               </td>
               <td className="py-2 text-right text-[var(--text-secondary)] tabular-nums">
                 {r.total_runs_with || r.count || "—"}


### PR DESCRIPTION
## What

Three things on the stats surfaces:

- **Codex Elo on /leaderboards/stats**: the Cards tab gets a sortable Codex Elo column, fed by the existing `/api/runs/scores/cards` endpoint. Only reward-pick cards carry an Elo, so curses, statuses, events, and tokens show a blank instead of a fake number.
- **Dig-deeper links**: a strip under the page header linking to the in-depth views built on the same run data: Run Charts, Community Stats, Card Metrics, Tier List, and the scoring methodology.
- **Honest blob-chart empty state on /charts**: after a deploy the combat/curve/entity charts are empty until the first snapshot rebuild lands, and the page showed the same message as a filter matching nothing. The API now flags that state, the page says the stats are minutes away, and the empty answer caches for 30 seconds instead of the full five minutes.

## Why the charts looked empty after the deploy

The blob-derived charts read cells from the stats snapshot, which rebuilds on the leader's cadence after a deploy (a 230k-run walk takes a few minutes), then each worker picks the new snapshot up on its 5-minute reload, and Redis holds each chart response for 5 minutes on top. I verified every blob chart against prod after the window passed: HP/gold/deck curves, encounter damage and turns, elites and smiths vs win rate, deaths by room, enchant win rates, and all 56 events in the outcome selector are live over the full 230k runs. The third change above turns that window from "looks broken" into a one-line explanation.

## Testing

- Scores endpoint verified on prod: 525 cards carry an Elo.
- ruff, tsc, and eslint clean; backend imports verified.
- Prod blob charts spot-checked after the rebuild window: all populated.

The Elo column sorts with blanks sinking to the bottom in either direction.