### PR TITLE
Presence v2: turn, current enemies, and a play-by-play event ticker

### DIFF
--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -24,9 +24,38 @@ _INT_FIELDS = (
     "gold",
     "ascension",
     "player_count",
+    "turn",
 )
 _STR_FIELDS = ("character", "seed", "screen", "sts2_version", "username")
-_LIST_CAPS = {"deck": 200, "relics": 100, "potions": 10}
+_LIST_CAPS = {"deck": 200, "relics": 100, "potions": 10, "fighting": 8}
+
+# Play-by-play ticker events riding the heartbeat: {"k": kind, "v": entity id,
+# "turn": combat turn, "t": unix seconds}. Kinds today: card, potion, combat,
+# victory, buy, death, act. Appended server-side to a rolling window per player.
+_EVENTS_PER_BEAT = 40
+
+
+def _clean_events(raw) -> list[dict]:
+    events: list[dict] = []
+    if not isinstance(raw, list):
+        return events
+    for e in raw[:_EVENTS_PER_BEAT]:
+        if not isinstance(e, dict):
+            continue
+        kind = e.get("k")
+        if not isinstance(kind, str) or not kind:
+            continue
+        ev: dict = {"k": kind[:24]}
+        if isinstance(e.get("v"), str) and e["v"]:
+            ev["v"] = e["v"][:_MAX_STR]
+        if isinstance(e.get("turn"), (int, float)) and not isinstance(
+            e.get("turn"), bool
+        ):
+            ev["turn"] = int(e["turn"])
+        if isinstance(e.get("t"), (int, float)) and not isinstance(e.get("t"), bool):
+            ev["t"] = int(e["t"])
+        events.append(ev)
+    return events
 
 
 def _require_mongo():
@@ -88,7 +117,7 @@ async def post_presence(request: Request):
     except Exception:
         pass
 
-    presence_db.heartbeat(steam_id, fields)
+    presence_db.heartbeat(steam_id, fields, _clean_events(data.get("events")))
     return {"ok": True}
 
 

--- a/backend/app/services/presence_db.py
+++ b/backend/app/services/presence_db.py
@@ -41,13 +41,22 @@ def _presence_coll():
     return _coll
 
 
-def heartbeat(steam_id: str, fields: dict[str, Any]) -> None:
+# Rolling per-player window of ticker events ("played X", "fighting Y"); old entries
+# fall off as new beats arrive, and the whole doc still dies with the 90s TTL.
+EVENT_WINDOW = 50
+
+
+def heartbeat(
+    steam_id: str, fields: dict[str, Any], events: list[dict] | None = None
+) -> None:
     now = datetime.now(timezone.utc)
-    _presence_coll().update_one(
-        {"_id": steam_id},
-        {"$set": {**fields, "updated_at": now}, "$setOnInsert": {"started_at": now}},
-        upsert=True,
-    )
+    update: dict[str, Any] = {
+        "$set": {**fields, "updated_at": now},
+        "$setOnInsert": {"started_at": now},
+    }
+    if events:
+        update["$push"] = {"events": {"$each": events, "$slice": -EVENT_WINDOW}}
+    _presence_coll().update_one({"_id": steam_id}, update, upsert=True)
 
 
 def end(steam_id: str) -> None:
@@ -60,7 +69,10 @@ def active(limit: int = 50) -> list[dict]:
     cutoff = datetime.now(timezone.utc) - timedelta(seconds=PRESENCE_TTL_SECONDS)
     docs = (
         _presence_coll()
-        .find({"updated_at": {"$gte": cutoff}}, {"deck": 0, "relics": 0, "potions": 0})
+        .find(
+            {"updated_at": {"$gte": cutoff}},
+            {"deck": 0, "relics": 0, "potions": 0, "events": 0},
+        )
         .sort([("total_floor", -1), ("updated_at", -1)])
         .limit(limit)
     )

--- a/markdown-docs/live-presence.md
+++ b/markdown-docs/live-presence.md
@@ -43,7 +43,31 @@ for "climbing for 41 min".
 Public. The full live doc for one player: everything above plus `deck` (card ids, `+`
 suffix = upgraded, e.g. `"STRIKE+"`), `relics`, and `potions` (bare ids). 404 when the
 player is not live. This is the data for a per-player live run view (spectator-lite,
-refresh every 15-30s).
+refresh every 10-15s).
+
+Combat context (v2, absent between fights):
+
+- `turn`: the combat round number
+- `fighting`: bare ids of the living enemies, e.g. `["GREMLIN_NOB"]`
+
+Play-by-play ticker (v2): `events` is a rolling window (last 50) of moments, oldest
+first, appended by each heartbeat:
+
+```json
+"events": [
+  {"k": "combat", "turn": 1, "t": 1781650000},
+  {"k": "card", "v": "WHIRLWIND", "turn": 2, "t": 1781650031},
+  {"k": "potion", "v": "FIRE_POTION", "turn": 3, "t": 1781650055},
+  {"k": "victory", "t": 1781650070},
+  {"k": "buy", "v": "FROZEN_EYE", "t": 1781650120}
+]
+```
+
+Kinds: `card` (played), `potion` (used), `combat` (fight started), `victory`,
+`buy` (shop purchase; `v` may be absent), `death` (the player died), `act` (entered a
+new act). `v` is a bare entity id for the usual name/image lookups. Render as a feed:
+"Turn 2 - played Whirlwind". The mod beats every ~12s during combat and ~30s outside
+it, so poll this endpoint at 10-15s for a live-feeling ticker.
 
 ### POST /api/presence
 


### PR DESCRIPTION
Backend half of the mod's new live ticker. The mod now heartbeats every ~12s during combat (~30s otherwise) and each beat carries the combat turn, the living enemy ids, and the events since the last delivered beat (card played, potion used, combat start, victory, shop purchase, death, act entered).

What lands here:

- Router: `turn` joins the whitelisted int fields, `fighting` joins the list caps (8 entries), and `events` get their own scrubber: each event is `{k, v, turn, t}` with the kind capped at 24 chars, the entity id at 64, turn and t coerced to ints, and at most 40 events accepted per beat. Everything else in the body is dropped, same as v1.
- Service: `heartbeat()` now `$push`es events into a rolling 50-entry window per player (`$slice: -50`), so the doc never grows unbounded and still expires with the 90s TTL. The `/active` roster projection excludes `events`; the per-player endpoint serves them for the live run view.
- `markdown-docs/live-presence.md` gains the v2 section with the event shape and render guidance ("Turn 2 - played Whirlwind", poll at 10-15s during combat).

Compatibility both ways: every new field is optional, so the already-installed v2 mod against the current backend just has its new fields silently dropped (presence keeps working as today), and an old mod against this backend sends nothing new. No migration, no index changes beyond what v1 already created.

Verify after deploy, mid-fight:

    curl -s https://spire-codex.com/api/presence/<steamid> | python3 -m json.tool

should show `turn`, `fighting` with the enemy ids, and a growing `events` array on a ~12s pulse.