### PR TITLE
relic tier list: filter survivorship noise + modded ids from the act view

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -1032,7 +1032,20 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
         # the relic tier list. Acts past the third fold into the last bucket.
         try:
             act_floors_list = blob.get("map_point_history") or []
-            if act_floors_list:
+            # A run carrying a modded relic id is a modded-content run: mods can
+            # grant relics on any floor, so its floor_added_to_deck is unreliable
+            # (that is how act-2/3 ancients like Meat Cleaver leaked into act 1).
+            # Skip its act attribution entirely so each act keeps only its real
+            # relics. Fail-open: an empty catalog means "don't filter".
+            official_relics = _official_relic_ids()
+            is_modded_run = bool(official_relics) and any(
+                (s := _strip_prefix(rel.get("id", "")))
+                and s[0] == "relics"
+                and s[1] not in official_relics
+                for player in (blob.get("players") or [])
+                for rel in (player.get("relics") or [])
+            )
+            if act_floors_list and not is_modded_run:
                 bounds: list[int] = []
                 running = 0
                 for act_floors in act_floors_list:

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -89,6 +89,13 @@ _ELO_TOL = 1e-6
 # Acts beyond the third fold into the last bucket.
 _ACT_BUCKETS = 3
 
+# Minimum acquisitions in an act before a relic appears in that act's tier view.
+# The act split shrinks each relic's sample ~3x, and a relic rarely grabbed in an
+# act (e.g. a lategame relic bought from an act-1 shop) carries a survivorship-
+# inflated win rate that otherwise tops the list. The real act relics sit in the
+# thousands, the noise under ~150, so this cleanly separates them. Tunable.
+_ACT_MIN_PICKS = 200
+
 # Run brackets the metrics table can be sliced by. "all" is the default and
 # lives in the top-level entity fields (also what scores/stats read). The
 # rest are pre-built in the same snapshot walk and stored nested per entity,
@@ -276,6 +283,30 @@ def _official_character_ids() -> frozenset[str]:
         except Exception:
             _official_characters_cache = frozenset()
     return _official_characters_cache
+
+
+_official_relics_cache: frozenset[str] | None = None
+
+
+def _official_relic_ids() -> frozenset[str]:
+    """Uppercase ids of the official relics (the real relic catalog).
+
+    Runs can carry modded relic ids (e.g. forge/rune entities) that aren't real
+    relics; the act tier view excludes them. Loaded once; an empty set (catalog
+    unreadable) means "don't filter" so a transient read failure can't blank the
+    list.
+    """
+    global _official_relics_cache
+    if _official_relics_cache is None:
+        try:
+            from .data_service import load_relics
+
+            _official_relics_cache = frozenset(
+                (r.get("id") or "").upper() for r in load_relics() if r.get("id")
+            )
+        except Exception:
+            _official_relics_cache = frozenset()
+    return _official_relics_cache
 
 
 # Card colors that are never a real card-reward choice: curses and status
@@ -1594,8 +1625,9 @@ def get_all_entity_scores(
     to pickups made during that act: picks/wins/score come from the act
     bucket, graded against a per-act baseline. Later-act pickups only happen
     in runs that already got there, so their raw win rates are survivorship-
-    inflated; comparing act-mates against each other cancels that out.
-    Entities never picked up in that act are omitted.
+    inflated; comparing act-mates against each other cancels that out. Modded
+    relic ids and relics with fewer than `_ACT_MIN_PICKS` acquisitions in the
+    act are omitted (a relic rarely grabbed that act is survivorship noise).
     """
     _maybe_rebuild()
     if act is not None:
@@ -1674,13 +1706,21 @@ def _entity_scores_for_act(entity_type: str, act: int) -> dict[str, dict[str, An
 
     Same shape as the all-acts response (`elo` stays null: Codex Elo is a
     card-reward signal, not a relic one). The baseline is the pick-weighted
-    average win rate of every pickup in that act, so each entity is graded
-    against its act-mates rather than the global pool.
+    average win rate of every official pickup in that act, so each entity is
+    graded against its act-mates rather than the global pool.
+
+    Two filters keep the list honest: non-official (modded) relic ids are
+    dropped, and a relic must clear `_ACT_MIN_PICKS` acquisitions in the act to
+    appear, since a relic rarely grabbed in that act (e.g. a lategame relic
+    bought from an act-1 shop) carries a survivorship-inflated win rate that
+    would otherwise top the list. The baseline still spans every official pickup
+    so it stays representative.
     """
     idx = min(max(act, 1), _ACT_BUCKETS) - 1
+    official = _official_relic_ids() if entity_type == "relics" else frozenset()
     total_picks = total_wins = 0
-    for (etype, _), agg in _cache.items():
-        if etype != entity_type:
+    for (etype, eid), agg in _cache.items():
+        if etype != entity_type or (official and eid not in official):
             continue
         act_picks = agg.get("act_picks")
         if act_picks:
@@ -1689,10 +1729,10 @@ def _entity_scores_for_act(entity_type: str, act: int) -> dict[str, dict[str, An
     baseline = (total_wins / total_picks) if total_picks else _baseline_win_rate()
     out: dict[str, dict[str, Any]] = {}
     for (etype, eid), agg in _cache.items():
-        if etype != entity_type:
+        if etype != entity_type or (official and eid not in official):
             continue
         act_picks = agg.get("act_picks")
-        if not act_picks or not act_picks[idx]:
+        if not act_picks or act_picks[idx] < _ACT_MIN_PICKS:
             continue
         picks = act_picks[idx]
         wins = (agg.get("act_wins") or [0] * _ACT_BUCKETS)[idx]


### PR DESCRIPTION
Following up on the report that `/tier-list/relics?act=1` looks wrong.

## What I checked
I pulled real runs from the live API and ran the exact act-bucketing logic against them. **The bucketing is correct:**
- `floor_added_to_deck` is a global run floor, on the same scale as the cumulative per-act floor counts from `map_point_history` (the charts code treats it the same way), so the comparison is valid.
- 0% of relic acquisitions fell into the default bucket (i.e. nothing leaked to "act 3" by accident).
- Leafy Poultice bucketed to act 1 (6/6), Meat Cleaver to act 3 (3/3), common relics cluster in act 1, rares/ancients in act 3 — all correct.

## What was actually wrong
The act view had no minimum-sample floor and no official-content filter, so the `?act=1` response had **989 entities**, of which:
- **699 were non-relic modded ids** (forge/rune entities). The page hides them via the catalog, but the API was bloated and other consumers (e.g. the mod) saw them.
- The **top of the list was survivorship noise**: relics rarely grabbed in act 1 (Meat Cleaver 59 picks, Glitter 16, Looming Fruit 31, Sword of Jade 142) had win rates inflated by *who* grabs them early, and the Bayesian prior (50 virtual picks, tuned for the full-data view where relics have thousands of picks) was too weak to tame those small act-split samples, so they saturated at score 100. The real act-1 relics sit in the thousands of picks; the noise is all under ~150.

## Fix
`_entity_scores_for_act` now:
- drops non-official relic ids (catalog filter, fail-open if the catalog can't load), and
- requires `_ACT_MIN_PICKS` (200) acquisitions in the act before a relic shows. The act-1 picks distribution is cleanly bimodal — ~96 relics under ~150 picks, the rest in the thousands — so 200 removes the noise without touching real relics. It's a module constant, easy to tune.

The baseline still spans every official pickup, so it stays representative.