### PR TITLE
Mod DAU telemetry: commit the backend, hide it from Swagger, show it in the admin dashboard

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -64,6 +64,7 @@ from .routers import (
     mod_meta,
     presence,
     announcements,
+    telemetry,
 )
 from .services.data_service import (
     current_channel,
@@ -576,6 +577,9 @@ app.include_router(tierlists.router)
 app.include_router(mod_meta.router)
 app.include_router(presence.router)
 app.include_router(announcements.router)
+# Hidden from the OpenAPI schema (/docs): the mod's DAU ping is an internal
+# endpoint, not part of the public API surface.
+app.include_router(telemetry.router, include_in_schema=False)
 # Overlay-direct OpenID flow uses /auth/steam-popup as Steam's return_to.
 # This is intentionally outside /api/* — it's a user-facing HTML page,
 # not a JSON API — so it's mounted at the app level rather than under

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -114,15 +114,66 @@ def _snapshot_info() -> dict:
         return {}
 
 
+def _dau_info() -> dict:
+    """Mod usage from the telemetry_dau collection (distinct salted steam-id
+    hashes per day): today's count, 7- and 30-day distinct accounts, and a
+    14-day daily series. Empty without Mongo."""
+    try:
+        if not os.environ.get("MONGO_URL", "").strip():
+            return {}
+        from ..services.runs_db_mongo import get_database
+
+        coll = get_database().telemetry_dau
+        rows = list(
+            coll.aggregate(
+                [
+                    {"$group": {"_id": "$day", "count": {"$sum": 1}}},
+                    {"$sort": {"_id": -1}},
+                    {"$limit": 14},
+                ]
+            )
+        )
+        series = [{"day": r["_id"], "count": r["count"]} for r in reversed(rows)]
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        today_count = next((r["count"] for r in series if r["day"] == today), 0)
+
+        def _distinct_since(days: int) -> int:
+            cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime(
+                "%Y-%m-%d"
+            )
+            res = list(
+                coll.aggregate(
+                    [
+                        {"$match": {"day": {"$gte": cutoff}}},
+                        {"$group": {"_id": "$uid"}},
+                        {"$count": "n"},
+                    ]
+                )
+            )
+            return res[0]["n"] if res else 0
+
+        return {
+            "today": today_count,
+            "wau": _distinct_since(7),
+            "mau": _distinct_since(30),
+            "series": series,
+        }
+    except Exception:
+        logger.warning("admin dau info failed", exc_info=True)
+        return {}
+
+
 @router.get("/overview")
 def overview(request: Request):
-    """Operational vitals: run volume, users, snapshot freshness, Redis."""
+    """Operational vitals: run volume, users, snapshot freshness, Redis, and
+    the mod's daily-active-user counts."""
     _audit(request)
     return {
         "runs": _runs_info(),
         "users": _users_info(),
         "snapshot": _snapshot_info(),
         "redis": app_cache.info(),
+        "dau": _dau_info(),
         "environment": os.environ.get("ENVIRONMENT", "development"),
     }
 

--- a/backend/app/routers/telemetry.py
+++ b/backend/app/routers/telemetry.py
@@ -1,0 +1,108 @@
+"""Daily-active-user telemetry.
+
+The in-game mod posts once per launch to POST /api/telemetry/ping, authenticated with the
+Steam-issued JWT it already holds (a public client can carry no static secret, so the
+Steam ticket is the security gate). The backend stores only a salted hash of the steam id,
+one doc per (day, hash) - so DAU(day) = distinct hashes that day, one count per account per
+day, pseudonymous in storage, and not inflatable without real game-owning Steam accounts.
+Docs carry a TTL (~120 days); longer history would want a separate daily rollup. Mongo-only:
+without MONGO_URL the endpoints return 503.
+
+Set TELEMETRY_SALT (a server-side secret, in neither repo) so the stored hashes are not
+reversible by brute-forcing the 17-digit steam id space.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+
+router = APIRouter(prefix="/api/telemetry", tags=["Telemetry"])
+
+DAU_TTL_DAYS = 120
+_MAX_STR = 64
+
+_coll = None
+
+
+def _dau_coll():
+    global _coll
+    if _coll is None:
+        from ..services.runs_db_mongo import get_database
+
+        coll = get_database().telemetry_dau
+        coll.create_index("seen_at", expireAfterSeconds=DAU_TTL_DAYS * 86400)
+        coll.create_index("day")
+        _coll = coll
+    return _coll
+
+
+def _require_mongo():
+    if not os.environ.get("MONGO_URL", "").strip():
+        raise HTTPException(status_code=503, detail="telemetry unavailable")
+
+
+def _clean(v):
+    return v[:_MAX_STR] if isinstance(v, str) and v else None
+
+
+def _hash_steam_id(steam_id: str) -> str:
+    salt = os.environ.get("TELEMETRY_SALT", "")
+    return hashlib.sha256(f"{salt}:{steam_id}".encode()).hexdigest()
+
+
+@router.post("/ping")
+async def ping(request: Request):
+    _require_mongo()
+
+    auth = request.headers.get("authorization") or ""
+    if not auth.lower().startswith("bearer "):
+        raise HTTPException(status_code=401, detail="telemetry requires sign-in")
+    from ..services.auth_jwt import decode_token
+
+    claims = decode_token(auth[7:].strip())
+    steam_id = str((claims or {}).get("steam_id") or "")
+    if not steam_id.isdigit():
+        raise HTTPException(status_code=401, detail="invalid token")
+
+    try:
+        data = await request.json()
+    except Exception:
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+
+    now = datetime.now(timezone.utc)
+    day = now.strftime("%Y-%m-%d")
+    uid = _hash_steam_id(steam_id)
+    _dau_coll().update_one(
+        {"_id": f"{day}:{uid}"},
+        {
+            "$set": {
+                "day": day,
+                "uid": uid,
+                "mod_version": _clean(data.get("mod_version")),
+                "sts2_version": _clean(data.get("sts2_version")),
+                "seen_at": now,
+            }
+        },
+        upsert=True,
+    )
+    return {"ok": True}
+
+
+@router.get("/dau")
+def dau(days: int = 30):
+    _require_mongo()
+    days = max(1, min(days, DAU_TTL_DAYS))
+    rows = _dau_coll().aggregate(
+        [
+            {"$group": {"_id": "$day", "count": {"$sum": 1}}},
+            {"$sort": {"_id": -1}},
+            {"$limit": days},
+        ]
+    )
+    return {"dau": [{"day": r["_id"], "count": r["count"]} for r in rows]}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -57,6 +57,10 @@ services:
       - R2_PUBLIC_BASE_URL=${R2_PUBLIC_BASE_URL:-}
       - SENTRY_DSN=${SENTRY_DSN:-}
       - ADMIN_IDS=${ADMIN_IDS:-}
+      # Server-side secret (in neither repo) so the stored daily DAU hashes
+      # aren't brute-forceable back to steam ids. The count works without it,
+      # but set it. See routers/telemetry.py.
+      - TELEMETRY_SALT=${TELEMETRY_SALT:-}
       - STEAM_WEB_API_KEY=${STEAM_WEB_API_KEY:-}
       - GITHUB_APP_ID=${GITHUB_APP_ID:-}
       - GITHUB_APP_INSTALLATION_ID=${GITHUB_APP_INSTALLATION_ID:-}

--- a/frontend/app/admin/AdminClient.tsx
+++ b/frontend/app/admin/AdminClient.tsx
@@ -26,6 +26,12 @@ interface Overview {
     hit_rate?: number | null;
     uptime_days?: number;
   };
+  dau?: {
+    today?: number;
+    wau?: number;
+    mau?: number;
+    series?: { day: string; count: number }[];
+  };
   environment: string;
 }
 
@@ -102,7 +108,7 @@ export default function AdminClient() {
           </div>
 
           <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Redis</h2>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
             <Card
               label="Status"
               value={!redis?.enabled ? "disabled" : redis.ok ? "up" : "down"}
@@ -119,6 +125,44 @@ export default function AdminClient() {
               sub={redis?.uptime_days != null ? `up ${redis.uptime_days}d` : undefined}
             />
           </div>
+
+          <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">
+            Mod usage
+          </h2>
+          <div className="grid grid-cols-3 gap-3 mb-4">
+            <Card label="Active today" value={(data.dau?.today ?? 0).toLocaleString()} />
+            <Card
+              label="Last 7 days"
+              value={(data.dau?.wau ?? 0).toLocaleString()}
+              sub="distinct players"
+            />
+            <Card
+              label="Last 30 days"
+              value={(data.dau?.mau ?? 0).toLocaleString()}
+              sub="distinct players"
+            />
+          </div>
+          {(data.dau?.series?.length ?? 0) > 0 && (
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+              <div className="text-xs uppercase tracking-wider text-[var(--text-muted)] mb-2">
+                Daily active, last {data.dau!.series!.length} days
+              </div>
+              <div className="flex items-end gap-1 h-20">
+                {(() => {
+                  const series = data.dau!.series!;
+                  const max = Math.max(1, ...series.map((d) => d.count));
+                  return series.map((d) => (
+                    <div
+                      key={d.day}
+                      title={`${d.day}: ${d.count}`}
+                      className="flex-1 rounded-t bg-[var(--accent-gold)]/60"
+                      style={{ height: `${Math.max(4, Math.round((d.count / max) * 100))}%` }}
+                    />
+                  ));
+                })()}
+              </div>
+            </div>
+          )}
         </>
       )}
     </AdminShell>


### PR DESCRIPTION
Commits the mod session's DAU telemetry and surfaces it where I can see it.

**Telemetry backend** (`routers/telemetry.py`, handed over uncommitted):
- `POST /api/telemetry/ping` - the mod posts once per launch, authenticated with the Steam-issued JWT it already holds (a public client carries no static secret, so the Steam ticket is the gate). Stores only `sha256(TELEMETRY_SALT:steam_id)` keyed per day, one doc per (day, hash) with a ~120-day TTL. So DAU = distinct hashes/day = one count per account per day; the raw steam id is never stored and the hash isn't reversible without the salt.
- `GET /api/telemetry/dau` - daily counts.

**Hidden from Swagger:** wired via `app.include_router(telemetry.router, include_in_schema=False)`, so neither endpoint shows in `/docs`.

**Deploy secret:** added `TELEMETRY_SALT` to the prod compose backend env (value goes in the box `.env`, in neither repo). The count works without it, but then the hashes are brute-forceable back to steam ids, so set it.

**Admin dashboard:** `/api/admin/overview` now includes a `dau` block (today, 7-day and 30-day distinct players, and a 14-day daily series), and the admin page renders a "Mod usage" section: cards for Active today / Last 7 days / Last 30 days plus a small daily-active bar chart. Read behind the existing admin auth.

Tradeoff worth knowing (from the mod session): DAU now counts Steam-authenticated launches, not every launch - essentially everyone for a Steam game, but offline/auth-failed launches won't count. That's the cost of making it forgery-resistant.

`GET /api/telemetry/dau` is left open (just hidden from the schema); the admin reads the same collection behind auth. Happy to gate that public read too if you'd rather DAU not be readable without auth.