### PR TITLE
Ship the live presence backend and the mod update check

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -61,6 +61,8 @@ from .routers import (
     uninstall,
     qa_feedback,
     tierlists,
+    mod_meta,
+    presence,
 )
 from .services.data_service import (
     current_channel,
@@ -548,6 +550,8 @@ app.include_router(auth_steam.router)
 app.include_router(auth_discord.router)
 app.include_router(auth.router)
 app.include_router(tierlists.router)
+app.include_router(mod_meta.router)
+app.include_router(presence.router)
 # Overlay-direct OpenID flow uses /auth/steam-popup as Steam's return_to.
 # This is intentionally outside /api/* — it's a user-facing HTML page,
 # not a JSON API — so it's mounted at the app level rather than under

--- a/backend/app/routers/mod_meta.py
+++ b/backend/app/routers/mod_meta.py
@@ -1,0 +1,23 @@
+"""Mod metadata endpoint for the in-game SpireCodex mod's update check."""
+
+import os
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api/mod", tags=["Mod"])
+
+
+@router.get("/latest")
+def latest_mod_version():
+    """Latest published mod build + the newest game version it was verified against.
+
+    The in-game mod compares these against its own version and the running game build,
+    and shows an "update available" or "untested game build" line in its overlay. Values
+    come from env vars so they can be bumped after a game patch without a code change
+    (restart the backend to pick them up).
+    """
+    return {
+        "version": os.getenv("MOD_LATEST_VERSION", "v0.1.0"),
+        "url": os.getenv("MOD_DOWNLOAD_URL", "https://spire-codex.com"),
+        "sts2_tested": os.getenv("MOD_STS2_TESTED", "v0.103.3"),
+    }

--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -1,0 +1,115 @@
+"""Live presence endpoints for the in-game mod ("who is in a run right now").
+
+POST /api/presence            — heartbeat from the mod, Bearer JWT required (the verified
+                                steam_id keys the entry, so nobody can publish as someone
+                                else). Body {"ended": true} clears the entry.
+GET  /api/presence/active     — public roster of live runs (no deck detail), deepest first.
+GET  /api/presence/{steam_id} — one player's full live doc (deck/relics/potions) for a
+                                live run view. 404 when not live.
+"""
+
+import os
+
+from fastapi import APIRouter, HTTPException, Request
+
+router = APIRouter(prefix="/api/presence", tags=["Presence"])
+
+_MAX_STR = 64
+_INT_FIELDS = (
+    "act",
+    "act_floor",
+    "total_floor",
+    "hp",
+    "max_hp",
+    "gold",
+    "ascension",
+    "player_count",
+)
+_STR_FIELDS = ("character", "seed", "screen", "sts2_version", "username")
+_LIST_CAPS = {"deck": 200, "relics": 100, "potions": 10}
+
+
+def _require_mongo():
+    if not os.environ.get("MONGO_URL", "").strip():
+        raise HTTPException(status_code=503, detail="presence unavailable")
+
+
+@router.post("")
+async def post_presence(request: Request):
+    _require_mongo()
+
+    auth_header = request.headers.get("authorization") or ""
+    if not auth_header.lower().startswith("bearer "):
+        raise HTTPException(status_code=401, detail="presence requires Steam sign-in")
+    from ..services.auth_jwt import decode_token
+
+    claims = decode_token(auth_header[7:].strip())
+    steam_id = str((claims or {}).get("steam_id") or "")
+    if not steam_id.isdigit():
+        raise HTTPException(status_code=401, detail="invalid token")
+
+    try:
+        data = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid json")
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail="invalid payload")
+
+    from ..services import presence_db
+
+    if data.get("ended"):
+        presence_db.end(steam_id)
+        return {"ok": True, "ended": True}
+
+    # Whitelist-copy the heartbeat; everything else in the body is dropped.
+    fields: dict = {}
+    for k in _INT_FIELDS:
+        v = data.get(k)
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            fields[k] = int(v)
+    for k in _STR_FIELDS:
+        v = data.get(k)
+        if isinstance(v, str) and v:
+            fields[k] = v[:_MAX_STR]
+    for k, cap in _LIST_CAPS.items():
+        v = data.get(k)
+        if isinstance(v, list):
+            fields[k] = [
+                str(x)[:_MAX_STR] for x in v[:cap] if isinstance(x, (str, int))
+            ]
+
+    # Display name: the verified user record outranks the client-sent username.
+    try:
+        from ..services.users_db import get_user_by_steam_id
+
+        user = get_user_by_steam_id(steam_id)
+        if user and user.get("username"):
+            fields["username"] = user["username"]
+    except Exception:
+        pass
+
+    presence_db.heartbeat(steam_id, fields)
+    return {"ok": True}
+
+
+@router.get("/active")
+def get_active(limit: int = 50):
+    _require_mongo()
+    from ..services import presence_db
+
+    players = presence_db.active(max(1, min(limit, 100)))
+    return {"count": len(players), "players": players}
+
+
+@router.get("/{steam_id}")
+def get_player(steam_id: str):
+    _require_mongo()
+    digits = "".join(ch for ch in steam_id if ch.isdigit())
+    if not digits:
+        raise HTTPException(status_code=400, detail="bad steam_id")
+    from ..services import presence_db
+
+    doc = presence_db.get(digits)
+    if not doc:
+        raise HTTPException(status_code=404, detail="not live")
+    return doc

