### PR TITLE
Content brackets on encounters + community stats, and a modded rest-site scrub

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -663,6 +663,7 @@ def get_encounter_stats_endpoint(
     multiplayer: str | None = None,
     page: int = 1,
     limit: int = 50,
+    bracket: str | None = None,
 ):
     """Per-encounter combat stats over submitted runs.
 
@@ -682,21 +683,17 @@ def get_encounter_stats_endpoint(
         `exclude` removes multiplayer runs, omit for both.
       * `page` (default 1) + `limit` (default 50, max 200) — pagination
         applied after grouping, sorted by sample size descending.
+      * `bracket` — content bracket: `a10`, `wr30`, `wr50`, `wr75`
+        (A10-gated win-rate tiers). Omit for all runs.
 
     Each row contains the encounter's total appearances, fatal count,
     avg damage taken, avg turns, plus a `characters` array with the
     same fields scoped per character. Returns `{encounters, page,
-    limit, total, has_next}`. Mongo-only (returns empty when MONGO_URL
-    is unset for local dev).
+    limit, total, has_next}`. Served from the in-memory snapshot, which
+    is built on both the Mongo and SQLite paths.
     """
-    if not os.environ.get("MONGO_URL", "").strip():
-        return {
-            "encounters": [],
-            "page": page,
-            "limit": limit,
-            "total": 0,
-            "has_next": False,
-        }
+    if bracket is not None and bracket not in ("a10", "wr30", "wr50", "wr75"):
+        raise HTTPException(status_code=400, detail="bad bracket")
 
     from ..services.run_entity_stats import (
         get_encounter_stats as _get_encounter_stats,
@@ -714,6 +711,7 @@ def get_encounter_stats_endpoint(
         multiplayer=multiplayer,
         page=page,
         limit=limit,
+        bracket=bracket,
     )
 
 
@@ -983,18 +981,23 @@ def runs_snapshot_status(request: Request, response: Response):
 
 @router.get("/community-stats", tags=["Runs"])
 @limiter.limit("60/minute")
-def community_stats(request: Request, response: Response):
+def community_stats(request: Request, response: Response, bracket: str | None = None):
     """Community / fun stats for the /community-stats page: per-event player
     decision breakdowns, deadliest encounters/events, headline totals by
     ascension and character, and a few records and quirks. Official game
     content only (modded entities are filtered out). Built in the same walk
-    as the Codex Score cache, so this is an in-memory read."""
+    as the Codex Score cache, so this is an in-memory read.
+
+    `bracket` slices to a content bracket (`a10`, `wr30`, `wr50`, `wr75`);
+    omit for all runs."""
+    if bracket is not None and bracket not in ("a10", "wr30", "wr50", "wr75"):
+        raise HTTPException(status_code=400, detail="bad bracket")
     # An empty shell during a post-deploy rebuild must not stick in the
     # edge cache for 5 minutes on top of the rebuild itself.
     response.headers["Cache-Control"] = (
         "public, max-age=300" if snapshot_loaded() else "no-store"
     )
-    return get_community_fun_stats()
+    return get_community_fun_stats(bracket=bracket)
 
 
 @router.get("/me/picks", tags=["Runs"])

--- a/backend/app/services/community_stats.py
+++ b/backend/app/services/community_stats.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+from functools import lru_cache
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -70,8 +71,15 @@ def _merge_starter(cid: str | None) -> str | None:
     return cid
 
 
-def new_accumulator() -> dict[str, Any]:
-    """A fresh, mutable accumulator for one full run-file walk."""
+COMMUNITY_VERSION = 1
+# Content brackets the blob is accumulated per (matches charts_stats /
+# encounter_stats): "all" plus the A10-gated win-rate ladder, so the community
+# datasets can re-slice by skill.
+_BLOB_BRACKETS = ["all", "a10", "wr30", "wr50", "wr75"]
+
+
+def _new_acc_one() -> dict[str, Any]:
+    """A fresh, mutable accumulator for one full run-file walk (one bracket)."""
     return {
         "total_runs": 0,
         "total_wins": 0,
@@ -98,6 +106,12 @@ def new_accumulator() -> dict[str, Any]:
     }
 
 
+def new_accumulator() -> dict[str, Any]:
+    """Per-bracket accumulators; accumulate() folds each run into every content
+    bracket it belongs to."""
+    return {b: _new_acc_one() for b in _BLOB_BRACKETS}
+
+
 def _bump(d: dict, key: Any, n: int = 1) -> None:
     d[key] = d.get(key, 0) + n
 
@@ -106,13 +120,37 @@ def accumulate(
     acc: dict[str, Any],
     blob: dict,
     *,
+    brackets,
     run_hash: str,
     is_win: bool,
     character: str,
     ascension: int,
 ) -> None:
-    """Fold one run into the accumulator. Safe on partial/old blobs: every
-    field is read defensively so a missing key never aborts the walk."""
+    """Fold one run into the sub-accumulator of every bracket it belongs to."""
+    for b in brackets:
+        sub = acc.get(b)
+        if sub is not None:
+            _accumulate_one(
+                sub,
+                blob,
+                run_hash=run_hash,
+                is_win=is_win,
+                character=character,
+                ascension=ascension,
+            )
+
+
+def _accumulate_one(
+    acc: dict[str, Any],
+    blob: dict,
+    *,
+    run_hash: str,
+    is_win: bool,
+    character: str,
+    ascension: int,
+) -> None:
+    """Fold one run into ONE bracket's accumulator. Safe on partial/old blobs:
+    every field is read defensively so a missing key never aborts the walk."""
     acc["total_runs"] += 1
     if is_win:
         acc["total_wins"] += 1
@@ -264,9 +302,14 @@ def accumulate(
 # ── Finalize: resolve names + compute percentages ────────────────────────────
 
 
+@lru_cache(maxsize=1)
 def _name_maps() -> dict[str, dict[str, str]]:
     """Build id -> display-name lookups from the game data. Each is best
-    effort; a failed load just means we fall back to a prettified id."""
+    effort; a failed load just means we fall back to a prettified id.
+
+    Memoized: per-bracket finalize calls this once per bracket, but the catalog
+    is stable within a process (a beta promotion is a deploy = restart), so the
+    underlying data loads happen once."""
     from . import data_service
 
     out: dict[str, dict[str, str]] = {}
@@ -409,7 +452,12 @@ def _beta_spotlight(acc: dict[str, Any], names: dict) -> dict[str, Any]:
 
 
 def finalize(acc: dict[str, Any]) -> dict[str, Any]:
-    """Turn the raw accumulator into the JSON the API/page render."""
+    """Per-bracket finalized blob for the snapshot: {bracket: <datasets>}."""
+    return {b: _finalize_one(sub) for b, sub in acc.items()}
+
+
+def _finalize_one(acc: dict[str, Any]) -> dict[str, Any]:
+    """Turn one bracket's raw accumulator into the JSON the API/page render."""
     names = _name_maps()
     ev_names = names["events"]
     ev_opts = names["_event_options"]  # type: ignore[index]
@@ -578,5 +626,10 @@ def _ancient_picks(acc: dict[str, Any], names: dict) -> list[dict]:
 
 
 def empty() -> dict[str, Any]:
-    """The shape returned before any snapshot exists."""
+    """Per-bracket empty blob, before any snapshot exists."""
     return finalize(new_accumulator())
+
+
+def empty_one() -> dict[str, Any]:
+    """One bracket's empty finalized blob (the read-side fallback)."""
+    return _finalize_one(_new_acc_one())

--- a/backend/app/services/encounter_stats.py
+++ b/backend/app/services/encounter_stats.py
@@ -20,11 +20,19 @@ stats.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 # Bump when the cell shape below changes so stale snapshots are ignored
 # (the run_entity_stats snapshot version gates the actual reload).
-ENCOUNTER_VERSION = 1
+ENCOUNTER_VERSION = 2
+
+# Content brackets the blob is accumulated per (matches charts_stats). A run
+# feeds every bracket it matches: "all" plus the A10-gated win-rate ladder, so
+# the encounter table can re-slice by skill.
+_BLOB_BRACKETS = ["all", "a10", "wr30", "wr50", "wr75"]
 
 # Room types that count as combat. Matches the old aggregation's default
 # `rooms_filter` ([monster, elite, boss]); other room types never carry an
@@ -32,7 +40,7 @@ ENCOUNTER_VERSION = 1
 _COMBAT_ROOMS = ("monster", "elite", "boss")
 
 
-def new_accumulator() -> dict[str, Any]:
+def _new_acc_one() -> dict[str, Any]:
     return {
         # (encounter_id, act, room_type, character, mp) ->
         #   [total, fatal, total_damage, total_turns]
@@ -42,7 +50,37 @@ def new_accumulator() -> dict[str, Any]:
     }
 
 
+def new_accumulator() -> dict[str, Any]:
+    """Per-bracket accumulators; accumulate() folds each run into every content
+    bracket it belongs to."""
+    return {b: _new_acc_one() for b in _BLOB_BRACKETS}
+
+
 def accumulate(
+    acc: dict[str, Any],
+    blob: dict,
+    *,
+    brackets,
+    character: str,
+    is_win: bool,
+    player_count: int,
+    killed_by: str | None,
+) -> None:
+    """Fold one run into the sub-accumulator of every bracket it belongs to."""
+    for b in brackets:
+        sub = acc.get(b)
+        if sub is not None:
+            _accumulate_one(
+                sub,
+                blob,
+                character=character,
+                is_win=is_win,
+                player_count=player_count,
+                killed_by=killed_by,
+            )
+
+
+def _accumulate_one(
     acc: dict[str, Any],
     blob: dict,
     *,
@@ -108,9 +146,14 @@ def accumulate(
 
 
 def finalize(acc: dict[str, Any]) -> dict[str, Any]:
-    """JSON/BSON-able cell list for the snapshot. Tuple keys flatten into a
-    list so entity ids never collide with Mongo field-name rules; rollups
-    happen per request."""
+    """Per-bracket JSON/BSON-able blob for the snapshot: {bracket: <cells>}."""
+    return {b: _finalize_one(sub) for b, sub in acc.items()}
+
+
+def _finalize_one(acc: dict[str, Any]) -> dict[str, Any]:
+    """JSON/BSON-able cell list for one bracket. Tuple keys flatten into a list
+    so entity ids never collide with Mongo field-name rules; rollups happen per
+    request."""
     return {
         "version": ENCOUNTER_VERSION,
         "cells": [
@@ -126,7 +169,49 @@ def finalize(acc: dict[str, Any]) -> dict[str, Any]:
 
 
 def empty() -> dict[str, Any]:
+    """Per-bracket empty blob ({bracket: <empty cells>})."""
     return finalize(new_accumulator())
+
+
+def empty_one() -> dict[str, Any]:
+    """One bracket's empty finalized blob (the rollup fallback)."""
+    return _finalize_one(_new_acc_one())
+
+
+_official_enc_ids: frozenset[str] | None = None
+
+
+def _official_encounter_ids() -> frozenset[str]:
+    """Uppercase official encounter ids (main + current beta catalog), memoized.
+    Beta-only encounters are official (they ship in the Steam beta build), so
+    they're included. An empty set means the catalog could not be read; rollup
+    then skips the filter, so a transient data-read failure never blanks the
+    table (matches the modded-id guards elsewhere)."""
+    global _official_enc_ids
+    if _official_enc_ids is not None:
+        return _official_enc_ids
+    ids: set[str] = set()
+    try:
+        from . import data_service
+
+        def _add() -> None:
+            for e in data_service.load_encounters() or []:
+                eid = e.get("id") or ""
+                if eid:
+                    ids.add(eid.split(".", 1)[-1].upper())
+
+        _add()
+        if data_service.get_beta_version():
+            token = data_service.current_channel.set("beta")
+            try:
+                _add()
+            finally:
+                data_service.current_channel.reset(token)
+    except Exception:
+        logger.warning("encounter official-id load failed", exc_info=True)
+        return frozenset()
+    _official_enc_ids = frozenset(ids)
+    return _official_enc_ids
 
 
 def rollup(
@@ -156,10 +241,16 @@ def rollup(
     else:
         mp_keep = {"solo", "multi"}
 
+    # Modded-id scrub: drop encounter ids not in the official (main + beta)
+    # catalog, like charts_stats.encounter_ranking. Empty set -> don't filter.
+    official = _official_encounter_ids()
+
     # (encounter, act, room_type) -> aggregate with a nested per-character map.
     grouped: dict[tuple[str, int, str], dict[str, Any]] = {}
     for cell in cells:
         enc_id, act, room_type, character, mp, total, fatal, dmg, turns = cell
+        if official and enc_id not in official:
+            continue
         if mp not in mp_keep:
             continue
         if room_type not in rooms_filter:

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -178,7 +178,10 @@ SNAPSHOT_COLLECTION_NAME = "entity_stats_snapshot"
 # it to its own "charts" snapshot doc, so blob charts re-slice by content bracket.
 # Version 8 renames the persisted cohort_* fields to bracket_* (and each entity's
 # "cohorts" sub-tree to "brackets"); the loader reads either for back-compat.
-SNAPSHOT_VERSION = 8
+# Version 9 makes the community and encounter blobs per-bracket (like charts) and
+# moves each to its own snapshot doc; the loader falls back to the old inline
+# __meta__ fields and to a flat blob for a pre-v9 snapshot.
+SNAPSHOT_VERSION = 9
 # The oldest snapshot version readers can still serve. Bump SNAPSHOT_VERSION
 # on every shape change; bump this floor ONLY when a change actually breaks
 # readers (a removed/retyped field). Everything in between is additive, and
@@ -464,7 +467,10 @@ def _walk_rest_upgrade_choices(blob: dict) -> Iterable[tuple[list[str], list[str
             if not stripped or stripped[0] != "cards":
                 continue
             cid = stripped[1]
-            if cid in upgradeable:
+            # Empty upgradeable set (catalog read failed) -> don't filter, like
+            # the other modded scrubs, so a transient failure can't blank the
+            # Upgrade Elo. Official upgradeable cards only otherwise.
+            if not upgradeable or cid in upgradeable:
                 deck_cards.append((c.get("floor_added_to_deck") or 0, cid))
         if not deck_cards:
             continue
@@ -483,7 +489,15 @@ def _walk_rest_upgrade_choices(blob: dict) -> Iterable[tuple[list[str], list[str
                     winners = []
                     for raw in ps.get("upgraded_cards") or []:
                         stripped = _strip_prefix(raw)
-                        if stripped and stripped[0] == "cards":
+                        # Official upgradeable cards only (empty set = catalog
+                        # unavailable -> don't filter, matching the deck side and
+                        # the other modded scrubs), so a modded rest-site upgrade
+                        # never feeds the Upgrade Elo.
+                        if (
+                            stripped
+                            and stripped[0] == "cards"
+                            and (not upgradeable or stripped[1] in upgradeable)
+                        ):
                             winners.append(stripped[1])
                     if not winners:
                         continue
@@ -827,12 +841,20 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
             logger.warning("skipping unreadable run %s: %s", run_hash, e)
             continue
 
+        # The content brackets this run feeds, shared by the community, charts,
+        # and encounter blobs so all three re-slice by skill: "all" plus the
+        # A10-gated win-rate brackets it already matched above.
+        blob_brackets = ["all"] + [
+            c for c in extra_brackets if c in ("a10", "wr30", "wr50", "wr75")
+        ]
+
         # Community / fun stats, accumulated from the same blob. Guarded so
         # one malformed blob can't abort the whole snapshot rebuild.
         try:
             community_stats.accumulate(
                 community_acc,
                 blob,
+                brackets=blob_brackets,
                 run_hash=run_hash,
                 is_win=is_win,
                 character=character,
@@ -843,17 +865,12 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
                 "community-stats accumulate failed for %s", run_hash, exc_info=True
             )
 
-        # Chart cells for /api/charts, same guard. The blob is accumulated per
-        # content bracket so blob charts can re-slice by skill: "all" plus the
-        # A10-gated win-rate brackets this run already matched above.
-        chart_brackets = ["all"] + [
-            c for c in extra_brackets if c in ("a10", "wr30", "wr50", "wr75")
-        ]
+        # Chart cells for /api/charts, same guard.
         try:
             charts_stats.accumulate(
                 charts_acc,
                 blob,
-                brackets=chart_brackets,
+                brackets=blob_brackets,
                 is_win=is_win,
                 character=character,
                 player_count=row.get("player_count") or 1,
@@ -871,6 +888,7 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
             encounter_stats.accumulate(
                 encounter_acc,
                 blob,
+                brackets=blob_brackets,
                 character=character,
                 is_win=is_win,
                 player_count=row.get("player_count") or 1,
@@ -1214,14 +1232,15 @@ def _persist_snapshot(
             upsert=True,
         )
     bracket_meta = bracket_meta or {}
-    # The charts blob is now per-bracket (~5x bigger), so it lives in its own doc
-    # rather than __meta__ — that keeps either one from bumping Mongo's 16MB
-    # per-document cap as more bracketed cells accumulate.
-    coll.replace_one(
-        {"_id": "charts"},
-        {"_id": "charts", "blob": bracket_meta.get("charts", {}), "updated_at": now},
-        upsert=True,
-    )
+    # The charts, community, and encounter blobs are all per-bracket now (~5x
+    # bigger), so each lives in its own doc rather than __meta__ to stay well
+    # under Mongo's 16MB per-document cap as more bracketed cells accumulate.
+    for blob_id in ("charts", "community", "encounters"):
+        coll.replace_one(
+            {"_id": blob_id},
+            {"_id": blob_id, "blob": bracket_meta.get(blob_id, {}), "updated_at": now},
+            upsert=True,
+        )
     coll.replace_one(
         {"_id": "__meta__"},
         {
@@ -1230,8 +1249,6 @@ def _persist_snapshot(
             "type_baselines": baselines,
             "bracket_baselines": bracket_meta.get("baselines", {}),
             "bracket_totals": bracket_meta.get("totals", {}),
-            "community": bracket_meta.get("community", {}),
-            "encounters": bracket_meta.get("encounters", {}),
             "entity_types": list(by_type.keys()),
             "built_at": now,
             "snapshot_version": SNAPSHOT_VERSION,
@@ -1306,10 +1323,15 @@ def _load_snapshot() -> bool:
                 agg["act_picks"] = e["act_picks"]
                 agg["act_wins"] = e.get("act_wins") or [0] * _ACT_BUCKETS
             new_cache[(etype, e["id"])] = agg
-    # Charts blob lives in its own doc (see _persist_snapshot). A pre-split
-    # snapshot has none; it stays empty until the leader rebuilds the new shape.
-    charts_doc = coll.find_one({"_id": "charts"})
-    charts_blob = (charts_doc or {}).get("blob") or {}
+
+    # The charts, community, and encounter blobs each live in their own doc (see
+    # _persist_snapshot). Back-compat: a pre-split snapshot kept community and
+    # encounters inline in __meta__, so fall back to that. A genuinely missing
+    # blob stays empty until the leader rebuilds the new shape.
+    def _blob_doc(blob_id: str):
+        doc = coll.find_one({"_id": blob_id})
+        return (doc or {}).get("blob") or meta.get(blob_id) or {}
+
     _apply_cache(
         new_cache,
         meta.get("global_totals", {"total_runs": 0, "total_wins": 0}),
@@ -1320,9 +1342,9 @@ def _load_snapshot() -> bool:
             or meta.get("cohort_baselines")
             or {},
             "totals": meta.get("bracket_totals") or meta.get("cohort_totals") or {},
-            "community": meta.get("community", {}),
-            "charts": charts_blob,
-            "encounters": meta.get("encounters", {}),
+            "community": _blob_doc("community"),
+            "charts": _blob_doc("charts"),
+            "encounters": _blob_doc("encounters"),
         },
     )
     _cache_snapshot_version = meta_version
@@ -1459,15 +1481,30 @@ def _compute_score(wins: int, picks: int, baseline: float) -> int | None:
     return max(0, min(100, round(raw)))
 
 
-def get_community_stats() -> dict[str, Any]:
+def _pick_bracket_blob(blob: dict, bracket: str | None, empty_one):
+    """Pick one bracket's finalized sub-blob from a per-bracket blob. Unknown
+    bracket falls back to 'all'; a pre-v9 FLAT blob (no per-bracket keys) is
+    served as-is for any bracket; an empty/missing blob -> a single empty blob."""
+    if not blob:
+        return empty_one()
+    if "all" in blob:  # per-bracket shape {all: ..., a10: ..., ...}
+        return blob.get(bracket or "all") or blob.get("all") or empty_one()
+    return blob  # flat pre-v9 blob; the bracket can't apply until it rebuilds
+
+
+def get_community_stats(bracket: str | None = None) -> dict[str, Any]:
     """Community / fun stats (event decisions, deaths, headline numbers,
-    records). Built in the same walk as the entity cache and carried through
-    the snapshot, so this is an O(1) read. Empty shape before the first
-    snapshot exists."""
+    records) for one content bracket. Built in the same walk as the entity
+    cache and carried through the snapshot, so this is an O(1) read. Empty
+    shape before the first snapshot exists."""
     _maybe_rebuild()
     from . import community_stats
 
-    return _community_stats or community_stats.empty()
+    return _pick_bracket_blob(
+        _community_stats or community_stats.empty(),
+        bracket,
+        community_stats.empty_one,
+    )
 
 
 def get_charts_blob_stats() -> dict[str, Any]:
@@ -1486,16 +1523,23 @@ def get_encounter_stats(
     multiplayer: str | None = None,
     page: int = 1,
     limit: int = 50,
+    bracket: str | None = None,
 ) -> dict[str, Any]:
     """Per-encounter combat stats for /api/runs/encounter-stats, rolled up
-    from the precomputed snapshot cells. Same lifecycle as the community /
-    charts stats: built in the walk, carried through the snapshot, O(rows)
-    to slice — no per-request walk over every run's map_point_history."""
+    from the precomputed snapshot cells for one content bracket. Same lifecycle
+    as the community / charts stats: built in the walk, carried through the
+    snapshot, O(rows) to slice — no per-request walk over every run's
+    map_point_history."""
     _maybe_rebuild()
     from . import encounter_stats
 
-    return encounter_stats.rollup(
+    sub = _pick_bracket_blob(
         _encounter_blob_stats or encounter_stats.empty(),
+        bracket,
+        encounter_stats.empty_one,
+    )
+    return encounter_stats.rollup(
+        sub,
         acts=acts,
         room_types=room_types,
         multiplayer=multiplayer,
@@ -1853,7 +1897,7 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
     # against that bracket's own baseline). Elo is card-reward only, so it's null
     # for relics/potions and for non-offered cards. Brackets with no data in
     # this entity are omitted.
-    brackets = agg.get("brackets") or {}
+    agg_brackets = agg.get("brackets") or {}
     brackets: dict[str, Any] = {
         "all": {
             "picks": picks,
@@ -1864,7 +1908,7 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
         }
     }
     for ck in ("a10", "wr30", "wr50", "wr75"):
-        cd = brackets.get(ck)
+        cd = agg_brackets.get(ck)
         if not cd:
             continue
         cp = cd.get("picks", 0)

--- a/frontend/app/community-stats/page.tsx
+++ b/frontend/app/community-stats/page.tsx
@@ -4,6 +4,8 @@ import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE, buildLanguageAlternates } from "
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 import { RankBars, EventDonut, OPTION_HEX } from "./charts";
+import BracketFilter from "@/app/components/BracketFilter";
+import { normalizeBracket, bracketParam } from "@/lib/content-brackets";
 
 const API_INTERNAL =
   process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -61,9 +63,12 @@ const SKY = "#38bdf8";
 const ROSE = "#fb7185";
 const GOLD = "#d4a843";
 
-async function fetchStats(): Promise<CommunityStats | null> {
+async function fetchStats(param?: string | null): Promise<CommunityStats | null> {
   try {
-    const res = await fetch(`${API_INTERNAL}/api/runs/community-stats`, { next: { revalidate: 300 } });
+    const qs = param ? `?bracket=${param}` : "";
+    const res = await fetch(`${API_INTERNAL}/api/runs/community-stats${qs}`, {
+      next: { revalidate: 300 },
+    });
     if (!res.ok) return null;
     return (await res.json()) as CommunityStats;
   } catch {
@@ -100,20 +105,27 @@ function RecordCard({ label, value, hash }: { label: string; value: string; hash
   return hash ? <Link href={`/runs/${hash}`}>{body}</Link> : body;
 }
 
-function Empty({ jsonLd }: { jsonLd: object[] }) {
+function Empty({ jsonLd, current }: { jsonLd: object[]; current: string }) {
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2"><span className="text-[var(--accent-gold)]">Community Stats</span></h1>
+      <BracketFilter basePath="/community-stats" current={current} />
       <p className="text-sm text-[var(--text-muted)]">
-        No data yet. Stats build from community-submitted runs, <Link href="/leaderboards/submit" className="text-[var(--accent-gold)] hover:underline">submit a run</Link> to seed them.
+        No data for this bracket yet. Stats build from community-submitted runs, <Link href="/leaderboards/submit" className="text-[var(--accent-gold)] hover:underline">submit a run</Link> to seed them.
       </p>
     </div>
   );
 }
 
-export default async function CommunityStatsPage() {
-  const stats = await fetchStats();
+export default async function CommunityStatsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ bracket?: string }>;
+}) {
+  const sp = await searchParams;
+  const bracket = normalizeBracket(sp.bracket);
+  const stats = await fetchStats(bracketParam(bracket));
 
   const jsonLd = [
     buildBreadcrumbJsonLd([
@@ -128,7 +140,7 @@ export default async function CommunityStatsPage() {
     }),
   ];
 
-  if (!stats || stats.total_runs === 0) return <Empty jsonLd={jsonLd} />;
+  if (!stats || stats.total_runs === 0) return <Empty jsonLd={jsonLd} current={bracket} />;
 
   const { records } = stats;
   const rankPct = (rows: Ranked[]) =>
@@ -147,6 +159,9 @@ export default async function CommunityStatsPage() {
         How the community actually plays <em>Slay the Spire 2</em>, drawn from {stats.total_runs.toLocaleString()} submitted runs.
         A naive snapshot of the data, not a verdict on what is correct.
       </p>
+
+      {/* Content bracket: slice every dataset below by skill. */}
+      <BracketFilter basePath="/community-stats" current={bracket} />
 
       {/* Headline numbers */}
       <section className="mb-10">

--- a/frontend/app/leaderboards/encounters/EncounterStatsClient.tsx
+++ b/frontend/app/leaderboards/encounters/EncounterStatsClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { cachedFetch } from "@/lib/fetch-cache";
+import { CONTENT_BRACKETS } from "@/lib/content-brackets";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -66,6 +67,7 @@ export default function EncounterStatsClient() {
   const [acts, setActs] = useState<Set<number>>(new Set());
   const [roomTypes, setRoomTypes] = useState<Set<string>>(new Set());
   const [multiplayer, setMultiplayer] = useState<"any" | "only" | "exclude">("any");
+  const [bracket, setBracket] = useState("all");
   const [page, setPage] = useState(1);
 
   const [data, setData] = useState<EncounterResponse | null>(null);
@@ -94,6 +96,7 @@ export default function EncounterStatsClient() {
     if (acts.size) params.set("act", Array.from(acts).join(","));
     if (roomTypes.size) params.set("room_type", Array.from(roomTypes).join(","));
     if (multiplayer !== "any") params.set("multiplayer", multiplayer);
+    if (bracket !== "all") params.set("bracket", bracket);
     params.set("page", String(page));
     params.set("limit", "50");
     fetch(`${API}/api/runs/encounter-stats?${params}`)
@@ -101,13 +104,13 @@ export default function EncounterStatsClient() {
       .then((d: EncounterResponse) => setData(d))
       .catch(() => setData({ encounters: [], page, limit: 50, total: 0, has_next: false }))
       .finally(() => setLoading(false));
-  }, [acts, roomTypes, multiplayer, page]);
+  }, [acts, roomTypes, multiplayer, bracket, page]);
 
   // Reset to page 1 whenever the filter set changes, paging through a
   // previous query's results after a filter change would be confusing.
   useEffect(() => {
     setPage(1);
-  }, [acts, roomTypes, multiplayer]);
+  }, [acts, roomTypes, multiplayer, bracket]);
 
   const totalPages = useMemo(() => {
     if (!data) return 1;
@@ -202,6 +205,26 @@ export default function EncounterStatsClient() {
                 }`}
               >
                 {labels[m]}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-[var(--text-muted)] w-20">Bracket:</span>
+          {CONTENT_BRACKETS.map((b) => {
+            const active = bracket === b.key;
+            return (
+              <button
+                key={b.key}
+                onClick={() => setBracket(b.key)}
+                className={`px-3 py-1 rounded-md text-sm border transition-colors ${
+                  active
+                    ? "border-[var(--accent-gold)] text-[var(--accent-gold)] bg-[var(--accent-gold)]/10"
+                    : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50"
+                }`}
+              >
+                {b.label}
               </button>
             );
           })}


### PR DESCRIPTION
Follows up the content-brackets work (#521) by extending the brackets to the last two stats surfaces that didn't have them, plus a modded-content scrub on the rest-site path.

## Brackets on encounters + community stats
Both are pre-aggregated blobs, so I made each accumulate per content bracket (All, Asc 10, and the A10-gated win-rate tiers), the same way the charts blob already works. Each blob moves to its own snapshot doc so the ~5x size growth stays under Mongo's 16MB per-document cap. The endpoints take `?bracket=`, and the loader falls back to the old inline shape and to a flat pre-v9 blob, so a rolling deploy doesn't blank a page.

- Encounter stats (`/leaderboards/encounters`): a bracket pill row, client side.
- Community stats (`/community-stats`): a `BracketFilter` driven by `searchParams`, kept server-rendered so the 5-minute HTML cache survives.

## Modded rest-site scrub
- The Upgrade Elo now only counts official upgradeable cards on both the deck and the winner side, so a modded rest-site upgrade can't feed it.
- The encounter table drops ids that aren't in the official (main + beta) catalog.
- Both filters are fail-open: an empty catalog set skips the filter, so a transient read can't blank a whole table (matches the existing character/encounter guards).

## Also in here
- Dropped the stale Mongo-only gate on `encounter-stats` so it serves from the snapshot on SQLite too.
- Fixed the entity Stats bracket sub-menu, where a variable collision was dropping every bracket but All. This is the same fix as #522 (the review re-flagged it because this branch is based on main before #522 merged), so #522 is now redundant and can be closed.
- Snapshot version bumped to 9.

## Verification
Seeded 110 synthetic runs locally and confirmed the counts nest per bracket: encounter samples all=330 / a10=168 / wr50=78 / wr75=39, community runs all=110 / a10=56 / wr50=26 / wr75=13, a bad bracket returns 400, the entity sub-menu returns all five brackets, and card Elo still computes (the upgrade filter didn't over-scrub). An adversarial review pass over the six changed files surfaced the two fixes above; nothing else.