### PR TITLE
Build out /admin into the full operator dashboard

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -63,6 +63,7 @@ from .routers import (
     tierlists,
     mod_meta,
     presence,
+    announcements,
 )
 from .services.data_service import (
     current_channel,
@@ -552,6 +553,7 @@ app.include_router(auth.router)
 app.include_router(tierlists.router)
 app.include_router(mod_meta.router)
 app.include_router(presence.router)
+app.include_router(announcements.router)
 # Overlay-direct OpenID flow uses /auth/steam-popup as Steam's return_to.
 # This is intentionally outside /api/* — it's a user-facing HTML page,
 # not a JSON API — so it's mounted at the app level rather than under

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -125,3 +125,137 @@ def overview(request: Request):
         "redis": app_cache.info(),
         "environment": os.environ.get("ENVIRONMENT", "development"),
     }
+
+
+# ── The operational surfaces (the rest of the lair) ─────────────────────
+
+
+@router.get("/runs/search")
+def runs_search(
+    request: Request,
+    username: str | None = None,
+    seed: str | None = None,
+    run_hash: str | None = None,
+    limit: int = 25,
+):
+    """Find submitted runs to inspect or delete. run_hash wins when given;
+    otherwise username/seed filter the normal listing, newest first."""
+    _audit(request)
+    if not os.environ.get("MONGO_URL", "").strip():
+        return {"runs": [], "total": 0}
+    from ..services.runs_db_mongo import get_database, list_runs
+
+    limit = max(1, min(limit, 100))
+    if run_hash:
+        docs = list(get_database()["runs"].find({"run_hash": run_hash.strip()}))
+        for d in docs:
+            d.pop("_id", None)
+            d.pop("raw", None)
+        return {"runs": docs, "total": len(docs)}
+    result = list_runs(
+        username=(username or "").strip() or None,
+        seed=(seed or "").strip() or None,
+        sort="newest",
+        page=1,
+        limit=limit,
+    )
+    return result
+
+
+@router.delete("/runs/{run_hash}")
+def runs_delete(request: Request, run_hash: str):
+    """Remove a submitted run: every Mongo doc sharing the hash, the blob
+    file, and the in-process blob cache. Aggregates (snapshot, leaderboard
+    summaries) drop it on their next scheduled rebuild."""
+    _audit(request)
+    from ..services import admin_db
+    from .runs import _data_dir, _load_run_blob
+
+    result = admin_db.delete_run(run_hash.strip(), _data_dir / "runs")
+    # The shared-run endpoint serves blobs from an in-process LRU; evict so
+    # a deleted run stops being served by this worker immediately. Other
+    # workers age it out on their own.
+    _load_run_blob.cache_clear()
+    logger.info(
+        "admin deleted run %s: %s docs, file_removed=%s",
+        run_hash,
+        result["deleted_docs"],
+        result["file_removed"],
+    )
+    return {"run_hash": run_hash, **result}
+
+
+@router.get("/feedback")
+def feedback_inbox(request: Request, include_resolved: bool = False, limit: int = 50):
+    """The feedback inbox: site feedback and QA card reports, newest first.
+    Submissions land here alongside the Discord webhook."""
+    _audit(request)
+    from ..services import admin_db
+
+    return {
+        "items": admin_db.list_feedback(limit=limit, include_resolved=include_resolved)
+    }
+
+
+@router.post("/feedback/{item_id}/resolve")
+def feedback_resolve(request: Request, item_id: str):
+    _audit(request)
+    from ..services import admin_db
+
+    return {"resolved": admin_db.resolve_feedback(item_id)}
+
+
+@router.get("/guides/pending")
+def guides_pending(request: Request, limit: int = 50):
+    """Guide submissions awaiting review. Publishing stays a git operation
+    (guides ship in data/guides.json); dismiss clears handled entries."""
+    _audit(request)
+    from ..services import admin_db
+
+    return {"items": admin_db.list_pending_guides(limit=limit)}
+
+
+@router.post("/guides/submissions/{sub_id}/dismiss")
+def guides_dismiss(request: Request, sub_id: str):
+    _audit(request)
+    from ..services import admin_db
+
+    return {"dismissed": admin_db.dismiss_guide_submission(sub_id)}
+
+
+@router.post("/cf/purge")
+async def cf_purge(request: Request):
+    """Purge the Cloudflare cache: body {"paths": ["/cards", ...]} purges
+    those URLs on the apex domain; an empty/missing list purges the whole
+    zone. Needs CF_TOKEN + CF_ZONE in the backend env."""
+    _audit(request)
+    token = os.environ.get("CF_TOKEN", "").strip()
+    zone = os.environ.get("CF_ZONE", "").strip()
+    if not token or not zone:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=503, detail="CF_TOKEN / CF_ZONE not configured")
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    paths = [p for p in (body.get("paths") or []) if isinstance(p, str) and p.strip()]
+    if paths:
+        site = os.environ.get("PUBLIC_SITE_BASE", "https://spire-codex.com").rstrip("/")
+        files = [f"{site}{p if p.startswith('/') else '/' + p}" for p in paths[:30]]
+        payload: dict = {"files": files}
+    else:
+        payload = {"purge_everything": True}
+
+    import httpx
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.post(
+            f"https://api.cloudflare.com/client/v4/zones/{zone}/purge_cache",
+            headers={"Authorization": f"Bearer {token}"},
+            json=payload,
+        )
+    ok = resp.status_code == 200 and resp.json().get("success") is True
+    logger.info("admin CF purge (%s): ok=%s", "paths" if paths else "everything", ok)
+    return {"ok": ok, "purged": "paths" if paths else "everything", "count": len(paths)}

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -259,3 +259,148 @@ async def cf_purge(request: Request):
     ok = resp.status_code == 200 and resp.json().get("success") is True
     logger.info("admin CF purge (%s): ok=%s", "paths" if paths else "everything", ok)
     return {"ok": ok, "purged": "paths" if paths else "everything", "count": len(paths)}