--- a/backend/app/services/presence_db.py
+++ b/backend/app/services/presence_db.py
@@ -1,0 +1,83 @@
+"""Live presence ("who is in a run right now") storage.
+
+One Mongo doc per actively-playing player, upserted by the in-game mod's ~30s heartbeat
+and expired by a TTL index ~90s after the last beat, so crashes and quits fall off the
+list on their own. Mongo-only: without MONGO_URL the presence endpoints return 503 and
+nothing else depends on this module.
+
+Document shape (one doc per live player):
+
+    {
+        "_id": <steam_id>,
+        "username": ..., "character": ..., "ascension": ...,
+        "act": ..., "act_floor": ..., "total_floor": ...,
+        "hp": ..., "max_hp": ..., "gold": ..., "screen": ..., "seed": ...,
+        "player_count": ..., "sts2_version": ...,
+        "deck": ["STRIKE+", ...], "relics": [...], "potions": [...],
+        "started_at": ISODate(...),   # first heartbeat of this session
+        "updated_at": ISODate(...),   # last heartbeat (TTL anchor)
+    }
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+PRESENCE_TTL_SECONDS = 90
+
+_coll = None  # lazy — set by _presence_coll
+
+
+def _presence_coll():
+    global _coll
+    if _coll is None:
+        from .runs_db_mongo import get_database
+
+        coll = get_database().presence
+        # Mongo's TTL sweep only runs ~every 60s, so reads also filter by freshness.
+        coll.create_index("updated_at", expireAfterSeconds=PRESENCE_TTL_SECONDS)
+        _coll = coll
+    return _coll
+
+
+def heartbeat(steam_id: str, fields: dict[str, Any]) -> None:
+    now = datetime.now(timezone.utc)
+    _presence_coll().update_one(
+        {"_id": steam_id},
+        {"$set": {**fields, "updated_at": now}, "$setOnInsert": {"started_at": now}},
+        upsert=True,
+    )
+
+
+def end(steam_id: str) -> None:
+    _presence_coll().delete_one({"_id": steam_id})
+
+
+def active(limit: int = 50) -> list[dict]:
+    """Fresh live players, deepest run first. Excludes deck/relic/potion detail —
+    the per-player endpoint serves those for the live run view."""
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=PRESENCE_TTL_SECONDS)
+    docs = (
+        _presence_coll()
+        .find({"updated_at": {"$gte": cutoff}}, {"deck": 0, "relics": 0, "potions": 0})
+        .sort([("total_floor", -1), ("updated_at", -1)])
+        .limit(limit)
+    )
+    return [_public(d) for d in docs]
+
+
+def get(steam_id: str) -> dict | None:
+    """One player's full live doc (incl. deck/relics/potions), or None when not live."""
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=PRESENCE_TTL_SECONDS)
+    d = _presence_coll().find_one({"_id": steam_id, "updated_at": {"$gte": cutoff}})
+    return _public(d) if d else None
+
+
+def _public(d: dict) -> dict:
+    d = dict(d)
+    d["steam_id"] = d.pop("_id")
+    for k in ("updated_at", "started_at"):
+        if isinstance(d.get(k), datetime):
+            d[k] = d[k].replace(tzinfo=timezone.utc).isoformat()
+    return d

