### PR TITLE
Promote the new Nexus Mods mod across the site

### DIFF
--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -305,6 +305,17 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
               ),
             },
             {
+              title: "Download the mod",
+              desc: "Get the Spire Codex mod on Nexus Mods for in-game stats contribution, auto run uploads, and a route planner.",
+              href: "https://www.nexusmods.com/slaythespire2/mods/1272",
+              ext: true,
+              icon: (
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" className="h-9 w-9">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v12m0 0l-4-4m4 4l4-4M4 15v4a2 2 0 002 2h12a2 2 0 002-2v-4" />
+                </svg>
+              ),
+            },
+            {
               title: "Support on Patreon",
               desc: "Like the project? Support us directly to unlock more features and keep the data free and as up to date as possible.",
               href: "https://www.patreon.com/cw/SpireCodex",

--- a/frontend/app/components/ModBanner.tsx
+++ b/frontend/app/components/ModBanner.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "mod-banner-dismissed";
+const MOD_URL = "https://www.nexusmods.com/slaythespire2/mods/1272";
+
+// Light-orange (Nexus Mods style) banner announcing the in-game mod. Sits
+// under the Overwolf banner and above the admin announcement banner. Dismiss
+// is remembered per browser, same pattern as the Overwolf banner.
+export default function ModBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!localStorage.getItem(STORAGE_KEY)) {
+      setVisible(true);
+    }
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="bg-orange-400 border-b border-orange-500">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2.5 flex items-center gap-3">
+        <p className="flex-1 min-w-0 text-sm text-orange-950">
+          <span className="font-semibold">Spire Codex now has a mod.</span>{" "}
+          Get the mod with in-game stats contribution, auto uploads, and route
+          planner{" "}
+          <a
+            href={MOD_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-semibold underline hover:text-black transition-colors"
+          >
+            here
+          </a>
+          .
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            localStorage.setItem(STORAGE_KEY, "1");
+            setVisible(false);
+          }}
+          aria-label="Dismiss mod banner"
+          className="text-orange-900/70 hover:text-orange-950 transition-colors text-lg leading-none flex-shrink-0"
+        >
+          &times;
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/RunDropZone.tsx
+++ b/frontend/app/components/RunDropZone.tsx
@@ -99,6 +99,14 @@ export default function RunDropZone({ onFiles, uploading, uploadProgress }: RunD
           >
             Download Overwolf Companion App
           </a>
+          <a
+            href="https://www.nexusmods.com/slaythespire2/mods/1272"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center justify-center w-full sm:w-auto px-5 py-2.5 sm:py-2 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-white hover:opacity-90 transition-opacity"
+          >
+            Get the Mod
+          </a>
           <label className="inline-flex items-center justify-center w-full sm:w-auto px-5 py-2.5 sm:py-2 rounded-lg text-sm font-medium bg-[var(--bg-primary)] text-[var(--text-primary)] border border-[var(--border-accent)] hover:bg-[var(--bg-card-hover)] transition-colors cursor-pointer">
             {t("Choose Files", lang)}
             <input

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -6,6 +6,7 @@ import Navbar from "./components/Navbar";
 import BetaChrome from "./components/BetaChrome";
 import DonationBanner from "./components/DonationBanner";
 import OverwolfBanner from "./components/OverwolfBanner";
+import ModBanner from "./components/ModBanner";
 import Footer from "./components/Footer";
 import GlobalSearch from "./components/GlobalSearch";
 import { Suspense } from "react";
@@ -107,6 +108,7 @@ export default function RootLayout({
               <Navbar />
               <div className="pt-16">
                 <OverwolfBanner />
+                <ModBanner />
                 <DonationBanner />
                 {/* tabIndex=-1 lets Navbar's main.focus() (PR #142) clear
                     focus-within from the dropdown after route changes. The


### PR DESCRIPTION
The mod is live on Nexus Mods (https://www.nexusmods.com/slaythespire2/mods/1272). This surfaces it in three spots:

1. Home get-started: a new "Download the mod" card between "Download the app" and "Support on Patreon", using the same download icon as "Download the app".

2. Run upload: a new "Get the Mod" button between "Download Overwolf Companion App" and "Choose Files". This lives in RunDropZone, the shared component, so it shows on both the submit-runs page and the profile from one change.

3. A new light-orange (Nexus style) banner under the Overwolf banner and above the admin announcement banner: "Spire Codex now has a mod. Get the mod with in-game stats contribution, auto uploads, and route planner here", where "here" links to the Nexus page. Dismissible per browser, same as the Overwolf banner.

tsc clean, eslint no errors.