### PR TITLE
Forced-release deploys and the post-recreate nginx reload

### DIFF
--- a/infrastructure/ansible/README.md
+++ b/infrastructure/ansible/README.md
@@ -85,10 +85,12 @@ Single DigitalOcean droplet (`primary`). Runs everything: the backend and fronte
 `install-autodeploy.yml` installs `/usr/local/bin/spire-codex-autodeploy` + a cron entry at `/etc/cron.d/spire-codex-autodeploy` that fires every hour at :03. Each tick:
 
 1. `git pull` in `/var/www/spire-codex`
-2. If HEAD advanced and changes are not purely `data/news/*` or `data-beta/*` (both hot-reload without a restart): `docker compose pull` + `up -d --force-recreate` for `docker-compose.prod.yml`
+2. If HEAD advanced and changes are not purely `data/news/*` or `data-beta/*` (both hot-reload without a restart): `docker compose pull`, a stats snapshot prewarm with the new image when the backend image changed (so a snapshot version bump never serves empty stats), then `up -d --force-recreate` for `docker-compose.prod.yml` and an nginx reload (recreated containers get new IPs; without the reload the site 502s)
 3. CF cache purge (token + zone live in `/etc/spire-codex/cf-purge.env` on the box, mode 600, root-only)
 
 News-only updates (`data/news/*.json`) skip the recreate — the backend mounts `./data:/data` so the news API re-reads from disk on every request, no restart needed.
