### PR TITLE
Stop the live pill from pushing the profile menu off-screen at lg

### DIFF
--- a/frontend/app/components/LiveNavButton.tsx
+++ b/frontend/app/components/LiveNavButton.tsx
@@ -80,7 +80,11 @@ export default function LiveNavButton({
       className="hidden lg:inline-flex items-center gap-2 h-9 px-3 rounded-full text-xs font-semibold text-red-300 border border-red-500/40 bg-red-500/10 hover:bg-red-500/20 transition-colors shrink-0 shadow-[0_0_12px_rgba(239,68,68,0.35)]"
     >
       <LiveCircle />
-      {label}
+      {/* Compact (count only) from lg to xl, where the full nav row is
+          tight and the long label would shove the profile menu off-screen;
+          the full label appears at xl+ once there's room. */}
+      <span className="tabular-nums xl:hidden">{count}</span>
+      <span className="hidden xl:inline">{label}</span>
     </Link>
   );
 }


### PR DESCRIPTION
At the lg breakpoint the navbar drops the burger menu and shows the full horizontal nav, search icon, and right cluster at once. The live pill added about 110px to a row where nothing shrinks or wraps, so the rightmost item, the profile menu, got pushed off the right edge. It only happened when someone is live, and longer-label languages made it worse.

Fix: keep the pill at lg but render it compact there, just the glowing dot and the count. The full N Players Live label only renders at xl where there is room. The common laptop sizes (1366x768, 1440x900) are below xl, so gating the whole pill to xl would hide it from exactly the people most likely to use it. The compact form keeps it visible everywhere without overflowing, and since the long label only renders at xl no language can break the row.