### PR TITLE
Float beta-only entities to the top of each tier-list tray

### DIFF
--- a/frontend/app/tier-list-maker/TierListBuilder.tsx
+++ b/frontend/app/tier-list-maker/TierListBuilder.tsx
@@ -38,6 +38,10 @@ import type { EntityType, Tier, TierEntity, TierList } from "./types";
 
 type Containers = Record<string, string[]>;
 
+// Synthetic tray filter that matches beta-only entities by their `beta` flag
+// instead of their color/pool group, so beta content has a one-click pill.
+const BETA_GROUP = "__beta__";
+
 interface Props {
   entityType: EntityType;
   entities: TierEntity[];
@@ -391,7 +395,12 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
   // the loaded pool, so we never render an empty pill.
   const trayGroups = useMemo(() => {
     const defs = GROUPS_BY_TYPE[entityType] ?? [];
-    return defs.filter((g) => entities.some((e) => e.group === g.value));
+    const present = defs.filter((g) => entities.some((e) => e.group === g.value));
+    // Lead with a Beta pill whenever the pool has beta-only entities, so the
+    // new content is one click away no matter how it groups by color or pool.
+    return entities.some((e) => e.beta)
+      ? [{ value: BETA_GROUP, label: "Beta" }, ...present]
+      : present;
   }, [entities, entityType]);
 
   // Rarities present in this pool, in canonical order, for the rarity
@@ -411,7 +420,9 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
     return trayItems.filter((id) => {
       const e = entityMap.get(id);
       if (!e) return false;
-      if (groupFilter && e.group !== groupFilter) return false;
+      if (groupFilter === BETA_GROUP) {
+        if (!e.beta) return false;
+      } else if (groupFilter && e.group !== groupFilter) return false;
       if (rarityFilter && e.rarity !== rarityFilter) return false;
       if (q && !e.name.toLowerCase().includes(q)) return false;
       return true;

--- a/frontend/app/tier-list-maker/api.ts
+++ b/frontend/app/tier-list-maker/api.ts
@@ -110,13 +110,20 @@ export async function fetchEntities(type: EntityType): Promise<TierEntity[]> {
   // or entity fetch just means no additions.
   const betaRaw = await fetchBetaAdditions(type);
   const mainIds = new Set(raw.map((e) => e.id));
+  const isBeta = (e: RawEntity) => !mainIds.has(e.id);
 
-  return [
-    ...raw,
-    ...betaRaw.filter((e) => !mainIds.has(e.id)),
-  ]
-    .sort((a, b) => (a.compendium_order ?? 0) - (b.compendium_order ?? 0))
-    .map((e) => toEntity(e, !mainIds.has(e.id)));
+  return [...raw, ...betaRaw.filter(isBeta)]
+    // Float beta-only entities to the top of the tray (and so to the top of
+    // whatever group filter is active) instead of letting their compendium
+    // order bury them mid-list among hundreds of cards/relics. Otherwise the
+    // only beta entity people notice is the one that happens to lack an order
+    // and sorts first by accident. Ties fall back to compendium order.
+    .sort((a, b) => {
+      const ra = isBeta(a) ? 0 : 1;
+      const rb = isBeta(b) ? 0 : 1;
+      return ra - rb || (a.compendium_order ?? 0) - (b.compendium_order ?? 0);
+    })
+    .map((e) => toEntity(e, isBeta(e)));
 }
 
 /** The current beta's added entities for a type, fetched from the beta


### PR DESCRIPTION
The beta cards and relics already load into the tier list maker, they were just buried. The tray sorts by compendium order, so SCARE and the beta relics land in the middle of a few hundred entries. AEONGLASS only stood out because it has no compendium order, so it floated to the top by accident.

Two changes here. Beta-only entities now sort to the top of the tray, and to the top of whatever filter is active. And there is a Beta filter pill that shows only the beta content for the current type. So the new cards, relics, and monsters are obvious in every list.

I checked against the live API first that the beta entities load and their images resolve, so this is about prominence, not loading.