+
+`--force` (what `./tools/startup.sh release` invokes) runs the full sequence even when HEAD didn't move: manual releases right after a merge, or re-pulling a rebuilt image on the same commit.
 
 ```bash
 # Run the cron manually (don't want to wait for :03)

--- a/infrastructure/ansible/files/autodeploy.sh
+++ b/infrastructure/ansible/files/autodeploy.sh
@@ -8,8 +8,15 @@
 # /etc/cron.d/spire-codex-autodeploy. Manual run: just exec this script.
 #
 # Idempotent: same-HEAD ticks no-op and don't log unless DEBUG=1.
+# `--force` overrides that: full deploy (pull, prewarm, recreate, nginx
+# reload, CF purge) even with no new commit. Used for manual releases
+# right after a merge (./tools/startup.sh release) and for re-pulling a
+# rebuilt image on the same commit.
 
 set -euo pipefail
+
+FORCE=0
+[ "${1:-}" = "--force" ] && FORCE=1
 
 REPO="${SPIRE_REPO:-/var/www/spire-codex}"
 LOG="${SPIRE_AUTODEPLOY_LOG:-/var/log/spire-codex-autodeploy.log}"
@@ -31,38 +38,43 @@ git fetch origin main --quiet
 git reset --hard origin/main >> "$LOG" 2>&1
 AFTER=$(git rev-parse HEAD)
 
-if [ "$BEFORE" = "$AFTER" ]; then
+if [ "$BEFORE" = "$AFTER" ] && [ "$FORCE" != "1" ]; then
   [ "${DEBUG:-0}" = "1" ] && log "no change ($AFTER)"
   exit 0
 fi
 
-log "==== change detected: ${BEFORE:0:8} -> ${AFTER:0:8} ===="
-
-# Detect whether this update needs a container recreate at all. Two
-# classes don't:
-#
-#   data/news/*  : the compose file mounts ./data:/data and the news API
-#                  re-reads from disk on every request.
-#   data-beta/*  : the beta catalogs are cached keyed BY VERSION and the
-#                  `latest` pointer is re-read per request, so a new
-#                  beta ingest (the beta-watch auto-PR) starts serving
-#                  the moment the files land on disk. Exception: a
-#                  re-parse of an EXISTING version keeps its cache key;
-#                  bounce the backend manually after one of those.
-#
-# Skipping the recreate saves ~30s of downtime for the two most frequent
-# update classes. Anything else (code, stable data files cached
-# without a version key so they need the restart, images, frontend,
-# infra) still does the full recreate.
-CHANGED=$(git diff --name-only "$BEFORE..$AFTER")
-NON_HOT=$(echo "$CHANGED" | grep -v '^data/news/' | grep -v '^data-beta/' | grep -v '^$' || true)
-
-if [ -z "$NON_HOT" ]; then
-  log "hot-reloadable update ($(echo "$CHANGED" | wc -l | tr -d ' ') file(s), news/beta data only), skipping container recreate"
-  RECREATE=0
-else
-  log "full deploy ($(echo "$NON_HOT" | wc -l | tr -d ' ') file(s) outside the hot-reload classes)"
+if [ "$FORCE" = "1" ]; then
+  log "==== forced deploy at ${AFTER:0:8} ===="
   RECREATE=1
+else
+  log "==== change detected: ${BEFORE:0:8} -> ${AFTER:0:8} ===="
+
+  # Detect whether this update needs a container recreate at all. Two
+  # classes don't:
+  #
+  #   data/news/*  : the compose file mounts ./data:/data and the news API
+  #                  re-reads from disk on every request.
+  #   data-beta/*  : the beta catalogs are cached keyed BY VERSION and the
+  #                  `latest` pointer is re-read per request, so a new
+  #                  beta ingest (the beta-watch auto-PR) starts serving
+  #                  the moment the files land on disk. Exception: a
+  #                  re-parse of an EXISTING version keeps its cache key;
+  #                  bounce the backend manually after one of those.
+  #
+  # Skipping the recreate saves ~30s of downtime for the two most frequent
+  # update classes. Anything else (code, stable data files cached
+  # without a version key so they need the restart, images, frontend,
+  # infra) still does the full recreate.
+  CHANGED=$(git diff --name-only "$BEFORE..$AFTER")
+  NON_HOT=$(echo "$CHANGED" | grep -v '^data/news/' | grep -v '^data-beta/' | grep -v '^$' || true)
+
+  if [ -z "$NON_HOT" ]; then
+    log "hot-reloadable update ($(echo "$CHANGED" | wc -l | tr -d ' ') file(s), news/beta data only), skipping container recreate"
+    RECREATE=0
+  else
+    log "full deploy ($(echo "$NON_HOT" | wc -l | tr -d ' ') file(s) outside the hot-reload classes)"
+    RECREATE=1
+  fi
 fi
 
 if [ "$RECREATE" = "1" ]; then
@@ -98,6 +110,17 @@ if [ "$RECREATE" = "1" ]; then
 
   # Settle. 5s is enough for FastAPI startup; longer waits don't help.
   sleep 5
+
+  # Recreated containers get new IPs on the shared docker network, and
+  # nginx resolves upstream container names once at startup, so without
+  # a reload it keeps proxying to the dead addresses and the whole site
+  # 502s (bit us on 2026-06-11 and again on 2026-06-12). Reload is
+  # zero-downtime and re-resolves every upstream.
+  if docker exec web-server nginx -s reload >> "$LOG" 2>&1; then
+    log "✓ nginx reloaded"
+  else
+    log "⚠ nginx reload failed or web-server not on this host"
+  fi
 
   if docker compose -f "$COMPOSE_FILE" logs --tail 50 backend 2>/dev/null | grep -q "Spire Codex API ready"; then
     log "✓ backend ready"

--- a/tools/startup.sh
+++ b/tools/startup.sh
@@ -1,17 +1,32 @@
 #!/bin/bash
-# Manual deploy entrypoint. When the autodeploy script is installed (via
-# infrastructure/ansible/playbooks/install-autodeploy.yml) this defers to
-# it, because that path also has the news/data-beta hot-reload short
-# circuit, the stats snapshot prewarm, a post-deploy health check, and the
-# Cloudflare cache purge. The fallback below is the bare-minimum safe
-# sequence for a box where the cron isn't installed yet.
+# Manual deploy entrypoint.
+#
+#   ./tools/startup.sh           defer to the installed autodeploy script
+#                                (no-op when there's no new commit on main)
+#   ./tools/startup.sh release   force a full deploy NOW: pull images,
+#                                snapshot prewarm, recreate backend+frontend,
+#                                nginx reload, Cloudflare purge - even when
+#                                the commit didn't change (rebuilt image,
+#                                post-incident recovery, ...)
+#
+# The autodeploy script (installed via
+# infrastructure/ansible/playbooks/install-autodeploy.yml) is the single
+# implementation; this wrapper only picks the mode. The fallback below is
+# the bare-minimum safe sequence for a box where it isn't installed yet.
 set -e
 
+MODE="${1:-}"
+
 if [ -x /usr/local/bin/spire-codex-autodeploy ]; then
+    if [ "$MODE" = "release" ]; then
+        echo "forcing a full deploy via spire-codex-autodeploy --force"
+        exec sudo /usr/local/bin/spire-codex-autodeploy --force
+    fi
     echo "delegating to spire-codex-autodeploy"
     exec sudo /usr/local/bin/spire-codex-autodeploy
 fi
 
+# Fallback (autodeploy not installed): always a full deploy.
 git pull
 
 # pull + force-recreate, never `down && up`: down removes every container
@@ -23,9 +38,10 @@ docker compose -f docker-compose.prod.yml up -d --force-recreate backend fronten
 
 # Recreated containers get new IPs on the shared docker network, but nginx
 # resolves upstream hostnames once at startup, so without a reload it keeps
-# proxying to the old addresses (beta 502'd this way on 2026-06-11). Reload is
-# zero-downtime and re-resolves every upstream. Best-effort: skip quietly when
-# the web-server container isn't on this host.
+# proxying to the old addresses and the whole site 502s (2026-06-11, and
+# again 2026-06-12). Reload is zero-downtime and re-resolves every
+# upstream. Best-effort: skip quietly when the web-server container isn't
+# on this host.
 docker exec web-server nginx -s reload 2>/dev/null \
     && echo "nginx reloaded" \
     || echo "nginx reload skipped (web-server not running here)"


### PR DESCRIPTION
The tail of #450 that didn't make the merge (I pushed these onto the branch after it was merged):

- autodeploy takes `--force`: the full deploy sequence (pull, snapshot prewarm, recreate, nginx reload, CF purge) even when HEAD didn't move - for manual releases right after a merge or re-pulling a rebuilt image on the same commit. The cron's plain invocation is unchanged.
- `./tools/startup.sh release` invokes it. Without this, the release mode prints "delegating" and the delegated run no-ops on its same-HEAD check, which is exactly the trap I just hit in prod.
- autodeploy reloads nginx after recreating containers (recreated containers get new IPs; nginx resolves upstream names once at startup; skipping the reload 502'd the site twice in two days).
- Ansible README updated to document the prewarm, the reload, and the force flow.

After merging: re-run install-autodeploy.yml so the installed script picks up --force and the reload.