### PR TITLE
Presence v4+v5 backend: live event, shop, and combat-enemy detail

### DIFF
--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -104,6 +104,93 @@ def _clean_map(raw) -> dict | None:
     return out
 
 
+# Current-screen spectator detail: the live event (name/prompt/options) and the shop
+# (items/costs). Both are transient and cleared when the player leaves the screen.
+_EVENT_OPTIONS_CAP = 12
+_SHOP_ITEMS_CAP = 12
+_TITLE_CAP = 200
+_PROMPT_CAP = 2000
+_OPT_TEXT_CAP = 400
+
+
+def _clean_event_ctx(raw) -> dict | None:
+    """The live event the player is reading: id + resolved title/prompt + the options on
+    offer. The mod ships already-localized text, so the frontend renders it as-is."""
+    if not isinstance(raw, dict):
+        return None
+    eid = raw.get("id")
+    if not isinstance(eid, str) or not _safe_id(eid[:_MAX_STR]):
+        return None
+    out: dict = {"id": eid[:_MAX_STR]}
+    if isinstance(raw.get("title"), str) and raw["title"]:
+        out["title"] = raw["title"][:_TITLE_CAP]
+    if isinstance(raw.get("prompt"), str) and raw["prompt"]:
+        out["prompt"] = raw["prompt"][:_PROMPT_CAP]
+    options: list[dict] = []
+    raw_opts = raw.get("options")
+    if isinstance(raw_opts, list):
+        for o in raw_opts[:_EVENT_OPTIONS_CAP]:
+            if not isinstance(o, dict):
+                continue
+            opt: dict = {}
+            if isinstance(o.get("key"), str):
+                opt["key"] = o["key"][:_MAX_STR]
+            if isinstance(o.get("text"), str):
+                opt["text"] = o["text"][:_OPT_TEXT_CAP]
+            for flag in ("locked", "proceed", "chosen"):
+                if isinstance(o.get(flag), bool):
+                    opt[flag] = o[flag]
+            if opt:
+                options.append(opt)
+    out["options"] = options
+    return out
+
+
+def _shop_item(o) -> dict | None:
+    if not isinstance(o, dict):
+        return None
+    # A shop slot is only renderable with a resolvable item id, so require a
+    # safe one; this also drops any id carrying a path-traversal sequence
+    # (rather than leaving a costed orphan with no name or image).
+    oid = o.get("id")
+    if not isinstance(oid, str) or not _safe_id(oid[:_MAX_STR]):
+        return None
+    item: dict = {"id": oid[:_MAX_STR]}
+    if isinstance(o.get("cost"), (int, float)) and not isinstance(o.get("cost"), bool):
+        item["cost"] = int(o["cost"])
+    for flag in ("stocked", "on_sale"):
+        if isinstance(o.get(flag), bool):
+            item[flag] = o[flag]
+    if isinstance(o.get("slot"), str) and o["slot"]:
+        item["slot"] = o["slot"][:16]
+    return item or None
+
+
+def _clean_shop(raw) -> dict | None:
+    """The current merchant inventory: items (frontend resolves id -> name/image) + costs."""
+    if not isinstance(raw, dict):
+        return None
+    out: dict = {}
+    for cat in ("cards", "relics", "potions"):
+        lst = raw.get(cat)
+        if isinstance(lst, list):
+            out[cat] = [
+                it for it in (_shop_item(o) for o in lst[:_SHOP_ITEMS_CAP]) if it
+            ]
+    rm = raw.get("removal")
+    if isinstance(rm, dict):
+        r: dict = {}
+        if isinstance(rm.get("cost"), (int, float)) and not isinstance(
+            rm.get("cost"), bool
+        ):
+            r["cost"] = int(rm["cost"])
+        if isinstance(rm.get("stocked"), bool):
+            r["stocked"] = rm["stocked"]
+        if r:
+            out["removal"] = r
+    return out or None
+
+
 def _clean_events(raw) -> list[dict]:
     events: list[dict] = []
     if not isinstance(raw, list):
@@ -193,11 +280,20 @@ async def post_presence(request: Request):
     if (m := _clean_map(data.get("map"))) is not None:
         fields["map"] = m
 
