### PR TITLE
Fix admin analytics: hit umami directly, handle its new API shapes, show realtime

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -326,9 +326,13 @@ async def _umami_get(client, url: str, params: dict) -> dict | None:
     # host-side var arrives as an EMPTY string, not a missing key; a
     # plain .get() default never kicks in and httpx then explodes on a
     # host-less URL. `or` past the empty string to the real default.
-    base = (
-        os.environ.get("UMAMI_URL", "").strip() or "https://analytics.spire-codex.com"
-    ).rstrip("/")
+    #
+    # Default to the container next door over the shared docker network, NOT
+    # the public host. analytics.spire-codex.com sits behind Cloudflare
+    # Access, so a server-side login POST there gets the CF challenge page
+    # instead of the API and every call silently returns None - blank cards
+    # that look like zero traffic. umami:3000 is the same box, no edge.
+    base = (os.environ.get("UMAMI_URL", "").strip() or "http://umami:3000").rstrip("/")
     username = os.environ.get("UMAMI_USERNAME", "").strip()
     password = os.environ.get("UMAMI_PASSWORD", "").strip()
     for attempt in (1, 2):
@@ -356,11 +360,41 @@ async def _umami_get(client, url: str, params: dict) -> dict | None:
     return None
 
 
+def _active_count(raw) -> int:
+    """Umami's /active endpoint has shipped two shapes across versions:
+    `[{"x": N}]` (older) and `{"visitors": N}` (current). Accept either, and
+    None (the call failed) as 0."""
+    if isinstance(raw, list):
+        return int(raw[0].get("x", 0)) if raw and isinstance(raw[0], dict) else 0
+    if isinstance(raw, dict):
+        return int(raw.get("visitors", raw.get("x", 0)) or 0)
+    return 0
+
+
+def _norm_stats(raw) -> dict | None:
+    """Umami's /stats shape changed across versions. Current builds return flat
+    numbers with the previous period under `comparison`:
+        {"pageviews": 4938, "visitors": 1302, ..., "comparison": {"pageviews": 4891, ...}}
+    older builds nested each metric as {"value": N, "prev": M}. Normalise both
+    to {metric: {value, prev}} so the admin UI has one stable contract."""
+    if not isinstance(raw, dict):
+        return None
+    comp = raw.get("comparison") or {}
+    out: dict = {}
+    for k in ("pageviews", "visitors", "visits", "bounces", "totaltime"):
+        v = raw.get(k)
+        if isinstance(v, dict):  # already {value, prev}
+            out[k] = {"value": v.get("value"), "prev": v.get("prev")}
+        elif v is not None:
+            out[k] = {"value": v, "prev": comp.get(k)}
+    return out or None
+
+
 @router.get("/analytics")
 async def analytics(request: Request):
