### PR TITLE
live: 2 columns on vertical screens, 4 only when wide

### DIFF
--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -1160,7 +1160,7 @@ export default function LivePlayerClient() {
           The rail is dropped entirely when there's no map. */}
       {/* Four columns on desktop (play-by-play | character + deck | combat
           context | map); stacks to one column on mobile. */}
-      <div className="mt-3 grid grid-cols-1 lg:grid-cols-4 gap-4 items-start">
+      <div className="mt-3 grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-4 gap-4 items-start">
         <div className="min-w-0">{playByPlay}</div>
         <div className="space-y-4 min-w-0">
           {characterCard}


### PR DESCRIPTION
The 4-column layout (#546) kicked in at the `lg` breakpoint (1024px), so a vertical/portrait monitor (~1080px wide) squeezed all 4 columns into ~270px each — cramped.

Now: **1 column** on mobile, **2 columns** from `lg` to `2xl` (1024–1536px, which is where vertical monitors land), and **4 columns** only at `2xl` (≥1536px) where there's actually room. Branched off main (#546 is merged).