### PR TITLE
live: enemy portraits on the spectator map (boss/ancient + progressive reveals)

### DIFF
--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -131,6 +131,23 @@ def _clean_map(raw) -> dict | None:
     return out
 
 
+def _clean_reveals(raw) -> list | None:
+    """Per-node progressive reveals for the spectator map: one
+    [col, row, room_type, encounter_id] per VISITED node, the actual resolved
+    room type (so a `?` node shows what it became) and the encounter/event id
+    (null for shop/rest/treasure). Same coord space as the map nodes; grows as
+    the player walks. Capped (an act is ~15 nodes)."""
+    if not isinstance(raw, list):
+        return None
+    out = []
+    for e in raw[:64]:
+        if isinstance(e, list) and len(e) == 4 and _int_pair(e[:2]):
+            rt = e[2] if isinstance(e[2], str) else ""
+            enc = e[3] if isinstance(e[3], str) else None
+            out.append([int(e[0]), int(e[1]), rt[:_MAX_STR], enc])
+    return out
+
+
 # Route (the act's structure) + loot (the combat/reward screen). Route persists
 # per act like the map; loot is transient, cleared when the player leaves the
 # reward screen.
@@ -483,6 +500,8 @@ async def post_presence(request: Request):
         fields["pos"] = pos
     if (m := _clean_map(data.get("map"))) is not None:
         fields["map"] = m
+    if (rv := _clean_reveals(data.get("reveals"))) is not None:
+        fields["reveals"] = rv
 
     # Current-screen detail: the live event, the shop, and combat enemies. Present
     # only on those screens.

--- a/backend/app/services/presence_db.py
+++ b/backend/app/services/presence_db.py
@@ -94,6 +94,7 @@ def active(limit: int = 50) -> list[dict]:
                 "potions": 0,
                 "events": 0,
                 "map": 0,
+                "reveals": 0,
                 "event": 0,
                 "shop": 0,
                 "enemies": 0,

--- a/frontend/app/live/LiveMap.tsx
+++ b/frontend/app/live/LiveMap.tsx
@@ -7,8 +7,23 @@
 // Coordinates are the game's own grid: row is act depth (0 = act start),
 // col is horizontal lane. We render row 0 at the bottom so it reads like
 // the in-game map (climb upward toward the boss).
+//
+// Enemy portraits in the circles: the boss/ancient are knowable ahead (joined
+// from route.boss/route.ancient), and every other circle fills in as the player
+// walks via the `reveals` array (the actual resolved room type + encounter id),
+// resolved encounter -> representative monster -> portrait. The game binds an
+// encounter to a node only on entry, so an unvisited node's enemy is genuinely
+// unknowable; unrevealed nodes keep the type glyph.
 
-import type { Coord, LiveMapData } from "./live-shared";
+import { imageUrl } from "@/lib/image-url";
+import type {
+  Coord,
+  EncounterMap,
+  LiveMapData,
+  LiveRoute,
+  MonsterMap,
+  Reveal,
+} from "./live-shared";
 
 // Per-node-type styling. Types arrive lowercase; an unrecognized type falls
 // back to the neutral "node" entry so a new map symbol never breaks rendering.
