### PR TITLE
Re-slice the entity character table by content bracket

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -142,6 +142,11 @@ def _run_extra_brackets(player_count: int, ascension: int, game_mode: str) -> li
 # filter. Anonymous / below-floor submitters resolve to None -> no wr bracket.
 _WR_TIERS = (("wr30", 0.30), ("wr50", 0.50), ("wr75", 0.75))
 
+# Brackets whose per-entity data also carries a per-character split (so the
+# entity detail page's character table can re-slice by bracket). Only the tiers
+# the page actually shows, to keep the other brackets' snapshot data lean.
+_CHAR_BRACKETS = ("a10", "wr30", "wr50", "wr75")
+
 
 def _winrate_brackets(ascension: int, winrate: float | None) -> list[str]:
     """wrNN bracket keys a single run belongs to, given its submitter's overall
@@ -181,7 +186,9 @@ SNAPSHOT_COLLECTION_NAME = "entity_stats_snapshot"
 # Version 9 makes the community and encounter blobs per-bracket (like charts) and
 # moves each to its own snapshot doc; the loader falls back to the old inline
 # __meta__ fields and to a flat blob for a pre-v9 snapshot.
-SNAPSHOT_VERSION = 9
+# Version 10 adds a per-character split to each entity's win-rate/A10 bracket data
+# so the detail page's character table re-slices by bracket (additive).
+SNAPSHOT_VERSION = 10
 # The oldest snapshot version readers can still serve. Bump SNAPSHOT_VERSION
 # on every shape change; bump this floor ONLY when a change actually breaks
 # readers (a removed/retyped field). Everything in between is additive, and
@@ -936,6 +943,8 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
                 agg["last_run_hash"] = run_hash
 
             # Deck membership for each matched bracket (lighter: picks/wins).
+            # For the win-rate / A10 tiers the detail page shows, also keep a
+            # per-character split so its character table can re-slice by bracket.
             for ck in extra_brackets:
                 cagg = bracket_accs[ck]["cache"].setdefault(
                     entity, {"picks": 0, "wins": 0}
@@ -943,6 +952,13 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
                 cagg["picks"] += 1
                 if is_win:
                     cagg["wins"] += 1
+                if ck in _CHAR_BRACKETS:
+                    cch = cagg.setdefault("by_character", {}).setdefault(
+                        character, {"picks": 0, "wins": 0}
+                    )
+                    cch["picks"] += 1
+                    if is_win:
+                        cch["wins"] += 1
 
         # Base vs upgraded deck membership, so the metrics table can split
         # each card into its base and "+" rows. The merged picks/wins above
@@ -1117,6 +1133,8 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
                 "off_act": cagg.get("off_act", [0] * _ACT_BUCKETS),
                 "pick_act": cagg.get("pick_act", [0] * _ACT_BUCKETS),
                 "elo": cagg.get("elo"),
+                # Per-character split for the char-brackets (empty otherwise).
+                "by_character": cagg.get("by_character", {}),
             }
     bracket_meta = {
         "baselines": bracket_baselines,
@@ -1875,21 +1893,25 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
         return None
     picks = agg["picks"]
     wins = agg["wins"]
-    by_character = [
-        {
-            "character": ch,
-            "picks": stats["picks"],
-            "wins": stats["wins"],
-            "win_rate": round(stats["wins"] / stats["picks"] * 100, 1)
-            if stats["picks"]
-            else 0.0,
-        }
-        for ch, stats in sorted(
-            agg["by_character"].items(),
-            key=lambda kv: kv[1]["picks"],
-            reverse=True,
-        )
-    ]
+
+    def _shape_chars(char_map: dict) -> list[dict]:
+        return [
+            {
+                "character": ch,
+                "picks": s["picks"],
+                "wins": s["wins"],
+                "win_rate": round(s["wins"] / s["picks"] * 100, 1)
+                if s["picks"]
+                else 0.0,
+            }
+            for ch, s in sorted(
+                (char_map or {}).items(),
+                key=lambda kv: kv[1]["picks"],
+                reverse=True,
+            )
+        ]
+
+    by_character = _shape_chars(agg["by_character"])
     total_runs = _global_totals["total_runs"]
     baseline = _type_baseline(entity_type)
     # Per-bracket breakdown for the entity detail page: All + A10 + the win-rate
@@ -1910,6 +1932,8 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
             # global run count.
             "total_runs": total_runs,
             "pick_rate": round(picks / total_runs * 100, 1) if total_runs else 0.0,
+            # "All" reuses the global per-character split.
+            "by_character": by_character,
         }
     }
     for ck in ("a10", "wr30", "wr50", "wr75"):
@@ -1928,6 +1952,7 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
             "score": _compute_score(cw, cp, cbase),
             "total_runs": ctot,
             "pick_rate": round(cp / ctot * 100, 1) if ctot else 0.0,
+            "by_character": _shape_chars(cd.get("by_character")),
         }
     return {
         "entity_type": entity_type,

--- a/frontend/app/components/EntityRunStats.tsx
+++ b/frontend/app/components/EntityRunStats.tsx
@@ -23,6 +23,7 @@ interface BracketStat {
   score: number | null;
   total_runs: number;
   pick_rate: number;
+  by_character?: CharacterRow[];
 }
 
 interface EntityStats {
@@ -95,20 +96,20 @@ export default function EntityRunStats({ entityType, entityId, entityName }: Pro
   }
 
   const empty = stats.picks === 0;
-  const top = stats.by_character[0];
   const last = relativeTime(stats.last_submitted_at);
-  const maxCharPicks = top?.picks ?? 0;
 
   // Bracket sub-menu: only the brackets with data for this entity. Selecting
-  // one re-scopes the headline stats below to that bracket's numbers.
+  // one re-scopes the headline stats AND the per-character table below.
   const brackets = stats.brackets ?? {};
   const availableBrackets = CONTENT_BRACKETS.filter((b) => brackets[b.key]);
   const sel = brackets[selectedBracket] ?? brackets["all"];
-  // Pick rate scoped to the selected bracket (picks / runs in that bracket).
-  // Fall back to the global figures for a pre-update API response that lacks
-  // the per-bracket denominator.
+  // Everything below scopes to the selected bracket, with a fall back to the
+  // global figures for a pre-update API response that lacks the per-bracket data.
   const selPickRate = sel?.pick_rate ?? stats.pick_rate;
   const selTotalRuns = sel?.total_runs ?? stats.total_runs;
+  const selByChar = sel?.by_character ?? stats.by_character;
+  const top = selByChar[0];
+  const maxCharPicks = top?.picks ?? 0;
   const isAll = selectedBracket === "all";
   const selLabel =
     CONTENT_BRACKETS.find((b) => b.key === selectedBracket)?.label ?? "All";
@@ -188,14 +189,14 @@ export default function EntityRunStats({ entityType, entityId, entityName }: Pro
           <>
             <strong className="text-[var(--text-primary)]">{sel.win_rate}%</strong> win
             rate across <strong>{sel.picks.toLocaleString()}</strong> picks
-            {top && isAll && (
+            {top && (
               <>
                 . Most often taken by{" "}
                 <strong className="text-[var(--text-primary)]">
                   {characterPretty(top.character)}
                 </strong>{" "}
                 players ({top.picks.toLocaleString()} picks ·{" "}
-                {Math.round((top.picks / stats.picks) * 100)}% share)
+                {Math.round((top.picks / sel.picks) * 100)}% share)
               </>
             )}
             . Last picked <strong>{last}</strong>
@@ -219,10 +220,10 @@ export default function EntityRunStats({ entityType, entityId, entityName }: Pro
       </p>
 
       {/* Per-character breakdown table, hidden when empty. */}
-      {!empty && stats.by_character.length > 0 && (
+      {!empty && selByChar.length > 0 && (
         <div>
           <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-2">
-            Picks by character{!isAll ? " (all runs)" : ""}
+            Picks by character{!isAll ? ` · ${selLabel}` : ""}
           </h3>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -235,7 +236,7 @@ export default function EntityRunStats({ entityType, entityId, entityName }: Pro
                 </tr>
               </thead>
               <tbody>
-                {stats.by_character.map((row) => {
+                {selByChar.map((row) => {
                   const pct = maxCharPicks ? (row.picks / maxCharPicks) * 100 : 0;
                   return (
                     <tr


### PR DESCRIPTION
Follow-up to the per-bracket pick rate (#526). On a card/relic/potion Stats tab, the headline (win rate, Elo, score, picks, pick rate) re-scoped when you changed the bracket, but the **"Picks by character"** table stayed global — it just got an "(all runs)" label. The request was for that table to re-slice by bracket too.

## What it does
Each entity's per-bracket data now carries a per-character split (picks/wins), and the detail page's character table uses the selected bracket's split. So picking **Asc. >50% WR** shows that tier's per-character picks and win rates, not the all-runs ones; characters with no picks in a tier drop out.

Backend: accumulate `by_character` per entity per bracket, but only for the four tiers the page shows (`a10`/`wr30`/`wr50`/`wr75`) to keep the other brackets lean. The `all` bracket reuses the existing global split. `get_entity_stats` returns `by_character` on each bracket; the frontend reads `sel.by_character` and falls back to the global split for a pre-deploy API response.

## Verified (local SQLite seed)
```
ACROBATICS
  all  : IRO 15/46.7%  DEF 15/53.3%  NEC 15/46.7%  REG 15/26.7%  SIL 14/42.9%
  a10  : IRO 10/50.0%  DEF 10/60.0%  REG 8/25.0%   NEC 6/33.3%   SIL 4/25.0%
  wr50 : IRO 6/66.7%   DEF 6/66.7%   REG 4/25.0%   NEC 2/100%
  wr75 : IRO 3/66.7%   DEF 3/66.7%   REG 2/50.0%   NEC 1/100%
```
Per-character picks and win rates change per bracket, and the per-bracket counts sum to that bracket's total.

## Deploy note
This is a snapshot data-shape change (`SNAPSHOT_VERSION` 9 → 10), so after merge + deploy it needs the usual entity-stats **snapshot rebuild** (~25-40 min on the leader) before the per-bracket character splits show. It's additive — until the rebuild finishes, the table just serves an empty split for non-All brackets, then fills in. Leave the backend alone and let the rebuild complete (don't re-kick it).