### PR TITLE
stats: A10 bracket labels, uncap entity lists, unfreeze filtered stats

### DIFF
--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -910,25 +910,19 @@ def get_stats(
         ]
     )
 
-    # Per-entity stats caps. Sized to comfortably cover the full live
-    # catalog (576 cards / 293 relics / 63 potions) plus headroom for a
-    # patch's worth of new content. The earlier 100-cap was a JSON-
-    # serialization guard from when /api/runs/stats served live on every
-    # request -- a 1000-cap previously produced an 8MB response that
-    # took 1-4s to serialize. With Redis (PR #388) and the existing
-    # stats_summary materialization in front of this, the doc is
-    # serialized once per refresh cycle and served from cache for every
-    # user request, so the per-request cost no longer scales with the
-    # cap. The Discord-flagged "only 20 ancient relics visible" issue
-    # was the rarity filter slicing the already-capped top-100 -- this
-    # restores the full catalog into the stats so frontend filters can
-    # find their full set.
+    # No per-entity cap. The result is bounded by the live catalog (576 cards /
+    # 293 relics / 63 potions) plus the rare modded id the frontend filters out,
+    # so the full list is small. Redis (PR #388) + the stats_summary
+    # materialization serialize it once per refresh and serve from cache, so the
+    # per-request cost doesn't scale with the count. An uncapped list means the
+    # frontend's rarity / skill filters slice the full set instead of an
+    # already-truncated top-N (the "only 20 ancient relics" / "100 relics when
+    # filtered" reports were the filter biting into a capped list).
     cards = agg(
         [
             {"$match": match},
             *_item_stats_pipeline("deck"),
             {"$sort": {"count": -1}},
-            {"$limit": 600},
         ]
     )
     relics = agg(
@@ -936,7 +930,6 @@ def get_stats(
             {"$match": match},
             *_item_stats_pipeline("relics"),
             {"$sort": {"count": -1}},
-            {"$limit": 300},
         ]
     )
     potions_owned_list = agg(
@@ -944,7 +937,6 @@ def get_stats(
             {"$match": match},
             *_item_stats_pipeline("potions"),
             {"$sort": {"count": -1}},
-            {"$limit": 100},
         ]
     )
     potion_owned = {r["_id"]: r for r in potions_owned_list}
