### PR TITLE
Show an Admin link in the account menu for admins

### DIFF
--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -439,6 +439,18 @@ export default function Navbar() {
                   >
                     Settings
                   </Link>
+                  {/* Admin pages are unlocalized, so no langPrefix here. The
+                      link is cosmetic gating only; /admin itself 404s for
+                      anyone not on the server-side allowlist. */}
+                  {user.is_admin && (
+                    <Link
+                      href="/admin"
+                      onClick={() => setUserMenuOpen(false)}
+                      className="flex items-center gap-2 px-2.5 py-2 text-sm rounded-md hover:bg-[var(--bg-card)] text-[var(--accent-gold)] hover:text-[var(--accent-gold)] transition-colors"
+                    >
+                      Admin
+                    </Link>
+                  )}
                   <button
                     onClick={() => { setUserMenuOpen(false); logout(); }}
                     className="w-full flex items-center gap-2 px-2.5 py-2 text-sm rounded-md hover:bg-[var(--bg-card)] text-red-400 hover:text-red-300 transition-colors"

--- a/frontend/app/contexts/AuthContext.tsx
+++ b/frontend/app/contexts/AuthContext.tsx
@@ -11,6 +11,7 @@ interface User {
   steam_id: string | null;
   discord_id: string | null;
   needs_email: boolean;
+  is_admin?: boolean;
 }
 
 interface AuthContextType {


### PR DESCRIPTION
Adds an Admin entry to the signed-in account dropdown, shown only when /api/auth/me says the user is on the admin allowlist. The dropdown renders on both desktop and mobile, so the link shows up everywhere.

This is cosmetic gating only: the link just saves typing the URL. /admin and /api/admin/* still 404 server-side for anyone not on the ADMIN_IDS allowlist, same as before. The auth context now carries the is_admin flag that the me endpoint was already returning.