### PR TITLE
Match usernames case-insensitively (normalized username_lower)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -174,6 +174,23 @@ def _warm_run_entity_stats() -> None:
             start_stats_refresher()
         except Exception:
             pass
+        # One-time username_lower backfill for pre-normalization runs, off the
+        # request path (the runs collection is large). Idempotent via the
+        # $exists guard, so running it on every worker is safe — all but the
+        # first are a bounded no-op.
+        import threading
+
+        def _backfill_username_lower():
+            try:
+                from .services.runs_db_mongo import backfill_username_lower
+
+                backfill_username_lower()
+            except Exception:
+                pass
+
+        threading.Thread(
+            target=_backfill_username_lower, daemon=True, name="username-lc-backfill"
+        ).start()
         return
     import threading
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -240,7 +240,7 @@ def _compute_personal_bests(username: str) -> dict:
 
     coll = _get_collection()
     base_match = {
-        "username": username,
+        "username_lower": username.lower() if username else None,
         "win": {"$in": [True, 1]},
     }
     proj = {
@@ -505,7 +505,12 @@ def _propagate_username(user_id: str, new_username: str) -> None:
 
         coll.update_many(
             {"user_id": ObjectId(user_id)},
-            {"$set": {"username": new_username}},
+            {
+                "$set": {
+                    "username": new_username,
+                    "username_lower": (new_username or "").lower() or None,
+                }
+            },
         )
     except Exception:
         pass
@@ -527,6 +532,7 @@ def _try_claim_run(run_hash: str, user: dict) -> None:
                 "$set": {
                     "user_id": ObjectId(user["_id"]),
                     "username": user.get("username", ""),
+                    "username_lower": (user.get("username") or "").lower() or None,
                 }
             },
         )

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -298,6 +298,10 @@ def list_runs(
     win rate percentage; only users with at least 5 submitted runs qualify,
     and anonymous runs never match.
     """
+    # Normalize once so the cache key and the DB filter key off the same
+    # case-insensitive value (the runs are matched on username_lower).
+    if username:
+        username = username.strip().lower()
     # Browser/edge caching: new runs arrive constantly, but 30s of staleness
     # on a browse page is invisible and lets Cloudflare absorb repeat hits.
     response.headers["Cache-Control"] = "public, max-age=30"
@@ -371,8 +375,10 @@ def list_runs(
         elif win == "false":
             conditions.append("win = 0 AND was_abandoned = 0")
         if username:
-            conditions.append("username LIKE ?")
-            params.append(f"%{username}%")
+            # Case-insensitive exact match (replaces the LIKE substring that
+            # bled peter->peter123); mirrors the Mongo username_lower path.
+            conditions.append("username_lower = ?")
+            params.append(username.lower())
         if seed:
             conditions.append("seed LIKE ?")
             params.append(f"%{seed}%")
@@ -390,8 +396,9 @@ def list_runs(
             # Mirror the Mongo path: submitter winrate within range, with a
             # 5-run floor so one-run wonders don't flood winrate:100.
             conditions.append(
-                "username IN (SELECT username FROM runs WHERE username != '' "
-                "GROUP BY username HAVING COUNT(*) >= 5 "
+                "username_lower IN (SELECT username_lower FROM runs "
+                "WHERE username_lower IS NOT NULL AND username_lower != '' "
+                "GROUP BY username_lower HAVING COUNT(*) >= 5 "
                 "AND 100.0 * SUM(win) / COUNT(*) BETWEEN ? AND ?)"
             )
             params.append(winrate_min if winrate_min is not None else 0.0)
@@ -1232,6 +1239,11 @@ def get_community_stats(
          materialized yet, fall through to a process-local TTL cache.
       3. On cache miss, run the live aggregation (slow, ~5-10s).
     """
+    # Normalize once so the Redis key, the materialized-summary key, and the DB
+    # filter all key off the same case-insensitive value (the per-user docs are
+    # keyed and matched on the lowercased name).
+    if username:
+        username = username.strip().lower()
     # 0. Redis layer: one cluster-wide copy per filter combo, refreshed on
     # the same cadence as the refresher cycle. Misses fall through to the
     # existing chain unchanged.

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -1267,14 +1267,12 @@ def build_user_blob_stats(username: str) -> dict[str, Any]:
         return empty_one()
     rows: list[dict] = []
     if os.environ.get("MONGO_URL", "").strip():
-        import re as _re
-
         from .runs_db_mongo import _get_collection
 
         cursor = (
             _get_collection()
             .find(
-                {"username": {"$regex": f"^{_re.escape(u)}$", "$options": "i"}},
+                {"username_lower": u.lower()},
                 {
                     "_id": 1,
                     "character": 1,
@@ -1304,9 +1302,9 @@ def build_user_blob_stats(username: str) -> dict[str, Any]:
                 dict(r)
                 for r in conn.execute(
                     "SELECT run_hash, character, win, player_count, submitted_at"
-                    " FROM runs WHERE username = ? COLLATE NOCASE"
+                    " FROM runs WHERE username_lower = ?"
                     " ORDER BY id DESC LIMIT ?",
-                    (u, _USER_BLOB_CAP),
+                    (u.lower(), _USER_BLOB_CAP),
                 )
             ]
 

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -765,7 +765,7 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
         WINRATE_MIN_RUNS = 5
     _wr_counts: dict[str, list[int]] = {}
     for row in rows:
-        uname = row.get("username") or ""
+        uname = (row.get("username") or "").lower()
         if not uname:
             continue
         c = _wr_counts.setdefault(uname, [0, 0])
@@ -803,7 +803,7 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
         # Skill brackets: append the A10-gated win-rate brackets the submitter
         # qualifies for, so they flow through every downstream consumer of
         # extra_brackets (totals, deck membership, card-reward picks) unchanged.
-        uname = row.get("username") or ""
+        uname = (row.get("username") or "").lower()
         if uname:
             extra_brackets = extra_brackets + _winrate_brackets(_asc, wr_map.get(uname))
         for ck in extra_brackets:

--- a/backend/app/services/runs_db.py
+++ b/backend/app/services/runs_db.py
@@ -168,6 +168,7 @@ def init_db():
                 deck_size INTEGER NOT NULL DEFAULT 0,
                 relic_count INTEGER NOT NULL DEFAULT 0,
                 username TEXT,
+                username_lower TEXT,
                 submitted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );
 
@@ -222,6 +223,7 @@ def init_db():
             ("was_abandoned", "INTEGER NOT NULL DEFAULT 0"),
             ("player_count", "INTEGER NOT NULL DEFAULT 1"),
             ("username", "TEXT"),
+            ("username_lower", "TEXT"),
             ("build_id", "TEXT"),
         ]:
             try:
@@ -237,6 +239,24 @@ def init_db():
         try:
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_runs_build_id ON runs(build_id)"
+            )
+        except Exception:
+            pass
+        try:
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_runs_username_lower "
+                "ON runs(username_lower)"
+            )
+        except Exception:
+            pass
+        # One-time backfill: normalize existing rows. Idempotent via the NULL
+        # guard, so later boots are near-instant no-ops. SQLite lower() is
+        # ASCII-only, fine since usernames are already sanitized to ASCII.
+        try:
+            conn.execute(
+                "UPDATE runs SET username_lower = lower(username) "
+                "WHERE username IS NOT NULL AND username != '' "
+                "AND (username_lower IS NULL OR username_lower = '')"
             )
         except Exception:
             pass
