### PR TITLE
Use Kreon as the site typeface

### DIFF
--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -215,7 +215,7 @@ export default function Navbar() {
             <span className="hidden sm:inline text-xl font-bold text-[var(--accent-gold)]">
               SPIRE
             </span>
-            <span className="hidden sm:inline text-xl font-light text-[var(--text-primary)]">
+            <span className="hidden sm:inline text-xl font-normal text-[var(--text-primary)]">
               CODEX
             </span>
           </Link>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -43,7 +43,10 @@
 @theme inline {
   --color-background: var(--bg-primary);
   --color-foreground: var(--text-primary);
-  --font-sans: var(--font-geist-sans);
+  /* Kreon (the Slay the Spire 2 typeface) is the site font; Geist stays as the
+     sans fallback if Kreon fails to load. Mono keeps Geist Mono for tabular
+     alignment of ids and numbers. */
+  --font-sans: var(--font-kreon), var(--font-geist-sans), Arial, Helvetica, sans-serif;
   --font-mono: var(--font-geist-mono);
 }
 

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Script from "next/script";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Kreon } from "next/font/google";
 import "./globals.css";
 import Navbar from "./components/Navbar";
 import BetaChrome from "./components/BetaChrome";
@@ -48,6 +48,15 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+// The site typeface: Kreon, the serif Slay the Spire 2 uses, self-hosted via
+// next/font (woff2, weights 300-700). Geist stays loaded as the fallback. The
+// 1:1 card renderer keeps its own exact local Kreon @font-face for pixel match.
+const kreon = Kreon({
+  variable: "--font-kreon",
+  subsets: ["latin"],
+  weight: ["300", "400", "500", "600", "700"],
+});
+
 // Belt-and-suspenders alongside the beta branch in robots.ts. Some bots
 // honor robots.txt only partially; an explicit noindex meta on every
 // beta page makes it impossible for a beta URL to enter the index.
@@ -88,7 +97,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}
+        className={`${kreon.variable} ${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}
       >
         <LanguageProvider>
           <Suspense>


### PR DESCRIPTION
Switch the site default font from Geist to Kreon, the serif Slay the Spire 2 uses, so the whole site matches the game.

Kreon now loads through next/font/google (self-hosted woff2, weights 300-700, same setup as Geist) and is the primary --font-sans, so it applies everywhere the sans font is used: body, headings, tables, and the SPIRE CODEX wordmark. Geist stays as the fallback if Kreon fails to load. Geist Mono is unchanged for monospace ids and numbers, where tabular alignment matters.

The 1:1 card renderer is untouched: it keeps its own exact local Kreon @font-face (extracted from the game files) for pixel-accurate card text, separate from the next/font copy.

One thing to watch after this ships: Kreon is a serif, so dense stat and leaderboard tables read a little heavier than with Geist. If any spots feel cramped, the fix is per-component, drop those back to var(--font-geist-sans).