### PR TITLE
Hold the refresher lease for the whole cycle

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -905,67 +905,87 @@ def start_stats_refresher() -> None:
         # imports below raise; we catch and back off).
         while True:
             try:
-                from ..services.runs_db_mongo import (
-                    refresh_leaderboard_summary,
-                    refresh_stats_summary,
-                    try_acquire_refresh_lease,
-                )
-                from ..services.run_entity_stats import (
-                    refresh_entity_stats_snapshot,
-                )
+                from ..services.runs_db_mongo import try_acquire_refresh_lease
 
                 if try_acquire_refresh_lease():
+                    # The lease lasts 90s but the snapshot walk inside this
+                    # cycle can take 10+ minutes. Without renewal mid-cycle,
+                    # leadership rotates while the holder is still walking and
+                    # every worker ends up rebuilding concurrently (the
+                    # June 11 forty-minute stampede). Heartbeat keeps the
+                    # lease ours for as long as the cycle actually runs.
+                    hb_stop = threading.Event()
+
+                    def _heartbeat() -> None:
+                        while not hb_stop.wait(30):
+                            try:
+                                try_acquire_refresh_lease()
+                            except Exception:
+                                pass
+
+                    hb = threading.Thread(
+                        target=_heartbeat, daemon=True, name="lease-heartbeat"
+                    )
+                    hb.start()
                     try:
-                        refresh_stats_summary()
-                    except Exception:
-                        logger.warning("stats summary refresh failed", exc_info=True)
-                    # Pre-compute the default (category, character) ladder
-                    # views into leaderboard_summary. Reads for the common
-                    # combos become O(1) find_one instead of a 500ms
-                    # count+sort. Cheap (~600ms total) and idempotent.
-                    try:
-                        refresh_leaderboard_summary()
-                    except Exception:
-                        logger.warning(
-                            "leaderboard summary refresh failed", exc_info=True
-                        )
-                    # Rebuild the shared entity-stats snapshot (tier-list
-                    # / Codex Score source) on the same leader-only loop.
-                    # Internally throttled, so this is a no-op find_one
-                    # most cycles and only walks the run files every
-                    # ~10 min on one worker.
-                    try:
-                        refresh_entity_stats_snapshot()
-                    except Exception:
-                        logger.warning(
-                            "entity-stats snapshot refresh failed", exc_info=True
-                        )
-                    # Proactive warm of the entity-scores cache (in-memory
-                    # reads, cheap every cycle) so tier pages serve straight
-                    # from Redis cluster-wide instead of recomputing per
-                    # worker. Includes the per-act relic views.
-                    try:
-                        if app_cache.enabled():
-                            for etype in ("cards", "relics", "potions"):
-                                app_cache.set_json(
-                                    app_cache.entity_scores_key(etype),
-                                    get_all_entity_scores(etype),
-                                    ttl_seconds=app_cache.WARM_TTL_SECONDS,
-                                )
-                            for warm_act in (1, 2, 3):
-                                app_cache.set_json(
-                                    app_cache.entity_scores_key("relics", act=warm_act),
-                                    get_all_entity_scores("relics", act=warm_act),
-                                    ttl_seconds=app_cache.WARM_TTL_SECONDS,
-                                )
-                    except Exception:
-                        pass
+                        _run_refresh_cycle()
+                    finally:
+                        hb_stop.set()
             except Exception:
                 # Expected on the SQLite path (no Mongo to refresh); a real
                 # Mongo deployment failing here must be visible, not silent.
                 if os.environ.get("MONGO_URL", "").strip():
                     logger.warning("stats refresher cycle failed", exc_info=True)
             time.sleep(_REFRESHER_INTERVAL_SECONDS)
+
+    def _run_refresh_cycle() -> None:
+        from ..services.runs_db_mongo import (
+            refresh_leaderboard_summary,
+            refresh_stats_summary,
+        )
+        from ..services.run_entity_stats import refresh_entity_stats_snapshot
+
+        try:
+            refresh_stats_summary()
+        except Exception:
+            logger.warning("stats summary refresh failed", exc_info=True)
+        # Pre-compute the default (category, character) ladder
+        # views into leaderboard_summary. Reads for the common
+        # combos become O(1) find_one instead of a 500ms
+        # count+sort. Cheap (~600ms total) and idempotent.
+        try:
+            refresh_leaderboard_summary()
+        except Exception:
+            logger.warning("leaderboard summary refresh failed", exc_info=True)
+        # Rebuild the shared entity-stats snapshot (tier-list
+        # / Codex Score source) on the same leader-only loop.
+        # Internally throttled, so this is a no-op find_one
+        # most cycles and only walks the run files every
+        # ~10 min on one worker.
+        try:
+            refresh_entity_stats_snapshot()
+        except Exception:
+            logger.warning("entity-stats snapshot refresh failed", exc_info=True)
+        # Proactive warm of the entity-scores cache (in-memory
+        # reads, cheap every cycle) so tier pages serve straight
+        # from Redis cluster-wide instead of recomputing per
+        # worker. Includes the per-act relic views.
+        try:
+            if app_cache.enabled():
+                for etype in ("cards", "relics", "potions"):
+                    app_cache.set_json(
+                        app_cache.entity_scores_key(etype),
+                        get_all_entity_scores(etype),
+                        ttl_seconds=app_cache.WARM_TTL_SECONDS,
+                    )
+                for warm_act in (1, 2, 3):
+                    app_cache.set_json(
+                        app_cache.entity_scores_key("relics", act=warm_act),
+                        get_all_entity_scores("relics", act=warm_act),
+                        ttl_seconds=app_cache.WARM_TTL_SECONDS,
+                    )
+        except Exception:
+            logger.warning("entity-scores cache warm failed", exc_info=True)
 
     threading.Thread(target=_loop, daemon=True, name="stats-refresher").start()
 


### PR DESCRIPTION
## What

Follow-up to #445 (this commit raced that merge and never landed). The leader lease lasts 90 seconds; the snapshot walk inside a cycle takes 10+ minutes. Leadership rotated mid-rebuild, so all four workers ended up walking 231k run files concurrently on 4 vCPUs - that's how a 10-minute rebuild became tonight's 40-plus-minute outage tail.

A heartbeat thread now re-acquires the lease every 30 seconds for as long as the cycle body runs, so leadership can't rotate away from a working leader. Dead-leader failover is unchanged: the heartbeat dies with the process and the lease expires in 90 seconds as before. The cycle body moves into `_run_refresh_cycle()` and the cache-warm step now logs failures too.

## Testing

ruff clean; app and refresher import clean. Cycle body is behaviorally identical to what #445 shipped, just hoisted with the heartbeat around it.