### PR TITLE
Add a Live players button to the navbar

### DIFF
--- a/frontend/app/components/LiveNavButton.tsx
+++ b/frontend/app/components/LiveNavButton.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+// "N Players Live" pill for the navbar. Polls /api/presence/active for the
+// live count and links to /live. Renders nothing when nobody is playing, so
+// it only lights up (red, glowing) when there's actually live activity.
+//
+// Self-contained on purpose: the navbar mounts on every page, so this keeps
+// its own tiny poll rather than pulling in the live-page module chain.
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+// Gentle: this runs on every page for every visitor, and a live count does
+// not need to be second-accurate.
+const POLL_MS = 60_000;
+
+function LiveCircle() {
+  return (
+    <span className="relative flex h-2.5 w-2.5 shrink-0">
+      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-500 opacity-75" />
+      <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-red-500" />
+    </span>
+  );
+}
+
+export default function LiveNavButton({
+  variant = "desktop",
+}: {
+  variant?: "desktop" | "mobile";
+}) {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function poll() {
+      if (document.hidden) return;
+      try {
+        const r = await fetch(`${API}/api/presence/active`);
+        if (!r.ok) return;
+        const d = await r.json();
+        const n = typeof d.count === "number" ? d.count : (d.players?.length ?? 0);
+        if (!cancelled) setCount(n);
+      } catch {
+        // Leave the last known count; the next beat recovers.
+      }
+    }
+    poll();
+    const t = setInterval(poll, POLL_MS);
+    const onVis = () => {
+      if (!document.hidden) poll();
+    };
+    document.addEventListener("visibilitychange", onVis);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+      document.removeEventListener("visibilitychange", onVis);
+    };
+  }, []);
+
+  if (count <= 0) return null;
+  const label = `${count} ${count === 1 ? "Player" : "Players"} Live`;
+
+  if (variant === "mobile") {
+    return (
+      <Link
+        href="/live"
+        className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-red-300 hover:bg-[var(--bg-card)] transition-colors"
+      >
+        <LiveCircle />
+        {label}
+      </Link>
+    );
+  }
+
+  return (
+    <Link
+      href="/live"
+      title="Watch players live"
+      className="hidden lg:inline-flex items-center gap-2 h-9 px-3 rounded-full text-xs font-semibold text-red-300 border border-red-500/40 bg-red-500/10 hover:bg-red-500/20 transition-colors shrink-0 shadow-[0_0_12px_rgba(239,68,68,0.35)]"
+    >
+      <LiveCircle />
+      {label}
+    </Link>
+  );
+}

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import LanguageSelector from "./LanguageSelector";
 import SearchTrigger from "./SearchTrigger";
 import SiteSwitcher from "./SiteSwitcher";
+import LiveNavButton from "./LiveNavButton";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { useAuth } from "@/app/contexts/AuthContext";
 import DiscordIcon from "./DiscordIcon";
@@ -219,6 +220,9 @@ export default function Navbar() {
             </span>
           </Link>
 
+          {/* Live indicator, between the logo and the nav groups. Shows only
+              when players are in a run; lights up red and links to /live. */}
+          <LiveNavButton />
 
           {/* Desktop nav, lg+ only. Single-row mega-menu pattern: each
               group button opens a multi-column panel below the row. Pure
@@ -491,7 +495,7 @@ export default function Navbar() {
                 ref={menuRef}
                 className="absolute right-0 top-full mt-2 w-48 max-w-[calc(100vw-1rem)] rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-black/30 max-h-[calc(100vh-5rem)] overflow-y-auto"
               >
-                {/* Home link */}
+                {/* Home link, with the live indicator right under it. */}
                 <div className="py-1">
                   <Link
                     href={`${langPrefix}/`}
@@ -503,6 +507,7 @@ export default function Navbar() {
                   >
                     {t("Home", lang)}
                   </Link>
+                  <LiveNavButton variant="mobile" />
                 </div>
 
                 {/* Collapsible groups */}


### PR DESCRIPTION
Adds a "N Players Live" entry point to the navbar, promoting the /live page.

- A red, glowing pulsing dot + "N Players Live", linking to `/live`.
- **Desktop:** sits between the site logo and the Database nav group.
- **Mobile:** appears in the menu directly under Home, in the same section.
- It polls `/api/presence/active` for the count and renders **nothing** when nobody is in a run, so it only lights up when there is live activity. Singular/plural handled ("1 Player Live").

`LiveNavButton` is self-contained (its own lightweight 60s poll) on purpose: the navbar mounts on every page, so I avoided importing the live-page module chain into the global bundle. The 60s cadence is gentle since a live count does not need to be second-accurate.

Note: this is the first public surfacing of `/live` (it was unlisted before), which matches making it discoverable now. tsc + eslint clean.