### PR TITLE
Add keyset pagination and time-range filters to the run export api

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -526,6 +526,10 @@ app.add_middleware(RequestLoggingMiddleware)
 app.add_middleware(CORSStaticMiddleware)
 app.add_middleware(GZipMiddleware, minimum_size=1000)
 _cors_origins = os.environ.get("CORS_ORIGINS", "").strip()
+# Response headers a browser client is allowed to read; wildcard allow_headers
+# only covers the *request* side. X-Next-Cursor carries the run-export keyset
+# token (GET /api/exports/runs).
+_cors_expose_headers = ["X-Next-Cursor"]
 if _cors_origins:
     app.add_middleware(
         CORSMiddleware,
@@ -533,6 +537,7 @@ if _cors_origins:
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
+        expose_headers=_cors_expose_headers,
     )
 else:
     app.add_middleware(
@@ -540,6 +545,7 @@ else:
         allow_origins=["*"],
         allow_methods=["*"],
         allow_headers=["*"],
+        expose_headers=_cors_expose_headers,
     )
 
 # ── Prometheus metrics ────────────────────────────────────────

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -130,7 +130,12 @@ data_exports = Counter(
 
 run_exports = Counter(
     "spire_codex_run_exports_total",
-    "Bulk run data export downloads",
+    "Bulk run data export downloads (unbounded full dumps)",
+)
+
+run_export_pages = Counter(
+    "spire_codex_run_export_pages_total",
+    "Paginated run export page fetches (a bounded ?limit= request)",
 )
 
 # ── Auth ────────────────────────────────────────────────────

--- a/backend/app/routers/exports.py
+++ b/backend/app/routers/exports.py
@@ -7,7 +7,7 @@ import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pymongo import ASCENDING
 from slowapi import Limiter
@@ -156,6 +156,30 @@ def _page_hashes(start, end, cursor, limit):
     return [doc["_id"] for doc in docs], next_cursor
 
 
+def _page_params(
+    start: str | None = Query(
+        None, description="Inclusive lower bound on submitted_at (ISO-8601)."
+    ),
+    end: str | None = Query(
+        None, description="Exclusive upper bound on submitted_at (ISO-8601)."
+    ),
+    cursor: str | None = Query(
+        None,
+        description="Opaque keyset token from a prior page's X-Next-Cursor header.",
+    ),
+):
+    """Parse the window/cursor params as a dependency. Dependencies resolve
+    before the rate-limit decorator charges the request, so a malformed value
+    400s without spending budget — the same phase FastAPI validates ``limit``
+    in. Parsed inside the handler these would be charged first (60 for an
+    unbounded request), letting a few junk requests lock an IP out."""
+    return (
+        _parse_iso(start, "start") if start else None,
+        _parse_iso(end, "end") if end else None,
+        _decode_cursor(cursor) if cursor else None,
+    )
+
+
 def _export_cost(request: Request) -> int:
     """Rate-limit cost: a bounded (paginated) pull is cheap; an unbounded full
     dump stays rare. 60 against the 120/hour bucket reproduces the historical
@@ -202,16 +226,7 @@ def export_runs(
         le=MAX_PAGE_LIMIT,
         description="Max runs in this page. Omit for the full (unbounded) export.",
     ),
-    start: str | None = Query(
-        None, description="Inclusive lower bound on submitted_at (ISO-8601)."
-    ),
-    end: str | None = Query(
-        None, description="Exclusive upper bound on submitted_at (ISO-8601)."
-    ),
-    cursor: str | None = Query(
-        None,
-        description="Opaque keyset token from a prior page's X-Next-Cursor header.",
-    ),
+    page: tuple = Depends(_page_params),
 ):
     """Bulk export of submitted runs as gzipped JSONL.
 
@@ -244,9 +259,7 @@ def export_runs(
     * Browser clients reading ``X-Next-Cursor`` need it in the CORS
       ``Access-Control-Expose-Headers`` list; non-browser clients are unaffected.
     """
-    start_dt = _parse_iso(start, "start") if start else None
-    end_dt = _parse_iso(end, "end") if end else None
-    cursor_key = _decode_cursor(cursor) if cursor else None
+    start_dt, end_dt, cursor_key = page
 
     (run_export_pages if limit is not None else run_exports).inc()
     hashes, next_cursor = _page_hashes(start_dt, end_dt, cursor_key, limit)

--- a/backend/app/routers/exports.py
+++ b/backend/app/routers/exports.py
@@ -1,16 +1,19 @@
+import base64
 import gzip
 import io
 import json
 import os
 import zipfile
+from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
+from pymongo import ASCENDING
 from slowapi import Limiter
 
 from ..dependencies import VALID_LANGUAGES, client_ip
-from ..metrics import data_exports, run_exports
+from ..metrics import data_exports, run_export_pages, run_exports
 from ..services.data_service import DATA_DIR
 
 router = APIRouter(prefix="/api/exports", tags=["Exports"])
@@ -43,30 +46,124 @@ _RUNS_DIR = (
 
 OFFICIAL_CHARACTERS = {"IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"}
 
+# Upper bound on a single page so one request can't ask for the whole corpus
+# while still claiming the cheap (paginated) rate-limit cost.
+MAX_PAGE_LIMIT = 50000
 
-def _official_run_hashes() -> list[str]:
-    """Get hashes of official runs from Mongo: an official character AND the
-    official ascension range (A11+ is modded)."""
+
+def _parse_iso(value: str, field: str) -> datetime:
+    """Parse an ISO-8601 timestamp param into an aware UTC datetime (400 on
+    malformed input). Naive timestamps are assumed UTC."""
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        raise HTTPException(
+            status_code=400, detail=f"invalid {field}: expected an ISO-8601 timestamp"
+        )
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _encode_cursor(submitted_at, run_hash: str) -> str:
+    """Encode a keyset position as an opaque, URL-safe token. Runs missing a
+    submitted_at sort first, encoded with an empty timestamp."""
+    sa = submitted_at.isoformat() if submitted_at is not None else ""
+    return base64.urlsafe_b64encode(f"{sa}|{run_hash}".encode("utf-8")).decode("ascii")
+
+
+def _decode_cursor(token: str):
+    """Decode an X-Next-Cursor token back into (submitted_at|None, run_hash).
+    400 on a malformed token. binascii.Error subclasses ValueError, so a bad
+    base64 payload is covered too."""
+    try:
+        raw = base64.urlsafe_b64decode(token.encode("ascii")).decode("utf-8")
+        sa_str, run_hash = raw.split("|", 1)
+    except (ValueError, UnicodeDecodeError):
+        raise HTTPException(status_code=400, detail="invalid cursor")
+    submitted_at = _parse_iso(sa_str, "cursor") if sa_str else None
+    return submitted_at, run_hash
+
+
+def _build_match(start, end, cursor) -> dict:
+    """Mongo filter for the export: official runs (an official character in
+    the official ascension range; A11+ is modded), an optional half-open
+    [start, end) submitted_at window, and an optional keyset continuation
+    strictly after `cursor`'s (submitted_at, _id)."""
+    clauses: list[dict] = [
+        {"character": {"$in": list(OFFICIAL_CHARACTERS)}},
+        {"ascension": {"$gte": 0, "$lte": 10}},
+    ]
+
+    range_q: dict = {}
+    if start is not None:
+        range_q["$gte"] = start
+    if end is not None:
+        range_q["$lt"] = end
+    if range_q:
+        clauses.append({"submitted_at": range_q})
+
+    if cursor is not None:
+        sa, run_hash = cursor
+        if sa is None:
+            # Still inside the leading null/missing-submitted_at block: take
+            # the remaining nulls by _id, then everything with a timestamp.
+            clauses.append(
+                {
+                    "$or": [
+                        {"submitted_at": None, "_id": {"$gt": run_hash}},
+                        {"submitted_at": {"$ne": None}},
+                    ]
+                }
+            )
+        else:
+            clauses.append(
+                {
+                    "$or": [
+                        {"submitted_at": {"$gt": sa}},
+                        {"submitted_at": sa, "_id": {"$gt": run_hash}},
+                    ]
+                }
+            )
+
+    return clauses[0] if len(clauses) == 1 else {"$and": clauses}
+
+
+def _page_hashes(start, end, cursor, limit):
+    """Return (ordered_hashes, next_cursor). Runs are ordered by
+    (submitted_at, _id); next_cursor is None unless a bounded page is full
+    and at least one more run follows it."""
     from ..services.runs_db_mongo import _get_collection
 
     coll = _get_collection()
-    cursor = coll.find(
-        {
-            "character": {"$in": list(OFFICIAL_CHARACTERS)},
-            "ascension": {"$gte": 0, "$lte": 10},
-        },
-        {"_id": 1},
+    finder = coll.find(
+        _build_match(start, end, cursor),
+        {"_id": 1, "submitted_at": 1},
         no_cursor_timeout=True,
-    )
+    ).sort([("submitted_at", ASCENDING), ("_id", ASCENDING)])
+    if limit is not None:
+        finder = finder.limit(limit + 1)  # one extra row probes for a next page
     try:
-        return [doc["_id"] for doc in cursor]
+        docs = list(finder)
     finally:
-        cursor.close()
+        finder.close()
+
+    next_cursor = None
+    if limit is not None and len(docs) > limit:
+        docs = docs[:limit]
+        last = docs[-1]
+        next_cursor = _encode_cursor(last.get("submitted_at"), last["_id"])
+    return [doc["_id"] for doc in docs], next_cursor
 
 
-def _stream_runs_jsonl():
-    hashes = _official_run_hashes()
+def _export_cost(request: Request) -> int:
+    """Rate-limit cost: a bounded (paginated) pull is cheap; an unbounded full
+    dump stays rare. 60 against the 120/hour bucket reproduces the historical
+    2/hour ceiling for the full export."""
+    return 1 if request.query_params.get("limit") else 60
 
+
+def _stream_runs_jsonl(hashes):
     buf = io.BytesIO()
     gz = gzip.GzipFile(fileobj=buf, mode="wb")
 
@@ -96,22 +193,75 @@ def _stream_runs_jsonl():
 # Declared BEFORE the /{lang} route so FastAPI matches the literal
 # path "runs" instead of treating it as a language code.
 @router.get("/runs")
-@limiter.limit("2/hour")
-def export_runs(request: Request):
-    """Bulk export of all submitted runs as gzipped JSONL.
+@limiter.limit("120/hour", cost=_export_cost)
+def export_runs(
+    request: Request,
+    limit: int | None = Query(
+        None,
+        ge=1,
+        le=MAX_PAGE_LIMIT,
+        description="Max runs in this page. Omit for the full (unbounded) export.",
+    ),
+    start: str | None = Query(
+        None, description="Inclusive lower bound on submitted_at (ISO-8601)."
+    ),
+    end: str | None = Query(
+        None, description="Exclusive upper bound on submitted_at (ISO-8601)."
+    ),
+    cursor: str | None = Query(
+        None,
+        description="Opaque keyset token from a prior page's X-Next-Cursor header.",
+    ),
+):
+    """Bulk export of submitted runs as gzipped JSONL.
 
     Each line is the full raw game JSON as submitted by the client,
     including players, map_point_history, acts, deck, relics, and
     card_choices. Only runs with official characters are included.
+
+    Runs are ordered by ``(submitted_at, _id)``. With no params the response
+    is the full corpus (unchanged behaviour). To pull it in reliable chunks:
+
+    * ``limit=N`` bounds the page to N runs. When more runs follow, the
+      response carries an ``X-Next-Cursor`` header; pass it back as
+      ``cursor=`` to fetch the next page. The ascending order means runs
+      submitted *during* a long bootstrap sort after the cursor, so a
+      forward pager never misses them.
+    * ``start`` / ``end`` restrict to a half-open ``[start, end)``
+      submitted_at window (e.g. an incremental "everything since my last
+      sync"). Combine with ``limit`` to also bound each page.
+
+    Consumer notes:
+
+    * Terminate a paged walk on the **absence of ``X-Next-Cursor``**, never on
+      "fewer lines than ``limit``": a page is ``limit`` *runs*, but the streamed
+      line count can differ (missing/unreadable run files are skipped, and a
+      multiplayer run emits one raw line per player).
+    * The cursor does **not** embed the window, so keep ``start`` / ``end``
+      constant across a paged sequence.
+    * ``start`` / ``end`` filter on ``submitted_at``, so they exclude legacy
+      runs that have no ``submitted_at``. Omit both to receive the whole corpus.
+    * Browser clients reading ``X-Next-Cursor`` need it in the CORS
+      ``Access-Control-Expose-Headers`` list; non-browser clients are unaffected.
     """
-    run_exports.inc()
+    start_dt = _parse_iso(start, "start") if start else None
+    end_dt = _parse_iso(end, "end") if end else None
+    cursor_key = _decode_cursor(cursor) if cursor else None
+
+    (run_export_pages if limit is not None else run_exports).inc()
+    hashes, next_cursor = _page_hashes(start_dt, end_dt, cursor_key, limit)
+
+    headers = {
+        "Content-Disposition": 'attachment; filename="spire-codex-runs.jsonl.gz"',
+        "Cache-Control": "no-store",
+    }
+    if next_cursor is not None:
+        headers["X-Next-Cursor"] = next_cursor
+
     return StreamingResponse(
-        _stream_runs_jsonl(),
+        _stream_runs_jsonl(hashes),
         media_type="application/gzip",
-        headers={
-            "Content-Disposition": 'attachment; filename="spire-codex-runs.jsonl.gz"',
-            "Cache-Control": "no-store",
-        },
+        headers=headers,
     )
 
 

--- a/backend/app/routers/exports.py
+++ b/backend/app/routers/exports.py
@@ -256,8 +256,8 @@ def export_runs(
       constant across a paged sequence.
     * ``start`` / ``end`` filter on ``submitted_at``, so they exclude legacy
       runs that have no ``submitted_at``. Omit both to receive the whole corpus.
-    * Browser clients reading ``X-Next-Cursor`` need it in the CORS
-      ``Access-Control-Expose-Headers`` list; non-browser clients are unaffected.
+    * ``X-Next-Cursor`` is in the CORS ``Access-Control-Expose-Headers`` list,
+      so browser clients can read it too; non-browser clients never needed it.
     """
     start_dt, end_dt, cursor_key = page
 

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import time
 from contextlib import contextmanager
@@ -50,6 +51,8 @@ from pymongo.errors import DuplicateKeyError
 
 from ..metrics import db_operations, db_operation_duration
 from . import cache as app_cache
+
+logger = logging.getLogger(__name__)
 
 OFFICIAL_CHARACTERS = {"IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"}
 
@@ -316,8 +319,12 @@ def _ensure_run_validator(coll) -> None:
             validationLevel="moderate",
             validationAction="error",
         )
-    except Exception as e:
-        print(f"Warning: could not apply runs submitted_at validator: {e}")
+    except Exception:
+        logger.exception(
+            "could not apply the runs submitted_at validator; inserts are NOT "
+            "being schema-checked — new-run ordering relies on the submit path "
+            "alone until collMod succeeds on a later startup"
+        )
 
 
 # ── helpers (mirrors of the sqlite module) ──────────────────────────────

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -23,11 +23,15 @@ Indexes (created on import — idempotent):
     {character: 1}
     {username: 1, submitted_at: -1}
     {submitted_at: -1}
+    {submitted_at: 1, _id: 1}   (keyset-paginated run export)
     {character: 1, win: 1, ascension: 1}
     {build_id: 1}
     {"deck.id": 1}            (multikey)
     {relics.id: 1}            (multikey)
     {killed_by: 1}
+
+Schema validation (applied on import — idempotent, level "moderate"):
+    submitted_at must be a BSON date — see _ensure_run_validator.
 """
 
 from __future__ import annotations
@@ -140,6 +144,7 @@ def _get_collection():
     # Database name comes from the connection string's default db.
     _coll = _client.get_default_database().runs
     _ensure_indexes(_coll)
+    _ensure_run_validator(_coll)
     return _coll
 
 
@@ -155,6 +160,11 @@ def _ensure_indexes(coll) -> None:
     # that don't normalize (claim, username-for-hash).
     coll.create_index([("username_lower", ASCENDING), ("submitted_at", DESCENDING)])
     coll.create_index([("submitted_at", DESCENDING)])
+    # Ascending (submitted_at, _id) backs the keyset-paginated run export
+    # (GET /api/exports/runs ordered by (submitted_at, _id)). The {submitted_at: -1}
+    # index above is descending and lacks the _id tiebreaker, so it can't serve
+    # the ordered scan the cursor walks.
+    coll.create_index([("submitted_at", ASCENDING), ("_id", ASCENDING)])
     coll.create_index(
         [("character", ASCENDING), ("win", ASCENDING), ("ascension", ASCENDING)]
     )
@@ -255,6 +265,59 @@ def _ensure_indexes(coll) -> None:
         [("game_mode", ASCENDING), ("win", ASCENDING), ("run_time", ASCENDING)],
         name="mode_win_runtime",
     )
+
+
+def _ensure_run_validator(coll) -> None:
+    """Require every run doc to carry a BSON-date ``submitted_at``. Idempotent;
+    applied on first collection access alongside the indexes, so a deploy turns
+    it on with no manual step.
+
+    Why: the keyset run export (GET /api/exports/runs) orders by
+    ``(submitted_at, _id)``, and a forward pager only reliably sees new runs
+    because every new run sorts at the *end* — i.e. is stamped with a real
+    ``submitted_at`` (submit_run always sets ``now()``). A run inserted *without*
+    one would sort into the leading null block and be silently dropped from the
+    export for any pager that had already advanced past it. This makes that
+    invariant enforced rather than assumed: a future code path that tried to
+    insert a run with a missing / null / non-date ``submitted_at`` fails loudly
+    here instead of quietly corrupting the export.
+
+    ``validationLevel="moderate"`` so the rule gates all new inserts but spares
+    *updates* to any pre-existing legacy doc whose ``submitted_at`` is null /
+    missing (the duplicate-key linking ``$set``, backfill_user_runs, claim_runs
+    keep working). Best-effort: if collMod can't run (permissions, or a
+    deliberate bulk-import window) it logs and continues — the export stays
+    correct as long as the submit path keeps stamping ``submitted_at``, which it
+    does; this is defense in depth, not a load-bearing dependency.
+
+    NB for a bulk re-import of untimestamped legacy runs: ``moderate`` still
+    validates *inserts*, so such an import would now be rejected. Stamp
+    ``submitted_at`` in the import, or temporarily set ``validationAction``
+    to ``"warn"`` for that window.
+    """
+    try:
+        coll.database.command(
+            "collMod",
+            coll.name,
+            validator={
+                "$jsonSchema": {
+                    "required": ["submitted_at"],
+                    "properties": {
+                        "submitted_at": {
+                            "bsonType": "date",
+                            "description": (
+                                "must be a BSON date; keyset export ordering "
+                                "depends on it"
+                            ),
+                        }
+                    },
+                }
+            },
+            validationLevel="moderate",
+            validationAction="error",
+        )
+    except Exception as e:
+        print(f"Warning: could not apply runs submitted_at validator: {e}")
 
 
 # ── helpers (mirrors of the sqlite module) ──────────────────────────────

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,5 @@
+# Dev/test-only dependencies. Install on top of requirements.txt:
+#   pip install -r requirements.txt -r requirements-dev.txt
+# Run the tests from the backend/ dir:
+#   pytest
+pytest>=8,<10

--- a/backend/tests/test_export_helpers.py
+++ b/backend/tests/test_export_helpers.py
@@ -1,0 +1,143 @@
+"""Unit tests for the run-export pagination helpers.
+
+Pure-function coverage of the cursor codec, the keyset/range Mongo match
+builder, ISO parsing, and the rate-limit cost - none of which touch Mongo
+(the router imports `_get_collection` lazily, so these run with no database
+and no FastAPI app). Run from the backend/ dir: `pytest`.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers.exports import (
+    OFFICIAL_CHARACTERS,
+    _build_match,
+    _decode_cursor,
+    _encode_cursor,
+    _export_cost,
+    _parse_iso,
+)
+
+
+# --- _parse_iso ------------------------------------------------------------
+
+def test_parse_iso_aware_passthrough():
+    dt = _parse_iso("2026-06-22T19:51:28+00:00", "start")
+    assert dt == datetime(2026, 6, 22, 19, 51, 28, tzinfo=timezone.utc)
+
+
+def test_parse_iso_naive_assumed_utc():
+    dt = _parse_iso("2026-06-22T00:00:00", "start")
+    assert dt.tzinfo == timezone.utc
+
+
+def test_parse_iso_rejects_garbage():
+    with pytest.raises(HTTPException) as err:
+        _parse_iso("not-a-date", "start")
+    assert err.value.status_code == 400
+
+
+# --- cursor codec ----------------------------------------------------------
+
+def test_cursor_roundtrip_with_timestamp():
+    dt = datetime(2026, 6, 22, 19, 51, 28, 664000, tzinfo=timezone.utc)
+    token = _encode_cursor(dt, "aaaabbbbcccc1111")
+    sa, run_hash = _decode_cursor(token)
+    assert sa == dt
+    assert run_hash == "aaaabbbbcccc1111"
+
+
+def test_cursor_roundtrip_null_submitted_at():
+    # Legacy/null block: submitted_at encodes as empty and decodes back to None.
+    token = _encode_cursor(None, "aaaabbbbcccc1111")
+    sa, run_hash = _decode_cursor(token)
+    assert sa is None
+    assert run_hash == "aaaabbbbcccc1111"
+
+
+def test_decode_cursor_rejects_bad_base64():
+    # "x" is a malformed base64 payload (1 char, an invalid length), so the
+    # decode raises binascii.Error (a ValueError subclass) before any "|"
+    # split - exercising the base64 guard specifically, not the UTF-8 one.
+    with pytest.raises(HTTPException) as err:
+        _decode_cursor("x")
+    assert err.value.status_code == 400
+
+
+def test_decode_cursor_rejects_missing_separator():
+    import base64
+
+    # Valid base64 but no "|" separator -> the unpack fails -> 400.
+    token = base64.urlsafe_b64encode(b"noseparator").decode("ascii")
+    with pytest.raises(HTTPException) as err:
+        _decode_cursor(token)
+    assert err.value.status_code == 400
+
+
+# --- _build_match ----------------------------------------------------------
+
+def _char_clause(match):
+    """Pull the official-character clause out of a match (order-independent)."""
+    clause = match if "character" in match else next(
+        c for c in match["$and"] if "character" in c
+    )
+    return set(clause["character"]["$in"])
+
+
+def test_build_match_no_params_is_official_runs_filter():
+    match = _build_match(None, None, None)
+    # No range/cursor -> only the baseline official-runs clauses:
+    # official characters and the official ascension range (A11+ is modded).
+    assert _char_clause(match) == OFFICIAL_CHARACTERS
+    ascension_clause = next(c for c in match["$and"] if "ascension" in c)
+    assert ascension_clause["ascension"] == {"$gte": 0, "$lte": 10}
+    assert len(match["$and"]) == 2
+
+
+def test_build_match_half_open_range():
+    start = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 6, 20, tzinfo=timezone.utc)
+    match = _build_match(start, end, None)
+    range_clause = next(c for c in match["$and"] if "submitted_at" in c)
+    assert range_clause["submitted_at"] == {"$gte": start, "$lt": end}
+
+
+def test_build_match_start_only():
+    start = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    match = _build_match(start, None, None)
+    range_clause = next(c for c in match["$and"] if "submitted_at" in c)
+    assert range_clause["submitted_at"] == {"$gte": start}
+
+
+def test_build_match_cursor_inside_null_block():
+    # Cursor with sa=None: take remaining nulls by _id, then everything timed.
+    match = _build_match(None, None, (None, "abc"))
+    or_clause = next(c for c in match["$and"] if "$or" in c)["$or"]
+    assert {"submitted_at": None, "_id": {"$gt": "abc"}} in or_clause
+    assert {"submitted_at": {"$ne": None}} in or_clause
+
+
+def test_build_match_cursor_past_nulls():
+    sa = datetime(2026, 6, 10, tzinfo=timezone.utc)
+    match = _build_match(None, None, (sa, "abc"))
+    or_clause = next(c for c in match["$and"] if "$or" in c)["$or"]
+    # Strictly after (sa, abc) in (submitted_at, _id) order.
+    assert {"submitted_at": {"$gt": sa}} in or_clause
+    assert {"submitted_at": sa, "_id": {"$gt": "abc"}} in or_clause
+
+
+# --- _export_cost ----------------------------------------------------------
+
+class _FakeRequest:
+    def __init__(self, query):
+        self.query_params = query
+
+
+def test_export_cost_paged_is_cheap():
+    assert _export_cost(_FakeRequest({"limit": "5000"})) == 1
+
+
+def test_export_cost_full_dump_is_expensive():
+    assert _export_cost(_FakeRequest({})) == 60

