### PR TITLE
Fix per-user Metrics freezing at a stale run count (TTL stats_summary)

### DIFF
--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1161,6 +1161,19 @@ def _filter_key(
     return "|".join(parts) if parts else "global"
 
 
+# Per-username summary docs are only ever written lazily (write-through on a
+# cache miss in get_community_stats); the periodic refresher only touches the
+# hot community/character combos, never a username combo. Without a TTL the
+# first doc written for a user is therefore served forever, freezing their run
+# count at whatever it was on the first query — which pins users first queried
+# at ~0 runs (e.g. the overlay's Metrics tab firing on sign-in before uploads
+# finish) at 0. Past this TTL we ignore a per-username doc so the read falls
+# through to a live recompute that rewrites a fresh one. Existing frozen docs
+# have a stale updated_at, so they go stale immediately — no manual purge
+# needed.
+_USER_SUMMARY_TTL = timedelta(minutes=10)
+
+
 @_instrument("read_stats_summary", collection="stats_summary")
 def read_stats_summary(
     character: str | None = None,
@@ -1170,13 +1183,25 @@ def read_stats_summary(
     players: str | None = None,
     username: str | None = None,
 ) -> dict | None:
-    """Read a pre-computed stats doc by filter key. Returns None if no
-    doc exists (refresher hasn't populated it yet). O(1) read."""
+    """Read a pre-computed stats doc by filter key. Returns None if no doc
+    exists (refresher hasn't populated it yet), or if a per-username doc is
+    older than _USER_SUMMARY_TTL (so a stale personal count recomputes instead
+    of serving frozen). O(1) read."""
     try:
         key = _filter_key(character, win, ascension, game_mode, players, username)
         doc = _summary_coll().find_one({"_id": key})
         if not doc:
             return None
+        # Per-username docs are never refreshed in the background, so honor
+        # their age; hot (no-username) combos stay always-served.
+        if username:
+            updated = doc.get("updated_at")
+            if not isinstance(updated, datetime):
+                return None
+            if updated.tzinfo is None:
+                updated = updated.replace(tzinfo=timezone.utc)
+            if datetime.now(timezone.utc) - updated >= _USER_SUMMARY_TTL:
+                return None
         # Strip the wrapper fields before returning to the API caller.
         doc.pop("_id", None)
         doc.pop("updated_at", None)


### PR DESCRIPTION
## The bug
Per-user Metrics (`/api/runs/stats?username=X`) returns a run count far below reality, and 0 for some users, while `/api/runs/list?username=X` and the community stats are correct. Live evidence from 2026-06-24: plydogg shows 242 runs on list but 0 on stats; monkeytes 10 vs 0; 4EverMomOfAngel 40 vs 0.

## Root cause
Per-username stats are served from a materialized `stats_summary` doc that is written once and never refreshed. `read_stats_summary` returns the doc regardless of age, the doc is created by a lazy write-through on the first cache miss, and the periodic refresher only iterates the hot community/character combos, never a per-username one. So the first time anyone fetches a user's stats, the count is frozen forever. Users first queried while they had ~0 runs (the overlay's Metrics tab firing on sign-in, before uploads finish) get pinned at 0.

## The fix
`read_stats_summary` now honors `updated_at` for per-username docs: past a 10-minute TTL it returns None, so the read falls through to the live aggregation, which rewrites a fresh doc. Hot community/character combos carry no username and stay always-served (the refresher keeps them warm), so the cache win for the common path is unchanged.

A nice side effect: existing frozen docs already have a stale `updated_at`, so they go stale on the very next read and recompute. No manual `stats_summary` purge is required.

## Verification
The repo has no test harness, so I exercised the logic directly by mocking the collection: a fresh per-user doc is served, a 10-minute-stale per-user doc (tz-aware and naive) returns None to force a recompute, a per-user doc missing `updated_at` returns None, and a stale hot combo is still served. All as expected.

## Not included
The secondary list-vs-stats username matching mismatch (list does case-insensitive substring, stats does exact case-sensitive) is real but was not the cause here and is lower priority, so I left it for a follow-up.