### PR TITLE
Beta spotlight on the community stats page

### DIFF
--- a/backend/app/services/community_stats.py
+++ b/backend/app/services/community_stats.py
@@ -271,7 +271,13 @@ def _name_maps() -> dict[str, dict[str, str]]:
             logger.warning("community-stats name load failed", exc_info=True)
             return {}
 
-    def _index_with_beta(loader, key="id", name="name") -> dict[str, str]:
+    # Ids that exist ONLY in the current beta, per type. Feeds the beta
+    # spotlight in `finalize`: beta entities can't outrank main content in
+    # the global top-N lists (the beta branch is a few percent of all
+    # runs), so their numbers get their own uncapped section.
+    beta_only: dict[str, set[str]] = {}
+
+    def _index_with_beta(tkey: str, loader, key="id", name="name") -> dict[str, str]:
         """Main catalog names, plus names for entities that only exist in
         the current beta. Beta-only entities are official content (they
         ship in the Steam beta build) and players on that branch submit
@@ -281,6 +287,7 @@ def _name_maps() -> dict[str, dict[str, str]]:
         filtered: they're in neither catalog. Main names win for entities
         in both."""
         names = _index(loader, key, name)
+        beta_only[tkey] = set()
         if not names or not data_service.get_beta_version():
             return names
         token = data_service.current_channel.set("beta")
@@ -289,16 +296,18 @@ def _name_maps() -> dict[str, dict[str, str]]:
                 rid = r.get(key)
                 if rid and rid not in names:
                     names[rid] = r.get(name) or _prettify(rid)
+                    beta_only[tkey].add(rid)
         except Exception:
             logger.warning("community-stats beta name overlay failed", exc_info=True)
         finally:
             data_service.current_channel.reset(token)
         return names
 
-    out["events"] = _index_with_beta(data_service.load_events)
-    out["encounters"] = _index_with_beta(data_service.load_encounters)
-    out["relics"] = _index_with_beta(data_service.load_relics)
-    out["cards"] = _index_with_beta(data_service.load_cards)
+    out["events"] = _index_with_beta("events", data_service.load_events)
+    out["encounters"] = _index_with_beta("encounters", data_service.load_encounters)
+    out["relics"] = _index_with_beta("relics", data_service.load_relics)
+    out["cards"] = _index_with_beta("cards", data_service.load_cards)
+    out["_beta_only"] = beta_only  # type: ignore[assignment]
     # The merged starter ids most-removed uses aren't real catalog cards, so
     # name them here (and only when the catalog loaded, to keep the modded
     # filter's empty-map fallback intact).
@@ -364,6 +373,30 @@ def _ranked(counts: dict[str, int], names: dict[str, str], limit: int) -> list[d
         }
         for cid, n in rows
     ]
+
+
+def _beta_spotlight(acc: dict[str, Any], names: dict) -> dict[str, Any]:
+    """Death counts for beta-only encounters/events, unranked against main
+    content. Empty dict when no beta is staged or nothing recorded yet."""
+    beta_only = names.get("_beta_only") or {}
+    out: dict[str, Any] = {}
+    for section, counts_key, names_key in (
+        ("encounters", "deaths_encounter", "encounters"),
+        ("events", "deaths_event", "events"),
+    ):
+        ids = beta_only.get(names_key) or set()
+        if not ids:
+            continue
+        rows = [
+            {"id": i, "name": names[names_key].get(i) or _prettify(i), "count": n}
+            for i, n in sorted(
+                acc[counts_key].items(), key=lambda kv: kv[1], reverse=True
+            )
+            if i in ids
+        ]
+        if rows:
+            out.setdefault("deaths", {})[section] = rows
+    return out
 
 
 def finalize(acc: dict[str, Any]) -> dict[str, Any]:
