### PR TITLE
Presence v3 + v4 backend: act map, live event/shop detail, combat-end clearing, id guard

### DIFF
--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -29,10 +29,79 @@ _INT_FIELDS = (
 _STR_FIELDS = ("character", "seed", "screen", "sts2_version", "username")
 _LIST_CAPS = {"deck": 200, "relics": 100, "potions": 10, "fighting": 8}
 
+
+def _safe_id(s: str) -> bool:
+    """Entity ids (cards, relics, potions, monsters, events) flow straight
+    into image/CDN URLs and Link hrefs on the frontend, so reject anything
+    that could smuggle a path-traversal sequence through the heartbeat. Real
+    game ids are letters/digits/underscore with an optional `+` upgrade
+    suffix; a `/`, `\\`, or `..` never appears in one."""
+    return bool(s) and "/" not in s and "\\" not in s and ".." not in s
+
+
 # Play-by-play ticker events riding the heartbeat: {"k": kind, "v": entity id,
 # "turn": combat turn, "t": unix seconds}. Kinds today: card, potion, combat,
-# victory, buy, death, act. Appended server-side to a rolling window per player.
+# victory, buy, death, act, event, remove. Appended server-side to a rolling
+# window per player.
 _EVENTS_PER_BEAT = 40
+
+# Spectator map caps: nodes [col,row,type], edges [c,r,childC,childR],
+# path/pos coords [col,row]. An act map is ~50 nodes; caps are headroom.
+_MAP_NODES_CAP = 150
+_MAP_EDGES_CAP = 400
+_PATH_CAP = 64
+
+
+def _int_pair(v) -> list[int] | None:
+    if (
+        isinstance(v, list)
+        and len(v) == 2
+        and all(isinstance(x, (int, float)) and not isinstance(x, bool) for x in v)
+    ):
+        return [int(v[0]), int(v[1])]
+    return None
+
+
+def _clean_map(raw) -> dict | None:
+    """The static act graph the mod sends once per act: nodes/edges for the
+    spectator mini-map. Returns None when the payload has no usable map."""
+    if not isinstance(raw, dict):
+        return None
+    nodes = []
+    for n in (
+        raw.get("nodes", [])[:_MAP_NODES_CAP]
+        if isinstance(raw.get("nodes"), list)
+        else []
+    ):
+        if (
+            isinstance(n, list)
+            and len(n) == 3
+            and all(
+                isinstance(x, (int, float)) and not isinstance(x, bool) for x in n[:2]
+            )
+            and isinstance(n[2], str)
+        ):
+            nodes.append([int(n[0]), int(n[1]), n[2][:16]])
+    edges = []
+    for e in (
+        raw.get("edges", [])[:_MAP_EDGES_CAP]
+        if isinstance(raw.get("edges"), list)
+        else []
+    ):
+        if (
+            isinstance(e, list)
+            and len(e) == 4
+            and all(isinstance(x, (int, float)) and not isinstance(x, bool) for x in e)
+        ):
+            edges.append([int(x) for x in e])
+    if not nodes:
+        return None
+    out: dict = {"nodes": nodes, "edges": edges}
+    if isinstance(raw.get("act"), (int, float)) and not isinstance(
+        raw.get("act"), bool
+    ):
+        out["act"] = int(raw["act"])
+    return out
 
 
 def _clean_events(raw) -> list[dict]:
@@ -47,7 +116,12 @@ def _clean_events(raw) -> list[dict]:
             continue
         ev: dict = {"k": kind[:24]}
         if isinstance(e.get("v"), str) and e["v"]:
-            ev["v"] = e["v"][:_MAX_STR]
+            v = e["v"][:_MAX_STR]
+            # Same traversal guard as the id lists: an event's `v` is an entity
+            # id the frontend turns into an image/link. Drop only the unsafe
+            # value, keep the event (its kind/turn still render).
+            if _safe_id(v):
+                ev["v"] = v
         if isinstance(e.get("turn"), (int, float)) and not isinstance(
             e.get("turn"), bool
         ):
@@ -104,8 +178,20 @@ async def post_presence(request: Request):
         v = data.get(k)
         if isinstance(v, list):
             fields[k] = [
-                str(x)[:_MAX_STR] for x in v[:cap] if isinstance(x, (str, int))
+                s
+                for x in v[:cap]
+                if isinstance(x, (str, int)) and _safe_id(s := str(x)[:_MAX_STR])
             ]
+
+    # Spectator map: path + position ride every beat; the node/edge graph only
+    # arrives when the act changes (the $set keeps the stored one between beats).
+    if isinstance(data.get("path"), list):
+        path = [p for p in (_int_pair(x) for x in data["path"][:_PATH_CAP]) if p]
+        fields["path"] = path
+    if (pos := _int_pair(data.get("pos"))) is not None:
+        fields["pos"] = pos
+    if (m := _clean_map(data.get("map"))) is not None:
+        fields["map"] = m
 
     # Display name: the verified user record outranks the client-sent username.
     try:

--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -193,6 +193,12 @@ async def post_presence(request: Request):
     if (m := _clean_map(data.get("map"))) is not None:
         fields["map"] = m
 
+    # Transient combat context: when the mod sends these as explicit null (combat
+    # just ended), clear them rather than leaving the last fight's values stale.
+    # pos is NOT in this set on purpose: keeping the last node avoids a blinking
+    # map marker while the player travels between nodes.
+    unset = [k for k in ("turn", "fighting") if k in data and data[k] is None]
+
     # Display name: the verified user record outranks the client-sent username.
     try:
         from ..services.users_db import get_user_by_steam_id
@@ -203,7 +209,7 @@ async def post_presence(request: Request):
     except Exception:
         pass
 
-    presence_db.heartbeat(steam_id, fields, _clean_events(data.get("events")))
+    presence_db.heartbeat(steam_id, fields, _clean_events(data.get("events")), unset)
     return {"ok": True}
 
 

--- a/backend/app/services/presence_db.py
+++ b/backend/app/services/presence_db.py
@@ -14,6 +14,9 @@ Document shape (one doc per live player):
         "hp": ..., "max_hp": ..., "gold": ..., "screen": ..., "seed": ...,
         "player_count": ..., "sts2_version": ...,
         "deck": ["STRIKE+", ...], "relics": [...], "potions": [...],
+        "turn": ..., "fighting": [...],        # combat context (absent between fights)
+        "events": [{k, v, turn, t}, ...],      # rolling play-by-play window
+        "map": {act, nodes, edges}, "path": [[col,row], ...], "pos": [col,row],
         "started_at": ISODate(...),   # first heartbeat of this session
         "updated_at": ISODate(...),   # last heartbeat (TTL anchor)
     }
