### PR TITLE
Add A10, win-rate, mods, and version filters to the charts

### DIFF
--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -12,6 +12,7 @@ is set.
 """
 
 import logging
+import os
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from slowapi import Limiter
@@ -277,7 +278,32 @@ def charts_meta(request: Request):
         "stats": [{"key": k, "label": v["label"]} for k, v in cs.STATS.items()],
         "characters": [{"id": cid, "name": name} for cid, name in chars.items()],
         "events": cs.event_list(get_charts_blob_stats()),
+        "versions": _build_versions(),
     }
+
+
+def _build_versions() -> list[str]:
+    """Distinct game build_ids present in the data, newest first, for the
+    version filter. Best-effort: empty list on any error."""
+    try:
+        if os.environ.get("MONGO_URL", "").strip():
+            from ..services.runs_db_mongo import distinct_build_ids
+
+            return distinct_build_ids()
+        from ..services.runs_db import get_conn
+
+        with get_conn() as conn:
+            return [
+                r["build_id"]
+                for r in conn.execute(
+                    "SELECT DISTINCT build_id FROM runs"
+                    " WHERE build_id IS NOT NULL AND build_id != ''"
+                    " ORDER BY build_id DESC"
+                )
+            ]
+    except Exception:
+        logger.warning("charts version list failed", exc_info=True)
+        return []
 
 
 def _build_frame_chart(
@@ -371,13 +397,20 @@ def _chart_cache_key(
     event,
     etype,
     entity,
+    *,
+    exclude_a10=False,
+    min_wr=None,
+    exclude_mods=False,
+    version=None,
 ) -> str:
     """Redis key for one chart + filter combo. Shared by the live endpoint and
     the prewarmer so a warmed entry is a byte-for-byte hit on a real request."""
     return (
         f"charts:{chart_key}:{players or ''}:{ascension if ascension is not None else ''}:"
         f"{game_mode or ''}:{(username or '').lower()}:{split}:{stat or ''}:{x or ''}:{y or ''}:"
-        f"{(encounter or '').lower()}:{(event or '').lower()}:{etype or ''}:{(entity or '').lower()}"
+        f"{(encounter or '').lower()}:{(event or '').lower()}:{etype or ''}:{(entity or '').lower()}:"
+        f"{int(bool(exclude_a10))}:{min_wr if min_wr is not None else ''}:"
+        f"{int(bool(exclude_mods))}:{(version or '').strip()}"
     )
 
 
@@ -396,33 +429,62 @@ def _compute_chart(
     event,
     etype,
     entity,
+    *,
+    exclude_a10=False,
+    min_wr=None,
+    exclude_mods=False,
+    version=None,
 ) -> dict:
     """Build one chart payload (no caching). Raises HTTPException for invalid
     blob filters, same as the endpoint."""
     building = False
+    # The four cross-cutting filters apply to both frame and blob charts.
+    filters_active = bool(
+        exclude_a10 or exclude_mods or (version or "").strip() or min_wr is not None
+    )
     if spec["kind"] == "frame":
         mode = "daily" if spec.get("daily") else game_mode
-        rows = cs.filter_rows(cs.get_frame(), players, ascension, mode, username)
+        rows = cs.filter_rows(
+            cs.get_frame(),
+            players,
+            ascension,
+            mode,
+            username,
+            exclude_a10=exclude_a10,
+            min_wr=min_wr,
+            exclude_mods=exclude_mods,
+            build_id=version,
+        )
         series = _build_frame_chart(chart_key, rows, stat, x, y, split)
         total = len(rows)
     else:
-        # Blob charts: snapshot rollup, or a per-user walk when username set.
+        # Blob charts: the precomputed snapshot for the unfiltered all-data view,
+        # a per-user walk when username is set, or a capped on-demand walk over
+        # the matching blobs when any cross-cutting filter is on.
         if ascension is not None or game_mode:
             raise HTTPException(
                 status_code=400,
-                detail="This chart covers all ascensions and modes; drop those filters.",
+                detail="This chart uses an exact ascension/mode via the dedicated"
+                " filters; use Exclude A10 / Exclude mods instead here.",
             )
-        stats = (
-            cs.build_user_blob_stats(username) if username else get_charts_blob_stats()
-        )
+        if username:
+            stats = cs.build_user_blob_stats(username)
+        elif filters_active:
+            stats = cs.build_filtered_blob_stats(
+                exclude_a10=exclude_a10,
+                min_wr=min_wr,
+                exclude_mods=exclude_mods,
+                build_id=version,
+            )
+        else:
+            stats = get_charts_blob_stats()
         series = _build_blob_chart(
             chart_key, stats, spec, players, encounter, event, etype, entity
         )
         total = sum(n for _wk, n, _w in stats.get("week_totals") or [])
-        # Blob stats land with the first snapshot rebuild after a deploy;
-        # until then the cells are missing entirely, which is different from
-        # a filter matching nothing. Surface that so the page can say so.
-        if not username and not stats.get("week_totals"):
+        # Only the unfiltered snapshot path can be "still building"; a filtered
+        # or per-user walk that comes back empty just means no matching runs.
+        if not username and not filters_active and not stats.get("week_totals"):
             building = True
 
     return {
@@ -443,6 +505,10 @@ def _compute_chart(
             "event": event,
             "etype": etype,
             "entity": entity,
+            "exclude_a10": exclude_a10,
+            "min_wr": min_wr,
+            "exclude_mods": exclude_mods,
+            "version": version,
         },
         "series": series,
         "total_runs": total,
@@ -533,6 +599,19 @@ def get_chart(
     event: str | None = Query(None, max_length=80, description="Event id"),
     etype: str | None = Query(None, description="cards | relics | potions"),
     entity: str | None = Query(None, max_length=80, description="Entity id"),
+    exclude_a10: bool = Query(False, description="Drop A10 (ascension cap) runs"),
+    min_wr: int | None = Query(
+        None,
+        ge=0,
+        le=100,
+        description="Only runs by players whose overall win rate is >= this %",
+    ),
+    exclude_mods: bool = Query(
+        False, description="Drop custom / gameplay-modifier runs"
+    ),
+    version: str | None = Query(
+        None, max_length=40, description="Game build_id to filter to"
+    ),
 ):
     """One pre-aggregated chart. See /api/charts/meta for the available
     charts, their filters, splits, and the run stats usable for stat/x/y."""
@@ -566,6 +645,10 @@ def get_chart(
         event,
         etype,
         entity,
+        exclude_a10=exclude_a10,
+        min_wr=min_wr,
+        exclude_mods=exclude_mods,
+        version=version,
     )
     cached = app_cache.get_json(cache_key)
     if cached is not None:
@@ -586,6 +669,10 @@ def get_chart(
         event,
         etype,
         entity,
+        exclude_a10=exclude_a10,
+        min_wr=min_wr,
+        exclude_mods=exclude_mods,
+        version=version,
     )
     # A still-building snapshot resolves within minutes; don't pin the empty
     # answer for the full TTL.

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -57,7 +57,8 @@ _RUNS_DIR = _DATA_DIR / "runs"
     ABANDONED,
     ACTS,
     DAILY,
-) = range(14)
+    BUILD,
+) = range(15)
 
 _FRAME: list[tuple] = []
 _FRAME_TS: float = 0.0
@@ -147,6 +148,7 @@ def _load_frame() -> list[tuple]:
                 "was_abandoned": 1,
                 "acts_completed": 1,
                 "seed": 1,
+                "build_id": 1,
             },
         )
         for d in cursor:
@@ -167,6 +169,7 @@ def _load_frame() -> list[tuple]:
                     1 if d.get("was_abandoned") else 0,
                     int(d.get("acts_completed") or 0),
                     _daily_date(d.get("seed"), mode),
+                    (d.get("build_id") or ""),
                 )
             )
     else:
@@ -176,7 +179,8 @@ def _load_frame() -> list[tuple]:
             for d in conn.execute(
                 "SELECT character, win, ascension, game_mode, player_count,"
                 " run_time, floors_reached, deck_size, relic_count,"
-                " submitted_at, username, was_abandoned, acts_completed, seed"
+                " submitted_at, username, was_abandoned, acts_completed, seed,"
+                " build_id"
                 " FROM runs"
             ):
                 mode = (d["game_mode"] or "standard").lower()
@@ -196,6 +200,7 @@ def _load_frame() -> list[tuple]:
                         1 if d["was_abandoned"] else 0,
                         int(d["acts_completed"] or 0),
                         _daily_date(d["seed"], mode),
+                        (d["build_id"] or ""),
                     )
                 )
     return rows
@@ -238,14 +243,52 @@ def _official_characters() -> dict[str, str]:
         return {}
 
 
+# Smallest run count before a player's win rate is trusted by the skill filter,
+# so a 1-win-1-run player doesn't read as a 100% god.
+_WR_MIN_GAMES = 5
+
+
+def _player_wr_counts(rows: list[tuple]) -> dict[str, list[int]]:
+    """{username: [wins, total]} over the rows, anonymous excluded. Feeds the
+    player win-rate (skill) filter."""
+    counts: dict[str, list[int]] = {}
+    for r in rows:
+        user = r[USER]
+        if not user:
+            continue
+        c = counts.setdefault(user, [0, 0])
+        c[0] += r[WIN]
+        c[1] += 1
+    return counts
+
+
+def _high_wr_users(rows: list[tuple], min_wr: int) -> set[str]:
+    """Usernames whose overall win rate is >= min_wr% over a real sample."""
+    return {
+        user
+        for user, (wins, total) in _player_wr_counts(rows).items()
+        if total >= _WR_MIN_GAMES and wins * 100 >= min_wr * total
+    }
+
+
 def filter_rows(
     rows: list[tuple],
     players: int | None,
     ascension: int | None,
     game_mode: str | None,
     username: str | None,
+    *,
+    exclude_a10: bool = False,
+    min_wr: int | None = None,
+    exclude_mods: bool = False,
+    build_id: str | None = None,
 ) -> list[tuple]:
     u = (username or "").lower().strip()
+    bid = (build_id or "").strip()
+    # Player-skill filter: keep only runs by players above the win-rate
+    # threshold (computed over their full history). Anonymous runs can't be
+    # scored, so they fall out when the filter is on.
+    wr_ok = _high_wr_users(rows, min_wr) if min_wr is not None else None
     out = []
     for r in rows:
         if players is not None and r[PLAYERS] != players:
@@ -255,6 +298,14 @@ def filter_rows(
         if game_mode is not None and r[MODE] != game_mode:
             continue
         if u and r[USER] != u:
+            continue
+        if exclude_a10 and r[ASC] == 10:
+            continue
+        if exclude_mods and r[MODE] == "custom":
+            continue
+        if bid and r[BUILD] != bid:
+            continue
+        if wr_ok is not None and r[USER] not in wr_ok:
             continue
         out.append(r)
     return out
@@ -1217,6 +1268,115 @@ def build_user_blob_stats(username: str) -> dict[str, Any]:
 
     acc = new_accumulator()
     for row in rows:
+        path = _RUNS_DIR / f"{row['run_hash']}.json"
+        if not path.exists():
+            continue
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                blob = json.load(f)
+            accumulate(
+                acc,
+                blob,
+                is_win=bool(row["win"]),
+                character=row["character"],
+                player_count=row["player_count"],
+                submitted=row.get("submitted_at"),
+            )
+        except Exception:
+            continue
+    return finalize(acc)
+
+
+# Most-recent matching runs walked for a filtered blob chart. The unfiltered
+# case uses the precomputed snapshot, so this only bounds the filtered path.
+_FILTERED_BLOB_CAP = 8000
+
+
+def _blob_candidate_rows(limit: int = 60000) -> list[dict]:
+    """Run metadata (newest first), with enough fields to apply the chart
+    filters before deciding which blobs to read."""
+    if os.environ.get("MONGO_URL", "").strip():
+        from .runs_db_mongo import _get_collection
+
+        cursor = (
+            _get_collection()
+            .find(
+                {},
+                {
+                    "_id": 1,
+                    "character": 1,
+                    "win": 1,
+                    "player_count": 1,
+                    "submitted_at": 1,
+                    "ascension": 1,
+                    "game_mode": 1,
+                    "build_id": 1,
+                    "username": 1,
+                },
+            )
+            .sort("submitted_at", -1)
+            .limit(limit)
+        )
+        return [
+            {
+                "run_hash": d["_id"],
+                "character": d.get("character") or "",
+                "win": bool(d.get("win")),
+                "player_count": d.get("player_count") or 1,
+                "submitted_at": d.get("submitted_at"),
+                "ascension": int(d.get("ascension") or 0),
+                "game_mode": (d.get("game_mode") or "standard").lower(),
+                "build_id": d.get("build_id") or "",
+                "username": (d.get("username") or "").lower(),
+            }
+            for d in cursor
+        ]
+    from .runs_db import get_conn
+
+    with get_conn() as conn:
+        out: list[dict] = []
+        for r in conn.execute(
+            "SELECT run_hash, character, win, player_count, submitted_at,"
+            " ascension, game_mode, build_id, username"
+            " FROM runs ORDER BY id DESC LIMIT ?",
+            (limit,),
+        ):
+            d = dict(r)
+            d["game_mode"] = (d.get("game_mode") or "standard").lower()
+            d["username"] = (d.get("username") or "").lower()
+            d["ascension"] = int(d.get("ascension") or 0)
+            d["build_id"] = d.get("build_id") or ""
+            out.append(d)
+        return out
+
+
+def build_filtered_blob_stats(
+    exclude_a10: bool = False,
+    min_wr: int | None = None,
+    exclude_mods: bool = False,
+    build_id: str | None = None,
+) -> dict[str, Any]:
+    """Blob stats over runs matching the chart filters, walked on demand from
+    the same on-disk blobs the snapshot uses. Capped at the most-recent
+    _FILTERED_BLOB_CAP matches so latency stays bounded; the chart notes it's a
+    recent sample. The unfiltered case uses the precomputed snapshot instead."""
+    bid = (build_id or "").strip()
+    wr_ok = _high_wr_users(get_frame(), min_wr) if min_wr is not None else None
+    picked: list[dict] = []
+    for row in _blob_candidate_rows():
+        if exclude_a10 and row["ascension"] == 10:
+            continue
+        if exclude_mods and row["game_mode"] == "custom":
+            continue
+        if bid and row["build_id"] != bid:
+            continue
+        if wr_ok is not None and row["username"] not in wr_ok:
+            continue
+        picked.append(row)
+        if len(picked) >= _FILTERED_BLOB_CAP:
+            break
+    acc = new_accumulator()
+    for row in picked:
         path = _RUNS_DIR / f"{row['run_hash']}.json"
         if not path.exists():
             continue

--- a/frontend/app/charts/ChartsClient.tsx
+++ b/frontend/app/charts/ChartsClient.tsx
@@ -144,6 +144,7 @@ interface Meta {
   stats: StatOpt[];
   characters: NamedOpt[];
   events: NamedOpt[];
+  versions: string[];
 }
 
 const PLAYER_OPTS = [
@@ -226,6 +227,11 @@ export default function ChartsClient() {
   const [event, setEvent] = useState(searchParams.get("event") || "");
   const [etype, setEtype] = useState(searchParams.get("etype") || "cards");
   const [entity, setEntity] = useState(searchParams.get("entity") || "");
+  // Cross-cutting filters (apply to every chart).
+  const [excludeA10, setExcludeA10] = useState(searchParams.get("a10") === "1");
+  const [minWr, setMinWr] = useState(searchParams.get("minwr") || "");
+  const [excludeMods, setExcludeMods] = useState(searchParams.get("nomods") === "1");
+  const [version, setVersion] = useState(searchParams.get("version") || "");
 
   const [encounters, setEncounters] = useState<NamedOpt[]>([]);
   const [entityLists, setEntityLists] = useState<Record<string, NamedOpt[]>>({});
@@ -318,9 +324,13 @@ export default function ChartsClient() {
       if (!spec?.etype_fixed) p.set("etype", etype);
       p.set("entity", entity);
     }
+    if (excludeA10) p.set("a10", "1");
+    if (minWr) p.set("minwr", minWr);
+    if (excludeMods) p.set("nomods", "1");
+    if (version) p.set("version", version);
     const qs = p.toString();
     router.replace(`/charts${qs ? `?${qs}` : ""}`, { scroll: false });
-  }, [chart, players, ascension, gameMode, username, split, stat, xStat, yStat, encounter, event, etype, entity, needsEntity, spec, router]);
+  }, [chart, players, ascension, gameMode, username, split, stat, xStat, yStat, encounter, event, etype, entity, needsEntity, spec, router, excludeA10, minWr, excludeMods, version]);
 
   // Fetch the chart itself.
   useEffect(() => {
@@ -345,6 +355,11 @@ export default function ChartsClient() {
       p.set("etype", effEtype);
       p.set("entity", entity);
     }
+    // Cross-cutting filters: sent for every chart, frame and blob.
+    if (excludeA10) p.set("exclude_a10", "true");
+    if (minWr) p.set("min_wr", minWr);
+    if (excludeMods) p.set("exclude_mods", "true");
+    if (version) p.set("version", version);
     setLoading(true);
     setError(null);
     const ctrl = new AbortController();
@@ -368,7 +383,7 @@ export default function ChartsClient() {
         }
       });
     return () => ctrl.abort();
-  }, [spec, meta, players, ascension, gameMode, username, split, stat, xStat, yStat, encounter, event, effEtype, entity, needsEntity]);
+  }, [spec, meta, players, ascension, gameMode, username, split, stat, xStat, yStat, encounter, event, effEtype, entity, needsEntity, excludeA10, minWr, excludeMods, version]);
 
   const groups = useMemo(() => {
     const g = new Map<string, ChartSpec[]>();
@@ -516,6 +531,54 @@ export default function ChartsClient() {
           )}
           {spec?.daily && (
             <span className="text-xs text-[var(--text-muted)]">Daily runs only.</span>
+          )}
+        </div>
+
+        {/* Cross-cutting filters: apply to every chart, frame and blob. */}
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          <label className="flex items-center gap-2 text-sm text-[var(--text-secondary)] cursor-pointer">
+            <input
+              type="checkbox"
+              checked={excludeA10}
+              onChange={(e) => setExcludeA10(e.target.checked)}
+              className="accent-[var(--accent-gold)]"
+            />
+            Exclude A10
+          </label>
+          <label className="flex items-center gap-2 text-sm text-[var(--text-secondary)] cursor-pointer">
+            <input
+              type="checkbox"
+              checked={excludeMods}
+              onChange={(e) => setExcludeMods(e.target.checked)}
+              className="accent-[var(--accent-gold)]"
+            />
+            Exclude mods
+          </label>
+          <select
+            className={selectCls}
+            value={minWr}
+            onChange={(e) => setMinWr(e.target.value)}
+            aria-label="Minimum player win rate"
+          >
+            <option value="">Any win rate</option>
+            <option value="50">Players 50%+ WR</option>
+            <option value="60">Players 60%+ WR</option>
+            <option value="70">Players 70%+ WR</option>
+          </select>
+          {(meta?.versions?.length ?? 0) > 0 && (
+            <select
+              className={selectCls}
+              value={version}
+              onChange={(e) => setVersion(e.target.value)}
+              aria-label="Game version"
+            >
+              <option value="">All versions</option>
+              {meta!.versions.map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </select>
           )}
         </div>
       </div>


### PR DESCRIPTION
Adds four cross-cutting filters to the /charts page, working on every chart (frame and blob), per the scoping answers (player win-rate thresholds, exclude gameplay-modifier runs, blob charts included).

Filters:
- Exclude A10: drop ascension-cap runs.
- Player win rate: keep only runs by players whose overall win rate is at or above 50 / 60 / 70 percent, measured over at least 5 runs. Anonymous runs drop out since they cannot be scored.
- Exclude mods: drop custom / gameplay-modifier runs (game_mode custom).
- Game version: filter to one build_id (dropdown populated from the data).

How it works:
- Frame charts (win rates, survival, distributions, volume) filter the in-memory run frame. Added build_id as a frame column; mods map to the custom game mode.
- Blob charts (curves, encounter damage, entity stats) use a new capped on-demand walk over the most-recent matching blobs when any filter is on, and the precomputed snapshot when none are. The cap keeps latency bounded, so a filtered blob view is a recent sample rather than all-time.
- The filters join the chart cache key, so each combo caches separately, and /meta lists the versions.

Notes:
- Stacked on #489 (the prewarm PR) since it is the base that has _compute_chart. Merge #489 first, then this retargets to main.
- Localhost only has a handful of local runs, so the charts there are sparse. The filter controls and behavior are reviewable locally; populated data needs beta.