### PR TITLE
presence: capture combat vitals, hand, loot, and act route for /live

### DIFF
--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -169,7 +169,9 @@ def _clean_loot(raw) -> dict | None:
     if not isinstance(raw, dict):
         return None
     out: dict = {}
-    if isinstance(raw.get("gold"), (int, float)) and not isinstance(raw.get("gold"), bool):
+    if isinstance(raw.get("gold"), (int, float)) and not isinstance(
+        raw.get("gold"), bool
+    ):
         out["gold"] = int(raw["gold"])
     for cat in ("cards", "relics", "potions"):
         lst = raw.get(cat)

--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -25,6 +25,14 @@ _INT_FIELDS = (
     "ascension",
     "player_count",
     "turn",
+    # Live combat vitals + pile sizes for the spectator combat view; combat-only,
+    # cleared by the transient-unset list below when the mod sends null.
+    "block",
+    "energy",
+    "max_energy",
+    "draw_count",
+    "discard_count",
+    "exhaust_count",
     # Live combat damage (DPS) for the spectator view; absent / null outside a
     # fight, cleared by the transient-unset list below when the mod sends null.
     "damage_dealt",
@@ -33,7 +41,9 @@ _INT_FIELDS = (
     "biggest_hit",
 )
 _STR_FIELDS = ("character", "seed", "screen", "sts2_version", "username")
-_LIST_CAPS = {"deck": 200, "relics": 100, "potions": 10, "fighting": 8}
+# `hand` is the live combat hand (card ids); combat-only, so it's in the
+# transient-unset list below too.
+_LIST_CAPS = {"deck": 200, "relics": 100, "potions": 10, "fighting": 8, "hand": 12}
 
 
 def _safe_id(s: str) -> bool:
@@ -108,6 +118,73 @@ def _clean_map(raw) -> dict | None:
     ):
         out["act"] = int(raw["act"])
     return out
+
+
+# Route (the act's structure) + loot (the combat/reward screen). Route persists
+# per act like the map; loot is transient, cleared when the player leaves the
+# reward screen.
+_LOOT_CAP = 20
+_ROUTE_CAP = 30
+
+
+def _route_node(o) -> dict | None:
+    """One route entry (boss / ancient / an elite/monster/event). Keeps the id
+    plus optional name/room_type and grid position, when the mod sends them."""
+    if not isinstance(o, dict):
+        return None
+    out: dict = {}
+    for key in ("id", "name", "room_type"):
+        v = o.get(key)
+        if isinstance(v, str) and v:
+            out[key] = v[:_MAX_STR]
+    for key in ("col", "row", "floor"):
+        v = o.get(key)
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            out[key] = int(v)
+    return out or None
+
+
+def _clean_route(raw) -> dict | None:
+    """The act's route: the boss + ancient (single nodes) and the elite / monster
+    / event nodes. Persists between beats (the $set keeps it until the act changes)."""
+    if not isinstance(raw, dict):
+        return None
+    out: dict = {}
+    for single in ("boss", "ancient"):
+        node = _route_node(raw.get(single))
+        if node:
+            out[single] = node
+    for key in ("elites", "monsters", "events"):
+        lst = raw.get(key)
+        if isinstance(lst, list):
+            nodes = [n for n in (_route_node(o) for o in lst[:_ROUTE_CAP]) if n]
+            if nodes:
+                out[key] = nodes
+    return out or None
+
+
+def _clean_loot(raw) -> dict | None:
+    """The combat/reward-screen loot: gold plus the card / relic / potion ids on
+    offer, and whether card removal is available."""
+    if not isinstance(raw, dict):
+        return None
+    out: dict = {}
+    if isinstance(raw.get("gold"), (int, float)) and not isinstance(raw.get("gold"), bool):
+        out["gold"] = int(raw["gold"])
+    for cat in ("cards", "relics", "potions"):
+        lst = raw.get(cat)
+        if isinstance(lst, list):
+            out[cat] = [
+                s
+                for x in lst[:_LOOT_CAP]
+                if isinstance(x, (str, int)) and _safe_id(s := str(x)[:_MAX_STR])
+            ]
+    cr = raw.get("card_removal")
+    if isinstance(cr, bool):
+        out["card_removal"] = cr
+    elif isinstance(cr, (int, float)):
+        out["card_removal"] = int(cr)
+    return out or None
 
 
 # Current-screen spectator detail: the live event (name/prompt/options) and the shop