@@ -370,8 +390,8 @@ def _submit_player_run(
             """
             INSERT INTO runs (run_hash, seed, character, win, was_abandoned, ascension, game_mode,
                               player_count, run_time, floors_reached, acts_completed, killed_by,
-                              deck_size, relic_count, username, build_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                              deck_size, relic_count, username, username_lower, build_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
             (
                 run_hash,
@@ -389,6 +409,7 @@ def _submit_player_run(
                 len(player["deck"]),
                 len(player["relics"]),
                 username,
+                username.lower() if username else None,
                 data.get("build_id"),
             ),
         )
@@ -515,10 +536,10 @@ def claim_runs(username: str, hashes: list[str]) -> dict:
         if unclaimed:
             unclaimed_placeholders = ",".join("?" for _ in unclaimed)
             conn.execute(
-                f"UPDATE runs SET username = ? "
+                f"UPDATE runs SET username = ?, username_lower = ? "
                 f"WHERE run_hash IN ({unclaimed_placeholders}) "
                 f"AND (username IS NULL OR username = '')",
-                [username, *unclaimed],
+                [username, username.lower(), *unclaimed],
             )
 
     return {
@@ -568,8 +589,8 @@ def get_stats(
         elif players == "multi":
             non_char_conditions.append("r.player_count > 1")
         if username:
-            non_char_conditions.append("r.username = ?")
-            non_char_params.append(username)
+            non_char_conditions.append("r.username_lower = ?")
+            non_char_params.append(username.lower())
 
         conditions: list[str] = list(non_char_conditions)
         params: list = list(non_char_params)

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -148,6 +148,12 @@ def _ensure_indexes(coll) -> None:
     no-op when an equivalent index already exists."""
     coll.create_index([("character", ASCENDING)])
     coll.create_index([("username", ASCENDING), ("submitted_at", DESCENDING)])
+    # Case-insensitive username matching (stats/list/leaderboard filter on
+    # username_lower). The compound prefix serves the stats equality match; the
+    # full compound serves list filter + submitted_at sort without an in-memory
+    # sort. The plain `username` index above stays for the display-name reads
+    # that don't normalize (claim, username-for-hash).
+    coll.create_index([("username_lower", ASCENDING), ("submitted_at", DESCENDING)])
     coll.create_index([("submitted_at", DESCENDING)])
     coll.create_index(
         [("character", ASCENDING), ("win", ASCENDING), ("ascension", ASCENDING)]
@@ -515,6 +521,10 @@ def _submit_player_run(
         "deck_size": len(deck),
         "relic_count": len(relics),
         "username": username,
+        # Normalized for case-insensitive matching (stats/list/leaderboard all
+        # filter on this; display `username` keeps its original case). Mirrors
+        # the users collection's username_lower convention.
+        "username_lower": username.lower() if username else None,
         # Submitter identity (when the client sends it). Lets a run be linked
         # to its owner's account on sign-in even if it was submitted
         # anonymously. user_id is set here when an account already exists for
@@ -569,6 +579,7 @@ def _submit_player_run(
             owner_set: dict = {"user_id": ObjectId(linked_user_id)}
             if username:
                 owner_set["username"] = username
+                owner_set["username_lower"] = username.lower()
             coll.update_one(
                 {"_id": run_hash, "user_id": None},
                 {"$set": owner_set},
@@ -614,12 +625,29 @@ def backfill_user_runs(
     update: dict = {"user_id": ObjectId(user_id)}
     if username:
         update["username"] = username
+        update["username_lower"] = username.lower()
 
     result = coll.update_many(
         {"user_id": None, "$or": identity_conds},
         {"$set": update},
     )
     return result.modified_count
+
+
+def backfill_username_lower() -> int:
+    """One-time backfill: set username_lower = lower(username) on existing docs
+    that predate the field. Idempotent via the username_lower $exists guard, so
+    re-runs are bounded no-ops. Returns the number of docs updated. Best effort
+    (failures swallowed): the write sites keep new docs current regardless."""
+    try:
+        coll = _get_collection()
+        result = coll.update_many(
+            {"username": {"$nin": [None, ""]}, "username_lower": {"$exists": False}},
+            [{"$set": {"username_lower": {"$toLower": "$username"}}}],
+        )
+        return result.modified_count
+    except Exception:
+        return 0
 
 
 @_instrument("claim_runs")
@@ -641,7 +669,7 @@ def claim_runs(username: str, hashes: list[str]) -> dict:
     if unclaimed:
         coll.update_many(
             {"_id": {"$in": unclaimed}, "$or": [{"username": None}, {"username": ""}]},
-            {"$set": {"username": username}},
+            {"$set": {"username": username, "username_lower": username.lower()}},
         )
 
     return {
@@ -695,7 +723,8 @@ def _build_match(
     elif players == "multi":
         m["player_count"] = {"$gt": 1}
     if username:
-        m["username"] = username
+        # Case-insensitive, exact (anchored) match on the normalized field.
+        m["username_lower"] = username.lower()
     return m
 
 
@@ -1157,7 +1186,9 @@ def _filter_key(
     if players:
         parts.append(f"players:{players}")
     if username:
-        parts.append(f"username:{username}")
+        # Lowercased so PeTeR and peter share one summary doc (the match is
+        # case-insensitive, so the cache key must be too).
+        parts.append(f"username:{username.lower()}")
     return "|".join(parts) if parts else "global"
 
 
@@ -1429,16 +1460,21 @@ def get_user_winrates() -> dict[str, list[int]]:
     One $group over the collection (a few hundred ms) once per TTL instead
     of per request. Anonymous runs (no username) are excluded; abandoned
     runs count as losses, matching the profile-page win rate.
+
+    Keyed by username_lower (not display username) so the keys compose with the
+    case-insensitive username_lower filters that consume this map (list /
+    leaderboard winrate filters); otherwise mixed-case users would silently
+    drop out.
     """
-    cached = app_cache.get_json("user_winrates:all")
+    cached = app_cache.get_json("user_winrates:all:lc")
     if cached is not None:
         return cached
     coll = _get_collection()
     pipeline = [
-        {"$match": {"username": {"$nin": [None, ""]}}},
+        {"$match": {"username_lower": {"$nin": [None, ""]}}},
         {
             "$group": {
-                "_id": "$username",
+                "_id": "$username_lower",
                 "total": {"$sum": 1},
                 "wins": {"$sum": {"$cond": [{"$in": ["$win", [True, 1]]}, 1, 0]}},
             }
@@ -1447,7 +1483,7 @@ def get_user_winrates() -> dict[str, list[int]]:
     out: dict[str, list[int]] = {}
     for row in coll.aggregate(pipeline, allowDiskUse=True):
         out[str(row["_id"])] = [int(row["total"]), int(row["wins"])]
-    app_cache.set_json("user_winrates:all", out, ttl_seconds=300)
+    app_cache.set_json("user_winrates:all:lc", out, ttl_seconds=300)
     return out
 
 
@@ -1484,12 +1520,13 @@ def list_runs(
         q["win"] = {"$in": [False, 0]}
         q["was_abandoned"] = {"$in": [False, 0]}
     if username:
-        q["username"] = {"$regex": username, "$options": "i"}
+        # Case-insensitive exact match on the normalized field (replaces the old
+        # unanchored, unescaped $regex substring match that bled peter->peter123).
+        q["username_lower"] = username.lower()
     if winrate_min is not None or winrate_max is not None:
-        # Filter runs by their submitter's overall win rate. The per-user
-        # map is one cached aggregation; the run query then becomes an $in
-        # over the qualifying usernames (composable with the regex above,
-        # since both live under the same field's operator object).
+        # Filter runs by their submitter's overall win rate. The per-user map is
+        # one cached aggregation keyed by username_lower; restrict the query to
+        # the qualifying users.
         lo = winrate_min if winrate_min is not None else 0.0
         hi = winrate_max if winrate_max is not None else 100.0
         rates = get_user_winrates()
@@ -1498,7 +1535,10 @@ def list_runs(
             for name, (total, wins) in rates.items()
             if total >= WINRATE_MIN_RUNS and lo <= (wins / total * 100) <= hi
         ]
-        if not names:
+        # With a username filter the equality above already pins one user, so it
+        # only needs to qualify; without one, restrict to the qualifying users.
+        disqualified = (username.lower() not in set(names)) if username else (not names)
+        if disqualified:
             return {
                 "runs": [],
                 "total": 0,
@@ -1506,11 +1546,8 @@ def list_runs(
                 "per_page": min(limit, 100),
                 "total_pages": 0,
             }
-        user_q = q.get("username")
-        if isinstance(user_q, dict):
-            user_q["$in"] = names
-        else:
-            q["username"] = {"$in": names}
+        if not username:
+            q["username_lower"] = {"$in": names}
     if seed:
         # Anchored prefix, case-sensitive: uses the seed index instead of
         # scanning every document. Daily seeds are date-prefixed so the
@@ -1698,7 +1735,8 @@ def _leaderboard_live(
             for name, (total, wins) in rates.items()
             if total >= WINRATE_MIN_RUNS and (wins / total * 100) >= winrate_min
         ]
-        q["username"] = {"$in": names}  # empty -> no matches, the correct result
+        # names are username_lower keys, so match the normalized field.
+        q["username_lower"] = {"$in": names}  # empty -> no matches, correct
     if today:
         q["seed"] = _today_daily_seed_match()
 
@@ -1946,13 +1984,15 @@ def get_daily_leaderboard(username: str | None = None) -> dict:
     runs = []
     for r in top_10:
         row = _row_to_dict(r)
-        row["is_current_user"] = bool(username and row.get("username") == username)
+        row["is_current_user"] = bool(
+            username and (row.get("username") or "").lower() == username.lower()
+        )
         runs.append(row)
 
     user_rank = None
     if username:
         user_run = coll.find_one(
-            {**base, "username": username},
+            {**base, "username_lower": username.lower()},
             {"run_time": 1},
             sort=[("run_time", 1)],
         )
@@ -2024,7 +2064,7 @@ def get_win_rate_comparison(username: str) -> list[dict]:
     user_chars = list(
         coll.aggregate(
             [
-                {"$match": {"username": username}},
+                {"$match": {"username_lower": username.lower()}},
                 {
                     "$group": {
                         "_id": "$character",

--- a/backend/app/services/users_db.py
+++ b/backend/app/services/users_db.py
@@ -779,7 +779,10 @@ def admin_set_username(user_id: str, new_name: str) -> dict:
     try:
         runs = _runs_collection()
         hashes = [d["_id"] for d in runs.find({"user_id": oid}, {"_id": 1})]
-        runs.update_many({"user_id": oid}, {"$set": {"username": cleaned}})
+        runs.update_many(
+            {"user_id": oid},
+            {"$set": {"username": cleaned, "username_lower": lower}},
+        )
         _bust_run_cache(hashes)
     except Exception:
         pass
@@ -846,7 +849,13 @@ def admin_merge_users(source_id: str, target_id: str) -> dict:
         moved_hashes = [d["_id"] for d in runs.find({"user_id": s_oid}, {"_id": 1})]
         res = runs.update_many(
             {"user_id": s_oid},
-            {"$set": {"user_id": t_oid, "username": target.get("username")}},
+            {
+                "$set": {
+                    "user_id": t_oid,
+                    "username": target.get("username"),
+                    "username_lower": (target.get("username") or "").lower() or None,
+                }
+            },
         )
         moved = res.modified_count
     except Exception:


### PR DESCRIPTION
Follow-up to the metrics fix (#524): align how a username is matched across the run endpoints so a user's runs/stats resolve consistently, the way Steam/Discord/Twitch hand the name over, without introducing a mismatch.

## The split today
- `/api/runs/stats` matched `username` exactly, case-sensitive.
- `/api/runs/list` matched a case-insensitive **unanchored substring** (`{$regex: username, $options: "i"}`, unescaped).

So a profile/list could surface other people's runs (`peter` matched `peter123`), and stats could miss a user whose query case differed from the stored name. The runs are really keyed by `steam_id`/`discord_id`; `username` is a display label that rides along.

## The fix
Add a normalized `username_lower` to every run (display `username` stays case-preserved, matching the users collection's existing convention) and match on it everywhere a username filter applies, anchored and case-insensitive: stats, list, the browse + leaderboard winrate filters (with `get_user_winrates` re-keyed to `username_lower` so the `$in` lists compose), the daily leaderboard, win-rate comparison, personal bests, and per-user charts. Both the Mongo and SQLite paths.

Every username write site sets `username_lower` too: submit, claim, owner-link, account-link on sign-in, self-service rename, admin rename, and admin merge. (An adversarial completeness sweep caught the two admin paths in `users_db.py`, which a first pass missed.)

A `username_lower` index and a one-time idempotent backfill (Mongo `update_many` with `$toLower`, SQLite `UPDATE`, both guarded so reruns are no-ops) cover existing runs. The backfill runs off the request path on startup. The `stats_summary` doc key and the stats/list cache keys are lowercased so casings collapse to one entry.

## Verification
On the local SQLite path: `stats` and `list` both return 25 for `ProArcher` / `proarcher` / `PROARCHER`, a space-padded `' ProArcher '` matches (read normalization strips), and `Pro` / `Archer` return 0 (no substring bleed). The SQLite backfill repopulates NULLed rows on `init_db`. The Mongo path mirrors the same logic (not locally runnable without mongod).

Identity keys (`steam_id`/`discord_id`) and the API contract (the `username` query param and display field) are unchanged, so no client change is needed.

## Noted, not changed
The self-service rename propagates to runs via `auth._propagate_username` (fixed here); `users_db.update_username` itself doesn't touch runs, which is pre-existing and internally consistent.