### PR TITLE
live: render event BBCode, name the monster on wins, mobile fixes

### DIFF
--- a/frontend/app/components/RichDescription.tsx
+++ b/frontend/app/components/RichDescription.tsx
@@ -403,7 +403,7 @@ function WordTooltip({ word, info, children }: { word: string; info: Interactive
 }
 
 /** Simple renderer without interactive words (for tooltips to avoid infinite recursion) */
-function RichDescriptionSimple({ text }: { text: string }) {
+export function RichDescriptionSimple({ text }: { text: string }) {
   keyCounter = 0;
   const cleaned = cleanTemplateVars(text);
   const tokens = tokenize(cleaned);

--- a/frontend/app/live/LiveClient.tsx
+++ b/frontend/app/live/LiveClient.tsx
@@ -108,7 +108,7 @@ function PlayerCard({
         </div>
       </div>
 
-      <div className="mt-2 flex items-center gap-2">
+      <div className="mt-2 flex flex-wrap items-center gap-2">
         <FightingChip p={p} monsters={monsters} />
         {p.twitch_live && p.twitch_login && (
           <WatchOnTwitch

--- a/frontend/app/live/LiveEventShop.tsx
+++ b/frontend/app/live/LiveEventShop.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 // Live current-screen detail (v4): what the player sees on the event and shop
-// screens. The event text is already localized by the mod, so it renders as-is.
+// screens. Event text is localized by the mod and carries the game's BBCode
+// tags ([gold]/[sine]/[jitter]/...), rendered via RichDescriptionSimple.
 // Shop item ids resolve to names/images through the run-page pills (hover shows
 // the full card / relic tooltip). Contract: markdown-docs/live-presence.md (v4).
 
 import Link from "next/link";
 import { imageUrl, fullCardUrl } from "@/lib/image-url";
+import { RichDescriptionSimple } from "@/app/components/RichDescription";
 import {
   CardPill,
   PotionPill,
@@ -51,7 +53,7 @@ export function LiveEventPanel({ ev, lp }: { ev: LiveEventCtx; lp: string }) {
       </div>
       {ev.prompt && (
         <p className="text-sm text-[var(--text-secondary)] whitespace-pre-line mb-3 leading-relaxed">
-          {ev.prompt}
+          <RichDescriptionSimple text={ev.prompt} />
         </p>
       )}
       {(ev.options?.length ?? 0) > 0 && (
@@ -75,7 +77,7 @@ export function LiveEventPanel({ ev, lp }: { ev: LiveEventCtx; lp: string }) {
                     {o.chosen ? "✓" : disabled ? "\u{1F512}" : "•"}
                   </span>
                   <span className={`min-w-0 flex-1 ${disabled ? "line-through" : ""}`}>
-                    {o.text || o.key || "(option)"}
+                    {o.text ? <RichDescriptionSimple text={o.text} /> : o.key || "(option)"}
                   </span>
                   {o.proceed && !o.chosen && (
                     <span className="text-[10px] text-[var(--text-muted)] shrink-0">leave</span>

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -66,11 +66,13 @@ function TickerRow({
   cat,
   monsters,
   lp,
+  won,
 }: {
   e: LiveEvent;
   cat: Catalogs;
   monsters: MonsterMap;
   lp: string;
+  won?: string;
 }) {
   let icon: React.ReactNode = null;
   let body: React.ReactNode;
@@ -227,7 +229,11 @@ function TickerRow({
       );
       break;
     case "victory":
-      body = <span className="text-emerald-300">Won the fight</span>;
+      body = (
+        <span className="text-emerald-300">
+          {won ? `Won the fight against ${monsterName(won, monsters)}` : "Won the fight"}
+        </span>
+      );
       break;
     case "death":
       body = <span className="text-rose-400 font-semibold">Died</span>;
@@ -368,8 +374,16 @@ export default function LivePlayerClient() {
   const eventKeys = withOrdinalKeys(
     rawEvents.map((e) => `${e.k}|${e.v ?? ""}|${e.turn ?? ""}|${e.t ?? 0}`),
   );
+  // The "victory" beat carries no enemy id, so tag each win with the monster
+  // from the most recent preceding "combat" beat (append order). Degrades to a
+  // plain "Won the fight" if that beat has rolled off the window.
+  let lastFightMonster: string | undefined;
+  const wonAgainst = rawEvents.map((e) => {
+    if (e.k === "combat" && e.v) lastFightMonster = e.v;
+    return e.k === "victory" ? e.v || lastFightMonster : undefined;
+  });
   const events = rawEvents
-    .map((e, i) => ({ e, key: eventKeys[i].key }))
+    .map((e, i) => ({ e, key: eventKeys[i].key, won: wonAgainst[i] }))
     .reverse();
   // Group identical deck entries (STRIKE vs STRIKE+ stay distinct) in
   // acquisition order of first appearance.
@@ -503,8 +517,8 @@ export default function LivePlayerClient() {
             </p>
           ) : (
             <ul>
-              {events.map(({ e, key }) => (
-                <TickerRow key={key} e={e} cat={cat} monsters={monsters} lp={lp} />
+              {events.map(({ e, key, won }) => (
+                <TickerRow key={key} e={e} cat={cat} monsters={monsters} lp={lp} won={won} />
               ))}
             </ul>
           )}

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -313,19 +313,30 @@ export function FightingChip({
   circle?: string;
 }) {
   if (p.screen !== "combat" || !p.fighting?.length) return null;
-  const names = p.fighting.map((id) => monsterName(id, monsters));
+  // Merge identical enemies (a multi-segment foe like Decimillipede arrives as
+  // the same id repeated) into one entry with a count, so the chip stays short.
+  const groups: { id: string; count: number }[] = [];
+  for (const id of p.fighting) {
+    const g = groups.find((x) => x.id === id);
+    if (g) g.count += 1;
+    else groups.push({ id, count: 1 });
+  }
+  const names = groups.map((g) => {
+    const n = monsterName(g.id, monsters);
+    return g.count > 1 ? `${n} ×${g.count}` : n;
+  });
   const label =
     names.length <= 2 ? names.join(" & ") : `${names[0]} +${names.length - 1}`;
   return (
-    <span className="inline-flex items-center gap-1.5 px-2 py-1 rounded-full bg-rose-950/50 border border-rose-900/50 text-xs text-rose-200">
-      <span className="flex -space-x-2">
-        {withOrdinalKeys(p.fighting.slice(0, 3)).map(({ item, key }) => (
+    <span className="inline-flex min-w-0 max-w-full items-center gap-1.5 px-2 py-1 rounded-full bg-rose-950/50 border border-rose-900/50 text-xs text-rose-200">
+      <span className="flex -space-x-2 shrink-0">
+        {withOrdinalKeys(groups.slice(0, 3).map((g) => g.id)).map(({ item, key }) => (
           <EnemyCircle key={key} id={item} monsters={monsters} className={circle} />
         ))}
       </span>
-      <span className="truncate">Fighting {label}</span>
+      <span className="min-w-0 truncate">Fighting {label}</span>
       {p.turn != null && p.turn > 0 && (
-        <span className="text-rose-400/80 whitespace-nowrap">· Turn {p.turn}</span>
+        <span className="text-rose-400/80 whitespace-nowrap shrink-0">· Turn {p.turn}</span>
       )}
     </span>
   );


### PR DESCRIPTION
Three site-side improvements to the /live spectator, all frontend-only.

## BBCode in the event panel
Event text from the mod carries the game's BBCode tags (`[gold]`, `[sine]`, `[jitter]`, `[green]`, nested like `[green][sine]...[/sine][/green]`). It was rendering raw. Now it goes through the existing card-description renderer (`RichDescriptionSimple`, exported from `RichDescription.tsx`): color tags become colored text, `[sine]`/`[jitter]` become the wave/shake CSS animations, unknown tags are stripped. Span-based, so mod text is never injected as HTML.

## "Won the fight against {Monster}"
The play-by-play `victory` beat carries no enemy id, but the preceding `combat` beat does. So I tag each win with the monster from the most recent preceding combat beat. Falls back to plain "Won the fight" when that beat has rolled out of the ticker window.

## Mobile
- The roster card's bottom row now wraps, so "Watch live →" can't get shoved off screen on narrow phones.
- The Fighting chip merges identical enemies into one entry with a count (a multi-segment Decimillipede was rendering as a row of duplicates), and it now shrinks/truncates instead of overflowing.

## Not in here (blocked on the mod)
Two of the requested items need the in-game mod (separate repo) to emit more data, plus a backend `presence.py` whitelist + contract update, before the site can show anything:
- **Event choice + reward in the play-by-play** — the payload only sends `event = ID`; there's no chosen-option or reward field, and the backend strips anything extra.
- **Map hover history (ancient / monster fought / event + choice)** — map nodes are just `[col, row, type]`; there's no per-node history in the payload.

I can spec and do the site side (backend whitelist + inert frontend + contract) once we decide the field shapes the mod will send.