### PR TITLE
Fix potion drop rates page: a bonus-zone drop lowers pity, not raises it

### DIFF
--- a/data/mechanics_pages/potion-drop-rates.md
+++ b/data/mechanics_pages/potion-drop-rates.md
@@ -1,6 +1,6 @@
 ---
 title: Potion Drop Rates
-description: Potion drop chances from combat with an adaptive pity system. Starts at 40%, ±10% per combat, no hard cap. Elite encounters add a 12.5% effective bonus that doesn't move pity.
+description: Potion drop chances from combat with an adaptive pity system. Starts at 40%, ±10% per combat (down on a drop, up on a miss), no hard cap. Elites add a 12.5% effective drop bonus, but any drop still moves pity down 10%.
 category: mechanics
 order: 3
 ---
@@ -18,25 +18,20 @@ order: 3
 > Starts at {{constants.potion_reward_odds._basePotionRewardOdds | pct}}. After each combat the counter moves ±10% — **down 10%** if a potion drops, **up 10%** if not. There is **no hard cap** in the code (the underlying `AbstractOdds.CurrentValue` is an unclamped `float`). The constant `targetOdds = {{constants.potion_reward_odds.targetOdds | pct}}` is a design target, not an enforced ceiling.
 
 > **Elite bonus:**
-> The source constant `eliteBonus = {{constants.potion_reward_odds.eliteBonus | pct}}` is *halved* when applied to the roll: `currentValue + eliteBonus * 0.5`. So the **effective** Elite bonus is **+12.5%**, not +25%. The bonus is **freebie territory** — if your random roll lands between the bare pity counter and the bonus zone, you get the potion *and* pity still ticks up by 10% (the pity check uses the bare counter, not the post-bonus value).
+> The source constant `eliteBonus = {{constants.potion_reward_odds.eliteBonus | pct}}` is *halved* when applied to the roll: `currentValue + eliteBonus * 0.5`. So the **effective** Elite bonus is **+12.5%**, not +25%. That bonus is added to the drop threshold for one roll only — it is never written into the pity counter. The roll is a single check (`rng < currentValue + bonus`); if it passes you get the potion **and** pity moves **−10%**, exactly like any other drop, even when the potion only landed because of the bonus.
 
-> **Bosses roll just like monsters.** The reward switch in `RewardsSet.GenerateRewardsForRoom` calls the same `RollForPotionAndAddTo` path for `Monster`, `Elite`, and `Boss`. Bosses don't get the Elite bonus, so they roll against the bare pity counter, and the result *does* move the counter ±10% like any other combat.
+> **Bosses roll just like monsters.** The reward switch in `RewardsSet.GenerateRewardsForRoom` calls the same `RollForPotionAndAddTo` path for `Monster`, `Elite`, and `Boss`. Bosses don't get the Elite bonus, so they roll against the bare pity counter, and the result moves the counter ±10% like any other combat.
 
-### Elite drops create hidden pity state
+### What the Elite bonus actually does
 
-A subtle consequence of the bonus being decoupled from the pity check: **after a potion drops from an Elite, you can't tell which direction your pity counter moved.** Walking through the three roll outcomes:
+The bonus shifts where the drop / no-drop line sits; it does not change which way pity moves. In every combat the rule is the same:
 
-| Roll lands at... | Drop? | Pity moves |
+| Roll vs threshold | Drop? | Pity |
 |---|------:|------:|
-| `num < currentValue` | ✅ | **−10%** |
-| `currentValue ≤ num < currentValue + 0.125` | ✅ | **+10%** |
-| `num ≥ currentValue + 0.125` | ❌ | **+10%** |
+| `rng < currentValue + bonus` | ✅ | **−10%** |
+| `rng ≥ currentValue + bonus` | ❌ | **+10%** |
 
-Both successful-drop cases look identical to the player — you just see a potion. But internally, the pity counter is now in one of two states 20 percentage points apart. For Normal monsters and Bosses (no bonus zone), `drop ⇒ pity went down` and `no-drop ⇒ pity went up` are clean inverses. Elites break that.
-
-The asymmetry has a real gameplay implication: **the lower your pity is going into an Elite, the more likely a drop is from the bonus zone** (because most of the bare counter is below your random roll), so **pity ticks UP despite the drop**. Counter-intuitive but mechanically correct.
-
-If you're trying to time potion drops around predictable pity movements, prefer routing through Normal/Boss fights where the signal is unambiguous.
+`bonus` is 12.5% for Elites and 0 for Monsters and Bosses. So **a drop always lowers pity and a miss always raises it** — there is no outcome where a drop leaves pity higher. The Elite's +12.5% only widens the drop side of the line: it makes a potion more likely, but a bonus-driven drop still spends the full −10% of pity, so an Elite borrows against your future drop chance rather than handing out a truly free potion.
 
 ## Rarity Distribution
 


### PR DESCRIPTION
The potion drop rates mechanics page described a quirk the game doesn't have.

It claimed the Elite bonus and the pity check were decoupled, that a drop landing in the elite bonus zone grants the potion *and* still ticks pity **up** 10% because "the pity check uses the bare counter, not the post-bonus value", and built an "Elite drops create hidden pity state" section on it.

The decompiled source disagrees. `PotionRewardOdds.Roll` is a single branch:

```csharp
float num3 = currentValue + num2 * 0.5f;   // + bonus (12.5% for Elite)
if (flag || num4 < num3) { CurrentValue -= 0.1f; return true; }  // drop -> pity DOWN
CurrentValue += 0.1f; return false;                              // miss -> pity UP
```

`RollForPotionAndAddTo` just calls `Roll` once. So any drop, including one only possible because of the Elite bonus, moves pity **down** 10%; a miss moves it up 10%. There's no separate bare-counter check and no case where a drop leaves pity higher.

Rewrote the section to match the source: a drop always lowers pity, a miss always raises it, and the Elite +12.5% only widens the drop side of the line (it borrows against future drop chance rather than being free).