+
+
+@router.get("/announcements")
+def announcements_list(request: Request):
+    """Every banner announcement, active or not, newest first."""
+    _audit(request)
+    from ..services import admin_db
+
+    return {"items": admin_db.list_announcements()}
+
+
+@router.post("/announcements")
+async def announcements_create(request: Request):
+    """Create a banner announcement: body {"message": "..."} with optional
+    inline [label](/href) links. New announcements start active, and each
+    visitor's dismissal is keyed per announcement, so publishing a new one
+    reshows the banner for everyone automatically."""
+    _audit(request)
+    from fastapi import HTTPException
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    message = (body.get("message") or "").strip()
+    if not message or len(message) > 500:
+        raise HTTPException(status_code=422, detail="message required, max 500 chars")
+    from ..services import admin_db
+
+    item = admin_db.create_announcement(message)
+    app_cache.delete("announcements:active")
+    return item
+
+
+@router.post("/announcements/{ann_id}/toggle")
+def announcements_toggle(request: Request, ann_id: str):
+    _audit(request)
+    from ..services import admin_db
+
+    ok = admin_db.toggle_announcement(ann_id)
+    app_cache.delete("announcements:active")
+    return {"toggled": ok}
+
+
+@router.delete("/announcements/{ann_id}")
+def announcements_delete(request: Request, ann_id: str):
+    _audit(request)
+    from ..services import admin_db
+
+    ok = admin_db.delete_announcement(ann_id)
+    app_cache.delete("announcements:active")
+    return {"deleted": ok}
+
+
+# ── Umami analytics (proxied so credentials stay server-side) ───────────
+
+_umami_token: str | None = None
+
+
+async def _umami_get(client, url: str, params: dict) -> dict | None:
+    """GET with the cached bearer token, re-logging-in once on a 401
+    (self-hosted Umami tokens expire)."""
+    global _umami_token
+    base = os.environ.get("UMAMI_URL", "https://analytics.spire-codex.com").rstrip("/")
+    username = os.environ.get("UMAMI_USERNAME", "").strip()
+    password = os.environ.get("UMAMI_PASSWORD", "").strip()
+    for attempt in (1, 2):
+        if not _umami_token:
+            resp = await client.post(
+                f"{base}/api/auth/login",
+                json={"username": username, "password": password},
+            )
+            if resp.status_code != 200:
+                logger.warning("umami login failed: %s", resp.status_code)
+                return None
+            _umami_token = resp.json().get("token")
+        resp = await client.get(
+            f"{base}{url}",
+            params=params,
+            headers={"Authorization": f"Bearer {_umami_token}"},
+        )
+        if resp.status_code == 401 and attempt == 1:
+            _umami_token = None
+            continue
+        if resp.status_code != 200:
+            logger.warning("umami %s failed: %s", url, resp.status_code)
+            return None
+        return resp.json()
+    return None
+
+
+@router.get("/analytics")
+async def analytics(request: Request):
+    """Umami headline numbers: visitors and pageviews for the last 24h and
+    7d, plus the top pages, proxied server-side. 503 until UMAMI_USERNAME
+    and UMAMI_PASSWORD are configured."""
+    _audit(request)
+    if not (
+        os.environ.get("UMAMI_USERNAME", "").strip()
+        and os.environ.get("UMAMI_PASSWORD", "").strip()
+    ):
+        from fastapi import HTTPException
+
+        raise HTTPException(
+            status_code=503, detail="UMAMI_USERNAME / UMAMI_PASSWORD not configured"
+        )
+
+    import time as _time
+
+    import httpx
+
+    website = os.environ.get(
+        "UMAMI_WEBSITE_ID", "715a2b92-5064-4369-9d33-cdd1c0ea8f93"
+    ).strip()
+    now_ms = int(_time.time() * 1000)
+    day_ms = 24 * 3600 * 1000
+    async with httpx.AsyncClient(timeout=15) as client:
+        stats_24h = await _umami_get(
+            client,
+            f"/api/websites/{website}/stats",
+            {"startAt": now_ms - day_ms, "endAt": now_ms},
+        )
+        stats_7d = await _umami_get(
+            client,
+            f"/api/websites/{website}/stats",
+            {"startAt": now_ms - 7 * day_ms, "endAt": now_ms},
+        )
+        top_pages = await _umami_get(
+            client,
+            f"/api/websites/{website}/metrics",
+            {
+                "type": "url",
+                "startAt": now_ms - 7 * day_ms,
+                "endAt": now_ms,
+                "limit": 10,
+            },
+        )
+    return {
+        "last_24h": stats_24h,
+        "last_7d": stats_7d,
+        "top_pages": top_pages or [],
+        "dashboard_url": os.environ.get(
+            "UMAMI_URL", "https://analytics.spire-codex.com"
+        ),
+    }

--- a/backend/app/routers/announcements.py
+++ b/backend/app/routers/announcements.py
@@ -1,0 +1,37 @@
+"""Public read side of the site announcement banner.
+
+The banner content is managed from /admin (announcements collection); this
+endpoint serves the active ones to every visitor, so it leans on Redis +
+edge caching to keep the per-pageview cost at zero.
+"""
+
+import logging
+
+from fastapi import APIRouter, Response
+
+from ..services import cache as app_cache
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/announcements", tags=["Announcements"])
+
+_CACHE_KEY = "announcements:active"
+
+
+@router.get("")
+def active_announcements(response: Response):
+    """The active banner messages, newest first. `message` may contain
+    inline [label](/href) links the frontend renders as real links."""
+    response.headers["Cache-Control"] = "public, max-age=60"
+    cached = app_cache.get_json(_CACHE_KEY)
+    if cached is not None:
+        return cached
+    from ..services import admin_db
+
+    items = [
+        {"id": a["id"], "message": a.get("message", "")}
+        for a in admin_db.list_announcements(active_only=True)
+    ]
+    result = {"items": items}
+    app_cache.set_json(_CACHE_KEY, result, ttl_seconds=60)
+    return result

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -59,6 +59,12 @@ async def submit_feedback(request: Request, body: FeedbackRequest):
         if resp.status_code >= 400:
             raise HTTPException(status_code=502, detail="Failed to send feedback")
 
+    # Copy into the admin inbox so feedback is reviewable on /admin, not
+    # just a Discord scrollback. Best effort by design.
+    from ..services.admin_db import record_feedback
+
+    record_feedback("feedback", body.model_dump())
+
     # ── GitHub issue (best-effort, non-blocking failure) ───────
     if github_issues.is_configured():
         try:

--- a/backend/app/routers/guides.py
+++ b/backend/app/routers/guides.py
@@ -235,4 +235,9 @@ async def submit_guide(request: Request, body: GuideSubmission):
             raise HTTPException(status_code=502, detail="Failed to send submission")
 
     guide_submissions.labels(status="success").inc()
+    # Copy into the moderation queue so submissions are reviewable on
+    # /admin instead of only living in a Discord scrollback. Best effort.
+    from ..services.admin_db import record_guide_submission
+
+    record_guide_submission(body.model_dump())
     return {"ok": True}

--- a/backend/app/routers/qa_feedback.py
+++ b/backend/app/routers/qa_feedback.py
@@ -84,4 +84,7 @@ async def submit_qa_feedback(request: Request, body: QAFeedback):
             )
             raise HTTPException(status_code=502, detail="Failed to send feedback")
 
+    from ..services.admin_db import record_feedback
+
+    record_feedback("qa", body.model_dump())
     return {"ok": True}

