### PR TITLE
Stop ancient events leaking a raw localization key on the run page

### DIFF
--- a/frontend/app/runs/[hash]/RunSummary.tsx
+++ b/frontend/app/runs/[hash]/RunSummary.tsx
@@ -441,11 +441,15 @@ function MapNode({
           + {ps.relic_choices.filter((r) => r.was_picked).map((r) => displayName(r.choice)).join(", ")}
         </div>
       )}
-      {ps?.event_choices?.[0]?.title?.key && (
-        <div className="text-[10px] text-[var(--text-secondary)] mt-1 italic">
-          chose {humanizeChoiceKey(ps.event_choices[0].title.key)}
-        </div>
-      )}
+      {(() => {
+        const choiceKey = ps?.event_choices?.[0]?.title?.key;
+        const choice = choiceKey ? humanizeChoiceKey(choiceKey) : "";
+        return choice ? (
+          <div className="text-[10px] text-[var(--text-secondary)] mt-1 italic">
+            chose {choice}
+          </div>
+        ) : null;
+      })()}
       <div className="absolute left-1/2 -translate-x-1/2 top-full w-2 h-2 bg-[var(--bg-card)] border-r border-b border-[var(--border-subtle)] rotate-45 -mt-1" />
     </div>
   );
@@ -479,13 +483,20 @@ function MapNode({
 }
 
 function humanizeChoiceKey(key: string): string {
-  // e.g. "MORPHIC_GROVE.pages.INITIAL.options.LONER.title" → "Loner"
+  // Event choices are stored as the game's localization key, e.g.
+  // "MORPHIC_GROVE.pages.INITIAL.options.LONER.title" → "Loner". Pull the
+  // segment after "options" when the event had a branching choice.
   const parts = key.split(".");
   const idx = parts.findIndex((p) => p === "options");
   if (idx >= 0 && parts[idx + 1]) {
     return parts[idx + 1].replace(/_/g, " ").toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase());
   }
-  return key;
+  // No "options" segment means there was no real choice: ancients and other
+  // single-outcome events record a page key like
+  // "ancients.NONUPEIPE.pages.DONE.description". Returning the raw dotted key
+  // would leak it onto the page, so drop it (the caller skips the line). A
+  // plain, dot-free label is already human and passes through.
+  return key.includes(".") ? "" : key;
 }
 
 function IconStat({ icon, alt, value, color }: { icon: string; alt: string; value: ReactNode; color?: string }) {


### PR DESCRIPTION
On a run page (the NONUPEIPE ancient) the map node showed a raw localization key under the event: ancients.NONUPEIPE.pages.DONE.description.

The map renders the chosen option through humanizeChoiceKey, which only handled keys with an options segment (a branching choice like MORPHIC_GROVE.pages.INITIAL.options.LONER.title becomes Loner). Ancients and other single-outcome events have no branching choice, so the game records a page key with no options segment, which fell through to returning the raw key.

Fix: humanizeChoiceKey returns an empty string for any dotted key with no options segment (a plain label still passes through), and the render skips the line when there is nothing to show. Single-outcome events no longer print a key; the event node already names the event. One file, frontend only.