### PR TITLE
Show every live spectator panel at once (interim layout)

### DIFF
--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -378,6 +378,17 @@ export default function LivePlayerClient() {
     else deckGroups.push({ raw, count: 1 });
   }
 
+  const hasEnemies = (p.enemies?.length ?? 0) > 0 || (p.fighting?.length ?? 0) > 0;
+  const mapCard =
+    (p.map?.nodes?.length ?? 0) > 0 ? (
+      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+        <h2 className="text-sm font-semibold text-[var(--accent-gold)] mb-2">
+          Map{p.map?.act != null ? ` · Act ${p.map.act}` : ""}
+        </h2>
+        <LiveMap map={p.map} path={p.path} pos={p.pos} />
+      </div>
+    ) : null;
+
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <Link href="/live" className="text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)]">
@@ -444,16 +455,15 @@ export default function LivePlayerClient() {
           )}
         </div>
 
-        {/* The context panel: whatever the player is doing right now. Combat
-            enemies, the event reader, or the shop take priority; otherwise the
-            act map, then a plain screen note so the column is never blank. */}
-        <div>
-          {p.screen === "combat" &&
-          ((p.enemies?.length ?? 0) > 0 || (p.fighting?.length ?? 0) > 0) ? (
-            <LiveEnemiesPanel p={p} monsters={monsters} />
-          ) : p.screen === "event" && p.event ? (
-            <LiveEventPanel ev={p.event} lp={lp} />
-          ) : p.screen === "merchant" && p.shop ? (
+        {/* Context column. For now every panel with data shows at once (combat
+            enemies, the event reader, the shop, and the act map) instead of one
+            at a time, so we can see everything while settling the final layout.
+            Each is gated only on its own data, which the backend clears on
+            screen exit, so nothing lingers stale. */}
+        <div className="space-y-4">
+          {hasEnemies && <LiveEnemiesPanel p={p} monsters={monsters} />}
+          {p.event && <LiveEventPanel ev={p.event} lp={lp} />}
+          {p.shop && (
             <LiveShopPanel
               shop={p.shop}
               cards={cat.cards}
@@ -462,14 +472,9 @@ export default function LivePlayerClient() {
               lp={lp}
               lang={lang}
             />
-          ) : (p.map?.nodes?.length ?? 0) > 0 ? (
-            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
-              <h2 className="text-sm font-semibold text-[var(--accent-gold)] mb-2">
-                Map{p.map?.act != null ? ` · Act ${p.map.act}` : ""}
-              </h2>
-              <LiveMap map={p.map} path={p.path} pos={p.pos} />
-            </div>
-          ) : (
+          )}
+          {mapCard}
+          {!hasEnemies && !p.event && !p.shop && !mapCard && (
             <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4 text-sm text-[var(--text-muted)]">
               {p.screen ? `On the ${p.screen} screen.` : "No live detail for this screen."}
             </div>

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -329,9 +329,10 @@ function intentLabel(it: EnemyIntent): { text: string; cls: string } {
 /** The spectator combat panel: every living enemy with portrait, HP bar, block,
  * and its upcoming intent(s). Uses the rich `enemies` field when the mod sends
  * it, falling back to the bare `fighting` id list (portrait + name only) so it
- * still shows something on an older mod. Renders nothing off the combat screen. */
+ * still shows something on an older mod. Gated on enemy data, not the screen:
+ * the backend clears enemies/fighting when combat ends, so data presence is the
+ * correct gate and the panel naturally disappears after a fight. */
 export function LiveEnemiesPanel({ p, monsters }: { p: LivePlayer; monsters: MonsterMap }) {
-  if (p.screen !== "combat") return null;
   const rich = (p.enemies ?? []).filter((e) => e && (e.id || e.name));
   const enemies: Enemy[] = rich.length
     ? rich


### PR DESCRIPTION
Per the request to keep all the assets visible until we settle on a final layout.

The redesign's context column showed one panel at a time (combat enemies, the event reader, the shop, or the act map), which is why the map kept disappearing during fights. For now I stack every panel that has data, all at once, in the right-hand context column: enemies, event reader, shop, and the act map all render together. Each is gated only on its own data, and the backend clears that data on screen exit, so nothing lingers stale.

`LiveEnemiesPanel` now gates on enemy data rather than the combat screen (same reasoning). The 50/50 player-left layout and the row-2 ticker + deck/relics/potions are unchanged.

This is interim scaffolding so we can see everything together and pick the final arrangement. tsc + eslint clean.