### PR TITLE
Spectator page redesign: 50/50 split with combat/event/shop context panels

### DIFF
--- a/frontend/app/live/LiveEventShop.tsx
+++ b/frontend/app/live/LiveEventShop.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+// Live current-screen detail (v4): what the player sees on the event and shop
+// screens. The event text is already localized by the mod, so it renders as-is.
+// Shop item ids resolve to names/images through the run-page pills (hover shows
+// the full card / relic tooltip). Contract: markdown-docs/live-presence.md (v4).
+
+import Link from "next/link";
+import { imageUrl, fullCardUrl } from "@/lib/image-url";
+import {
+  CardPill,
+  PotionPill,
+  RelicPill,
+  cleanId,
+  displayName,
+  type CardInfo,
+  type PotionInfo,
+  type RelicInfo,
+} from "../runs/[hash]/RunPills";
+import {
+  parseDeckId,
+  safeId,
+  withOrdinalKeys,
+  type LiveEventCtx,
+  type LiveShop,
+  type ShopItem,
+} from "./live-shared";
+
+function Gold({ cost }: { cost?: number }) {
+  if (cost == null) return null;
+  return <span className="text-[var(--accent-gold)] tabular-nums font-semibold">{cost}g</span>;
+}
+
+export function LiveEventPanel({ ev, lp }: { ev: LiveEventCtx; lp: string }) {
+  const id = cleanId(ev.id);
+  const titleText = ev.title || displayName(`EVENT.${id}`);
+  return (
+    <div className="rounded-lg border border-purple-900/50 bg-purple-950/20 p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-[10px] font-bold uppercase tracking-wider text-purple-300">Event</span>
+        {safeId(id) ? (
+          <Link
+            href={`${lp}/events/${id.toLowerCase()}`}
+            className="text-sm font-semibold text-[var(--text-primary)] hover:text-[var(--accent-gold)]"
+          >
+            {titleText}
+          </Link>
+        ) : (
+          <span className="text-sm font-semibold text-[var(--text-primary)]">{titleText}</span>
+        )}
+      </div>
+      {ev.prompt && (
+        <p className="text-sm text-[var(--text-secondary)] whitespace-pre-line mb-3 leading-relaxed">
+          {ev.prompt}
+        </p>
+      )}
+      {(ev.options?.length ?? 0) > 0 && (
+        <ul className="space-y-1.5">
+          {withOrdinalKeys((ev.options ?? []).map((o, i) => o.key || o.text || String(i))).map(
+            ({ key }, i) => {
+              const o = (ev.options ?? [])[i];
+              const disabled = o.locked;
+              return (
+                <li
+                  key={key}
+                  className={`flex items-start gap-2 rounded-md border px-2.5 py-1.5 text-sm ${
+                    o.chosen
+                      ? "border-[var(--accent-gold)]/50 bg-[var(--accent-gold)]/10 text-[var(--text-primary)]"
+                      : disabled
+                        ? "border-[var(--border-subtle)] bg-[var(--bg-primary)] text-[var(--text-muted)]"
+                        : "border-[var(--border-subtle)] bg-[var(--bg-card)] text-[var(--text-secondary)]"
+                  }`}
+                >
+                  <span className="mt-0.5 shrink-0">
+                    {o.chosen ? "✓" : disabled ? "\u{1F512}" : "•"}
+                  </span>
+                  <span className={`min-w-0 flex-1 ${disabled ? "line-through" : ""}`}>
+                    {o.text || o.key || "(option)"}
+                  </span>
+                  {o.proceed && !o.chosen && (
+                    <span className="text-[10px] text-[var(--text-muted)] shrink-0">leave</span>
+                  )}
+                </li>
+              );
+            },
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ShopSection({
+  title,
+  items,
+  kind,
+  cards,
+  relics,
+  potions,
+  lp,
+  lang,
+}: {
+  title: string;
+  items: ShopItem[];
+  kind: "card" | "relic" | "potion";
+  cards: Record<string, CardInfo>;
+  relics: Record<string, RelicInfo>;
+  potions: Record<string, PotionInfo>;
+  lp: string;
+  lang: string;
+}) {
+  const real = items.filter((it) => it.id);
+  if (real.length === 0) return null;
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-1.5">{title}</div>
+      <ul className="space-y-1">
+        {withOrdinalKeys(real.map((it) => it.id as string)).map(({ key }, idx) => {
+          const it = real[idx];
+          const rawId = it.id as string;
+          const { id, upgraded } = parseDeckId(rawId);
+          const sold = it.stocked === false;
+          const info =
+            kind === "card" ? cards[id] : kind === "relic" ? relics[id] : potions[id];
+          const name = info?.name || displayName(`${kind.toUpperCase()}.${id}`);
+          const portrait = info?.image_url ? imageUrl(info.image_url) : "";
+          const thumb =
+            kind === "card" ? (
+              <img
+                src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                alt={name}
+                className="w-7 h-auto rounded-sm"
+                crossOrigin="anonymous"
+                loading="lazy"
+                onError={(e) => {
+                  const el = e.target as HTMLImageElement;
+                  if (portrait && el.src !== portrait) el.src = portrait;
+                  else el.style.visibility = "hidden";
+                }}
+              />
+            ) : (
+              <img
+                src={
+                  portrait ||
+                  imageUrl(`/static/images/${kind === "relic" ? "relics" : "potions"}/${id.toLowerCase()}.png`)
+                }
+                alt={name}
+                className="w-7 h-7 object-contain"
+                crossOrigin="anonymous"
+                loading="lazy"
+                onError={(e) => {
+                  (e.target as HTMLImageElement).style.visibility = "hidden";
+                }}
+              />
+            );
+          const pill =
+            kind === "card" ? (
+              <CardPill cardId={id} upgraded={upgraded} cardData={cards} lp={lp} className="block shrink-0">
+                {thumb}
+              </CardPill>
+            ) : kind === "relic" ? (
+              <RelicPill relicId={id} relicData={relics} lp={lp} className="block shrink-0">
+                {thumb}
+              </RelicPill>
+            ) : (
+              <PotionPill potionId={id} potionData={potions} lp={lp} className="block shrink-0">
+                {thumb}
+              </PotionPill>
+            );
+          return (
+            <li key={key} className={`flex items-center gap-2 ${sold ? "opacity-40" : ""}`}>
+              {pill}
+              <span className={`text-sm min-w-0 flex-1 truncate ${sold ? "line-through" : "text-[var(--text-secondary)]"}`}>
+                {name}
+                {upgraded ? "+" : ""}
+              </span>
+              {it.on_sale && !sold && (
+                <span className="text-[9px] font-bold uppercase rounded bg-emerald-600 px-1 text-white shrink-0">
+                  sale
+                </span>
+              )}
+              {sold ? (
+                <span className="text-[10px] text-[var(--text-muted)] shrink-0">sold</span>
+              ) : (
+                <Gold cost={it.cost} />
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export function LiveShopPanel({
+  shop,
+  cards,
+  relics,
+  potions,
+  lp,
+  lang,
+}: {
+  shop: LiveShop;
+  cards: Record<string, CardInfo>;
+  relics: Record<string, RelicInfo>;
+  potions: Record<string, PotionInfo>;
+  lp: string;
+  lang: string;
+}) {
+  const removal = shop.removal;
+  return (
+    <div className="rounded-lg border border-[var(--accent-gold)]/30 bg-[var(--bg-card)] p-4 space-y-3">
+      <div className="text-[10px] font-bold uppercase tracking-wider text-[var(--accent-gold)]">
+        Shop
+      </div>
+      <ShopSection title="Cards" items={shop.cards ?? []} kind="card" cards={cards} relics={relics} potions={potions} lp={lp} lang={lang} />
+      <ShopSection title="Relics" items={shop.relics ?? []} kind="relic" cards={cards} relics={relics} potions={potions} lp={lp} lang={lang} />
+      <ShopSection title="Potions" items={shop.potions ?? []} kind="potion" cards={cards} relics={relics} potions={potions} lp={lp} lang={lang} />
+      {removal && removal.cost != null && (
+        <div className="flex items-center gap-2 pt-1 border-t border-[var(--border-subtle)]">
+          <span className={`text-sm flex-1 ${removal.stocked === false ? "text-[var(--text-muted)] line-through" : "text-[var(--text-secondary)]"}`}>
+            Card removal
+          </span>
+          {removal.stocked === false ? (
+            <span className="text-[10px] text-[var(--text-muted)]">used</span>
+          ) : (
+            <Gold cost={removal.cost} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -15,6 +15,7 @@ import { useLanguage } from "@/app/contexts/LanguageContext";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { imageUrl, fullCardUrl } from "@/lib/image-url";
 import LiveMap from "../LiveMap";
+import { LiveEventPanel, LiveShopPanel } from "../LiveEventShop";
 import {
   CardPill,
   PotionPill,
@@ -457,6 +458,26 @@ export default function LivePlayerClient() {
           </div>
         )}
       </div>
+
+      {/* Current-screen detail: what the player is looking at right now.
+          Screen-gated and mutually exclusive, so only one shows at a time. */}
+      {p.screen === "event" && p.event && (
+        <div className="mt-4">
+          <LiveEventPanel ev={p.event} lp={lp} />
+        </div>
+      )}
+      {p.screen === "merchant" && p.shop && (
+        <div className="mt-4">
+          <LiveShopPanel
+            shop={p.shop}
+            cards={cat.cards}
+            relics={cat.relics}
+            potions={cat.potions}
+            lp={lp}
+            lang={lang}
+          />
+        </div>
+      )}
 
       <div className="mt-4 grid grid-cols-1 lg:grid-cols-2 gap-4">
         <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -29,8 +29,8 @@ import {
 import {
   API,
   CharacterIcon,
-  EnemyCircle,
   LiveDot,
+  LiveEnemiesPanel,
   ago,
   elapsed,
   monsterName,
@@ -384,100 +384,98 @@ export default function LivePlayerClient() {
         ← Live roster
       </Link>
 
-      <div className="mt-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
-        <div className="flex items-center gap-3">
-          <CharacterIcon character={p.character} className="w-16 h-16" />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2 flex-wrap">
-              {status === "live" ? <LiveDot /> : null}
-              <h1 className="text-xl font-bold text-[var(--text-primary)] truncate">
-                {p.username || "Anonymous climber"}
-              </h1>
-              {p.ascension != null && p.ascension > 0 && (
-                <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-[var(--accent-gold)]/15 text-[var(--accent-gold)] border border-[var(--accent-gold)]/30">
-                  A{p.ascension}
-                </span>
-              )}
-              {(p.player_count ?? 1) > 1 && (
-                <span className="text-xs text-[var(--text-muted)]">co-op ×{p.player_count}</span>
-              )}
-              {status === "ended" && (
-                <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-[var(--bg-primary)] text-[var(--text-muted)] border border-[var(--border-subtle)]">
-                  run ended
-                </span>
-              )}
+      {/* Row 1: the player on the left at ~50%, and what they're looking at
+          right now on the right (combat enemies, the event reader, the shop,
+          or the act map when idle). */}
+      <div className="mt-3 grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+          <div className="flex items-center gap-3">
+            <CharacterIcon character={p.character} className="w-16 h-16" />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 flex-wrap">
+                {status === "live" ? <LiveDot /> : null}
+                <h1 className="text-xl font-bold text-[var(--text-primary)] truncate">
+                  {p.username || "Anonymous climber"}
+                </h1>
+                {p.ascension != null && p.ascension > 0 && (
+                  <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-[var(--accent-gold)]/15 text-[var(--accent-gold)] border border-[var(--accent-gold)]/30">
+                    A{p.ascension}
+                  </span>
+                )}
+                {(p.player_count ?? 1) > 1 && (
+                  <span className="text-xs text-[var(--text-muted)]">co-op ×{p.player_count}</span>
+                )}
+                {status === "ended" && (
+                  <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-[var(--bg-primary)] text-[var(--text-muted)] border border-[var(--border-subtle)]">
+                    run ended
+                  </span>
+                )}
+              </div>
+              <div className="text-sm text-[var(--text-muted)] truncate">
+                {displayName(`CHARACTER.${p.character ?? ""}`)}
+                {p.screen ? ` · ${p.screen}` : ""}
+                {p.started_at ? ` · climbing for ${elapsed(p.started_at)}` : ""}
+                {p.seed ? ` · seed ${p.seed}` : ""}
+              </div>
             </div>
-            <div className="text-sm text-[var(--text-muted)] truncate">
-              {displayName(`CHARACTER.${p.character ?? ""}`)}
-              {p.screen ? ` · ${p.screen}` : ""}
-              {p.started_at ? ` · climbing for ${elapsed(p.started_at)}` : ""}
-              {p.seed ? ` · seed ${p.seed}` : ""}
+            <div className="text-right shrink-0">
+              <div className="text-lg font-bold text-[var(--text-primary)] tabular-nums">
+                {p.act != null ? `Act ${p.act}` : ""}
+                {p.total_floor != null ? ` · F${p.total_floor}` : ""}
+              </div>
+              <div className="text-sm text-[var(--text-muted)] tabular-nums">
+                {p.gold != null ? `${p.gold} gold` : ""}
+              </div>
             </div>
           </div>
-          <div className="text-right shrink-0">
-            <div className="text-lg font-bold text-[var(--text-primary)] tabular-nums">
-              {p.act != null ? `Act ${p.act}` : ""}
-              {p.total_floor != null ? ` · F${p.total_floor}` : ""}
+
+          {hpPct != null && (
+            <div className="mt-3">
+              <div className="flex justify-between text-[10px] text-[var(--text-muted)] mb-1 tabular-nums">
+                <span>HP</span>
+                <span>
+                  {p.hp}/{p.max_hp}
+                </span>
+              </div>
+              <div className="h-2 rounded bg-[var(--bg-primary)]">
+                <div className="h-2 rounded bg-rose-500" style={{ width: `${hpPct}%` }} />
+              </div>
             </div>
-            <div className="text-sm text-[var(--text-muted)] tabular-nums">
-              {p.gold != null ? `${p.gold} gold` : ""}
-            </div>
-          </div>
+          )}
         </div>
 
-        {hpPct != null && (
-          <div className="mt-3">
-            <div className="flex justify-between text-[10px] text-[var(--text-muted)] mb-1 tabular-nums">
-              <span>HP</span>
-              <span>
-                {p.hp}/{p.max_hp}
-              </span>
+        {/* The context panel: whatever the player is doing right now. Combat
+            enemies, the event reader, or the shop take priority; otherwise the
+            act map, then a plain screen note so the column is never blank. */}
+        <div>
+          {p.screen === "combat" &&
+          ((p.enemies?.length ?? 0) > 0 || (p.fighting?.length ?? 0) > 0) ? (
+            <LiveEnemiesPanel p={p} monsters={monsters} />
+          ) : p.screen === "event" && p.event ? (
+            <LiveEventPanel ev={p.event} lp={lp} />
+          ) : p.screen === "merchant" && p.shop ? (
+            <LiveShopPanel
+              shop={p.shop}
+              cards={cat.cards}
+              relics={cat.relics}
+              potions={cat.potions}
+              lp={lp}
+              lang={lang}
+            />
+          ) : (p.map?.nodes?.length ?? 0) > 0 ? (
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+              <h2 className="text-sm font-semibold text-[var(--accent-gold)] mb-2">
+                Map{p.map?.act != null ? ` · Act ${p.map.act}` : ""}
+              </h2>
+              <LiveMap map={p.map} path={p.path} pos={p.pos} />
             </div>
-            <div className="h-2 rounded bg-[var(--bg-primary)]">
-              <div className="h-2 rounded bg-rose-500" style={{ width: `${hpPct}%` }} />
+          ) : (
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4 text-sm text-[var(--text-muted)]">
+              {p.screen ? `On the ${p.screen} screen.` : "No live detail for this screen."}
             </div>
-          </div>
-        )}
-
-        {p.screen === "combat" && (p.fighting?.length ?? 0) > 0 && (
-          <div className="mt-4 rounded-lg border border-rose-900/50 bg-rose-950/30 p-3">
-            <div className="flex items-center gap-3 flex-wrap">
-              <span className="text-xs font-bold uppercase tracking-wider text-rose-300">
-                Fighting
-              </span>
-              {withOrdinalKeys(p.fighting ?? []).map(({ item: id, key }) => (
-                <span key={key} className="inline-flex items-center gap-1.5">
-                  <EnemyCircle id={id} monsters={monsters} className="w-9 h-9" />
-                  <span className="text-sm text-rose-100">{monsterName(id, monsters)}</span>
-                </span>
-              ))}
-              {p.turn != null && p.turn > 0 && (
-                <span className="ml-auto text-sm text-rose-300 tabular-nums">Turn {p.turn}</span>
-              )}
-            </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
-
-      {/* Current-screen detail: what the player is looking at right now.
-          Screen-gated and mutually exclusive, so only one shows at a time. */}
-      {p.screen === "event" && p.event && (
-        <div className="mt-4">
-          <LiveEventPanel ev={p.event} lp={lp} />
-        </div>
-      )}
-      {p.screen === "merchant" && p.shop && (
-        <div className="mt-4">
-          <LiveShopPanel
-            shop={p.shop}
-            cards={cat.cards}
-            relics={cat.relics}
-            potions={cat.potions}
-            lp={lp}
-            lang={lang}
-          />
-        </div>
-      )}
 
       <div className="mt-4 grid grid-cols-1 lg:grid-cols-2 gap-4">
         <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
@@ -497,15 +495,6 @@ export default function LivePlayerClient() {
         </div>
 
         <div className="space-y-4">
-          {(p.map?.nodes?.length ?? 0) > 0 && (
-            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
-              <h2 className="text-sm font-semibold text-[var(--accent-gold)] mb-2">
-                Map{p.map?.act != null ? ` · Act ${p.map.act}` : ""}
-              </h2>
-              <LiveMap map={p.map} path={p.path} pos={p.pos} />
-            </div>
-          )}
-
           <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
             <h2 className="text-sm font-semibold text-[var(--accent-gold)] mb-2">
               Deck{p.deck ? ` (${p.deck.length})` : ""}

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -64,6 +64,18 @@ export interface LiveShop {
   removal?: { cost?: number; stocked?: boolean };
 }
 
+// Rich combat enemy (v5): id + HP + intent for the spectator combat panel.
+// `intent` is a kind keyword; intent_value/intent_hits describe an attack.
+export interface Enemy {
+  id: string;
+  hp?: number;
+  max_hp?: number;
+  block?: number;
+  intent?: string;
+  intent_value?: number;
+  intent_hits?: number;
+}
+
 export interface LivePlayer {
   steam_id: string;
   username?: string | null;
@@ -92,6 +104,7 @@ export interface LivePlayer {
   pos?: Coord | null;
   event?: LiveEventCtx | null;
   shop?: LiveShop | null;
+  enemies?: Enemy[] | null;
 }
 
 export interface MonsterInfo {
@@ -265,6 +278,101 @@ export function FightingChip({
         <span className="text-rose-400/80 whitespace-nowrap">· Turn {p.turn}</span>
       )}
     </span>
+  );
+}
+
+// Enemy intent as a short colored label. Returns null when there's nothing to
+// show (so we don't render an empty pill on a sparse beat).
+function intentLabel(e: Enemy): { text: string; cls: string } | null {
+  const kind = (e.intent || "").toLowerCase();
+  const hits = e.intent_hits && e.intent_hits > 1 ? `×${e.intent_hits}` : "";
+  const dmg = e.intent_value != null ? `${e.intent_value}${hits}` : "";
+  switch (kind) {
+    case "attack":
+      return { text: dmg ? `ATK ${dmg}` : "ATK", cls: "text-rose-200 bg-rose-950/50 border-rose-900/50" };
+    case "defend":
+      return { text: "BLOCK", cls: "text-sky-200 bg-sky-950/50 border-sky-900/50" };
+    case "buff":
+      return { text: "BUFF", cls: "text-emerald-200 bg-emerald-950/50 border-emerald-900/50" };
+    case "debuff":
+      return { text: "DEBUFF", cls: "text-fuchsia-200 bg-fuchsia-950/50 border-fuchsia-900/50" };
+    case "stun":
+      return { text: "STUN", cls: "text-amber-200 bg-amber-950/50 border-amber-900/50" };
+    case "sleep":
+      return { text: "ASLEEP", cls: "text-[var(--text-muted)] bg-[var(--bg-primary)] border-[var(--border-subtle)]" };
+    case "escape":
+      return { text: "FLEE", cls: "text-amber-200 bg-amber-950/50 border-amber-900/50" };
+    case "":
+      return null;
+    default:
+      return { text: kind.toUpperCase(), cls: "text-[var(--text-secondary)] bg-[var(--bg-primary)] border-[var(--border-subtle)]" };
+  }
+}
+
+/** The spectator combat panel: every living enemy with portrait, HP bar, block,
+ * and intent. Uses the rich `enemies` field when the mod sends it, falling back
+ * to the bare `fighting` id list (portrait + name only) so it still shows
+ * something on an older mod. Renders nothing off the combat screen. */
+export function LiveEnemiesPanel({ p, monsters }: { p: LivePlayer; monsters: MonsterMap }) {
+  if (p.screen !== "combat") return null;
+  const rich = (p.enemies ?? []).filter((e) => e && e.id);
+  const enemies: Enemy[] = rich.length
+    ? rich
+    : (p.fighting ?? []).filter(Boolean).map((id) => ({ id }));
+  if (!enemies.length) return null;
+
+  return (
+    <div className="rounded-lg border border-rose-900/50 bg-rose-950/20 p-4">
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-[10px] font-bold uppercase tracking-wider text-rose-300">Fighting</span>
+        {p.turn != null && p.turn > 0 && (
+          <span className="ml-auto text-xs text-rose-300 tabular-nums">Turn {p.turn}</span>
+        )}
+      </div>
+      <ul className="space-y-2.5">
+        {withOrdinalKeys(enemies.map((e) => e.id)).map(({ key }, i) => {
+          const e = enemies[i];
+          const hpPct =
+            e.hp != null && e.max_hp ? Math.max(0, Math.min(100, (e.hp / e.max_hp) * 100)) : null;
+          const intent = intentLabel(e);
+          return (
+            <li key={key} className="flex items-center gap-2.5">
+              <EnemyCircle id={e.id} monsters={monsters} className="w-10 h-10" />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-rose-100 truncate">{monsterName(e.id, monsters)}</span>
+                  {(e.block ?? 0) > 0 && (
+                    <span className="text-[10px] text-sky-300 tabular-nums shrink-0" title="block">
+                      [{e.block}]
+                    </span>
+                  )}
+                  {intent && (
+                    <span
+                      className={`ml-auto text-[10px] font-bold rounded border px-1.5 py-0.5 shrink-0 ${intent.cls}`}
+                    >
+                      {intent.text}
+                    </span>
+                  )}
+                </div>
+                {hpPct != null ? (
+                  <div className="mt-1">
+                    <div className="flex justify-between text-[9px] text-rose-300/70 tabular-nums">
+                      <span>HP</span>
+                      <span>
+                        {e.hp}/{e.max_hp}
+                      </span>
+                    </div>
+                    <div className="h-1.5 rounded bg-[var(--bg-primary)]">
+                      <div className="h-1.5 rounded bg-rose-500" style={{ width: `${hpPct}%` }} />
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
   );
 }
 

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -64,16 +64,22 @@ export interface LiveShop {
   removal?: { cost?: number; stocked?: boolean };
 }
 
-// Rich combat enemy (v5): id + HP + intent for the spectator combat panel.
-// `intent` is a kind keyword; intent_value/intent_hits describe an attack.
+// Rich combat enemy (v5) for the spectator combat panel: hp/block plus the
+// upcoming intent(s). `intents` is a list because one move can do several things
+// (attack + buff). Each intent's `type` is a codex category; `dmg`/`hits`
+// describe an attack ("16 ×2"). id or name may be absent on a sparse beat.
+export interface EnemyIntent {
+  type: string;
+  dmg?: number;
+  hits?: number;
+}
 export interface Enemy {
-  id: string;
+  id?: string;
+  name?: string;
   hp?: number;
   max_hp?: number;
   block?: number;
-  intent?: string;
-  intent_value?: number;
-  intent_hits?: number;
+  intents?: EnemyIntent[];
 }
 
 export interface LivePlayer {
@@ -281,41 +287,52 @@ export function FightingChip({
   );
 }
 
-// Enemy intent as a short colored label. Returns null when there's nothing to
-// show (so we don't render an empty pill on a sparse beat).
-function intentLabel(e: Enemy): { text: string; cls: string } | null {
-  const kind = (e.intent || "").toLowerCase();
-  const hits = e.intent_hits && e.intent_hits > 1 ? `×${e.intent_hits}` : "";
-  const dmg = e.intent_value != null ? `${e.intent_value}${hits}` : "";
+// One intent as a short colored label. `type` is the codex intent category;
+// for attacks `dmg`/`hits` give the incoming damage ("16 ×2").
+function intentLabel(it: EnemyIntent): { text: string; cls: string } {
+  const kind = (it.type || "").toLowerCase();
+  const hits = it.hits && it.hits > 1 ? `×${it.hits}` : "";
+  const dmg = it.dmg != null ? `${it.dmg}${hits}` : "";
+  const rose = "text-rose-200 bg-rose-950/50 border-rose-900/50";
+  const sky = "text-sky-200 bg-sky-950/50 border-sky-900/50";
+  const emerald = "text-emerald-200 bg-emerald-950/50 border-emerald-900/50";
+  const fuchsia = "text-fuchsia-200 bg-fuchsia-950/50 border-fuchsia-900/50";
+  const amber = "text-amber-200 bg-amber-950/50 border-amber-900/50";
+  const muted = "text-[var(--text-muted)] bg-[var(--bg-primary)] border-[var(--border-subtle)]";
   switch (kind) {
     case "attack":
-      return { text: dmg ? `ATK ${dmg}` : "ATK", cls: "text-rose-200 bg-rose-950/50 border-rose-900/50" };
+      return { text: dmg ? `ATK ${dmg}` : "ATK", cls: rose };
+    case "deathblow":
+      return { text: dmg ? `LETHAL ${dmg}` : "LETHAL", cls: "text-rose-100 bg-rose-900/60 border-rose-700/60" };
     case "defend":
-      return { text: "BLOCK", cls: "text-sky-200 bg-sky-950/50 border-sky-900/50" };
+      return { text: "BLOCK", cls: sky };
     case "buff":
-      return { text: "BUFF", cls: "text-emerald-200 bg-emerald-950/50 border-emerald-900/50" };
+      return { text: "BUFF", cls: emerald };
+    case "heal":
+      return { text: "HEAL", cls: emerald };
     case "debuff":
-      return { text: "DEBUFF", cls: "text-fuchsia-200 bg-fuchsia-950/50 border-fuchsia-900/50" };
-    case "stun":
-      return { text: "STUN", cls: "text-amber-200 bg-amber-950/50 border-amber-900/50" };
-    case "sleep":
-      return { text: "ASLEEP", cls: "text-[var(--text-muted)] bg-[var(--bg-primary)] border-[var(--border-subtle)]" };
+      return { text: "DEBUFF", cls: fuchsia };
+    case "carddebuff":
+      return { text: "CARD", cls: fuchsia };
     case "escape":
-      return { text: "FLEE", cls: "text-amber-200 bg-amber-950/50 border-amber-900/50" };
-    case "":
-      return null;
+      return { text: "FLEE", cls: amber };
+    case "summon":
+      return { text: "SUMMON", cls: amber };
+    case "hidden":
+    case "unknown":
+      return { text: "?", cls: muted };
     default:
-      return { text: kind.toUpperCase(), cls: "text-[var(--text-secondary)] bg-[var(--bg-primary)] border-[var(--border-subtle)]" };
+      return { text: kind.toUpperCase(), cls: muted };
   }
 }
 
 /** The spectator combat panel: every living enemy with portrait, HP bar, block,
- * and intent. Uses the rich `enemies` field when the mod sends it, falling back
- * to the bare `fighting` id list (portrait + name only) so it still shows
- * something on an older mod. Renders nothing off the combat screen. */
+ * and its upcoming intent(s). Uses the rich `enemies` field when the mod sends
+ * it, falling back to the bare `fighting` id list (portrait + name only) so it
+ * still shows something on an older mod. Renders nothing off the combat screen. */
 export function LiveEnemiesPanel({ p, monsters }: { p: LivePlayer; monsters: MonsterMap }) {
   if (p.screen !== "combat") return null;
-  const rich = (p.enemies ?? []).filter((e) => e && e.id);
+  const rich = (p.enemies ?? []).filter((e) => e && (e.id || e.name));
   const enemies: Enemy[] = rich.length
     ? rich
     : (p.fighting ?? []).filter(Boolean).map((id) => ({ id }));
@@ -330,29 +347,42 @@ export function LiveEnemiesPanel({ p, monsters }: { p: LivePlayer; monsters: Mon
         )}
       </div>
       <ul className="space-y-2.5">
-        {withOrdinalKeys(enemies.map((e) => e.id)).map(({ key }, i) => {
+        {withOrdinalKeys(enemies.map((e) => e.id || e.name || "?")).map(({ key }, i) => {
           const e = enemies[i];
+          const name = e.name || (e.id ? monsterName(e.id, monsters) : "Enemy");
           const hpPct =
             e.hp != null && e.max_hp ? Math.max(0, Math.min(100, (e.hp / e.max_hp) * 100)) : null;
-          const intent = intentLabel(e);
+          const intents = e.intents ?? [];
           return (
             <li key={key} className="flex items-center gap-2.5">
-              <EnemyCircle id={e.id} monsters={monsters} className="w-10 h-10" />
+              {e.id ? (
+                <EnemyCircle id={e.id} monsters={monsters} className="w-10 h-10" />
+              ) : (
+                <span className="inline-flex w-10 h-10 shrink-0 items-center justify-center rounded-full border border-[var(--border-subtle)] bg-[var(--bg-primary)] text-sm text-[var(--text-muted)]">
+                  {(name[0] || "?").toUpperCase()}
+                </span>
+              )}
               <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm text-rose-100 truncate">{monsterName(e.id, monsters)}</span>
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-sm text-rose-100 truncate">{name}</span>
                   {(e.block ?? 0) > 0 && (
                     <span className="text-[10px] text-sky-300 tabular-nums shrink-0" title="block">
                       [{e.block}]
                     </span>
                   )}
-                  {intent && (
-                    <span
-                      className={`ml-auto text-[10px] font-bold rounded border px-1.5 py-0.5 shrink-0 ${intent.cls}`}
-                    >
-                      {intent.text}
-                    </span>
-                  )}
+                  <span className="ml-auto flex items-center gap-1 shrink-0">
+                    {intents.map((it, j) => {
+                      const l = intentLabel(it);
+                      return (
+                        <span
+                          key={`${it.type}-${j}`}
+                          className={`text-[10px] font-bold rounded border px-1.5 py-0.5 ${l.cls}`}
+                        >
+                          {l.text}
+                        </span>
+                      );
+                    })}
+                  </span>
                 </div>
                 {hpPct != null ? (
                   <div className="mt-1">

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -34,6 +34,36 @@ export interface LiveMapData {
 }
 export type Coord = [number, number];
 
+// Live current-screen detail (v4). event: the room the player is reading, with
+// already-localized title/prompt and the options on offer. shop: the merchant
+// inventory with per-item cost/sale/stock. Both present only on their screen.
+export interface LiveEventOption {
+  key?: string;
+  text?: string;
+  locked?: boolean;
+  proceed?: boolean;
+  chosen?: boolean;
+}
+export interface LiveEventCtx {
+  id: string;
+  title?: string;
+  prompt?: string;
+  options?: LiveEventOption[];
+}
+export interface ShopItem {
+  id?: string;
+  cost?: number;
+  stocked?: boolean;
+  on_sale?: boolean;
+  slot?: string;
+}
+export interface LiveShop {
+  cards?: ShopItem[];
+  relics?: ShopItem[];
+  potions?: ShopItem[];
+  removal?: { cost?: number; stocked?: boolean };
+}
+
 export interface LivePlayer {
   steam_id: string;
   username?: string | null;
@@ -60,6 +90,8 @@ export interface LivePlayer {
   map?: LiveMapData | null;
   path?: Coord[];
   pos?: Coord | null;
+  event?: LiveEventCtx | null;
+  shop?: LiveShop | null;
 }
 
 export interface MonsterInfo {


### PR DESCRIPTION
Reworks `/live/[steamId]` so the spectator view shows what the player is doing right now, and adds the live event/shop/enemy panels. Frontend for presence v4+v5 (backend in #470).

**New layout.** The player box no longer spans full width with the fight stacked underneath. The top is now a 50/50 split: the player on the left (character, HP, gold, act/floor, seed), and a context panel on the right that switches on screen:

- **Combat** -> enemies on the right, each with portrait, **HP bar**, block, and an **intent** label (ATK 14, BLOCK, BUFF, ...).
- **Event** -> the event reader: localized title (linked), prompt, and every option with its real label and state (chosen highlighted, locked struck through).
- **Shop** -> cards/relics/potions resolved to names + images (hover for detail), each with live cost, a SALE badge, and sold-out styling, plus the removal cost.
- **Otherwise** -> the act mini-map (moved up from the lower-right), or a plain screen note so the column is never blank.

Below, row 2 keeps the play-by-play ticker (left) and deck/relics/potions (right).

**Enemy HP + intent.** `LiveEnemiesPanel` consumes the new `enemies` field (`{id, hp, max_hp, block, intent, intent_value, intent_hits}`) from #470. The mod does not populate it yet, so it falls back to the bare `fighting` ids (portrait + name only) and lights up fully once the mod sends enemy HP/intent. The intent label maps the kind keyword to a colored ATK/BLOCK/BUFF/etc. badge with the damage value.

Includes the v4 event + shop panels (`LiveEventShop.tsx`) that this layout positions. tsc + eslint clean.

Merge order: #470 (backend) -> this. Stacks cleanly on the merged #466/#468.