### PR TITLE
Generate ancient relic pools from the C# (no more drift)

### DIFF
--- a/backend/app/parsers/ancient_pool_parser.py
+++ b/backend/app/parsers/ancient_pool_parser.py
@@ -1,24 +1,31 @@
-"""Parse ancient relic-offering pools from decompiled C# event files.
+"""Generate ancient relic-offering pools from decompiled C# event files.
 
-Companion to the hand-maintained `data/ancient_pools.json`. The hand file
-holds human-curated condition strings ("Deck has 3+ Attack cards"), which
-are easy to phrase but hard to auto-derive from arbitrary lambda
-predicates. This parser extracts the deterministic part — *which relics
-each ancient can offer* — straight from
-`extraction/decompiled/MegaCrit.Sts2.Core.Models.Events/{Ancient}.cs`.
+`data/ancient_pools.json` (consumed by `/api/ancient-pools` and the
+`/ancients` page) used to be hand-maintained, which meant a game update that
+added/moved an ancient's relics silently shipped a stale pool until someone
+noticed. That drifted to production several times.
 
-Output: `data/ancient_pools_parsed.json` — list of `{ancient_id, relics}`,
-one entry per ancient with the flat set of relic IDs the C# references.
+This parser now GENERATES that file from the C# event sources in
+`extraction/decompiled/MegaCrit.Sts2.Core.Models.Events/{Ancient}.cs`:
 
-Validation step prints every relic that's in C# but missing from the
-hand-coded file (likely a new release we haven't synced) and every relic
-in the hand file but not in C# (probably renamed/removed). Drift on
-relic membership now surfaces every parse run instead of silently sitting
-on the site for months — see PR #170 for the bug that motivated this.
+  - Pool MEMBERSHIP (which relics sit in which pool/option) is read straight
+    from the C# option groups, so adding a relic in a new release flows
+    through automatically — no hand edit, no drift.
+  - A self-check asserts the generated pools cover the FULL C# relic set per
+    ancient. If a relic lands in a group `POOL_LAYOUT` doesn't list, the parse
+    FAILS loudly (telling you which relic/group to add) instead of dropping it.
+  - CONDITIONS and prose DESCRIPTIONS are the only hand-curated bits left.
+    They are carried forward from the previous `ancient_pools.json` by
+    (ancient, relic) and (ancient, pool), exactly like `diff_data.py` preserves
+    hand-written release notes across regen. A brand-new relic comes through
+    with `condition: null` until someone annotates it — but it is PRESENT and
+    in the right pool, which is what matters.
 
-Conditions are intentionally NOT parsed here. They live in
-`data/ancient_pools.json` and stay hand-curated until we have a
-predicate-to-prose translator we trust.
+`ancient_pools_parsed.json` (flat relic set + per-character expansions) is
+still emitted for the relic-page cross-reference.
+
+`POOL_LAYOUT` only needs editing when Mega Crit RESTRUCTURES an ancient's code
+(renames an option group, adds a brand-new ancient) — not when they add relics.
 """
 
 import json
@@ -28,9 +35,7 @@ from parser_paths import BASE, DECOMPILED, DATA_DIR
 
 EVENTS_DIR = DECOMPILED / "MegaCrit.Sts2.Core.Models.Events"
 
-# Files to parse. Names match the in-code class file names — Tanx.cs etc.
-# Update this list (and the hand-coded `ancient_pools.json`) when Mega
-# Crit ships a new ancient.
+# Source file per ancient. Add a row when Mega Crit ships a new ancient.
 ANCIENT_FILES = {
     "DARV": "Darv.cs",
     "NEOW": "Neow.cs",
@@ -42,37 +47,91 @@ ANCIENT_FILES = {
     "VAKUU": "Vakuu.cs",
 }
 
+# Display name per ancient (only thing not derivable from the file name).
+ANCIENT_NAMES = {
+    "DARV": "Darv",
+    "NEOW": "Neow",
+    "NONUPEIPE": "Nonupeipe",
+    "OROBAS": "Orobas",
+    "PAEL": "Pael",
+    "TANX": "Tanx",
+    "TEZCATARA": "Tezcatara",
+    "VAKUU": "Vakuu",
+}
+
+# Maps each ancient's display pools to the C# option groups (and standalone
+# `XOption` properties) whose relics they contain. Order is the in-game pool
+# order. Relics WITHIN a group come from the C# automatically — this only maps
+# the group NAMES, which change only on a code restructure, never on a relic
+# add. DARV is special-cased below (it builds a flat _validRelicSets array).
+POOL_LAYOUT: dict[str, list[tuple[str, list[str]]]] = {
+    "NEOW": [
+        ("Curse Pool", ["CurseOptions"]),
+        (
+            "Positive Pool",
+            [
+                "PositiveOptions",
+                "LavaRockOption",
+                "NeowsTalismanOption",
+                "NutritiousOysterOption",
+                "PomanderOption",
+                "SmallCapsuleOption",
+                "StoneHumidifierOption",
+            ],
+        ),
+    ],
+    "TEZCATARA": [
+        ("Pool 1", ["OptionPool1", "NutritiousSoupOption"]),
+        ("Pool 2", ["OptionPool2"]),
+        ("Pool 3", ["OptionPool3"]),
+    ],
+    "PAEL": [
+        ("Pool 1", ["OptionPool1"]),
+        (
+            "Pool 2",
+            ["OptionPool2", "PaelsClawOption", "PaelsToothOption", "PaelsGrowthOption"],
+        ),
+        ("Pool 3", ["OptionPool3", "PaelsLegionOption"]),
+    ],
+    "OROBAS": [
+        ("Pool 1", ["OptionPool1", "PrismaticGemOption", "SeaGlassOptions"]),
+        ("Pool 2", ["OptionPool2"]),
+        ("Pool 3", ["OptionPool3"]),
+    ],
+    "VAKUU": [
+        ("Pool 1", ["Pool1"]),
+        ("Pool 2", ["Pool2"]),
+        ("Pool 3", ["Pool3"]),
+    ],
+    "TANX": [
+        ("Relic Pool", ["BaseOptionPool", "TriBoomerangOption"]),
+    ],
+    "NONUPEIPE": [
+        ("Relic Pool", ["OptionPool", "BeautifulBraceletEventOption"]),
+    ],
+    # DARV handled specially (see generate_pools): one "Relic Pool" of every
+    # relic except Dusty Tome, plus a "Dusty Tome" pool for the swap option.
+}
+
 
 def class_name_to_id(name: str) -> str:
-    """PascalCase relic class name → SCREAMING_SNAKE relic ID.
+    """PascalCase relic class name -> SCREAMING_SNAKE relic ID.
 
-    Mirrors the convention used by every other parser in this directory
-    (relic_parser, monster_parser, etc.) so the IDs we emit match
-    exactly what the rest of the data layer uses.
+    Mirrors every other parser in this directory so the IDs match the rest
+    of the data layer.
     """
     s = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name)
     s = re.sub(r"(?<=[A-Z])(?=[A-Z][a-z])", "_", s)
     return s.upper()
 
 
