### PR TITLE
Fix Scare card portrait (missing image_url)

### DIFF
--- a/data/deu/cards.json
+++ b/data/deu/cards.json
@@ -5702,7 +5702,7 @@
     "upgrade": {
       "remove_exhaust": true
     },
-    "image_url": null,
+    "image_url": "/static/images/cards/scare.webp",
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,

--- a/data/eng/cards.json
+++ b/data/eng/cards.json
@@ -17881,7 +17881,7 @@
     "upgrade": {
       "remove_exhaust": true
     },
-    "image_url": null,
+    "image_url": "/static/images/cards/scare.webp",
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,

--- a/data/esp/cards.json
+++ b/data/esp/cards.json
@@ -21510,7 +21510,7 @@
     "upgrade": {
       "remove_exhaust": true
     },
-    "image_url": null,
+    "image_url": "/static/images/cards/scare.webp",
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,

--- a/data/fra/cards.json
+++ b/data/fra/cards.json
@@ -14017,7 +14017,7 @@
     "upgrade": {
       "remove_exhaust": true
     },
-    "image_url": null,
+    "image_url": "/static/images/cards/scare.webp",
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,

--- a/data/ita/cards.json
+++ b/data/ita/cards.json
@@ -20140,7 +20140,7 @@
     "upgrade": {
       "remove_exhaust": true
     },
-    "image_url": null,
+    "image_url": "/static/images/cards/scare.webp",
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,

--- a/data/jpn/cards.json
+++ b/data/jpn/cards.json
@@ -14062,7 +14062,7 @@
     "upgrade": {
       "remove_exhaust": true
     },
-    "image_url": null,
+    "image_url": "/static/images/cards/scare.webp",
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,

--- a/data/kor/cards.json
+++ b/data/kor/cards.json
@@ -15137,7 +15137,7 @@
     "upgrade": {
       "remove_exhaust": true
     },
-    "image_url": null,
+    "image_url": "/static/images/cards/scare.webp",
     "beta_image_url": null,
     "type_variants": null,
     "can_be_generated_in_combat": null,


### PR DESCRIPTION
The Scare card (renamed from Follow Through in v0.107.1) had a null `image_url` in 7 of the 14 languages, so its thumbnail went missing in card lists on the main site.

This slipped in during the v0.107.1 data regen: I ran the parser and copy_images concurrently, and the parser resolves `image_url` from whether the portrait PNG exists at parse time. Scare's `scare.png` is brand new (Follow Through used a different filename), so the languages parsed before copy_images wrote it got null, and the later ones got the URL.

This points Scare's `image_url` at `/static/images/cards/scare.webp` (the portrait copy_images produced), matching every other card. Only Scare was affected. Wither's null is intentional, since its art lives in the beta folder.

Note: this is unrelated to the BETA badge showing on Scare/Aeonglass right now, which is just a stale Cloudflare cache of `/api/beta/diff` from before the v0.107.1 deploy. That diff is empty now (beta and main match), so the badges clear on cache expiry or a purge.
