### PR TITLE
Per-user pick rates endpoint + env-driven ancient-offer gate

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -920,6 +920,27 @@ def community_stats(request: Request, response: Response):
     return get_community_fun_stats()
 
 
+@router.get("/me/picks", tags=["Runs"])
+@limiter.limit("60/minute")
+def my_picks(request: Request, response: Response):
+    """The signed-in player's own pick rates across decision surfaces (card
+    rewards + ancient 3-relic offers for now). Scoped to the JWT's verified
+    steam_id; never accepts an arbitrary steam_id param (self-only)."""
+    auth_header = request.headers.get("authorization") or ""
+    if not auth_header.lower().startswith("bearer "):
+        raise HTTPException(status_code=401, detail="auth required")
+    from ..services.auth_jwt import decode_token
+    from ..services.runs_db_mongo import get_user_picks
+
+    claims = decode_token(auth_header[7:].strip())
+    steam_id = str((claims or {}).get("steam_id") or "")
+    if not steam_id.isdigit():
+        raise HTTPException(status_code=401, detail="invalid token")
+
+    response.headers["Cache-Control"] = "private, max-age=60"
+    return get_user_picks(steam_id)
+
+
 @router.get("/metrics/{entity_type}", tags=["Runs"])
 @limiter.limit("60/minute")
 def get_entity_metrics(

--- a/backend/app/services/community_stats.py
+++ b/backend/app/services/community_stats.py
@@ -15,6 +15,7 @@ the aggregation + display-name resolution; it must not import
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,14 @@ _NAMESPACES = frozenset(
 _SMITH = "SMITH"
 # How many rows to keep in each ranked list (events keeps all, they're finite).
 _TOP_N = 15
+# Minimum times a relic must have been offered at Ancient screens before its
+# take rate is published. Each of the eight ancients draws from its own relic
+# pool, so any one relic's offered-count climbs slowly; the default keeps thin
+# beta samples out of the in-game tip, but the beta env sets it to 1 so take
+# rates show from the first offers (the tip prints "(N offers)" for context).
+# `.strip() or "20"` so a docker-compose `${VAR:-}` passthrough (empty string,
+# not an absent key) still falls back to the default instead of crashing int("").
+MIN_ANCIENT_OFFERS = int(os.getenv("COMMUNITY_ANCIENT_MIN_OFFERS", "").strip() or "20")
 
 
 def _bare(raw: str | None) -> str | None:
@@ -512,7 +521,7 @@ def finalize(acc: dict[str, Any]) -> dict[str, Any]:
                 "take_rate": _pct(rec[0], rec[1]),
             }
             for rid, rec in acc["ancient"].items()
-            if rec[1] >= 20
+            if rec[1] >= MIN_ANCIENT_OFFERS
         },
         "most_removed": _ranked(removed, names["cards"], _TOP_N),
         "hopper_stolen": _ranked(acc.get("stolen") or {}, names["cards"], 10),

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -2008,6 +2008,74 @@ def distinct_build_ids() -> list[str]:
     return sorted([v for v in coll.distinct("build_id") if v], reverse=True)
 
 