-# Two patterns cover every ancient we've seen so far:
-#   `RelicOption<X>(...)` — the standard event-option helper used by Tanx,
-#                            Tezcatara, Vakuu, Pael, Orobas, Nonupeipe, Neow
-#   `ModelDb.Relic<X>()`   — Darv builds its `_validRelicSets` array using
-#                            ModelDb references directly instead of the helper
-# Both produce the same downstream class name; we collect from both.
 _RELIC_PATTERNS = (
     re.compile(r"RelicOption<(\w+)>"),
     re.compile(r"ModelDb\.Relic<(\w+)>"),
 )
+_RELIC_IN_SCOPE = re.compile(r"(?:RelicOption|ModelDb\.Relic)<(\w+)>")
 
-# A few relics (today: just SeaGlass) reskin themselves per character.
-# When an event creates one with `relic.CharacterId = ...` inside a
-# `foreach (CharacterModel x in ModelDb.AllCharacters)`, the player
-# actually sees five distinct options on that screen — one for each
-# character variant (Demon/Venom/Gear/Lich/Noble Glass for Sea Glass).
-# Capture this so the parsed pool reflects the in-game option count and
-# the drift check can flag a hand file that lists the relic only once.
+# Per-character reskins (today: Sea Glass) expand to one option per character.
 _PER_CHARACTER_FOREACH = re.compile(
     r"foreach\s*\(\s*CharacterModel\s+\w+\s+in\s+ModelDb\.AllCharacters\s*\)\s*\{(?P<body>.*?)\}",
     re.DOTALL,
@@ -81,25 +140,16 @@ _RELIC_INSTANCE = re.compile(r"ModelDb\.Relic<(\w+)>\(\)\.ToMutable\(\)")
 _CHARACTER_ID_ASSIGN = re.compile(r"\.CharacterId\s*=\s*\w+\.Id")
 
 
-def parse_ancient_relics(filepath) -> set[str]:
-    """Return the set of relic IDs an ancient .cs file can offer."""
-    if not filepath.exists():
-        return set()
-    content = filepath.read_text(encoding="utf-8")
-    class_names: set[str] = set()
+def parse_ancient_relics(content: str) -> set[str]:
+    """Every relic ID an ancient .cs references (the full set, order-free)."""
+    names: set[str] = set()
     for pattern in _RELIC_PATTERNS:
-        for match in pattern.finditer(content):
-            class_names.add(match.group(1))
-    return {class_name_to_id(n) for n in class_names}
+        names.update(m.group(1) for m in pattern.finditer(content))
+    return {class_name_to_id(n) for n in names}
 
 
-def parse_per_character_relics(filepath) -> set[str]:
-    """Return the set of relic IDs that the ancient offers as 5 separate
-    per-character options (the `foreach AllCharacters { relic.CharacterId
-    = x.Id }` shape, e.g. Orobas's DiscoveryTotems pool with Sea Glass)."""
-    if not filepath.exists():
-        return set()
-    content = filepath.read_text(encoding="utf-8")
+def parse_per_character_relics(content: str) -> set[str]:
+    """Relics offered as one option per character (foreach AllCharacters)."""
     out: set[str] = set()
     for fe in _PER_CHARACTER_FOREACH.finditer(content):
         body = fe.group("body")
@@ -110,131 +160,191 @@ def parse_per_character_relics(filepath) -> set[str]:
     return out
 
 
-def parse_all_ancients() -> dict[str, dict[str, set[str]]]:
-    """Walk every known ancient .cs file. Returns
-    `{ancient_id: {"all": {ids}, "per_character": {ids}}}`. The
-    `per_character` set is a strict subset of `all` and just flags
-    which relics expand to 5 in-game options."""
-    out: dict[str, dict[str, set[str]]] = {}
-    for ancient_id, filename in ANCIENT_FILES.items():
-        path = EVENTS_DIR / filename
-        out[ancient_id] = {
-            "all": parse_ancient_relics(path),
-            "per_character": parse_per_character_relics(path),
-        }
-    return out
+def _group_relic_ids(content: str, group: str) -> list[str]:
+    """Ordered relic IDs declared inside a named C# option group/property.
 
-
-def load_hand_coded() -> dict[str, set[str]]:
-    """Flatten `data/ancient_pools.json` into {ancient_id: {relic_ids}}.
-
-    The hand file is structured by named pools per ancient; for drift
-    comparison we flatten across pools — what matters is *whether the
-    relic appears at all*, not which pool it lives in.
+    Handles all three shapes seen in the event files:
+      arrow array:  `... PositiveOptions => new EventOption[N] { RelicOption<X>(), ... }`
+      getter:       `... List<EventOption> OptionPool1 { get { ... RelicOption<X>(); } }`
+      standalone:   `... EventOption LavaRockOption => RelicOption<LavaRock>(...)`
+    Matches the DECLARATION (a type precedes the name) so usages like
+    `OptionPool1.ToList()` are ignored.
     """
-    hand_file = DATA_DIR / "ancient_pools.json"
-    if not hand_file.exists():
+    decl = re.search(
+        r"(?:IEnumerable<EventOption>|List<EventOption>|EventOption)\s+"
+        + re.escape(group)
+        + r"\b\s*(?:=>|\{|=)",
+        content,
+    )
+    if not decl:
+        return []
+    rest = content[decl.end() :]
+    semi = rest.find(";")
+    brace = rest.find("{")
+    if brace != -1 and (semi == -1 or brace < semi):
+        scope = _brace_block(rest[brace:])
+    else:
+        scope = rest if semi == -1 else rest[:semi]
+    ids: list[str] = []
+    for m in _RELIC_IN_SCOPE.finditer(scope):
+        rid = class_name_to_id(m.group(1))
+        if rid not in ids:
+            ids.append(rid)
+    return ids
+
+
+def _brace_block(text: str) -> str:
+    """Given text starting at an opening brace, return the balanced contents."""
+    depth = 0
+    for i, ch in enumerate(text):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[1:i]
+    return text
+
+
+def generate_pools(ancient_id: str, content: str) -> list[tuple[str, list[str]]]:
+    """Build `[(pool_name, [relic_ids])]` for an ancient from its C# source."""
+    if ancient_id == "DARV":
+        ordered: list[str] = []
+        for m in _RELIC_IN_SCOPE.finditer(content):
+            rid = class_name_to_id(m.group(1))
+            if rid not in ordered:
+                ordered.append(rid)
+        relic_pool = [r for r in ordered if r != "DUSTY_TOME"]
+        pools = [("Relic Pool", relic_pool)]
+        if "DUSTY_TOME" in ordered:
+            pools.append(("Dusty Tome", ["DUSTY_TOME"]))
+        return pools
+
+    pools: list[tuple[str, list[str]]] = []
+    for pool_name, groups in POOL_LAYOUT[ancient_id]:
+        ids: list[str] = []
+        for group in groups:
+            for rid in _group_relic_ids(content, group):
+                if rid not in ids:
+                    ids.append(rid)
+        pools.append((pool_name, ids))
+    return pools
+
+
+def load_existing(path) -> dict:
+    """Index the previous ancient_pools.json for condition/description reuse."""
+    if not path.exists():
         return {}
-    with open(hand_file, "r", encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         data = json.load(f)
-    out: dict[str, set[str]] = {}
-    for ancient in data:
-        ids: set[str] = set()
-        for pool in ancient.get("pools", []):
-            for relic in pool.get("relics", []):
-                if relic.get("id"):
-                    ids.add(relic["id"])
-        out[ancient["id"]] = ids
-    return out
-
-
-def diff_against_hand_coded(parsed: dict[str, dict[str, set[str]]]) -> list[str]:
-    """Return human-readable drift lines comparing parsed vs hand-coded.
-
-    Each line names an ancient and lists relic IDs that diverge in
-    either direction. Also flags any per-character-expanding relic
-    (e.g. Sea Glass) whose hand-file entry doesn't mention the 5
-    character variants.
-    """
-    hand = load_hand_coded()
-    drift: list[str] = []
-    for ancient_id in sorted(set(parsed) | set(hand)):
-        c_set = parsed.get(ancient_id, {}).get("all", set())
-        per_char = parsed.get(ancient_id, {}).get("per_character", set())
-        h_set = hand.get(ancient_id, set())
-        only_in_c = c_set - h_set
-        only_in_h = h_set - c_set
-        # Per-character relics in C# whose hand entry doesn't note
-        # they expand to 5 options. We can't reliably parse the hand
-        # file's free-form `description`/`condition` strings, so just
-        # surface a hint when the relic is on the per-character list.
-        per_char_present = per_char & h_set
-        if not (only_in_c or only_in_h or per_char_present):
-            continue
-        parts: list[str] = [f"  {ancient_id}:"]
-        if only_in_c:
-            parts.append(
-                f"    + {len(only_in_c)} in C# but missing from hand file: {sorted(only_in_c)}"
-            )
-        if only_in_h:
-            parts.append(
-                f"    - {len(only_in_h)} in hand file but not in C#: {sorted(only_in_h)}"
-            )
-        if per_char_present:
-            parts.append(
-                f"    ! per-character expansion (5 options shown in-game): {sorted(per_char_present)}"
-            )
-        drift.append("\n".join(parts))
-    return drift
-
-
-def write_parsed_output(parsed: dict[str, dict[str, set[str]]]) -> None:
-    """Persist the parsed relic lists to `data/ancient_pools_parsed.json`.
-
-    Written sorted for stable diffs across parse runs. Each ancient
-    entry carries `relics` (every relic the ancient can offer) and
-    `per_character_relics` (the subset that expands to 5 in-game
-    options, one per character). The expanded list lets the relic
-    page cross-reference Sea Glass → Orobas without parsing the C#
-    again, and lets the drift check flag stale hand-file entries.
-    """
-    out_file = DATA_DIR / "ancient_pools_parsed.json"
-    out = [
-        {
-            "id": ancient_id,
-            "relics": sorted(parsed[ancient_id]["all"]),
-            "per_character_relics": sorted(parsed[ancient_id]["per_character"]) or None,
+    idx: dict = {}
+    for a in data:
+        conditions = {}
+        pool_desc = {}
+        for p in a.get("pools", []):
+            if p.get("description"):
+                pool_desc[p["name"]] = p["description"]
+            for r in p.get("relics", []):
+                if r.get("id") and r.get("condition") is not None:
+                    conditions[r["id"]] = r["condition"]
+        idx[a["id"]] = {
+            "description": a.get("description"),
+            "selection": a.get("selection"),
+            "conditions": conditions,
+            "pool_desc": pool_desc,
         }
-        for ancient_id in sorted(parsed)
-    ]
-    out_file.parent.mkdir(parents=True, exist_ok=True)
-    with open(out_file, "w", encoding="utf-8") as f:
-        json.dump(out, f, indent=2, ensure_ascii=False)
-        f.write("\n")
+    return idx
+
+
+def build_ancient(ancient_id: str, content: str, prior: dict) -> dict:
+    """Assemble the full generated entry for one ancient, merging prior prose."""
+    p = prior.get(ancient_id, {})
+    conditions = p.get("conditions", {})
+    pool_desc = p.get("pool_desc", {})
+    pools_out = []
+    for pool_name, relic_ids in generate_pools(ancient_id, content):
+        pool = {"name": pool_name}
+        if pool_name in pool_desc:
+            pool["description"] = pool_desc[pool_name]
+        pool["relics"] = [
+            {"id": rid, "condition": conditions.get(rid)} for rid in relic_ids
+        ]
+        pools_out.append(pool)
+    entry = {"id": ancient_id, "name": ANCIENT_NAMES.get(ancient_id, ancient_id)}
+    if p.get("description"):
+        entry["description"] = p["description"]
+    if p.get("selection"):
+        entry["selection"] = p["selection"]
+    entry["pools"] = pools_out
+    return entry
 
 
 def main() -> None:
-    parsed = parse_all_ancients()
-    write_parsed_output(parsed)
-    total = sum(len(v["all"]) for v in parsed.values())
-    print(
-        f"Parsed {total} relic offerings across {len(parsed)} ancients "
-        f"-> data/ancient_pools_parsed.json"
-    )
-    drift = diff_against_hand_coded(parsed)
-    if drift:
-        print("Ancient pool drift (hand-coded vs C# extraction):")
-        for line in drift:
-            print(line)
-        print(
-            "  Update data/ancient_pools.json to add/remove the listed relics, "
-            "or update ANCIENT_FILES if Mega Crit renamed an ancient."
+    prior = load_existing(DATA_DIR / "ancient_pools.json")
+
+    generated: list[dict] = []
+    parsed_out: list[dict] = []
+    failures: list[str] = []
+
+    for ancient_id, filename in ANCIENT_FILES.items():
+        path = EVENTS_DIR / filename
+        if not path.exists():
+            failures.append(f"{ancient_id}: source file {filename} not found")
+            continue
+        content = path.read_text(encoding="utf-8")
+
+        full_set = parse_ancient_relics(content)
+        per_char = parse_per_character_relics(content)
+
+        entry = build_ancient(ancient_id, content, prior)
+        covered = {r["id"] for pool in entry["pools"] for r in pool["relics"]}
+
+        # The guarantee: generated pools must cover every relic the C# offers.
+        # A miss means a relic landed in a group POOL_LAYOUT doesn't list.
+        uncovered = full_set - covered
+        extra = covered - full_set
+        if uncovered:
+            failures.append(
+                f"{ancient_id}: {len(uncovered)} relic(s) in C# not captured by any "
+                f"configured pool {sorted(uncovered)} -- add the relic's option group "
+                f"to POOL_LAYOUT['{ancient_id}']"
+            )
+        if extra:
+            failures.append(
+                f"{ancient_id}: {len(extra)} relic(s) in generated pools but not in C# "
+                f"{sorted(extra)} -- stale group name in POOL_LAYOUT['{ancient_id}']?"
+            )
+
+        generated.append(entry)
+        parsed_out.append(
+            {
+                "id": ancient_id,
+                "relics": sorted(full_set),
+                "per_character_relics": sorted(per_char) or None,
+            }
         )
+
+    if failures:
+        raise SystemExit(
+            "Ancient pool generation failed -- POOL_LAYOUT is out of date with the C#:\n  "
+            + "\n  ".join(failures)
+        )
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with open(DATA_DIR / "ancient_pools.json", "w", encoding="utf-8") as f:
+        json.dump(generated, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    with open(DATA_DIR / "ancient_pools_parsed.json", "w", encoding="utf-8") as f:
+        json.dump(parsed_out, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+    total = sum(len(a["relics"]) for a in parsed_out)
+    print(
+        f"Generated ancient_pools.json + ancient_pools_parsed.json: "
+        f"{total} relic offerings across {len(generated)} ancients."
+    )
 
 
 if __name__ == "__main__":
-    # Path manipulation so this works whether you run it directly or via
-    # `python -m`. parser_paths uses BASE for relative resolution, so
-    # importing it from here works either way.
-    _ = BASE  # silence unused import warning when run as a script
+    _ = BASE  # parser_paths resolves relative dirs from BASE
     main()

--- a/backend/app/parsers/parse_all.py
+++ b/backend/app/parsers/parse_all.py
@@ -88,10 +88,11 @@ if __name__ == "__main__":
     # Steam news is language-agnostic — fetch once after the per-lang sweep.
     parse_news()
 
-    # Ancient relic pools — language-agnostic. Validates the hand-coded
-    # `data/ancient_pools.json` against the C# event source so additions
-    # / removals show up immediately instead of weeks later via a user
-    # bug report (see PR #170).
+    # Ancient relic pools — language-agnostic. GENERATES
+    # `data/ancient_pools.json` straight from the C# event sources so relic
+    # additions/moves can never silently drift the /ancients page (the recurring
+    # bug behind PR #170 and the v0.107.1 follow-up). Conditions/descriptions
+    # are carried forward from the previous file; membership comes from the C#.
     from ancient_pool_parser import main as parse_ancient_pools
 
     parse_ancient_pools()

--- a/data/ancient_pools.json
+++ b/data/ancient_pools.json
@@ -1,5 +1,73 @@
 [
   {
+    "id": "DARV",
+    "name": "Darv",
+    "description": "Has a large pool of powerful relics. 50% chance to get 3 options from the pool, 50% chance to get 2 options plus Dusty Tome.",
+    "selection": "50% chance: 3 from pool OR 2 from pool + Dusty Tome",
+    "pools": [
+      {
+        "name": "Relic Pool",
+        "description": "Each set has one relic chosen at random. Sets with act conditions are only included if the condition is met.",
+        "relics": [
+          {
+            "id": "ASTROLABE",
+            "condition": null
+          },
+          {
+            "id": "BLACK_STAR",
+            "condition": null
+          },
+          {
+            "id": "CALLING_BELL",
+            "condition": null
+          },
+          {
+            "id": "EMPTY_CAGE",
+            "condition": null
+          },
+          {
+            "id": "PANDORAS_BOX",
+            "condition": "Excluded with Draft, Sealed Deck, or Insanity modifiers"
+          },
+          {
+            "id": "RUNIC_PYRAMID",
+            "condition": null
+          },
+          {
+            "id": "SNECKO_EYE",
+            "condition": null
+          },
+          {
+            "id": "ECTOPLASM",
+            "condition": "Act 2 only; 50% chance (vs Sozu)"
+          },
+          {
+            "id": "SOZU",
+            "condition": "Act 2 only; 50% chance (vs Ectoplasm)"
+          },
+          {
+            "id": "PHILOSOPHERS_STONE",
+            "condition": "Act 3 only; 50% chance (vs Velvet Choker)"
+          },
+          {
+            "id": "VELVET_CHOKER",
+            "condition": "Act 3 only; 50% chance (vs Philosopher's Stone)"
+          }
+        ]
+      },
+      {
+        "name": "Dusty Tome",
+        "description": "50% chance to replace one of the three options.",
+        "relics": [
+          {
+            "id": "DUSTY_TOME",
+            "condition": "50% chance to appear as the third option"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "id": "NEOW",
     "name": "Neow",
     "description": "Presents 2 positive options and 1 curse option. The curse pool is built first, then excluded relics are removed from the positive pool.",
@@ -9,107 +77,177 @@
         "name": "Curse Pool",
         "description": "One relic is chosen at random from this pool as the curse option.",
         "relics": [
-          { "id": "CURSED_PEARL", "condition": null },
-          { "id": "HEFTY_TABLET", "condition": null },
-          { "id": "LARGE_CAPSULE", "condition": null },
-          { "id": "LEAFY_POULTICE", "condition": null },
-          { "id": "NEOWS_BONES", "condition": null },
-          { "id": "PRECARIOUS_SHEARS", "condition": null },
-          { "id": "SILKEN_TRESS", "condition": null },
-          { "id": "SILVER_CRUCIBLE", "condition": "Single player only" }
+          {
+            "id": "CURSED_PEARL",
+            "condition": null
+          },
+          {
+            "id": "HEFTY_TABLET",
+            "condition": null
+          },
+          {
+            "id": "LARGE_CAPSULE",
+            "condition": null
+          },
+          {
+            "id": "LEAFY_POULTICE",
+            "condition": null
+          },
+          {
+            "id": "NEOWS_BONES",
+            "condition": null
+          },
+          {
+            "id": "PRECARIOUS_SHEARS",
+            "condition": null
+          },
+          {
+            "id": "SILKEN_TRESS",
+            "condition": null
+          },
+          {
+            "id": "SILVER_CRUCIBLE",
+            "condition": "Single player only"
+          }
         ]
       },
       {
         "name": "Positive Pool",
         "description": "Two relics are chosen at random. Some relics are excluded based on which curse was selected.",
         "relics": [
-          { "id": "ARCANE_SCROLL", "condition": "Excluded if Hefty Tablet is the curse option" },
-          { "id": "BOOMING_CONCH", "condition": null },
-          { "id": "FISHING_ROD", "condition": null },
-          { "id": "KALEIDOSCOPE", "condition": null },
-          { "id": "POMANDER", "condition": "50% chance (vs Neow's Talisman)" },
-          { "id": "LEAD_PAPERWEIGHT", "condition": null },
-          { "id": "NEOWS_TALISMAN", "condition": "50% chance (vs Pomander)" },
-          { "id": "NEOWS_TORMENT", "condition": null },
-          { "id": "LOST_COFFER", "condition": null },
-          { "id": "GOLDEN_PEARL", "condition": "Excluded if Cursed Pearl is the curse option" },
-          { "id": "PHIAL_HOLSTER", "condition": null },
-          { "id": "PRECISE_SCISSORS", "condition": "Excluded if Precarious Shears is the curse option" },
-          { "id": "WINGED_BOOTS", "condition": null },
-          { "id": "NEW_LEAF", "condition": "Excluded if Leafy Poultice is the curse option" },
-          { "id": "NUTRITIOUS_OYSTER", "condition": "50% chance (vs Stone Humidifier)" },
-          { "id": "STONE_HUMIDIFIER", "condition": "50% chance (vs Nutritious Oyster)" },
-          { "id": "LAVA_ROCK", "condition": "50% chance (vs Small Capsule); excluded if Large Capsule is the curse option" },
-          { "id": "SMALL_CAPSULE", "condition": "50% chance (vs Lava Rock); excluded if Large Capsule is the curse option" },
-          { "id": "MASSIVE_SCROLL", "condition": "Multiplayer only" },
-          { "id": "SCROLL_BOXES", "condition": "Player has cards that can form bundles" }
+          {
+            "id": "ARCANE_SCROLL",
+            "condition": "Excluded if Hefty Tablet is the curse option"
+          },
+          {
+            "id": "BOOMING_CONCH",
+            "condition": null
+          },
+          {
+            "id": "FISHING_ROD",
+            "condition": null
+          },
+          {
+            "id": "GOLDEN_PEARL",
+            "condition": "Excluded if Cursed Pearl is the curse option"
+          },
+          {
+            "id": "KALEIDOSCOPE",
+            "condition": null
+          },
+          {
+            "id": "LEAD_PAPERWEIGHT",
+            "condition": null
+          },
+          {
+            "id": "LOST_COFFER",
+            "condition": null
+          },
+          {
+            "id": "MASSIVE_SCROLL",
+            "condition": "Multiplayer only"
+          },
+          {
+            "id": "NEOWS_TORMENT",
+            "condition": null
+          },
+          {
+            "id": "NEW_LEAF",
+            "condition": "Excluded if Leafy Poultice is the curse option"
+          },
+          {
+            "id": "PHIAL_HOLSTER",
+            "condition": null
+          },
+          {
+            "id": "PRECISE_SCISSORS",
+            "condition": "Excluded if Precarious Shears is the curse option"
+          },
+          {
+            "id": "SCROLL_BOXES",
+            "condition": "Player has cards that can form bundles"
+          },
+          {
+            "id": "WINGED_BOOTS",
+            "condition": null
+          },
+          {
+            "id": "LAVA_ROCK",
+            "condition": "50% chance (vs Small Capsule); excluded if Large Capsule is the curse option"
+          },
+          {
+            "id": "NEOWS_TALISMAN",
+            "condition": "50% chance (vs Pomander)"
+          },
+          {
+            "id": "NUTRITIOUS_OYSTER",
+            "condition": "50% chance (vs Stone Humidifier)"
+          },
+          {
+            "id": "POMANDER",
+            "condition": "50% chance (vs Neow's Talisman)"
+          },
+          {
+            "id": "SMALL_CAPSULE",
+            "condition": "50% chance (vs Lava Rock); excluded if Large Capsule is the curse option"
+          },
+          {
+            "id": "STONE_HUMIDIFIER",
+            "condition": "50% chance (vs Nutritious Oyster)"
+          }
         ]
       }
     ]
   },
   {
-    "id": "TEZCATARA",
-    "name": "Tezcatara",
-    "description": "Offers one relic from each of three pools, chosen at random.",
-    "selection": "1 from each pool (3 total)",
+    "id": "NONUPEIPE",
+    "name": "Nonupeipe",
+    "description": "Has a single large pool. Three relics are chosen at random.",
+    "selection": "3 from pool",
     "pools": [
       {
-        "name": "Pool 1",
+        "name": "Relic Pool",
         "relics": [
-          { "id": "NUTRITIOUS_SOUP", "condition": null },
-          { "id": "VERY_HOT_COCOA", "condition": null },
-          { "id": "YUMMY_COOKIE", "condition": null }
-        ]
-      },
-      {
-        "name": "Pool 2",
-        "relics": [
-          { "id": "BIIIG_HUG", "condition": null },
-          { "id": "STORYBOOK", "condition": null },
-          { "id": "TOASTY_MITTENS", "condition": null }
-        ]
-      },
-      {
-        "name": "Pool 3",
-        "relics": [
-          { "id": "GOLDEN_COMPASS", "condition": null },
-          { "id": "PUMPKIN_CANDLE", "condition": null },
-          { "id": "TOY_BOX", "condition": null },
-          { "id": "SEAL_OF_GOLD", "condition": null }
-        ]
-      }
-    ]
-  },
-  {
-    "id": "PAEL",
-    "name": "Pael",
-    "description": "Offers one relic from each of three pools. Pool 2 has conditional additions and Pael's Growth has a reduced chance.",
-    "selection": "1 from each pool (3 total)",
-    "pools": [
-      {
-        "name": "Pool 1",
-        "relics": [
-          { "id": "PAELS_FLESH", "condition": null },
-          { "id": "PAELS_HORN", "condition": null },
-          { "id": "PAELS_TEARS", "condition": null }
-        ]
-      },
-      {
-        "name": "Pool 2",
-        "description": "The pool is doubled before adding Pael's Growth, giving Growth a reduced chance.",
-        "relics": [
-          { "id": "PAELS_WING", "condition": null },
-          { "id": "PAELS_CLAW", "condition": "Deck has 3+ cards that can be enchanted with Goopy" },
-          { "id": "PAELS_TOOTH", "condition": "Deck has 5+ removable cards" },
-          { "id": "PAELS_GROWTH", "condition": "Always in pool but at reduced odds (pool is doubled before adding)" }
-        ]
-      },
-      {
-        "name": "Pool 3",
-        "relics": [
-          { "id": "PAELS_EYE", "condition": null },
-          { "id": "PAELS_BLOOD", "condition": null },
-          { "id": "PAELS_LEGION", "condition": "Player does not have an event pet (Byrdpip relic or Byrdonis Egg card)" }
+          {
+            "id": "BLESSED_ANTLER",
+            "condition": null
+          },
+          {
+            "id": "BRILLIANT_SCARF",
+            "condition": null
+          },
+          {
+            "id": "DELICATE_FROND",
+            "condition": null
+          },
+          {
+            "id": "DIAMOND_DIADEM",
+            "condition": null
+          },
+          {
+            "id": "FUR_COAT",
+            "condition": null
+          },
+          {
+            "id": "GLITTER",
+            "condition": null
+          },
+          {
+            "id": "JEWELRY_BOX",
+            "condition": null
+          },
+          {
+            "id": "LOOMING_FRUIT",
+            "condition": null
+          },
+          {
+            "id": "SIGNET_RING",
+            "condition": null
+          },
+          {
+            "id": "BEAUTIFUL_BRACELET",
+            "condition": "Deck has 4+ cards that can be enchanted with Swift"
+          }
         ]
       }
     ]
@@ -124,82 +262,121 @@
         "name": "Pool 1",
         "description": "Includes either Prismatic Gem (33% chance) or Sea Glass (67% chance). Sea Glass picks from a random unlocked character other than the current one.",
         "relics": [
-          { "id": "ELECTRIC_SHRYMP", "condition": null },
-          { "id": "GLASS_EYE", "condition": null },
-          { "id": "SAND_CASTLE", "condition": null },
-          { "id": "PRISMATIC_GEM", "condition": "33% chance (vs Sea Glass)" },
-          { "id": "SEA_GLASS", "condition": "67% chance (vs Prismatic Gem); character is random unlocked non-current" }
+          {
+            "id": "ELECTRIC_SHRYMP",
+            "condition": null
+          },
+          {
+            "id": "GLASS_EYE",
+            "condition": null
+          },
+          {
+            "id": "SAND_CASTLE",
+            "condition": null
+          },
+          {
+            "id": "PRISMATIC_GEM",
+            "condition": "33% chance (vs Sea Glass)"
+          },
+          {
+            "id": "SEA_GLASS",
+            "condition": "67% chance (vs Prismatic Gem); character is random unlocked non-current"
+          }
         ]
       },
       {
         "name": "Pool 2",
         "relics": [
-          { "id": "ALCHEMICAL_COFFER", "condition": null },
-          { "id": "DRIFTWOOD", "condition": null },
-          { "id": "RADIANT_PEARL", "condition": null }
+          {
+            "id": "ALCHEMICAL_COFFER",
+            "condition": null
+          },
+          {
+            "id": "DRIFTWOOD",
+            "condition": null
+          },
+          {
+            "id": "RADIANT_PEARL",
+            "condition": null
+          }
         ]
       },
       {
         "name": "Pool 3",
         "description": "Both relics require player setup. If neither is available, a locked option is shown.",
         "relics": [
-          { "id": "TOUCH_OF_OROBAS", "condition": "Requires player setup (starter relic upgrade)" },
-          { "id": "ARCHAIC_TOOTH", "condition": "Requires player setup" }
+          {
+            "id": "TOUCH_OF_OROBAS",
+            "condition": "Requires player setup (starter relic upgrade)"
+          },
+          {
+            "id": "ARCHAIC_TOOTH",
+            "condition": "Requires player setup"
+          }
         ]
       }
     ]
   },
   {
-    "id": "DARV",
-    "name": "Darv",
-    "description": "Has a large pool of powerful relics. 50% chance to get 3 options from the pool, 50% chance to get 2 options plus Dusty Tome.",
-    "selection": "50% chance: 3 from pool OR 2 from pool + Dusty Tome",
+    "id": "PAEL",
+    "name": "Pael",
+    "description": "Offers one relic from each of three pools. Pool 2 has conditional additions and Pael's Growth has a reduced chance.",
+    "selection": "1 from each pool (3 total)",
     "pools": [
       {
-        "name": "Relic Pool",
-        "description": "Each set has one relic chosen at random. Sets with act conditions are only included if the condition is met.",
+        "name": "Pool 1",
         "relics": [
-          { "id": "ASTROLABE", "condition": null },
-          { "id": "BLACK_STAR", "condition": null },
-          { "id": "CALLING_BELL", "condition": null },
-          { "id": "EMPTY_CAGE", "condition": null },
-          { "id": "PANDORAS_BOX", "condition": "Excluded with Draft, Sealed Deck, or Insanity modifiers" },
-          { "id": "RUNIC_PYRAMID", "condition": null },
-          { "id": "SNECKO_EYE", "condition": null },
-          { "id": "ECTOPLASM", "condition": "Act 2 only; 50% chance (vs Sozu)" },
-          { "id": "SOZU", "condition": "Act 2 only; 50% chance (vs Ectoplasm)" },
-          { "id": "PHILOSOPHERS_STONE", "condition": "Act 3 only; 50% chance (vs Velvet Choker)" },
-          { "id": "VELVET_CHOKER", "condition": "Act 3 only; 50% chance (vs Philosopher's Stone)" }
+          {
+            "id": "PAELS_FLESH",
+            "condition": null
+          },
+          {
+            "id": "PAELS_HORN",
+            "condition": null
+          },
+          {
+            "id": "PAELS_TEARS",
+            "condition": null
+          }
         ]
       },
       {
-        "name": "Dusty Tome",
-        "description": "50% chance to replace one of the three options.",
+        "name": "Pool 2",
+        "description": "The pool is doubled before adding Pael's Growth, giving Growth a reduced chance.",
         "relics": [
-          { "id": "DUSTY_TOME", "condition": "50% chance to appear as the third option" }
+          {
+            "id": "PAELS_WING",
+            "condition": null
+          },
+          {
+            "id": "PAELS_CLAW",
+            "condition": "Deck has 3+ cards that can be enchanted with Goopy"
+          },
+          {
+            "id": "PAELS_TOOTH",
+            "condition": "Deck has 5+ removable cards"
+          },
+          {
+            "id": "PAELS_GROWTH",
+            "condition": "Always in pool but at reduced odds (pool is doubled before adding)"
+          }
         ]
-      }
-    ]
-  },
-  {
-    "id": "NONUPEIPE",
-    "name": "Nonupeipe",
-    "description": "Has a single large pool. Three relics are chosen at random.",
-    "selection": "3 from pool",
-    "pools": [
+      },
       {
-        "name": "Relic Pool",
+        "name": "Pool 3",
         "relics": [
-          { "id": "BLESSED_ANTLER", "condition": null },
-          { "id": "BRILLIANT_SCARF", "condition": null },
-          { "id": "DELICATE_FROND", "condition": null },
-          { "id": "DIAMOND_DIADEM", "condition": null },
-          { "id": "FUR_COAT", "condition": null },
-          { "id": "GLITTER", "condition": null },
-          { "id": "JEWELRY_BOX", "condition": null },
-          { "id": "LOOMING_FRUIT", "condition": null },
-          { "id": "SIGNET_RING", "condition": null },
-          { "id": "BEAUTIFUL_BRACELET", "condition": "Deck has 4+ cards that can be enchanted with Swift" }
+          {
+            "id": "PAELS_EYE",
+            "condition": null
+          },
+          {
+            "id": "PAELS_BLOOD",
+            "condition": null
+          },
+          {
+            "id": "PAELS_LEGION",
+            "condition": "Player does not have an event pet (Byrdpip relic or Byrdonis Egg card)"
+          }
         ]
       }
     ]
@@ -213,16 +390,109 @@
       {
         "name": "Relic Pool",
         "relics": [
-          { "id": "CLAWS", "condition": null },
-          { "id": "CROSSBOW", "condition": null },
-          { "id": "IRON_CLUB", "condition": null },
-          { "id": "MEAT_CLEAVER", "condition": null },
-          { "id": "SAI", "condition": null },
-          { "id": "SPIKED_GAUNTLETS", "condition": null },
-          { "id": "TANXS_WHISTLE", "condition": null },
-          { "id": "THROWING_AXE", "condition": null },
-          { "id": "WAR_HAMMER", "condition": null },
-          { "id": "TRI_BOOMERANG", "condition": "Deck has 3+ Attack cards (the type filter Instinct enforces)" }
+          {
+            "id": "CLAWS",
+            "condition": null
+          },
+          {
+            "id": "CROSSBOW",
+            "condition": null
+          },
+          {
+            "id": "IRON_CLUB",
+            "condition": null
+          },
+          {
+            "id": "MEAT_CLEAVER",
+            "condition": null
+          },
+          {
+            "id": "SAI",
+            "condition": null
+          },
+          {
+            "id": "SPIKED_GAUNTLETS",
+            "condition": null
+          },
+          {
+            "id": "TANXS_WHISTLE",
+            "condition": null
+          },
+          {
+            "id": "THROWING_AXE",
+            "condition": null
+          },
+          {
+            "id": "WAR_HAMMER",
+            "condition": null
+          },
+          {
+            "id": "TRI_BOOMERANG",
+            "condition": "Deck has 3+ Attack cards (the type filter Instinct enforces)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "TEZCATARA",
+    "name": "Tezcatara",
+    "description": "Offers one relic from each of three pools, chosen at random.",
+    "selection": "1 from each pool (3 total)",
+    "pools": [
+      {
+        "name": "Pool 1",
+        "relics": [
+          {
+            "id": "VERY_HOT_COCOA",
+            "condition": null
+          },
+          {
+            "id": "YUMMY_COOKIE",
+            "condition": null
+          },
+          {
+            "id": "NUTRITIOUS_SOUP",
+            "condition": null
+          }
+        ]
+      },
+      {
+        "name": "Pool 2",
+        "relics": [
+          {
+            "id": "BIIIG_HUG",
+            "condition": null
+          },
+          {
+            "id": "STORYBOOK",
+            "condition": null
+          },
+          {
+            "id": "TOASTY_MITTENS",
+            "condition": null
+          }
+        ]
+      },
+      {
+        "name": "Pool 3",
+        "relics": [
+          {
+            "id": "GOLDEN_COMPASS",
+            "condition": null
+          },
+          {
+            "id": "PUMPKIN_CANDLE",
+            "condition": null
+          },
+          {
+            "id": "TOY_BOX",
+            "condition": null
+          },
+          {
+            "id": "SEAL_OF_GOLD",
+            "condition": null
+          }
         ]
       }
     ]
@@ -236,26 +506,56 @@
       {
         "name": "Pool 1",
         "relics": [
-          { "id": "BLOOD_SOAKED_ROSE", "condition": null },
-          { "id": "WHISPERING_EARRING", "condition": null },
-          { "id": "FIDDLE", "condition": null }
+          {
+            "id": "BLOOD_SOAKED_ROSE",
+            "condition": null
+          },
+          {
+            "id": "WHISPERING_EARRING",
+            "condition": null
+          },
+          {
+            "id": "FIDDLE",
+            "condition": null
+          }
         ]
       },
       {
         "name": "Pool 2",
         "relics": [
-          { "id": "PRESERVED_FOG", "condition": null },
-          { "id": "SERE_TALON", "condition": null },
-          { "id": "DISTINGUISHED_CAPE", "condition": null }
+          {
+            "id": "PRESERVED_FOG",
+            "condition": null
+          },
+          {
+            "id": "SERE_TALON",
+            "condition": null
+          },
+          {
+            "id": "DISTINGUISHED_CAPE",
+            "condition": null
+          }
         ]
       },
       {
         "name": "Pool 3",
         "relics": [
-          { "id": "CHOICES_PARADOX", "condition": null },
-          { "id": "LORDS_PARASOL", "condition": null },
-          { "id": "JEWELED_MASK", "condition": null },
-          { "id": "MUSIC_BOX", "condition": null }
+          {
+            "id": "CHOICES_PARADOX",
+            "condition": null
+          },
+          {
+            "id": "MUSIC_BOX",
+            "condition": null
+          },
+          {
+            "id": "LORDS_PARASOL",
+            "condition": null
+          },
+          {
+            "id": "JEWELED_MASK",
+            "condition": null
+          }
         ]
       }
     ]


### PR DESCRIPTION
The ancient (Neow/Tezcatara/etc.) relic pools on `/ancients` keep going stale after game updates because `data/ancient_pools.json` was hand-maintained. The parser only flagged drift in a log nobody acted on, so new relics like Fishing Rod silently never showed and Seal of Gold sat in the wrong pool. It has drifted to production several times.

This makes the file **generated** instead. `ancient_pool_parser.py` now reads each ancient's pool membership directly from the decompiled C# event sources and writes `data/ancient_pools.json` on every `parse_all` run:

- Adding a relic in a new release flows through automatically (membership comes from the C#), so no hand edit and no drift.
- A self-check asserts the generated pools cover the full C# relic set per ancient. If a relic ever lands in an option group `POOL_LAYOUT` does not list, `parse_all` fails loudly and names the relic/group to add, instead of dropping it.
- Conditions and prose descriptions (the only genuinely hand-authored bits) are carried forward from the previous file by (ancient, relic) and (ancient, pool), the same way `diff_data.py` preserves hand-written release notes across regen.

`POOL_LAYOUT` (the per-ancient group-to-pool map) only needs touching when Mega Crit restructures an ancient's code or adds a new ancient, never when they add relics.

This also fixes the current v0.107.1 drift: Neow now offers Fishing Rod, Kaleidoscope, and Silken Tress, Scroll Boxes is in the positive pool, and Tezcatara's Seal of Gold is in pool 3. I verified the generated pools match the correct set across all 8 ancients.

Supersedes the manual fix in #500.
