### PR TITLE
Self-hosted GlitchTip on the home server: move error tracking off sentry.io

### DIFF
--- a/README.glitchtip.md
+++ b/README.glitchtip.md
@@ -1,0 +1,77 @@
+# Self-hosted GlitchTip (error tracking)
+
+GlitchTip replaces the sentry.io SaaS. It is Sentry-API-compatible, so every
+project keeps its `sentry-sdk` and only needs its `SENTRY_DSN` repointed at a
+project created here. It runs on the **home server**, not the spire-codex DO
+box (the box is 8 GB and already full; full Sentry self-hosted needs ~16 GB).
+
+The stack is `docker-compose.glitchtip.yml`: a Django web container, a Celery
+worker, a one-shot migrate, plus its own Postgres and Redis. It is
+self-contained and publishes the web UI / event ingest on `127.0.0.1:8080`.
+
+## Deploy on the home server
+
+1. Put `docker-compose.glitchtip.yml` on the home server (clone the repo or
+   copy the file) and create the data dir:
+
+   ```bash
+   mkdir -p glitchtip-data
+   ```
+
+2. Create a `.env` next to the compose file (never commit it):
+
+   ```bash
+   GLITCHTIP_SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_urlsafe(50))")
+   GLITCHTIP_DB_PASSWORD=$(openssl rand -base64 32)
+   GLITCHTIP_DOMAIN=https://glitchtip.spire-codex.com
+   # Optional: real email for invites/alerts (otherwise they log to stdout):
+   # GLITCHTIP_EMAIL_URL=smtp+tls://user:pass@smtp.host:587
+   ```
+
+   `GLITCHTIP_DOMAIN` must match the public HTTPS URL exactly; GlitchTip uses
+   it for CSRF and the DSNs it generates.
+
+3. Bring it up (migrate runs first, then web + worker):
+
+   ```bash
+   docker compose -f docker-compose.glitchtip.yml up -d
+   ```
+
+## Make it publicly reachable
+
+The DO backend and the player-side SDKs (overlay, desktop app) post events
+from the open internet, so GlitchTip needs a public HTTPS URL. The cleanest
+option for a home server (no port-forwarding, no static IP) is a Cloudflare
+Tunnel, since DNS already lives in Cloudflare:
+
+1. Install `cloudflared` on the home server and authenticate it.
+2. In Cloudflare Zero Trust -> Networks -> Tunnels, create a tunnel and add a
+   public hostname: `glitchtip.spire-codex.com` -> `http://127.0.0.1:8080`.
+
+A LAN reverse proxy (nginx/Traefik/Caddy) in front of `127.0.0.1:8080` works
+too; just make sure it forwards every path (the SDKs hit
+`/api/<project_id>/envelope/`).
+
+## First account, then lock it down
+
+Registration is closed by default. To create the first account:
+
+1. Add `GLITCHTIP_OPEN_REGISTRATION=true` to `.env`, then
+   `docker compose -f docker-compose.glitchtip.yml up -d glitchtip-web`.
+2. Open `https://glitchtip.spire-codex.com`, register, and create an
+   organization.
+3. Remove `GLITCHTIP_OPEN_REGISTRATION` from `.env` and run the `up -d` again
+   so the instance is private.
+
+## Repoint each app's DSN (the actual migration)
+
+In GlitchTip create one project per app, copy its DSN
+(`https://<key>@glitchtip.spire-codex.com/<project_id>`), and set `SENTRY_DSN`:
+
+- **spire-codex backend** (DO box): set `SENTRY_DSN` in the box `.env`, then
+  `docker compose -f docker-compose.prod.yml up -d backend`. No code change;
+  `main.py` already reads `SENTRY_DSN`.
+- **spire-overwolf / spire-compendium / Knowledge-Demon**: set `SENTRY_DSN`
+  in each project's own config (separate repos).
+
+Once events arrive in GlitchTip, the sentry.io project can be retired.