--- a/markdown-docs/live-presence.md
+++ b/markdown-docs/live-presence.md
@@ -1,0 +1,61 @@
+# Live presence ("who is in a run right now")
+
+The in-game SpireCodex mod heartbeats each player's in-progress run to the backend every
+~30 seconds. The backend keeps one Mongo doc per live player with a 90 second TTL, so
+quits and crashes fall off the list on their own. This doc is the contract for building
+the frontend view; the backend half is done (`app/routers/presence.py`,
+`app/services/presence_db.py`).
+
+## Endpoints
+
+### GET /api/presence/active
+
+Public. The roster for a "Live now" rail or /live page. Deepest run first.
+
+```json
+{
+  "count": 2,
+  "players": [
+    {
+      "steam_id": "7656119...",
+      "username": "ptrlrd",
+      "character": "NECROBINDER",
+      "ascension": 3,
+      "act": 2, "act_floor": 7, "total_floor": 23,
+      "hp": 23, "max_hp": 75, "gold": 142,
+      "screen": "combat",
+      "seed": "ABC123",
+      "player_count": 1,
+      "sts2_version": "v0.103.3+460a0ece",
+      "started_at": "2026-06-11T19:02:11+00:00",
+      "updated_at": "2026-06-11T19:14:41+00:00"
+    }
+  ]
+}
+```
+
+`?limit=` caps the list (default 50, max 100). Numeric fields can be absent on a sparse
+heartbeat; render defensively. `started_at` is the first heartbeat of the session, good
+for "climbing for 41 min".
+
+### GET /api/presence/{steam_id}
+
+Public. The full live doc for one player: everything above plus `deck` (card ids, `+`
+suffix = upgraded, e.g. `"STRIKE+"`), `relics`, and `potions` (bare ids). 404 when the
+player is not live. This is the data for a per-player live run view (spectator-lite,
+refresh every 15-30s).
+
+### POST /api/presence
+
+Mod-only; requires the Steam JWT (`Authorization: Bearer`). The frontend never calls it.
+503 until MONGO_URL is set, 401 without a valid token.
+
+## Notes for the frontend
+
+- Poll `/active` every 15-30s. No websockets; the data only changes on a ~30s beat.
+- Entries are at most 90s stale by construction; no client-side freshness math needed.
+- `screen` is the mod's coarse location: combat, map, merchant, event, rest, etc.
+- Privacy is handled upstream: only players who opted into uploads (consent gate), kept
+  Share live status on, and are Steam-signed-in ever appear here.
+- Card/relic/potion ids are bare game ids (same convention as run docs) — the usual
+  image/name lookups apply.


### PR DESCRIPTION
Closes the gap where these four files were written alongside the mod backend (#444) but never committed, so presence and the mod update check 404 in prod.

- POST /api/presence: heartbeat from the in-game mod, Bearer JWT required; the verified steam_id keys the entry so nobody can publish as someone else. One Mongo doc per live player, 90 second TTL, so quits and crashes fall off the roster on their own.
- GET /api/presence/active: public deepest-first roster for a Live now view.
- GET /api/presence/{steam_id}: one player's full live doc (deck/relics/potions), 404 when not live.
- GET /api/mod/latest: the mod's update check.
- markdown-docs/live-presence.md: the frontend contract for the Live now view.

Wired both routers into main.py. Self-contained against main: decode_token, get_user_by_steam_id, and get_database all exist already.

## Testing

ruff (check + format) clean. Booted locally: presence endpoints return the documented 503 without MONGO_URL (Mongo-gated by design), /api/mod/latest returns the update payload. The TTL index and the live behavior need prod Mongo, which is where the mod is already pointed.