### PR TITLE
Let beta entities through the community stats modded filter

### DIFF
--- a/backend/app/services/community_stats.py
+++ b/backend/app/services/community_stats.py
@@ -271,10 +271,34 @@ def _name_maps() -> dict[str, dict[str, str]]:
             logger.warning("community-stats name load failed", exc_info=True)
             return {}
 
-    out["events"] = _index(data_service.load_events)
-    out["encounters"] = _index(data_service.load_encounters)
-    out["relics"] = _index(data_service.load_relics)
-    out["cards"] = _index(data_service.load_cards)
+    def _index_with_beta(loader, key="id", name="name") -> dict[str, str]:
+        """Main catalog names, plus names for entities that only exist in
+        the current beta. Beta-only entities are official content (they
+        ship in the Steam beta build) and players on that branch submit
+        runs containing them, so they must pass the modded-ID filter in
+        `_ranked` - otherwise deaths to a beta boss silently vanish from
+        every list until the beta promotes. Genuinely modded ids stay
+        filtered: they're in neither catalog. Main names win for entities
+        in both."""
+        names = _index(loader, key, name)
+        if not names or not data_service.get_beta_version():
+            return names
+        token = data_service.current_channel.set("beta")
+        try:
+            for r in loader():
+                rid = r.get(key)
+                if rid and rid not in names:
+                    names[rid] = r.get(name) or _prettify(rid)
+        except Exception:
+            logger.warning("community-stats beta name overlay failed", exc_info=True)
+        finally:
+            data_service.current_channel.reset(token)
+        return names
+
+    out["events"] = _index_with_beta(data_service.load_events)
+    out["encounters"] = _index_with_beta(data_service.load_encounters)
+    out["relics"] = _index_with_beta(data_service.load_relics)
+    out["cards"] = _index_with_beta(data_service.load_cards)
     # The merged starter ids most-removed uses aren't real catalog cards, so
     # name them here (and only when the catalog loaded, to keep the modded
     # filter's empty-map fallback intact).


### PR DESCRIPTION
The stats walk has been counting deaths to the Aeonglass boss all along, but the community stats display layer filters every ranked list to the main catalog, and a beta-only id looks exactly like a modded one to that filter, so it got dropped.

The name maps now overlay names for entities that only exist in the current beta, loaded from the beta catalog with the channel pinned. They pass the modded filter and render with their real names (Aeonglass, Wither, Fishing Rod). Main names win for entities that exist in both channels, and genuinely modded ids stay filtered since they appear in neither catalog. No-op when no beta version is staged.

Verified against the real catalogs: AEONGLASS_BOSS, WITHER, and FISHING_ROD resolve with beta names, POUNCE keeps its main name, and unknown ids stay out. ruff clean.

Takes effect on the first snapshot rebuild after deploy (~10 min cadence), since names resolve at build time. Worth merging after the in-flight stats branch if that one touches community_stats.py, the conflict surface is one function.