### PR TITLE
Keep stats serving through deploys and snapshot version bumps

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -17,6 +17,8 @@ from ..services.run_entity_stats import (
     get_entity_metrics_table,
     get_entity_stats,
     get_top_entities_for_character,
+    snapshot_loaded,
+    snapshot_status,
 )
 from ..metrics import (
     run_submissions,
@@ -884,8 +886,22 @@ def get_entity_scores(
     if cached is not None:
         return cached
     result = get_all_entity_scores(entity_type, character=char, act=act)
-    app_cache.set_json(cache_key, result, ttl_seconds=5 * 60)
+    # While the snapshot is rebuilding (post-deploy), the result is an empty
+    # shell; caching it would extend the gap past the rebuild for everyone.
+    if snapshot_loaded():
+        app_cache.set_json(cache_key, result, ttl_seconds=5 * 60)
     return result
+
+
+@router.get("/snapshot-status", tags=["Runs"])
+@limiter.limit("120/minute")
+def runs_snapshot_status(request: Request, response: Response):
+    """Whether the stats snapshot is loaded, rebuilding after a deploy, or
+    serving a previous version while the current one builds. Lets the UI
+    show "stats are rebuilding" instead of rendering empty charts as if the
+    data were gone."""
+    response.headers["Cache-Control"] = "no-store"
+    return snapshot_status()
 
 
 @router.get("/community-stats", tags=["Runs"])
@@ -896,7 +912,11 @@ def community_stats(request: Request, response: Response):
     ascension and character, and a few records and quirks. Official game
     content only (modded entities are filtered out). Built in the same walk
     as the Codex Score cache, so this is an in-memory read."""
-    response.headers["Cache-Control"] = "public, max-age=300"
+    # An empty shell during a post-deploy rebuild must not stick in the
+    # edge cache for 5 minutes on top of the rebuild itself.
+    response.headers["Cache-Control"] = (
+        "public, max-age=300" if snapshot_loaded() else "no-store"
+    )
     return get_community_fun_stats()
 
 
@@ -924,8 +944,12 @@ def get_entity_metrics(
             detail=f"entity_type must be one of {sorted(_ENTITY_STATS_TYPES)}",
         )
     # Snapshot refreshes at most every 10 min; let edges/clients cache it.
+    # Except while a post-deploy rebuild runs: an empty table cached at the
+    # edge would outlive the rebuild.
     response.headers["Cache-Control"] = (
         "public, max-age=300, stale-while-revalidate=600"
+        if snapshot_loaded()
+        else "no-store"
     )
     return get_entity_metrics_table(entity_type, cohort)
 
@@ -1049,7 +1073,9 @@ def start_stats_refresher() -> None:
         # from Redis cluster-wide instead of recomputing per
         # worker. Includes the per-act relic views.
         try:
-            if app_cache.enabled():
+            # Never warm Redis from an unloaded cache: that would push
+            # empty score maps cluster-wide with the warm TTL.
+            if app_cache.enabled() and snapshot_loaded():
                 for etype in ("cards", "relics", "potions"):
                     app_cache.set_json(
                         app_cache.entity_scores_key(etype),

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -140,6 +140,13 @@ SNAPSHOT_COLLECTION_NAME = "entity_stats_snapshot"
 # Version 4 = community map_danger (per act/node-type damage + death rates),
 # rest-site win/HP-band stats, and ancient offer take rates for the mod.
 SNAPSHOT_VERSION = 4
+# The oldest snapshot version readers can still serve. Bump SNAPSHOT_VERSION
+# on every shape change; bump this floor ONLY when a change actually breaks
+# readers (a removed/retyped field). Everything in between is additive, and
+# serving a slightly-stale snapshot for the ~15 minutes a version-bump
+# rebuild takes beats serving nothing: to users an empty stats page is
+# indistinguishable from the site losing its data.
+SNAPSHOT_MIN_COMPAT = 3
 # Leader rebuilds the heavy walk at most this often.
 _SNAPSHOT_REBUILD_SECONDS = 10 * 60
 # Workers reload the snapshot from Mongo this often (cheap read).
@@ -171,6 +178,10 @@ _community_stats: dict[str, Any] = {}
 _charts_blob_stats: dict[str, Any] = {}
 _cache_built_at: float = 0.0
 _building: bool = False
+# The snapshot_version of whatever is currently loaded (None = nothing
+# loaded yet). Differs from SNAPSHOT_VERSION while serving a compatible
+# older snapshot during a post-deploy rebuild.
+_cache_snapshot_version: int | None = None
 
 
 def _strip_prefix(raw: str) -> tuple[str, str] | None:
@@ -983,8 +994,10 @@ def _build_cache() -> None:
 
     Only used when the Mongo snapshot is unavailable (SQLite path, or a
     cold start before the leader has written the first snapshot)."""
+    global _cache_snapshot_version
     cache, totals, baselines, cohort_meta = _build_cache_data()
     _apply_cache(cache, totals, baselines, cohort_meta)
+    _cache_snapshot_version = SNAPSHOT_VERSION
     logger.info(
         "run-entity-stats cache rebuilt (local): %d entities across %d runs",
         len(cache),
@@ -1008,6 +1021,18 @@ def _persist_snapshot(
     meta doc. Entities are stored as arrays (not dicts) so entity IDs
     never collide with Mongo field-name restrictions."""
     coll = _snapshot_coll()
+    # Never overwrite a snapshot written by NEWER code (a deploy-time
+    # prewarm, or the new containers mid rolling deploy). Without this, the
+    # outgoing leader's final rebuild can clobber the new version's snapshot
+    # and force a second full walk.
+    existing = coll.find_one({"_id": "__meta__"}, {"snapshot_version": 1})
+    if existing and (existing.get("snapshot_version") or 0) > SNAPSHOT_VERSION:
+        logger.warning(
+            "not overwriting entity-stats snapshot version %s with older version %s",
+            existing.get("snapshot_version"),
+            SNAPSHOT_VERSION,
+        )
+        return
     by_type: dict[str, list] = {}
     for (etype, eid), agg in cache.items():
         entry = {
@@ -1070,20 +1095,34 @@ def _persist_snapshot(
 def _load_snapshot() -> bool:
     """Load the shared snapshot from Mongo into module globals. Returns
     False if no snapshot exists yet (caller falls back to local build)."""
+    global _cache_snapshot_version
     coll = _snapshot_coll()
     meta = coll.find_one({"_id": "__meta__"})
     if not meta:
         return False
-    if meta.get("snapshot_version") != SNAPSHOT_VERSION:
-        # Written by a different code version (e.g. a stale container sharing
-        # the Mongo). Keep whatever this worker already serves rather than
-        # regressing to a snapshot missing fields the readers depend on.
+    meta_version = meta.get("snapshot_version") or 0
+    if meta_version < SNAPSHOT_MIN_COMPAT:
+        # Too old to read safely (a truly breaking shape change). Keep
+        # whatever this worker already serves rather than regressing to a
+        # snapshot missing fields the readers depend on.
         logger.warning(
-            "ignoring entity-stats snapshot with version %s (want %s)",
-            meta.get("snapshot_version"),
-            SNAPSHOT_VERSION,
+            "ignoring entity-stats snapshot with version %s (min compatible %s)",
+            meta_version,
+            SNAPSHOT_MIN_COMPAT,
         )
         return False
+    if meta_version != SNAPSHOT_VERSION:
+        # Compatible but not current: written by a different code version
+        # (a pre-bump snapshot right after a deploy, or a newer writer mid
+        # rolling deploy). Serve it anyway - the loader and readers default
+        # every version-specific field - and let the leader rebuild the
+        # current version over it. Stats stay populated instead of every
+        # surface going empty for the length of the rebuild.
+        logger.info(
+            "serving entity-stats snapshot version %s while %s rebuilds",
+            meta_version,
+            SNAPSHOT_VERSION,
+        )
     new_cache: dict[tuple[str, str], dict[str, Any]] = {}
     for etype in meta.get("entity_types", []):
         doc = coll.find_one({"_id": etype})
@@ -1128,6 +1167,7 @@ def _load_snapshot() -> bool:
             "charts": meta.get("charts", {}),
         },
     )
+    _cache_snapshot_version = meta_version
     return True
 
 
@@ -1154,15 +1194,43 @@ def refresh_entity_stats_snapshot() -> int:
         ):
             return 0  # snapshot still fresh
 
+    global _cache_snapshot_version
     cache, totals, baselines, cohort_meta = _build_cache_data()
     _persist_snapshot(cache, totals, baselines, cohort_meta)
     _apply_cache(cache, totals, baselines, cohort_meta)
+    _cache_snapshot_version = SNAPSHOT_VERSION
     logger.info(
         "entity-stats snapshot rebuilt: %d entities across %d runs",
         len(cache),
         totals["total_runs"],
     )
     return len(cache)
+
+
+def snapshot_loaded() -> bool:
+    """True once any compatible snapshot (or local build) is in memory.
+    While False, snapshot-backed endpoints serve empty shells; callers use
+    this to keep those empties out of Redis and edge caches."""
+    return bool(_cache)
+
+
+def snapshot_status() -> dict[str, Any]:
+    """Cheap in-memory status so the UI can tell "no data" apart from
+    "warming up after a deploy". No Mongo round-trip: this gets hit by
+    every stats page while a rebuild runs."""
+    return {
+        # Nothing loaded yet: a rebuild or first snapshot load is pending,
+        # and snapshot-backed endpoints are serving empty in the meantime.
+        "building": not _cache,
+        # Serving an older-but-compatible snapshot while the current
+        # version rebuilds (post-deploy window).
+        "stale_version": bool(_cache)
+        and _cache_snapshot_version not in (None, SNAPSHOT_VERSION),
+        "version": _cache_snapshot_version,
+        "want_version": SNAPSHOT_VERSION,
+        "built_at": _cache_built_at or None,
+        "total_runs": (_global_totals or {}).get("total_runs", 0),
+    }
 
 
 def _maybe_rebuild() -> None:

--- a/frontend/app/components/StatsRebuildingNotice.tsx
+++ b/frontend/app/components/StatsRebuildingNotice.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+// Shown on snapshot-backed stats surfaces while the backend rebuilds its
+// stats snapshot (right after a deploy or a snapshot version bump). The
+// pages would otherwise render empty tables and charts, which reads as
+// "the site lost all its data". Polls /api/runs/snapshot-status once a
+// minute and removes itself when the snapshot lands.
+
+import { useEffect, useState } from "react";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+export default function StatsRebuildingNotice() {
+  const [building, setBuilding] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    const check = () =>
+      fetch(`${API}/api/runs/snapshot-status`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((s) => {
+          if (active && s) setBuilding(Boolean(s.building));
+        })
+        .catch(() => {});
+    check();
+    const timer = setInterval(check, 60_000);
+    return () => {
+      active = false;
+      clearInterval(timer);
+    };
+  }, []);
+
+  if (!building) return null;
+  return (
+    <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-2.5 mb-4 text-sm text-[var(--text-secondary)]">
+      <span className="font-semibold text-amber-300 mr-2">Heads up</span>
+      Stats are rebuilding after an update. Charts, metrics, and scores
+      usually fill back in within 15 minutes; no data is lost.
+    </div>
+  );
+}

--- a/frontend/app/leaderboards/metrics/MetricsClient.tsx
+++ b/frontend/app/leaderboards/metrics/MetricsClient.tsx
@@ -7,6 +7,7 @@ import { fullCardUrl, imageUrl } from "@/lib/image-url";
 import { colorTextClass } from "@/lib/character-colors";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { useLanguage } from "@/app/contexts/LanguageContext";
+import StatsRebuildingNotice from "@/app/components/StatsRebuildingNotice";
 
 export interface MetricRow {
   id: string;
@@ -192,6 +193,7 @@ export default function MetricsClient({
 
   return (
     <div className="mx-auto max-w-[1400px] px-3 sm:px-5 py-6">
+      <StatsRebuildingNotice />
       <header className="mb-5">
         <h1 className="text-2xl sm:text-3xl font-bold text-[var(--text-primary)]">
           Card Metrics

--- a/frontend/app/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/leaderboards/stats/StatsClient.tsx
@@ -9,6 +9,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import RichDescription from "@/app/components/RichDescription";
 import { fullCardUrl } from "@/lib/image-url";
 import { characterHex } from "@/lib/character-colors";
+import StatsRebuildingNotice from "@/app/components/StatsRebuildingNotice";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -577,6 +578,7 @@ export default function StatsClient() {
 
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <StatsRebuildingNotice />
       <h1 className="text-3xl font-bold mb-2">
         <span className="text-[var(--accent-gold)]">{t("Stats", lang)}</span>
       </h1>

--- a/frontend/app/meta/MetaClient.tsx
+++ b/frontend/app/meta/MetaClient.tsx
@@ -10,6 +10,7 @@ import {
   PieChart, Pie, Cell, Legend,
 } from "recharts";
 import { characterHex } from "@/lib/character-colors";
+import StatsRebuildingNotice from "@/app/components/StatsRebuildingNotice";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -284,6 +285,7 @@ export default function MetaClient() {
 
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <StatsRebuildingNotice />
       <h1 className="text-3xl font-bold text-[var(--text-primary)] mb-2">Community Meta</h1>
       <p className="text-[var(--text-secondary)] mb-4">
         Aggregated stats from {stats?.total_runs || 0} submitted runs.{" "}

--- a/infrastructure/ansible/files/autodeploy.sh
+++ b/infrastructure/ansible/files/autodeploy.sh
@@ -72,6 +72,28 @@ if [ "$RECREATE" = "1" ]; then
   # second pass over docker-compose.beta.yml is gone.
   log "  deploying $COMPOSE_FILE"
   docker compose -f "$COMPOSE_FILE" pull backend frontend >> "$LOG" 2>&1
+
+  # Pre-warm the stats snapshot with the NEW image before swapping
+  # containers. If the new code bumped SNAPSHOT_VERSION, this runs the
+  # full walk while the old containers keep serving the old snapshot, so
+  # the new workers boot with their snapshot already in Mongo and the
+  # stats surfaces never go empty during a deploy. When the version did
+  # not change, refresh_entity_stats_snapshot() sees a fresh same-version
+  # snapshot and returns immediately, so routine deploys pay one cheap
+  # find_one. Failures are non-fatal: serve-stale on the new code covers
+  # the gap.
+  RUNNING_IMG=$(docker inspect --format '{{.Image}}' spire-codex-backend 2>/dev/null || true)
+  PULLED_IMG=$(docker image inspect --format '{{.Id}}' ptrlrd/spire-codex-backend:latest 2>/dev/null || true)
+  if [ -n "$PULLED_IMG" ] && [ "$RUNNING_IMG" != "$PULLED_IMG" ]; then
+    log "  backend image changed; pre-warming stats snapshot with the new code"
+    if timeout 30m docker compose -f "$COMPOSE_FILE" run --rm --no-deps --entrypoint python backend -c \
+        "from app.services.run_entity_stats import refresh_entity_stats_snapshot as r; print('prewarm entities:', r())" >> "$LOG" 2>&1; then
+      log "  ✓ snapshot prewarm done"
+    else
+      log "  ⚠ snapshot prewarm failed or timed out; continuing (serve-stale covers the gap)"
+    fi
+  fi
+
   docker compose -f "$COMPOSE_FILE" up -d --force-recreate backend frontend >> "$LOG" 2>&1
 
   # Settle. 5s is enough for FastAPI startup; longer waits don't help.

--- a/tools/startup.sh
+++ b/tools/startup.sh
@@ -1,28 +1,25 @@
 #!/bin/bash
+# Manual deploy entrypoint. When the autodeploy script is installed (via
+# infrastructure/ansible/playbooks/install-autodeploy.yml) this defers to
+# it, because that path also has the news/data-beta hot-reload short
+# circuit, the stats snapshot prewarm, a post-deploy health check, and the
+# Cloudflare cache purge. The fallback below is the bare-minimum safe
+# sequence for a box where the cron isn't installed yet.
 set -e
+
+if [ -x /usr/local/bin/spire-codex-autodeploy ]; then
+    echo "delegating to spire-codex-autodeploy"
+    exec sudo /usr/local/bin/spire-codex-autodeploy
+fi
 
 git pull
 
-if [ "$1" = "--beta" ]; then
-    # Start both prod and beta
-    docker compose -f docker-compose.prod.yml pull
-    docker compose -f docker-compose.prod.yml down
-    docker compose -f docker-compose.prod.yml up -d
-
-    docker compose -f docker-compose.beta.yml pull
-    docker compose -f docker-compose.beta.yml down
-    docker compose -f docker-compose.beta.yml up -d
-elif [ "$1" = "--beta-only" ]; then
-    # Start only beta
-    docker compose -f docker-compose.beta.yml pull
-    docker compose -f docker-compose.beta.yml down
-    docker compose -f docker-compose.beta.yml up -d
-else
-    # Start only prod (default)
-    docker compose -f docker-compose.prod.yml pull
-    docker compose -f docker-compose.prod.yml down
-    docker compose -f docker-compose.prod.yml up -d
-fi
+# pull + force-recreate, never `down && up`: down removes every container
+# including Redis, which wipes the response cache and serves a hard 502
+# window while nothing is running. force-recreate swaps backend and
+# frontend in place and leaves Redis (and its cache) untouched.
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d --force-recreate backend frontend
 
 # Recreated containers get new IPs on the shared docker network, but nginx
 # resolves upstream hostnames once at startup, so without a reload it keeps


### PR DESCRIPTION
## What

Tonight's deploy bumped SNAPSHOT_VERSION (3 to 4) and every snapshot-backed surface (charts, metrics, scores, community stats) served empty for the length of the ~15 minute rebuild. To users that is indistinguishable from the site losing its data. This hardens the whole path, plus the deploy tooling that made the incident worse.

### Serve-stale (availability through version bumps)
- New `SNAPSHOT_MIN_COMPAT` floor: readers load any snapshot at or above it instead of refusing everything but the current version. After a bump, workers serve the previous snapshot (flagged stale) while the leader rebuilds the new one over it. Bump `SNAPSHOT_VERSION` on every shape change as before; move the floor only for a truly breaking change.
- `_persist_snapshot` refuses to overwrite a snapshot written by NEWER code, so an outgoing leader's final rebuild can't clobber a prewarmed or rolling-deploy snapshot.

### Never cache emptiness (Redis + edge poisoning)
While the snapshot isn't loaded:
- the scores endpoint skips its Redis write (it was caching `{}` for 5 minutes)
- the refresher skips its cluster-wide Redis warm
- community-stats and metrics respond `no-store` instead of `public, max-age=300`, keeping empty shells out of the Cloudflare edge where they used to outlive the rebuild

### Honest degraded state
- `GET /api/runs/snapshot-status`: `building` / `stale_version` / versions, served from memory (no Mongo round-trip)
- The metrics, community stats, and meta pages show "Stats are rebuilding after an update... no data is lost" instead of empty tables. /charts already had its own building notice.

### Deploy tooling
- autodeploy prewarms the stats snapshot with the NEW image before swapping containers whenever the backend image changed: old containers keep serving while the new code's snapshot builds, so even a version-bump deploy boots warm. Same-version deploys pay one cheap find_one.
- autodeploy now reloads nginx after recreating containers. Recreated containers get new IPs and nginx resolves upstream names once at startup; skipping the reload 502'd the whole site twice in two days.
- autodeploy takes `--force`: the full sequence even when HEAD didn't move (manual release after a merge, re-pulled image on the same commit).
- startup.sh stops doing `down && up` (which removed Redis and its cache and served a hard 502 window every deploy) and becomes a thin entrypoint: plain runs defer to autodeploy, `./tools/startup.sh release` forces a full deploy via `--force`. The fallback for a box without autodeploy installed is the same safe pull + in-place recreate + nginx reload.

## Testing

ruff (check + format), tsc, and bash -n clean. Loader/status/persist behavior verified against a fake Mongo collection:
- v3 snapshot loads under min-compat 3 and serves, status flags `stale_version` with version 3 / want 4
- v2 snapshot rejected; status shows `building`
- persist refuses to overwrite a v5 snapshot from v4 code; still replaces same/older versions

End-to-end in a browser: with an empty local cache, `/api/runs/snapshot-status` reports `building: true` and /leaderboards/metrics renders the rebuilding notice instead of an empty table.

The incident itself is already resolved (manual rebuild wrote the v4 snapshot; prod serves 241k runs again). This PR is the prevention. After merging: re-run install-autodeploy.yml so the box picks up the new script.
