### PR TITLE
Resolve beta-only deck/relic/potion entities on the run page

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -728,6 +728,13 @@ def get_shared_run(run_hash: str, request: Request):
         return redis_cached
 
     def _attach_username(blob: dict) -> dict:
+        # Flag beta-build runs so the client merges the beta catalog when it
+        # resolves deck/relic/potion entities that only exist in the beta data
+        # tree. build_id like "v0.107.0" with a matching data-beta dir = beta.
+        from ..services.data_service import BETA_DATA_DIR
+
+        bid = (blob.get("build_id") or "").strip()
+        blob["is_beta"] = bool(bid) and (BETA_DATA_DIR / bid).exists()
         if using_mongo:
             from ..services.runs_db_mongo import get_username_for_hash
 

--- a/frontend/app/runs/[hash]/SharedRunClient.tsx
+++ b/frontend/app/runs/[hash]/SharedRunClient.tsx
@@ -73,6 +73,55 @@ export default function SharedRunClient() {
     });
   }, [hash, lang]);
 
+  // Beta-build runs reference cards/relics/potions that only exist in the beta
+  // data tree. Merge the beta catalog over the main maps so those resolve (name
+  // + image); main wins for shared ids, and entities in neither channel still
+  // show nothing. is_beta is flagged server-side from the run's build_id.
+  useEffect(() => {
+    if (!run?.is_beta) return;
+    let cancelled = false;
+    cachedFetch<CardInfo[]>(`${API}/api/cards?lang=${lang}&channel=beta`).then((cards) => {
+      if (cancelled) return;
+      setCardData((prev) => {
+        const m = { ...prev };
+        for (const c of cards) if (!(c.id in m)) m[c.id] = c;
+        return m;
+      });
+    });
+    cachedFetch<RelicInfo[]>(`${API}/api/relics?lang=${lang}&channel=beta`).then((relics) => {
+      if (cancelled) return;
+      setRelicData((prev) => {
+        const m = { ...prev };
+        for (const r of relics) if (!(r.id in m)) m[r.id] = r;
+        return m;
+      });
+    });
+    cachedFetch<PotionInfo[]>(`${API}/api/potions?lang=${lang}&channel=beta`).then((potions) => {
+      if (cancelled) return;
+      setPotionData((prev) => {
+        const m = { ...prev };
+        for (const p of potions) if (!(p.id in m)) m[p.id] = p;
+        return m;
+      });
+    });
+    cachedFetch<{ id: string; name: string }[]>(
+      `${API}/api/encounters?lang=${lang}&channel=beta`,
+    ).then((encs) => {
+      if (cancelled) return;
+      setEncounterNames((prev) => {
+        const m = { ...prev };
+        for (const e of encs) {
+          const k = e.id.toUpperCase();
+          if (!(k in m)) m[k] = e.name;
+        }
+        return m;
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [run?.is_beta, lang]);
+
   function localizedCharName(id: string): string {
     const key = cleanId(id).toUpperCase();
     return charNames[key] ?? displayName(id);


### PR DESCRIPTION
On https://spire-codex.com/runs/c8411f57e8331e64 the FISHING_ROD relic does not show, even though it exists in beta with an image. The run is a v0.107.0 beta build, and FISHING_ROD is a beta-only relic absent from the main catalog.

The run page resolved card / relic / potion names and images from the main-channel catalogs only, so beta-only entities had nothing to resolve against and rendered as missing. The map-node icon fallback from before only covered boss / event icons, not the deck / relic / potion strip.

Fix: the shared-run response flags beta-build runs (is_beta, from build_id matching a data-beta version dir). For those runs the client merges the beta catalog over the main maps: main wins for shared ids, beta-only entities fill the gaps, and anything in neither channel still shows nothing. Covers cards, relics, potions, and encounter names. Non-beta runs are unaffected (no extra fetches).

Backend + frontend, two files. Verifiable on prod after deploy (the specific run is not in local data).