### PR TITLE
Merge the duplicate beta bars on entity pages into one

### DIFF
--- a/frontend/app/components/BetaBanner.tsx
+++ b/frontend/app/components/BetaBanner.tsx
@@ -19,13 +19,12 @@ export default function BetaBanner({ stablePath = "/" }: { stablePath?: string }
   }, []);
 
   return (
-    <div className="rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-4 py-2.5 mb-6 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
-      <span className="font-semibold text-emerald-300">
+    <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 mb-4 flex items-center gap-2 text-xs">
+      <span className="font-semibold text-emerald-300 shrink-0">
         Beta{version ? ` ${version}` : ""}
       </span>
-      <span className="text-[var(--text-secondary)]">
-        You are viewing content from the game&apos;s beta branch. Numbers and text
-        here can change before they reach main.
+      <span className="text-[var(--text-muted)] truncate">
+        Preview content; numbers and text can change before they reach main.
       </span>
       <Link
         href={stablePath}

--- a/frontend/app/components/BetaChrome.tsx
+++ b/frontend/app/components/BetaChrome.tsx
@@ -31,6 +31,10 @@ export default function BetaChrome() {
   if (channel !== "beta") return null;
   // The landing page renders its own banner inside its own container.
   if (pathname === "/beta" || /^\/[a-z]{3}\/beta$/.test(pathname)) return null;
+  // Card/relic/event detail pages render their own BetaDiffNotice, which now
+  // carries the version + channel line too, so the global banner would be a
+  // second redundant bar on those pages. Let the per-page one stand alone.
+  if (/^(\/[a-z]{3})?\/beta\/(cards|relics|events)\/[^/]+$/.test(pathname)) return null;
   // Strip the beta segment for the switch-to-stable link, preserving lang.
   let stablePath = pathname.replace(/^(\/[a-z]{3})?\/beta(?=\/|$)/, "$1") || "/";
   // A beta-only entity has no stable twin; clicking through to its stripped

--- a/frontend/app/components/BetaDiffNotice.tsx
+++ b/frontend/app/components/BetaDiffNotice.tsx
@@ -61,37 +61,41 @@ export default function BetaDiffNotice({
       .catch(() => {});
   }, []);
 
-  const t = diff?.types?.[entityType];
-  if (!t || !diff?.beta_version) return null;
+  if (!diff?.beta_version) return null;
+  const t = diff.types?.[entityType];
   const id = entityId.toUpperCase();
-  const changedFields = t.changed[id];
-  const isAdded = t.added.includes(id);
-  const isRemoved = t.removed.includes(id);
-  if (!changedFields && !isAdded && !isRemoved) return null;
+  const changedFields = t?.changed[id];
+  const isAdded = !!t?.added.includes(id);
+  const isRemoved = !!t?.removed.includes(id);
 
   const counterpartPath =
     channel === "beta"
       ? pathname.replace(/^(\/[a-z]{3})?\/beta(?=\/)/, "$1")
       : pathname.replace(/^(\/[a-z]{3})?(?=\/)/, "$1/beta");
+  const noun = entityType.replace(/s$/, "");
 
-  let body: React.ReactNode = null;
+  let body: React.ReactNode;
   if (channel === "stable") {
+    // On main, only flag entities that differ from (or are gone in) beta; a
+    // matching entity needs no notice here.
     if (isRemoved) {
-      body = <>Removed in the current beta ({diff.beta_version}).</>;
+      body = <>Removed in the current beta.</>;
     } else if (changedFields) {
       body = (
         <>
-          This is different in the current beta ({diff.beta_version}): {summarize(changedFields)}{" "}
-          changed.{" "}
+          This is different in the current beta: {summarize(changedFields)} changed.{" "}
           <Link href={counterpartPath} className="text-emerald-300 hover:underline">
             View the beta version →
           </Link>
         </>
       );
     } else {
-      return null; // added entities have no stable page to show this on
+      return null; // matching/added entities need no notice on main
     }
   } else {
+    // On beta this is the page's only beta bar (the global banner is suppressed
+    // on these detail routes), so it always renders, carrying both the channel
+    // line and the per-entity status.
     if (isAdded) {
       body = <>New in this beta. There is no main version of this yet.</>;
     } else if (changedFields) {
@@ -104,13 +108,22 @@ export default function BetaDiffNotice({
         </>
       );
     } else {
-      return null;
+      body = (
+        <>
+          Viewing the beta version of this {noun}.{" "}
+          <Link href={counterpartPath} className="text-emerald-300 hover:underline">
+            Switch to main →
+          </Link>
+        </>
+      );
     }
   }
 
   return (
-    <div className="rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-4 py-2.5 my-4 text-sm text-[var(--text-secondary)]">
-      <span className="font-semibold text-emerald-300 mr-2">Beta</span>
+    <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 my-3 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-xs text-[var(--text-secondary)]">
+      <span className="font-semibold text-emerald-300">
+        Beta{diff.beta_version ? ` ${diff.beta_version}` : ""}
+      </span>
       {body}
     </div>
   );


### PR DESCRIPTION
On card, relic, and event detail pages there were two emerald beta bars stacking: the global beta banner ("viewing content from the beta branch / Switch to main") and the per-entity `BetaDiffNotice` ("Beta — New in this beta. There is no main version of this yet."). On a beta-only entity like Scare that read as two near-identical bars, and the "Switch to main" link was meaningless since there is no main version.

I merged them into one:
- The global banner (`BetaChrome`) is now suppressed on `/beta/{cards,relics,events}/{id}` routes.
- `BetaDiffNotice` is the single bar there. It always renders on beta now and carries the version plus the right message: "New in this beta. There is no main version of this yet." for beta-only entities, "Differs from main: … changed. View the main version →" for changed ones, or "Viewing the beta version of this card. Switch to main →" for unchanged ones.
- I slimmed the bar (and the global banner used on list/hub pages) to a compact single line, since the old block was too tall.

So `/beta/cards/scare` and the beta relics on `/beta/events/neow` now show one beta bar, not two. tsc + eslint clean.