-    # Transient combat context: when the mod sends these as explicit null (combat
-    # just ended), clear them rather than leaving the last fight's values stale.
-    # pos is NOT in this set on purpose: keeping the last node avoids a blinking
-    # map marker while the player travels between nodes.
-    unset = [k for k in ("turn", "fighting") if k in data and data[k] is None]
+    # Current-screen detail: the live event and the shop. Present only on those screens.
+    if (ev := _clean_event_ctx(data.get("event"))) is not None:
+        fields["event"] = ev
+    if (shp := _clean_shop(data.get("shop"))) is not None:
+        fields["shop"] = shp
+
+    # Transient fields: when the mod sends these as explicit null (combat ended / left the
+    # screen), clear them rather than leaving stale values. pos is NOT in this set on
+    # purpose: keeping the last node avoids a blinking map marker between nodes.
+    unset = [
+        k
+        for k in ("turn", "fighting", "event", "shop")
+        if k in data and data[k] is None
+    ]
 
     # Display name: the verified user record outranks the client-sent username.
     try:

--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -191,6 +191,38 @@ def _clean_shop(raw) -> dict | None:
     return out or None
 
 
+# Live combat enemies for the spectator combat panel: each enemy's id, current
+# HP, and intent. `intent` is a kind string (attack, defend, buff, debuff, stun,
+# sleep, escape, unknown); intent_value/intent_hits describe an attack.
+_ENEMIES_CAP = 8
+_INTENT_CAP = 24
+_ENEMY_INT_FIELDS = ("hp", "max_hp", "block", "intent_value", "intent_hits")
+
+
+def _clean_enemies(raw) -> list[dict] | None:
+    """The living enemies in the current fight, with HP and intent. Richer than
+    the bare `fighting` id list (which stays for the roster chip)."""
+    if not isinstance(raw, list):
+        return None
+    out: list[dict] = []
+    for o in raw[:_ENEMIES_CAP]:
+        if not isinstance(o, dict):
+            continue
+        oid = o.get("id")
+        if not isinstance(oid, str) or not _safe_id(oid[:_MAX_STR]):
+            continue
+        item: dict = {"id": oid[:_MAX_STR]}
+        for k in _ENEMY_INT_FIELDS:
+            v = o.get(k)
+            if isinstance(v, (int, float)) and not isinstance(v, bool):
+                item[k] = int(v)
+        intent = o.get("intent")
+        if isinstance(intent, str) and intent:
+            item["intent"] = intent[:_INTENT_CAP]
+        out.append(item)
+    return out or None
+
+
 def _clean_events(raw) -> list[dict]:
     events: list[dict] = []
     if not isinstance(raw, list):
@@ -280,18 +312,21 @@ async def post_presence(request: Request):
     if (m := _clean_map(data.get("map"))) is not None:
         fields["map"] = m
 
-    # Current-screen detail: the live event and the shop. Present only on those screens.
+    # Current-screen detail: the live event, the shop, and combat enemies. Present
+    # only on those screens.
     if (ev := _clean_event_ctx(data.get("event"))) is not None:
         fields["event"] = ev
     if (shp := _clean_shop(data.get("shop"))) is not None:
         fields["shop"] = shp
+    if (en := _clean_enemies(data.get("enemies"))) is not None:
+        fields["enemies"] = en
 
     # Transient fields: when the mod sends these as explicit null (combat ended / left the
     # screen), clear them rather than leaving stale values. pos is NOT in this set on
     # purpose: keeping the last node avoids a blinking map marker between nodes.
     unset = [
         k
-        for k in ("turn", "fighting", "event", "shop")
+        for k in ("turn", "fighting", "event", "shop", "enemies")
         if k in data and data[k] is None
     ]
 

--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -191,35 +191,59 @@ def _clean_shop(raw) -> dict | None:
     return out or None
 
 
-# Live combat enemies for the spectator combat panel: each enemy's id, current
-# HP, and intent. `intent` is a kind string (attack, defend, buff, debuff, stun,
-# sleep, escape, unknown); intent_value/intent_hits describe an attack.
+# Live combat enemies for the spectator combat panel: per enemy hp/block plus the
+# upcoming intent(s). A move can carry several intents (e.g. attack + buff), so
+# `intents` is a list of {type, dmg?, hits?}; `type` is the codex intent category
+# (attack, defend, buff, debuff, heal, escape, summon, carddebuff, deathblow,
+# hidden, unknown), `dmg` the base per-hit damage and `hits` the strike count.
 _ENEMIES_CAP = 8
