### PR TITLE
tier list maker: fix blank exports and stale shared previews

### DIFF
--- a/backend/app/services/tierlists_db.py
+++ b/backend/app/services/tierlists_db.py
@@ -214,6 +214,14 @@ def set_preview_image(tierlist_id: str, user_id: str, data: bytes) -> dict | Non
         return None
     url = r2_storage.upload_preview(doc["share_id"], data)
     if url:
+        # Version the URL by content hash. The R2 key is stable per share_id and
+        # the CDN caches it for an hour, so without this an edited preview (e.g.
+        # after deleting rows) keeps serving the old image until the cache
+        # expires. A content hash gives a fresh URL only when the image actually
+        # changes, so identical re-saves still hit the cache.
+        import hashlib
+
+        url = f"{url}?v={hashlib.md5(data).hexdigest()[:10]}"
         coll.update_one(
             {"_id": oid},
             {"$set": {"image_url": url, "updated_at": datetime.now(timezone.utc)}},

--- a/frontend/app/tier-list-maker/TierListBuilder.tsx
+++ b/frontend/app/tier-list-maker/TierListBuilder.tsx
@@ -38,6 +38,64 @@ import type { EntityType, Tier, TierEntity, TierList } from "./types";
 
 type Containers = Record<string, string[]>;
 
+// html-to-image renders a blank capture when the cloned styles contain oklch()
+// colors. Tailwind v4's default palette (neutral/sky/emerald/...) is all oklch,
+// and the serialized SVG fails to load, leaving only the background. Before
+// snapshotting, rewrite every oklch() the capture resolves to into rasterized
+// sRGB rgb() as an inline override; returns a function that reverts it after.
+const OKLCH_PROPS = [
+  "color",
+  "backgroundColor",
+  "backgroundImage",
+  "borderTopColor",
+  "borderRightColor",
+  "borderBottomColor",
+  "borderLeftColor",
+  "outlineColor",
+  "textDecorationColor",
+  "boxShadow",
+  "fill",
+  "stroke",
+] as const;
+
+function inlineOklchAsRgb(root: HTMLElement): () => void {
+  const ctx = document.createElement("canvas").getContext("2d");
+  if (!ctx) return () => {};
+  const cache = new Map<string, string>();
+  const toRgb = (oklch: string): string => {
+    const cached = cache.get(oklch);
+    if (cached !== undefined) return cached;
+    ctx.fillStyle = "#000";
+    ctx.fillStyle = oklch; // canvas rasterizes any CSS color, incl. oklch
+    ctx.fillRect(0, 0, 1, 1);
+    const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
+    const rgb = `rgba(${r}, ${g}, ${b}, ${(a / 255).toFixed(3)})`;
+    cache.set(oklch, rgb);
+    return rgb;
+  };
+  const undo: Array<() => void> = [];
+  const els = [root, ...Array.from(root.querySelectorAll<HTMLElement>("*"))];
+  for (const el of els) {
+    const cs = getComputedStyle(el) as unknown as Record<string, string>;
+    for (const prop of OKLCH_PROPS) {
+      const val = cs[prop];
+      if (typeof val === "string" && val.includes("oklch")) {
+        const prev = (el.style as unknown as Record<string, string>)[prop];
+        (el.style as unknown as Record<string, string>)[prop] = val.replace(
+          /oklch\([^)]*\)/g,
+          (m) => toRgb(m),
+        );
+        undo.push(() => {
+          (el.style as unknown as Record<string, string>)[prop] = prev;
+        });
+      }
+    }
+  }
+  return () => {
+    for (const f of undo) f();
+  };
+}
+
 // Synthetic tray filter that matches beta-only entities by their `beta` flag
 // instead of their color/pool group, so beta content has a one-click pill.
 const BETA_GROUP = "__beta__";
@@ -322,17 +380,24 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
     node.querySelectorAll("textarea").forEach((el) => {
       el.textContent = (el as HTMLTextAreaElement).value;
     });
-    const canvas = await toCanvas(node, {
-      pixelRatio,
-      backgroundColor: "#0a0a0a",
-      // cacheBust forces a fresh CORS fetch of the CDN art (cached copies
-      // were loaded without an Origin header and would taint the canvas).
-      cacheBust: true,
-      // Drop the per-row "edit" controls / popovers from the image.
-      filter: (n) => !(n instanceof HTMLElement && n.dataset.exportHide === "true"),
-    });
-    // webp is smaller/faster than png and is what we store on the CDN.
-    return canvas.toDataURL("image/webp", 0.92);
+    // Tailwind v4 colors resolve to oklch(), which makes html-to-image render a
+    // blank image; swap them for rgb() for the duration of the capture.
+    const restoreColors = inlineOklchAsRgb(node);
+    try {
+      const canvas = await toCanvas(node, {
+        pixelRatio,
+        backgroundColor: "#0a0a0a",
+        // cacheBust forces a fresh CORS fetch of the CDN art (cached copies
+        // were loaded without an Origin header and would taint the canvas).
+        cacheBust: true,
+        // Drop the per-row "edit" controls / popovers from the image.
+        filter: (n) => !(n instanceof HTMLElement && n.dataset.exportHide === "true"),
+      });
+      // webp is smaller/faster than png and is what we store on the CDN.
+      return canvas.toDataURL("image/webp", 0.92);
+    } finally {
+      restoreColors();
+    }
   }
 
   async function handleExport() {


### PR DESCRIPTION
Two bugs in the tier list maker's export.

## Blank export
The downloaded image came out blank (just the dark background). Cause: `html-to-image` serializes the capture region into an SVG and loads it as an image, and that SVG fails to load when the inlined styles contain `oklch()` colors — which is Tailwind v4's entire default palette (`neutral`, `sky`, `emerald`, the tier colors, etc.). So only the background rendered.

Fix: right before the snapshot, walk the capture region and rewrite every `oklch()` it resolves to into plain `rgb()` (rasterized through a 1x1 canvas, so it's exact sRGB), applied as an inline override and reverted immediately after. No visual change to the live editor; the export now renders.

## Deleted rows still showing
The shared/preview image kept showing old content (deleted rows, etc.) after an edit. The downloaded image is always a fresh live capture, so this was the **saved preview** on R2: the object key is stable per `share_id` and it's served with `s-maxage=3600`, so the CDN kept serving the previous image for up to an hour after a re-save.

Fix: version the stored `image_url` with a hash of the image bytes, so an edited preview gets a new URL (cache miss → fresh) while an identical re-save reuses the same URL (cache hit). The R2 object is still overwritten in place, so no orphaned files.