### PR TITLE
Disconnect button on every connector, grey Connected label

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -44,6 +44,30 @@ async def me(request: Request):
     }
 
 
+@router.post("/steam/disconnect")
+@limiter.limit("10/minute")
+async def disconnect_steam(request: Request):
+    user = require_user(request)
+    from ..services.users_db import unlink_steam
+
+    result = unlink_steam(user["_id"])
+    if result.get("error"):
+        raise HTTPException(status_code=400, detail=result["error"])
+    return result
+
+
+@router.post("/discord/disconnect")
+@limiter.limit("10/minute")
+async def disconnect_discord(request: Request):
+    user = require_user(request)
+    from ..services.users_db import unlink_discord
+
+    result = unlink_discord(user["_id"])
+    if result.get("error"):
+        raise HTTPException(status_code=400, detail=result["error"])
+    return result
+
+
 @router.post("/twitch/disconnect")
 @limiter.limit("10/minute")
 async def disconnect_twitch(request: Request):

--- a/backend/app/services/users_db.py
+++ b/backend/app/services/users_db.py
@@ -455,24 +455,60 @@ def link_twitch(
     return {"success": True}
 
 
-def unlink_twitch(user_id: str) -> dict:
-    """Disconnect Twitch from an account, clearing the partner flag with it."""
+_SIGNIN_FIELDS = ("steam_id", "discord_id", "twitch_id")
+
+
+def _signin_count(user: dict) -> int:
+    """How many sign-in identities the account has. A disconnect must never drop
+    this to zero, or the user could never sign back in."""
+    return sum(1 for f in _SIGNIN_FIELDS if user.get(f))
+
+
+def _unlink_identity(
+    user_id: str, *, present: str, fields: list[str], label: str
+) -> dict:
     coll = _get_collection()
-    result = coll.update_one(
-        {"_id": ObjectId(user_id)},
+    try:
+        oid = ObjectId(user_id)
+    except Exception:
+        return {"error": "Invalid user id"}
+    user = coll.find_one({"_id": oid})
+    if not user:
+        return {"error": "User not found"}
+    if not user.get(present):
+        return {"error": f"No {label} account linked"}
+    if _signin_count(user) <= 1:
+        return {"error": f"Cannot disconnect your only sign-in method ({label})"}
+    coll.update_one(
+        {"_id": oid},
         {
-            "$unset": {
-                "twitch_id": "",
-                "twitch_login": "",
-                "twitch_display_name": "",
-                "is_partner": "",
-            },
+            "$unset": {f: "" for f in fields},
             "$set": {"updated_at": datetime.now(timezone.utc)},
         },
     )
-    if result.matched_count == 0:
-        return {"error": "User not found"}
     return {"success": True}
+
+
+def unlink_steam(user_id: str) -> dict:
+    return _unlink_identity(
+        user_id, present="steam_id", fields=["steam_id"], label="Steam"
+    )
+
+
+def unlink_discord(user_id: str) -> dict:
+    return _unlink_identity(
+        user_id, present="discord_id", fields=["discord_id"], label="Discord"
+    )
+
+
+def unlink_twitch(user_id: str) -> dict:
+    """Disconnect Twitch from an account, clearing the partner flag with it."""
+    return _unlink_identity(
+        user_id,
+        present="twitch_id",
+        fields=["twitch_id", "twitch_login", "twitch_display_name", "is_partner"],
+        label="Twitch",
+    )
 
 
 def set_partner(user_id: str, is_partner: bool) -> dict:

--- a/frontend/app/settings/SettingsClient.tsx
+++ b/frontend/app/settings/SettingsClient.tsx
@@ -14,7 +14,9 @@ export default function SettingsClient() {
 
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
-  const [disconnecting, setDisconnecting] = useState(false);
+  const [disconnecting, setDisconnecting] = useState<"steam" | "discord" | "twitch" | null>(
+    null,
+  );
   const [changesRemaining, setChangesRemaining] = useState(3);
   const [saving, setSaving] = useState<"username" | "email" | null>(null);
   const [usernameAvailable, setUsernameAvailable] = useState<boolean | null>(null);
@@ -103,24 +105,25 @@ export default function SettingsClient() {
     }
   };
 
-  const disconnectTwitch = async () => {
-    setDisconnecting(true);
+  const disconnect = async (provider: "steam" | "discord" | "twitch") => {
+    const label = provider.charAt(0).toUpperCase() + provider.slice(1);
+    setDisconnecting(provider);
     try {
-      const res = await fetch(`${API_BASE}/api/auth/twitch/disconnect`, {
+      const res = await fetch(`${API_BASE}/api/auth/${provider}/disconnect`, {
         method: "POST",
         credentials: "include",
       });
       if (res.ok) {
-        toast("Twitch disconnected", "success");
+        toast(`${label} disconnected`, "success");
         refresh();
       } else {
         const err = await res.json().catch(() => null);
-        toast(err?.detail || "Failed to disconnect Twitch", "error");
+        toast(err?.detail || `Failed to disconnect ${label}`, "error");
       }
     } catch {
       toast("Network error", "error");
     } finally {
-      setDisconnecting(false);
+      setDisconnecting(null);
     }
   };
 
@@ -220,7 +223,16 @@ export default function SettingsClient() {
                 <svg className="w-4 h-4 text-[var(--text-secondary)]" viewBox="0 0 24 24" fill="currentColor"><path d="M11.979 0C5.678 0 .511 4.86.022 11.037l6.432 2.658a3.387 3.387 0 0 1 1.912-.593c.064 0 .127.003.19.007l2.862-4.146v-.058a4.533 4.533 0 0 1 4.53-4.53 4.533 4.533 0 0 1 4.53 4.53 4.533 4.533 0 0 1-4.53 4.53h-.106l-4.08 2.91c0 .053.003.107.003.161a3.4 3.4 0 0 1-3.4 3.4 3.404 3.404 0 0 1-3.367-2.936L.256 15.21C1.542 20.2 6.218 24 11.979 24 18.627 24 24 18.627 24 11.979 24 5.373 18.627 0 11.979 0z"/></svg>
                 <span className="text-sm text-[var(--text-primary)]">Steam</span>
               </div>
-              <span className="text-xs text-green-400">Connected</span>
+              <div className="flex items-center gap-3 shrink-0">
+                <span className="text-xs text-[var(--text-muted)]">Connected</span>
+                <button
+                  onClick={() => disconnect("steam")}
+                  disabled={disconnecting === "steam"}
+                  className="text-xs text-[var(--text-secondary)] hover:text-red-400 disabled:opacity-40"
+                >
+                  {disconnecting === "steam" ? "..." : "Disconnect"}
+                </button>
+              </div>
             </div>
           ) : (
             <button
@@ -240,7 +252,16 @@ export default function SettingsClient() {
                 <DiscordIcon className="w-4 h-4 text-[var(--text-secondary)]" />
                 <span className="text-sm text-[var(--text-primary)]">Discord</span>
               </div>
-              <span className="text-xs text-green-400">Connected</span>
+              <div className="flex items-center gap-3 shrink-0">
+                <span className="text-xs text-[var(--text-muted)]">Connected</span>
+                <button
+                  onClick={() => disconnect("discord")}
+                  disabled={disconnecting === "discord"}
+                  className="text-xs text-[var(--text-secondary)] hover:text-red-400 disabled:opacity-40"
+                >
+                  {disconnecting === "discord" ? "..." : "Disconnect"}
+                </button>
+              </div>
             </div>
           ) : (
             <button
@@ -275,13 +296,16 @@ export default function SettingsClient() {
                   </span>
                 )}
               </div>
-              <button
-                onClick={disconnectTwitch}
-                disabled={disconnecting}
-                className="text-xs text-[var(--text-secondary)] hover:text-red-400 disabled:opacity-40 shrink-0"
-              >
-                {disconnecting ? "..." : "Disconnect"}
-              </button>
+              <div className="flex items-center gap-3 shrink-0">
+                <span className="text-xs text-[var(--text-muted)]">Connected</span>
+                <button
+                  onClick={() => disconnect("twitch")}
+                  disabled={disconnecting === "twitch"}
+                  className="text-xs text-[var(--text-secondary)] hover:text-red-400 disabled:opacity-40"
+                >
+                  {disconnecting === "twitch" ? "..." : "Disconnect"}
+                </button>
+              </div>
             </div>
           ) : (
             <button


### PR DESCRIPTION
A settings tweak plus the backend it needs.

- All three connectors (Steam, Discord, Twitch) now show a grey "Connected" label and a Disconnect button on the right. Previously only Twitch had Disconnect, and the indicator was green.
- Adds `/api/auth/steam/disconnect` and `/api/auth/discord/disconnect` (Twitch already had one), backed by `unlink_steam` / `unlink_discord`.
- A shared guard refuses to remove an account's **only** sign-in identity, so a disconnect can never lock someone out. The guard now also covers Twitch (a Twitch-only account can't drop its last login either).
- Disconnect is generalized to a single handler keyed by provider.