@@ -1192,17 +1184,17 @@ def _filter_key(
     return "|".join(parts) if parts else "global"
 
 
-# Per-username summary docs are only ever written lazily (write-through on a
-# cache miss in get_community_stats); the periodic refresher only touches the
-# hot community/character combos, never a username combo. Without a TTL the
-# first doc written for a user is therefore served forever, freezing their run
-# count at whatever it was on the first query — which pins users first queried
-# at ~0 runs (e.g. the overlay's Metrics tab firing on sign-in before uploads
-# finish) at 0. Past this TTL we ignore a per-username doc so the read falls
-# through to a live recompute that rewrites a fresh one. Existing frozen docs
-# have a stale updated_at, so they go stale immediately — no manual purge
-# needed.
-_USER_SUMMARY_TTL = timedelta(minutes=10)
+# Non-hot summary docs (anything beyond the no-filter / per-character combos the
+# refresher warms) are only written lazily on a cache miss. Without a TTL the
+# first doc written for such a combo is served forever: it freezes a user's run
+# count (the overlay's Metrics tab firing on sign-in before uploads finish pins
+# them at ~0), and it pins a filtered list (e.g. an A10 relic stats list) to
+# whatever it was when first written, including an old result cap. Past this TTL
+# we ignore a non-hot doc so the read falls through to a live recompute that
+# rewrites a fresh one. Hot combos stay always-served (the refresher keeps them
+# warm). Existing frozen docs have a stale updated_at, so they go stale
+# immediately — no manual purge needed.
+_FILTERED_SUMMARY_TTL = timedelta(minutes=10)
 
 
 @_instrument("read_stats_summary", collection="stats_summary")
@@ -1215,23 +1207,25 @@ def read_stats_summary(
     username: str | None = None,
 ) -> dict | None:
     """Read a pre-computed stats doc by filter key. Returns None if no doc
-    exists (refresher hasn't populated it yet), or if a per-username doc is
-    older than _USER_SUMMARY_TTL (so a stale personal count recomputes instead
-    of serving frozen). O(1) read."""
+    exists (refresher hasn't populated it yet), or if a non-hot (filtered) doc is
+    older than _FILTERED_SUMMARY_TTL (so a stale filtered list or personal count
+    recomputes instead of serving frozen). O(1) read."""
     try:
         key = _filter_key(character, win, ascension, game_mode, players, username)
         doc = _summary_coll().find_one({"_id": key})
         if not doc:
             return None
-        # Per-username docs are never refreshed in the background, so honor
-        # their age; hot (no-username) combos stay always-served.
-        if username:
+        # Hot combos (no filter, or character only) are kept fresh by the
+        # refresher and always served. Every other combo is write-through only,
+        # so honor its age and fall through to a recompute past the TTL.
+        non_hot = bool(win or ascension or game_mode or players or username)
+        if non_hot:
             updated = doc.get("updated_at")
             if not isinstance(updated, datetime):
                 return None
             if updated.tzinfo is None:
                 updated = updated.replace(tzinfo=timezone.utc)
-            if datetime.now(timezone.utc) - updated >= _USER_SUMMARY_TTL:
+            if datetime.now(timezone.utc) - updated >= _FILTERED_SUMMARY_TTL:
                 return None
         # Strip the wrapper fields before returning to the API caller.
         doc.pop("_id", None)

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -906,7 +906,6 @@ def get_stats(
                 }
             },
             {"$sort": {"offered": -1}},
-            {"$limit": 600},
         ]
     )
 

--- a/frontend/app/leaderboards/metrics/MetricsClient.tsx
+++ b/frontend/app/leaderboards/metrics/MetricsClient.tsx
@@ -58,13 +58,13 @@ const BRACKETS = [
   { key: "2p", label: "2P" },
   { key: "3p", label: "3P" },
   { key: "4p", label: "4P" },
-  { key: "a10", label: "Asc. 10" },
+  { key: "a10", label: "A10" },
   { key: "daily", label: "Daily" },
   { key: "custom", label: "Custom" },
   // Win-rate skill brackets (A10-gated quality ladder). Mirror _BRACKET_KEYS.
-  { key: "wr30", label: "Asc. >30% WR" },
-  { key: "wr50", label: "Asc. >50% WR" },
-  { key: "wr75", label: "Asc. >75% WR" },
+  { key: "wr30", label: "A10 >30% WR" },
+  { key: "wr50", label: "A10 >50% WR" },
+  { key: "wr75", label: "A10 >75% WR" },
 ];
 
 type SortKey =

--- a/frontend/app/leaderboards/metrics/page.tsx
+++ b/frontend/app/leaderboards/metrics/page.tsx
@@ -92,13 +92,13 @@ export const BRACKETS = [
   { key: "2p", label: "2P" },
   { key: "3p", label: "3P" },
   { key: "4p", label: "4P" },
-  { key: "a10", label: "Asc. 10" },
+  { key: "a10", label: "A10" },
   { key: "daily", label: "Daily" },
   { key: "custom", label: "Custom" },
   // Win-rate skill brackets (A10-gated quality ladder). Mirror _BRACKET_KEYS.
-  { key: "wr30", label: "Asc. >30% WR" },
-  { key: "wr50", label: "Asc. >50% WR" },
-  { key: "wr75", label: "Asc. >75% WR" },
+  { key: "wr30", label: "A10 >30% WR" },
+  { key: "wr50", label: "A10 >50% WR" },
+  { key: "wr75", label: "A10 >75% WR" },
 ] as const;
 
 export async function loadMetrics(

--- a/frontend/lib/content-brackets.ts
+++ b/frontend/lib/content-brackets.ts
@@ -11,10 +11,10 @@ export interface ContentBracket {
 
 export const CONTENT_BRACKETS: ContentBracket[] = [
   { key: "all", param: null, label: "All" },
-  { key: "a10", param: "a10", label: "Asc. 10" },
-  { key: "wr30", param: "wr30", label: "Asc. >30% WR" },
-  { key: "wr50", param: "wr50", label: "Asc. >50% WR" },
-  { key: "wr75", param: "wr75", label: "Asc. >75% WR" },
+  { key: "a10", param: "a10", label: "A10" },
+  { key: "wr30", param: "wr30", label: "A10 >30% WR" },
+  { key: "wr50", param: "wr50", label: "A10 >50% WR" },
+  { key: "wr75", param: "wr75", label: "A10 >75% WR" },
 ];
 
 const _BY_KEY = new Map(CONTENT_BRACKETS.map((b) => [b.key, b]));


### PR DESCRIPTION
Three things from the Discord thread (AlmostMatt's relic-stats report + the label change).

## Bracket labels -> A10 style
Renamed the bracket labels everywhere they show: "Asc. 10" -> "A10", "Asc. >30% WR" -> "A10 >30% WR", etc. Makes it clear the win-rate tiers are A10-gated. Changed in the shared `content-brackets.ts` (which drives the tier lists, charts, entity pages, community stats, encounters) and the metrics page/client that keep their own copy.

## Uncap the entity stats lists
`get_stats` no longer caps cards/relics/potions (was 600/300/100). The list is bounded by the catalog (~576/293/63) and served from Redis + the materialized summary, so it's cheap, and an uncapped list means the rarity/skill filters slice the full set instead of an already-truncated top-N.

## The actual "100 relics when filtered" cause
The relic cap was 300, above the 293-relic catalog, so it wasn't biting unfiltered — the real cause was a **frozen `stats_summary` doc**. Same root as the #524 metrics freeze, but #524 only TTL'd *per-username* docs; ascension/player-filtered combos (A10, single-player) were still written once and served forever, pinned to whatever they were when first written, including an old cap. `read_stats_summary` now applies the TTL to **all** non-hot combos, so filtered stats recompute fresh (and uncapped). Existing frozen docs have a stale `updated_at`, so they go stale immediately — no manual purge.

## Deploy
Backend + frontend, no snapshot rebuild and no version bump. After deploy the filtered summary docs go stale on the next read and recompute uncapped on their own; nothing to purge. (Frontend: keep Rocket Loader off; clear the cache as usual.)