@@ -64,14 +67,16 @@ def end(steam_id: str) -> None:
 
 
 def active(limit: int = 50) -> list[dict]:
-    """Fresh live players, deepest run first. Excludes deck/relic/potion detail —
-    the per-player endpoint serves those for the live run view."""
+    """Fresh live players, deepest run first. Excludes the heavy per-run detail
+    (deck/relics/potions, the event window, and the map node/edge graph): the
+    per-player endpoint serves those for the live run view. Keeps path/pos so the
+    roster can show a player's position on a mini progress indicator."""
     cutoff = datetime.now(timezone.utc) - timedelta(seconds=PRESENCE_TTL_SECONDS)
     docs = (
         _presence_coll()
         .find(
             {"updated_at": {"$gte": cutoff}},
-            {"deck": 0, "relics": 0, "potions": 0, "events": 0},
+            {"deck": 0, "relics": 0, "potions": 0, "events": 0, "map": 0},
         )
         .sort([("total_floor", -1), ("updated_at", -1)])
         .limit(limit)

--- a/backend/app/services/presence_db.py
+++ b/backend/app/services/presence_db.py
@@ -50,7 +50,10 @@ EVENT_WINDOW = 50
 
 
 def heartbeat(
-    steam_id: str, fields: dict[str, Any], events: list[dict] | None = None
+    steam_id: str,
+    fields: dict[str, Any],
+    events: list[dict] | None = None,
+    unset: list[str] | None = None,
 ) -> None:
     now = datetime.now(timezone.utc)
     update: dict[str, Any] = {
@@ -59,6 +62,11 @@ def heartbeat(
     }
     if events:
         update["$push"] = {"events": {"$each": events, "$slice": -EVENT_WINDOW}}
+    # Clear transient fields the mod explicitly nulled (combat just ended), so the
+    # roster never shows a stale "Turn 7 vs Gremlin Nob" for someone now in a shop.
+    # unset keys never overlap $set (the router only unsets keys absent from fields).
+    if unset:
+        update["$unset"] = {k: "" for k in unset}
     _presence_coll().update_one({"_id": steam_id}, update, upsert=True)
 
 

--- a/markdown-docs/live-presence.md
+++ b/markdown-docs/live-presence.md
@@ -64,10 +64,42 @@ first, appended by each heartbeat:
 ```
 
 Kinds: `card` (played), `potion` (used), `combat` (fight started), `victory`,
-`buy` (shop purchase; `v` may be absent), `death` (the player died), `act` (entered a
-new act). `v` is a bare entity id for the usual name/image lookups. Render as a feed:
-"Turn 2 - played Whirlwind". The mod beats every ~12s during combat and ~30s outside
-it, so poll this endpoint at 10-15s for a live-feeling ticker.
+`buy` (shop purchase; `v` is the relic/card/potion id, absent for card-removal
+service), `remove` (a card left the deck; `v` = the removed card), `event` (entered an
+event room; `v` = the event id), `death` (the player died), `act` (entered a new act).
+`v` is a bare entity id for the usual name/image lookups. Render as a feed:
+"Turn 2 - played Whirlwind", "Event: Abyssal Baths", "Removed Strike".
+
+Heartbeats are event-driven with a 2s debounce: a card play reaches the server in
+~2-3s, with a 5s cadence floor during combat (enemy HP, turn) and 15s between rooms.
+Poll this endpoint at 3-5s for a live-feeling ticker; poll `/active` at 10-15s (the
+roster doesn't carry events, so it doesn't need to be hot).
+
+### The act map (v3, for a spectator mini-map)
+
+The per-player doc carries the current act's map graph and the route taken so far:
+
+```json
+"map": {
+  "act": 2,
+  "nodes": [[0, 0, "monster"], [1, 0, "monster"], [0, 1, "elite"], [2, 6, "boss"]],
+  "edges": [[0, 0, 0, 1], [0, 0, 1, 1], [1, 0, 1, 1]]
+},
+"path": [[3, 0], [3, 1], [2, 2]],
+"pos": [2, 2]
+```
+
+- `map.nodes`: `[col, row, type]` per node. Types: `monster`, `elite`, `boss`, `shop`,
+  `treasure`, `restsite`, `event`/`unknown`, `ancient`. Lowercase; render defensively
+  (a type you don't recognize is just a generic node).
+- `map.edges`: `[col, row, childCol, childRow]`, a directed link from a node to a node
+  one row deeper. Build the DAG from these.
+- `path`: visited coords in travel order; `pos`: the player's current coord (absent
+  while moving between nodes). Highlight `path` and mark `pos` on the mini-map.
+- `(col, row)` is the game's own grid: `row` is act depth (0 = act start, increasing
+  toward the boss), `col` is the horizontal lane.
+- The bulky `map` graph is sent once per act (it's static) and omitted from `/active`;
+  `path`/`pos` ride every beat and DO appear on `/active` for a roster progress hint.
 
 ### POST /api/presence
 
@@ -76,7 +108,9 @@ Mod-only; requires the Steam JWT (`Authorization: Bearer`). The frontend never c
 
 ## Notes for the frontend
 
-- Poll `/active` every 15-30s. No websockets; the data only changes on a ~30s beat.
+- Poll `/active` at 10-15s for the roster; poll a player's `/{steam_id}` at 3-5s for a
+  live-feeling ticker (the mod beats event-driven, ~2-3s after a play, see above). No
+  websockets.
 - Entries are at most 90s stale by construction; no client-side freshness math needed.
 - `screen` is the mod's coarse location: combat, map, merchant, event, rest, etc.
 - Privacy is handled upstream: only players who opted into uploads (consent gate), kept


### PR DESCRIPTION
The backend for the live presence feature, covering the mod's v3 and v4 heartbeat additions plus a security fix from a review. All new fields are optional, so old mod vs this backend and this backend vs the frontend all keep working. Deploy this before the frontend PRs (#466, #468, and the v4 frontend).

**v3: spectator act map.** The mod exports the current act's map graph once per act (`map = {act, nodes[[col,row,type]], edges[[c,r,childC,childR]]}`) plus `path` (route taken) and `pos` (current coord) every beat. Whitelisted and capped (`_clean_map`, `_int_pair`). `active()` excludes the bulky `map` graph but keeps `path`/`pos` for a roster hint. The `event` (room-entry) and `remove` (card-left-deck) ticker kinds pass through the existing event whitelist.

**v4: live event + shop detail.** When the player is on the event screen, the doc carries `event = {id, title, prompt, options:[{key, text, locked, proceed, chosen}]}` with already-localized text. On the shop screen, `shop = {cards, relics, potions, removal}` with each item's `id`, `cost`, `stocked`, `on_sale`, `slot`. Both are screen-gated, excluded from `/active`, and clear when the player leaves.

**Combat-end clearing.** `turn`/`fighting` (and now `event`/`shop`) are `$unset` when the mod sends them as explicit null, so the roster never shows a stale "Turn 7 vs Gremlin Nob" for someone now in a shop. `pos` deliberately persists so the map marker doesn't blink between nodes. Keys sent as null are excluded from `$set` by the type checks, so `$set` and `$unset` never collide.

**Security: `_safe_id` path-traversal guard.** A review flagged that entity ids (deck, relics, potions, fighting, ticker `v`, and now event id + shop item ids) were stored unvalidated and then spliced into image/CDN URLs and Link hrefs on the frontend. `_safe_id` drops any id containing `/`, `\`, or `..` before storage, killing the class at the source for every client. Real game ids never contain those, so nothing valid is dropped; a shop slot whose id is unsafe is dropped whole rather than left as a costed orphan. Unit-tested against the real id formats, the v4 event/shop cleaners, and traversal payloads. (Starlette's StaticFiles already blocks traversal server-side, so this is defense-in-depth at the right layer.)