### PR TITLE
Filter modded runs (Ascension 11+) out of the stats

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -681,6 +681,11 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
             rows = [dict(r) for r in rows]
 
     for row in rows:
+        # Official runs only: A11-A99 are modded (the game caps at Ascension
+        # 10), so skip them from entity scores and the community stats
+        # accumulated in this same walk.
+        if (row.get("ascension") or 0) > 10:
+            continue
         new_totals["total_runs"] += 1
         if row["win"]:
             new_totals["total_wins"] += 1

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -624,6 +624,11 @@ def _build_match(
         m["was_abandoned"] = {"$in": [True, 1]}
     if ascension is not None and ascension != "":
         m["ascension"] = int(ascension)
+    else:
+        # Official runs only: the game caps at Ascension 10, so A11-A99 come
+        # from mods. Exclude them from every stats breakdown (and the
+        # by-ascension grouping) so the stats reflect the real game.
+        m["ascension"] = {"$lte": 10}
     if game_mode:
         m["game_mode"] = game_mode
     if players == "single":


### PR DESCRIPTION
The `/leaderboards/stats` page was showing Ascension 11-99 and the entity-stats scores had mod-related numbers, because modded runs were being counted. The game caps at Ascension 10 (`data/ascensions.json` has levels 0-10), so anything A11-A99 is from a mod.

Two changes, both filtering to official runs only:

- `runs_db_mongo._build_match` now caps ascension at `<= 10` when no specific ascension is requested. That feeds every `get_stats` breakdown (the `/leaderboards/stats` overview, pick rates, and the by-ascension grouping), so the modded A11-A99 levels stop appearing.
- `run_entity_stats` skips A11+ runs in its run walk. That walk also accumulates `community_stats` in the same pass, so this one skip cleans both the entity scores and the `/community-stats` by-ascension breakdown.

Net effect: stats and entity scores reflect only what's officially in the game. A specific in-range ascension filter (A0-A10) still works; requesting A11+ just returns nothing.

Note: this excludes whole modded runs by ascension, which covers the reported cases (modded runs are high-ascension). If modded entities ever slip in from a low-ascension modded run, the follow-up would be a catalog filter on the entity scores.
