### PR TITLE
live: render combat vitals, DPS, powers, hand, run timer, modifiers

### DIFF
--- a/frontend/app/live/LiveEventShop.tsx
+++ b/frontend/app/live/LiveEventShop.tsx
@@ -24,6 +24,7 @@ import {
   safeId,
   withOrdinalKeys,
   type LiveEventCtx,
+  type LiveLoot,
   type LiveShop,
   type ShopItem,
 } from "./live-shared";
@@ -228,6 +229,92 @@ export function LiveShopPanel({
           ) : (
             <Gold cost={removal.cost} />
           )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** The combat/reward-screen loot: the gold and card/relic/potion rewards on
+ * offer, plus whether card removal is available. Each item links to its page. */
+export function LiveLootPanel({
+  loot,
+  cards,
+  relics,
+  potions,
+  lp,
+}: {
+  loot: LiveLoot;
+  cards: Record<string, CardInfo>;
+  relics: Record<string, RelicInfo>;
+  potions: Record<string, PotionInfo>;
+  lp: string;
+}) {
+  const cardIds = loot.cards ?? [];
+  const relicIds = loot.relics ?? [];
+  const potionIds = loot.potions ?? [];
+  const hasGold = loot.gold != null && loot.gold > 0;
+  const removal = !!loot.card_removal;
+  if (
+    !cardIds.length &&
+    !relicIds.length &&
+    !potionIds.length &&
+    !hasGold &&
+    !removal
+  ) {
+    return null;
+  }
+  const row = "flex items-center gap-2 text-sm text-[var(--text-secondary)]";
+  return (
+    <div className="rounded-lg border border-amber-900/50 bg-amber-950/20 p-4">
+      <div className="mb-2 flex items-center gap-2">
+        <span className="text-[10px] font-bold uppercase tracking-wider text-amber-300">
+          Rewards
+        </span>
+        {hasGold && (
+          <span className="text-sm font-semibold tabular-nums text-[var(--accent-gold)]">
+            {loot.gold}g
+          </span>
+        )}
+      </div>
+      {(cardIds.length > 0 || relicIds.length > 0 || potionIds.length > 0) && (
+        <ul className="space-y-1.5">
+          {withOrdinalKeys(cardIds).map(({ item, key }) => {
+            const { id, upgraded } = parseDeckId(item);
+            return (
+              <li key={`c-${key}`} className={row}>
+                <CardPill cardId={id} upgraded={upgraded} cardData={cards} lp={lp} className="truncate">
+                  {cards[id]?.name || displayName(`CARD.${id}`)}
+                  {upgraded ? "+" : ""}
+                </CardPill>
+              </li>
+            );
+          })}
+          {withOrdinalKeys(relicIds).map(({ item, key }) => {
+            const id = cleanId(item);
+            return (
+              <li key={`r-${key}`} className={row}>
+                <RelicPill relicId={id} relicData={relics} lp={lp} className="truncate">
+                  {relics[id]?.name || displayName(`RELIC.${id}`)}
+                </RelicPill>
+              </li>
+            );
+          })}
+          {withOrdinalKeys(potionIds).map(({ item, key }) => {
+            const id = cleanId(item);
+            return (
+              <li key={`p-${key}`} className={row}>
+                <PotionPill potionId={id} potionData={potions} lp={lp} className="truncate">
+                  {potions[id]?.name || displayName(`POTION.${id}`)}
+                </PotionPill>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      {removal && (
+        <div className="mt-2 text-xs text-[var(--text-muted)]">
+          Card removal available
         </div>
       )}
     </div>

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -15,7 +15,7 @@ import { useLanguage } from "@/app/contexts/LanguageContext";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { imageUrl, fullCardUrl } from "@/lib/image-url";
 import LiveMap from "../LiveMap";
-import { LiveEventPanel, LiveShopPanel } from "../LiveEventShop";
+import { LiveEventPanel, LiveLootPanel, LiveShopPanel } from "../LiveEventShop";
 import {
   CardPill,
   PotionPill,
@@ -42,6 +42,9 @@ import {
   withOrdinalKeys,
   type LiveEvent,
   type LivePlayer,
+  type LiveRoute,
+  type LiveRouteNode,
+  type LiveSeat,
   type MonsterMap,
 } from "../live-shared";
 
@@ -379,6 +382,130 @@ function LiveCombatPanel({
   );
 }
 
+/** Co-op partner cards: one compact card per seat with vitals, the local seat
+ * highlighted and dead seats dimmed. Only shown when 2+ players are in the run. */
+function LiveCoopPanel({ players }: { players: LiveSeat[] }) {
+  if (!players.length) return null;
+  return (
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+      <h2 className="mb-2 text-sm font-semibold text-[var(--accent-gold)]">Party</h2>
+      <div className="space-y-2">
+        {players.map((s, i) => {
+          const hpPct =
+            s.hp != null && s.max_hp
+              ? Math.max(0, Math.min(100, (s.hp / s.max_hp) * 100))
+              : null;
+          return (
+            <div
+              key={i}
+              className={`flex items-center gap-3 rounded-md border px-2.5 py-2 ${
+                s.is_me
+                  ? "border-[var(--accent-gold)]/40 bg-[var(--accent-gold)]/5"
+                  : "border-[var(--border-subtle)] bg-[var(--bg-primary)]"
+              } ${s.alive === false ? "opacity-50" : ""}`}
+            >
+              <CharacterIcon character={s.character} className="h-9 w-9 shrink-0" />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 text-sm">
+                  <span className="truncate text-[var(--text-secondary)]">
+                    {displayName(`CHARACTER.${s.character ?? ""}`)}
+                  </span>
+                  {s.is_me && (
+                    <span className="rounded bg-[var(--accent-gold)]/20 px-1 text-[9px] font-bold uppercase text-[var(--accent-gold)]">
+                      you
+                    </span>
+                  )}
+                  {s.alive === false && (
+                    <span className="text-[10px] text-rose-400">dead</span>
+                  )}
+                </div>
+                {hpPct != null && (
+                  <div className="mt-1 h-1.5 rounded bg-[var(--bg-card)]">
+                    <div
+                      className="h-1.5 rounded bg-rose-500"
+                      style={{ width: `${hpPct}%` }}
+                    />
+                  </div>
+                )}
+                <div className="mt-1 flex flex-wrap gap-x-3 text-[10px] tabular-nums text-[var(--text-muted)]">
+                  {s.hp != null && (
+                    <span>
+                      {s.hp}/{s.max_hp} HP
+                    </span>
+                  )}
+                  {(s.block ?? 0) > 0 && (
+                    <span className="text-sky-300">Block {s.block}</span>
+                  )}
+                  {s.gold != null && <span>{s.gold}g</span>}
+                  {s.deck_size != null && <span>{s.deck_size} cards</span>}
+                  {s.relic_count != null && <span>{s.relic_count} relics</span>}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function RouteNodeChip({ node }: { node: LiveRouteNode }) {
+  const label = node.name || (node.id ? displayName(node.id) : "?");
+  return (
+    <span
+      title={node.room_type || undefined}
+      className="rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)]"
+    >
+      {label}
+    </span>
+  );
+}
+
+/** Act route preview: the boss, ancient, and the elite/monster/event nodes the
+ * mod surfaced for the current act. Complements the mini-map. */
+function LiveRoutePanel({
+  route,
+  act,
+  actName,
+  actFloor,
+}: {
+  route: LiveRoute;
+  act?: number | null;
+  actName?: string | null;
+  actFloor?: number | null;
+}) {
+  const groups: [string, LiveRouteNode[]][] = [];
+  if (route.boss) groups.push(["Boss", [route.boss]]);
+  if (route.ancient) groups.push(["Ancient", [route.ancient]]);
+  if (route.elites?.length) groups.push(["Elites", route.elites]);
+  if (route.monsters?.length) groups.push(["Monsters", route.monsters]);
+  if (route.events?.length) groups.push(["Events", route.events]);
+  if (!groups.length) return null;
+  const heading = actName || (act != null ? `Act ${act}` : "Route");
+  return (
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+      <h2 className="mb-2 text-sm font-semibold text-[var(--accent-gold)]">
+        Route · {heading}
+        {actFloor != null ? ` · F${actFloor}` : ""}
+      </h2>
+      <div className="space-y-2">
+        {groups.map(([label, nodes]) => (
+          <div key={label}>
+            <div className="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
+              {label}
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {nodes.map((n, i) => (
+                <RouteNodeChip key={(n.id || "") + i} node={n} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function LivePlayerClient() {
   const params = useParams<{ steamId: string }>();
   const steamId = (params?.steamId ?? "").replace(/\D/g, "");
@@ -511,7 +638,7 @@ export default function LivePlayerClient() {
 
   // Whether there's a current-screen panel (combat enemies / event / shop) to
   // sit beside the player; when there isn't, the player spans the full width.
-  const hasContext = hasEnemies || !!p.event || !!p.shop;
+  const hasContext = hasEnemies || !!p.event || !!p.shop || !!p.loot;
 
   return (
     <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -638,6 +765,15 @@ export default function LivePlayerClient() {
                     potions={cat.potions}
                     lp={lp}
                     lang={lang}
+                  />
+                )}
+                {p.loot && (
+                  <LiveLootPanel
+                    loot={p.loot}
+                    cards={cat.cards}
+                    relics={cat.relics}
+                    potions={cat.potions}
+                    lp={lp}
                   />
                 )}
               </div>
@@ -781,6 +917,16 @@ export default function LivePlayerClient() {
                 })}
               </div>
             </div>
+          )}
+
+          {(p.players?.length ?? 0) > 0 && <LiveCoopPanel players={p.players!} />}
+          {p.route && (
+            <LiveRoutePanel
+              route={p.route}
+              act={p.act}
+              actName={p.act_name}
+              actFloor={p.act_floor}
+            />
           )}
 
           {p.sts2_version && (

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -275,6 +275,110 @@ function TickerRow({
   );
 }
 
+/** Live combat detail: the DPS meter, the local player's powers, the current
+ * hand, and the pile counts. Each row renders only when its field is present, so
+ * the panel collapses to nothing outside combat. */
+function LiveCombatPanel({
+  p,
+  cat,
+  lp,
+  lang,
+}: {
+  p: LivePlayer;
+  cat: Catalogs;
+  lp: string;
+  lang: string;
+}) {
+  const dmg: [string, number | null | undefined][] = [
+    ["Dealt", p.damage_dealt],
+    ["This turn", p.damage_dealt_this_turn],
+    ["Taken", p.damage_taken],
+    ["Biggest hit", p.biggest_hit],
+  ];
+  const shownDmg = dmg.filter(([, v]) => v != null);
+  const piles: [string, number | null | undefined][] = [
+    ["Draw", p.draw_count],
+    ["Discard", p.discard_count],
+    ["Exhaust", p.exhaust_count],
+  ];
+  const shownPiles = piles.filter(([, v]) => v != null);
+  const powers = p.player_powers ?? [];
+  const hand = p.hand ?? [];
+  if (!shownDmg.length && !shownPiles.length && !powers.length && !hand.length) {
+    return null;
+  }
+  return (
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+      <h2 className="mb-2 text-sm font-semibold text-[var(--accent-gold)]">Combat</h2>
+      {powers.length > 0 && (
+        <div className="mb-3 flex flex-wrap gap-1">
+          {powers.map((pw) => (
+            <span
+              key={pw.id}
+              title={displayName(pw.id)}
+              className="rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-1.5 py-0.5 text-[10px] tabular-nums text-[var(--text-secondary)]"
+            >
+              {displayName(pw.id)}
+              {pw.amount != null && pw.amount !== 0 ? ` ${pw.amount}` : ""}
+            </span>
+          ))}
+        </div>
+      )}
+      {shownDmg.length > 0 && (
+        <div className="mb-3 grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+          {shownDmg.map(([label, v]) => (
+            <div key={label} className="flex justify-between">
+              <span className="text-[var(--text-muted)]">{label}</span>
+              <span className="font-medium tabular-nums text-[var(--text-secondary)]">
+                {v}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+      {hand.length > 0 && (
+        <div className="mb-2">
+          <div className="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
+            Hand ({hand.length})
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {withOrdinalKeys(hand).map(({ item, key }) => {
+              const { id, upgraded } = parseDeckId(item);
+              return (
+                <CardPill
+                  key={key}
+                  cardId={id}
+                  upgraded={upgraded}
+                  cardData={cat.cards}
+                  lp={lp}
+                  className="relative block w-12 shrink-0"
+                >
+                  <img
+                    src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                    alt={cat.cards[id]?.name || displayName(`CARD.${id}`)}
+                    className="h-auto w-12 rounded-sm"
+                    crossOrigin="anonymous"
+                    loading="lazy"
+                  />
+                </CardPill>
+              );
+            })}
+          </div>
+        </div>
+      )}
+      {shownPiles.length > 0 && (
+        <div className="flex gap-3 text-xs tabular-nums text-[var(--text-muted)]">
+          {shownPiles.map(([label, v]) => (
+            <span key={label}>
+              {label} {v}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function LivePlayerClient() {
   const params = useParams<{ steamId: string }>();
   const steamId = (params?.steamId ?? "").replace(/\D/g, "");
@@ -453,8 +557,25 @@ export default function LivePlayerClient() {
                 {displayName(`CHARACTER.${p.character ?? ""}`)}
                 {p.screen ? ` · ${p.screen}` : ""}
                 {p.started_at ? ` · climbing for ${elapsed(p.started_at)}` : ""}
+                {p.run_time != null
+                  ? ` · run ${Math.floor(p.run_time / 60)}:${String(
+                      Math.floor(p.run_time % 60),
+                    ).padStart(2, "0")}`
+                  : ""}
                 {p.seed ? ` · seed ${p.seed}` : ""}
               </div>
+              {(p.modifiers?.length ?? 0) > 0 && (
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {p.modifiers!.map((m) => (
+                    <span
+                      key={m}
+                      className="px-1.5 py-0.5 rounded text-[10px] bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-muted)]"
+                    >
+                      {displayName(m)}
+                    </span>
+                  ))}
+                </div>
+              )}
               {p.twitch_live && p.twitch_login && (
                 <div className="mt-2">
                   <WatchOnTwitch login={p.twitch_login} viewers={p.twitch_viewers} />
@@ -485,6 +606,21 @@ export default function LivePlayerClient() {
               </div>
             </div>
           )}
+          {((p.block ?? 0) > 0 || p.energy != null) && (
+            <div className="mt-2 flex items-center gap-3 text-xs tabular-nums">
+              {(p.block ?? 0) > 0 && (
+                <span className="text-sky-300" title="Block">
+                  Block {p.block}
+                </span>
+              )}
+              {p.energy != null && (
+                <span className="text-[var(--accent-gold)]" title="Energy">
+                  Energy {p.energy}
+                  {p.max_energy != null ? `/${p.max_energy}` : ""}
+                </span>
+              )}
+            </div>
+          )}
         </div>
 
             {/* Current-screen panels (combat enemies, event reader, shop), each
@@ -492,6 +628,7 @@ export default function LivePlayerClient() {
             {hasContext && (
               <div className="space-y-4">
                 {hasEnemies && <LiveEnemiesPanel p={p} monsters={monsters} />}
+                <LiveCombatPanel p={p} cat={cat} lp={lp} lang={lang} />
                 {p.event && <LiveEventPanel ev={p.event} lp={lp} />}
                 {p.shop && (
                   <LiveShopPanel

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -83,6 +83,55 @@ export interface Enemy {
   intents?: EnemyIntent[];
 }
 
+/** A combat buff/debuff on the local player (v6): id + stack amount. */
+export interface LivePower {
+  id: string;
+  amount?: number;
+}
+
+/** One route node (v6): a boss/ancient/elite/monster/event in the act, with an
+ * optional grid position so it can be matched to the map graph. */
+export interface LiveRouteNode {
+  id?: string;
+  name?: string;
+  room_type?: string;
+  col?: number;
+  row?: number;
+  floor?: number;
+}
+
+/** The act's route (v6): the boss + ancient and the elite/monster/event nodes. */
+export interface LiveRoute {
+  boss?: LiveRouteNode;
+  ancient?: LiveRouteNode;
+  elites?: LiveRouteNode[];
+  monsters?: LiveRouteNode[];
+  events?: LiveRouteNode[];
+}
+
+/** Combat / reward-screen loot on offer (v6). */
+export interface LiveLoot {
+  gold?: number | null;
+  cards?: string[];
+  relics?: string[];
+  potions?: string[];
+  card_removal?: boolean | number;
+}
+
+/** Co-op per-seat vitals (v6); `is_me` marks the local player's seat. */
+export interface LiveSeat {
+  character?: string | null;
+  hp?: number;
+  max_hp?: number;
+  block?: number;
+  gold?: number;
+  alive?: boolean;
+  deck_size?: number;
+  relic_count?: number;
+  potion_count?: number;
+  is_me?: boolean;
+}
+
 export interface LivePlayer {
   steam_id: string;
   username?: string | null;
@@ -112,6 +161,27 @@ export interface LivePlayer {
   event?: LiveEventCtx | null;
   shop?: LiveShop | null;
   enemies?: Enemy[] | null;
+  // Combat vitals + DPS (v6). `block`/`max_energy` ride the whole run; `energy`,
+  // the pile counts, damage, hand, and player_powers are combat-only. See
+  // markdown-docs/live-presence.md.
+  block?: number | null;
+  energy?: number | null;
+  max_energy?: number | null;
+  draw_count?: number | null;
+  discard_count?: number | null;
+  exhaust_count?: number | null;
+  damage_dealt?: number | null;
+  damage_dealt_this_turn?: number | null;
+  damage_taken?: number | null;
+  biggest_hit?: number | null;
+  hand?: string[];
+  player_powers?: LivePower[];
+  loot?: LiveLoot | null;
+  route?: LiveRoute | null;
+  players?: LiveSeat[];
+  run_time?: number | null;
+  modifiers?: string[];
+  act_name?: string | null;
   // Twitch enrichment from /api/presence (only when the player linked Twitch):
   // their channel, whether they are streaming right now, viewer count, and the
   // curated-partner flag. All optional and absent until the backend attaches them.


### PR DESCRIPTION
Part 3 (frontend) of the live-fields handoff — renders the per-player detail the mod has been sending and the backend (#534) newly captures.

## What's rendered (per-player `/live/[steamId]` view)
- **Block + energy** under the HP bar.
- **Run timer** (`run_time`, the in-game clock, distinct from wall-clock "climbing for") and **modifiers** (daily/custom mutators) in the header.
- **Combat panel** (collapses to nothing outside combat):
  - DPS meter — `damage_dealt` / `damage_dealt_this_turn` / `damage_taken` / `biggest_hit`
  - `player_powers` as buff/debuff chips (id + stacks)
  - the current `hand` as card pills (resolves to art, `+` = upgraded)
  - `draw_count` / `discard_count` / `exhaust_count` pile sizes

Every row is gated on its own field, so a sparse/non-combat beat just shows nothing.

## Dependency / sequencing
The new fields only flow once **#534** (the backend whitelist) is deployed; until then these render inert (no errors — defensive). The already-existing fields (HP, deck, event options incl. the `chosen` flag, shop) are unaffected.

## Not in here (next chunk)
- Co-op partner cards from `players[]` (`is_me` highlight)
- A route preview from `route{boss, ancient, monsters, elites, events}` + `act_name`/`act_floor`
- A loot panel from `loot{...}`

These are more layout-heavy; I'll do them as a focused follow-up. **Worth a browser test after #534 deploys** — I can't exercise the live render from here.