### PR TITLE
Fix duplicate accounts on Steam linking, add an admin Users panel

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -236,6 +236,96 @@ def runs_delete(request: Request, run_hash: str):
     return {"run_hash": run_hash, **result}
 
 
+# ── Users ───────────────────────────────────────────────────────────────
+
+
+def _require_mongo_users() -> None:
+    if not os.environ.get("MONGO_URL", "").strip():
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=503, detail="user management needs MongoDB")
+
+
+@router.get("/users")
+def users_list(request: Request, q: str | None = None, page: int = 1, limit: int = 50):
+    """Every registered account, newest first, with linked identities and run
+    counts. `q` filters by username, email, or any identity id (Steam/Discord/
+    Twitch/account id)."""
+    _audit(request)
+    _require_mongo_users()
+    from ..services.users_db import admin_list_users
+
+    return admin_list_users(q=q, page=page, limit=limit)
+
+
+@router.patch("/users/{user_id}")
+async def users_rename(request: Request, user_id: str):
+    """Admin rename: bypasses the 3/day self-service cap but still enforces
+    sanitization + uniqueness, and re-stamps the name on the account's runs."""
+    _audit(request)
+    _require_mongo_users()
+    from fastapi import HTTPException
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    username = (body.get("username") or "").strip()
+    if not username:
+        raise HTTPException(status_code=422, detail="username required")
+    from ..services.users_db import admin_set_username
+
+    result = admin_set_username(user_id, username)
+    if result.get("error"):
+        raise HTTPException(status_code=400, detail=result["error"])
+    logger.info("admin renamed user %s -> %s", user_id, result.get("username"))
+    return result
+
+
+@router.delete("/users/{user_id}")
+def users_delete(request: Request, user_id: str):
+    """Delete an account. Its runs are kept but unlinked (user_id cleared), so
+    nothing is lost; merge instead when you want to keep the attribution."""
+    _audit(request)
+    _require_mongo_users()
+    from fastapi import HTTPException
+
+    from ..services.users_db import admin_delete_user
+
+    result = admin_delete_user(user_id)
+    if result.get("error"):
+        raise HTTPException(status_code=404, detail=result["error"])
+    logger.info("admin deleted user %s: %s", user_id, result)
+    return result
+
+
+@router.post("/users/merge")
+async def users_merge(request: Request):
+    """Merge one account into another: body {"source_id", "target_id"}. Moves
+    the source's runs onto the target, lifts any identities the target lacks
+    (Steam / Discord / Twitch / email / partner) from the source, then deletes
+    the source."""
+    _audit(request)
+    _require_mongo_users()
+    from fastapi import HTTPException
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    source_id = (body.get("source_id") or "").strip()
+    target_id = (body.get("target_id") or "").strip()
+    if not source_id or not target_id:
+        raise HTTPException(status_code=422, detail="source_id and target_id required")
+    from ..services.users_db import admin_merge_users
+
+    result = admin_merge_users(source_id, target_id)
+    if result.get("error"):
+        raise HTTPException(status_code=400, detail=result["error"])
+    logger.info("admin merged user %s into %s: %s", source_id, target_id, result)
+    return result
+
+
 @router.get("/feedback")
 def feedback_inbox(request: Request, include_resolved: bool = False, limit: int = 50):
     """The feedback inbox: site feedback and QA card reports, newest first.

--- a/backend/app/routers/auth_steam.py
+++ b/backend/app/routers/auth_steam.py
@@ -102,6 +102,10 @@ async def start(request: Request) -> dict:
 async def redirect_to_steam(request: Request):
     """Direct browser redirect to Steam login. For mobile and popup-blocked flows."""
     sid = auth_session_store.create_session()
+    # Mark this as the website flow so the callback may link Steam to an already
+    # signed-in account (the cookie rides along on the top-level return). The
+    # overlay's /start flow leaves this unset, so its callback never links.
+    auth_session_store.update_session(sid, web=True)
     base = _public_base(request)
     return_to = f"{base}/api/auth/steam/callback?session={sid}"
     realm = base + "/"
@@ -186,13 +190,40 @@ async def callback(request: Request) -> HTMLResponse:
     user_id = None
     token = None
     needs_email = False
+    linked_existing = False
     try:
-        from ..services.users_db import find_or_create_by_steam
-        from ..services.auth_jwt import create_token
+        from ..services.users_db import find_or_create_by_steam, link_steam
+        from ..services.auth_jwt import create_token, get_current_user
 
-        user = find_or_create_by_steam(steamid, persona)
+        # When this came from the website (the /redirect flow) and the browser
+        # still carries a valid session cookie for an account without a Steam id
+        # yet, link Steam to THAT account rather than creating a second,
+        # Steam-only one. The Discord connector already links this way; the Steam
+        # side used to always create-or-find, which is exactly how a Discord-first
+        # user ended up with a duplicate Steam-only account.
+        existing_user = get_current_user(request) if session.get("web") else None
+        if existing_user and not existing_user.get("steam_id"):
+            result = link_steam(existing_user["_id"], steamid)
+            if result.get("error"):
+                # The Steam id already belongs to a different account, so we
+                # can't silently merge. Send them back to settings with why.
+                frontend = os.environ.get("FRONTEND_URL", "").strip() or _public_base(
+                    request
+                )
+                auth_session_store.pop_session(session_id)
+                return RedirectResponse(f"{frontend}/settings?error=steam_in_use")
+            user = existing_user
+            user["steam_id"] = steamid
+            linked_existing = True
+        else:
+            user = find_or_create_by_steam(steamid, persona)
+
         user_id = user["_id"]
-        token = create_token(user_id=user["_id"], steam_id=steamid)
+        token = create_token(
+            user_id=user["_id"],
+            steam_id=steamid,
+            discord_id=user.get("discord_id"),
+        )
         needs_email = not user.get("email")
 
         # Link any runs the overlay / Compendium submitted under this Steam
@@ -245,7 +276,14 @@ async def callback(request: Request) -> HTMLResponse:
     if token:
         frontend = os.environ.get("FRONTEND_URL", "").strip() or _public_base(request)
         auth_session_store.pop_session(session_id)
-        response = RedirectResponse(f"{frontend}/profile?auth=steam&token={token}")
+        # A link lands back on settings (where the connect button lives); a
+        # fresh sign-in lands on the profile, as before.
+        dest = (
+            f"{frontend}/settings?linked=steam&token={token}"
+            if linked_existing
+            else f"{frontend}/profile?auth=steam&token={token}"
+        )
+        response = RedirectResponse(dest)
         response.headers["Cache-Control"] = "no-store, no-cache"
         response.headers["Pragma"] = "no-cache"
         return response

--- a/backend/app/services/users_db.py
+++ b/backend/app/services/users_db.py
@@ -370,3 +370,244 @@ def _deduplicate_username(coll, username: str, username_lower: str) -> tuple[str
     suffix = secrets.token_hex(3)
     fallback = f"{username[: _USERNAME_MAX - 7]}_{suffix}"
     return fallback, fallback.lower()
+
+
+# ── Admin user management ────────────────────────────────────────────────
+#
+# Backs the /admin/users panel: list/search every account, rename (admin
+# override of the 3/day limit), delete (keeps the runs, just unlinks them),
+# and merge (fold one account into another, moving runs and lifting any
+# identities the target lacks). All Mongo-only; the admin router gates access.
+
+_ADMIN_USER_FIELDS = {
+    "username": 1,
+    "email": 1,
+    "steam_id": 1,
+    "discord_id": 1,
+    "twitch_id": 1,
+    "twitch_login": 1,
+    "is_partner": 1,
+    "created_at": 1,
+}
+
+# Identity fields a merge lifts from the source onto the target when the
+# target doesn't already have them. steam_id/discord_id/twitch_id are the
+# partial-unique ones, freed automatically when the source doc is deleted.
+_IDENTITY_FIELDS = (
+    "steam_id",
+    "discord_id",
+    "twitch_id",
+    "twitch_login",
+    "twitch_display_name",
+    "email",
+)
+
+
+def _public_admin_user(d: dict) -> dict:
+    return {
+        "_id": str(d["_id"]),
+        "username": d.get("username"),
+        "email": d.get("email"),
+        "steam_id": d.get("steam_id"),
+        "discord_id": d.get("discord_id"),
+        "twitch_id": d.get("twitch_id"),
+        "twitch_login": d.get("twitch_login"),
+        "is_partner": bool(d.get("is_partner")),
+        "created_at": (
+            d["created_at"].isoformat()
+            if isinstance(d.get("created_at"), datetime)
+            else d.get("created_at")
+        ),
+        "run_count": d.get("run_count", 0),
+    }
+
+
+def _runs_collection():
+    """The runs collection, imported lazily to avoid a circular import
+    (runs_db_mongo imports this module)."""
+    from .runs_db_mongo import get_database
+
+    return get_database()["runs"]
+
+
+def _attach_run_counts(users: list[dict]) -> None:
+    oids = []
+    for u in users:
+        try:
+            oids.append(ObjectId(u["_id"]))
+        except Exception:
+            pass
+    counts: dict[str, int] = {}
+    if oids:
+        try:
+            for row in _runs_collection().aggregate(
+                [
+                    {"$match": {"user_id": {"$in": oids}}},
+                    {"$group": {"_id": "$user_id", "n": {"$sum": 1}}},
+                ]
+            ):
+                counts[str(row["_id"])] = row["n"]
+        except Exception:
+            pass
+    for u in users:
+        u["run_count"] = counts.get(u["_id"], 0)
+
+
+def admin_list_users(q: str | None = None, page: int = 1, limit: int = 50) -> dict:
+    coll = _get_collection()
+    page = max(1, page)
+    limit = max(1, min(limit, 100))
+
+    query: dict = {}
+    if q and q.strip():
+        term = q.strip()
+        ors: list[dict] = [
+            {"username_lower": {"$regex": re.escape(term.lower())}},
+            {"steam_id": term},
+            {"discord_id": term},
+            {"twitch_login": term.lower()},
+            {"email": term.lower()},
+        ]
+        try:
+            ors.append({"_id": ObjectId(term)})
+        except Exception:
+            pass
+        query = {"$or": ors}
+
+    total = coll.count_documents(query)
+    cursor = (
+        coll.find(query, _ADMIN_USER_FIELDS)
+        .sort([("created_at", -1)])
+        .skip((page - 1) * limit)
+        .limit(limit)
+    )
+    users = []
+    for d in cursor:
+        d["_id"] = str(d["_id"])
+        users.append(d)
+    _attach_run_counts(users)
+    return {
+        "users": [_public_admin_user(u) for u in users],
+        "total": total,
+        "page": page,
+        "limit": limit,
+    }
+
+
+def admin_set_username(user_id: str, new_name: str) -> dict:
+    """Rename an account as an admin: enforces sanitization and uniqueness but
+    skips the per-day self-service cap, and re-stamps the name on the runs."""
+    coll = _get_collection()
+    try:
+        oid = ObjectId(user_id)
+    except Exception:
+        return {"error": "Invalid user id"}
+
+    cleaned = sanitize_username(new_name)
+    if not cleaned:
+        return {"error": "Username is empty after sanitization"}
+    lower = cleaned.lower()
+
+    conflict = coll.find_one({"username_lower": lower, "_id": {"$ne": oid}}, {"_id": 1})
+    if conflict:
+        return {"error": "Username is already taken"}
+
+    result = coll.update_one(
+        {"_id": oid},
+        {
+            "$set": {
+                "username": cleaned,
+                "username_lower": lower,
+                "updated_at": datetime.now(timezone.utc),
+            }
+        },
+    )
+    if result.matched_count == 0:
+        return {"error": "User not found"}
+
+    try:
+        _runs_collection().update_many(
+            {"user_id": oid}, {"$set": {"username": cleaned}}
+        )
+    except Exception:
+        pass
+    return {"success": True, "username": cleaned}
+
+
+def admin_delete_user(user_id: str) -> dict:
+    """Delete an account. Its runs are kept but unlinked (user_id cleared) so
+    nothing is lost; use merge when you want to keep the run attribution."""
+    coll = _get_collection()
+    try:
+        oid = ObjectId(user_id)
+    except Exception:
+        return {"error": "Invalid user id"}
+
+    if not coll.find_one({"_id": oid}, {"_id": 1}):
+        return {"error": "User not found"}
+
+    unlinked = 0
+    try:
+        res = _runs_collection().update_many(
+            {"user_id": oid}, {"$set": {"user_id": None}}
+        )
+        unlinked = res.modified_count
+    except Exception:
+        pass
+    coll.delete_one({"_id": oid})
+    return {"success": True, "runs_unlinked": unlinked}
+
+
+def admin_merge_users(source_id: str, target_id: str) -> dict:
+    """Fold the source account into the target: move the source's runs onto the
+    target, lift any identities the target lacks from the source, then delete
+    the source."""
+    coll = _get_collection()
+    if source_id == target_id:
+        return {"error": "Source and target are the same account"}
+    try:
+        s_oid = ObjectId(source_id)
+        t_oid = ObjectId(target_id)
+    except Exception:
+        return {"error": "Invalid user id"}
+
+    source = coll.find_one({"_id": s_oid})
+    target = coll.find_one({"_id": t_oid})
+    if not source:
+        return {"error": "Source account not found"}
+    if not target:
+        return {"error": "Target account not found"}
+
+    copy_fields: dict = {}
+    for f in _IDENTITY_FIELDS:
+        if not target.get(f) and source.get(f):
+            copy_fields[f] = source.get(f)
+    if source.get("is_partner") and not target.get("is_partner"):
+        copy_fields["is_partner"] = True
+
+    # Move runs first (source still exists), then delete the source so its
+    # partial-unique identity values are free, then graft them onto the target.
+    moved = 0
+    try:
+        res = _runs_collection().update_many(
+            {"user_id": s_oid},
+            {"$set": {"user_id": t_oid, "username": target.get("username")}},
+        )
+        moved = res.modified_count
+    except Exception:
+        pass
+
+    coll.delete_one({"_id": s_oid})
+
+    if copy_fields:
+        copy_fields["updated_at"] = datetime.now(timezone.utc)
+        try:
+            coll.update_one({"_id": t_oid}, {"$set": copy_fields})
+        except DuplicateKeyError:
+            return {"error": "Identity conflict while merging onto the target"}
+
+    return {
+        "success": True,
+        "runs_moved": moved,
+        "copied": [k for k in copy_fields if k != "updated_at"],
+    }

--- a/frontend/app/admin/shared.tsx
+++ b/frontend/app/admin/shared.tsx
@@ -78,6 +78,7 @@ function NotFound() {
 const SECTIONS = [
   { href: "/admin", label: "Overview" },
   { href: "/admin/runs", label: "Runs" },
+  { href: "/admin/users", label: "Users" },
   { href: "/admin/feedback", label: "Feedback" },
   { href: "/admin/guides", label: "Guides" },
   { href: "/admin/banners", label: "Banners" },

--- a/frontend/app/admin/users/UsersClient.tsx
+++ b/frontend/app/admin/users/UsersClient.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+// User admin: list/search every account, rename (admin override of the 3/day
+// cap), delete (keeps runs, just unlinks them), and merge one account into
+// another (moves runs + lifts missing identities, then deletes the source).
+
+import { useCallback, useEffect, useState } from "react";
+import { AdminShell, adminFetch } from "../shared";
+
+interface UserRow {
+  _id: string;
+  username: string | null;
+  email: string | null;
+  steam_id: string | null;
+  discord_id: string | null;
+  twitch_id: string | null;
+  twitch_login: string | null;
+  is_partner: boolean;
+  created_at: string | null;
+  run_count: number;
+}
+
+interface UsersResponse {
+  users: UserRow[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+const LIMIT = 50;
+
+function IdentityBadges({ u }: { u: UserRow }) {
+  const badge = "px-1.5 py-0.5 rounded text-[10px] font-bold border";
+  return (
+    <span className="flex flex-wrap gap-1">
+      {u.steam_id && (
+        <span
+          className={`${badge} bg-sky-950/50 text-sky-300 border-sky-900/50`}
+          title={`Steam ${u.steam_id}`}
+        >
+          Steam
+        </span>
+      )}
+      {u.discord_id && (
+        <span
+          className={`${badge} bg-indigo-950/50 text-indigo-300 border-indigo-900/50`}
+          title={`Discord ${u.discord_id}`}
+        >
+          Discord
+        </span>
+      )}
+      {u.twitch_id && (
+        <span
+          className={`${badge} bg-[#9146FF]/15 text-[#b794ff] border-[#9146FF]/40`}
+          title={`Twitch ${u.twitch_login ?? u.twitch_id}`}
+        >
+          Twitch
+        </span>
+      )}
+      {u.is_partner && (
+        <span className={`${badge} bg-amber-950/50 text-amber-300 border-amber-900/50`}>
+          Partner
+        </span>
+      )}
+    </span>
+  );
+}
+
+export default function UsersClient() {
+  const [q, setQ] = useState("");
+  const [rows, setRows] = useState<UserRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+  // When set, the table is in "pick a target" mode for merging this account.
+  const [mergeSource, setMergeSource] = useState<UserRow | null>(null);
+
+  const load = useCallback(async (search: string, pg: number) => {
+    setBusy(true);
+    setNote(null);
+    try {
+      const params = new URLSearchParams({ page: String(pg), limit: String(LIMIT) });
+      if (search.trim()) params.set("q", search.trim());
+      const data = await adminFetch<UsersResponse>(`/api/admin/users?${params}`);
+      setRows(data.users ?? []);
+      setTotal(data.total ?? 0);
+      setPage(data.page ?? pg);
+      if (!(data.users ?? []).length) setNote("No accounts matched.");
+    } catch (e) {
+      setNote(String((e as Error)?.message || e));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load("", 1);
+  }, [load]);
+
+  function search() {
+    setMergeSource(null);
+    load(q, 1);
+  }
+
+  async function rename(u: UserRow) {
+    const next = window.prompt(`New display name for "${u.username ?? u._id}":`, u.username ?? "");
+    if (next == null) return;
+    if (!next.trim() || next.trim() === (u.username ?? "")) return;
+    try {
+      const res = await adminFetch<{ username: string }>(`/api/admin/users/${u._id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: next.trim() }),
+      });
+      setRows((prev) =>
+        prev.map((r) => (r._id === u._id ? { ...r, username: res.username } : r)),
+      );
+      setNote(`Renamed to "${res.username}".`);
+    } catch (e) {
+      setNote(String((e as Error)?.message || e));
+    }
+  }
+
+  async function remove(u: UserRow) {
+    const msg =
+      `Delete account "${u.username ?? u._id}"?\n\n` +
+      `Its ${u.run_count} run(s) are kept but unlinked (set to anonymous). ` +
+      `Use Merge instead to keep run attribution.`;
+    if (!window.confirm(msg)) return;
+    try {
+      const res = await adminFetch<{ runs_unlinked: number }>(
+        `/api/admin/users/${u._id}`,
+        { method: "DELETE" },
+      );
+      setRows((prev) => prev.filter((r) => r._id !== u._id));
+      setTotal((t) => Math.max(0, t - 1));
+      setNote(`Deleted "${u.username ?? u._id}". ${res.runs_unlinked} run(s) unlinked.`);
+    } catch (e) {
+      setNote(String((e as Error)?.message || e));
+    }
+  }
+
+  async function mergeInto(target: UserRow) {
+    const src = mergeSource;
+    if (!src) return;
+    if (src._id === target._id) {
+      setNote("Pick a different account as the target.");
+      return;
+    }
+    const msg =
+      `Merge "${src.username ?? src._id}" INTO "${target.username ?? target._id}"?\n\n` +
+      `- ${src.run_count} run(s) move to "${target.username ?? target._id}"\n` +
+      `- "${target.username ?? target._id}" gains any Steam/Discord/Twitch/email it is missing\n` +
+      `- "${src.username ?? src._id}" is then deleted\n\nThis cannot be undone.`;
+    if (!window.confirm(msg)) return;
+    try {
+      const res = await adminFetch<{ runs_moved: number; copied: string[] }>(
+        `/api/admin/users/merge`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ source_id: src._id, target_id: target._id }),
+        },
+      );
+      setMergeSource(null);
+      setNote(
+        `Merged. ${res.runs_moved} run(s) moved` +
+          (res.copied.length ? `, lifted: ${res.copied.join(", ")}.` : "."),
+      );
+      load(q, page);
+    } catch (e) {
+      setNote(String((e as Error)?.message || e));
+    }
+  }
+
+  const inputClass =
+    "px-3 py-1.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]/50";
+  const actionBtn =
+    "px-2.5 py-1 rounded text-xs font-semibold border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-card)]";
+  const lastPage = Math.max(1, Math.ceil(total / LIMIT));
+
+  return (
+    <AdminShell title="Users" subtitle="search, rename, delete, merge">
+      <div className="flex flex-wrap gap-2 mb-4">
+        <input
+          className={`${inputClass} w-80`}
+          placeholder="Search username, email, Steam / Discord / Twitch id"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") search();
+          }}
+        />
+        <button
+          onClick={search}
+          disabled={busy}
+          className="px-4 py-1.5 rounded-lg bg-[var(--accent-gold)] text-[var(--bg-primary)] text-sm font-semibold hover:opacity-90 disabled:opacity-50"
+        >
+          {busy ? "Loading..." : "Search"}
+        </button>
+        <span className="ml-auto self-center text-xs text-[var(--text-muted)]">
+          {total} account{total === 1 ? "" : "s"}
+        </span>
+      </div>
+
+      {mergeSource && (
+        <div className="flex items-center gap-3 mb-4 px-3 py-2 rounded-lg border border-[var(--accent-gold)]/40 bg-[var(--accent-gold)]/10">
+          <span className="text-sm text-[var(--text-primary)]">
+            Merging <b>{mergeSource.username ?? mergeSource._id}</b> into… pick a target
+            row.
+          </span>
+          <button
+            onClick={() => setMergeSource(null)}
+            className={`${actionBtn} ml-auto`}
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {note && <p className="text-sm text-[var(--text-secondary)] mb-4">{note}</p>}
+
+      {rows.length > 0 && (
+        <div className="overflow-x-auto rounded-lg border border-[var(--border-subtle)]">
+          <table className="w-full text-sm">
+            <thead className="bg-[var(--bg-card)] text-left text-xs uppercase tracking-wider text-[var(--text-muted)]">
+              <tr>
+                <th className="px-3 py-2">User</th>
+                <th className="px-3 py-2">Identities</th>
+                <th className="px-3 py-2">Runs</th>
+                <th className="px-3 py-2">Created</th>
+                <th className="px-3 py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((u) => {
+                const isSource = mergeSource?._id === u._id;
+                return (
+                  <tr
+                    key={u._id}
+                    className={`border-t border-[var(--border-subtle)] ${
+                      isSource ? "bg-[var(--accent-gold)]/10" : ""
+                    }`}
+                  >
+                    <td className="px-3 py-2">
+                      <div className="text-[var(--text-primary)]">{u.username ?? "-"}</div>
+                      <div className="font-mono text-[10px] text-[var(--text-muted)]">
+                        {u._id}
+                        {u.email ? ` · ${u.email}` : ""}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2">
+                      <IdentityBadges u={u} />
+                    </td>
+                    <td className="px-3 py-2 tabular-nums">{u.run_count}</td>
+                    <td className="px-3 py-2 text-xs">
+                      {u.created_at ? new Date(u.created_at).toLocaleDateString() : "-"}
+                    </td>
+                    <td className="px-3 py-2">
+                      <div className="flex justify-end gap-1.5">
+                        {mergeSource ? (
+                          isSource ? (
+                            <span className="text-xs text-[var(--accent-gold)] self-center">
+                              source
+                            </span>
+                          ) : (
+                            <button
+                              onClick={() => mergeInto(u)}
+                              className="px-2.5 py-1 rounded text-xs font-semibold bg-[var(--accent-gold)]/20 text-[var(--accent-gold)] border border-[var(--accent-gold)]/40 hover:bg-[var(--accent-gold)]/30"
+                            >
+                              Merge here
+                            </button>
+                          )
+                        ) : (
+                          <>
+                            <button onClick={() => rename(u)} className={actionBtn}>
+                              Rename
+                            </button>
+                            <button
+                              onClick={() => {
+                                setNote(null);
+                                setMergeSource(u);
+                              }}
+                              className={actionBtn}
+                            >
+                              Merge
+                            </button>
+                            <button
+                              onClick={() => remove(u)}
+                              className="px-2.5 py-1 rounded text-xs font-semibold bg-rose-950/60 text-rose-300 border border-rose-900/40 hover:bg-rose-900/60"
+                            >
+                              Delete
+                            </button>
+                          </>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {total > LIMIT && (
+        <div className="flex items-center justify-center gap-3 mt-4">
+          <button
+            onClick={() => load(q, page - 1)}
+            disabled={busy || page <= 1}
+            className={`${actionBtn} disabled:opacity-40`}
+          >
+            ← Prev
+          </button>
+          <span className="text-xs text-[var(--text-muted)] tabular-nums">
+            Page {page} / {lastPage}
+          </span>
+          <button
+            onClick={() => load(q, page + 1)}
+            disabled={busy || page >= lastPage}
+            className={`${actionBtn} disabled:opacity-40`}
+          >
+            Next →
+          </button>
+        </div>
+      )}
+    </AdminShell>
+  );
+}

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import UsersClient from "./UsersClient";
+
+export const metadata: Metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminUsersPage() {
+  return <UsersClient />;
+}


### PR DESCRIPTION
Fixes the duplicate-account bug and adds account management to the admin panel.

## Steam account linking
Connecting Steam while already signed in (for example via Discord) was creating a second, Steam-only account instead of linking. The Steam callback always called `find_or_create_by_steam`, unlike the Discord connector which links to the current account on its callback.

Now the website Steam flow links Steam to the signed-in account when there is one without a Steam id, and returns `?error=steam_in_use` if that Steam id already belongs to a different account. The overlay `/start` flow and the in-game ticket flow are unchanged.

## Admin Users panel (`/admin/users`)
- List and search every account by username, email, or any linked Steam / Discord / Twitch / account id, with identity badges and run counts.
- Rename, as an admin override of the 3/day self-service cap.
- Delete, which keeps the runs and just unlinks them so nothing is lost.
- Merge one account into another: moves the source's runs onto the target, lifts any identities the target is missing, then deletes the source.

Merge is the clean fix for an account that already got duplicated: fold the older account into the kept one to combine the identities and move the runs.