### PR TITLE
live: pile drawer — fix card clipping + bigger cards

### DIFF
--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -564,11 +564,11 @@ function LiveCombatPanel({
       )}
       {openPile && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          className="fixed inset-0 z-[60] flex items-start justify-center overflow-y-auto bg-black/60 p-4"
           onClick={() => setOpenPile(null)}
         >
           <div
-            className="max-h-[80vh] w-full max-w-2xl overflow-auto rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4"
+            className="my-8 w-full max-w-3xl rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4"
             onClick={(ev) => ev.stopPropagation()}
           >
             <div className="mb-3 flex items-center justify-between">
@@ -594,12 +594,12 @@ function LiveCombatPanel({
                     upgraded={upgraded}
                     cardData={cat.cards}
                     lp={lp}
-                    className="relative block w-24 shrink-0"
+                    className="relative block w-32 shrink-0"
                   >
                     <img
                       src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
                       alt={cat.cards[id]?.name || displayName(`CARD.${id}`)}
-                      className="h-auto w-24 rounded-sm"
+                      className="h-auto w-32 rounded-sm"
                       crossOrigin="anonymous"
                       loading="lazy"
                     />


### PR DESCRIPTION
Follow-up to the pile drawer (#544).

- **Clipping + z-index** — CardPill renders an enlarged card on hover (`absolute z-50 bottom-full`); the drawer box's `overflow-auto` was clipping it. Raised the overlay to `z-[60]`, removed the box's overflow (the backdrop scrolls instead, `overflow-y-auto` + `items-start`) so the hover renders escape, and widened the box to `max-w-3xl`.
- **Bigger cards** — drawer cards `w-24 → w-32`.

Browser QA after deploy is yours. (Branched fresh off main since #544 is merged.)