### PR TITLE
Add the missing admin section pages and queue multiple announcements

### DIFF
--- a/frontend/app/admin/cache/page.tsx
+++ b/frontend/app/admin/cache/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import CacheClient from "./CacheClient";
+
+export const metadata: Metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminCachePage() {
+  return <CacheClient />;
+}

--- a/frontend/app/admin/feedback/page.tsx
+++ b/frontend/app/admin/feedback/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import FeedbackClient from "./FeedbackClient";
+
+export const metadata: Metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminFeedbackPage() {
+  return <FeedbackClient />;
+}

--- a/frontend/app/admin/guides/page.tsx
+++ b/frontend/app/admin/guides/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import GuidesClient from "./GuidesClient";
+
+export const metadata: Metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminGuidesPage() {
+  return <GuidesClient />;
+}

--- a/frontend/app/admin/runs/page.tsx
+++ b/frontend/app/admin/runs/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import RunsClient from "./RunsClient";
+
+export const metadata: Metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminRunsPage() {
+  return <RunsClient />;
+}

--- a/frontend/app/components/DonationBanner.tsx
+++ b/frontend/app/components/DonationBanner.tsx
@@ -276,6 +276,7 @@ export default function DonationBanner() {
   const [banner, setBanner] = useState<
     "none" | "announcement" | "patreon" | "rotating"
   >("none");
+  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
   const [announcement, setAnnouncement] = useState<Announcement | null>(null);
   const [rotatingIndex, setRotatingIndex] = useState(0);
 
@@ -300,7 +301,9 @@ export default function DonationBanner() {
     fetch(`${API}/api/announcements`)
       .then((r) => (r.ok ? r.json() : null))
       .then((d: { items?: Announcement[] } | null) => {
-        const fresh = (d?.items ?? []).find(
+        const items = d?.items ?? [];
+        setAnnouncements(items);
+        const fresh = items.find(
           (a) => !localStorage.getItem(`announce-dismissed-${a.id}`),
         );
         if (fresh) {
@@ -314,9 +317,19 @@ export default function DonationBanner() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Several announcements can be active at once; dismissing one slides the
+  // next undismissed one in, and only after the last does the banner fall
+  // through to the Patreon/rotating tiers.
   function dismissAnnouncement() {
     if (announcement) {
       localStorage.setItem(`announce-dismissed-${announcement.id}`, "1");
+    }
+    const next = announcements.find(
+      (a) => !localStorage.getItem(`announce-dismissed-${a.id}`),
+    );
+    if (next) {
+      setAnnouncement(next);
+      return;
     }
     fallthrough();
   }


### PR DESCRIPTION
Fixes the dead sections in the admin panel. The runs, feedback, guides, and cache sections shipped with their client components but the `page.tsx` files never made it into the admin PR, so Next never registered those routes and the nav links landed on the site 404. Only overview, banners, and analytics had real pages, which is exactly the working/broken split I was seeing. The four new pages are one-liners that mount the existing clients, noindex'd like the rest of /admin.

Two sections also need env vars on the box before they light up (the pages now load and will say so themselves):

- Cache needs `CF_TOKEN` + `CF_ZONE` (returns 503 with a clear message until set)
- Analytics needs `UMAMI_USERNAME` + `UMAMI_PASSWORD` (same deal)

Also in here: multiple active announcements now queue. Banners already supported several announcements with per-item on/off toggles, but the public banner only showed the newest undismissed one and dismissing it fell straight through to the Patreon banner until the next page load. Now dismissing one slides the next active announcement in immediately, and the fallthrough only happens after the last one.