### PR TITLE
Live spectator pages and a home page Live now rail

### DIFF
--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -8,6 +8,7 @@ import { cachedFetch, getBetaVersion } from "@/lib/fetch-cache";
 import { useLanguage } from "./contexts/LanguageContext";
 import { useAuth } from "./contexts/AuthContext";
 import { t } from "@/lib/ui-translations";
+import LiveNowRail from "./components/LiveNowRail";
 
 const LANG_CODES = new Set(["deu", "esp", "fra", "ita", "jpn", "kor", "pol", "ptb", "rus", "spa", "tha", "tur", "zhs"]);
 
@@ -230,6 +231,10 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
           })}
         </div>
       </section>
+
+      {/* Who is in a run with the mod right now; renders nothing when the
+          roster is empty, so the section only exists while someone climbs. */}
+      <LiveNowRail />
 
       {/* Get started: one card, a gold CTA header, then a single row of
           the sign-in cell (signed out only) plus the 4 action tiles. */}

--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -8,7 +8,6 @@ import { cachedFetch, getBetaVersion } from "@/lib/fetch-cache";
 import { useLanguage } from "./contexts/LanguageContext";
 import { useAuth } from "./contexts/AuthContext";
 import { t } from "@/lib/ui-translations";
-import LiveNowRail from "./components/LiveNowRail";
 
 const LANG_CODES = new Set(["deu", "esp", "fra", "ita", "jpn", "kor", "pol", "ptb", "rus", "spa", "tha", "tur", "zhs"]);
 
@@ -231,10 +230,6 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
           })}
         </div>
       </section>
-
-      {/* Who is in a run with the mod right now; renders nothing when the
-          roster is empty, so the section only exists while someone climbs. */}
-      <LiveNowRail />
 
       {/* Get started: one card, a gold CTA header, then a single row of
           the sign-in cell (signed out only) plus the 4 action tiles. */}

--- a/frontend/app/components/LiveNowRail.tsx
+++ b/frontend/app/components/LiveNowRail.tsx
@@ -17,7 +17,7 @@ import {
   type LivePlayer,
 } from "@/app/live/live-shared";
 