-    """Umami headline numbers: visitors and pageviews for the last 24h and
-    7d, plus the top pages, proxied server-side. 503 until UMAMI_USERNAME
-    and UMAMI_PASSWORD are configured."""
+    """Umami headline numbers: active visitors right now, plus visitors and
+    pageviews for the last 24h and 7d and the top pages, proxied server-side.
+    503 until UMAMI_USERNAME and UMAMI_PASSWORD are configured."""
     _audit(request)
     if not (
         os.environ.get("UMAMI_USERNAME", "").strip()
@@ -384,6 +418,8 @@ async def analytics(request: Request):
     day_ms = 24 * 3600 * 1000
     try:
         async with httpx.AsyncClient(timeout=15) as client:
+            # Visitors active in the last ~5 min: the realtime figure.
+            active_raw = await _umami_get(client, f"/api/websites/{website}/active", {})
             stats_24h = await _umami_get(
                 client,
                 f"/api/websites/{website}/stats",
@@ -394,16 +430,24 @@ async def analytics(request: Request):
                 f"/api/websites/{website}/stats",
                 {"startAt": now_ms - 7 * day_ms, "endAt": now_ms},
             )
+            # Current Umami calls the page-URL metric "path"; older builds
+            # called it "url" (and reject "path"), so fall back once.
+            page_params = {
+                "startAt": now_ms - 7 * day_ms,
+                "endAt": now_ms,
+                "limit": 10,
+            }
             top_pages = await _umami_get(
                 client,
                 f"/api/websites/{website}/metrics",
-                {
-                    "type": "url",
-                    "startAt": now_ms - 7 * day_ms,
-                    "endAt": now_ms,
-                    "limit": 10,
-                },
+                {"type": "path", **page_params},
             )
+            if top_pages is None:
+                top_pages = await _umami_get(
+                    client,
+                    f"/api/websites/{website}/metrics",
+                    {"type": "url", **page_params},
+                )
     except httpx.HTTPError as exc:
         # Bad UMAMI_URL, DNS failure, timeout: degrade to a labelled 502
         # instead of an anonymous 500 so the admin UI says what to fix.
@@ -413,9 +457,24 @@ async def analytics(request: Request):
         raise HTTPException(
             status_code=502, detail=f"Umami unreachable: {type(exc).__name__}: {exc}"
         ) from exc
+    # Every call comes back None when login itself failed (wrong creds, or
+    # UMAMI_URL pointing at the Cloudflare-gated public host). Say so loudly
+    # instead of returning a payload of blanks that reads as zero traffic.
+    if stats_24h is None and stats_7d is None and active_raw is None:
+        from fastapi import HTTPException
+
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                "Umami login/website lookup failed. Check UMAMI_URL points at the "
+                "internal http://umami:3000 (not the Cloudflare-gated public host), "
+                "the credentials, and UMAMI_WEBSITE_ID."
+            ),
+        )
     return {
-        "last_24h": stats_24h,
-        "last_7d": stats_7d,
+        "active": _active_count(active_raw),
+        "last_24h": _norm_stats(stats_24h),
+        "last_7d": _norm_stats(stats_7d),
         "top_pages": top_pages or [],
         # Always the public dashboard, never the container-internal
         # UMAMI_URL (http://umami:3000) the proxy itself may use.

--- a/frontend/app/admin/analytics/AnalyticsClient.tsx
+++ b/frontend/app/admin/analytics/AnalyticsClient.tsx
@@ -12,6 +12,7 @@ interface UmamiStat {
   prev?: number;
 }
 interface Analytics {
+  active?: number;
   last_24h?: { pageviews?: UmamiStat; visitors?: UmamiStat; visits?: UmamiStat } | null;
   last_7d?: { pageviews?: UmamiStat; visitors?: UmamiStat; visits?: UmamiStat } | null;
   top_pages?: { x: string; y: number }[];
@@ -27,16 +28,30 @@ export default function AnalyticsClient() {
   const [note, setNote] = useState<string | null>(null);
 
   useEffect(() => {
-    adminFetch<Analytics>("/api/admin/analytics")
-      .then(setData)
-      .catch((e) => {
-        const msg = String((e as Error)?.message || e);
-        setNote(
-          msg.includes("503")
-            ? "Umami isn't wired up yet: set UMAMI_USERNAME and UMAMI_PASSWORD in the box .env (UMAMI_URL and UMAMI_WEBSITE_ID optional) and redeploy."
-            : msg,
-        );
-      });
+    let alive = true;
+    const load = () =>
+      adminFetch<Analytics>("/api/admin/analytics")
+        .then((d) => {
+          if (!alive) return;
+          setData(d);
+          setNote(null);
+        })
+        .catch((e) => {
+          if (!alive) return;
+          const msg = String((e as Error)?.message || e);
+          setNote(
+            msg.includes("503")
+              ? "Umami isn't wired up yet: set UMAMI_USERNAME and UMAMI_PASSWORD in the box .env (UMAMI_URL defaults to http://umami:3000) and redeploy."
+              : msg,
+          );
+        });
+    load();
+    // Re-poll so the active-now figure stays realtime.
+    const id = setInterval(load, 30000);
+    return () => {
+      alive = false;
+      clearInterval(id);
+    };
   }, []);
 
   return (
@@ -54,6 +69,26 @@ export default function AnalyticsClient() {
             >
               Open the full Umami dashboard →
             </a>
+          </div>
+
+          <div className="mb-8 flex flex-wrap items-center gap-4">
+            <div className="flex items-center gap-3 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-5 py-4">
+              <span className="relative flex h-3 w-3">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+                <span className="relative inline-flex h-3 w-3 rounded-full bg-emerald-500" />
+              </span>
+              <div>
+                <div className="text-2xl font-bold tabular-nums text-emerald-400">
+                  {(data.active ?? 0).toLocaleString()}
+                </div>
+                <div className="text-xs uppercase tracking-wider text-[var(--text-muted)]">
+                  Active now
+                </div>
+              </div>
+            </div>
+            <span className="text-xs text-[var(--text-muted)]">
+              visitors in the last 5 min · refreshes every 30s
+            </span>
           </div>
 
           <h2 className="text-lg font-semibold text-[var(--accent-gold)] mb-3">Last 24 hours</h2>

--- a/frontend/app/admin/shared.tsx
+++ b/frontend/app/admin/shared.tsx
@@ -27,7 +27,18 @@ export async function adminFetch<T>(path: string, init: RequestInit = {}): Promi
     ...init,
     headers: { ...authHeaders(), ...(init.headers as Record<string, string>) },
   });
-  if (!res.ok) throw new Error(`${path} -> ${res.status}`);
+  if (!res.ok) {
+    // Surface the backend's `detail` (e.g. the Umami misconfig hint), not just
+    // a bare status code, so the operator pages can show what to actually fix.
+    let detail = "";
+    try {
+      const body = await res.json();
+      if (body?.detail) detail = `: ${body.detail}`;
+    } catch {
+      /* non-JSON error body */
+    }
+    throw new Error(`${path} -> ${res.status}${detail}`);
+  }
   return res.json();
 }
 


### PR DESCRIPTION
The admin Analytics tab showed no data. I probed Umami from inside the backend container, using the same env and network the real proxy uses, and the data was always reachable: 1,302 visitors in 24h, 5 active now. Three things were wrong on the site side, all fixed here.

1. The proxy defaulted UMAMI_URL to the public host, which is behind Cloudflare Access, so the server-side login got the challenge page and every call silently returned nothing. It now defaults to http://umami:3000 (same box, no edge).
2. Umami's stats shape changed to flat numbers with the previous period under a comparison object, where the UI expected {value, prev}. Added _norm_stats to handle both shapes.
3. The page metric is type=path now (type=url returns 400). Switched, with a url fallback for older builds.

Also added the realtime figure (active visitors in the last 5 min) as an Active now card that re-polls every 30s, and made adminFetch surface the backend error detail instead of a bare status code.

Deploy: works with UMAMI_URL unset. Stats render on the new backend; the Active now card needs the new frontend.