### PR TITLE
Pass Twitch credentials into the prod container

### DIFF
--- a/backend/app/routers/auth_twitch.py
+++ b/backend/app/routers/auth_twitch.py
@@ -54,11 +54,17 @@ def _frontend_url(request: Request) -> str:
 @router.get("/start")
 @limiter.limit("20/minute")
 async def start(request: Request):
-    client_id, _ = _get_twitch_config()
+    base = _frontend_url(request)
+    try:
+        client_id, _ = _get_twitch_config()
+    except RuntimeError:
+        # Creds not configured in this environment: send the user back to
+        # settings with a clear reason instead of a raw 500.
+        logger.warning("twitch start: TWITCH_CLIENT_ID / TWITCH_CLIENT_SECRET unset")
+        return RedirectResponse(f"{base}/settings?error=twitch_unconfigured")
 
     state = create_oauth_state()
 
-    base = _frontend_url(request)
     redirect_uri = f"{base}/api/auth/twitch/callback"
 
     params = {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -91,11 +91,13 @@ services:
       # the external nginx_web-network and a bare "redis" alias would be
       # ambiguous between the two stacks.
       - REDIS_URL=${REDIS_URL:-redis://spire-codex-redis:6379/0}
-      # User accounts (Steam/Discord OAuth + JWT sessions). Values live
+      # User accounts (Steam/Discord/Twitch OAuth + JWT sessions). Values live
       # in the host .env; passed through so the auth endpoints work.
       - JWT_SECRET=${JWT_SECRET:-}
       - DISCORD_CLIENT_ID=${DISCORD_CLIENT_ID:-}
       - DISCORD_CLIENT_SECRET=${DISCORD_CLIENT_SECRET:-}
+      - TWITCH_CLIENT_ID=${TWITCH_CLIENT_ID:-}
+      - TWITCH_CLIENT_SECRET=${TWITCH_CLIENT_SECRET:-}
       - FRONTEND_URL=${FRONTEND_URL:-https://spire-codex.com}
       - SPIRE_CODEX_PUBLIC_BASE=${SPIRE_CODEX_PUBLIC_BASE:-https://spire-codex.com}
       - ENVIRONMENT=${ENVIRONMENT:-production}


### PR DESCRIPTION
Fixes the 500 on `/api/auth/twitch/start`.

The backend container only receives the env vars that `docker-compose.prod.yml` explicitly passes through (the `DISCORD_CLIENT_ID=${DISCORD_CLIENT_ID:-}` pattern). The Twitch connector PR added the code that reads `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` but not the passthrough, so even with the values in the host `.env` the running process never saw them, and `_get_twitch_config()` raised, surfacing as a raw 500.

- Adds the two `TWITCH_*` passthrough lines next to the Discord ones (covers prod and beta, which share this compose file).
- `/api/auth/twitch/start` now redirects to `/settings?error=twitch_unconfigured` instead of 500 when the creds are missing, so a misconfigured environment fails cleanly.

After merge + deploy, the host `.env` next to the compose file needs `TWITCH_CLIENT_ID` and `TWITCH_CLIENT_SECRET` set, then recreate the backend container so it picks them up.