### PR TITLE
Fix the Beta pill count in the tier list maker

### DIFF
--- a/frontend/app/tier-list-maker/TierListBuilder.tsx
+++ b/frontend/app/tier-list-maker/TierListBuilder.tsx
@@ -384,8 +384,12 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
   const groupCounts = useMemo(() => {
     const m: Record<string, number> = {};
     for (const id of trayItems) {
-      const g = entityMap.get(id)?.group;
-      if (g) m[g] = (m[g] ?? 0) + 1;
+      const e = entityMap.get(id);
+      if (!e) continue;
+      if (e.group) m[e.group] = (m[e.group] ?? 0) + 1;
+      // The Beta pill matches on the beta flag, not a group key, so tally it
+      // separately or its count would always read 0.
+      if (e.beta) m[BETA_GROUP] = (m[BETA_GROUP] ?? 0) + 1;
     }
     return m;
   }, [trayItems, entityMap]);


### PR DESCRIPTION
The Beta filter pill in the tier list maker showed (0) even when beta content was present (2 for cards). The pill counts come from groupCounts, which only tallied entities by their color or pool group, and beta entities keep their real group, so nothing matched the Beta key. Clicking the pill already filtered to the right items; only the number was wrong.

This also tallies entities by their beta flag under the Beta key, so the count matches what the filter shows.

Follow-up to the Beta pill in #484, which merged before this fix was pushed.