@@ -42,10 +57,18 @@ export default function LiveMap({
   map,
   path,
   pos,
+  reveals,
+  route,
+  monsters,
+  encounters,
 }: {
   map?: LiveMapData | null;
   path?: Coord[];
   pos?: Coord | null;
+  reveals?: Reveal[];
+  route?: LiveRoute | null;
+  monsters?: MonsterMap;
+  encounters?: EncounterMap;
 }) {
   const nodes = map?.nodes ?? [];
   if (!nodes.length) return null;
@@ -64,6 +87,44 @@ export default function LiveMap({
   const isPos = (c: number, r: number) => !!pos && pos[0] === c && pos[1] === r;
 
   const edges = map?.edges ?? [];
+
+  // (col,row) -> [col, row, resolved room_type, encounter id|null] for visited nodes.
+  const revealMap = new Map<string, Reveal>();
+  for (const rv of reveals ?? []) revealMap.set(key(rv[0], rv[1]), rv);
+
+  // The portrait for a node, or null to fall back to the type glyph: a visited
+  // node resolves encounter -> first monster -> image; the boss/ancient resolve
+  // from route (knowable from the start).
+  function portraitFor(c: number, r: number, baseType: string): string | null {
+    const rv = revealMap.get(key(c, r));
+    if (rv && rv[3]) {
+      const monId = encounters?.[rv[3]]?.monsters?.[0]?.id;
+      if (monId) {
+        const info = monsters?.[monId];
+        return info?.image_url
+          ? imageUrl(info.image_url)
+          : imageUrl(`/static/images/monsters/${monId.toLowerCase()}.webp`);
+      }
+      return null; // shop/rest/treasure/event reveal: no portrait, keep glyph
+    }
+    if (baseType === "boss" && route?.boss?.id) {
+      return imageUrl(`/static/images/misc/bosses/${route.boss.id.toLowerCase()}.png`);
+    }
+    if (baseType === "ancient" && route?.ancient?.id) {
+      return imageUrl(`/static/images/misc/ancients/${route.ancient.id.toLowerCase()}.png`);
+    }
+    return null;
+  }
+
+  function titleFor(c: number, r: number, baseType: string, effType: string): string {
+    const rv = revealMap.get(key(c, r));
+    if (rv && rv[3]) return encounters?.[rv[3]]?.name || rv[3];
+    if (baseType === "boss" && route?.boss) return route.boss.name || route.boss.id || "Boss";
+    if (baseType === "ancient" && route?.ancient) {
+      return route.ancient.name || route.ancient.id || "Ancient";
+    }
+    return effType;
+  }
 
   return (
     <div className="overflow-auto">
@@ -91,9 +152,13 @@ export default function LiveMap({
           );
         })}
         {nodes.map(([c, r, type]) => {
-          const s = styleFor(type);
+          const rv = revealMap.get(key(c, r));
+          const effType = (rv && rv[2]) || type; // a `?` node shows what it became
+          const s = styleFor(effType);
           const here = isPos(c, r);
           const seen = onPath(c, r);
+          const portrait = portraitFor(c, r, type);
+          const dim = !(seen || here);
           return (
             <g key={`n-${c}-${r}`}>
               {here && (
@@ -102,29 +167,57 @@ export default function LiveMap({
                   <animate attributeName="stroke-opacity" values="1;0.3;1" dur="1.4s" repeatCount="indefinite" />
                 </circle>
               )}
-              <circle
-                cx={x(c)}
-                cy={y(r)}
-                r={R}
-                fill={s.fill}
-                stroke={seen ? "var(--accent-gold)" : s.ring}
-                strokeWidth={seen ? 2 : 1}
-                fillOpacity={seen || here ? 1 : 0.55}
-              />
-              {s.glyph && (
-                <text
-                  x={x(c)}
-                  y={y(r) + 3}
-                  textAnchor="middle"
-                  fontSize="9"
-                  fontWeight="bold"
-                  fill="#1a1a1a"
-                  pointerEvents="none"
-                >
-                  {s.glyph}
-                </text>
+              {portrait ? (
+                <>
+                  <clipPath id={`lm-${c}-${r}`}>
+                    <circle cx={x(c)} cy={y(r)} r={R} />
+                  </clipPath>
+                  <image
+                    href={portrait}
+                    x={x(c) - R}
+                    y={y(r) - R}
+                    width={R * 2}
+                    height={R * 2}
+                    clipPath={`url(#lm-${c}-${r})`}
+                    preserveAspectRatio="xMidYMid slice"
+                    opacity={dim ? 0.55 : 1}
+                  />
+                  <circle
+                    cx={x(c)}
+                    cy={y(r)}
+                    r={R}
+                    fill="none"
+                    stroke={seen ? "var(--accent-gold)" : s.ring}
+                    strokeWidth={seen ? 2 : 1}
+                  />
+                </>
+              ) : (
+                <>
+                  <circle
+                    cx={x(c)}
+                    cy={y(r)}
+                    r={R}
+                    fill={s.fill}
+                    stroke={seen ? "var(--accent-gold)" : s.ring}
+                    strokeWidth={seen ? 2 : 1}
+                    fillOpacity={dim ? 0.55 : 1}
+                  />
+                  {s.glyph && (
+                    <text
+                      x={x(c)}
+                      y={y(r) + 3}
+                      textAnchor="middle"
+                      fontSize="9"
+                      fontWeight="bold"
+                      fill="#1a1a1a"
+                      pointerEvents="none"
+                    >
+                      {s.glyph}
+                    </text>
+                  )}
+                </>
               )}
-              <title>{type}</title>
+              <title>{titleFor(c, r, type, effType)}</title>
             </g>
           );
         })}

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -38,6 +38,7 @@ import {
   elapsed,
   monsterName,
   parseDeckId,
+  useEncounterMap,
   useMonsterMap,
   usePoll,
   withOrdinalKeys,
@@ -606,6 +607,7 @@ export default function LivePlayerClient() {
   const [status, setStatus] = useState<"loading" | "live" | "ended" | "missing">("loading");
   const [cat, setCat] = useState<Catalogs>({ cards: {}, relics: {}, potions: {}, events: {} });
   const monsters = useMonsterMap(true);
+  const encounters = useEncounterMap(true);
 
   useEffect(() => {
     cachedFetch<CardInfo[]>(`${API}/api/cards?lang=${lang}`)
@@ -724,7 +726,15 @@ export default function LivePlayerClient() {
         <h2 className="text-sm font-semibold text-[var(--accent-gold)] mb-2">
           Map{p.map?.act != null ? ` · Act ${p.map.act}` : ""}
         </h2>
-        <LiveMap map={p.map} path={p.path} pos={p.pos} />
+        <LiveMap
+          map={p.map}
+          path={p.path}
+          pos={p.pos}
+          reveals={p.reveals}
+          route={p.route}
+          monsters={monsters}
+          encounters={encounters}
+        />
       </div>
     ) : null;
 

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -178,6 +178,7 @@ export interface LivePlayer {
   player_powers?: LivePower[];
   loot?: LiveLoot | null;
   route?: LiveRoute | null;
+  reveals?: Reveal[];
   players?: LiveSeat[];
   run_time?: number | null;
   modifiers?: string[];
@@ -198,6 +199,18 @@ export interface MonsterInfo {
 }
 
 export type MonsterMap = Record<string, MonsterInfo>;
+
+/** A per-node map reveal: [col, row, resolved room_type, encounter/event id|null]
+ * for a visited node. Same coord space as the map nodes; grows as the player walks. */
+export type Reveal = [number, number, string, string | null];
+
+export interface EncounterInfo {
+  id: string;
+  name?: string;
+  monsters?: { id: string; name?: string }[];
+}
+
+export type EncounterMap = Record<string, EncounterInfo>;
 
 export function elapsed(startedAt?: string | null): string {
   if (!startedAt) return "";
@@ -325,6 +338,24 @@ export function useMonsterMap(enabled: boolean): MonsterMap {
       .then((monsters) => {
         const m: MonsterMap = {};
         for (const x of monsters) m[x.id] = x;
+        setMap(m);
+      })
+      .catch(() => {});
+  }, [enabled, lang]);
+  return map;
+}
+
+/** Lazy encounter id -> {name, monsters} map, for resolving a map reveal's
+ * encounter id to a representative monster portrait. Fetches once enabled. */
+export function useEncounterMap(enabled: boolean): EncounterMap {
+  const { lang } = useLanguage();
+  const [map, setMap] = useState<EncounterMap>({});
+  useEffect(() => {
+    if (!enabled) return;
+    cachedFetch<EncounterInfo[]>(`${API}/api/encounters?lang=${lang}`)
+      .then((encs) => {
+        const m: EncounterMap = {};
+        for (const x of encs) m[x.id] = x;
         setMap(m);
       })
       .catch(() => {});

--- a/markdown-docs/live-presence.md
+++ b/markdown-docs/live-presence.md
@@ -147,6 +147,16 @@ The per-player doc carries the current act's map graph and the route taken so fa
 - The bulky `map` graph is sent once per act (it's static) and omitted from `/active`;
   `path`/`pos` ride every beat and DO appear on `/active` for a roster progress hint.
 
+`reveals` (per-node, progressive) rides every beat next to `path`/`pos`: one
+`[col, row, room_type, encounter_id]` per VISITED node — the ACTUAL resolved room type
+(so a `?` node shows what it became) and the encounter/event id (`null` for
+shop/rest/treasure). Same `col`/`row` space as `nodes[]`, so it overlays the map directly,
+and it grows as the player walks. Resolve `encounter_id` via `/api/encounters` to the
+encounter's first monster, then that monster's portrait, for the node art. The game binds an
+encounter to a node only on entry, so an unvisited node's enemy is genuinely unknowable
+except the boss and ancient (single fixed nodes: join the boss/ancient node coord in
+`nodes[]` with `route.boss` / `route.ancient`). Omitted from `/active`.
+
 ### Live event (v4, present only in an event room)
 
 When `screen == "event"`, the per-player doc carries the event the player is reading and


### PR DESCRIPTION
Lights up the spectator map circles with enemy portraits, off the mod's new `reveals` channel. Base `main`.

## Why it's progressive, not all-at-once
The game binds an encounter to a map node only **on entry** (visit-counter pull from the act grab-bag; `?` nodes roll on entry), so an unvisited node's enemy is genuinely unknowable — for the mod or anyone. The only nodes knowable ahead are the **boss** and **ancient** (single fixed nodes). So: boss/ancient lit from the start, everything else fills in as the player walks.

## Backend (`presence.py` / `presence_db.py`)
- `_clean_reveals` whitelists the new `reveals` array (`[int, int, str, str|null]` per entry, capped), wired next to `_clean_map`. Without this the field is dropped at ingest, same trap as the earlier live fields.
- The roster (`active()`) strips `reveals` — per-player detail only.

## Frontend (`LiveMap.tsx` + wiring)
- Each circle resolves a portrait: a visited node's `encounter_id` → the encounter's first monster (`/api/encounters`) → that monster's image; the boss/ancient node → `route.boss`/`route.ancient` art (`/misc/bosses`, `/misc/ancients`).
- A resolved `?` node shows what it became (the reveal's room type); nodes with no portrait (shop/rest/treasure, or not yet visited) keep the type glyph. Hover shows the encounter/enemy name.
- New `useEncounterMap` hook + `Reveal`/`EncounterMap` types in live-shared.

Contract updated in `markdown-docs/live-presence.md`.

Independent of #539 (the layout redesign) — different parts of the file, clean merge. All browser-rendered, so worth a look on a live run after deploy.