--- a/docker-compose.glitchtip.yml
+++ b/docker-compose.glitchtip.yml
@@ -1,0 +1,152 @@
+name: spire-codex-glitchtip
+
+# Self-hosted GlitchTip - Sentry-API-compatible error tracking, the
+# self-hosted replacement for sentry.io. Every project keeps its existing
+# sentry-sdk and just repoints SENTRY_DSN at a project created here.
+#
+# Chosen over getsentry/self-hosted because that needs ~16 GB RAM and ~30
+# containers; GlitchTip is a Django web + Celery worker + its own Postgres
+# and Redis. Memory is capped per service; raise the caps if the home box
+# has room to spare.
+#
+# Runs on a home server (not the spire-codex DO box, which is only 8 GB). It
+# is fully self-contained: a single private network, with the web UI and
+# event ingest published on host port 8080. Put it behind something that
+# gives it a public HTTPS URL so the DO backend and the player-side SDKs
+# (overlay, desktop app) can reach it - a Cloudflare Tunnel pointed at
+# 127.0.0.1:8080 is the cleanest (no port-forwarding); a reverse proxy works
+# too. Setup, secrets, first account, and the DSN repoint are in
+# README.glitchtip.md.
+
+x-glitchtip-env: &glitchtip-env
+  DATABASE_URL: "postgres://glitchtip:${GLITCHTIP_DB_PASSWORD}@glitchtip-postgres:5432/glitchtip"
+  REDIS_URL: "redis://glitchtip-redis:6379/0"
+  SECRET_KEY: "${GLITCHTIP_SECRET_KEY}"
+  PORT: "8080"
+  GLITCHTIP_DOMAIN: "${GLITCHTIP_DOMAIN:-https://glitchtip.spire-codex.com}"
+  DEFAULT_FROM_EMAIL: "${GLITCHTIP_FROM_EMAIL:-glitchtip@spire-codex.com}"
+  # consolemail:// just logs emails to the worker's stdout. Swap to an
+  # smtp+tls://user:pass@host:port URL in .env to send real invites/alerts.
+  EMAIL_URL: "${GLITCHTIP_EMAIL_URL:-consolemail://}"
+  # Closed by default. For the very first account, set this true in .env,
+  # `up -d`, register, then set it back to false and `up -d` again.
+  ENABLE_OPEN_USER_REGISTRATION: "${GLITCHTIP_OPEN_REGISTRATION:-false}"
+  # Bound worker memory and event retention so the small box stays healthy.
+  CELERY_WORKER_AUTOSCALE: "1,3"
+  CELERY_WORKER_MAX_TASKS_PER_CHILD: "10000"
+  GLITCHTIP_MAX_EVENT_LIFE_DAYS: "${GLITCHTIP_RETENTION_DAYS:-90}"
+
+services:
+  glitchtip-web:
+    image: glitchtip/glitchtip:latest
+    container_name: glitchtip-web
+    restart: unless-stopped
+    depends_on:
+      glitchtip-postgres:
+        condition: service_healthy
+      glitchtip-migrate:
+        condition: service_completed_successfully
+    environment: *glitchtip-env
+    mem_limit: 1g
+    ports:
+      # Bound to localhost: front this with a Cloudflare Tunnel or reverse
+      # proxy for public HTTPS rather than exposing it on the LAN directly.
+      - "127.0.0.1:8080:8080"
+    networks:
+      - glitchtip-db
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  glitchtip-worker:
+    image: glitchtip/glitchtip:latest
+    container_name: glitchtip-worker
+    restart: unless-stopped
+    command: ./bin/run-celery-with-beat.sh
+    depends_on:
+      glitchtip-postgres:
+        condition: service_healthy
+      glitchtip-migrate:
+        condition: service_completed_successfully
+    environment: *glitchtip-env
+    mem_limit: 768m
+    networks:
+      - glitchtip-db
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # One-shot DB migrations. Runs to completion on every `up`; web/worker wait
+  # for it via condition: service_completed_successfully.
+  glitchtip-migrate:
+    image: glitchtip/glitchtip:latest
+    container_name: glitchtip-migrate
+    command: ./manage.py migrate
+    restart: "no"
+    depends_on:
+      glitchtip-postgres:
+        condition: service_healthy
+    environment: *glitchtip-env
+    networks:
+      - glitchtip-db
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  glitchtip-postgres:
+    image: postgres:16-alpine
+    container_name: glitchtip-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: glitchtip
+      POSTGRES_USER: glitchtip
+      POSTGRES_PASSWORD: "${GLITCHTIP_DB_PASSWORD}"
+    volumes:
+      - ./glitchtip-data:/var/lib/postgresql/data
+    mem_limit: 512m
+    # Private network only; the DB never touches nginx_web-network.
+    networks:
+      - glitchtip-db
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U glitchtip -d glitchtip"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  glitchtip-redis:
+    image: redis:7-alpine
+    container_name: glitchtip-redis
+    restart: unless-stopped
+    # Celery broker/cache only; nothing here needs to survive a restart, so
+    # no persistence. Hard memory cap with LRU so it can't balloon.
+    command: redis-server --maxmemory 192mb --maxmemory-policy allkeys-lru --appendonly no --save ""
+    mem_limit: 256m
+    networks:
+      - glitchtip-db
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+networks:
+  # Self-contained; nothing here joins the DO box's app network.
+  glitchtip-db:
+    driver: bridge


### PR DESCRIPTION
I'm migrating error tracking from sentry.io to a self-hosted GlitchTip running on the home server (not the DO box). GlitchTip is Sentry-API-compatible, so every project keeps its `sentry-sdk` and I just repoint `SENTRY_DSN` at a project created here. No code change (the backend already reads `SENTRY_DSN`).

**Why home server, not the DO box:** full Sentry self-hosted needs ~16 GB; even lightweight GlitchTip (~2 GB) would make the 8 GB box (already running FastAPI×4, Mongo, Redis, Umami+Postgres, nginx, monitoring) too tight. Putting it on the home server keeps the box clear and gives GlitchTip real headroom.

What's here (just two files, fully decoupled from the box):
- `docker-compose.glitchtip.yml` - web + Celery worker + one-shot migrate + its own Postgres (16-alpine) + Redis, on a single private network, web UI/ingest published on `127.0.0.1:8080`, each service `mem_limit`-capped, 90-day retention. No dependency on the box's `nginx_web-network`.
- `README.glitchtip.md` - the home-server runbook: secrets, bring-up, fronting it with a Cloudflare Tunnel (`glitchtip.spire-codex.com` -> `127.0.0.1:8080`, no port-forwarding), the first-account-then-lock flow, and repointing each app's DSN.

(Earlier revisions of this PR wired it into the DO box's nginx + compose network; I reverted those so nothing box-specific ships - the box's nginx config and playbooks are untouched.)

After it's up: create a project per app in GlitchTip, set `SENTRY_DSN` (backend in the box `.env`; overlay/desktop/bot in their own repos), confirm events arrive, then retire the sentry.io project.