+@_instrument("get_user_picks")
+def get_user_picks(steam_id: str) -> dict[str, dict]:
+    """One player's own pick rates (by steam_id), no min-sample gate:
+      - cards:    card-reward keep rate, from the flat card_choices array
+                  (already scoped to the submitter at write time).
+      - ancients: relic take rate at the 3-relic ancient offers, from
+                  ancient_choice nested in map_point_history.
+    Keyed by entity id (uppercase bare, as stored)."""
+    coll = _get_collection()
+
+    def tally(rows) -> dict[str, dict]:
+        return {
+            r["_id"]: {"picked": r["picked"], "offered": r["offered"]}
+            for r in rows
+            if r.get("_id")
+        }
+
+    cards = coll.aggregate(
+        [
+            {"$match": {"steam_id": steam_id}},
+            {"$unwind": "$card_choices"},
+            {
+                "$group": {
+                    "_id": "$card_choices.card_id",
+                    "offered": {"$sum": 1},
+                    "picked": {"$sum": {"$cond": ["$card_choices.was_picked", 1, 0]}},
+                }
+            },
+        ],
+        allowDiskUse=True,
+    )
+
+    # ancient_choice isn't a flat field - it's nested in map_point_history
+    # (acts -> floors -> player_stats -> ancient_choice), so unwind down to it.
+    # Bounded to one user's runs, so the nested unwind stays cheap. Mirrors the
+    # community accumulation in community_stats.py: +1 offered per relic, +1
+    # picked when was_chosen. Single-player accurate; in multiplayer this counts
+    # every seat's offers in the run (map_point_history holds all players).
+    A = "$map_point_history"
+    ancients = coll.aggregate(
+        [
+            {"$match": {"steam_id": steam_id}},
+            {"$unwind": A},  # acts -> one act (a list of floors)
+            {"$unwind": A},  # floors -> one floor (a dict)
+            {"$unwind": f"{A}.player_stats"},
+            {"$unwind": f"{A}.player_stats.ancient_choice"},
+            {
+                "$group": {
+                    "_id": f"{A}.player_stats.ancient_choice.TextKey",
+                    "offered": {"$sum": 1},
+                    "picked": {
+                        "$sum": {
+                            "$cond": [
+                                f"{A}.player_stats.ancient_choice.was_chosen",
+                                1,
+                                0,
+                            ]
+                        }
+                    },
+                }
+            },
+        ],
+        allowDiskUse=True,
+    )
+
+    return {"cards": tally(cards), "ancients": tally(ancients)}
+
+
 @_instrument("get_username_for_hash")
 def get_username_for_hash(run_hash: str) -> str | None:
     """Look up the username associated with a single run hash."""

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -61,6 +61,11 @@ services:
       # aren't brute-forceable back to steam ids. The count works without it,
       # but set it. See routers/telemetry.py.
       - TELEMETRY_SALT=${TELEMETRY_SALT:-}
+      # Min times a relic must be offered at an Ancient screen before its
+      # community take-rate is published to the in-game tip. Empty here ->
+      # the code default (20); the beta .env sets it to 1 so take-rates show
+      # on a small corpus. See services/community_stats.py.
+      - COMMUNITY_ANCIENT_MIN_OFFERS=${COMMUNITY_ANCIENT_MIN_OFFERS:-}
       - STEAM_WEB_API_KEY=${STEAM_WEB_API_KEY:-}
       - GITHUB_APP_ID=${GITHUB_APP_ID:-}
       - GITHUB_APP_INSTALLATION_ID=${GITHUB_APP_INSTALLATION_ID:-}


### PR DESCRIPTION
Backend side of the mod's per-user pick stats. The mod is already built to these contracts and degrades silently until they ship, so deploy order does not matter.

Change 1: the community ancient take-rate only publishes a relic once it has been offered at least 20 times. Each of the eight ancients draws from its own pool, so any single relic climbs slowly and stays under 20 for a long time in a small beta. Made the threshold env-driven (COMMUNITY_ANCIENT_MIN_OFFERS, default 20); set it to 1 in the beta .env and take-rates show from the first offers. The strip-or-default guard keeps a docker-compose empty-string passthrough from crashing int of an empty string.

Change 2: GET /api/runs/me/picks (Steam JWT, scoped to the verified steam_id, never a query param) returns {cards, ancients}, each a map of id to {picked, offered}. Cards come from the flat card_choices array; ancients from a nested map_point_history unwind down to ancient_choice. No min-sample gate. I validated the nested path against a real v0.107.0 run blob: 3 acts, 9 ancient offers, picked and offered counts exact.

Single-player accurate; in multiplayer the ancient count includes every seat's offers, fine for now.

Deploy: set COMMUNITY_ANCIENT_MIN_OFFERS=1 in the beta .env. /me/picks needs no migration.