### PR TITLE
Add an Alloy service to ship nginx access logs to Loki

### DIFF
--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -1,0 +1,53 @@
+// Grafana Alloy: ship nginx access logs to Loki.
+//
+// The web-server (nginx:alpine) container writes the "combined" log format to
+// /var/log/nginx/access.log, which is the host dir /data/nginx/nginx/logs
+// bind-mounted read-only into this container (see docker-compose.monitoring.yml
+// and monitoring-install.yml). The Loki endpoint is behind Cloudflare Access,
+// so every push carries a CF Access service token.
+//
+// Env (from the .env next to the compose file, never committed):
+//   LOKI_URL, CF_ACCESS_CLIENT_ID, CF_ACCESS_CLIENT_SECRET
+//
+// Validate edits before deploy:
+//   docker run --rm -v "$PWD/alloy:/c" grafana/alloy fmt /c/config.alloy
+
+local.file_match "nginx" {
+  path_targets = [{
+    __path__ = "/var/log/nginx/access.log",
+    job      = "nginx",
+    host     = "spire-codex",
+  }]
+}
+
+loki.source.file "nginx" {
+  targets    = local.file_match.nginx.targets
+  forward_to = [loki.process.nginx.receiver]
+}
+
+loki.process "nginx" {
+  // nginx "combined": $remote_addr - $remote_user [$time_local] "$request"
+  //   $status $body_bytes_sent "$http_referer" "$http_user_agent"
+  // Pull method + status out as labels (both low-cardinality); the full line
+  // stays as the log body for ad-hoc querying.
+  stage.regex {
+    expression = `^(?P<remote_addr>\S+) \S+ \S+ \[[^\]]+\] "(?P<method>[A-Z]+) \S+ [^"]*" (?P<status>\d{3})`
+  }
+  stage.labels {
+    values = {
+      method = "",
+      status = "",
+    }
+  }
+  forward_to = [loki.write.default.receiver]
+}
+
+loki.write "default" {
+  endpoint {
+    url = sys.env("LOKI_URL")
+    http_headers = {
+      "CF-Access-Client-Id"     = [sys.env("CF_ACCESS_CLIENT_ID")],
+      "CF-Access-Client-Secret" = [sys.env("CF_ACCESS_CLIENT_SECRET")],
+    }
+  }
+}

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -32,3 +32,32 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+
+  # Ships nginx access logs to Loki. The web-server container writes the
+  # "combined" format to a real host file (monitoring-install.yml mounts
+  # /data/nginx/nginx/logs -> /var/log/nginx:rw on it), so Alloy reads that
+  # same host dir read-only. The Loki endpoint sits behind Cloudflare Access,
+  # so the config sends a service token on every push.
+  #
+  # Needs an .env next to this compose (NOT committed) with:
+  #   LOKI_URL=https://<loki-host>/loki/api/v1/push
+  #   CF_ACCESS_CLIENT_ID=<id>.access
+  #   CF_ACCESS_CLIENT_SECRET=<secret>
+  alloy:
+    image: grafana/alloy:latest
+    container_name: alloy
+    restart: unless-stopped
+    command: run --server.http.listen-addr=0.0.0.0:12345 /etc/alloy/config.alloy
+    volumes:
+      # The SAME host dir nginx writes its logs to (see monitoring-install.yml).
+      - /data/nginx/nginx/logs:/var/log/nginx:ro
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+    environment:
+      LOKI_URL: "${LOKI_URL}"
+      CF_ACCESS_CLIENT_ID: "${CF_ACCESS_CLIENT_ID}"
+      CF_ACCESS_CLIENT_SECRET: "${CF_ACCESS_CLIENT_SECRET}"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
I added an `alloy` service to `docker-compose.monitoring.yml` and an `alloy/config.alloy` to ship the nginx access logs to Loki.

Two facts I confirmed from the repo while wiring this, both different from the earlier guess:
- **Log path:** the web-server (nginx:alpine) container runs with `-v /data/nginx/nginx/logs:/var/log/nginx:rw` (from `monitoring-install.yml`), so the access log is a real host file at `/data/nginx/nginx/logs/access.log` (not `/data/nginx/logs`). Alloy mounts that same host dir read-only. So it's the easy file-based case, not the stdout case.
- **Format:** nginx writes the `combined` format (`access_log /var/log/nginx/access.log combined` in `nginx.conf.j2`), not JSON. The config.alloy parses combined with a regex and lifts `method` + `status` to labels.

The Loki endpoint is behind Cloudflare Access, so each push sends a service token. Nothing secret is committed: the service reads `LOKI_URL`, `CF_ACCESS_CLIENT_ID`, `CF_ACCESS_CLIENT_SECRET` from an `.env` next to the compose.

To bring it up on the box:
1. Put `LOKI_URL` + the two `CF_ACCESS_*` values in the `.env` next to the compose (uncommitted).
2. Make sure the repo's `alloy/` dir is alongside the compose on the box.
3. `docker compose -f docker-compose.monitoring.yml up -d alloy`.

One thing to validate before deploy: the `loki.write` `http_headers` field and the regex, with `docker run --rm -v "$PWD/alloy:/c" grafana/alloy fmt /c/config.alloy`. If the other session has a finalized `config.alloy`, it can drop in over this one (but note it must parse `combined`, not JSON, and point at `/var/log/nginx/access.log`).