### PR TITLE
Fix entity Stats brackets dropped by the rename

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -1853,7 +1853,7 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
     # against that bracket's own baseline). Elo is card-reward only, so it's null
     # for relics/potions and for non-offered cards. Brackets with no data in
     # this entity are omitted.
-    brackets = agg.get("brackets") or {}
+    agg_brackets = agg.get("brackets") or {}
     brackets: dict[str, Any] = {
         "all": {
             "picks": picks,
@@ -1864,7 +1864,7 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
         }
     }
     for ck in ("a10", "wr30", "wr50", "wr75"):
-        cd = brackets.get(ck)
+        cd = agg_brackets.get(ck)
         if not cd:
             continue
         cp = cd.get("picks", 0)

--- a/frontend/app/charts/ChartsClient.tsx
+++ b/frontend/app/charts/ChartsClient.tsx
@@ -160,7 +160,8 @@ const MODE_OPTS = [
   { value: "daily", label: "Daily" },
   { value: "custom", label: "Custom" },
 ];
-// Content brackets (frame charts only). "all" sends no param.
+// Content brackets (apply to frame and blob charts; only the daily chart opts
+// out). "all" sends no param.
 const BRACKET_OPTS = CONTENT_BRACKETS.map((b) => ({ value: b.key, label: b.label }));
 const SPLIT_LABELS: Record<string, string> = {
   character: "By character",


### PR DESCRIPTION
The cohort to bracket rename in #521 collided two variables in `get_entity_stats`: the source (the entity's per-bracket sub-tree, `agg.get("brackets")`) and the output dict both ended up named `brackets`, so the output silently overwrote the source. The per-bracket loop then read an empty dict and returned only the "All" bracket, so each entity's Stats tab lost the Asc 10 and win-rate tiers from its bracket sub-menu.

I renamed the source to `agg_brackets` so all brackets show again. Verified each card's stats now returns all five (all, a10, wr30, wr50, wr75).

Also corrected a stale comment in the charts client that called the bracket filter frame-only; it applies to blob charts too.

The other surfaces (tier lists, charts, metrics, run browser) were unaffected, since they render the bracket list statically. Only the entity Stats sub-menu, which only shows brackets that have data, was hit.