-const POLL_MS = 30_000;
+const POLL_MS = 15_000;
 const MAX_SHOWN = 6;
 
 export default function LiveNowRail() {

--- a/frontend/app/components/LiveNowRail.tsx
+++ b/frontend/app/components/LiveNowRail.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+// "Live now" strip for the home page: who is in a run with the mod right
+// now, with a "Fighting X" enemy portrait when they're mid-combat. Renders
+// nothing at all (zero layout footprint) until the roster has somebody in
+// it, so the home page is unchanged whenever nobody is climbing.
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  API,
+  CharacterIcon,
+  FightingChip,
+  LiveDot,
+  useMonsterMap,
+  usePoll,
+  type LivePlayer,
+} from "@/app/live/live-shared";
+
+const POLL_MS = 30_000;
+const MAX_SHOWN = 6;
+
+export default function LiveNowRail() {
+  const [players, setPlayers] = useState<LivePlayer[]>([]);
+  const monsters = useMonsterMap(
+    players.some((p) => p.screen === "combat" && (p.fighting?.length ?? 0) > 0),
+  );
+
+  usePoll(async () => {
+    try {
+      const r = await fetch(`${API}/api/presence/active?limit=${MAX_SHOWN + 6}`);
+      if (!r.ok) return;
+      const data: { players?: LivePlayer[] } = await r.json();
+      setPlayers(data.players ?? []);
+    } catch {
+      // Keep the last roster on a blip; the strip ages out naturally
+      // because entries vanish from the API within 90s of a quit.
+    }
+  }, POLL_MS);
+
+  if (players.length === 0) return null;
+
+  return (
+    <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-12">
+      <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <LiveDot />
+          <h2 className="text-sm font-bold uppercase tracking-wider text-[var(--text-primary)]">
+            Live now
+          </h2>
+          <span className="text-xs text-[var(--text-muted)]">
+            {players.length} {players.length === 1 ? "player" : "players"} climbing
+          </span>
+          <Link
+            href="/live"
+            className="ml-auto text-xs text-[var(--accent-gold)] hover:underline whitespace-nowrap"
+          >
+            Watch all →
+          </Link>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {players.slice(0, MAX_SHOWN).map((p) => (
+            <Link
+              key={p.steam_id}
+              href={`/live/${p.steam_id}`}
+              className="inline-flex items-center gap-2 pl-1.5 pr-3 py-1.5 rounded-full border border-[var(--border-subtle)] bg-[var(--bg-primary)] hover:border-[var(--border-accent)] transition-colors max-w-full"
+            >
+              <CharacterIcon character={p.character} className="w-7 h-7" />
+              <span className="text-sm font-medium text-[var(--text-primary)] truncate">
+                {p.username || "Anonymous climber"}
+              </span>
+              {p.total_floor != null && (
+                <span className="text-[10px] text-[var(--text-muted)] tabular-nums whitespace-nowrap">
+                  F{p.total_floor}
+                </span>
+              )}
+              <FightingChip p={p} monsters={monsters} circle="w-5 h-5" />
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/live/LiveClient.tsx
+++ b/frontend/app/live/LiveClient.tsx
@@ -23,97 +23,57 @@ import {
   type CardInfo,
   type RelicInfo,
 } from "../runs/[hash]/RunPills";
+import {
+  API,
+  CharacterIcon,
+  FightingChip,
+  LiveDot,
+  elapsed,
+  parseDeckId,
+  useMonsterMap,
+  usePoll,
+  type LivePlayer,
+  type MonsterMap,
+} from "./live-shared";
 
-const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 const POLL_MS = 20_000;
 const RECENT_CARDS = 5;
-
-interface LivePlayer {
-  steam_id: string;
-  username?: string | null;
-  character?: string | null;
-  ascension?: number | null;
-  act?: number | null;
-  act_floor?: number | null;
-  total_floor?: number | null;
-  hp?: number | null;
-  max_hp?: number | null;
-  gold?: number | null;
-  screen?: string | null;
-  player_count?: number | null;
-  sts2_version?: string | null;
-  started_at?: string | null;
-  deck?: string[];
-  relics?: string[];
-}
-
-function elapsed(startedAt?: string | null): string {
-  if (!startedAt) return "";
-  const ms = Date.now() - new Date(startedAt).getTime();
-  if (ms <= 0) return "";
-  const mins = Math.floor(ms / 60000);
-  if (mins < 1) return "under a minute";
-  if (mins < 60) return `${mins}m`;
-  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
-}
-
-// Deck entries use the run-doc convention: bare card id, `+` = upgraded.
-function parseDeckId(raw: string): { id: string; upgraded: boolean } {
-  const upgraded = raw.endsWith("+");
-  return { id: cleanId(upgraded ? raw.slice(0, -1) : raw), upgraded };
-}
-
-function LiveDot() {
-  return (
-    <span className="relative flex h-2 w-2">
-      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-      <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
-    </span>
-  );
-}
 
 function PlayerCard({
   p,
   cardData,
   relicData,
+  monsters,
   lp,
   lang,
 }: {
   p: LivePlayer;
   cardData: Record<string, CardInfo>;
   relicData: Record<string, RelicInfo>;
+  monsters: MonsterMap;
   lp: string;
   lang: string;
 }) {
-  const charSlug = cleanId(p.character || "").toLowerCase();
-  const charIcon = imageUrl(`/static/images/characters/character_icon_${charSlug}.webp`);
   const hpPct =
     p.hp != null && p.max_hp ? Math.max(0, Math.min(100, (p.hp / p.max_hp) * 100)) : null;
   // Newest acquisitions last in the deck array; show them newest-first.
   const recent = (p.deck ?? []).slice(-RECENT_CARDS).reverse();
 
   return (
-    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4 hover:border-[var(--border-accent)] transition-colors">
       <div className="flex items-center gap-3">
-        {charSlug && (
-          <Link href={`${lp}/characters/${charSlug}`} className="shrink-0">
-            <img
-              src={charIcon}
-              alt={displayName(`CHARACTER.${p.character ?? ""}`)}
-              className="w-12 h-12 object-contain"
-              crossOrigin="anonymous"
-              onError={(e) => {
-                (e.target as HTMLImageElement).style.visibility = "hidden";
-              }}
-            />
-          </Link>
-        )}
+        <Link href={`/live/${p.steam_id}`} className="shrink-0">
+          <CharacterIcon character={p.character} />
+        </Link>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <LiveDot />
-            <span className="font-semibold text-[var(--text-primary)] truncate">
+            <Link
+              href={`/live/${p.steam_id}`}
+              className="font-semibold text-[var(--text-primary)] truncate hover:text-[var(--accent-gold)] transition-colors"
+            >
               {p.username || "Anonymous climber"}
-            </span>
+            </Link>
             {p.ascension != null && p.ascension > 0 && (
               <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-[var(--accent-gold)]/15 text-[var(--accent-gold)] border border-[var(--accent-gold)]/30">
                 A{p.ascension}
@@ -138,6 +98,16 @@ function PlayerCard({
             {p.gold != null ? `${p.gold} gold` : ""}
           </div>
         </div>
+      </div>
+
+      <div className="mt-2 flex items-center gap-2">
+        <FightingChip p={p} monsters={monsters} />
+        <Link
+          href={`/live/${p.steam_id}`}
+          className="ml-auto text-xs text-[var(--accent-gold)] hover:underline whitespace-nowrap"
+        >
+          Watch live →
+        </Link>
       </div>
 
       {hpPct != null && (
@@ -244,62 +214,54 @@ export default function LiveClient() {
   const [stale, setStale] = useState(false);
   const [cardData, setCardData] = useState<Record<string, CardInfo>>({});
   const [relicData, setRelicData] = useState<Record<string, RelicInfo>>({});
+  const monsters = useMonsterMap(
+    (players ?? []).some((p) => p.screen === "combat" && (p.fighting?.length ?? 0) > 0),
+  );
 
   useEffect(() => {
-    cachedFetch<CardInfo[]>(`${API}/api/cards?lang=${lang}`).then((cards) => {
-      const m: Record<string, CardInfo> = {};
-      for (const c of cards) m[c.id] = c;
-      setCardData(m);
-    });
-    cachedFetch<RelicInfo[]>(`${API}/api/relics?lang=${lang}`).then((relics) => {
-      const m: Record<string, RelicInfo> = {};
-      for (const r of relics) m[r.id] = r;
-      setRelicData(m);
-    });
+    cachedFetch<CardInfo[]>(`${API}/api/cards?lang=${lang}`)
+      .then((cards) => {
+        const m: Record<string, CardInfo> = {};
+        for (const c of cards) m[c.id] = c;
+        setCardData(m);
+      })
+      .catch(() => {});
+    cachedFetch<RelicInfo[]>(`${API}/api/relics?lang=${lang}`)
+      .then((relics) => {
+        const m: Record<string, RelicInfo> = {};
+        for (const r of relics) m[r.id] = r;
+        setRelicData(m);
+      })
+      .catch(() => {});
   }, [lang]);
 
-  useEffect(() => {
-    let cancelled = false;
-
-    async function poll() {
-      try {
-        const r = await fetch(`${API}/api/presence/active`);
-        if (!r.ok) throw new Error(`active ${r.status}`);
-        const data: { players?: LivePlayer[] } = await r.json();
-        const roster = data.players ?? [];
-        // The roster is identity + progress only; deck/relics live on the
-        // per-player doc. The list is small, so fetch them all in parallel
-        // and fall back to the roster entry if one fetch fails.
-        const detailed = await Promise.all(
-          roster.map(async (p) => {
-            try {
-              const dr = await fetch(`${API}/api/presence/${p.steam_id}`);
-              if (!dr.ok) return p;
-              return { ...p, ...(await dr.json()) } as LivePlayer;
-            } catch {
-              return p;
-            }
-          }),
-        );
-        if (!cancelled) {
-          setPlayers(detailed);
-          setStale(false);
-        }
-      } catch {
-        if (!cancelled) {
-          setStale(true);
-          setPlayers((prev) => prev ?? []);
-        }
-      }
+  usePoll(async () => {
+    try {
+      const r = await fetch(`${API}/api/presence/active`);
+      if (!r.ok) throw new Error(`active ${r.status}`);
+      const data: { players?: LivePlayer[] } = await r.json();
+      const roster = data.players ?? [];
+      // The roster is identity + progress only; deck/relics live on the
+      // per-player doc. The list is small, so fetch them all in parallel
+      // and fall back to the roster entry if one fetch fails.
+      const detailed = await Promise.all(
+        roster.map(async (p) => {
+          try {
+            const dr = await fetch(`${API}/api/presence/${p.steam_id}`);
+            if (!dr.ok) return p;
+            return { ...p, ...(await dr.json()) } as LivePlayer;
+          } catch {
+            return p;
+          }
+        }),
+      );
+      setPlayers(detailed);
+      setStale(false);
+    } catch {
+      setStale(true);
+      setPlayers((prev) => prev ?? []);
     }
-
-    poll();
-    const t = setInterval(poll, POLL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(t);
-    };
-  }, []);
+  }, POLL_MS);
 
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -330,6 +292,7 @@ export default function LiveClient() {
               p={p}
               cardData={cardData}
               relicData={relicData}
+              monsters={monsters}
               lp={lp}
               lang={lang}
             />

--- a/frontend/app/live/LiveClient.tsx
+++ b/frontend/app/live/LiveClient.tsx
@@ -36,7 +36,9 @@ import {
   type MonsterMap,
 } from "./live-shared";
 
-const POLL_MS = 20_000;
+// The roster carries no ticker events, so the contract's 10-15s roster
+// guidance applies here rather than the hot 3-5s per-player cadence.
+const POLL_MS = 12_000;
 const RECENT_CARDS = 5;
 
 function PlayerCard({

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -2,9 +2,10 @@
 
 // One player's live run, spectator-lite: the full deck, relics, potions,
 // current fight, and the play-by-play ticker from the mod's heartbeats
-// (cards played, potions used, fights, purchases, acts, deaths). Polls
-// /api/presence/{steam_id} every 12s, matching the mod's combat beat.
-// Contract: markdown-docs/live-presence.md.
+// (cards played, potions used, fights, purchases, acts, deaths). The mod
+// beats event-driven with a 2s debounce (5s floor in combat), so polling
+// /api/presence/{steam_id} at 4s gives a near-live ticker per the
+// contract's 3-5s guidance. Contract: markdown-docs/live-presence.md.
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
@@ -39,7 +40,7 @@ import {
   type MonsterMap,
 } from "../live-shared";
 
-const POLL_MS = 12_000;
+const POLL_MS = 4_000;
 
 interface Catalogs {
   cards: Record<string, CardInfo>;

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -1,0 +1,537 @@
+"use client";
+
+// One player's live run, spectator-lite: the full deck, relics, potions,
+// current fight, and the play-by-play ticker from the mod's heartbeats
+// (cards played, potions used, fights, purchases, acts, deaths). Polls
+// /api/presence/{steam_id} every 12s, matching the mod's combat beat.
+// Contract: markdown-docs/live-presence.md.
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useLangPrefix } from "@/lib/use-lang-prefix";
+import { useLanguage } from "@/app/contexts/LanguageContext";
+import { cachedFetch } from "@/lib/fetch-cache";
+import { imageUrl, fullCardUrl } from "@/lib/image-url";
+import {
+  CardPill,
+  PotionPill,
+  RelicPill,
+  cleanId,
+  displayName,
+  type CardInfo,
+  type PotionInfo,
+  type RelicInfo,
+} from "../../runs/[hash]/RunPills";
+import {
+  API,
+  CharacterIcon,
+  EnemyCircle,
+  LiveDot,
+  ago,
+  elapsed,
+  monsterName,
+  parseDeckId,
+  useMonsterMap,
+  usePoll,
+  type LiveEvent,
+  type LivePlayer,
+  type MonsterMap,
+} from "../live-shared";
+
+const POLL_MS = 12_000;
+
+interface Catalogs {
+  cards: Record<string, CardInfo>;
+  relics: Record<string, RelicInfo>;
+  potions: Record<string, PotionInfo>;
+}
+
+/** Best-effort lookup for an event's entity id: shops sell relics, cards,
+ * and potions, so try all three catalogs before falling back to the
+ * prettified raw id. */
+function resolveEntity(
+  rawId: string,
+  cat: Catalogs,
+  lp: string,
+): { name: string; href: string | null; image: string | null } {
+  const id = cleanId(rawId.endsWith("+") ? rawId.slice(0, -1) : rawId);
+  const relic = cat.relics[id];
+  if (relic) {
+    return {
+      name: relic.name,
+      href: `${lp}/relics/${id.toLowerCase()}`,
+      image: relic.image_url ? imageUrl(relic.image_url) : null,
+    };
+  }
+  const card = cat.cards[id];
+  if (card) {
+    return {
+      name: card.name,
+      href: `${lp}/cards/${id.toLowerCase()}`,
+      image: card.image_url ? imageUrl(card.image_url) : null,
+    };
+  }
+  const potion = cat.potions[id];
+  if (potion) {
+    return {
+      name: potion.name,
+      href: `${lp}/potions/${id.toLowerCase()}`,
+      image: potion.image_url ? imageUrl(potion.image_url) : null,
+    };
+  }
+  return { name: displayName(`CARD.${id}`), href: null, image: null };
+}
+
+function TickerRow({
+  e,
+  cat,
+  monsters,
+  lp,
+}: {
+  e: LiveEvent;
+  cat: Catalogs;
+  monsters: MonsterMap;
+  lp: string;
+}) {
+  let icon: React.ReactNode = null;
+  let body: React.ReactNode;
+
+  switch (e.k) {
+    case "card": {
+      const { id, upgraded } = parseDeckId(e.v ?? "");
+      const info = cat.cards[id];
+      if (info?.image_url) {
+        icon = (
+          <img
+            src={imageUrl(info.image_url)}
+            alt=""
+            className="w-6 h-6 object-contain"
+            crossOrigin="anonymous"
+            loading="lazy"
+          />
+        );
+      }
+      body = (
+        <>
+          Played{" "}
+          <Link href={`${lp}/cards/${id.toLowerCase()}`} className="text-[var(--accent-gold)] hover:underline">
+            {info?.name || displayName(`CARD.${id}`)}
+            {upgraded ? "+" : ""}
+          </Link>
+        </>
+      );
+      break;
+    }
+    case "potion": {
+      const id = cleanId(e.v ?? "");
+      const info = cat.potions[id];
+      if (info?.image_url) {
+        icon = (
+          <img
+            src={imageUrl(info.image_url)}
+            alt=""
+            className="w-6 h-6 object-contain"
+            crossOrigin="anonymous"
+            loading="lazy"
+          />
+        );
+      }
+      body = (
+        <>
+          Used{" "}
+          <Link href={`${lp}/potions/${id.toLowerCase()}`} className="text-[var(--accent-gold)] hover:underline">
+            {info?.name || displayName(`POTION.${id}`)}
+          </Link>
+        </>
+      );
+      break;
+    }
+    case "buy": {
+      if (!e.v) {
+        body = <span className="text-[var(--text-secondary)]">Bought something at the shop</span>;
+        break;
+      }
+      const ent = resolveEntity(e.v, cat, lp);
+      if (ent.image) {
+        icon = (
+          <img src={ent.image} alt="" className="w-6 h-6 object-contain" crossOrigin="anonymous" loading="lazy" />
+        );
+      }
+      body = (
+        <>
+          Bought{" "}
+          {ent.href ? (
+            <Link href={ent.href} className="text-[var(--accent-gold)] hover:underline">
+              {ent.name}
+            </Link>
+          ) : (
+            <span className="text-[var(--text-primary)]">{ent.name}</span>
+          )}
+        </>
+      );
+      break;
+    }
+    case "combat":
+      body = e.v ? (
+        <span className="text-amber-300">Fight started: {monsterName(e.v, monsters)}</span>
+      ) : (
+        <span className="text-amber-300">Fight started</span>
+      );
+      break;
+    case "victory":
+      body = <span className="text-emerald-300">Won the fight</span>;
+      break;
+    case "death":
+      body = <span className="text-rose-400 font-semibold">Died</span>;
+      break;
+    case "act":
+      body = (
+        <span className="text-[var(--accent-gold)]">
+          Entered {e.v ? displayName(`ACT.${e.v}`) : "a new act"}
+        </span>
+      );
+      break;
+    default:
+      // Future event kinds render as plain text instead of vanishing.
+      body = (
+        <span className="text-[var(--text-secondary)]">
+          {displayName(`CARD.${e.k}`)}
+          {e.v ? ` ${displayName(`CARD.${e.v}`)}` : ""}
+        </span>
+      );
+  }
+
+  return (
+    <li className="flex items-center gap-2.5 py-1.5 border-b border-[var(--border-subtle)] last:border-0">
+      <span className="w-6 h-6 flex items-center justify-center shrink-0">{icon}</span>
+      <span className="text-sm text-[var(--text-secondary)] min-w-0 flex-1 truncate">{body}</span>
+      <span className="text-[10px] text-[var(--text-muted)] tabular-nums whitespace-nowrap shrink-0">
+        {e.turn != null ? `T${e.turn} · ` : ""}
+        {ago(e.t)}
+      </span>
+    </li>
+  );
+}
+
+export default function LivePlayerClient() {
+  const params = useParams<{ steamId: string }>();
+  const steamId = (params?.steamId ?? "").replace(/\D/g, "");
+  const lp = useLangPrefix();
+  const { lang } = useLanguage();
+
+  const [player, setPlayer] = useState<LivePlayer | null>(null);
+  // null = still loading; afterwards: live, ended (was live, dropped off),
+  // or missing (never seen this session).
+  const [status, setStatus] = useState<"loading" | "live" | "ended" | "missing">("loading");
+  const [cat, setCat] = useState<Catalogs>({ cards: {}, relics: {}, potions: {} });
+  const monsters = useMonsterMap(true);
+
+  useEffect(() => {
+    cachedFetch<CardInfo[]>(`${API}/api/cards?lang=${lang}`)
+      .then((cards) => {
+        const m: Record<string, CardInfo> = {};
+        for (const c of cards) m[c.id] = c;
+        setCat((prev) => ({ ...prev, cards: m }));
+      })
+      .catch(() => {});
+    cachedFetch<RelicInfo[]>(`${API}/api/relics?lang=${lang}`)
+      .then((relics) => {
+        const m: Record<string, RelicInfo> = {};
+        for (const r of relics) m[r.id] = r;
+        setCat((prev) => ({ ...prev, relics: m }));
+      })
+      .catch(() => {});
+    cachedFetch<PotionInfo[]>(`${API}/api/potions?lang=${lang}`)
+      .then((potions) => {
+        const m: Record<string, PotionInfo> = {};
+        for (const p of potions) m[p.id] = p;
+        setCat((prev) => ({ ...prev, potions: m }));
+      })
+      .catch(() => {});
+  }, [lang]);
+
+  usePoll(async () => {
+    if (!steamId) {
+      setStatus("missing");
+      return;
+    }
+    try {
+      const r = await fetch(`${API}/api/presence/${steamId}`);
+      if (r.status === 404) {
+        // Keep the last snapshot on screen when a watched run ends, so the
+        // viewer sees the final state instead of a sudden blank.
+        setStatus((prev) => (prev === "live" || prev === "ended" ? "ended" : "missing"));
+        return;
+      }
+      if (!r.ok) throw new Error(`presence ${r.status}`);
+      setPlayer((await r.json()) as LivePlayer);
+      setStatus("live");
+    } catch {
+      // Network blip: keep whatever we had; the next beat will recover.
+    }
+  }, POLL_MS);
+
+  if (status === "loading") {
+    return (
+      <div className="max-w-5xl mx-auto px-4 py-24 text-center text-sm text-[var(--text-muted)]">
+        Loading...
+      </div>
+    );
+  }
+
+  if (status === "missing" || !player) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-24 text-center">
+        <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-2">Not live right now</h1>
+        <p className="text-sm text-[var(--text-muted)] mb-6">
+          This player is not in a run, or their live status is off.
+        </p>
+        <Link href="/live" className="text-sm text-[var(--accent-gold)] hover:underline">
+          ← Back to the live roster
+        </Link>
+      </div>
+    );
+  }
+
+  const p = player;
+  const hpPct =
+    p.hp != null && p.max_hp ? Math.max(0, Math.min(100, (p.hp / p.max_hp) * 100)) : null;
+  const events = [...(p.events ?? [])].reverse();
+  // Group identical deck entries (STRIKE vs STRIKE+ stay distinct) in
+  // acquisition order of first appearance.
+  const deckGroups: { raw: string; count: number }[] = [];
+  for (const raw of p.deck ?? []) {
+    const g = deckGroups.find((x) => x.raw === raw);
+    if (g) g.count += 1;
+    else deckGroups.push({ raw, count: 1 });
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <Link href="/live" className="text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)]">
+        ← Live roster
+      </Link>
+
+      <div className="mt-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+        <div className="flex items-center gap-3">
+          <CharacterIcon character={p.character} className="w-16 h-16" />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 flex-wrap">
+              {status === "live" ? <LiveDot /> : null}
+              <h1 className="text-xl font-bold text-[var(--text-primary)] truncate">
+                {p.username || "Anonymous climber"}
+              </h1>
+              {p.ascension != null && p.ascension > 0 && (
+                <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-[var(--accent-gold)]/15 text-[var(--accent-gold)] border border-[var(--accent-gold)]/30">
+                  A{p.ascension}
+                </span>
+              )}
+              {(p.player_count ?? 1) > 1 && (
+                <span className="text-xs text-[var(--text-muted)]">co-op ×{p.player_count}</span>
+              )}
+              {status === "ended" && (
+                <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-[var(--bg-primary)] text-[var(--text-muted)] border border-[var(--border-subtle)]">
+                  run ended
+                </span>
+              )}
+            </div>
+            <div className="text-sm text-[var(--text-muted)] truncate">
+              {displayName(`CHARACTER.${p.character ?? ""}`)}
+              {p.screen ? ` · ${p.screen}` : ""}
+              {p.started_at ? ` · climbing for ${elapsed(p.started_at)}` : ""}
+              {p.seed ? ` · seed ${p.seed}` : ""}
+            </div>
+          </div>
+          <div className="text-right shrink-0">
+            <div className="text-lg font-bold text-[var(--text-primary)] tabular-nums">
+              {p.act != null ? `Act ${p.act}` : ""}
+              {p.total_floor != null ? ` · F${p.total_floor}` : ""}
+            </div>
+            <div className="text-sm text-[var(--text-muted)] tabular-nums">
+              {p.gold != null ? `${p.gold} gold` : ""}
+            </div>
+          </div>
+        </div>
+
+        {hpPct != null && (
+          <div className="mt-3">
+            <div className="flex justify-between text-[10px] text-[var(--text-muted)] mb-1 tabular-nums">
+              <span>HP</span>
+              <span>
+                {p.hp}/{p.max_hp}
+              </span>
+            </div>
+            <div className="h-2 rounded bg-[var(--bg-primary)]">
+              <div className="h-2 rounded bg-rose-500" style={{ width: `${hpPct}%` }} />
+            </div>
+          </div>
+        )}
+
+        {p.screen === "combat" && (p.fighting?.length ?? 0) > 0 && (
+          <div className="mt-4 rounded-lg border border-rose-900/50 bg-rose-950/30 p-3">
+            <div className="flex items-center gap-3 flex-wrap">
+              <span className="text-xs font-bold uppercase tracking-wider text-rose-300">
+                Fighting
+              </span>
+              {(p.fighting ?? []).map((id, i) => (
+                <span key={`${id}-${i}`} className="inline-flex items-center gap-1.5">
+                  <EnemyCircle id={id} monsters={monsters} className="w-9 h-9" />
+                  <span className="text-sm text-rose-100">{monsterName(id, monsters)}</span>
+                </span>
+              ))}
+              {p.turn != null && p.turn > 0 && (
+                <span className="ml-auto text-sm text-rose-300 tabular-nums">Turn {p.turn}</span>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+          <h2 className="text-sm font-semibold text-[var(--accent-gold)] mb-2">Play-by-play</h2>
+          {events.length === 0 ? (
+            <p className="text-sm text-[var(--text-muted)]">
+              No plays yet. Card plays, potions, fights, and purchases show up here as they
+              happen.
+            </p>
+          ) : (
+            <ul>
+              {events.map((e, i) => (
+                <TickerRow key={`${e.t ?? 0}-${e.k}-${i}`} e={e} cat={cat} monsters={monsters} lp={lp} />
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="space-y-4">
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+            <h2 className="text-sm font-semibold text-[var(--accent-gold)] mb-2">
+              Deck{p.deck ? ` (${p.deck.length})` : ""}
+            </h2>
+            {deckGroups.length === 0 ? (
+              <p className="text-sm text-[var(--text-muted)]">No deck data on this beat.</p>
+            ) : (
+              <div className="flex flex-wrap gap-1.5">
+                {deckGroups.map(({ raw, count }) => {
+                  const { id, upgraded } = parseDeckId(raw);
+                  const fallback = cat.cards[id]?.image_url
+                    ? imageUrl(cat.cards[id].image_url as string)
+                    : "";
+                  return (
+                    <CardPill
+                      key={raw}
+                      cardId={id}
+                      upgraded={upgraded}
+                      cardData={cat.cards}
+                      lp={lp}
+                      className="relative block w-14 shrink-0"
+                    >
+                      <img
+                        src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                        alt={cat.cards[id]?.name || displayName(`CARD.${id}`)}
+                        className="w-14 h-auto rounded-sm"
+                        crossOrigin="anonymous"
+                        loading="lazy"
+                        onError={(e) => {
+                          const el = e.target as HTMLImageElement;
+                          if (fallback && el.src !== fallback) el.src = fallback;
+                          else el.style.visibility = "hidden";
+                        }}
+                      />
+                      {count > 1 && (
+                        <span className="absolute -top-1 -right-1 px-1 rounded bg-[var(--accent-gold)] text-[var(--bg-primary)] text-[10px] font-bold">
+                          ×{count}
+                        </span>
+                      )}
+                    </CardPill>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+            <h2 className="text-sm font-semibold text-[var(--accent-gold)] mb-2">Relics</h2>
+            {(p.relics ?? []).length === 0 ? (
+              <p className="text-sm text-[var(--text-muted)]">No relic data on this beat.</p>
+            ) : (
+              <div className="flex flex-wrap gap-1.5">
+                {(p.relics ?? []).map((raw, i) => {
+                  const rid = cleanId(raw);
+                  const info = cat.relics[rid];
+                  const src = info?.image_url
+                    ? imageUrl(info.image_url)
+                    : imageUrl(`/static/images/relics/${rid.toLowerCase()}.png`);
+                  return (
+                    <RelicPill
+                      key={`${raw}-${i}`}
+                      relicId={rid}
+                      relicData={cat.relics}
+                      lp={lp}
+                      className="block shrink-0"
+                    >
+                      <img
+                        src={src}
+                        alt={info?.name || displayName(`RELIC.${raw}`)}
+                        className="w-9 h-9 object-contain"
+                        crossOrigin="anonymous"
+                        loading="lazy"
+                        onError={(e) => {
+                          (e.target as HTMLImageElement).style.display = "none";
+                        }}
+                      />
+                    </RelicPill>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {(p.potions ?? []).length > 0 && (
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+              <h2 className="text-sm font-semibold text-[var(--accent-gold)] mb-2">Potions</h2>
+              <div className="flex flex-wrap gap-1.5">
+                {(p.potions ?? []).map((raw, i) => {
+                  const pid = cleanId(raw);
+                  const info = cat.potions[pid];
+                  return (
+                    <PotionPill
+                      key={`${raw}-${i}`}
+                      potionId={pid}
+                      potionData={cat.potions}
+                      lp={lp}
+                      className="block shrink-0"
+                    >
+                      {info?.image_url ? (
+                        <img
+                          src={imageUrl(info.image_url)}
+                          alt={info.name}
+                          className="w-9 h-9 object-contain"
+                          crossOrigin="anonymous"
+                          loading="lazy"
+                          onError={(e) => {
+                            (e.target as HTMLImageElement).style.display = "none";
+                          }}
+                        />
+                      ) : (
+                        <span className="text-xs text-[var(--text-secondary)]">
+                          {displayName(`POTION.${raw}`)}
+                        </span>
+                      )}
+                    </PotionPill>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {p.sts2_version && (
+            <p className="text-[10px] text-[var(--text-muted)]">{p.sts2_version}</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/live/[steamId]/page.tsx
+++ b/frontend/app/live/[steamId]/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import LivePlayerClient from "./LivePlayerClient";
+
+export const metadata: Metadata = {
+  title: "Live",
+  robots: { index: false, follow: false },
+};
+
+export default function LivePlayerPage() {
+  return <LivePlayerClient />;
+}

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+// Shared plumbing for the live presence views: the /live roster, the
+// per-player /live/[steamId] breakdown, and the home page rail. Contract:
+// markdown-docs/live-presence.md. Every field is optional by design (old
+// mod against new backend and vice versa), so everything here renders
+// defensively and disappears quietly when data is absent.
+
+import { useEffect, useState } from "react";
+import { useLanguage } from "@/app/contexts/LanguageContext";
+import { cachedFetch } from "@/lib/fetch-cache";
+import { imageUrl } from "@/lib/image-url";
+import { cleanId, displayName } from "../runs/[hash]/RunPills";
+
+export const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+export interface LiveEvent {
+  k: string;
+  v?: string;
+  turn?: number;
+  t?: number;
+}
+
+export interface LivePlayer {
+  steam_id: string;
+  username?: string | null;
+  character?: string | null;
+  ascension?: number | null;
+  act?: number | null;
+  act_floor?: number | null;
+  total_floor?: number | null;
+  hp?: number | null;
+  max_hp?: number | null;
+  gold?: number | null;
+  screen?: string | null;
+  seed?: string | null;
+  player_count?: number | null;
+  sts2_version?: string | null;
+  started_at?: string | null;
+  turn?: number | null;
+  fighting?: string[];
+  deck?: string[];
+  relics?: string[];
+  potions?: string[];
+  events?: LiveEvent[];
+}
+
+export interface MonsterInfo {
+  id: string;
+  name: string;
+  image_url?: string | null;
+}
+
+export type MonsterMap = Record<string, MonsterInfo>;
+
+export function elapsed(startedAt?: string | null): string {
+  if (!startedAt) return "";
+  const ms = Date.now() - new Date(startedAt).getTime();
+  if (ms <= 0) return "";
+  const mins = Math.floor(ms / 60000);
+  if (mins < 1) return "under a minute";
+  if (mins < 60) return `${mins}m`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+}
+
+export function ago(unixSeconds?: number): string {
+  if (!unixSeconds) return "";
+  const s = Math.floor(Date.now() / 1000 - unixSeconds);
+  if (s < 5) return "now";
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  return `${Math.floor(m / 60)}h ago`;
+}
+
+// Deck entries use the run-doc convention: bare card id, `+` = upgraded.
+export function parseDeckId(raw: string): { id: string; upgraded: boolean } {
+  const upgraded = raw.endsWith("+");
+  return { id: cleanId(upgraded ? raw.slice(0, -1) : raw), upgraded };
+}
+
+export function LiveDot() {
+  return (
+    <span className="relative flex h-2 w-2">
+      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+      <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+    </span>
+  );
+}
+
+/** Poll on an interval, skipping beats while the tab is hidden and firing
+ * immediately when it becomes visible again. `fn` must only close over
+ * stable values (setState, constants, route params). */
+export function usePoll(fn: () => void, ms: number) {
+  useEffect(() => {
+    fn();
+    const t = setInterval(() => {
+      if (!document.hidden) fn();
+    }, ms);
+    const onVis = () => {
+      if (!document.hidden) fn();
+    };
+    document.addEventListener("visibilitychange", onVis);
+    return () => {
+      clearInterval(t);
+      document.removeEventListener("visibilitychange", onVis);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
+/** Lazy monster id -> {name, image_url} map; only fetches once enabled
+ * (i.e. once somebody is actually in a fight). */
+export function useMonsterMap(enabled: boolean): MonsterMap {
+  const { lang } = useLanguage();
+  const [map, setMap] = useState<MonsterMap>({});
+  useEffect(() => {
+    if (!enabled) return;
+    cachedFetch<MonsterInfo[]>(`${API}/api/monsters?lang=${lang}`)
+      .then((monsters) => {
+        const m: MonsterMap = {};
+        for (const x of monsters) m[x.id] = x;
+        setMap(m);
+      })
+      .catch(() => {});
+  }, [enabled, lang]);
+  return map;
+}
+
+export function monsterName(id: string, monsters: MonsterMap): string {
+  return monsters[cleanId(id)]?.name || displayName(`MONSTER.${id}`);
+}
+
+export function EnemyCircle({
+  id,
+  monsters,
+  className = "w-7 h-7",
+}: {
+  id: string;
+  monsters: MonsterMap;
+  className?: string;
+}) {
+  const mid = cleanId(id);
+  const info = monsters[mid];
+  const src = info?.image_url
+    ? imageUrl(info.image_url)
+    : imageUrl(`/static/images/monsters/${mid.toLowerCase()}.webp`);
+  return (
+    <span
+      className={`relative inline-flex ${className} shrink-0 rounded-full overflow-hidden border border-[var(--border-subtle)] bg-[var(--bg-primary)]`}
+      title={monsterName(id, monsters)}
+    >
+      <img
+        src={src}
+        alt={monsterName(id, monsters)}
+        className="w-full h-full object-cover object-top"
+        crossOrigin="anonymous"
+        loading="lazy"
+        onError={(e) => {
+          (e.target as HTMLImageElement).style.visibility = "hidden";
+        }}
+      />
+    </span>
+  );
+}
+
+/** "Fighting X · Turn N" with the enemies as small circular portraits.
+ * Renders nothing unless the player is actually on the combat screen with
+ * known enemies, so stale combat fields from an earlier fight never show. */
+export function FightingChip({
+  p,
+  monsters,
+  circle = "w-6 h-6",
+}: {
+  p: LivePlayer;
+  monsters: MonsterMap;
+  circle?: string;
+}) {
+  if (p.screen !== "combat" || !p.fighting?.length) return null;
+  const names = p.fighting.map((id) => monsterName(id, monsters));
+  const label =
+    names.length <= 2 ? names.join(" & ") : `${names[0]} +${names.length - 1}`;
+  return (
+    <span className="inline-flex items-center gap-1.5 px-2 py-1 rounded-full bg-rose-950/50 border border-rose-900/50 text-xs text-rose-200">
+      <span className="flex -space-x-2">
+        {p.fighting.slice(0, 3).map((id, i) => (
+          <EnemyCircle key={`${id}-${i}`} id={id} monsters={monsters} className={circle} />
+        ))}
+      </span>
+      <span className="truncate">Fighting {label}</span>
+      {p.turn != null && p.turn > 0 && (
+        <span className="text-rose-400/80 whitespace-nowrap">· Turn {p.turn}</span>
+      )}
+    </span>
+  );
+}
+
+export function CharacterIcon({
+  character,
+  className = "w-12 h-12",
+}: {
+  character?: string | null;
+  className?: string;
+}) {
+  const slug = cleanId(character || "").toLowerCase();
+  if (!slug) return null;
+  return (
+    <img
+      src={imageUrl(`/static/images/characters/character_icon_${slug}.webp`)}
+      alt={displayName(`CHARACTER.${character ?? ""}`)}
+      className={`${className} object-contain`}
+      crossOrigin="anonymous"
+      onError={(e) => {
+        (e.target as HTMLImageElement).style.visibility = "hidden";
+      }}
+    />
+  );
+}


### PR DESCRIPTION
Builds the live presence feature out on top of #463 (this branch contains it; merging this one covers both, in which case #463 can be closed).

**/live/[steamId]** is the full spectator view of one live run:

- the current fight: enemy portraits in circles, names, and the turn counter, shown only while the player is actually on the combat screen so stale combat fields from an earlier fight never render
- the play-by-play ticker from the mod's v2 heartbeats (#464): "Played Whirlwind" with the card art and a link, "Used Fire Potion", "Fight started", "Won the fight", "Bought Frozen Eye" (resolved across relic/card/potion catalogs), "Entered Act 2", "Died" - each with the combat turn and a relative timestamp, newest first
- the whole deck as small renders, grouped with ×N count badges and + for upgrades, hover pops the full card
- relics and potions with the usual tooltips, HP bar, gold, seed, ascension, co-op marker, elapsed time, game version
- polls every 4s (the contract's 3-5s guidance for the event-driven heartbeats); when a watched run ends, the final snapshot stays on screen with a "run ended" badge instead of blanking

**/live roster** gains a "Fighting X · Turn N" chip per player with the enemy circles, and every card links through to the spectator page. Polls at 12s.

**Home page: unchanged.** The Live now rail (character icon, name, floor, Fighting chip, links to the spectator pages) ships as an unmounted component (LiveNowRail.tsx) since the feature isn't ready for promotion yet; mounting it later is a two-line diff in HomeClient.

Robustness, since this rides a young contract: every field is optional in the shared types, unknown ticker event kinds render as plain text instead of vanishing, entity images hide on load error with name fallbacks, the monster catalog only fetches once somebody is actually fighting, polls pause while the tab is hidden and fire immediately on return, and failed polls keep the last good state with the roster aging out naturally via the API's 90s TTL.

The ticker and Fighting chips light up once #464 (presence v2 backend) is deployed; before that the pages run fine on v1 data and simply omit those sections.