### PR TITLE
Fix homepage dividers, fastest-wins count, and showcase arrows

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -444,10 +444,14 @@ def get_leaderboard(
     today: bool = False,
     page: int = 1,
     limit: int = 50,
+    ascension_min: int | None = None,
 ):
     """Leaderboard for winning runs.
 
     Categories: `fastest`, `highest_ascension`.
+    `ascension_min`: only runs at this ascension or higher (e.g. 10 for the
+    A10 fastest-wins board); without it the board spans every ascension, so a
+    low-ascension speedrun can outrank an A10 win.
     `players`: `single` (player_count == 1) or `multi` (player_count > 1).
     `game_mode`: `standard`, `daily`, or `custom`. Custom runs ride on
     custom seeds so their times aren't comparable to the standard
@@ -470,6 +474,7 @@ def get_leaderboard(
         today=today,
         page=page,
         limit=limit,
+        ascension_min=ascension_min,
     )
     cached = app_cache.get_json(cache_key)
     if cached is not None:
@@ -485,6 +490,7 @@ def get_leaderboard(
             today=today,
             page=page,
             limit=limit,
+            ascension_min=ascension_min,
         )
         app_cache.set_json(cache_key, result, ttl_seconds=60)
         return result
@@ -507,6 +513,9 @@ def get_leaderboard(
         if game_mode:
             conditions.append("game_mode = ?")
             params.append(game_mode)
+        if ascension_min is not None:
+            conditions.append("ascension >= ?")
+            params.append(ascension_min)
         where = "WHERE " + " AND ".join(conditions)
 
         if category == "highest_ascension":

--- a/backend/app/services/cache.py
+++ b/backend/app/services/cache.py
@@ -77,10 +77,11 @@ def leaderboard_key(
     today: bool = False,
     page: int = 1,
     limit: int = 50,
+    ascension_min: int | None = None,
 ) -> str:
     return (
         f"leaderboard:{category}:{(character or '').upper()}:{players or ''}:"
-        f"{game_mode or ''}:{int(today)}:{page}:{limit}"
+        f"{game_mode or ''}:{int(today)}:{page}:{limit}:{ascension_min if ascension_min is not None else ''}"
     )
 
 

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1789,6 +1789,7 @@ def leaderboard(
     today: bool = False,
     page: int = 1,
     limit: int = 50,
+    ascension_min: int | None = None,
 ) -> dict:
     """Wins-only leaderboard. Mirrors the /api/runs/leaderboard SQLite path.
 