--- a/backend/tests/test_export_helpers.py
+++ b/backend/tests/test_export_helpers.py
@@ -17,6 +17,7 @@ from app.routers.exports import (
     _decode_cursor,
     _encode_cursor,
     _export_cost,
+    _page_params,
     _parse_iso,
 )
 
@@ -126,6 +127,34 @@ def test_build_match_cursor_past_nulls():
     # Strictly after (sa, abc) in (submitted_at, _id) order.
     assert {"submitted_at": {"$gt": sa}} in or_clause
     assert {"submitted_at": sa, "_id": {"$gt": "abc"}} in or_clause
+
+
+# --- _page_params ------------------------------------------------------------
+
+def test_page_params_all_absent():
+    # Called directly (not via FastAPI), Query defaults are the sentinel
+    # objects, so pass the absent values explicitly.
+    assert _page_params(None, None, None) == (None, None, None)
+
+
+def test_page_params_parses_and_decodes():
+    sa = datetime(2026, 6, 22, 19, 51, 28, tzinfo=timezone.utc)
+    token = _encode_cursor(sa, "aaaabbbbcccc1111")
+    start, end, cursor = _page_params("2026-06-01T00:00:00", None, token)
+    assert start == datetime(2026, 6, 1, tzinfo=timezone.utc)
+    assert end is None
+    assert cursor == (sa, "aaaabbbbcccc1111")
+
+
+def test_page_params_rejects_malformed_before_handler():
+    # The dependency is what turns junk into a 400 before the rate limiter
+    # charges the request; a malformed value must raise, not pass through.
+    with pytest.raises(HTTPException) as err:
+        _page_params("not-a-date", None, None)
+    assert err.value.status_code == 400
+    with pytest.raises(HTTPException) as err:
+        _page_params(None, None, "x")
+    assert err.value.status_code == 400
 
 
 # --- _export_cost ----------------------------------------------------------