@@ -462,6 +495,11 @@ def finalize(acc: dict[str, Any]) -> dict[str, Any]:
             "encounters": _ranked(acc["deaths_encounter"], names["encounters"], _TOP_N),
             "events": _ranked(acc["deaths_event"], names["events"], _TOP_N),
         },
+        # Beta spotlight: numbers for entities that only exist in the
+        # current beta. They can't crack the global top-N (the beta branch
+        # is a few percent of all runs), so they get their own uncapped
+        # list; empties out on its own when the beta promotes to main.
+        "beta": _beta_spotlight(acc, names),
         "rest_sites": _rest_sites(acc),
         "ancient_picks": _ancient_picks(acc, names),
         # Complete per-relic ancient-offer stats for the in-game tip (the top-N

--- a/frontend/app/community-stats/page.tsx
+++ b/frontend/app/community-stats/page.tsx
@@ -28,6 +28,9 @@ interface CommunityStats {
   by_character: CharRow[];
   events: EventRow[];
   deaths: { encounters: Ranked[]; events: Ranked[] };
+  // Beta spotlight: numbers for entities that only exist in the current
+  // beta, uncapped (they can't outrank main content in the top lists).
+  beta?: { deaths?: { encounters?: { id: string; name: string; count: number }[]; events?: { id: string; name: string; count: number }[] } };
   rest_sites: { id: string; label: string; count: number; pct: number }[];
   ancient_picks: Ranked[];
   most_removed: Ranked[];
@@ -227,6 +230,31 @@ export default async function CommunityStatsPage() {
           <RankBars color={ROSE} data={rankPct(stats.deaths.events)} />
         </div>
       </section>
+
+      {/* Beta spotlight: beta-only content can't outrank 200k+ main runs in
+          the lists above, so its kill counts get their own card. Renders
+          nothing once the beta promotes (the section empties server-side). */}
+      {((stats.beta?.deaths?.encounters?.length ?? 0) > 0 || (stats.beta?.deaths?.events?.length ?? 0) > 0) && (
+        <section className="mb-10">
+          <h2 className="text-lg font-semibold text-emerald-300 mb-3">From the beta branch</h2>
+          <div className="rounded-lg border border-emerald-500/40 bg-emerald-500/10 p-4">
+            <p className="text-xs text-[var(--text-muted)] mb-3">
+              Deaths to content that only exists in the current beta, counted from beta-branch runs.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {[...(stats.beta?.deaths?.encounters ?? []), ...(stats.beta?.deaths?.events ?? [])].map((e) => (
+                <div key={e.id} className="flex items-center justify-between rounded bg-[var(--bg-card)] px-3 py-2 text-sm">
+                  <span className="text-[var(--text-primary)]">
+                    {e.name}
+                    <span className="ml-2 text-[10px] px-1.5 py-0.5 rounded-full font-semibold bg-emerald-500/15 text-emerald-400 border border-emerald-500/30">Beta</span>
+                  </span>
+                  <span className="text-[var(--text-secondary)] tabular-nums">{e.count.toLocaleString()} kills</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* Records */}
       <section className="mb-10">


### PR DESCRIPTION
Follow-up to #451. That fix lets beta entities through the modded-ID filter, but it turned out not to be enough to actually SEE them: the deadliest lists are capped at 15 and the 15th place has ~4,600 deaths, while the beta branch is ~4% of all runs (about 10k of 242k), so the Aeonglass boss can never rank no matter how many beta players it kills.

- The name maps now record which ids exist only in the current beta.
- finalize emits an uncapped `beta` section with death counts for beta-only encounters and events, named from the beta catalog.
- The community stats page renders them as a From the beta branch card with Beta badges, below the deadliest lists. The section disappears on its own when the beta promotes (the beta-only set goes empty).

## Testing

ruff and tsc clean. Behavioral test on a synthetic walk: Aeonglass deaths land in the spotlight with the right name and count, main encounters stay out of it, and the global list still includes beta entities whenever they genuinely rank. Takes effect on the first snapshot rebuild after deploy.