### PR TITLE
Scope the per-entity pick rate to the selected bracket

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -1905,6 +1905,11 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
             "win_rate": round(wins / picks * 100, 1) if picks else 0.0,
             "elo": agg.get("elo"),
             "score": _compute_score(wins, picks, baseline),
+            # Pick rate within the bracket: picks / runs in that bracket, so the
+            # detail page can re-scope it instead of always dividing by the
+            # global run count.
+            "total_runs": total_runs,
+            "pick_rate": round(picks / total_runs * 100, 1) if total_runs else 0.0,
         }
     }
     for ck in ("a10", "wr30", "wr50", "wr75"):
@@ -1914,12 +1919,15 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
         cp = cd.get("picks", 0)
         cw = cd.get("wins", 0)
         cbase = _bracket_baselines.get(ck, {}).get(entity_type, _baseline_win_rate())
+        ctot = _bracket_totals.get(ck, {}).get("total_runs", 0)
         brackets[ck] = {
             "picks": cp,
             "wins": cw,
             "win_rate": round(cw / cp * 100, 1) if cp else 0.0,
             "elo": cd.get("elo"),
             "score": _compute_score(cw, cp, cbase),
+            "total_runs": ctot,
+            "pick_rate": round(cp / ctot * 100, 1) if ctot else 0.0,
         }
     return {
         "entity_type": entity_type,

--- a/frontend/app/components/EntityRunStats.tsx
+++ b/frontend/app/components/EntityRunStats.tsx
@@ -21,6 +21,8 @@ interface BracketStat {
   win_rate: number;
   elo: number | null;
   score: number | null;
+  total_runs: number;
+  pick_rate: number;
 }
 
 interface EntityStats {
@@ -102,6 +104,12 @@ export default function EntityRunStats({ entityType, entityId, entityName }: Pro
   const brackets = stats.brackets ?? {};
   const availableBrackets = CONTENT_BRACKETS.filter((b) => brackets[b.key]);
   const sel = brackets[selectedBracket] ?? brackets["all"];
+  // Pick rate scoped to the selected bracket (picks / runs in that bracket).
+  // Fall back to the global figures for a pre-update API response that lacks
+  // the per-bracket denominator.
+  const selPickRate = sel?.pick_rate ?? stats.pick_rate;
+  const selTotalRuns = sel?.total_runs ?? stats.total_runs;
+  const isAll = selectedBracket === "all";
   const selLabel =
     CONTENT_BRACKETS.find((b) => b.key === selectedBracket)?.label ?? "All";
 
@@ -178,9 +186,9 @@ export default function EntityRunStats({ entityType, entityId, entityName }: Pro
           </>
         ) : (
           <>
-            <strong className="text-[var(--text-primary)]">{stats.win_rate}%</strong> win
-            rate across <strong>{stats.picks.toLocaleString()}</strong> picks
-            {top && (
+            <strong className="text-[var(--text-primary)]">{sel.win_rate}%</strong> win
+            rate across <strong>{sel.picks.toLocaleString()}</strong> picks
+            {top && isAll && (
               <>
                 . Most often taken by{" "}
                 <strong className="text-[var(--text-primary)]">
@@ -214,7 +222,7 @@ export default function EntityRunStats({ entityType, entityId, entityName }: Pro
       {!empty && stats.by_character.length > 0 && (
         <div>
           <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-2">
-            Picks by character
+            Picks by character{!isAll ? " (all runs)" : ""}
           </h3>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -262,9 +270,11 @@ export default function EntityRunStats({ entityType, entityId, entityName }: Pro
 
       <p className="text-xs text-[var(--text-muted)]">
         Stats reflect community-submitted runs only and refresh every 30 minutes.
-        {stats.total_runs > 0 && (
+        {selTotalRuns > 0 && (
           <>
-            {" "}Pick rate: <strong>{stats.pick_rate}%</strong> of {stats.total_runs.toLocaleString()} tracked runs.
+            {" "}Pick rate: <strong>{selPickRate}%</strong> of{" "}
+            {selTotalRuns.toLocaleString()}
+            {!isAll ? ` ${selLabel}` : ""} tracked runs.
           </>
         )}
       </p>


### PR DESCRIPTION
On a card/relic/potion Stats tab, switching the content bracket re-scoped the headline (Win%, Elo, Codex Score, picks) but the **pick rate didn't move** — it stayed `picks / 455,670` (the global run count), and the "Picks by character" table stayed global too. So a bracket's pick rate was meaningless (a bracket's picks divided by all runs).

## Fix
Each bracket already carries picks/wins/win_rate/elo/score; I added `total_runs` + `pick_rate` per bracket, computed as picks in the bracket over **runs in that bracket**. The per-bracket run totals are already in the snapshot (`_bracket_totals`), so this needs **no rebuild and no version bump** — it works on the current data.

The detail page now:
- uses the selected bracket's denominator for the pick rate (e.g. "Pick rate: 12% of 38,000 Asc. >50% WR tracked runs"),
- uses the selected bracket's picks/win-rate in the headline prose,
- labels the per-character table "Picks by character (all runs)" when a non-All bracket is selected, since there's no per-bracket character split yet.

## Verified (local SQLite seed)
```
card ABRASIVE:
  all  : picks=73 total_runs=110 pick_rate=66.4%
  a10  : picks=37 total_runs= 56 pick_rate=66.1%
  wr30 : picks=24 total_runs= 37 pick_rate=64.9%
  wr50 : picks=17 total_runs= 26 pick_rate=65.4%
  wr75 : picks= 9 total_runs= 13 pick_rate=69.2%
```
Each bracket now divides by its own run count.

## Not included
A true per-bracket per-character breakdown needs per-bracket-per-character data in the snapshot (a bigger storage change + a version bump), so the character table stays global for now, clearly labeled.