--- a/tools/sqlite_to_mongo.py
+++ b/tools/sqlite_to_mongo.py
@@ -47,6 +47,7 @@ import sqlite3
 import sys
 import time
 from collections import defaultdict
+from datetime import datetime, timezone
 from typing import Any
 
 try:
@@ -88,6 +89,22 @@ def build_doc(run_row: dict[str, Any], children: dict[str, dict]) -> dict[str, A
         "_id": rh,
         **{k: v for k, v in run_row.items() if k not in ("run_hash", "id")},
     }
+    # The runs collection requires a BSON-date submitted_at on every insert
+    # (see _ensure_run_validator in backend/app/services/runs_db_mongo.py) —
+    # the keyset run export orders by it. SQLite stores TIMESTAMP as text, so
+    # convert; CURRENT_TIMESTAMP is UTC. A missing/unparseable value is left
+    # as-is so the insert fails validation and shows up in _flush's error
+    # output, rather than silently landing where the export can't order it.
+    sa = doc.get("submitted_at")
+    if isinstance(sa, str):
+        try:
+            parsed = datetime.fromisoformat(sa)
+        except ValueError:
+            pass
+        else:
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            doc["submitted_at"] = parsed
     # Pull child arrays keyed by the integer run_id.
     doc["deck"] = children.get("run_cards", {}).get(rid, [])
     doc["relics"] = children.get("run_relics", {}).get(rid, [])


