### PR TITLE
Only count official ascensions (A0-A10) in stats

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -714,10 +714,11 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
 
     official_chars = _official_character_ids()
     for row in rows:
-        # Official runs only: A11-A99 are modded (the game caps at Ascension
-        # 10), so skip them from entity scores and the community stats
-        # accumulated in this same walk.
-        if (row.get("ascension") or 0) > 10:
+        # Official runs only: the game's ascensions are A0-A10. A11+ are modded
+        # and a negative/placeholder like A-1 is bad data; both must be skipped
+        # from entity scores and the community stats accumulated in this walk.
+        _asc = row.get("ascension") or 0
+        if _asc < 0 or _asc > 10:
             continue
         # A run played as a non-official character is a modded run too, so the
         # per-entity "Picks by character" table only shows the real cast.

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -622,13 +622,17 @@ def _build_match(
         m["was_abandoned"] = {"$in": [False, 0]}
     elif win == "abandoned":
         m["was_abandoned"] = {"$in": [True, 1]}
+    # Official runs only: the game's ascensions are A0-A10. Anything outside
+    # that (A11+ from mods, or a negative/placeholder like A-1 from bad data)
+    # must never show in the stats. Constrain every breakdown to the official
+    # range, and ignore a stray ?ascension= that asks for a non-official level
+    # rather than surfacing it.
+    official = {"$gte": 0, "$lte": 10}
     if ascension is not None and ascension != "":
-        m["ascension"] = int(ascension)
+        asc = int(ascension)
+        m["ascension"] = asc if 0 <= asc <= 10 else official
     else:
-        # Official runs only: the game caps at Ascension 10, so A11-A99 come
-        # from mods. Exclude them from every stats breakdown (and the
-        # by-ascension grouping) so the stats reflect the real game.
-        m["ascension"] = {"$lte": 10}
+        m["ascension"] = official
     if game_mode:
         m["game_mode"] = game_mode
     if players == "single":


### PR DESCRIPTION
Fixes non-official ascensions leaking into `/leaderboards/stats`.

The stats paths excluded modded A11+ but not negatives, so an **A-1** showed up in the ascension breakdown, and **A15/A20** lingered from a stale materialized summary.

- `_build_match` now constrains to the official range `{$gte: 0, $lte: 10}`, and a stray `?ascension=` for a non-official level falls back to the official range instead of surfacing that level.
- The run walk that feeds per-entity scores and community stats skips any ascension below 0 or above 10 (it previously only skipped `> 10`).

Fresh aggregations are correct immediately. The materialized `stats_summary` and the entity snapshot drop the stale A15/A20 rows on their next refresh after deploy.