### PR TITLE
tier list maker: fix the #185 crash and slowdown with many cards

### DIFF
--- a/frontend/app/tier-list-maker/TierListBuilder.tsx
+++ b/frontend/app/tier-list-maker/TierListBuilder.tsx
@@ -14,7 +14,6 @@ import {
   useSensors,
   type CollisionDetection,
   type DragEndEvent,
-  type DragOverEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
 import { SortableContext, arrayMove, rectSortingStrategy } from "@dnd-kit/sortable";
@@ -237,27 +236,12 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
     setActiveId(String(event.active.id));
   }
 
-  function onDragOver(event: DragOverEvent) {
-    const { active, over } = event;
-    if (!over) return;
-    const activeId = String(active.id);
-    const overId = String(over.id);
-    setContainers((prev) => {
-      const ac = findIn(prev, activeId);
-      const oc = findIn(prev, overId);
-      if (!ac || !oc || ac === oc) return prev;
-      const activeItems = prev[ac];
-      const overItems = prev[oc];
-      const insertAt =
-        overId === oc ? overItems.length : Math.max(0, overItems.indexOf(overId));
-      return {
-        ...prev,
-        [ac]: activeItems.filter((i) => i !== activeId),
-        [oc]: [...overItems.slice(0, insertAt), activeId, ...overItems.slice(insertAt)],
-      };
-    });
-  }
-
+  // All container moves happen on drop, not on hover. Moving items between
+  // containers inside onDragOver re-renders the board mid-drag, which shifts the
+  // layout, which fires another onDragOver, which moves again -- an oscillation
+  // that trips React's "maximum update depth" (#185) once the board is large.
+  // The drag overlay already shows what's being dragged, so settling on drop
+  // loses nothing visible and can't loop.
   function onDragEnd(event: DragEndEvent) {
     const { active, over } = event;
     setActiveId(null);
@@ -267,12 +251,26 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
     setContainers((prev) => {
       const ac = findIn(prev, activeId);
       const oc = findIn(prev, overId);
-      if (!ac || !oc || ac !== oc) return prev;
-      const items = prev[ac];
-      const oldIndex = items.indexOf(activeId);
-      const newIndex = overId === oc ? items.length - 1 : items.indexOf(overId);
-      if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) return prev;
-      return { ...prev, [ac]: arrayMove(items, oldIndex, newIndex) };
+      if (!ac || !oc) return prev;
+      if (ac === oc) {
+        // Reorder within the same container.
+        const items = prev[ac];
+        const oldIndex = items.indexOf(activeId);
+        const newIndex =
+          overId === oc ? items.length - 1 : items.indexOf(overId);
+        if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) return prev;
+        return { ...prev, [ac]: arrayMove(items, oldIndex, newIndex) };
+      }
+      // Move across containers, inserting at the drop position.
+      const activeItems = prev[ac];
+      const overItems = prev[oc];
+      const insertAt =
+        overId === oc ? overItems.length : Math.max(0, overItems.indexOf(overId));
+      return {
+        ...prev,
+        [ac]: activeItems.filter((i) => i !== activeId),
+        [oc]: [...overItems.slice(0, insertAt), activeId, ...overItems.slice(insertAt)],
+      };
     });
   }
 
@@ -566,7 +564,6 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
         sensors={sensors}
         collisionDetection={collisionDetection}
         onDragStart={onDragStart}
-        onDragOver={onDragOver}
         onDragEnd={onDragEnd}
       >
         <div

--- a/frontend/app/tier-list-maker/chip.tsx
+++ b/frontend/app/tier-list-maker/chip.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { TierEntity } from "./types";
@@ -8,7 +9,7 @@ import type { TierEntity } from "./types";
  * Used inside sortable items, the drag overlay, and the read-only view.
  * When `commentText` is set the chip shows a styled hover tooltip with the
  * note (rendered outside the clipped art box so it isn't cut off). */
-export function Chip({
+export const Chip = memo(function Chip({
   entity,
   size = 56,
   dragging = false,
@@ -50,6 +51,11 @@ export function Chip({
             src={entity.image}
             alt={entity.name}
             draggable={false}
+            // The card tray renders the whole catalog (~575 full-card images);
+            // lazy + async decode keeps offscreen art from being fetched and
+            // decoded all at once, which was spiking memory until the tab died.
+            loading="lazy"
+            decoding="async"
             className="h-full w-full object-contain"
           />
         ) : (
@@ -88,7 +94,7 @@ export function Chip({
       )}
     </div>
   );
-}
+});
 
 /** Draggable + sortable wrapper around a Chip. A plain click (no drag past the
  * sensor threshold) calls onClick, which the builder uses to open the note


### PR DESCRIPTION
Feedback from the Discord: the tier list maker got slower the more cards went on the board, then threw a React **#185** ("maximum update depth exceeded") and wouldn't let cards be placed at all.

## The crash (#185)
The drag-over handler (`onDragOver`) moved a card into a tier on every hover frame via `setContainers`. Each move re-renders the board, which shifts the layout, which makes the pointer land on a different droppable, which fires `onDragOver` again and moves it back — an oscillation. With big card chips and a full board the layout shifts are large, so it loops fast enough to hit React's max-update-depth guard and crash.

Fix: do all cross-tier moves **on drop** (`onDragEnd`), not on hover. There's already a `DragOverlay` that follows the cursor, so you still see what you're dragging; the card just settles into the tier when you release. Same-container reordering still uses dnd-kit's built-in transform preview. No mid-drag state updates means it can't oscillate.

## The slowdown before it
The card tray renders the whole catalog (~575 cards), each a full card image, and nothing was memoized — so every interaction re-rendered and re-decoded all of them. Memoized the chip (`React.memo`) and added `loading="lazy"` + `decoding="async"` to the art, so offscreen cards aren't fetched/decoded until needed and unaffected chips skip re-render.

Note: this is browser-rendered drag behavior I can't exercise from here — worth a quick test of dragging a bunch of cards onto the board after deploy, but the loop is structurally gone.