### PR TITLE
Stop the edge from caching the live presence roster

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -260,6 +260,12 @@ class CORSStaticMiddleware(BaseHTTPMiddleware):
                                              bypasses on cookie heuristics but
                                              the origin should declare intent
                                              explicitly.
+      /api/presence  no-store             - live "who is in a run now" feed:
+                                             30s heartbeats, 90s server TTL.
+                                             Any shared caching makes the
+                                             roster lie; the generic /api/*
+                                             hour froze the first-ever empty
+                                             response at the edge (2026-06-12).
       /api/runs/*  s-maxage=30             — user-submitted runs need to appear
                                              in lists/leaderboards within a
                                              minute, not an hour.
@@ -273,6 +279,13 @@ class CORSStaticMiddleware(BaseHTTPMiddleware):
                                              counters appear stuck and gauges
                                              rewind on cache refresh.
 
+    Endpoints that set Cache-Control themselves win: the middleware only
+    fills in a default when the handler didn't declare one. Several handlers
+    rely on that (snapshot-status at no-store, community-stats and metrics
+    flipping to no-store while the stats snapshot rebuilds) and were being
+    silently overwritten, which let the edge cache empty rebuild-window
+    responses despite their own guards.
+
     Cache headers are only applied to successful GETs. Caching 4xx/5xx on
     /static would prevent recovery by simply uploading the missing file.
     """
@@ -281,6 +294,10 @@ class CORSStaticMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
         response.headers["Access-Control-Allow-Origin"] = "*"
         if request.method != "GET" or response.status_code >= 400:
+            return response
+        # A handler that declared its own Cache-Control knows better than
+        # these path-prefix defaults; never overwrite it.
+        if "cache-control" in response.headers:
             return response
         path = request.url.path
         if path.startswith("/static/"):
@@ -301,6 +318,11 @@ class CORSStaticMiddleware(BaseHTTPMiddleware):
             # tier lists to everyone (and stale them for an hour after a save).
             # The public /api/tierlists/shared/* reads fall through and cache.
             response.headers["Cache-Control"] = "private, no-store"
+        elif path.startswith("/api/presence"):
+            # Live "who is in a run now" feed: 30s heartbeats, 90s server TTL.
+            # Any shared caching makes the roster lie; the generic /api/* hour
+            # froze the first-ever empty response at the edge (2026-06-12).
+            response.headers["Cache-Control"] = "no-store"
         elif path.startswith("/api/runs/"):
             response.headers["Cache-Control"] = "public, max-age=30, s-maxage=30"
         elif path.startswith("/api/"):


### PR DESCRIPTION
The mod side diagnosed it precisely: presence works end to end, but the cache middleware routes /api/presence/* through the generic /api/* rule (s-maxage=3600), so Cloudflare cached the first-ever empty roster and has been serving {"count":0} for up to an hour (cf-cache-status: HIT). Presence is a live feed with 30s heartbeats and a 90s server TTL, so any shared caching makes it lie: it sends no-store now.

While in there I found the deeper version of the same bug: the middleware overwrites Cache-Control on every successful GET, clobbering headers that handlers set deliberately. snapshot-status's no-store became 30s at the edge, and the no-store-while-rebuilding guard on community-stats/metrics (from #450) never actually reached Cloudflare. Handler-declared Cache-Control wins now; the path-prefix defaults only apply when the handler didn't declare one. That also makes the announcements endpoint's 60s TTL (in flight on #455) real instead of an hour.

## Testing

Verified locally per path class: generic entity gets the hour, /api/runs/ gets 30s, snapshot-status keeps its handler-declared no-store (previously overwritten), errors and non-GETs stay untouched. The presence 200 path needs Mongo, but the branch is shape-identical to the verified /metrics one.

After merge: deploy normally. The autodeploy purges the whole Cloudflare zone at the end of every deploy, which evicts the cached empty roster in the same step, so no manual purge needed.