@@ -1804,7 +1805,8 @@ def leaderboard(
     # Fast path: serve from the materialized summary when the combo is one
     # we materialize (find_one misses otherwise and we fall to live). Docs
     # store 50 rows, so any page-1 request up to that size can be sliced.
-    if not today and page == 1 and limit <= 50:
+    # An ascension_min filter isn't materialized, so skip straight to live.
+    if ascension_min is None and not today and page == 1 and limit <= 50:
         try:
             key = _leaderboard_key(
                 category=category,
@@ -1832,6 +1834,7 @@ def leaderboard(
         today=today,
         page=page,
         limit=limit,
+        ascension_min=ascension_min,
     )
 
 
@@ -1843,6 +1846,7 @@ def _leaderboard_live(
     today: bool = False,
     page: int = 1,
     limit: int = 50,
+    ascension_min: int | None = None,
 ) -> dict:
     """Live leaderboard query -- the original implementation, used directly
     by refresh_leaderboard_summary and as the fallback when the summary
@@ -1866,6 +1870,8 @@ def _leaderboard_live(
         q["player_count"] = {"$gt": 1}
     if game_mode:
         q["game_mode"] = game_mode
+    if ascension_min is not None:
+        q["ascension"] = {"$gte": ascension_min}
     if today:
         q["seed"] = _today_daily_seed_match()
 

--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -250,12 +250,12 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
           </div>
           {/* Row 2: sign-in cell (signed out only) + the 5 action tiles. */}
           <div
-            className={`relative grid grid-cols-1 gap-px bg-[var(--border-subtle)] sm:grid-cols-2 ${
+            className={`relative grid grid-cols-1 gap-0 bg-[var(--border-subtle)] sm:grid-cols-2 ${
               user ? "lg:grid-cols-5" : "lg:grid-cols-6"
             }`}
           >
             {!user && (
-              <div className="flex h-full flex-col items-center gap-3 bg-[var(--bg-card)] p-6 text-center">
+              <div className="flex h-full flex-col items-center gap-3 bg-[var(--bg-card)] p-6 text-center shadow-[inset_-1px_0_0_0_var(--border-subtle),inset_0_-1px_0_0_var(--border-subtle)]">
                 <span className="text-[var(--accent-gold)]">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" className="h-9 w-9">
                     <circle cx="12" cy="8" r="4" />
@@ -352,7 +352,7 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
             },
           ].map((c) => {
             const cls =
-              "group flex h-full flex-col items-center gap-3 bg-[var(--bg-card)] p-6 text-center transition-colors hover:bg-[var(--bg-card-hover)]";
+              "group flex h-full flex-col items-center gap-3 bg-[var(--bg-card)] p-6 text-center transition-colors hover:bg-[var(--bg-card-hover)] shadow-[inset_-1px_0_0_0_var(--border-subtle),inset_0_-1px_0_0_var(--border-subtle)]";
             const inner = (
               <>
                 <span className="text-[var(--accent-gold)]">{c.icon}</span>

--- a/frontend/app/components/HomeLeaderboardSection.tsx
+++ b/frontend/app/components/HomeLeaderboardSection.tsx
@@ -100,30 +100,19 @@ function killedByLabel(killedBy: string | null): string | null {
 }
 
 async function loadFastestWins(): Promise<{ runs: RunRow[]; ascension: number | null }> {
-  // No server-side ascension filter, pull a page of fastest wins, then
-  // pick the highest ascension tier that has at least one entry. Falls
-  // back to "any ascension" so the section never renders empty when wins
-  // exist at all.
+  // Ask the server for the fastest A10+ wins directly. Filtering client-side
+  // off a global fastest page didn't work: low-ascension speedruns dominate the
+  // global fastest list, so only a few A10 wins survived the filter (the card
+  // showed 3, not 5). ascension_min keeps it to the A10 board the badge claims.
   try {
-    const res = await fetch(`${RUNS_API}/api/runs/leaderboard?category=fastest&limit=50`, {
-      next: { revalidate: REVALIDATE },
-    });
+    const res = await fetch(
+      `${RUNS_API}/api/runs/leaderboard?category=fastest&ascension_min=${TARGET_ASCENSION}&limit=5`,
+      { next: { revalidate: REVALIDATE } },
+    );
     if (!res.ok) return { runs: [], ascension: null };
     const data = (await res.json()) as { runs: RunRow[] };
-    const wins = (data.runs || []).filter((r) => r.win === 1);
-    if (wins.length === 0) return { runs: [], ascension: null };
-    // Lead with A10+ wins (the showcase tier), then top up with the next
-    // fastest wins (any ascension) so the card always shows a full 5 instead
-    // of just however many A10 wins happen to exist. `wins` is already sorted
-    // fastest-first, so the filters preserve that order.
-    const a10 = wins.filter((r) => r.ascension >= TARGET_ASCENSION);
-    const rest = wins.filter((r) => r.ascension < TARGET_ASCENSION);
-    const runs = [...a10, ...rest].slice(0, 5);
-    const ascension =
-      a10.length > 0
-        ? TARGET_ASCENSION
-        : runs.reduce((m, r) => Math.max(m, r.ascension), 0);
-    return { runs, ascension };
+    const runs = (data.runs || []).filter((r) => r.win === 1).slice(0, 5);
+    return { runs, ascension: runs.length ? TARGET_ASCENSION : null };
   } catch {
     return { runs: [], ascension: null };
   }

--- a/frontend/app/components/HomeLeaderboardSection.tsx
+++ b/frontend/app/components/HomeLeaderboardSection.tsx
@@ -112,12 +112,18 @@ async function loadFastestWins(): Promise<{ runs: RunRow[]; ascension: number | 
     const data = (await res.json()) as { runs: RunRow[] };
     const wins = (data.runs || []).filter((r) => r.win === 1);
     if (wins.length === 0) return { runs: [], ascension: null };
+    // Lead with A10+ wins (the showcase tier), then top up with the next
+    // fastest wins (any ascension) so the card always shows a full 5 instead
+    // of just however many A10 wins happen to exist. `wins` is already sorted
+    // fastest-first, so the filters preserve that order.
     const a10 = wins.filter((r) => r.ascension >= TARGET_ASCENSION);
-    if (a10.length > 0) return { runs: a10.slice(0, 5), ascension: TARGET_ASCENSION };
-    // No A10+ wins yet, show fastest at the highest tier we do have.
-    const maxAsc = wins.reduce((m, r) => Math.max(m, r.ascension), 0);
-    const top = wins.filter((r) => r.ascension === maxAsc).slice(0, 5);
-    return { runs: top, ascension: maxAsc };
+    const rest = wins.filter((r) => r.ascension < TARGET_ASCENSION);
+    const runs = [...a10, ...rest].slice(0, 5);
+    const ascension =
+      a10.length > 0
+        ? TARGET_ASCENSION
+        : runs.reduce((m, r) => Math.max(m, r.ascension), 0);
+    return { runs, ascension };
   } catch {
     return { runs: [], ascension: null };
   }

--- a/frontend/app/components/HomeShowcaseSection.tsx
+++ b/frontend/app/components/HomeShowcaseSection.tsx
@@ -91,11 +91,8 @@ export default async function HomeShowcaseSection({
               rel="noopener noreferrer"
               className="group relative overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-card)] hover:border-[var(--border-accent)] hover:shadow-xl hover:shadow-black/30 transition-all flex flex-col p-5 gap-2"
             >
-              <div className="flex items-center justify-between gap-2 text-[10px] uppercase tracking-wider">
+              <div className="flex items-center gap-2 text-[10px] uppercase tracking-wider">
                 <span className={`px-2 py-0.5 rounded border ${badge}`}>{p.category}</span>
-                <span aria-hidden className="text-[var(--text-muted)] group-hover:text-[var(--accent-gold)] transition-colors">
-                  ↗
-                </span>
               </div>
               <h3 className="text-lg font-semibold text-[var(--text-primary)] leading-tight group-hover:text-[var(--accent-gold)] transition-colors">
                 {p.name}


### PR DESCRIPTION
Three small homepage / community-showcase fixes.

## Get started: missing divider between cards
The card dividers are hairlines made by a 1px grid gap showing the container background. On fractional grid tracks that 1px gap rounds to 0 at some viewport widths, so a divider (e.g. between the mod tile and the Patreon tile) disappears. Switched the dividers to inset 1px shadows on each cell with `gap-0`, which render reliably at every width.

## Fastest Wins showing 3 instead of 5
The card claims an A10 board but pulled the global fastest page and filtered to A10 client-side. Low-ascension speedruns dominate the global fastest list, so only a few A10 wins survived the filter (3, not 5) even though A10 has plenty of fast wins. Added an `ascension_min` filter to `/api/runs/leaderboard` (router + Mongo live query + SQLite path + cache key) and the card now requests `category=fastest&ascension_min=10`, showing the 5 fastest genuine A10 wins.

## Community Showcase arrows
Removed the per-card up-right arrow glyph on the home showcase widget (it read as visual noise). The dedicated showcase page already has no such arrows.

Backend syntax-checked; the leaderboard endpoint accepts the new param and runs the filter. Frontend typechecks clean.