-_INTENT_CAP = 24
-_ENEMY_INT_FIELDS = ("hp", "max_hp", "block", "intent_value", "intent_hits")
+_INTENTS_CAP = 6
+
+
+def _clean_intent(o) -> dict | None:
+    if not isinstance(o, dict):
+        return None
+    t = o.get("type")
+    if not isinstance(t, str) or not t:
+        return None
+    out: dict = {"type": t[:24]}
+    for k in ("dmg", "hits"):
+        v = o.get(k)
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            out[k] = int(v)
+    return out
 
 
 def _clean_enemies(raw) -> list[dict] | None:
-    """The living enemies in the current fight, with HP and intent. Richer than
-    the bare `fighting` id list (which stays for the roster chip)."""
+    """The living enemies in the current fight, with hp/block and intents. Richer
+    than the bare `fighting` id list (which stays for the roster chip)."""
     if not isinstance(raw, list):
         return None
     out: list[dict] = []
     for o in raw[:_ENEMIES_CAP]:
         if not isinstance(o, dict):
             continue
+        en: dict = {}
+        # id flows into the enemy portrait URL, so guard it; an enemy with no safe
+        # id still renders from its name, so keep the entry either way.
         oid = o.get("id")
-        if not isinstance(oid, str) or not _safe_id(oid[:_MAX_STR]):
-            continue
-        item: dict = {"id": oid[:_MAX_STR]}
-        for k in _ENEMY_INT_FIELDS:
+        if isinstance(oid, str) and _safe_id(oid[:_MAX_STR]):
+            en["id"] = oid[:_MAX_STR]
+        if isinstance(o.get("name"), str) and o["name"]:
+            en["name"] = o["name"][:_MAX_STR]
+        for k in ("hp", "max_hp", "block"):
             v = o.get(k)
             if isinstance(v, (int, float)) and not isinstance(v, bool):
-                item[k] = int(v)
-        intent = o.get("intent")
-        if isinstance(intent, str) and intent:
-            item["intent"] = intent[:_INTENT_CAP]
-        out.append(item)
+                en[k] = int(v)
+        raw_intents = o.get("intents")
+        if isinstance(raw_intents, list):
+            en["intents"] = [
+                it
+                for it in (_clean_intent(i) for i in raw_intents[:_INTENTS_CAP])
+                if it
+            ]
+        if en:
+            out.append(en)
     return out or None
 
 

--- a/backend/app/services/presence_db.py
+++ b/backend/app/services/presence_db.py
@@ -94,6 +94,7 @@ def active(limit: int = 50) -> list[dict]:
                 "map": 0,
                 "event": 0,
                 "shop": 0,
+                "enemies": 0,
             },
         )
         .sort([("total_floor", -1), ("updated_at", -1)])

--- a/backend/app/services/presence_db.py
+++ b/backend/app/services/presence_db.py
@@ -17,6 +17,8 @@ Document shape (one doc per live player):
         "turn": ..., "fighting": [...],        # combat context (absent between fights)
         "events": [{k, v, turn, t}, ...],      # rolling play-by-play window
         "map": {act, nodes, edges}, "path": [[col,row], ...], "pos": [col,row],
+        "event": {id, title, prompt, options}, # live event (only in an event room)
+        "shop": {cards, relics, potions, removal},  # shop inventory (only in a merchant)
         "started_at": ISODate(...),   # first heartbeat of this session
         "updated_at": ISODate(...),   # last heartbeat (TTL anchor)
     }
@@ -60,13 +62,13 @@ def heartbeat(
         "$set": {**fields, "updated_at": now},
         "$setOnInsert": {"started_at": now},
     }
-    if events:
-        update["$push"] = {"events": {"$each": events, "$slice": -EVENT_WINDOW}}
     # Clear transient fields the mod explicitly nulled (combat just ended), so the
     # roster never shows a stale "Turn 7 vs Gremlin Nob" for someone now in a shop.
-    # unset keys never overlap $set (the router only unsets keys absent from fields).
+    # unset keys never overlap $set (the router only unsets keys it left out of fields).
     if unset:
         update["$unset"] = {k: "" for k in unset}
+    if events:
+        update["$push"] = {"events": {"$each": events, "$slice": -EVENT_WINDOW}}
     _presence_coll().update_one({"_id": steam_id}, update, upsert=True)
 
 
