### PR TITLE
presence: finish the live-field capture (powers, co-op, run_time, modifiers, act_name)

### DIFF
--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -40,7 +40,7 @@ _INT_FIELDS = (
     "damage_taken",
     "biggest_hit",
 )
-_STR_FIELDS = ("character", "seed", "screen", "sts2_version", "username")
+_STR_FIELDS = ("character", "seed", "screen", "sts2_version", "username", "act_name")
 # `hand` is the live combat hand (card ids); combat-only, so it's in the
 # transient-unset list below too.
 _LIST_CAPS = {"deck": 200, "relics": 100, "potions": 10, "fighting": 8, "hand": 12}

--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -25,8 +25,11 @@ _INT_FIELDS = (
     "ascension",
     "player_count",
     "turn",
-    # Live combat vitals + pile sizes for the spectator combat view; combat-only,
-    # cleared by the transient-unset list below when the mod sends null.
+    # Run timer in seconds (freezes at win); present the whole run, not unset.
+    "run_time",
+    # Live combat vitals + pile sizes for the spectator combat view. `energy` and
+    # the pile counts are combat-only (cleared by the transient-unset list below);
+    # `block`/`max_energy` are sent the whole run, so they are NOT unset.
     "block",
     "energy",
     "max_energy",
@@ -42,8 +45,16 @@ _INT_FIELDS = (
 )
 _STR_FIELDS = ("character", "seed", "screen", "sts2_version", "username", "act_name")
 # `hand` is the live combat hand (card ids); combat-only, so it's in the
-# transient-unset list below too.
-_LIST_CAPS = {"deck": 200, "relics": 100, "potions": 10, "fighting": 8, "hand": 12}
+# transient-unset list below. `modifiers` are the run's daily/custom mutators —
+# valid the whole run, so NOT unset.
+_LIST_CAPS = {
+    "deck": 200,
+    "relics": 100,
+    "potions": 10,
+    "fighting": 8,
+    "hand": 20,
+    "modifiers": 20,
+}
 
 
 def _safe_id(s: str) -> bool:
@@ -187,6 +198,58 @@ def _clean_loot(raw) -> dict | None:
     elif isinstance(cr, (int, float)):
         out["card_removal"] = int(cr)
     return out or None
+
+
+_POWERS_CAP = 40
+_COOP_CAP = 4
+
+
+def _as_int(v) -> int:
+    """Coerce a heartbeat number to int; missing / non-numeric -> 0."""
+    return int(v) if isinstance(v, (int, float)) and not isinstance(v, bool) else 0
+
+
+def _clean_powers(raw) -> list[dict] | None:
+    """The local player's combat buffs/debuffs as [{id, amount}]. An empty list
+    is meaningful (in combat, no powers); only None means absent this beat, so
+    it's in the transient-unset set."""
+    if not isinstance(raw, list):
+        return None
+    out: list[dict] = []
+    for p in raw[:_POWERS_CAP]:
+        if not isinstance(p, dict):
+            continue
+        pid = p.get("id")
+        if isinstance(pid, str) and pid:
+            out.append({"id": pid[:_MAX_STR], "amount": _as_int(p.get("amount"))})
+    return out
+
+
+def _clean_players(raw) -> list[dict] | None:
+    """Co-op per-seat vitals; the mod sends this only with 2+ players. `is_me`
+    marks the local seat so the frontend can highlight it."""
+    if not isinstance(raw, list):
+        return None
+    out: list[dict] = []
+    for p in raw[:_COOP_CAP]:
+        if not isinstance(p, dict):
+            continue
+        ch = p.get("character")
+        out.append(
+            {
+                "character": ch[:_MAX_STR] if isinstance(ch, str) and ch else None,
+                "hp": _as_int(p.get("hp")),
+                "max_hp": _as_int(p.get("max_hp")),
+                "block": _as_int(p.get("block")),
+                "gold": _as_int(p.get("gold")),
+                "alive": bool(p.get("alive")),
+                "deck_size": _as_int(p.get("deck_size")),
+                "relic_count": _as_int(p.get("relic_count")),
+                "potion_count": _as_int(p.get("potion_count")),
+                "is_me": bool(p.get("is_me")),
+            }
+        )
+    return out
 
 
 # Current-screen spectator detail: the live event (name/prompt/options) and the shop
@@ -434,11 +497,17 @@ async def post_presence(request: Request):
         fields["route"] = rt
     if (lt := _clean_loot(data.get("loot"))) is not None:
         fields["loot"] = lt
+    # Local player's combat powers ([] is meaningful) + co-op per-seat vitals.
+    if (pw := _clean_powers(data.get("player_powers"))) is not None:
+        fields["player_powers"] = pw
+    if (pls := _clean_players(data.get("players"))) is not None:
+        fields["players"] = pls
 
     # Transient fields: when the mod sends these as explicit null (combat ended / left the
     # screen), clear them rather than leaving stale values. pos is NOT in this set on
     # purpose: keeping the last node avoids a blinking map marker between nodes. route is
     # NOT here either: it's act-scoped and persists until the next act overwrites it.
+    # block / max_energy / run_time / modifiers are sent the whole run, so NOT unset.
     unset = [
         k
         for k in (
@@ -449,12 +518,11 @@ async def post_presence(request: Request):
             "enemies",
             "hand",
             "loot",
-            "block",
             "energy",
-            "max_energy",
             "draw_count",
             "discard_count",
             "exhaust_count",
+            "player_powers",
             "damage_dealt",
             "damage_dealt_this_turn",
             "damage_taken",

--- a/backend/app/services/presence_db.py
+++ b/backend/app/services/presence_db.py
@@ -78,9 +78,11 @@ def end(steam_id: str) -> None:
 
 def active(limit: int = 50) -> list[dict]:
     """Fresh live players, deepest run first. Excludes the heavy per-run detail
-    (deck/relics/potions, the event window, and the map node/edge graph): the
+    (deck/relics/potions, the event window, the map node/edge graph, the combat
+    hand, the act route, loot, co-op seats, and the local player's powers): the
     per-player endpoint serves those for the live run view. Keeps path/pos so the
-    roster can show a player's position on a mini progress indicator."""
+    roster can show a player's position on a mini progress indicator. The light
+    scalars (run_time/block/energy/damage/pile counts) stay for a richer card."""
     cutoff = datetime.now(timezone.utc) - timedelta(seconds=PRESENCE_TTL_SECONDS)
     docs = (
         _presence_coll()
@@ -95,6 +97,11 @@ def active(limit: int = 50) -> list[dict]:
                 "event": 0,
                 "shop": 0,
                 "enemies": 0,
+                "hand": 0,
+                "route": 0,
+                "loot": 0,
+                "players": 0,
+                "player_powers": 0,
             },
         )
         .sort([("total_floor", -1), ("updated_at", -1)])

--- a/markdown-docs/live-presence.md
+++ b/markdown-docs/live-presence.md
@@ -51,9 +51,19 @@ Combat context (v2, absent between fights):
 - `fighting`: bare ids of the living enemies, e.g. `["GREMLIN_NOB"]` (kept for the
   lightweight roster chip)
 - `block`, `energy`, `max_energy`: the local player's current block and energy
-- `draw_count`, `discard_count`, `exhaust_count`: pile sizes
-- `hand`: card ids in the current hand, e.g. `["STRIKE", "DEFEND+"]`
+  (`block`/`max_energy` are sent the whole run; `energy` is combat-only)
+- `draw_count`, `discard_count`, `exhaust_count`: pile sizes (combat-only)
+- `hand`: card ids in the current hand, e.g. `["STRIKE", "DEFEND+"]` (combat-only)
 - `damage_dealt`, `damage_dealt_this_turn`, `damage_taken`, `biggest_hit`: live DPS
+- `player_powers`: the local player's combat buffs/debuffs as `[{id, amount}]`
+  (combat-only; `[]` means "in combat, no powers")
+- `run_time`: elapsed run seconds (freezes at win); present the whole run, distinct
+  from the wall-clock `started_at`
+- `modifiers`: bare ids of the run's daily/custom mutators (whole run)
+
+Co-op only (sent when `player_count > 1`): `players` is the per-seat vitals,
+`[{character, hp, max_hp, block, gold, alive, deck_size, relic_count, potion_count,
+is_me}]`; `is_me` marks the local seat.
 
 `loot` (v6, present on the combat/reward screen, transient): the rewards on offer —
 `{gold, cards: [ids], relics: [ids], potions: [ids], card_removal}` (`card_removal`


### PR DESCRIPTION
#534 merged at its first pass (block/energy/pile counts/hand/loot/route). The follow-up commits that completed the capture per the handoff doc didn't make that merge, so they're missing from main — and the frontend (#535) renders them. This brings them in:

- **`player_powers`** `[{id, amount}]` — the local player's combat buffs/debuffs
- **`players[]`** — co-op per-seat vitals (`is_me` marks the local seat)
- **`run_time`** and **`modifiers`** — whole-run fields (not in the transient-unset set)
- **`act_name`** — for the route preview header
- **Unset-list fix** — `block`/`max_energy` are sent all run, so they're no longer cleared off-combat (only `energy`/pile counts/hand/loot/powers/damage are transient)
- **Roster strip** — `active()` drops the heavy per-player detail (hand/route/loot/players/player_powers) so the public list stays small
- Contract doc updated

Cherry-picked from the now-merged #534 branch; `ruff format`/`ruff check`/compile all clean. Pairs with #535 (the frontend render).