### PR TITLE
Add Twitch connector, Watch-on-Twitch on /live, and curated partners

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,6 +57,7 @@ from .routers import (
     mechanics,
     auth_steam,
     auth_discord,
+    auth_twitch,
     auth,
     uninstall,
     qa_feedback,
@@ -572,6 +573,7 @@ app.include_router(merchant.router)
 app.include_router(mechanics.router)
 app.include_router(auth_steam.router)
 app.include_router(auth_discord.router)
+app.include_router(auth_twitch.router)
 app.include_router(auth.router)
 app.include_router(tierlists.router)
 app.include_router(mod_meta.router)

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -326,6 +326,29 @@ async def users_merge(request: Request):
     return result
 
 
+@router.post("/users/{user_id}/partner")
+async def users_set_partner(request: Request, user_id: str):
+    """Mark or unmark a curated partner: body {"is_partner": bool}. A partner
+    who is both live in the mod and streaming on Twitch floats to the top of the
+    /live roster. Requires the account to have a Twitch login linked."""
+    _audit(request)
+    _require_mongo_users()
+    from fastapi import HTTPException
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    is_partner = bool(body.get("is_partner"))
+    from ..services.users_db import set_partner
+
+    result = set_partner(user_id, is_partner)
+    if result.get("error"):
+        raise HTTPException(status_code=400, detail=result["error"])
+    logger.info("admin set partner=%s on user %s", is_partner, user_id)
+    return result
+
+
 @router.get("/feedback")
 def feedback_inbox(request: Request, include_resolved: bool = False, limit: int = 50):
     """The feedback inbox: site feedback and QA card reports, newest first.

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -35,10 +35,25 @@ async def me(request: Request):
         "email": user.get("email"),
         "steam_id": user.get("steam_id"),
         "discord_id": user.get("discord_id"),
+        "twitch_id": user.get("twitch_id"),
+        "twitch_login": user.get("twitch_login"),
+        "is_partner": bool(user.get("is_partner")),
         "created_at": user.get("created_at"),
         "needs_email": not user.get("email"),
         "is_admin": is_admin(user),
     }
+
+
+@router.post("/twitch/disconnect")
+@limiter.limit("10/minute")
+async def disconnect_twitch(request: Request):
+    user = require_user(request)
+    from ..services.users_db import unlink_twitch
+
+    result = unlink_twitch(user["_id"])
+    if result.get("error"):
+        raise HTTPException(status_code=400, detail=result["error"])
+    return result
 
 
 @router.post("/logout")

--- a/backend/app/routers/auth_twitch.py
+++ b/backend/app/routers/auth_twitch.py
@@ -1,0 +1,223 @@
+"""Twitch OAuth2 sign-in.
+
+Server-side redirect flow, the same shape as the Discord connector:
+1. GET /api/auth/twitch/start    -- redirects to Twitch's authorize page
+2. GET /api/auth/twitch/callback -- exchanges code for token, links/creates the
+   user, sets the cookie, redirects back to the frontend.
+
+Linking Twitch is what powers the live features: the /live roster shows a
+"Watch on Twitch" link for a present player whose account has a Twitch login,
+and curated partners who are both live in the mod and streaming float to the
+top of the roster.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import urllib.parse
+
+import httpx
+from fastapi import APIRouter, Request
+from fastapi.responses import RedirectResponse
+from slowapi import Limiter
+
+from ..dependencies import client_ip
+from ..services.auth_jwt import create_oauth_state, verify_oauth_state
+
+logger = logging.getLogger("spire-codex.auth")
+
+router = APIRouter(prefix="/api/auth/twitch", tags=["Auth"])
+limiter = Limiter(key_func=client_ip)
+
+_TWITCH_AUTHORIZE = "https://id.twitch.tv/oauth2/authorize"
+_TWITCH_TOKEN = "https://id.twitch.tv/oauth2/token"
+_TWITCH_USERS = "https://api.twitch.tv/helix/users"
+
+
+def _get_twitch_config() -> tuple[str, str]:
+    client_id = os.environ.get("TWITCH_CLIENT_ID", "").strip()
+    client_secret = os.environ.get("TWITCH_CLIENT_SECRET", "").strip()
+    if not client_id or not client_secret:
+        raise RuntimeError("TWITCH_CLIENT_ID and TWITCH_CLIENT_SECRET are required")
+    return client_id, client_secret
+
+
+def _frontend_url(request: Request) -> str:
+    explicit = os.environ.get("SPIRE_CODEX_PUBLIC_BASE")
+    if explicit:
+        return explicit.rstrip("/")
+    base = str(request.base_url).rstrip("/")
+    return base
+
+
+@router.get("/start")
+@limiter.limit("20/minute")
+async def start(request: Request):
+    client_id, _ = _get_twitch_config()
+
+    state = create_oauth_state()
+
+    base = _frontend_url(request)
+    redirect_uri = f"{base}/api/auth/twitch/callback"
+
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        # user:read:email lets the Helix /users call return the account email,
+        # the same identity scope the Discord flow asks for.
+        "scope": "user:read:email",
+        "state": state,
+        # Twitch's equivalent of Discord's prompt=consent: always show the
+        # consent screen so a user can pick which Twitch account to connect.
+        "force_verify": "true",
+    }
+    url = f"{_TWITCH_AUTHORIZE}?{urllib.parse.urlencode(params)}"
+    return RedirectResponse(url)
+
+
+@router.get("/callback")
+async def callback(request: Request):
+    base = _frontend_url(request)
+
+    error = request.query_params.get("error")
+    if error:
+        logger.info("twitch-auth denied: %s", error)
+        return RedirectResponse(f"{base}/settings?error=cancelled")
+
+    code = request.query_params.get("code")
+    state = request.query_params.get("state")
+
+    if not code or not state:
+        return RedirectResponse(f"{base}/settings?error=invalid_response")
+
+    if not verify_oauth_state(state):
+        return RedirectResponse(f"{base}/settings?error=invalid_session")
+
+    client_id, client_secret = _get_twitch_config()
+    redirect_uri = f"{base}/api/auth/twitch/callback"
+
+    # Exchange code for an access token.
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            token_resp = await client.post(
+                _TWITCH_TOKEN,
+                data={
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+        if token_resp.status_code != 200:
+            logger.warning("twitch token exchange failed: %s", token_resp.text[:200])
+            return RedirectResponse(f"{base}/settings?error=twitch_failed")
+
+        token_data = token_resp.json()
+        access_token = token_data.get("access_token")
+        if not access_token:
+            return RedirectResponse(f"{base}/settings?error=twitch_failed")
+    except Exception as exc:
+        logger.warning("twitch token exchange error: %s", exc)
+        return RedirectResponse(f"{base}/settings?error=twitch_unavailable")
+
+    # Fetch the user from Helix. The Client-Id header is required alongside the
+    # bearer token for every Helix call.
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            user_resp = await client.get(
+                _TWITCH_USERS,
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "Client-Id": client_id,
+                },
+            )
+        if user_resp.status_code != 200:
+            logger.warning("twitch user fetch failed: %s", user_resp.text[:200])
+            return RedirectResponse(f"{base}/settings?error=twitch_failed")
+
+        payload = user_resp.json()
+        data = payload.get("data") or []
+        twitch_user = data[0] if data else {}
+    except Exception as exc:
+        logger.warning("twitch user fetch error: %s", exc)
+        return RedirectResponse(f"{base}/settings?error=twitch_unavailable")
+
+    twitch_id = twitch_user.get("id")
+    twitch_login = twitch_user.get("login")
+    twitch_display = twitch_user.get("display_name") or twitch_login
+    email = twitch_user.get("email")
+
+    if not twitch_id or not twitch_login:
+        return RedirectResponse(f"{base}/settings?error=twitch_failed")
+
+    # If the user is already logged in (valid JWT) and has no Twitch yet, link
+    # Twitch to that account; otherwise sign them in by Twitch (creating the
+    # account on first sight, the same as the Discord flow).
+    try:
+        from ..services.auth_jwt import create_token, get_current_user, set_auth_cookie
+        from ..services.users_db import (
+            find_or_create_by_twitch,
+            link_twitch,
+            update_email as _update_email,
+        )
+
+        existing_user = get_current_user(request)
+
+        if existing_user and not existing_user.get("twitch_id"):
+            result = link_twitch(
+                existing_user["_id"], twitch_id, twitch_login, twitch_display
+            )
+            if result.get("error"):
+                return RedirectResponse(f"{base}/settings?error={result['error']}")
+            if email and not existing_user.get("email"):
+                _update_email(existing_user["_id"], email)
+            user = existing_user
+            user["twitch_id"] = twitch_id
+        else:
+            user = find_or_create_by_twitch(
+                twitch_id, twitch_login, twitch_display, email
+            )
+
+        token = create_token(
+            user_id=user["_id"],
+            steam_id=user.get("steam_id"),
+            discord_id=user.get("discord_id"),
+        )
+
+        # Link any runs already on file under this account's Steam id, so a
+        # Twitch sign-in on an account that later adds Steam still shows runs.
+        if os.environ.get("MONGO_URL", "").strip() and user.get("steam_id"):
+            try:
+                from ..services.runs_db_mongo import backfill_user_runs
+
+                linked = backfill_user_runs(
+                    user["_id"],
+                    steam_id=user.get("steam_id"),
+                    discord_id=user.get("discord_id"),
+                    username=user.get("username"),
+                )
+                if linked:
+                    logger.info(
+                        "twitch-auth linked %d run(s) to user=%s", linked, user["_id"]
+                    )
+            except Exception as exc:
+                logger.warning("twitch-auth run backfill failed: %s", exc)
+
+        response = RedirectResponse(f"{base}/settings?linked=twitch")
+        set_auth_cookie(response, token)
+
+        logger.info(
+            "twitch-auth ok twitch_id=%s login=%s user=%s linked=%s",
+            twitch_id,
+            twitch_login,
+            user["_id"],
+            bool(existing_user),
+        )
+        return response
+    except Exception as exc:
+        logger.warning("twitch-auth user creation failed: %s", exc)
+        return RedirectResponse(f"{base}/settings?error=twitch_failed")

--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -368,12 +368,53 @@ async def post_presence(request: Request):
     return {"ok": True}
 
 
+def _enrich_twitch(players: list[dict]) -> None:
+    """Attach each present player's Twitch channel + partner flag (joined from
+    the user record by steam_id), mark who is streaming right now via Helix, and
+    float live partners to the top. Best-effort: any failure leaves the roster
+    untouched, so Twitch never breaks the live page."""
+    if not players:
+        return
+    try:
+        from ..services import twitch_live
+        from ..services.users_db import twitch_info_by_steam_ids
+
+        steam_ids = [p["steam_id"] for p in players if p.get("steam_id")]
+        info = twitch_info_by_steam_ids(steam_ids)
+        if not info:
+            return
+        logins = {v["twitch_login"] for v in info.values() if v.get("twitch_login")}
+        live = twitch_live.live_logins(logins)
+        for p in players:
+            meta = info.get(p.get("steam_id"))
+            if not meta:
+                continue
+            login = meta.get("twitch_login")
+            if login:
+                p["twitch_login"] = login
+            if meta.get("is_partner"):
+                p["is_partner"] = True
+            stream = live.get(login) if login else None
+            if stream:
+                p["twitch_live"] = True
+                if stream.get("viewer_count") is not None:
+                    p["twitch_viewers"] = stream["viewer_count"]
+        # Stable sort: a partner who is live-streaming sorts first; everyone
+        # else keeps the deepest-floor order presence_db already returned.
+        players.sort(
+            key=lambda p: 0 if (p.get("is_partner") and p.get("twitch_live")) else 1
+        )
+    except Exception:
+        pass
+
+
 @router.get("/active")
 def get_active(limit: int = 50):
     _require_mongo()
     from ..services import presence_db
 
     players = presence_db.active(max(1, min(limit, 100)))
+    _enrich_twitch(players)
     return {"count": len(players), "players": players}
 
 
@@ -388,4 +429,5 @@ def get_player(steam_id: str):
     doc = presence_db.get(digits)
     if not doc:
         raise HTTPException(status_code=404, detail="not live")
+    _enrich_twitch([doc])
     return doc

--- a/backend/app/services/twitch_live.py
+++ b/backend/app/services/twitch_live.py
@@ -1,0 +1,119 @@
+"""Twitch live-stream detection for the /live roster.
+
+Given the Twitch logins of players currently in a run, ask the Helix API which
+of them are streaming right now, so the live page can show a "Watch on Twitch"
+link and float live partners to the top. Uses an app access token (client
+credentials grant), cached until it nears expiry.
+
+Degrades to "nobody is live" whenever TWITCH_CLIENT_ID / TWITCH_CLIENT_SECRET
+are unset or Helix is unreachable, so the roster never breaks because of Twitch.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+
+import httpx
+
+logger = logging.getLogger("spire-codex.twitch")
+
+_TOKEN_URL = "https://id.twitch.tv/oauth2/token"
+_STREAMS_URL = "https://api.twitch.tv/helix/streams"
+_MAX_LOGINS = 100  # Helix caps user_login at 100 ids per request
+
+_lock = threading.Lock()
+_token: str | None = None
+_token_expires_at = 0.0  # time.monotonic() deadline
+
+# Short cache of the last liveness result so repeated roster reads (each worker
+# process, plus edge-cache misses) do not each hit Helix. Keyed by the exact
+# login set asked for.
+_CACHE_TTL = 20.0
+_cache_key: frozenset[str] | None = None
+_cache_value: dict[str, dict] = {}
+_cache_at = 0.0
+
+
+def _config() -> tuple[str, str] | None:
+    cid = os.environ.get("TWITCH_CLIENT_ID", "").strip()
+    secret = os.environ.get("TWITCH_CLIENT_SECRET", "").strip()
+    if not cid or not secret:
+        return None
+    return cid, secret
+
+
+def _get_token(client: httpx.Client, cid: str, secret: str) -> str | None:
+    global _token, _token_expires_at
+    now = time.monotonic()
+    if _token and now < _token_expires_at:
+        return _token
+    resp = client.post(
+        _TOKEN_URL,
+        data={
+            "client_id": cid,
+            "client_secret": secret,
+            "grant_type": "client_credentials",
+        },
+    )
+    if resp.status_code != 200:
+        logger.warning("twitch app-token failed: %s", resp.text[:200])
+        return None
+    data = resp.json()
+    _token = data.get("access_token")
+    # Refresh 5 min early; fall back to 1h if Twitch omits expires_in.
+    _token_expires_at = now + float(data.get("expires_in", 3600)) - 300
+    return _token
+
+
+def live_logins(logins) -> dict[str, dict]:
+    """Map login -> {viewer_count, title, game_name} for the given logins that
+    are streaming right now. Empty when Twitch is unconfigured or unreachable."""
+    wanted = sorted({(name or "").lower() for name in logins if name})[:_MAX_LOGINS]
+    if not wanted:
+        return {}
+
+    cfg = _config()
+    if not cfg:
+        return {}
+    cid, secret = cfg
+
+    key = frozenset(wanted)
+    with _lock:
+        global _cache_key, _cache_value, _cache_at
+        now = time.monotonic()
+        if _cache_key == key and now - _cache_at < _CACHE_TTL:
+            return dict(_cache_value)
+
+        out: dict[str, dict] = {}
+        try:
+            with httpx.Client(timeout=8) as client:
+                token = _get_token(client, cid, secret)
+                if not token:
+                    return {}
+                headers = {"Authorization": f"Bearer {token}", "Client-Id": cid}
+                params = [("user_login", name) for name in wanted]
+                params.append(("first", "100"))
+                resp = client.get(_STREAMS_URL, headers=headers, params=params)
+                if resp.status_code != 200:
+                    logger.warning("twitch streams failed: %s", resp.text[:200])
+                    return {}
+                for stream in resp.json().get("data", []):
+                    if stream.get("type") != "live":
+                        continue
+                    login = (stream.get("user_login") or "").lower()
+                    if not login:
+                        continue
+                    out[login] = {
+                        "viewer_count": stream.get("viewer_count"),
+                        "title": stream.get("title"),
+                        "game_name": stream.get("game_name"),
+                    }
+        except Exception as exc:
+            logger.warning("twitch streams error: %s", exc)
+            return {}
+
+        _cache_key, _cache_value, _cache_at = key, out, now
+        return dict(out)

--- a/backend/app/services/users_db.py
+++ b/backend/app/services/users_db.py
@@ -6,6 +6,10 @@ Document shape:
         "_id": ObjectId,
         "steam_id": "76561198...",   # unique when set (partial index)
         "discord_id": "123456...",   # unique when set (partial index)
+        "twitch_id": "1234567",      # unique when set (partial index)
+        "twitch_login": "somechannel",       # lowercase login = twitch.tv/<login>
+        "twitch_display_name": "SomeChannel",
+        "is_partner": True,          # curated; live partners float to the top of /live
         "username": "SomeName",
         "username_lower": "somename",  # unique when set (partial index)
         "email": "user@example.com",
@@ -66,6 +70,7 @@ def _ensure_indexes(coll) -> None:
     # $type:"string" indexes only set values, exempting null/missing.
     _ensure_partial_unique(coll, "steam_id")
     _ensure_partial_unique(coll, "discord_id")
+    _ensure_partial_unique(coll, "twitch_id")
     _ensure_partial_unique(coll, "username_lower")
 
 
@@ -120,6 +125,18 @@ def get_user_by_discord_id(discord_id: str) -> dict | None:
         return None
     coll = _get_collection()
     existing = coll.find_one({"discord_id": discord_id})
+    if existing:
+        existing["_id"] = str(existing["_id"])
+        return existing
+    return None
+
+
+def get_user_by_twitch_id(twitch_id: str) -> dict | None:
+    """Look up a user by Twitch ID without creating one."""
+    if not twitch_id:
+        return None
+    coll = _get_collection()
+    existing = coll.find_one({"twitch_id": twitch_id})
     if existing:
         existing["_id"] = str(existing["_id"])
         return existing
@@ -204,6 +221,75 @@ def find_or_create_by_discord(
         doc["_id"] = str(result.inserted_id)
     except DuplicateKeyError:
         existing = coll.find_one({"discord_id": discord_id})
+        if existing:
+            existing["_id"] = str(existing["_id"])
+            return existing
+        raise
+
+    return doc
+
+
+def find_or_create_by_twitch(
+    twitch_id: str,
+    twitch_login: str,
+    twitch_display_name: str | None = None,
+    email: str | None = None,
+) -> dict:
+    coll = _get_collection()
+    now = datetime.now(timezone.utc)
+
+    login = (twitch_login or "").lower()
+    display = twitch_display_name or twitch_login
+
+    existing = coll.find_one({"twitch_id": twitch_id})
+    if existing:
+        # A Twitch login can change; keep the stored one current so the
+        # twitch.tv/<login> URL on /live stays correct.
+        if existing.get("twitch_login") != login or (
+            display and existing.get("twitch_display_name") != display
+        ):
+            coll.update_one(
+                {"_id": existing["_id"]},
+                {
+                    "$set": {
+                        "twitch_login": login,
+                        "twitch_display_name": display,
+                        "updated_at": now,
+                    }
+                },
+            )
+            existing["twitch_login"] = login
+            existing["twitch_display_name"] = display
+        existing["_id"] = str(existing["_id"])
+        return existing
+
+    username = sanitize_username(display) if display else None
+    username_lower = username.lower() if username else None
+
+    if username_lower:
+        username, username_lower = _deduplicate_username(coll, username, username_lower)
+
+    clean_email = email.strip() if email and validate_email(email) else None
+
+    doc = {
+        "steam_id": None,
+        "discord_id": None,
+        "twitch_id": twitch_id,
+        "twitch_login": login,
+        "twitch_display_name": display,
+        "username": username,
+        "username_lower": username_lower,
+        "email": clean_email,
+        "username_changes": [],
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    try:
+        result = coll.insert_one(doc)
+        doc["_id"] = str(result.inserted_id)
+    except DuplicateKeyError:
+        existing = coll.find_one({"twitch_id": twitch_id})
         if existing:
             existing["_id"] = str(existing["_id"])
             return existing
@@ -334,6 +420,120 @@ def link_discord(user_id: str, discord_id: str) -> dict:
     if result.matched_count == 0:
         return {"error": "User not found"}
     return {"success": True}
+
+
+def link_twitch(
+    user_id: str,
+    twitch_id: str,
+    twitch_login: str,
+    twitch_display_name: str | None = None,
+) -> dict:
+    coll = _get_collection()
+    conflict = coll.find_one(
+        {"twitch_id": twitch_id, "_id": {"$ne": ObjectId(user_id)}}
+    )
+    if conflict:
+        return {"error": "This Twitch account is already linked to another user"}
+
+    try:
+        result = coll.update_one(
+            {"_id": ObjectId(user_id)},
+            {
+                "$set": {
+                    "twitch_id": twitch_id,
+                    "twitch_login": (twitch_login or "").lower(),
+                    "twitch_display_name": twitch_display_name or twitch_login,
+                    "updated_at": datetime.now(timezone.utc),
+                }
+            },
+        )
+    except DuplicateKeyError:
+        return {"error": "This Twitch account is already linked to another user"}
+
+    if result.matched_count == 0:
+        return {"error": "User not found"}
+    return {"success": True}
+
+
+def unlink_twitch(user_id: str) -> dict:
+    """Disconnect Twitch from an account, clearing the partner flag with it."""
+    coll = _get_collection()
+    result = coll.update_one(
+        {"_id": ObjectId(user_id)},
+        {
+            "$unset": {
+                "twitch_id": "",
+                "twitch_login": "",
+                "twitch_display_name": "",
+                "is_partner": "",
+            },
+            "$set": {"updated_at": datetime.now(timezone.utc)},
+        },
+    )
+    if result.matched_count == 0:
+        return {"error": "User not found"}
+    return {"success": True}
+
+
+def set_partner(user_id: str, is_partner: bool) -> dict:
+    """Curated partner flag (admin only). A partner who is both live in the mod
+    and streaming on Twitch sorts to the top of the /live roster."""
+    coll = _get_collection()
+    try:
+        oid = ObjectId(user_id)
+    except Exception:
+        return {"error": "Invalid user id"}
+
+    user = coll.find_one({"_id": oid}, {"twitch_id": 1})
+    if not user:
+        return {"error": "User not found"}
+    if is_partner and not user.get("twitch_id"):
+        return {"error": "User has no Twitch account linked"}
+
+    update = (
+        {"$set": {"is_partner": True, "updated_at": datetime.now(timezone.utc)}}
+        if is_partner
+        else {
+            "$unset": {"is_partner": ""},
+            "$set": {"updated_at": datetime.now(timezone.utc)},
+        }
+    )
+    coll.update_one({"_id": oid}, update)
+    return {"success": True, "is_partner": is_partner}
+
+
+def list_partners() -> list[dict]:
+    """All curated partners, for the admin panel."""
+    coll = _get_collection()
+    docs = coll.find(
+        {"is_partner": True},
+        {"username": 1, "twitch_login": 1, "steam_id": 1, "discord_id": 1},
+    )
+    out = []
+    for d in docs:
+        d["_id"] = str(d["_id"])
+        out.append(d)
+    return out
+
+
+def twitch_info_by_steam_ids(steam_ids: list[str]) -> dict[str, dict]:
+    """Map steam_id -> {twitch_login, is_partner} for the given ids, used to
+    enrich the live roster (which is keyed by steam_id) with each player's
+    Twitch channel and partner status in one query."""
+    if not steam_ids:
+        return {}
+    coll = _get_collection()
+    docs = coll.find(
+        {"steam_id": {"$in": steam_ids}, "twitch_login": {"$type": "string"}},
+        {"steam_id": 1, "twitch_login": 1, "is_partner": 1},
+    )
+    out: dict[str, dict] = {}
+    for d in docs:
+        out[d["steam_id"]] = {
+            "twitch_login": d.get("twitch_login"),
+            "is_partner": bool(d.get("is_partner")),
+        }
+    return out
 
 
 def get_username_changes_remaining(user_id: str) -> int:

--- a/frontend/app/admin/users/UsersClient.tsx
+++ b/frontend/app/admin/users/UsersClient.tsx
@@ -141,6 +141,27 @@ export default function UsersClient() {
     }
   }
 
+  async function togglePartner(u: UserRow) {
+    const next = !u.is_partner;
+    try {
+      await adminFetch(`/api/admin/users/${u._id}/partner`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ is_partner: next }),
+      });
+      setRows((prev) =>
+        prev.map((r) => (r._id === u._id ? { ...r, is_partner: next } : r)),
+      );
+      setNote(
+        next
+          ? `"${u.username ?? u._id}" is now a partner.`
+          : `Removed partner from "${u.username ?? u._id}".`,
+      );
+    } catch (e) {
+      setNote(String((e as Error)?.message || e));
+    }
+  }
+
   async function mergeInto(target: UserRow) {
     const src = mergeSource;
     if (!src) return;
@@ -286,6 +307,23 @@ export default function UsersClient() {
                             >
                               Merge
                             </button>
+                            {u.twitch_id && (
+                              <button
+                                onClick={() => togglePartner(u)}
+                                className={
+                                  u.is_partner
+                                    ? "px-2.5 py-1 rounded text-xs font-semibold bg-[#9146FF]/20 text-[#b794ff] border border-[#9146FF]/40 hover:bg-[#9146FF]/30"
+                                    : actionBtn
+                                }
+                                title={
+                                  u.is_partner
+                                    ? "Remove curated-partner status"
+                                    : "Mark as a curated partner (floats to the top of /live when live + streaming)"
+                                }
+                              >
+                                {u.is_partner ? "Unpartner" : "Partner"}
+                              </button>
+                            )}
                             <button
                               onClick={() => remove(u)}
                               className="px-2.5 py-1 rounded text-xs font-semibold bg-rose-950/60 text-rose-300 border border-rose-900/40 hover:bg-rose-900/60"

--- a/frontend/app/components/TwitchIcon.tsx
+++ b/frontend/app/components/TwitchIcon.tsx
@@ -1,0 +1,12 @@
+export default function TwitchIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M2.149 0L.537 4.119v16.836h5.731V24h3.224l3.045-3.045h4.657L23.463 14.61V0H2.149zm19.164 13.612l-3.582 3.582h-5.731l-3.045 3.045v-3.045H4.119V2.149h17.194v11.463zM18.806 5.731v6.448h-2.149V5.731h2.149zm-5.731 0v6.448h-2.149V5.731h2.149z" />
+    </svg>
+  );
+}

--- a/frontend/app/contexts/AuthContext.tsx
+++ b/frontend/app/contexts/AuthContext.tsx
@@ -10,6 +10,9 @@ interface User {
   email: string | null;
   steam_id: string | null;
   discord_id: string | null;
+  twitch_id: string | null;
+  twitch_login: string | null;
+  is_partner?: boolean;
   needs_email: boolean;
   is_admin?: boolean;
 }
@@ -19,6 +22,7 @@ interface AuthContextType {
   loading: boolean;
   loginSteam: () => void;
   loginDiscord: () => void;
+  loginTwitch: () => void;
   logout: () => Promise<void>;
   refresh: () => Promise<void>;
 }
@@ -28,6 +32,7 @@ const AuthContext = createContext<AuthContextType>({
   loading: true,
   loginSteam: () => {},
   loginDiscord: () => {},
+  loginTwitch: () => {},
   logout: async () => {},
   refresh: async () => {},
 });
@@ -105,6 +110,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     window.location.href = `${API_BASE}/api/auth/discord/start`;
   }, []);
 
+  const loginTwitch = useCallback(() => {
+    window.location.href = `${API_BASE}/api/auth/twitch/start`;
+  }, []);
+
   const logout = useCallback(async () => {
     localStorage.removeItem("spire_token");
     try {
@@ -120,7 +129,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ user, loading, loginSteam, loginDiscord, logout, refresh: fetchMe }}
+      value={{ user, loading, loginSteam, loginDiscord, loginTwitch, logout, refresh: fetchMe }}
     >
       {children}
     </AuthContext.Provider>

--- a/frontend/app/live/LiveClient.tsx
+++ b/frontend/app/live/LiveClient.tsx
@@ -28,6 +28,8 @@ import {
   CharacterIcon,
   FightingChip,
   LiveDot,
+  PartnerBadge,
+  WatchOnTwitch,
   elapsed,
   parseDeckId,
   useMonsterMap,
@@ -87,6 +89,7 @@ function PlayerCard({
             {(p.player_count ?? 1) > 1 && (
               <span className="text-[10px] text-[var(--text-muted)]">co-op ×{p.player_count}</span>
             )}
+            {p.is_partner && <PartnerBadge />}
           </div>
           <div className="text-xs text-[var(--text-muted)] truncate">
             {displayName(`CHARACTER.${p.character ?? ""}`)}
@@ -107,9 +110,18 @@ function PlayerCard({
 
       <div className="mt-2 flex items-center gap-2">
         <FightingChip p={p} monsters={monsters} />
+        {p.twitch_live && p.twitch_login && (
+          <WatchOnTwitch
+            login={p.twitch_login}
+            viewers={p.twitch_viewers}
+            className="ml-auto"
+          />
+        )}
         <Link
           href={`/live/${p.steam_id}`}
-          className="ml-auto text-xs text-[var(--accent-gold)] hover:underline whitespace-nowrap"
+          className={`text-xs text-[var(--accent-gold)] hover:underline whitespace-nowrap ${
+            p.twitch_live && p.twitch_login ? "" : "ml-auto"
+          }`}
         >
           Watch live →
         </Link>

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -31,6 +31,8 @@ import {
   CharacterIcon,
   LiveDot,
   LiveEnemiesPanel,
+  PartnerBadge,
+  WatchOnTwitch,
   ago,
   elapsed,
   monsterName,
@@ -426,6 +428,7 @@ export default function LivePlayerClient() {
                 {(p.player_count ?? 1) > 1 && (
                   <span className="text-xs text-[var(--text-muted)]">co-op ×{p.player_count}</span>
                 )}
+                {p.is_partner && <PartnerBadge />}
                 {status === "ended" && (
                   <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-[var(--bg-primary)] text-[var(--text-muted)] border border-[var(--border-subtle)]">
                     run ended
@@ -438,6 +441,11 @@ export default function LivePlayerClient() {
                 {p.started_at ? ` · climbing for ${elapsed(p.started_at)}` : ""}
                 {p.seed ? ` · seed ${p.seed}` : ""}
               </div>
+              {p.twitch_live && p.twitch_login && (
+                <div className="mt-2">
+                  <WatchOnTwitch login={p.twitch_login} viewers={p.twitch_viewers} />
+                </div>
+              )}
             </div>
             <div className="text-right shrink-0">
               <div className="text-lg font-bold text-[var(--text-primary)] tabular-nums">

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -11,6 +11,7 @@ import { useLanguage } from "@/app/contexts/LanguageContext";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { imageUrl } from "@/lib/image-url";
 import { cleanId, displayName } from "../runs/[hash]/RunPills";
+import TwitchIcon from "@/app/components/TwitchIcon";
 
 export const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -111,6 +112,13 @@ export interface LivePlayer {
   event?: LiveEventCtx | null;
   shop?: LiveShop | null;
   enemies?: Enemy[] | null;
+  // Twitch enrichment from /api/presence (only when the player linked Twitch):
+  // their channel, whether they are streaming right now, viewer count, and the
+  // curated-partner flag. All optional and absent until the backend attaches them.
+  twitch_login?: string | null;
+  twitch_live?: boolean;
+  twitch_viewers?: number;
+  is_partner?: boolean;
 }
 
 export interface MonsterInfo {
@@ -176,6 +184,42 @@ export function LiveDot() {
       <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
       <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
     </span>
+  );
+}
+
+/** Curated-partner badge, shown next to a player's name on the live views. */
+export function PartnerBadge() {
+  return (
+    <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-[#9146FF]/15 text-[#b794ff] border border-[#9146FF]/40">
+      Partner
+    </span>
+  );
+}
+
+/** "Watch on Twitch" link, shown when a present player is streaming right now.
+ * Twitch purple, opens the channel in a new tab; viewer count when known. */
+export function WatchOnTwitch({
+  login,
+  viewers,
+  className = "",
+}: {
+  login: string;
+  viewers?: number;
+  className?: string;
+}) {
+  return (
+    <a
+      href={`https://twitch.tv/${login}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-[#9146FF] text-white text-xs font-semibold hover:bg-[#7d2ff5] transition-colors ${className}`}
+    >
+      <TwitchIcon className="w-3.5 h-3.5" />
+      Watch on Twitch
+      {viewers != null && (
+        <span className="font-normal opacity-80">· {viewers.toLocaleString()}</span>
+      )}
+    </a>
   );
 }
 

--- a/frontend/app/settings/SettingsClient.tsx
+++ b/frontend/app/settings/SettingsClient.tsx
@@ -4,15 +4,17 @@ import { useState, useEffect } from "react";
 import { useAuth } from "@/app/contexts/AuthContext";
 import { useToast } from "@/app/components/Toast";
 import DiscordIcon from "@/app/components/DiscordIcon";
+import TwitchIcon from "@/app/components/TwitchIcon";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 export default function SettingsClient() {
-  const { user, loading, refresh, loginSteam, loginDiscord } = useAuth();
+  const { user, loading, refresh, loginSteam, loginDiscord, loginTwitch } = useAuth();
   const { toast } = useToast();
 
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
+  const [disconnecting, setDisconnecting] = useState(false);
   const [changesRemaining, setChangesRemaining] = useState(3);
   const [saving, setSaving] = useState<"username" | "email" | null>(null);
   const [usernameAvailable, setUsernameAvailable] = useState<boolean | null>(null);
@@ -98,6 +100,27 @@ export default function SettingsClient() {
       toast("Network error", "error");
     } finally {
       setSaving(null);
+    }
+  };
+
+  const disconnectTwitch = async () => {
+    setDisconnecting(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/twitch/disconnect`, {
+        method: "POST",
+        credentials: "include",
+      });
+      if (res.ok) {
+        toast("Twitch disconnected", "success");
+        refresh();
+      } else {
+        const err = await res.json().catch(() => null);
+        toast(err?.detail || "Failed to disconnect Twitch", "error");
+      }
+    } catch {
+      toast("Network error", "error");
+    } finally {
+      setDisconnecting(false);
     }
   };
 
@@ -231,7 +254,52 @@ export default function SettingsClient() {
               <span className="text-xs text-[var(--text-secondary)]">Connect</span>
             </button>
           )}
+          {user.twitch_id ? (
+            <div className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)]">
+              <div className="flex items-center gap-2 min-w-0">
+                <TwitchIcon className="w-4 h-4 text-[#9146FF]" />
+                <span className="text-sm text-[var(--text-primary)] shrink-0">Twitch</span>
+                {user.twitch_login && (
+                  <a
+                    href={`https://twitch.tv/${user.twitch_login}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-[var(--text-muted)] truncate hover:text-[#9146FF]"
+                  >
+                    @{user.twitch_login}
+                  </a>
+                )}
+                {user.is_partner && (
+                  <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-[#9146FF]/15 text-[#9146FF] border border-[#9146FF]/30 shrink-0">
+                    Partner
+                  </span>
+                )}
+              </div>
+              <button
+                onClick={disconnectTwitch}
+                disabled={disconnecting}
+                className="text-xs text-[var(--text-secondary)] hover:text-red-400 disabled:opacity-40 shrink-0"
+              >
+                {disconnecting ? "..." : "Disconnect"}
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={loginTwitch}
+              className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] hover:border-[var(--border-accent)] transition-colors cursor-pointer"
+            >
+              <div className="flex items-center gap-2">
+                <TwitchIcon className="w-4 h-4 text-[var(--text-secondary)]" />
+                <span className="text-sm text-[var(--text-primary)]">Twitch</span>
+              </div>
+              <span className="text-xs text-[var(--text-secondary)]">Connect</span>
+            </button>
+          )}
         </div>
+        <p className="text-xs text-[var(--text-tertiary)]">
+          Connect Twitch to show a &ldquo;Watch on Twitch&rdquo; link on your live run when you
+          are streaming.
+        </p>
       </section>
     </div>
   );


### PR DESCRIPTION
Adds the Twitch side of the live features.

## Connector
Server-side OAuth, mirroring the Discord connector: connect or disconnect Twitch from settings, or sign in by Twitch. `/api/auth/me` reports the linked login.

Needs `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` in the backend env, and the redirect URL `https://spire-codex.com/api/auth/twitch/callback` (plus beta and `http://localhost:8000/...` for dev) registered on a **Confidential** Twitch app.

## /live
The presence roster joins each present player's Twitch login and partner flag by steam_id, asks Helix who is streaming right now (cached app access token, fail-safe when Twitch is unconfigured), and shows a "Watch on Twitch" button on the roster cards and the per-player live view.

## Partners
A curated partner who is both live in the mod and streaming on Twitch floats to the top of the roster. Partners are toggled per-account from the admin Users panel (`/admin/users`), backed by `/api/admin/users/{id}/partner`. The flag requires a linked Twitch account.

Degrades cleanly to no Twitch info (and the existing deepest-floor order) when the credentials are absent.