@@ -350,10 +427,16 @@ async def post_presence(request: Request):
         fields["shop"] = shp
     if (en := _clean_enemies(data.get("enemies"))) is not None:
         fields["enemies"] = en
+    # The act's route persists between beats (like the map); loot is per-screen.
+    if (rt := _clean_route(data.get("route"))) is not None:
+        fields["route"] = rt
+    if (lt := _clean_loot(data.get("loot"))) is not None:
+        fields["loot"] = lt
 
     # Transient fields: when the mod sends these as explicit null (combat ended / left the
     # screen), clear them rather than leaving stale values. pos is NOT in this set on
-    # purpose: keeping the last node avoids a blinking map marker between nodes.
+    # purpose: keeping the last node avoids a blinking map marker between nodes. route is
+    # NOT here either: it's act-scoped and persists until the next act overwrites it.
     unset = [
         k
         for k in (
@@ -362,6 +445,14 @@ async def post_presence(request: Request):
             "event",
             "shop",
             "enemies",
+            "hand",
+            "loot",
+            "block",
+            "energy",
+            "max_energy",
+            "draw_count",
+            "discard_count",
+            "exhaust_count",
             "damage_dealt",
             "damage_dealt_this_turn",
             "damage_taken",

--- a/markdown-docs/live-presence.md
+++ b/markdown-docs/live-presence.md
@@ -50,6 +50,18 @@ Combat context (v2, absent between fights):
 - `turn`: the combat round number
 - `fighting`: bare ids of the living enemies, e.g. `["GREMLIN_NOB"]` (kept for the
   lightweight roster chip)
+- `block`, `energy`, `max_energy`: the local player's current block and energy
+- `draw_count`, `discard_count`, `exhaust_count`: pile sizes
+- `hand`: card ids in the current hand, e.g. `["STRIKE", "DEFEND+"]`
+- `damage_dealt`, `damage_dealt_this_turn`, `damage_taken`, `biggest_hit`: live DPS
+
+`loot` (v6, present on the combat/reward screen, transient): the rewards on offer —
+`{gold, cards: [ids], relics: [ids], potions: [ids], card_removal}` (`card_removal`
+is a bool/count for the removal option).
+
+`route` (v6, the act's structure, persists per act like the map): `{boss, ancient,
+elites: [], monsters: [], events: []}`. Each node is `{id, name?, room_type?}` plus
+`col`/`row`/`floor` when the mod sends a position, so a node can be matched to the map.
 
 Rich combat enemies (v5, absent between fights): `enemies` is the per-player combat
 panel data, each enemy carrying hp/block and its upcoming intent(s):


### PR DESCRIPTION
First half of the /live catch-up. The mod is already sending far more than the page renders — boss/route, shop bought-state, buy events, hand, loot, pile counts, and (just added) block/energy. The reason /live only shows a fraction is the server-side whitelist in `presence.py`, which silently drops anything not explicitly captured.

This widens that whitelist:
- **ints:** `block`, `energy`, `max_energy`, `draw_count`, `discard_count`, `exhaust_count` — combat-only, added to the transient-unset list so they clear when the fight ends (like the existing damage fields).
- **`hand`:** combat card ids (added to the list whitelist + the transient set).
- **`loot`:** new `_clean_loot` — `{gold, cards, relics, potions, card_removal}`, transient per screen.
- **`route`:** new `_clean_route` — `{boss, ancient, elites[], monsters[], events[]}`, each node `{id, name?, room_type?}` plus `col`/`row`/`floor` when present. Persists per act like the map (not in the transient set).

Cleaners validate/cap like the existing ones, and fail closed on bad shapes. `GET /api/presence/{steam_id}` returns the full doc, so these flow to the API as soon as they're captured. Contract doc updated.

The frontend rendering (boss display, shop bought-state, buy/choice in the ticker, loot, hand, combat vitals, map node history from `route`) is the follow-up PR — I'll verify the real `route`/`loot` shapes against the live payload once this is deployed, then wire the UI to match.