### PR DESCRIPTION
## Overview
Add keyset pagination and time-range filters to the run export api.

The bulk `GET /api/exports/runs` is currently hundreds of thousands of runs. Pulling it in one shot is unreliable - the on-the-fly stream can get reset partway through (observed: Cloudflare closing the HTTP/2 stream before the dump completed), in addition to taking a while. This adds an opt-in way to pull it in resumable, bounded chunks. When calling the endpoint with no parameters results in the same behavior as before (a full export).

Changes:

- `backend/app/routers/exports.py`
  - Add `limit`, `start`, `end`, `cursor` params
  - Implement time-range and cursor query logic
  - Update rate limit logic from 2/h to 120/h - full export costs 60, one page costs 1
- `backend/app/services/runs_db_mongo.py`
  - Add new `(submitted_at, _id)` index
  - `_ensure_run_validator` validates that new run submissions have `submitted_at`
- `backend/app/metrics.py`
  - Add new `run_export_pages` counter
- `backend/tests/test_export_helpers.py`, `backend/pytest.ini`, `backend/requirements-dev.txt`
  - Add `pytest` (single dev dependency) + pure-function unit tests for the export pagination helpers

## Behavior

`GET /api/exports/runs` gains four optional query params:

| Param    | Meaning |
|----------|---------|
| `limit`  | Max runs in this page (1 to 50000). Enables keyset pagination. |
| `start`  | Inclusive lower bound on `submitted_at` (ISO-8601). |
| `end`    | Exclusive upper bound on `submitted_at` (ISO-8601). |
| `cursor` | Opaque keyset token from a prior page's `X-Next-Cursor` header. |

