### PR TITLE
live: reland the #537 polish + relic/ancient/loot ticker (orphaned by a stacked merge)

### DIFF
--- a/frontend/app/live/LiveEventShop.tsx
+++ b/frontend/app/live/LiveEventShop.tsx
@@ -235,20 +235,23 @@ export function LiveShopPanel({
   );
 }
 
-/** The combat/reward-screen loot: the gold and card/relic/potion rewards on
- * offer, plus whether card removal is available. Each item links to its page. */
+/** The combat/reward-screen loot: gold plus the cards (full renders), relics,
+ * and potions on offer, each with the run-page hover tooltip. Potions on top,
+ * cards + relics below. */
 export function LiveLootPanel({
   loot,
   cards,
   relics,
   potions,
   lp,
+  lang,
 }: {
   loot: LiveLoot;
   cards: Record<string, CardInfo>;
   relics: Record<string, RelicInfo>;
   potions: Record<string, PotionInfo>;
   lp: string;
+  lang: string;
 }) {
   const cardIds = loot.cards ?? [];
   const relicIds = loot.relics ?? [];
@@ -264,7 +267,6 @@ export function LiveLootPanel({
   ) {
     return null;
   }
-  const row = "flex items-center gap-2 text-sm text-[var(--text-secondary)]";
   return (
     <div className="rounded-lg border border-amber-900/50 bg-amber-950/20 p-4">
       <div className="mb-2 flex items-center gap-2">
@@ -277,40 +279,94 @@ export function LiveLootPanel({
           </span>
         )}
       </div>
-      {(cardIds.length > 0 || relicIds.length > 0 || potionIds.length > 0) && (
-        <ul className="space-y-1.5">
+      {potionIds.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-1.5">
+          {withOrdinalKeys(potionIds).map(({ item, key }) => {
+            const id = cleanId(item);
+            const info = potions[id];
+            return (
+              <PotionPill
+                key={`p-${key}`}
+                potionId={id}
+                potionData={potions}
+                lp={lp}
+                className="block shrink-0"
+              >
+                {info?.image_url ? (
+                  <img
+                    src={imageUrl(info.image_url)}
+                    alt={info.name}
+                    className="h-9 w-9 object-contain"
+                    crossOrigin="anonymous"
+                    loading="lazy"
+                    onError={(e) => {
+                      (e.target as HTMLImageElement).style.display = "none";
+                    }}
+                  />
+                ) : (
+                  <span className="text-xs text-[var(--text-secondary)]">
+                    {displayName(`POTION.${id}`)}
+                  </span>
+                )}
+              </PotionPill>
+            );
+          })}
+        </div>
+      )}
+      {(cardIds.length > 0 || relicIds.length > 0) && (
+        <div className="flex flex-wrap items-start gap-1.5">
           {withOrdinalKeys(cardIds).map(({ item, key }) => {
             const { id, upgraded } = parseDeckId(item);
             return (
-              <li key={`c-${key}`} className={row}>
-                <CardPill cardId={id} upgraded={upgraded} cardData={cards} lp={lp} className="truncate">
-                  {cards[id]?.name || displayName(`CARD.${id}`)}
-                  {upgraded ? "+" : ""}
-                </CardPill>
-              </li>
+              <CardPill
+                key={`c-${key}`}
+                cardId={id}
+                upgraded={upgraded}
+                cardData={cards}
+                lp={lp}
+                className="relative block w-16 shrink-0"
+              >
+                <img
+                  src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                  alt={cards[id]?.name || displayName(`CARD.${id}`)}
+                  className="h-auto w-16 rounded-sm"
+                  crossOrigin="anonymous"
+                  loading="lazy"
+                />
+              </CardPill>
             );
           })}
           {withOrdinalKeys(relicIds).map(({ item, key }) => {
             const id = cleanId(item);
+            const info = relics[id];
             return (
-              <li key={`r-${key}`} className={row}>
-                <RelicPill relicId={id} relicData={relics} lp={lp} className="truncate">
-                  {relics[id]?.name || displayName(`RELIC.${id}`)}
-                </RelicPill>
-              </li>
+              <RelicPill
+                key={`r-${key}`}
+                relicId={id}
+                relicData={relics}
+                lp={lp}
+                className="block shrink-0"
+              >
+                {info?.image_url ? (
+                  <img
+                    src={imageUrl(info.image_url)}
+                    alt={info.name}
+                    className="h-9 w-9 object-contain"
+                    crossOrigin="anonymous"
+                    loading="lazy"
+                    onError={(e) => {
+                      (e.target as HTMLImageElement).style.display = "none";
+                    }}
+                  />
+                ) : (
+                  <span className="text-xs text-[var(--text-secondary)]">
+                    {displayName(`RELIC.${id}`)}
+                  </span>
+                )}
+              </RelicPill>
             );
           })}
-          {withOrdinalKeys(potionIds).map(({ item, key }) => {
-            const id = cleanId(item);
-            return (
-              <li key={`p-${key}`} className={row}>
-                <PotionPill potionId={id} potionData={potions} lp={lp} className="truncate">
-                  {potions[id]?.name || displayName(`POTION.${id}`)}
-                </PotionPill>
-              </li>
-            );
-          })}
-        </ul>
+        </div>
       )}
       {removal && (
         <div className="mt-2 text-xs text-[var(--text-muted)]">

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -207,6 +207,69 @@ function TickerRow({
       );
       break;
     }
+    case "relic":
+    case "ancient": {
+      // A relic was obtained; `ancient` is the same but from an ancient event.
+      const id = cleanId(e.v ?? "");
+      const info = cat.relics[id];
+      if (info?.image_url) {
+        icon = (
+          <img
+            src={imageUrl(info.image_url)}
+            alt=""
+            className="w-6 h-6 object-contain"
+            crossOrigin="anonymous"
+            loading="lazy"
+          />
+        );
+      }
+      const verb = e.k === "ancient" ? "Ancient relic:" : "Got";
+      body = id ? (
+        <>
+          <span className="text-amber-300">{verb}</span>{" "}
+          <RelicPill relicId={id} relicData={cat.relics} lp={lp} className={TICKER_LINK}>
+            {info?.name || displayName(`RELIC.${id}`)}
+          </RelicPill>
+        </>
+      ) : (
+        <span className="text-amber-300">
+          {e.k === "ancient" ? "Took an ancient relic" : "Got a relic"}
+        </span>
+      );
+      break;
+    }
+    case "loot": {
+      // Reward taken: `v` is a potion id, or a gold amount as a numeric string.
+      const num = Number(e.v);
+      if (e.v && Number.isFinite(num)) {
+        body = <span className="text-[var(--accent-gold)]">Took {num} gold</span>;
+        break;
+      }
+      const id = cleanId(e.v ?? "");
+      const info = cat.potions[id];
+      if (info?.image_url) {
+        icon = (
+          <img
+            src={imageUrl(info.image_url)}
+            alt=""
+            className="w-6 h-6 object-contain"
+            crossOrigin="anonymous"
+            loading="lazy"
+          />
+        );
+      }
+      body = id ? (
+        <>
+          Took{" "}
+          <PotionPill potionId={id} potionData={cat.potions} lp={lp} className={TICKER_LINK}>
+            {info?.name || displayName(`POTION.${id}`)}
+          </PotionPill>
+        </>
+      ) : (
+        <span className="text-[var(--text-secondary)]">Took loot</span>
+      );
+      break;
+    }
     case "event": {
       // Event-room visit. The backend passes any kind through, so this
       // lights up as soon as the mod ships {"k": "event", "v": EVENT_ID}.

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -29,6 +29,7 @@ import {
 import {
   API,
   CharacterIcon,
+  EnemyCircle,
   LiveDot,
   LiveEnemiesPanel,
   PartnerBadge,
@@ -225,10 +226,11 @@ function TickerRow({
       break;
     }
     case "combat":
-      body = e.v ? (
-        <span className="text-amber-300">Fight started: {monsterName(e.v, monsters)}</span>
-      ) : (
-        <span className="text-amber-300">Fight started</span>
+      body = (
+        <span className="inline-flex items-center gap-1.5 text-amber-300">
+          Fight started
+          {e.v && <EnemyCircle id={e.v} monsters={monsters} className="h-5 w-5" />}
+        </span>
       );
       break;
     case "victory":
@@ -370,12 +372,35 @@ function LiveCombatPanel({
         </div>
       )}
       {shownPiles.length > 0 && (
-        <div className="flex gap-3 text-xs tabular-nums text-[var(--text-muted)]">
-          {shownPiles.map(([label, v]) => (
-            <span key={label}>
-              {label} {v}
-            </span>
-          ))}
+        <div className="flex items-center gap-4">
+          {shownPiles.map(([label, v]) =>
+            label === "Exhaust" ? (
+              <span
+                key={label}
+                title="Exhaust pile"
+                className="flex h-6 w-6 items-center justify-center rounded-full bg-purple-600 text-[11px] font-bold tabular-nums text-white"
+              >
+                {v}
+              </span>
+            ) : (
+              <span
+                key={label}
+                title={`${label} pile`}
+                className="inline-flex items-center gap-1 text-xs tabular-nums text-[var(--text-secondary)]"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={imageUrl(
+                    `/static/images/ui/combat/${label.toLowerCase()}_pile.png`,
+                  )}
+                  alt={label}
+                  className="h-6 w-6 object-contain"
+                  crossOrigin="anonymous"
+                />
+                {v}
+              </span>
+            ),
+          )}
         </div>
       )}
     </div>
@@ -625,7 +650,11 @@ export default function LivePlayerClient() {
     else deckGroups.push({ raw, count: 1 });
   }
 
-  const hasEnemies = (p.enemies?.length ?? 0) > 0 || (p.fighting?.length ?? 0) > 0;
+  // Gate combat UI on the combat screen so a stale enemies/fighting field (the
+  // mod not always nulling them on combat end) can't keep the fight panel up.
+  const hasEnemies =
+    p.screen === "combat" &&
+    ((p.enemies?.length ?? 0) > 0 || (p.fighting?.length ?? 0) > 0);
   const mapCard =
     (p.map?.nodes?.length ?? 0) > 0 ? (
       <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
@@ -714,8 +743,47 @@ export default function LivePlayerClient() {
                 {p.act != null ? `Act ${p.act}` : ""}
                 {p.total_floor != null ? ` · F${p.total_floor}` : ""}
               </div>
-              <div className="text-sm text-[var(--text-muted)] tabular-nums">
-                {p.gold != null ? `${p.gold} gold` : ""}
+              <div className="mt-0.5 flex items-center justify-end gap-3 text-sm tabular-nums">
+                {p.energy != null && (
+                  <span
+                    className="inline-flex items-center gap-1 text-[var(--text-secondary)]"
+                    title="Energy"
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={imageUrl(
+                        `/static/images/icons/${(p.character ?? "colorless").toLowerCase()}_energy_icon.png`,
+                      )}
+                      alt="Energy"
+                      className="h-4 w-4 object-contain"
+                      crossOrigin="anonymous"
+                      onError={(e) => {
+                        const el = e.target as HTMLImageElement;
+                        const fb = imageUrl(
+                          "/static/images/icons/colorless_energy_icon.png",
+                        );
+                        if (el.src !== fb) el.src = fb;
+                      }}
+                    />
+                    {p.energy}
+                    {p.max_energy != null ? `/${p.max_energy}` : ""}
+                  </span>
+                )}
+                {p.gold != null && (
+                  <span
+                    className="inline-flex items-center gap-1 text-[var(--accent-gold)]"
+                    title="Gold"
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={imageUrl("/static/images/icons/gold_icon.png")}
+                      alt="Gold"
+                      className="h-4 w-4 object-contain"
+                      crossOrigin="anonymous"
+                    />
+                    {p.gold}
+                  </span>
+                )}
               </div>
             </div>
           </div>
@@ -733,19 +801,11 @@ export default function LivePlayerClient() {
               </div>
             </div>
           )}
-          {((p.block ?? 0) > 0 || p.energy != null) && (
-            <div className="mt-2 flex items-center gap-3 text-xs tabular-nums">
-              {(p.block ?? 0) > 0 && (
-                <span className="text-sky-300" title="Block">
-                  Block {p.block}
-                </span>
-              )}
-              {p.energy != null && (
-                <span className="text-[var(--accent-gold)]" title="Energy">
-                  Energy {p.energy}
-                  {p.max_energy != null ? `/${p.max_energy}` : ""}
-                </span>
-              )}
+          {(p.block ?? 0) > 0 && (
+            <div className="mt-2 text-xs tabular-nums">
+              <span className="text-sky-300" title="Block">
+                Block {p.block}
+              </span>
             </div>
           )}
         </div>
@@ -755,7 +815,9 @@ export default function LivePlayerClient() {
             {hasContext && (
               <div className="space-y-4">
                 {hasEnemies && <LiveEnemiesPanel p={p} monsters={monsters} />}
-                <LiveCombatPanel p={p} cat={cat} lp={lp} lang={lang} />
+                {p.screen === "combat" && (
+                  <LiveCombatPanel p={p} cat={cat} lp={lp} lang={lang} />
+                )}
                 {p.event && <LiveEventPanel ev={p.event} lp={lp} />}
                 {p.shop && (
                   <LiveShopPanel
@@ -774,6 +836,7 @@ export default function LivePlayerClient() {
                     relics={cat.relics}
                     potions={cat.potions}
                     lp={lp}
+                    lang={lang}
                   />
                 )}
               </div>
@@ -781,7 +844,7 @@ export default function LivePlayerClient() {
           </div>
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4 lg:col-span-2">
           <h2 className="text-sm font-semibold text-[var(--accent-gold)] mb-2">Play-by-play</h2>
           {events.length === 0 ? (
             <p className="text-sm text-[var(--text-muted)]">
@@ -797,7 +860,7 @@ export default function LivePlayerClient() {
           )}
         </div>
 
-        <div className="space-y-4">
+        <div className="space-y-4 lg:col-span-2">
           <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
             <h2 className="text-sm font-semibold text-[var(--accent-gold)] mb-2">
               Deck{p.deck ? ` (${p.deck.length})` : ""}


### PR DESCRIPTION
**#537 never reached main.** It was opened with base `feat/live-render-fields` (stacked on #535), so when it "merged" it merged into *that* branch, not main — and #535 had already merged to main at an earlier point. So the whole polish + ticker batch was orphaned, which is why none of it showed up after deploy.

This re-applies the two orphaned commits (`68ceae31` polish, `82692ac8` ticker) cleanly onto current main.

What this brings into main (everything from #537):
- Fight-started ticker rows show the monster portrait instead of the name
- Combat pile counts use the in-game draw/discard pile images; exhaust is a purple count circle
- Rewards panel shows real card renders + potion/relic art with hover tooltips
- Combat UI gated on the combat screen (fighting no longer sticks after a fight)
- Play-by-play full-width directly under the character box
- Character box uses the per-character energy icon + gold icon
- `relic` / `ancient` / `loot` play-by-play ticker cases (the mod now emits these)

## Audit result (the rest is fine)
Verified every other live-fields PR's content IS in main: #534 (backend pass 1), #536 (backend pass 2 + act_name — these re-landed the commits that #534's early merge had orphaned), and #535 (frontend render). The only gap was #537, which this fixes.

Lesson logged: don't stack a PR on an open PR's branch — it merges into that branch, not main.