### PR TITLE
Ticker polish + live presence hardening (review fixes)

### DIFF
--- a/frontend/app/live/LiveClient.tsx
+++ b/frontend/app/live/LiveClient.tsx
@@ -32,6 +32,7 @@ import {
   parseDeckId,
   useMonsterMap,
   usePoll,
+  withOrdinalKeys,
   type LivePlayer,
   type MonsterMap,
 } from "./live-shared";
@@ -40,6 +41,8 @@ import {
 // guidance applies here rather than the hot 3-5s per-player cadence.
 const POLL_MS = 12_000;
 const RECENT_CARDS = 5;
+// Bounds the per-player detail fan-out (see the poll below).
+const ROSTER_LIMIT = 24;
 
 function PlayerCard({
   p,
@@ -132,14 +135,14 @@ function PlayerCard({
             Latest cards
           </div>
           <div className="flex gap-1.5">
-            {recent.map((raw, i) => {
+            {withOrdinalKeys(recent).map(({ item: raw, key }) => {
               const { id, upgraded } = parseDeckId(raw);
               const fallback = cardData[id]?.image_url
                 ? imageUrl(cardData[id].image_url as string)
                 : "";
               return (
                 <CardPill
-                  key={`${raw}-${i}`}
+                  key={key}
                   cardId={id}
                   upgraded={upgraded}
                   cardData={cardData}
@@ -171,7 +174,7 @@ function PlayerCard({
             Relics
           </div>
           <div className="flex flex-wrap gap-1">
-            {(p.relics ?? []).map((raw, i) => {
+            {(p.relics ?? []).map((raw) => {
               const rid = cleanId(raw);
               const info = relicData[rid];
               const src = info?.image_url
@@ -179,7 +182,7 @@ function PlayerCard({
                 : imageUrl(`/static/images/relics/${rid.toLowerCase()}.png`);
               return (
                 <RelicPill
-                  key={`${raw}-${i}`}
+                  key={raw}
                   relicId={rid}
                   relicData={relicData}
                   lp={lp}
@@ -239,13 +242,17 @@ export default function LiveClient() {
 
   usePoll(async () => {
     try {
-      const r = await fetch(`${API}/api/presence/active`);
+      // Cap the roster: the page shows recent cards + relics per player, which
+      // means one detail fetch each (an N+1). Capping the roster bounds that
+      // fan-out; a live count beyond this is vanishingly rare and the deepest
+      // runs sort first anyway.
+      const r = await fetch(`${API}/api/presence/active?limit=${ROSTER_LIMIT}`);
       if (!r.ok) throw new Error(`active ${r.status}`);
       const data: { players?: LivePlayer[] } = await r.json();
       const roster = data.players ?? [];
-      // The roster is identity + progress only; deck/relics live on the
-      // per-player doc. The list is small, so fetch them all in parallel
-      // and fall back to the roster entry if one fetch fails.
+      // The roster carries identity + progress only; deck/relics live on the
+      // per-player doc, so fetch those in parallel and fall back to the roster
+      // entry if one fetch fails.
       const detailed = await Promise.all(
         roster.map(async (p) => {
           try {

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -42,47 +42,19 @@ import {
 
 const POLL_MS = 4_000;
 
+interface EventInfo {
+  id: string;
+  name: string;
+}
+
 interface Catalogs {
   cards: Record<string, CardInfo>;
   relics: Record<string, RelicInfo>;
   potions: Record<string, PotionInfo>;
+  events: Record<string, EventInfo>;
 }
 
-/** Best-effort lookup for an event's entity id: shops sell relics, cards,
- * and potions, so try all three catalogs before falling back to the
- * prettified raw id. */
-function resolveEntity(
-  rawId: string,
-  cat: Catalogs,
-  lp: string,
-): { name: string; href: string | null; image: string | null } {
-  const id = cleanId(rawId.endsWith("+") ? rawId.slice(0, -1) : rawId);
-  const relic = cat.relics[id];
-  if (relic) {
-    return {
-      name: relic.name,
-      href: `${lp}/relics/${id.toLowerCase()}`,
-      image: relic.image_url ? imageUrl(relic.image_url) : null,
-    };
-  }
-  const card = cat.cards[id];
-  if (card) {
-    return {
-      name: card.name,
-      href: `${lp}/cards/${id.toLowerCase()}`,
-      image: card.image_url ? imageUrl(card.image_url) : null,
-    };
-  }
-  const potion = cat.potions[id];
-  if (potion) {
-    return {
-      name: potion.name,
-      href: `${lp}/potions/${id.toLowerCase()}`,
-      image: potion.image_url ? imageUrl(potion.image_url) : null,
-    };
-  }
-  return { name: displayName(`CARD.${id}`), href: null, image: null };
-}
+const TICKER_LINK = "inline text-[var(--accent-gold)] hover:underline";
 
 function TickerRow({
   e,
@@ -116,10 +88,10 @@ function TickerRow({
       body = (
         <>
           Played{" "}
-          <Link href={`${lp}/cards/${id.toLowerCase()}`} className="text-[var(--accent-gold)] hover:underline">
+          <CardPill cardId={id} upgraded={upgraded} cardData={cat.cards} lp={lp} className={TICKER_LINK}>
             {info?.name || displayName(`CARD.${id}`)}
             {upgraded ? "+" : ""}
-          </Link>
+          </CardPill>
         </>
       );
       break;
@@ -141,34 +113,69 @@ function TickerRow({
       body = (
         <>
           Used{" "}
-          <Link href={`${lp}/potions/${id.toLowerCase()}`} className="text-[var(--accent-gold)] hover:underline">
+          <PotionPill potionId={id} potionData={cat.potions} lp={lp} className={TICKER_LINK}>
             {info?.name || displayName(`POTION.${id}`)}
-          </Link>
+          </PotionPill>
         </>
       );
       break;
     }
     case "buy": {
       if (!e.v) {
+        // The mod did not resolve the purchased item on this beat; there is
+        // nothing to drill into until it ships the entity id.
         body = <span className="text-[var(--text-secondary)]">Bought something at the shop</span>;
         break;
       }
-      const ent = resolveEntity(e.v, cat, lp);
-      if (ent.image) {
+      // Shops sell relics, cards, and potions; resolve across all three
+      // catalogs and render the matching pill so hover shows the details.
+      const { id, upgraded } = parseDeckId(e.v);
+      const relic = cat.relics[id];
+      const card = relic ? undefined : cat.cards[id];
+      const potion = relic || card ? undefined : cat.potions[id];
+      const img = relic?.image_url || card?.image_url || potion?.image_url;
+      if (img) {
         icon = (
-          <img src={ent.image} alt="" className="w-6 h-6 object-contain" crossOrigin="anonymous" loading="lazy" />
+          <img src={imageUrl(img)} alt="" className="w-6 h-6 object-contain" crossOrigin="anonymous" loading="lazy" />
         );
       }
       body = (
         <>
           Bought{" "}
-          {ent.href ? (
-            <Link href={ent.href} className="text-[var(--accent-gold)] hover:underline">
-              {ent.name}
-            </Link>
+          {relic ? (
+            <RelicPill relicId={id} relicData={cat.relics} lp={lp} className={TICKER_LINK}>
+              {relic.name}
+            </RelicPill>
+          ) : card ? (
+            <CardPill cardId={id} upgraded={upgraded} cardData={cat.cards} lp={lp} className={TICKER_LINK}>
+              {card.name}
+              {upgraded ? "+" : ""}
+            </CardPill>
+          ) : potion ? (
+            <PotionPill potionId={id} potionData={cat.potions} lp={lp} className={TICKER_LINK}>
+              {potion.name}
+            </PotionPill>
           ) : (
-            <span className="text-[var(--text-primary)]">{ent.name}</span>
+            <span className="text-[var(--text-primary)]">{displayName(`CARD.${id}`)}</span>
           )}
+        </>
+      );
+      break;
+    }
+    case "event": {
+      // Event-room visit. The backend passes any kind through, so this
+      // lights up as soon as the mod ships {"k": "event", "v": EVENT_ID}.
+      const id = cleanId(e.v ?? "");
+      if (!id) {
+        body = <span className="text-purple-300">Visited an event</span>;
+        break;
+      }
+      body = (
+        <>
+          <span className="text-purple-300">Event:</span>{" "}
+          <Link href={`${lp}/events/${id.toLowerCase()}`} className={TICKER_LINK}>
+            {cat.events[id]?.name || displayName(`EVENT.${id}`)}
+          </Link>
         </>
       );
       break;
@@ -205,8 +212,11 @@ function TickerRow({
 
   return (
     <li className="flex items-center gap-2.5 py-1.5 border-b border-[var(--border-subtle)] last:border-0">
+      {/* No truncate/overflow-hidden here: the pill hover popups (full
+          card render, relic tooltip) position outside the row and would
+          get clipped by an overflow-hidden ancestor. */}
       <span className="w-6 h-6 flex items-center justify-center shrink-0">{icon}</span>
-      <span className="text-sm text-[var(--text-secondary)] min-w-0 flex-1 truncate">{body}</span>
+      <span className="text-sm text-[var(--text-secondary)] min-w-0 flex-1 break-words">{body}</span>
       <span className="text-[10px] text-[var(--text-muted)] tabular-nums whitespace-nowrap shrink-0">
         {e.turn != null ? `T${e.turn} · ` : ""}
         {ago(e.t)}
@@ -225,7 +235,7 @@ export default function LivePlayerClient() {
   // null = still loading; afterwards: live, ended (was live, dropped off),
   // or missing (never seen this session).
   const [status, setStatus] = useState<"loading" | "live" | "ended" | "missing">("loading");
-  const [cat, setCat] = useState<Catalogs>({ cards: {}, relics: {}, potions: {} });
+  const [cat, setCat] = useState<Catalogs>({ cards: {}, relics: {}, potions: {}, events: {} });
   const monsters = useMonsterMap(true);
 
   useEffect(() => {
@@ -248,6 +258,13 @@ export default function LivePlayerClient() {
         const m: Record<string, PotionInfo> = {};
         for (const p of potions) m[p.id] = p;
         setCat((prev) => ({ ...prev, potions: m }));
+      })
+      .catch(() => {});
+    cachedFetch<EventInfo[]>(`${API}/api/events?lang=${lang}`)
+      .then((events) => {
+        const m: Record<string, EventInfo> = {};
+        for (const ev of events) m[ev.id] = ev;
+        setCat((prev) => ({ ...prev, events: m }));
       })
       .catch(() => {});
   }, [lang]);

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -35,6 +35,7 @@ import {
   parseDeckId,
   useMonsterMap,
   usePoll,
+  withOrdinalKeys,
   type LiveEvent,
   type LivePlayer,
   type MonsterMap,
@@ -72,7 +73,11 @@ function TickerRow({
 
   switch (e.k) {
     case "card": {
-      const { id, upgraded } = parseDeckId(e.v ?? "");
+      if (!e.v) {
+        body = <span className="text-[var(--text-secondary)]">Played a card</span>;
+        break;
+      }
+      const { id, upgraded } = parseDeckId(e.v);
       const info = cat.cards[id];
       if (info?.image_url) {
         icon = (
@@ -210,6 +215,10 @@ function TickerRow({
       );
   }
 
+  // Join only the parts that exist, so a missing timestamp or turn never
+  // leaves a dangling "T2 · " with nothing after it.
+  const meta = [e.turn != null ? `T${e.turn}` : "", ago(e.t)].filter(Boolean).join(" · ");
+
   return (
     <li className="flex items-center gap-2.5 py-1.5 border-b border-[var(--border-subtle)] last:border-0">
       {/* No truncate/overflow-hidden here: the pill hover popups (full
@@ -217,10 +226,11 @@ function TickerRow({
           get clipped by an overflow-hidden ancestor. */}
       <span className="w-6 h-6 flex items-center justify-center shrink-0">{icon}</span>
       <span className="text-sm text-[var(--text-secondary)] min-w-0 flex-1 break-words">{body}</span>
-      <span className="text-[10px] text-[var(--text-muted)] tabular-nums whitespace-nowrap shrink-0">
-        {e.turn != null ? `T${e.turn} · ` : ""}
-        {ago(e.t)}
-      </span>
+      {meta && (
+        <span className="text-[10px] text-[var(--text-muted)] tabular-nums whitespace-nowrap shrink-0">
+          {meta}
+        </span>
+      )}
     </li>
   );
 }
@@ -315,7 +325,18 @@ export default function LivePlayerClient() {
   const p = player;
   const hpPct =
     p.hp != null && p.max_hp ? Math.max(0, Math.min(100, (p.hp / p.max_hp) * 100)) : null;
-  const events = [...(p.events ?? [])].reverse();
+  // Stable per-event keys: ordinals computed over the original (append-order)
+  // array, so a new beat appending at the end and the 50-window rolling off the
+  // front both leave surviving rows' keys unchanged. Index keys would shift
+  // every key on each new event, remounting every row and dropping open hover
+  // popups. Display is newest-first.
+  const rawEvents = p.events ?? [];
+  const eventKeys = withOrdinalKeys(
+    rawEvents.map((e) => `${e.k}|${e.v ?? ""}|${e.turn ?? ""}|${e.t ?? 0}`),
+  );
+  const events = rawEvents
+    .map((e, i) => ({ e, key: eventKeys[i].key }))
+    .reverse();
   // Group identical deck entries (STRIKE vs STRIKE+ stay distinct) in
   // acquisition order of first appearance.
   const deckGroups: { raw: string; count: number }[] = [];
@@ -392,8 +413,8 @@ export default function LivePlayerClient() {
               <span className="text-xs font-bold uppercase tracking-wider text-rose-300">
                 Fighting
               </span>
-              {(p.fighting ?? []).map((id, i) => (
-                <span key={`${id}-${i}`} className="inline-flex items-center gap-1.5">
+              {withOrdinalKeys(p.fighting ?? []).map(({ item: id, key }) => (
+                <span key={key} className="inline-flex items-center gap-1.5">
                   <EnemyCircle id={id} monsters={monsters} className="w-9 h-9" />
                   <span className="text-sm text-rose-100">{monsterName(id, monsters)}</span>
                 </span>
@@ -416,8 +437,8 @@ export default function LivePlayerClient() {
             </p>
           ) : (
             <ul>
-              {events.map((e, i) => (
-                <TickerRow key={`${e.t ?? 0}-${e.k}-${i}`} e={e} cat={cat} monsters={monsters} lp={lp} />
+              {events.map(({ e, key }) => (
+                <TickerRow key={key} e={e} cat={cat} monsters={monsters} lp={lp} />
               ))}
             </ul>
           )}
@@ -476,7 +497,7 @@ export default function LivePlayerClient() {
               <p className="text-sm text-[var(--text-muted)]">No relic data on this beat.</p>
             ) : (
               <div className="flex flex-wrap gap-1.5">
-                {(p.relics ?? []).map((raw, i) => {
+                {(p.relics ?? []).map((raw) => {
                   const rid = cleanId(raw);
                   const info = cat.relics[rid];
                   const src = info?.image_url
@@ -484,7 +505,7 @@ export default function LivePlayerClient() {
                     : imageUrl(`/static/images/relics/${rid.toLowerCase()}.png`);
                   return (
                     <RelicPill
-                      key={`${raw}-${i}`}
+                      key={raw}
                       relicId={rid}
                       relicData={cat.relics}
                       lp={lp}
@@ -511,12 +532,12 @@ export default function LivePlayerClient() {
             <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
               <h2 className="text-sm font-semibold text-[var(--accent-gold)] mb-2">Potions</h2>
               <div className="flex flex-wrap gap-1.5">
-                {(p.potions ?? []).map((raw, i) => {
+                {withOrdinalKeys(p.potions ?? []).map(({ item: raw, key }) => {
                   const pid = cleanId(raw);
                   const info = cat.potions[pid];
                   return (
                     <PotionPill
-                      key={`${raw}-${i}`}
+                      key={key}
                       potionId={pid}
                       potionData={cat.potions}
                       lp={lp}

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -37,6 +37,7 @@ export interface LivePlayer {
   player_count?: number | null;
   sts2_version?: string | null;
   started_at?: string | null;
+  updated_at?: string | null;
   turn?: number | null;
   fighting?: string[];
   deck?: string[];
@@ -64,7 +65,8 @@ export function elapsed(startedAt?: string | null): string {
 }
 
 export function ago(unixSeconds?: number): string {
-  if (!unixSeconds) return "";
+  // `== null` not `!unixSeconds`: a legitimate t of 0 is falsy but valid.
+  if (unixSeconds == null) return "";
   const s = Math.floor(Date.now() / 1000 - unixSeconds);
   if (s < 5) return "now";
   if (s < 60) return `${s}s ago`;
@@ -77,6 +79,28 @@ export function ago(unixSeconds?: number): string {
 export function parseDeckId(raw: string): { id: string; upgraded: boolean } {
   const upgraded = raw.endsWith("+");
   return { id: cleanId(upgraded ? raw.slice(0, -1) : raw), upgraded };
+}
+
+// Entity ids reach us from the presence API (a game mod) and get spliced
+// straight into image URLs and Link hrefs. The backend rejects path-traversal
+// ids at the source, but guard here too so a stale backend or a future caller
+// can never build a traversal URL.
+export function safeId(id: string): boolean {
+  return !!id && !id.includes("/") && !id.includes("\\") && !id.includes("..");
+}
+
+/** Stable React keys for a list that may hold duplicate ids and that grows or
+ * shrinks between polls (deck cards, potions, enemies). Keys by id plus a
+ * per-id occurrence ordinal, so appending or removing one item does not
+ * reshuffle the keys of the items before it. Plain array-index keys do, which
+ * remounts rows on every poll and drops open hover tooltips. */
+export function withOrdinalKeys(items: string[]): { item: string; key: string }[] {
+  const seen: Record<string, number> = {};
+  return items.map((item) => {
+    const n = seen[item] ?? 0;
+    seen[item] = n + 1;
+    return { item, key: `${item}#${n}` };
+  });
 }
 
 export function LiveDot() {
@@ -142,9 +166,10 @@ export function EnemyCircle({
 }) {
   const mid = cleanId(id);
   const info = monsters[mid];
-  const src = info?.image_url
-    ? imageUrl(info.image_url)
-    : imageUrl(`/static/images/monsters/${mid.toLowerCase()}.webp`);
+  const fallback = safeId(mid)
+    ? imageUrl(`/static/images/monsters/${mid.toLowerCase()}.webp`)
+    : "";
+  const src = info?.image_url ? imageUrl(info.image_url) : fallback;
   return (
     <span
       className={`relative inline-flex ${className} shrink-0 rounded-full overflow-hidden border border-[var(--border-subtle)] bg-[var(--bg-primary)]`}
@@ -183,8 +208,8 @@ export function FightingChip({
   return (
     <span className="inline-flex items-center gap-1.5 px-2 py-1 rounded-full bg-rose-950/50 border border-rose-900/50 text-xs text-rose-200">
       <span className="flex -space-x-2">
-        {p.fighting.slice(0, 3).map((id, i) => (
-          <EnemyCircle key={`${id}-${i}`} id={id} monsters={monsters} className={circle} />
+        {withOrdinalKeys(p.fighting.slice(0, 3)).map(({ item, key }) => (
+          <EnemyCircle key={key} id={item} monsters={monsters} className={circle} />
         ))}
       </span>
       <span className="truncate">Fighting {label}</span>
@@ -203,7 +228,7 @@ export function CharacterIcon({
   className?: string;
 }) {
   const slug = cleanId(character || "").toLowerCase();
-  if (!slug) return null;
+  if (!slug || !safeId(slug)) return null;
   return (
     <img
       src={imageUrl(`/static/images/characters/character_icon_${slug}.webp`)}


### PR DESCRIPTION
Two commits: the original ticker polish, then a round of hardening from an adversarial review of the whole live presence feature.

## Commit 1: ticker polish
- "Played X" / "Used X" rows render through CardPill/PotionPill, so hovering pops the full card render or potion tooltip.
- "Bought X" resolves the entity id across the relic, card, and potion catalogs and renders the matching pill; the bare "Bought something at the shop" line only remains when the mod sends no id.
- New `event`-room row ("Event: Abyssal Baths", linked), with the renderer ready before the mod emits it.

## Commit 2: review hardening
A multi-dimension review (correctness, security, React/perf, contract) raised 22 findings; 21 confirmed after independent verification. The dominant root cause was index-based React keys, plus an id-validation gap. Fixed:

- **Stable React keys everywhere.** A shared `withOrdinalKeys` keys duplicate-prone lists (deck cards, potions, enemies, ticker events) by id + per-id occurrence ordinal instead of array index; unique lists (relics) key by id. With index keys, every poll that grew the deck, changed relics/potions, killed an enemy, or rolled the 50-event window remounted rows and dropped any open hover popup mid-spectate. Ticker keys are computed over the original append-order array, so a new beat and a rolled window both leave surviving rows untouched.
- **Defense-in-depth on entity ids.** A `safeId` guard rejects path-traversal characters before any id is spliced into an image URL or href on the client, mirroring the backend guard in #467 (so even a stale backend can't yield a traversal URL).
- **Correctness nits.** `ago()` treats a timestamp of 0 as valid rather than falsy; the ticker meta joins turn and time so a missing timestamp never leaves a dangling "T2 ·"; a `card` event with no id renders "Played a card" instead of an empty link; the `LivePlayer` type gains `updated_at`.
- **Bounded roster N+1.** The roster shows recent cards + relics per player (one detail fetch each); capping the active fetch bounds the fan-out while keeping the rich roster.

The one refuted finding was a path-traversal claim on character image URLs that Starlette's StaticFiles already blocks server-side.

tsc + eslint clean. Independent of #467, but the contract-doc `event`/`remove` kind updates and the backend id guard live there.