--- a/backend/app/services/admin_db.py
+++ b/backend/app/services/admin_db.py
@@ -1,0 +1,155 @@
+"""Mongo-backed storage for the operator dashboard's mutable surfaces.
+
+Feedback and guide submissions historically only flew past as Discord
+webhook embeds; the admin inbox needs them queryable later, so the submit
+endpoints also drop a copy here. The writes are best effort: a Mongo
+hiccup must never fail the user-facing submission, the webhook already
+went out. Run deletion lives here too so the router stays thin.
+
+Everything degrades to no-ops/empties on the SQLite path (no MONGO_URL).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from bson import ObjectId
+from bson.errors import InvalidId
+
+logger = logging.getLogger(__name__)
+
+_FEEDBACK_COLLECTION = "feedback_inbox"
+_GUIDE_SUBMISSIONS_COLLECTION = "guide_submissions"
+
+
+def _enabled() -> bool:
+    return bool(os.environ.get("MONGO_URL", "").strip())
+
+
+def _db():
+    from .runs_db_mongo import get_database
+
+    return get_database()
+
+
+def _shape(row: dict) -> dict:
+    """Mongo doc -> JSON-safe dict with a string id."""
+    row["id"] = str(row.pop("_id"))
+    created = row.get("created_at")
+    if isinstance(created, datetime):
+        row["created_at"] = created.isoformat()
+    return row
+
+
+# ── Feedback inbox ───────────────────────────────────────────
+
+
+def record_feedback(source: str, payload: dict[str, Any]) -> None:
+    """Best-effort copy of a feedback submission for the admin inbox.
+    `source` distinguishes the general feedback form from QA card reports."""
+    if not _enabled():
+        return
+    try:
+        _db()[_FEEDBACK_COLLECTION].insert_one(
+            {
+                "source": source,
+                "created_at": datetime.now(timezone.utc),
+                "resolved": False,
+                **payload,
+            }
+        )
+    except Exception:
+        logger.warning("feedback inbox write failed", exc_info=True)
+
+
+def list_feedback(limit: int = 50, include_resolved: bool = False) -> list[dict]:
+    if not _enabled():
+        return []
+    query: dict[str, Any] = {} if include_resolved else {"resolved": {"$ne": True}}
+    rows = list(
+        _db()[_FEEDBACK_COLLECTION].find(query).sort("created_at", -1).limit(limit)
+    )
+    return [_shape(r) for r in rows]
+
+
+def resolve_feedback(item_id: str) -> bool:
+    if not _enabled():
+        return False
+    try:
+        oid = ObjectId(item_id)
+    except InvalidId:
+        return False
+    res = _db()[_FEEDBACK_COLLECTION].update_one(
+        {"_id": oid}, {"$set": {"resolved": True}}
+    )
+    return res.modified_count > 0
+
+
+# ── Guide submission queue ───────────────────────────────────
+
+
+def record_guide_submission(payload: dict[str, Any]) -> None:
+    """Best-effort copy of a guide submission for the moderation queue."""
+    if not _enabled():
+        return
+    try:
+        _db()[_GUIDE_SUBMISSIONS_COLLECTION].insert_one(
+            {
+                "status": "pending",
+                "created_at": datetime.now(timezone.utc),
+                **payload,
+            }
+        )
+    except Exception:
+        logger.warning("guide submission queue write failed", exc_info=True)
+
+
+def list_pending_guides(limit: int = 50) -> list[dict]:
+    if not _enabled():
+        return []
+    rows = list(
+        _db()[_GUIDE_SUBMISSIONS_COLLECTION]
+        .find({"status": "pending"})
+        .sort("created_at", -1)
+        .limit(limit)
+    )
+    return [_shape(r) for r in rows]
+
+
+def dismiss_guide_submission(sub_id: str) -> bool:
+    if not _enabled():
+        return False
+    try:
+        oid = ObjectId(sub_id)
+    except InvalidId:
+        return False
+    res = _db()[_GUIDE_SUBMISSIONS_COLLECTION].update_one(
+        {"_id": oid}, {"$set": {"status": "dismissed"}}
+    )
+    return res.modified_count > 0
+
+
+# ── Run deletion ─────────────────────────────────────────────
+
+
+def delete_run(run_hash: str, runs_dir: Path) -> dict[str, Any]:
+    """Remove a submitted run everywhere it lives synchronously: every Mongo
+    doc with the hash (multiplayer runs store one doc per player) and the
+    blob file. The stats snapshot and leaderboard summaries pick up the
+    removal on their next scheduled rebuild."""
+    deleted_docs = 0
+    if _enabled():
+        deleted_docs = _db()["runs"].delete_many({"run_hash": run_hash}).deleted_count
+    file_removed = False
+    blob = runs_dir / f"{run_hash}.json"
+    try:
+        if blob.is_file():
+            blob.unlink()
+            file_removed = True
+    except OSError:
+        logger.warning("run blob delete failed for %s", run_hash, exc_info=True)
+    return {"deleted_docs": deleted_docs, "file_removed": file_removed}

--- a/backend/app/services/admin_db.py
+++ b/backend/app/services/admin_db.py
@@ -153,3 +153,58 @@ def delete_run(run_hash: str, runs_dir: Path) -> dict[str, Any]:
     except OSError:
         logger.warning("run blob delete failed for %s", run_hash, exc_info=True)
     return {"deleted_docs": deleted_docs, "file_removed": file_removed}
+
+
+# ── Announcements (the site banner) ──────────────────────────
+
+
+_ANNOUNCEMENTS_COLLECTION = "announcements"
+
+
+def list_announcements(active_only: bool = False) -> list[dict]:
+    if not _enabled():
+        return []
+    query = {"active": True} if active_only else {}
+    rows = list(
+        _db()[_ANNOUNCEMENTS_COLLECTION].find(query).sort("created_at", -1).limit(50)
+    )
+    return [_shape(r) for r in rows]
+
+
+def create_announcement(message: str) -> dict:
+    """One banner message. Inline links use [label](/href) and the frontend
+    renders them as real links; everything else is plain text."""
+    doc = {
+        "message": message.strip(),
+        "active": True,
+        "created_at": datetime.now(timezone.utc),
+    }
+    res = _db()[_ANNOUNCEMENTS_COLLECTION].insert_one(doc)
+    doc["_id"] = res.inserted_id
+    return _shape(doc)
+
+
+def toggle_announcement(ann_id: str) -> bool:
+    if not _enabled():
+        return False
+    try:
+        oid = ObjectId(ann_id)
+    except InvalidId:
+        return False
+    doc = _db()[_ANNOUNCEMENTS_COLLECTION].find_one({"_id": oid}, {"active": 1})
+    if not doc:
+        return False
+    _db()[_ANNOUNCEMENTS_COLLECTION].update_one(
+        {"_id": oid}, {"$set": {"active": not doc.get("active", False)}}
+    )
+    return True
+
+
+def delete_announcement(ann_id: str) -> bool:
+    if not _enabled():
+        return False
+    try:
+        oid = ObjectId(ann_id)
+    except InvalidId:
+        return False
+    return _db()[_ANNOUNCEMENTS_COLLECTION].delete_one({"_id": oid}).deleted_count > 0

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,11 @@ services:
       # autodeploy script uses; set them in the box's .env.
       - CF_TOKEN=${CF_TOKEN:-}
       - CF_ZONE=${CF_ZONE:-}
+      # Umami analytics on the admin overview, proxied server-side.
+      - UMAMI_URL=${UMAMI_URL:-}
+      - UMAMI_USERNAME=${UMAMI_USERNAME:-}
+      - UMAMI_PASSWORD=${UMAMI_PASSWORD:-}
+      - UMAMI_WEBSITE_ID=${UMAMI_WEBSITE_ID:-}
       - GUIDE_WEBHOOK_URL=${GUIDE_WEBHOOK_URL:-}
       - RESEND_API_KEY=${RESEND_API_KEY:-}
       - UNINSTALL_FORWARD_FROM=${UNINSTALL_FORWARD_FROM:-}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,6 +32,10 @@ services:
       - DATA_DIR=/data
       - BETA_DATA_DIR=/data-beta
       - FEEDBACK_WEBHOOK_URL=${FEEDBACK_WEBHOOK_URL:-}
+      # Cloudflare purge from the admin cache tab. Same token/zone the
+      # autodeploy script uses; set them in the box's .env.
+      - CF_TOKEN=${CF_TOKEN:-}
+      - CF_ZONE=${CF_ZONE:-}
       - GUIDE_WEBHOOK_URL=${GUIDE_WEBHOOK_URL:-}
       - RESEND_API_KEY=${RESEND_API_KEY:-}
       - UNINSTALL_FORWARD_FROM=${UNINSTALL_FORWARD_FROM:-}

--- a/frontend/app/admin/AdminClient.tsx
+++ b/frontend/app/admin/AdminClient.tsx
@@ -1,17 +1,11 @@
 "use client";
 
-// Operator dashboard shell. Renders a 404-style screen unless /api/auth/me
-// says the signed-in user is on the admin allowlist; the data itself comes
-// from /api/admin/* which enforces the same allowlist server-side.
+// Operator overview: run volume, snapshot health, Redis. The shell handles
+// the gate and the section nav; the other surfaces live in their own
+// /admin/* routes.
 
 import { useEffect, useState } from "react";
-
-const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
-
-interface Me {
-  username: string | null;
-  is_admin?: boolean;
-}
+import { AdminShell, Card, adminFetch } from "./shared";
 
 interface Overview {
   runs: { total?: number; last_24h?: number; last_submission?: string | null };
@@ -35,34 +29,6 @@ interface Overview {
   environment: string;
 }
 
-function authHeaders(): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (typeof window !== "undefined") {
-    const token = localStorage.getItem("spire_token");
-    if (token) headers["Authorization"] = `Bearer ${token}`;
-  }
-  return headers;
-}
-
-function NotFound() {
-  return (
-    <div className="max-w-2xl mx-auto px-4 py-24 text-center">
-      <h1 className="text-3xl font-bold text-[var(--text-primary)] mb-2">404</h1>
-      <p className="text-sm text-[var(--text-muted)]">This page does not exist.</p>
-    </div>
-  );
-}
-
-function Card({ label, value, sub }: { label: string; value: string; sub?: string }) {
-  return (
-    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
-      <div className="text-2xl font-bold text-[var(--accent-gold)] tabular-nums">{value}</div>
-      <div className="text-xs uppercase tracking-wider text-[var(--text-muted)] mt-1">{label}</div>
-      {sub && <div className="text-xs text-[var(--text-secondary)] mt-1">{sub}</div>}
-    </div>
-  );
-}
-
 function fmtAge(seconds?: number | null): string {
   if (seconds == null) return "unknown";
   if (seconds < 90) return `${seconds}s ago`;
@@ -71,60 +37,21 @@ function fmtAge(seconds?: number | null): string {
 }
 
 export default function AdminClient() {
-  const [state, setState] = useState<"loading" | "denied" | "ok">("loading");
-  const [me, setMe] = useState<Me | null>(null);
   const [data, setData] = useState<Overview | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch(`${API}/api/auth/me`, { credentials: "include", headers: authHeaders() })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((m: Me | null) => {
-        if (!m?.is_admin) {
-          setState("denied");
-          return;
-        }
-        setMe(m);
-        setState("ok");
-        return fetch(`${API}/api/admin/overview`, {
-          credentials: "include",
-          headers: authHeaders(),
-        })
-          .then((r) => {
-            if (!r.ok) throw new Error(`overview ${r.status}`);
-            return r.json();
-          })
-          .then(setData);
-      })
-      .catch((e) => {
-        if (state !== "denied") setError(String(e?.message || e));
-        setState((s) => (s === "loading" ? "denied" : s));
-      });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    adminFetch<Overview>("/api/admin/overview")
+      .then(setData)
+      .catch((e) => setError(String(e?.message || e)));
   }, []);
-
-  if (state === "loading") {
-    return (
-      <div className="max-w-5xl mx-auto px-4 py-24 text-center text-sm text-[var(--text-muted)]">
-        Loading...
-      </div>
-    );
-  }
-  if (state === "denied") return <NotFound />;
 
   const r = data?.runs ?? {};
   const snap = data?.snapshot ?? {};
   const redis = data?.redis;
 
   return (
-    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <h1 className="text-3xl font-bold mb-1">
-        <span className="text-[var(--accent-gold)]">Admin</span>
-      </h1>
-      <p className="text-sm text-[var(--text-muted)] mb-6">
-        Signed in as {me?.username ?? "?"} · {data?.environment ?? "..."}
-      </p>
-
+    <AdminShell title="Admin" subtitle={data?.environment}>
       {error && <p className="text-sm text-rose-400 mb-4">{error}</p>}
       {!data && !error && (
         <p className="text-sm text-[var(--text-muted)]">Loading overview...</p>
@@ -172,6 +99,6 @@ export default function AdminClient() {
           </div>
         </>
       )}
-    </div>
+    </AdminShell>
   );
 }

--- a/frontend/app/admin/AdminClient.tsx
+++ b/frontend/app/admin/AdminClient.tsx
@@ -50,8 +50,30 @@ export default function AdminClient() {
   const snap = data?.snapshot ?? {};
   const redis = data?.redis;
 
+  const QUICK_LINKS = [
+    { href: "https://analytics.spire-codex.com", label: "Umami" },
+    { href: "https://github.com/ptrlrd/spire-codex", label: "GitHub" },
+    { href: "https://dash.cloudflare.com", label: "Cloudflare" },
+    { href: "https://git.ptrlrd.com", label: "Forgejo" },
+    { href: "https://hub.docker.com/u/ptrlrd", label: "Docker Hub" },
+  ];
+
   return (
     <AdminShell title="Admin" subtitle={data?.environment}>
+      <div className="flex flex-wrap gap-2 mb-8">
+        {QUICK_LINKS.map((l) => (
+          <a
+            key={l.href}
+            href={l.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="px-3 py-1 rounded-lg text-xs border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--accent-gold)] hover:border-[var(--accent-gold)]/40 transition-colors"
+          >
+            {l.label} ↗
+          </a>
+        ))}
+      </div>
+
       {error && <p className="text-sm text-rose-400 mb-4">{error}</p>}
       {!data && !error && (
         <p className="text-sm text-[var(--text-muted)]">Loading overview...</p>

--- a/frontend/app/admin/analytics/AnalyticsClient.tsx
+++ b/frontend/app/admin/analytics/AnalyticsClient.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+// Umami headline numbers without leaving the lair, proxied server-side so
+// the analytics credentials never reach the browser. The full dashboard is
+// one click away.
+
+import { useEffect, useState } from "react";
+import { AdminShell, Card, adminFetch } from "../shared";
+
+interface UmamiStat {
+  value?: number;
+  prev?: number;
+}
+interface Analytics {
+  last_24h?: { pageviews?: UmamiStat; visitors?: UmamiStat; visits?: UmamiStat } | null;
+  last_7d?: { pageviews?: UmamiStat; visitors?: UmamiStat; visits?: UmamiStat } | null;
+  top_pages?: { x: string; y: number }[];
+  dashboard_url?: string;
+}
+
+function n(stat?: UmamiStat): string {
+  return stat?.value != null ? stat.value.toLocaleString() : "-";
+}
+
+export default function AnalyticsClient() {
+  const [data, setData] = useState<Analytics | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+
+  useEffect(() => {
+    adminFetch<Analytics>("/api/admin/analytics")
+      .then(setData)
+      .catch((e) => {
+        const msg = String((e as Error)?.message || e);
+        setNote(
+          msg.includes("503")
+            ? "Umami isn't wired up yet: set UMAMI_USERNAME and UMAMI_PASSWORD in the box .env (UMAMI_URL and UMAMI_WEBSITE_ID optional) and redeploy."
+            : msg,
+        );
+      });
+  }, []);
+
+  return (
+    <AdminShell title="Analytics" subtitle="Umami">
+      {note && <p className="text-sm text-[var(--text-secondary)] mb-4">{note}</p>}
+
+      {data && (
+        <>
+          <div className="mb-6">
+            <a
+              href={data.dashboard_url || "https://analytics.spire-codex.com"}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-[var(--accent-gold)] hover:underline"
+            >
+              Open the full Umami dashboard →
+            </a>
+          </div>
+
+          <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Last 24 hours</h2>
+          <div className="grid grid-cols-3 gap-3 mb-8">
+            <Card label="Visitors" value={n(data.last_24h?.visitors)} />
+            <Card label="Visits" value={n(data.last_24h?.visits)} />
+            <Card label="Pageviews" value={n(data.last_24h?.pageviews)} />
+          </div>
+
+          <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Last 7 days</h2>
+          <div className="grid grid-cols-3 gap-3 mb-8">
+            <Card label="Visitors" value={n(data.last_7d?.visitors)} />
+            <Card label="Visits" value={n(data.last_7d?.visits)} />
+            <Card label="Pageviews" value={n(data.last_7d?.pageviews)} />
+          </div>
+
+          {(data.top_pages?.length ?? 0) > 0 && (
+            <>
+              <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">
+                Top pages (7d)
+              </h2>
+              <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] divide-y divide-[var(--border-subtle)]">
+                {data.top_pages!.map((p) => (
+                  <div key={p.x} className="flex items-center justify-between px-4 py-2 text-sm">
+                    <span className="font-mono text-xs text-[var(--text-primary)] truncate">{p.x}</span>
+                    <span className="text-[var(--text-secondary)] tabular-nums ml-3">
+                      {p.y.toLocaleString()}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </AdminShell>
+  );
+}

--- a/frontend/app/admin/analytics/page.tsx
+++ b/frontend/app/admin/analytics/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import AnalyticsClient from "./AnalyticsClient";
+
+export const metadata: Metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminAnalyticsPage() {
+  return <AnalyticsClient />;
+}

--- a/frontend/app/admin/banners/BannersClient.tsx
+++ b/frontend/app/admin/banners/BannersClient.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+// Announcement banner control. Whatever is active here renders as the
+// green NEW banner on every page; dismissals are keyed per announcement,
+// so publishing a new one reshows the banner for everyone.
+
+import { useEffect, useState } from "react";
+import { AdminShell, adminFetch } from "../shared";
+
+interface Announcement {
+  id: string;
+  message: string;
+  active?: boolean;
+  created_at?: string;
+}
+
+export default function BannersClient() {
+  const [items, setItems] = useState<Announcement[]>([]);
+  const [message, setMessage] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+
+  function load() {
+    adminFetch<{ items: Announcement[] }>("/api/admin/announcements")
+      .then((d) => setItems(d.items ?? []))
+      .catch((e) => setNote(String((e as Error)?.message || e)));
+  }
+  useEffect(load, []);
+
+  async function create() {
+    if (!message.trim()) return;
+    setBusy(true);
+    setNote(null);
+    try {
+      await adminFetch("/api/admin/announcements", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: message.trim() }),
+      });
+      setMessage("");
+      load();
+      setNote("Published. Visitors see it within a minute (60s cache).");
+    } catch (e) {
+      setNote(String((e as Error)?.message || e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function toggle(id: string) {
+    await adminFetch(`/api/admin/announcements/${id}/toggle`, { method: "POST" }).catch(() => {});
+    load();
+  }
+
+  async function remove(id: string) {
+    if (!window.confirm("Delete this announcement?")) return;
+    await adminFetch(`/api/admin/announcements/${id}`, { method: "DELETE" }).catch(() => {});
+    load();
+  }
+
+  return (
+    <AdminShell title="Banners" subtitle="the site announcement strip">
+      <p className="text-sm text-[var(--text-secondary)] mb-2">
+        Plain text plus inline links as{" "}
+        <code className="text-[var(--accent-gold)]">[label](/path)</code> or{" "}
+        <code className="text-[var(--accent-gold)]">[label](https://...)</code>. The newest active
+        announcement renders site-wide with the NEW badge.
+      </p>
+      <textarea
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        rows={3}
+        maxLength={500}
+        placeholder="The [Tier List Maker](/tier-list-maker) is here, make your list and share it."
+        className="w-full max-w-2xl px-3 py-2 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]/50 mb-2"
+      />
+      <div>
+        <button
+          onClick={create}
+          disabled={busy || !message.trim()}
+          className="px-4 py-1.5 rounded-lg bg-[var(--accent-gold)] text-[var(--bg-primary)] text-sm font-semibold hover:opacity-90 disabled:opacity-50"
+        >
+          Publish
+        </button>
+      </div>
+      {note && <p className="text-sm text-[var(--text-secondary)] mt-3">{note}</p>}
+
+      <div className="space-y-3 mt-8">
+        {items.map((a) => (
+          <div key={a.id} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+            <div className="flex items-center justify-between gap-3 mb-2">
+              <div className="text-xs text-[var(--text-muted)]">
+                <span
+                  className={`px-1.5 py-0.5 rounded mr-2 font-semibold ${
+                    a.active
+                      ? "bg-emerald-950/60 text-emerald-300 border border-emerald-900/40"
+                      : "bg-[var(--bg-primary)] text-[var(--text-muted)] border border-[var(--border-subtle)]"
+                  }`}
+                >
+                  {a.active ? "active" : "off"}
+                </span>
+                {a.created_at && new Date(a.created_at).toLocaleString()}
+              </div>
+              <div className="flex gap-2 shrink-0">
+                <button
+                  onClick={() => toggle(a.id)}
+                  className="px-2.5 py-1 rounded text-xs font-semibold border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                >
+                  {a.active ? "Turn off" : "Turn on"}
+                </button>
+                <button
+                  onClick={() => remove(a.id)}
+                  className="px-2.5 py-1 rounded text-xs font-semibold bg-rose-950/60 text-rose-300 border border-rose-900/40 hover:bg-rose-900/60"
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+            <p className="text-sm text-[var(--text-primary)] whitespace-pre-wrap break-words">{a.message}</p>
+          </div>
+        ))}
+      </div>
+    </AdminShell>
+  );
+}

--- a/frontend/app/admin/banners/page.tsx
+++ b/frontend/app/admin/banners/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import BannersClient from "./BannersClient";
+
+export const metadata: Metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminBannersPage() {
+  return <BannersClient />;
+}

--- a/frontend/app/admin/cache/CacheClient.tsx
+++ b/frontend/app/admin/cache/CacheClient.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+// Cloudflare cache purge without leaving the lair: specific paths, or the
+// whole zone. The token never reaches the browser - the backend holds
+// CF_TOKEN/CF_ZONE and proxies the purge.
+
+import { useState } from "react";
+import { AdminShell, adminFetch } from "../shared";
+
+export default function CacheClient() {
+  const [paths, setPaths] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+
+  async function purge(all: boolean) {
+    const list = all
+      ? []
+      : paths
+          .split("\n")
+          .map((p) => p.trim())
+          .filter(Boolean);
+    if (all && !window.confirm("Purge the ENTIRE Cloudflare cache?")) return;
+    if (!all && list.length === 0) {
+      setNote("Enter at least one path, or use purge everything.");
+      return;
+    }
+    setBusy(true);
+    setNote(null);
+    try {
+      const res = await adminFetch<{ ok: boolean; purged: string; count: number }>(
+        "/api/admin/cf/purge",
+        { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ paths: list }) },
+      );
+      setNote(
+        res.ok
+          ? res.purged === "everything"
+            ? "Purged the whole zone."
+            : `Purged ${res.count} path(s).`
+          : "Cloudflare rejected the purge; check the backend log.",
+      );
+    } catch (e) {
+      setNote(String((e as Error)?.message || e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <AdminShell title="Cache" subtitle="Cloudflare purge">
+      <p className="text-sm text-[var(--text-secondary)] mb-3">
+        One path per line, e.g. <code className="text-[var(--accent-gold)]">/cards</code> or{" "}
+        <code className="text-[var(--accent-gold)]">/api/runs/community-stats</code>. Paths purge on
+        the apex domain.
+      </p>
+      <textarea
+        value={paths}
+        onChange={(e) => setPaths(e.target.value)}
+        rows={6}
+        placeholder={"/cards\n/api/runs/community-stats"}
+        className="w-full max-w-xl px-3 py-2 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] text-sm font-mono text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]/50 mb-3"
+      />
+      <div className="flex gap-2">
+        <button
+          onClick={() => purge(false)}
+          disabled={busy}
+          className="px-4 py-1.5 rounded-lg bg-[var(--accent-gold)] text-[var(--bg-primary)] text-sm font-semibold hover:opacity-90 disabled:opacity-50"
+        >
+          Purge paths
+        </button>
+        <button
+          onClick={() => purge(true)}
+          disabled={busy}
+          className="px-4 py-1.5 rounded-lg text-sm font-semibold bg-rose-950/60 text-rose-300 border border-rose-900/40 hover:bg-rose-900/60 disabled:opacity-50"
+        >
+          Purge everything
+        </button>
+      </div>
+      {note && <p className="text-sm text-[var(--text-secondary)] mt-4">{note}</p>}
+    </AdminShell>
+  );
+}

--- a/frontend/app/admin/feedback/FeedbackClient.tsx
+++ b/frontend/app/admin/feedback/FeedbackClient.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+// Feedback inbox: every site-feedback and QA card report, newest first.
+// Submissions copy here alongside the Discord webhook, so this fills up
+// from the moment the backend with the inbox tap deploys.
+
+import { useEffect, useState } from "react";
+import { AdminShell, adminFetch } from "../shared";
+
+interface FeedbackItem {
+  id: string;
+  source: string;
+  created_at?: string;
+  resolved?: boolean;
+  type?: string;
+  contact?: string | null;
+  contents?: string;
+  feedback?: string;
+  card_id?: string;
+  card_name?: string | null;
+}
+
+export default function FeedbackClient() {
+  const [items, setItems] = useState<FeedbackItem[]>([]);
+  const [showResolved, setShowResolved] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+
+  function load(includeResolved: boolean) {
+    adminFetch<{ items: FeedbackItem[] }>(
+      `/api/admin/feedback?include_resolved=${includeResolved}`,
+    )
+      .then((d) => {
+        setItems(d.items ?? []);
+        if (!(d.items ?? []).length) setNote("Inbox empty. New submissions land here from now on.");
+        else setNote(null);
+      })
+      .catch((e) => setNote(String((e as Error)?.message || e)));
+  }
+
+  useEffect(() => load(showResolved), [showResolved]);
+
+  async function resolve(id: string) {
+    try {
+      await adminFetch(`/api/admin/feedback/${id}/resolve`, { method: "POST" });
+      setItems((prev) => prev.filter((i) => i.id !== id));
+    } catch (e) {
+      setNote(String((e as Error)?.message || e));
+    }
+  }
+
+  return (
+    <AdminShell title="Feedback" subtitle="site feedback + QA card reports">
+      <label className="inline-flex items-center gap-2 text-sm text-[var(--text-secondary)] mb-4">
+        <input
+          type="checkbox"
+          checked={showResolved}
+          onChange={(e) => setShowResolved(e.target.checked)}
+        />
+        Show resolved
+      </label>
+
+      {note && <p className="text-sm text-[var(--text-muted)] mb-4">{note}</p>}
+
+      <div className="space-y-3">
+        {items.map((i) => (
+          <div key={i.id} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+            <div className="flex items-center justify-between gap-3 mb-2">
+              <div className="text-xs text-[var(--text-muted)]">
+                <span className="px-1.5 py-0.5 rounded bg-[var(--bg-primary)] border border-[var(--border-subtle)] mr-2 uppercase">
+                  {i.source}
+                </span>
+                {i.type && <span className="mr-2">{i.type}</span>}
+                {i.card_name && <span className="mr-2">{i.card_name}</span>}
+                {i.created_at && new Date(i.created_at).toLocaleString()}
+                {i.contact && <span className="ml-2">· {i.contact}</span>}
+              </div>
+              {!i.resolved && (
+                <button
+                  onClick={() => resolve(i.id)}
+                  className="px-2.5 py-1 rounded text-xs font-semibold bg-emerald-950/60 text-emerald-300 border border-emerald-900/40 hover:bg-emerald-900/60 shrink-0"
+                >
+                  Resolve
+                </button>
+              )}
+            </div>
+            <p className="text-sm text-[var(--text-primary)] whitespace-pre-wrap break-words">
+              {i.contents || i.feedback || "(empty)"}
+            </p>
+          </div>
+        ))}
+      </div>
+    </AdminShell>
+  );
+}

--- a/frontend/app/admin/guides/GuidesClient.tsx
+++ b/frontend/app/admin/guides/GuidesClient.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+// Guide moderation queue. Publishing a guide stays a git operation (guides
+// ship in data/guides.json through the normal pipeline); this queue is for
+// reviewing what came in and clearing handled entries.
+
+import { useEffect, useState } from "react";
+import { AdminShell, adminFetch } from "../shared";
+
+interface GuideSub {
+  id: string;
+  created_at?: string;
+  title?: string;
+  author_name?: string;
+  contact?: string;
+  category?: string;
+  difficulty?: string;
+  character?: string | null;
+  summary?: string;
+  content?: string;
+}
+
+export default function GuidesClient() {
+  const [items, setItems] = useState<GuideSub[]>([]);
+  const [open, setOpen] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+
+  useEffect(() => {
+    adminFetch<{ items: GuideSub[] }>("/api/admin/guides/pending")
+      .then((d) => {
+        setItems(d.items ?? []);
+        if (!(d.items ?? []).length)
+          setNote("Queue empty. New submissions land here from now on.");
+      })
+      .catch((e) => setNote(String((e as Error)?.message || e)));
+  }, []);
+
+  async function dismiss(id: string) {
+    try {
+      await adminFetch(`/api/admin/guides/submissions/${id}/dismiss`, { method: "POST" });
+      setItems((prev) => prev.filter((i) => i.id !== id));
+    } catch (e) {
+      setNote(String((e as Error)?.message || e));
+    }
+  }
+
+  return (
+    <AdminShell title="Guides" subtitle="submission queue">
+      {note && <p className="text-sm text-[var(--text-muted)] mb-4">{note}</p>}
+
+      <div className="space-y-3">
+        {items.map((g) => (
+          <div key={g.id} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+            <div className="flex items-center justify-between gap-3 mb-1">
+              <h3 className="font-semibold text-[var(--text-primary)]">{g.title || "(untitled)"}</h3>
+              <div className="flex gap-2 shrink-0">
+                <button
+                  onClick={() => setOpen(open === g.id ? null : g.id)}
+                  className="px-2.5 py-1 rounded text-xs font-semibold border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                >
+                  {open === g.id ? "Hide" : "Read"}
+                </button>
+                <button
+                  onClick={() => dismiss(g.id)}
+                  className="px-2.5 py-1 rounded text-xs font-semibold bg-rose-950/60 text-rose-300 border border-rose-900/40 hover:bg-rose-900/60"
+                >
+                  Dismiss
+                </button>
+              </div>
+            </div>
+            <div className="text-xs text-[var(--text-muted)] mb-2">
+              {g.author_name} · {g.contact} · {g.category}
+              {g.character ? ` · ${g.character}` : ""} · {g.difficulty}
+              {g.created_at ? ` · ${new Date(g.created_at).toLocaleString()}` : ""}
+            </div>
+            {g.summary && <p className="text-sm text-[var(--text-secondary)] mb-2">{g.summary}</p>}
+            {open === g.id && (
+              <pre className="text-xs text-[var(--text-secondary)] whitespace-pre-wrap break-words bg-[var(--bg-primary)] rounded p-3 max-h-96 overflow-y-auto">
+                {g.content || "(no content)"}
+              </pre>
+            )}
+          </div>
+        ))}
+      </div>
+    </AdminShell>
+  );
+}

--- a/frontend/app/admin/runs/RunsClient.tsx
+++ b/frontend/app/admin/runs/RunsClient.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+// Run admin: search by username / seed / hash, inspect, delete. Deletion
+// removes the Mongo docs and the blob file immediately; aggregates drop
+// the run on their next rebuild.
+
+import { useState } from "react";
+import Link from "next/link";
+import { AdminShell, adminFetch } from "../shared";
+
+interface RunRow {
+  run_hash?: string;
+  username?: string | null;
+  character?: string | null;
+  ascension?: number | null;
+  win?: boolean | number | null;
+  player_count?: number | null;
+  build_id?: string | null;
+  submitted_at?: string | null;
+  seed?: string | null;
+}
+
+export default function RunsClient() {
+  const [username, setUsername] = useState("");
+  const [seed, setSeed] = useState("");
+  const [hash, setHash] = useState("");
+  const [rows, setRows] = useState<RunRow[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+
+  async function search() {
+    setBusy(true);
+    setNote(null);
+    try {
+      const params = new URLSearchParams();
+      if (username.trim()) params.set("username", username.trim());
+      if (seed.trim()) params.set("seed", seed.trim());
+      if (hash.trim()) params.set("run_hash", hash.trim());
+      const data = await adminFetch<{ runs: RunRow[]; total?: number }>(
+        `/api/admin/runs/search?${params}`,
+      );
+      setRows(data.runs ?? []);
+      if (!(data.runs ?? []).length) setNote("No runs matched.");
+    } catch (e) {
+      setNote(String((e as Error)?.message || e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove(runHash: string) {
+    if (!window.confirm(`Delete run ${runHash}? This removes it permanently.`)) return;
+    try {
+      const res = await adminFetch<{ deleted_docs: number; file_removed: boolean }>(
+        `/api/admin/runs/${runHash}`,
+        { method: "DELETE" },
+      );
+      setRows((prev) => prev.filter((r) => r.run_hash !== runHash));
+      setNote(`Deleted ${runHash}: ${res.deleted_docs} doc(s), file removed: ${String(res.file_removed)}.`);
+    } catch (e) {
+      setNote(String((e as Error)?.message || e));
+    }
+  }
+
+  const inputClass =
+    "px-3 py-1.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]/50";
+
+  return (
+    <AdminShell title="Runs" subtitle="search, inspect, delete">
+      <div className="flex flex-wrap gap-2 mb-4">
+        <input className={inputClass} placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
+        <input className={inputClass} placeholder="Seed" value={seed} onChange={(e) => setSeed(e.target.value)} />
+        <input className={`${inputClass} w-72`} placeholder="Run hash" value={hash} onChange={(e) => setHash(e.target.value)} />
+        <button
+          onClick={search}
+          disabled={busy}
+          className="px-4 py-1.5 rounded-lg bg-[var(--accent-gold)] text-[var(--bg-primary)] text-sm font-semibold hover:opacity-90 disabled:opacity-50"
+        >
+          {busy ? "Searching..." : "Search"}
+        </button>
+      </div>
+
+      {note && <p className="text-sm text-[var(--text-secondary)] mb-4">{note}</p>}
+
+      {rows.length > 0 && (
+        <div className="overflow-x-auto rounded-lg border border-[var(--border-subtle)]">
+          <table className="w-full text-sm">
+            <thead className="bg-[var(--bg-card)] text-left text-xs uppercase tracking-wider text-[var(--text-muted)]">
+              <tr>
+                <th className="px-3 py-2">Hash</th>
+                <th className="px-3 py-2">User</th>
+                <th className="px-3 py-2">Character</th>
+                <th className="px-3 py-2">Asc</th>
+                <th className="px-3 py-2">Win</th>
+                <th className="px-3 py-2">Build</th>
+                <th className="px-3 py-2">Submitted</th>
+                <th className="px-3 py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.run_hash} className="border-t border-[var(--border-subtle)]">
+                  <td className="px-3 py-2 font-mono text-xs">
+                    {r.run_hash ? (
+                      <Link href={`/runs/${r.run_hash}`} className="text-[var(--accent-gold)] hover:underline">
+                        {r.run_hash.slice(0, 12)}...
+                      </Link>
+                    ) : "-"}
+                  </td>
+                  <td className="px-3 py-2">{r.username ?? "-"}</td>
+                  <td className="px-3 py-2">{(r.character ?? "-").replace("CHARACTER.", "")}</td>
+                  <td className="px-3 py-2 tabular-nums">{r.ascension ?? "-"}</td>
+                  <td className="px-3 py-2">{r.win ? "yes" : "no"}</td>
+                  <td className="px-3 py-2 text-xs">{r.build_id ?? "-"}</td>
+                  <td className="px-3 py-2 text-xs">
+                    {r.submitted_at ? new Date(r.submitted_at).toLocaleString() : "-"}
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    {r.run_hash && (
+                      <button
+                        onClick={() => remove(r.run_hash!)}
+                        className="px-2.5 py-1 rounded text-xs font-semibold bg-rose-950/60 text-rose-300 border border-rose-900/40 hover:bg-rose-900/60"
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </AdminShell>
+  );
+}

--- a/frontend/app/admin/shared.tsx
+++ b/frontend/app/admin/shared.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+// Shared plumbing for the operator pages: the admin gate (404 for anyone
+// not on the allowlist), the section nav, and the card primitives. Every
+// /admin/* page wraps itself in <AdminShell>; the real enforcement is
+// server-side on /api/admin/* plus Cloudflare Access at the edge - this
+// gate only keeps the UI from flashing for non-admins.
+
+import { useEffect, useState, type ReactNode } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+export function authHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (typeof window !== "undefined") {
+    const token = localStorage.getItem("spire_token");
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+export async function adminFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${API}${path}`, {
+    credentials: "include",
+    ...init,
+    headers: { ...authHeaders(), ...(init.headers as Record<string, string>) },
+  });
+  if (!res.ok) throw new Error(`${path} -> ${res.status}`);
+  return res.json();
+}
+
+interface Me {
+  username: string | null;
+  is_admin?: boolean;
+}
+
+export function useAdminGate(): { state: "loading" | "denied" | "ok"; me: Me | null } {
+  const [state, setState] = useState<"loading" | "denied" | "ok">("loading");
+  const [me, setMe] = useState<Me | null>(null);
+  useEffect(() => {
+    fetch(`${API}/api/auth/me`, { credentials: "include", headers: authHeaders() })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((m: Me | null) => {
+        if (!m?.is_admin) {
+          setState("denied");
+          return;
+        }
+        setMe(m);
+        setState("ok");
+      })
+      .catch(() => setState("denied"));
+  }, []);
+  return { state, me };
+}
+
+function NotFound() {
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-24 text-center">
+      <h1 className="text-3xl font-bold text-[var(--text-primary)] mb-2">404</h1>
+      <p className="text-sm text-[var(--text-muted)]">This page does not exist.</p>
+    </div>
+  );
+}
+
+const SECTIONS = [
+  { href: "/admin", label: "Overview" },
+  { href: "/admin/runs", label: "Runs" },
+  { href: "/admin/feedback", label: "Feedback" },
+  { href: "/admin/guides", label: "Guides" },
+  { href: "/admin/cache", label: "Cache" },
+];
+
+export function AdminShell({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+}) {
+  const { state, me } = useAdminGate();
+  const pathname = usePathname();
+
+  if (state === "loading") {
+    return (
+      <div className="max-w-5xl mx-auto px-4 py-24 text-center text-sm text-[var(--text-muted)]">
+        Loading...
+      </div>
+    );
+  }
+  if (state === "denied") return <NotFound />;
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <h1 className="text-3xl font-bold mb-1">
+        <span className="text-[var(--accent-gold)]">{title}</span>
+      </h1>
+      <p className="text-sm text-[var(--text-muted)] mb-4">
+        Signed in as {me?.username ?? "?"}
+        {subtitle ? ` · ${subtitle}` : ""}
+      </p>
+      <nav className="flex flex-wrap gap-1.5 mb-8">
+        {SECTIONS.map((s) => (
+          <Link
+            key={s.href}
+            href={s.href}
+            className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${
+              pathname === s.href
+                ? "bg-[var(--accent-gold)]/15 text-[var(--accent-gold)] border-[var(--accent-gold)]/30"
+                : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-card)]"
+            }`}
+          >
+            {s.label}
+          </Link>
+        ))}
+      </nav>
+      {children}
+    </div>
+  );
+}
+
+export function Card({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+      <div className="text-2xl font-bold text-[var(--accent-gold)] tabular-nums">{value}</div>
+      <div className="text-xs uppercase tracking-wider text-[var(--text-muted)] mt-1">{label}</div>
+      {sub && <div className="text-xs text-[var(--text-secondary)] mt-1">{sub}</div>}
+    </div>
+  );
+}

--- a/frontend/app/admin/shared.tsx
+++ b/frontend/app/admin/shared.tsx
@@ -69,6 +69,8 @@ const SECTIONS = [
   { href: "/admin/runs", label: "Runs" },
   { href: "/admin/feedback", label: "Feedback" },
   { href: "/admin/guides", label: "Guides" },
+  { href: "/admin/banners", label: "Banners" },
+  { href: "/admin/analytics", label: "Analytics" },
   { href: "/admin/cache", label: "Cache" },
 ];
 

--- a/frontend/app/components/DonationBanner.tsx
+++ b/frontend/app/components/DonationBanner.tsx
@@ -203,7 +203,47 @@ function AncientBanner({ banner, onDismiss }: { banner: RotatingBanner; onDismis
   );
 }
 
-function TierListBanner({ onDismiss }: { onDismiss: () => void }) {
+interface Announcement {
+  id: string;
+  message: string;
+}
+
+/** Inline [label](/href) links in an admin-entered announcement become real
+ * links; everything else renders as plain text, so banner content can never
+ * inject markup. */
+function renderAnnouncement(message: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  const re = /\[([^\]]+)\]\(([^)\s]+)\)/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  const linkClass = "font-medium text-green-100 underline hover:text-white transition-colors";
+  while ((m = re.exec(message)) !== null) {
+    if (m.index > last) out.push(message.slice(last, m.index));
+    const [, label, href] = m;
+    out.push(
+      href.startsWith("/") ? (
+        <Link key={m.index} href={href} className={linkClass}>
+          {label}
+        </Link>
+      ) : (
+        <a key={m.index} href={href} target="_blank" rel="noopener noreferrer" className={linkClass}>
+          {label}
+        </a>
+      ),
+    );
+    last = m.index + m[0].length;
+  }
+  if (last < message.length) out.push(message.slice(last));
+  return out;
+}
+
+function AnnouncementBanner({
+  ann,
+  onDismiss,
+}: {
+  ann: Announcement;
+  onDismiss: () => void;
+}) {
   return (
     <div className="bg-green-900/40 border-b border-green-700/30">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex items-center justify-between gap-4">
@@ -217,29 +257,7 @@ function TierListBanner({ onDismiss }: { onDismiss: () => void }) {
             <span className="mr-2 rounded bg-green-500 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white">
               New
             </span>
-            The{" "}
-            <Link
-              href="/tier-list-maker"
-              className="font-medium text-green-100 underline hover:text-white transition-colors"
-            >
-              Tier List Maker
-            </Link>{" "}
-            is here, make your list and share it. Introducing the Codex Elo
-            system, check out our{" "}
-            <Link
-              href="/leaderboards/metrics"
-              className="font-medium text-green-100 underline hover:text-white transition-colors"
-            >
-              card metrics
-            </Link>{" "}
-            for an in-depth view of picks. Plus a new 1:1{" "}
-            <Link
-              href="/cards"
-              className="font-medium text-green-100 underline hover:text-white transition-colors"
-            >
-              card view
-            </Link>{" "}
-            is now available.
+            {renderAnnouncement(ann.message)}
           </p>
         </div>
         <button
@@ -256,27 +274,16 @@ function TierListBanner({ onDismiss }: { onDismiss: () => void }) {
 
 export default function DonationBanner() {
   const [banner, setBanner] = useState<
-    "none" | "tierlist" | "patreon" | "rotating"
+    "none" | "announcement" | "patreon" | "rotating"
   >("none");
+  const [announcement, setAnnouncement] = useState<Announcement | null>(null);
   const [rotatingIndex, setRotatingIndex] = useState(0);
 
-  useEffect(() => {
-    const tierlistDismissed = localStorage.getItem("announce-dismissed-v2");
-    const patreonDismissed = localStorage.getItem("donation-banner-dismissed");
-    const rotatingDismissed = sessionStorage.getItem("community-banner-dismissed");
-    if (!tierlistDismissed) {
-      setBanner("tierlist");
-    } else if (!patreonDismissed) {
-      setBanner("patreon");
-    } else if (!rotatingDismissed) {
-      // Pick a random banner for this session
-      setRotatingIndex(Math.floor(Math.random() * ROTATING_BANNERS.length));
-      setBanner("rotating");
-    }
-  }, []);
-
-  function dismissTierlist() {
-    localStorage.setItem("announce-dismissed-v2", "1");
+  // Priority: undismissed admin announcement, then the Patreon ask, then a
+  // random rotating ancient for the session. Announcement dismissals are
+  // keyed per announcement id, so publishing a new one from /admin reshows
+  // the banner for everyone without any code change.
+  function fallthrough(): void {
     const patreonDismissed = localStorage.getItem("donation-banner-dismissed");
     const rotatingDismissed = sessionStorage.getItem("community-banner-dismissed");
     if (!patreonDismissed) {
@@ -287,6 +294,31 @@ export default function DonationBanner() {
     } else {
       setBanner("none");
     }
+  }
+
+  useEffect(() => {
+    fetch(`${API}/api/announcements`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: { items?: Announcement[] } | null) => {
+        const fresh = (d?.items ?? []).find(
+          (a) => !localStorage.getItem(`announce-dismissed-${a.id}`),
+        );
+        if (fresh) {
+          setAnnouncement(fresh);
+          setBanner("announcement");
+        } else {
+          fallthrough();
+        }
+      })
+      .catch(() => fallthrough());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function dismissAnnouncement() {
+    if (announcement) {
+      localStorage.setItem(`announce-dismissed-${announcement.id}`, "1");
+    }
+    fallthrough();
   }
 
   function dismissPatreon() {
@@ -305,8 +337,8 @@ export default function DonationBanner() {
     setBanner("none");
   }
 
-  if (banner === "tierlist")
-    return <TierListBanner onDismiss={dismissTierlist} />;
+  if (banner === "announcement" && announcement)
+    return <AnnouncementBanner ann={announcement} onDismiss={dismissAnnouncement} />;
   if (banner === "patreon") return <PatreonBanner onDismiss={dismissPatreon} />;
   if (banner === "rotating")
     return <AncientBanner banner={ROTATING_BANNERS[rotatingIndex]} onDismiss={dismissRotating} />;

--- a/frontend/scripts/generate-site-pages.mjs
+++ b/frontend/scripts/generate-site-pages.mjs
@@ -17,6 +17,7 @@ const OUT = join(FRONTEND, "lib", "site-pages.json");
 const EXCLUDE = new Set([
   "/thank-you", "/uninstall", "/meta", "/tier-list-maker/new", "/beta",
   "/admin", "/admin/runs", "/admin/feedback", "/admin/guides", "/admin/cache",
+  "/admin/banners", "/admin/analytics",
 ]);
 
 function walk(dir, segments = []) {

--- a/frontend/scripts/generate-site-pages.mjs
+++ b/frontend/scripts/generate-site-pages.mjs
@@ -14,7 +14,10 @@ const OUT = join(FRONTEND, "lib", "site-pages.json");
 
 // Routes that exist but don't belong in a search palette: post-action
 // landers, bare redirects, sub-flows of another page, and the operator panel.
-const EXCLUDE = new Set(["/thank-you", "/uninstall", "/meta", "/tier-list-maker/new", "/admin", "/beta"]);
+const EXCLUDE = new Set([
+  "/thank-you", "/uninstall", "/meta", "/tier-list-maker/new", "/beta",
+  "/admin", "/admin/runs", "/admin/feedback", "/admin/guides", "/admin/cache",
+]);
 
 function walk(dir, segments = []) {
   const routes = [];


### PR DESCRIPTION
The original spire-admin design (the private repo) was a separate Access-gated app whose feature pages were scaffolds pointing at backend endpoints that never got built. The in-app /admin already won on auth (user-id allowlist + JWT + 404-for-strangers + CF Access at the edge), so this builds the actual surfaces there.

## New tabs

- **Runs**: search by username / seed / hash, inspect, delete. Deletion removes every Mongo doc sharing the hash (multiplayer stores one per player), the blob file, and the in-process blob cache; the snapshot and leaderboard summaries drop it on their next scheduled rebuild.
- **Feedback**: site feedback and QA card reports now also land in a Mongo inbox alongside the Discord webhook (best effort; the webhook path is byte-for-byte unchanged). Inbox tab with show-resolved toggle and per-item resolve.
- **Guides**: submissions copy into a moderation queue the same way; read full content inline, dismiss handled ones. Publishing stays a git operation since guides ship in data/guides.json.
- **Cache**: Cloudflare purge by path list or whole zone, proxied through the backend so the token never reaches the browser. Needs CF_TOKEN/CF_ZONE in the box .env (compose passes them through; same values the autodeploy purge uses).
- Overview unchanged, now inside a shared shell with section nav.

## Security

Every new endpoint sits on the same router whose allowlist dependency is applied at the router level, so a forgotten decorator can't open a hole. Verified unauthenticated: all six new routes return 404, never data, never 403.

## Testing

ruff (check + format) and tsc clean; backend imports and boots. Public submission endpoints verified unbroken. The Mongo-backed pieces (inbox writes, queue, deletion) degrade to no-ops/empties without MONGO_URL by construction.

- **Banners**: the announcement strip (the green NEW banner) is now data-driven. Publish from the tab with inline [label](/href) links (parsed into real links, never raw markup), toggle or delete; dismissals are keyed per announcement, so publishing a new one reshows the banner for everyone without a deploy or a bumped dismissal key. Visitors read a 60s-cached public endpoint; the Patreon and rotating ancient banners are unchanged below it in the priority chain.
- **Analytics**: Umami headline numbers (24h and 7d visitors/visits/pageviews, top pages) proxied server-side with a cached login token, plus a link to the full dashboard. Set UMAMI_USERNAME/UMAMI_PASSWORD in the box .env (UMAMI_URL and UMAMI_WEBSITE_ID optional).
- Overview gains quick links: Umami, GitHub, Cloudflare, Forgejo, Docker Hub.

Phase 2 candidates from the original design, not in this PR: runtime-tunable rate limits and retention bulk-delete.

After deploy: add CF_TOKEN and CF_ZONE to the box's .env for the cache tab; the other tabs work immediately, with inboxes filling from the first post-deploy submission.