@@ -84,7 +86,15 @@ def active(limit: int = 50) -> list[dict]:
         _presence_coll()
         .find(
             {"updated_at": {"$gte": cutoff}},
-            {"deck": 0, "relics": 0, "potions": 0, "events": 0, "map": 0},
+            {
+                "deck": 0,
+                "relics": 0,
+                "potions": 0,
+                "events": 0,
+                "map": 0,
+                "event": 0,
+                "shop": 0,
+            },
         )
         .sort([("total_floor", -1), ("updated_at", -1)])
         .limit(limit)

--- a/markdown-docs/live-presence.md
+++ b/markdown-docs/live-presence.md
@@ -48,7 +48,25 @@ refresh every 10-15s).
 Combat context (v2, absent between fights):
 
 - `turn`: the combat round number
-- `fighting`: bare ids of the living enemies, e.g. `["GREMLIN_NOB"]`
+- `fighting`: bare ids of the living enemies, e.g. `["GREMLIN_NOB"]` (kept for the
+  lightweight roster chip)
+
+Rich combat enemies (v5, absent between fights): `enemies` is the per-player combat
+panel data, each enemy carrying HP and intent:
+
+```json
+"enemies": [
+  {"id": "GREMLIN_NOB", "hp": 52, "max_hp": 85, "intent": "attack", "intent_value": 14, "intent_hits": 1},
+  {"id": "SPIKER", "hp": 42, "max_hp": 42, "block": 5, "intent": "defend"}
+]
+```
+
+`intent` is a kind keyword (`attack`, `defend`, `buff`, `debuff`, `stun`, `sleep`,
+`escape`, `unknown`); `intent_value` is damage per hit and `intent_hits` the hit count
+for an attack (so `14 x1` or `6 x3`). `block` is the enemy's current block. All numeric
+fields optional; the frontend renders an HP bar plus an intent icon + value when present.
+Excluded from `/active` (per-player only) and cleared when combat ends (same null-to-clear
+rule as `turn`/`fighting`).
 
 Play-by-play ticker (v2): `events` is a rolling window (last 50) of moments, oldest
 first, appended by each heartbeat:

--- a/markdown-docs/live-presence.md
+++ b/markdown-docs/live-presence.md
@@ -52,21 +52,27 @@ Combat context (v2, absent between fights):
   lightweight roster chip)
 
 Rich combat enemies (v5, absent between fights): `enemies` is the per-player combat
-panel data, each enemy carrying HP and intent:
+panel data, each enemy carrying hp/block and its upcoming intent(s):
 
 ```json
 "enemies": [
-  {"id": "GREMLIN_NOB", "hp": 52, "max_hp": 85, "intent": "attack", "intent_value": 14, "intent_hits": 1},
-  {"id": "SPIKER", "hp": 42, "max_hp": 42, "block": 5, "intent": "defend"}
+  {"id": "GREMLIN_NOB", "name": "Gremlin Nob", "hp": 52, "max_hp": 85,
+   "intents": [{"type": "attack", "dmg": 16, "hits": 2}]},
+  {"id": "SPIKER", "name": "Spiker", "hp": 42, "max_hp": 42, "block": 5,
+   "intents": [{"type": "defend"}, {"type": "buff"}]}
 ]
 ```
 