- **Ordering:** `(submitted_at, _id)` ascending, always.
- **Pagination:** with `limit`, a full page returns an opaque `X-Next-Cursor` response header. Pass it back as `cursor=` to get the next page; its absence means you've reached the end. Ascending order means runs submitted *during* a paginated scan will sort *after* the cursor, so a forward pager never misses or double-counts. In other words, You can page through the whole corpus while clients submit run concurrently; the runs will be picked up before you've reached the end. 
- **Time-range:** `start`/`end` give a half-open `[start, end)` window on `submitted_at`, for incremental "everything since my last sync" pulls. Combine with `limit` to also bound each page.
- **No params behavior is unchanged:** full export (same body, same semantics).

```
# bootstrap the whole corpus in 5000-run pages
GET /api/exports/runs?limit=5000
GET /api/exports/runs?limit=5000&cursor=<X-Next-Cursor from previous>
...until no X-Next-Cursor

# incremental: just the new runs since the last sync
GET /api/exports/runs?start=2026-06-20T00:00:00Z&limit=5000
```

## Implementation

- **Index** (`runs_db_mongo.py`): adds ascending `(submitted_at, _id)`. The existing `{submitted_at: -1}` index is descending and lacks the `_id` tiebreaker, so it can't serve the ordered keyset scan. With the new index the scan is index-ordered with no blocking in-memory sort (`IXSCAN -> FETCH -> LIMIT`, no SORT stage). The export filters to official characters (`$in OFFICIAL_CHARACTERS`); since `character` isn't in the index, it stays a post-fetch filter (the `FETCH` evaluates it), so the query isn't covered. That's fine today because official-character runs dominate the corpus, so few fetched docs are rejected. The submit path *does* store modded-character runs (they're excluded only at read/snapshot time), so if modded runs ever became a large fraction of stored runs, a `(character, submitted_at, _id)` index would make `character` an indexed predicate (`SORT_MERGE` over the official values, fully covered, no post-fetch rejection). I kept the simpler index since I assume the fraction to be negligible currently.
- **Two effective rate limits: full dumps stay at 2/hour, paged reads get 120/hour.** The split is expressed with slowapi's per-request `cost`: the route is `120/hour` where a bounded (`limit`) page costs 1 and a the full export costs 60 - so the old 2/hour for full export is reserved.
- **Null/legacy `submitted_at`** (older runs that predate upload-time tracking and haven't been stamped) sort as a leading block ordered by `_id`; the cursor handles that block explicitly, so a full bootstrap (no `start`/`end`) still returns them. A `start`/`end` window filters on `submitted_at` and therefore excludes them - intended for incremental sync, documented on the endpoint. Null *volume* doesn't degrade paging (the non-sparse index keys nulls too) - see Verification.
- **Metric split** so paging doesn't silently change an existing dashboard: `spire_codex_run_exports_total` still counts unbounded dumps; new `spire_codex_run_export_pages_total` counts bounded pages.
- **Schema validator enforcing the ordering invariant** (`runs_db_mongo.py`): the export's "a forward pager never misses a new run" guarantee holds only because every new run sorts at the *end* - i.e. is stamped with a real `submitted_at`. A run inserted without `submitted_at` sorts into the leading null block. So `_ensure_run_validator` attaches a `$jsonSchema` validator requiring `submitted_at` to be a BSON `date`. The `validationLevel: "moderate"` means the validator enforces new runs bot not pre-existing runs. Note that a bulk re-import of untimestamped legacy runs would now be rejected. You should be able to get around it by adding `submitted_at` in the import or setting `validationAction: "warn"` for that window.
- Cursor format is base64url of `submitted_at|_id`.

## Verification

Tested manually against a local instance (Docker, in-memory slowapi), seeded with runs. To reproduce:

```bash
# in-memory rate limit note: a 429 returns a (non-gzip) JSON error body; reset
# the limiter any time with: docker compose -f docker-compose.local.yml restart backend

# 1. start the stack (Mongo + backend on :8000)
docker compose -f docker-compose.local.yml up -d

# 2. seed raw run blobs (POST /api/runs dedups on a canonical run_hash)
for f in seed-runs/*.json; do
  curl -s -X POST "http://localhost:8000/api/runs?username=seed_local" \
    -H "Content-Type: application/json" --data-binary "@$f" >/dev/null
done

# 3. full (unbounded) export - the unchanged path - count lines
curl -s "http://localhost:8000/api/exports/runs" | gunzip | wc -l

# 4. page through, following X-Next-Cursor until it's gone, concatenating pages
cursor=""; : > /tmp/paged.jsonl
while :; do
  url="http://localhost:8000/api/exports/runs?limit=50"
  [ -n "$cursor" ] && url="$url&cursor=$cursor"
  curl -s -D /tmp/hdr "$url" | gunzip >> /tmp/paged.jsonl
  cursor=$(grep -i '^x-next-cursor:' /tmp/hdr | tr -d '\r' | awk '{print $2}')
  [ -z "$cursor" ] && break
done
wc -l /tmp/paged.jsonl          # has equal line set as full export

# 5. half-open [start, end) window (incremental "since my last sync")
curl -s "http://localhost:8000/api/exports/runs?start=2026-06-01T00:00:00Z&end=2026-06-20T00:00:00Z" \
  | gunzip | wc -l

# 6. inspect the query plan (expect IXSCAN -> FETCH -> LIMIT, no SORT stage)
docker exec spire-codex-local-mongo mongosh spire_codex --quiet --eval '
  db.runs.find({character:{$in:["IRONCLAD","SILENT","DEFECT","NECROBINDER","REGENT"]}})
    .sort({submitted_at:1,_id:1}).limit(50).explain().queryPlanner.winningPlan'

# 7. (optional) null-volume test: inject 8k null-submitted_at docs straight into
#    Mongo (bypasses the submit path on purpose), then plan the null-block
#    continuation query - expect SORT_MERGE over two IXSCANs, not a COLLSCAN/SORT
docker exec spire-codex-local-mongo mongosh spire_codex --quiet --eval '
  const bulk = [];
  for (let i = 0; i < 8000; i++)
    bulk.push({_id:"null"+i, character:"IRONCLAD", submitted_at:null});
  db.runs.insertMany(bulk);
  db.runs.find({$and:[
      {character:{$in:["IRONCLAD","SILENT","DEFECT","NECROBINDER","REGENT"]}},
      {$or:[{submitted_at:null,_id:{$gt:"null0"}},{submitted_at:{$ne:null}}]}]})
    .sort({submitted_at:1,_id:1}).limit(50).explain("executionStats").executionStats'
```

Results:

- **Paginated export == full export:** the concatenated pages (step 4) are the identical line set as the unbounded export (step 3) - no gaps, overlaps, or double-counts. (Line count can differ from *run* count: unreadable/missing run files are skipped, and a multiplayer run emits one line per player - but both paths skip the same ones, so the sets match.)
- **Half-open ranges partition exactly:** splitting the corpus at a midpoint timestamp into `[min, mid)` and `[mid, max]` yields disjoint windows whose counts sum to the whole (e.g. 146 + 147 = 293), and `[mid, mid)` is empty - the run sitting exactly on the boundary lands in exactly one window, never both or neither.
- **Query plan:** `IXSCAN -> FETCH -> LIMIT`, no SORT stage (step 6).
- **Null volume doesn't degrade paging:** with the 8k injected null docs (step 7), the null-block continuation query plans as `SORT_MERGE` over two `IXSCAN`s, examining `docsExamined ~= 2x limit` (sub-ms) - bounded by page size, not null count; no collection scan, no in-memory sort.
- **Param validation:** bad `cursor`/`start` -> 400, `limit` outside `[1, 50000]` -> 422, future-dated window -> empty 200. Validation runs before rate-limit consumption, so malformed requests don't burn budget.

## Notes

- **Difference in pagination practices.** Every other paginated endpoint here uses offset pagination (`page` + `limit`) and returns its metadata in the JSON body (`total`/`page`/`per_page`/`has_next`); this is the only endpoint using a keyset `cursor` and a data-bearing `X-Next-Cursor` response header. I diverged because: (1) the response is a gzipped JSONL *stream*, which has no JSON envelope to carry `next`/`has_next` without either wrapping (and breaking) the stream or violating the "no params = unchanged body" guarantee; and (2) offset pagination means a deep `skip`/`OFFSET` walks and discards that many index entries per page (O(offset)) and double-counts or skips under concurrent inserts, whereas keyset is O(page-size) and insert-stable, which is what a full-corpus export needs. Let me know if you want to change the approach.
- **The new index makes the current `{submitted_at: -1}` index redundant.** `(submitted_at, _id)` ascending is a superset: it serves the keyset export and everything that uses `{submitted_at: -1}` today - the unfiltered newest-first runs list (`sort=date`), the admin "last submission" `find_one`, and the 24h-count range - because MongoDB serves a sort and its reverse from one index and range filters ignore direction. I kept the previous index in this PR so it's additive-only. You could have just one `(submitted_at: 1, _id: 1)` or `(submitted_at: -1, _id: -1)` index to serve current use cases and this PR. The `{username|character|user_id: 1, submitted_at: -1}` compounds have different prefixes and are unaffected.
- **Direction (ascending vs descending) doesn't matter for pagination.** I chose ascending. The only sort a uniform-direction index *can't* serve is a mixed-direction one such as `submitted_at: 1, _id: -1`, which afaict nothing in the codebase needs currently.
- **Confirm `submitted_at` is stored as a BSON `Date` everywhere.** This repo flags ETL type drift elsewhere (e.g. `win`/`was_abandoned` as 0/1 vs bool). If any legacy ETL'd docs hold `submitted_at` as a *string*, BSON type-bracketing would make the ordered scan and `$gt`/`$ne` comparisons silently skip them. I couldn't check against prod. I think you can check with this:
  ```
  db.runs.aggregate([{$group: {_id: {$type: "$submitted_at"}, n: {$sum: 1}}}])
  ```
  (Expected: only `date` and `null`. A `string` bucket means we'd want a normalization pass first.)
- **The design assumes new runs are never null `submitted_at`** The live submit path always fills `submitted_at`, so new runs get added at the end. If a future bug or query ever inserted runs *without* `submitted_at`, they'd be silently missed for in-progress paginated scans - nulls sort first, so they land behind any pager that has advanced past the null block (and the `start`/`end` window excludes nulls entirely). They would only be picked up if you rescanned the null block from the beginning. This To mitigate this:
  - **(Implemented) Enforce the invariant at write time:** The `$jsonSchema` validator (see "How") makes a buggy null/missing insert a loud failure, applied automatically on deploy. If you'd rather ease it in, set `validationAction: "warn"` to log violations without rejecting.
  - **Monitor the null count:** Alert if `count_documents({submitted_at: null})` trends up; under the invariant it should be flat or shrinking. A second signal even with the validator on.
  - **Rescan the null block on the client side:** Periodically rescan to pick up new rows in the null block.
- **`cost` keys on `limit` presence**, so a windowed-but-unbounded pull (`start`/`end`, no `limit`) still costs 60. Defensible (it *could* return the whole corpus), and the guidance is simply "always pass `limit` for the cheap path."
- **CORS:** `X-Next-Cursor` isn't in `expose_headers`, so a browser `fetch` can't read it. The current consumer is a C# `HttpClient` (unaffected); if your frontend ever consumes the export, add `expose_headers=["X-Next-Cursor"]`.
- **Tests (`backend/tests/test_export_helpers.py`).** The repo had no test suite, so this adds `pytest` as a single dev dependency (`requirements-dev.txt` + a minimal `pytest.ini`); run with `pytest` from `backend/`. The added tests are pure-function unit tests - no database, no app, no CI needed (the router imports `_get_collection` lazily, so the helpers import clean): cursor encode/decode round-trip (including the null-`submitted_at` block) and malformed-cursor rejection (a real base64 error and a valid-base64-but-no-separator token, both -> 400), `_build_match` keyset/range clause construction (no-params, half-open window, null-block continuation, past-nulls continuation), ISO parsing + its 400, and the rate-limit `cost`. For more test coverage, we need a Mongo-backed test fixture, which this PR does not introduce. This would allow endpoint behavior tests, e.g. paginate == full export and range partitioning. 
