### PR TITLE
Speed up image builds: stop re-uploading the 2.6 GB static layer every release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # No setup-buildx-action on purpose: it boots a fresh ephemeral
+      # builder every run (and destroys it in post), which throws away
+      # all local layer cache and forces every build to round-trip
+      # gigabytes through the Docker Hub registry cache. The self-hosted
+      # runner's own daemon persists between runs, so building on the
+      # default builder gives us a warm local cache for free: the pip
+      # layer, the 2.6 GB backend static layer, npm's node_modules, and
+      # the cache mounts in the Dockerfiles all survive run to run.
+      # Housekeeping: the daemon's build cache grows over time; prune
+      # occasionally with `docker builder prune --filter until=336h`.
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -143,8 +151,6 @@ jobs:
         with:
           context: ./backend
           push: true
-          cache-from: type=registry,ref=ptrlrd/spire-codex-backend:buildcache
-          cache-to: type=registry,ref=ptrlrd/spire-codex-backend:buildcache,mode=max
           tags: |
             ptrlrd/spire-codex-backend:latest
             ptrlrd/spire-codex-backend:${{ github.sha }}
@@ -156,8 +162,6 @@ jobs:
           context: ./frontend
           file: ./frontend/Dockerfile
           push: true
-          cache-from: type=registry,ref=ptrlrd/spire-codex-frontend:buildcache
-          cache-to: type=registry,ref=ptrlrd/spire-codex-frontend:buildcache,mode=max
           build-args: |
             NEXT_PUBLIC_API_URL=
             NEXT_PUBLIC_SITE_URL=https://spire-codex.com

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,8 +5,12 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ app/
+# static/ is ~2.6 GB of PNG and audio that only changes on game updates;
+# app/ changes every release. Copy static/ first so a code-only change
+# reuses the cached static layer instead of rebuilding and re-uploading
+# 2.6 GB on every build (and re-downloading it on every deploy pull).
 COPY static/ static/
+COPY app/ app/
 
 EXPOSE 8000
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,10 @@ ARG BUILDPLATFORM=linux/amd64
 FROM --platform=$BUILDPLATFORM node:20-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci
+# The cache mount keeps the npm download cache on the builder between
+# builds, so a lockfile change re-resolves from local cache instead of
+# re-downloading every package.
+RUN --mount=type=cache,target=/root/.npm npm ci
 
 ARG BUILDPLATFORM=linux/amd64
 FROM --platform=$BUILDPLATFORM node:20-alpine AS builder
@@ -20,7 +23,10 @@ ARG NEXT_PUBLIC_UMAMI_WEBSITE_ID
 ENV NEXT_PUBLIC_UMAMI_WEBSITE_ID=${NEXT_PUBLIC_UMAMI_WEBSITE_ID}
 ARG NEXT_PUBLIC_CDN_URL
 ENV NEXT_PUBLIC_CDN_URL=${NEXT_PUBLIC_CDN_URL}
-RUN npm run build
+# Persist Next's incremental compiler cache across builds. Source always
+# changes between releases so this stage never layer-caches; the mount is
+# what makes the rebuild incremental instead of from scratch.
+RUN --mount=type=cache,target=/app/.next/cache npm run build
 
 FROM node:20-alpine AS runner
 WORKDIR /app


### PR DESCRIPTION
My builds were taking 8 to 26 minutes per image. I dug into the step timings and found three compounding problems:

**The 2.6 GB layer rebuild.** `backend/static/images` is 2.6 GB and the Dockerfile copied `app/` before `static/`. Docker layer caching is order-dependent, so every code change invalidated the static layer, re-hashed 2.6 GB, and re-uploaded it to Docker Hub on every single release. The box then re-pulled it on every deploy. A backend-only change (the presence PR) spent 7m50s on this. I reordered the copies so `static/` sits above `app/`: code-only builds now reuse the cached layer and only ship the few-MB app layer. The 2.6 GB cost only comes back when game assets actually change.

**No local cache on the runner.** CI created a fresh buildx builder every run and destroyed it in the post step, so every build started cold and round-tripped everything through the Docker Hub registry cache (`mode=max` was even exporting the frontend's whole node_modules build stage). The "Set up Docker Buildx" step alone took 4 minutes on one run. Since the self-hosted runner's daemon persists between runs, I dropped the ephemeral builder and the registry cache entirely: builds now use the default builder and its warm local layer cache. One bit of housekeeping to be aware of: the daemon's build cache grows over time, so an occasional `docker builder prune --filter until=336h` on the runner keeps it in check.

**Frontend rebuilt from scratch every time.** Source changes every release, so the `npm run build` layer never cache-hits; that's expected. What was missing is Next's incremental compiler cache, which lived inside the throwaway layer. I added a BuildKit cache mount for `.next/cache` so rebuilds are incremental, plus one for npm's download cache so lockfile changes don't re-download every package.

Expected result: backend code-only builds drop from ~8 min to ~1-2 min, frontend builds shed the registry cache transfer and get incremental compiles. First build after merge is still cold (the local cache starts empty); the wins show up from the second build on.

No runtime behavior changes: same base images, same final layers, same tags.