-`intent` is a kind keyword (`attack`, `defend`, `buff`, `debuff`, `stun`, `sleep`,
-`escape`, `unknown`); `intent_value` is damage per hit and `intent_hits` the hit count
-for an attack (so `14 x1` or `6 x3`). `block` is the enemy's current block. All numeric
-fields optional; the frontend renders an HP bar plus an intent icon + value when present.
-Excluded from `/active` (per-player only) and cleared when combat ends (same null-to-clear
-rule as `turn`/`fighting`).
+`intents` is a list because one move can do several things (attack + buff). Each intent's
+`type` is the codex intent category (`attack`, `defend`, `buff`, `debuff`, `heal`,
+`escape`, `summon`, `carddebuff`, `deathblow`, `hidden`, `unknown`); render the game's
+intent icon from it. For attacks, `dmg` is the base per-hit damage and `hits` the strike
+count, so `dmg:16, hits:2` is "16 x2" = 32 incoming (`dmg` is the base value; in-combat
+modifiers like strength/vulnerable aren't folded in). Non-attacks omit `dmg`/`hits`.
+`name` is the resolved enemy name (fall back to the id lookup if absent), `block` the
+enemy's current block. All fields except the intent `type` are optional. Excluded from
+`/active` (per-player only) and cleared when combat ends (same null-to-clear rule as
+`turn`/`fighting`).
 
 Play-by-play ticker (v2): `events` is a rolling window (last 50) of moments, oldest
 first, appended by each heartbeat:

--- a/markdown-docs/live-presence.md
+++ b/markdown-docs/live-presence.md
@@ -101,6 +101,56 @@ The per-player doc carries the current act's map graph and the route taken so fa
 - The bulky `map` graph is sent once per act (it's static) and omitted from `/active`;
   `path`/`pos` ride every beat and DO appear on `/active` for a roster progress hint.
 
+### Live event (v4, present only in an event room)
+
+When `screen == "event"`, the per-player doc carries the event the player is reading and
+the options on offer. The mod ships the ALREADY-LOCALIZED text the player sees, so render
+it directly (no need to resolve from the codex event data; the `id` is there if you want
+to link to the event page).
+
+```json
+"event": {
+  "id": "ABYSSAL_BATHS",
+  "title": "Abyssal Baths",
+  "prompt": "You come upon a hot spring rumored to wash away the past...",
+  "options": [
+    {"key": "BATHE", "text": "[Bathe] Lose all but 1 Max HP. Become Cleansed.", "locked": false, "proceed": false, "chosen": false},
+    {"key": "LEAVE", "text": "Leave", "locked": false, "proceed": true, "chosen": false}
+  ]
+}
+```
+
+- `title`/`prompt` are resolved localized strings (may be absent on a sparse beat).
+- each option: `key` (stable loc key), `text` (the localized button label), `locked` (greyed
+  out / requirement unmet), `proceed` (the leave/continue option), `chosen` (already picked).
+- Cleared when the player leaves the event (the mod sends `event: null` -> server `$unset`).
+  Omitted from `/active`.
+
+### Live shop (v4, present only in a merchant room)
+
+When `screen == "merchant"`, the doc carries the full inventory. Item ids are bare
+(`"FROZEN_EYE"`) -> resolve name/image via the usual card/relic/potion lookups, same as
+the deck. Costs are the live gold price.
+
+```json
+"shop": {
+  "cards":   [{"id": "WHIRLWIND", "cost": 75, "stocked": true, "on_sale": false, "slot": "character"}],
+  "relics":  [{"id": "FROZEN_EYE", "cost": 143, "stocked": true}],
+  "potions": [{"id": "FIRE_POTION", "cost": 50, "stocked": true}],
+  "removal": {"cost": 75, "stocked": true}
+}
+```
+
+- `stocked: false` means the slot was already bought (its `id` is then absent). Show it as
+  sold/empty so viewers see purchases happen live.
+- `on_sale` (cards only) is the 50%-off discount; relics/potions never have it.
+- `slot` tags a card `"character"` (one of the 5 typed slots) or `"colorless"`.
+- `removal` is the card-removal service (null if this shop has none). Cleared on leaving
+  the shop; omitted from `/active`.
+
+Note the singular `event`/`shop` objects are distinct from the plural `events` ticker
+array above.
+
 ### POST /api/presence
 
 Mod-only; requires the Steam JWT (`Authorization: Bearer`). The frontend never calls it.


### PR DESCRIPTION
Follow-up to #467 (merged). Adds the current-screen spectator detail the mod ships after v3.

- **Live event** (`_clean_event_ctx`): `event = {id, title, prompt, options:[{key, text, locked, proceed, chosen}]}`, already-localized; event id guarded by `_safe_id`.
- **Live shop** (`_clean_shop`/`_shop_item`): `shop = {cards, relics, potions, removal}`, each item `{id, cost, stocked, on_sale, slot}`; item ids guarded; a slot with a missing/unsafe id is dropped whole, not left as a costed orphan.
- **Combat enemies** (`_clean_enemies`): new `enemies = [{id, hp, max_hp, block?, intent?, intent_value?, intent_hits?}]` so the spectator combat panel can show HP bars + intent. `fighting` (bare ids) stays for the lightweight roster chip. `intent` is a kind keyword; value/hits describe an attack.

All three are screen-gated, excluded from `/active` (per-player only), and join the combat-transient `$unset` list so they clear when the player leaves. Every new field optional; old mod vs this backend and this backend vs the frontend keep working. `_safe_id` guards every new id. Unit-tested the cleaners against valid payloads and traversal/garbage inputs.

The mod populates event/shop today; `enemies` is a new ask (the frontend renders HP/intent when present and falls back to `fighting` ids meanwhile). Pairs with the frontend in #469.