### PR TITLE
Pick up beta content in the tier list maker

### DIFF
--- a/frontend/app/tier-list-maker/api.ts
+++ b/frontend/app/tier-list-maker/api.ts
@@ -81,30 +81,69 @@ export async function fetchEntities(type: EntityType): Promise<TierEntity[]> {
   ]);
   if (!res.ok) throw new Error(`Failed to load ${type}`);
   const raw: RawEntity[] = await res.json();
-  return raw
-    .slice()
+
+  const toEntity = (e: RawEntity, beta = false): TierEntity => ({
+    id: e.id,
+    name: e.name,
+    // Characters default to the char-select portrait; the tier list reads
+    // better with the compact round character icon instead.
+    image:
+      type === "characters"
+        ? imageUrl(`/static/images/characters/character_icon_${e.id.toLowerCase()}.webp`)
+        : type === "cards"
+          ? fullCardUrl(e.id.toLowerCase(), false, beta ? "beta" : "stable")
+          : imageUrl(e.image_url),
+    group:
+      type === "relics"
+        ? ancientMap[e.id.toUpperCase()] ?? e.pool ?? undefined
+        : type === "monsters"
+          ? monsterActGroup(e.encounters)
+          : e.color ?? undefined,
+    // "None" is the API's placeholder for the odd un-raritied entry; treat
+    // it as no rarity so it doesn't pollute the rarity dropdown.
+    rarity: e.rarity_key && e.rarity_key !== "None" ? e.rarity_key : undefined,
+    ...(beta && { beta: true }),
+  });
+
+  // Beta-only entities join the pool so tier lists can rank unreleased
+  // content; their chips carry a Beta marker. Best effort: a failed diff
+  // or entity fetch just means no additions.
+  const betaRaw = await fetchBetaAdditions(type);
+  const mainIds = new Set(raw.map((e) => e.id));
+
+  return [
+    ...raw,
+    ...betaRaw.filter((e) => !mainIds.has(e.id)),
+  ]
     .sort((a, b) => (a.compendium_order ?? 0) - (b.compendium_order ?? 0))
-    .map((e) => ({
-      id: e.id,
-      name: e.name,
-      // Characters default to the char-select portrait; the tier list reads
-      // better with the compact round character icon instead.
-      image:
-        type === "characters"
-          ? imageUrl(`/static/images/characters/character_icon_${e.id.toLowerCase()}.webp`)
-          : type === "cards"
-            ? fullCardUrl(e.id.toLowerCase())
-            : imageUrl(e.image_url),
-      group:
-        type === "relics"
-          ? ancientMap[e.id.toUpperCase()] ?? e.pool ?? undefined
-          : type === "monsters"
-            ? monsterActGroup(e.encounters)
-            : e.color ?? undefined,
-      // "None" is the API's placeholder for the odd un-raritied entry; treat
-      // it as no rarity so it doesn't pollute the rarity dropdown.
-      rarity: e.rarity_key && e.rarity_key !== "None" ? e.rarity_key : undefined,
-    }));
+    .map((e) => toEntity(e, !mainIds.has(e.id)));
+}
+
+/** The current beta's added entities for a type, fetched from the beta
+ * channel. Types the diff doesn't track (ancients, characters, badges,
+ * intents) come back empty. */
+async function fetchBetaAdditions(type: EntityType): Promise<RawEntity[]> {
+  try {
+    const res = await fetch(`${API}/api/beta/diff`);
+    if (!res.ok) return [];
+    const diff: { beta_version: string | null; types: Record<string, { added: string[] }> } =
+      await res.json();
+    const added = diff.beta_version ? (diff.types?.[type]?.added ?? []) : [];
+    if (added.length === 0) return [];
+    const fetched = await Promise.all(
+      added.map(async (id) => {
+        try {
+          const r = await fetch(`${API}/api/${type}/${id.toLowerCase()}?lang=eng&channel=beta`);
+          return r.ok ? ((await r.json()) as RawEntity) : null;
+        } catch {
+          return null;
+        }
+      }),
+    );
+    return fetched.filter((e): e is RawEntity => e !== null);
+  } catch {
+    return [];
+  }
 }
 
 function authHeaders(): Record<string, string> {

--- a/frontend/app/tier-list-maker/chip.tsx
+++ b/frontend/app/tier-list-maker/chip.tsx
@@ -63,6 +63,14 @@ export function Chip({
             className="absolute right-0.5 top-0.5 h-2.5 w-2.5 rounded-full bg-sky-400 ring-1 ring-black/60"
           />
         )}
+        {entity.beta && (
+          <span
+            aria-label="Beta-only"
+            className="absolute left-0.5 top-0.5 rounded bg-emerald-500/90 px-1 text-[8px] font-bold leading-tight text-black ring-1 ring-black/60"
+          >
+            β
+          </span>
+        )}
       </div>
 
       {commentText && !dragging && (

--- a/frontend/app/tier-list-maker/types.ts
+++ b/frontend/app/tier-list-maker/types.ts
@@ -61,6 +61,9 @@ export interface TierEntity {
   /** Rarity key (Common, Uncommon, Rare, Shop, Event, Ancient, …) for the
    * tray's secondary rarity filter. Set wherever the API exposes one. */
   rarity?: string;
+  /** Beta-only entity (in the current beta but not main); shown with a
+   * Beta marker on its chip. */
+  beta?: boolean;
 }
 
 /** Canonical rarity ordering for the tray's rarity dropdown. Anything not


### PR DESCRIPTION
## What

The tier list maker's entity pool only loaded the main catalog, so beta-only content (Wither, Scare, the new relics, Aeonglass) couldn't be ranked. Follow-up to #448.

- fetchEntities appends the current beta's added entities for the chosen type, fetched with `?channel=beta`, slotted into compendium order alongside everything else.
- Their chips carry a small emerald beta marker so lists stay readable.
- Beta cards resolve their full renders from the beta CDN path (cards-full/beta/<version>/).
- Types the diff doesn't track (ancients, characters, badges, intents) are unaffected, and a failed diff fetch degrades to the main pool.
- Saved and shared lists resolve beta ids through the same path, so a shared list with a beta card renders for everyone.

## Testing

tsc and eslint clean. Verified in headless Chrome: the relics tray renders Fishing Rod, Kaleidoscope, and Silken Tress with the beta marker; the cards pool fetches Wither and Scare from the beta channel (they sit in their character groups in the tray).