### PR TITLE
Fix ancient relic pools for v0.107.1 (Neow new relics, Tezcatara Seal of Gold)

### DIFF
--- a/data/ancient_pools.json
+++ b/data/ancient_pools.json
@@ -15,7 +15,7 @@
           { "id": "LEAFY_POULTICE", "condition": null },
           { "id": "NEOWS_BONES", "condition": null },
           { "id": "PRECARIOUS_SHEARS", "condition": null },
-          { "id": "SCROLL_BOXES", "condition": "Player has cards that can form bundles" },
+          { "id": "SILKEN_TRESS", "condition": null },
           { "id": "SILVER_CRUCIBLE", "condition": "Single player only" }
         ]
       },
@@ -25,6 +25,8 @@
         "relics": [
           { "id": "ARCANE_SCROLL", "condition": "Excluded if Hefty Tablet is the curse option" },
           { "id": "BOOMING_CONCH", "condition": null },
+          { "id": "FISHING_ROD", "condition": null },
+          { "id": "KALEIDOSCOPE", "condition": null },
           { "id": "POMANDER", "condition": "50% chance (vs Neow's Talisman)" },
           { "id": "LEAD_PAPERWEIGHT", "condition": null },
           { "id": "NEOWS_TALISMAN", "condition": "50% chance (vs Pomander)" },
@@ -39,7 +41,8 @@
           { "id": "STONE_HUMIDIFIER", "condition": "50% chance (vs Nutritious Oyster)" },
           { "id": "LAVA_ROCK", "condition": "50% chance (vs Small Capsule); excluded if Large Capsule is the curse option" },
           { "id": "SMALL_CAPSULE", "condition": "50% chance (vs Lava Rock); excluded if Large Capsule is the curse option" },
-          { "id": "MASSIVE_SCROLL", "condition": "Multiplayer only" }
+          { "id": "MASSIVE_SCROLL", "condition": "Multiplayer only" },
+          { "id": "SCROLL_BOXES", "condition": "Player has cards that can form bundles" }
         ]
       }
     ]
@@ -63,7 +66,6 @@
         "relics": [
           { "id": "BIIIG_HUG", "condition": null },
           { "id": "STORYBOOK", "condition": null },
-          { "id": "SEAL_OF_GOLD", "condition": null },
           { "id": "TOASTY_MITTENS", "condition": null }
         ]
       },
@@ -72,7 +74,8 @@
         "relics": [
           { "id": "GOLDEN_COMPASS", "condition": null },
           { "id": "PUMPKIN_CANDLE", "condition": null },
-          { "id": "TOY_BOX", "condition": null }
+          { "id": "TOY_BOX", "condition": null },
+          { "id": "SEAL_OF_GOLD", "condition": null }
         ]
       }
     ]


### PR DESCRIPTION
The Neow and Tezcatara ancient relic pools on `/ancients` were stale after v0.107.1, so the pools shown did not match the game (the new Neow relics were absent and Scroll Boxes / Seal of Gold were in the wrong pools).

I checked the decompiled event sources (`Neow.cs`, `Tezcatara.cs`) and corrected `ancient_pools.json` to match exactly:

Neow:
- Added Fishing Rod and Kaleidoscope to the positive pool (new in v0.107.1).
- Added Silken Tress to the curse pool (Neow.cs offers it in the curse slot).
- Moved Scroll Boxes from the curse pool to the positive pool, where the game now has it.

Tezcatara:
- Moved Seal of Gold from pool 2 to pool 3 so it shares Pumpkin Candle's pool, matching both the patch note and Tezcatara.cs.

The ancient pool parser now reports zero drift against the C# source (only the expected Orobas Sea Glass per-character note remains). This is a hand-file fix only; `ancient_pools_parsed.json` was already current from the v0.107.1 data update.
