### PR TITLE
live: game-like battle scene as the default view

### DIFF
--- a/backend/app/parsers/ancient_pool_parser.py
+++ b/backend/app/parsers/ancient_pool_parser.py
@@ -31,7 +31,7 @@ still emitted for the relic-page cross-reference.
 import json
 import re
 
-from parser_paths import BASE, DECOMPILED, DATA_DIR
+from parser_paths import BASE, DECOMPILED, DATA_DIR, RAW_DIR
 
 EVENTS_DIR = DECOMPILED / "MegaCrit.Sts2.Core.Models.Events"
 
@@ -256,7 +256,35 @@ def load_existing(path) -> dict:
     return idx
 
 
-def build_ancient(ancient_id: str, content: str, prior: dict) -> dict:
+_LOC_KEY_RE = re.compile(r"^[\w.]+$")
+
+
+def _looks_like_loc_key(s: str) -> bool:
+    """True for an unresolved loc key like 'ancients.NEOW.pages.DONE.description'
+    (dotted, no spaces) -- never a real prose description. Dialogue ancients
+    (NEOW, PAEL, ...) have no pages description, so a stale carried value can be
+    one of these keys; we must not ship it."""
+    return bool(s) and "." in s and bool(_LOC_KEY_RE.match(s))
+
+
+def load_epithets() -> dict[str, str]:
+    """Each ancient's epithet (e.g. NEOW -> "Mother of Resurrection (Exiled)")
+    from the eng loc, used as the description fallback for dialogue ancients that
+    have no prose description."""
+    loc_file = RAW_DIR / "localization" / "eng" / "ancients.json"
+    if not loc_file.exists():
+        return {}
+    with open(loc_file, "r", encoding="utf-8") as f:
+        loc = json.load(f)
+    out: dict[str, str] = {}
+    for aid in ANCIENT_FILES:
+        raw = loc.get(f"{aid}.epithet")
+        if isinstance(raw, str) and raw:
+            out[aid] = re.sub(r"\[/?[^\]]+\]", "", raw).strip()
+    return out
+
+
+def build_ancient(ancient_id: str, content: str, prior: dict, epithets: dict) -> dict:
     """Assemble the full generated entry for one ancient, merging prior prose."""
     p = prior.get(ancient_id, {})
     conditions = p.get("conditions", {})
@@ -271,8 +299,16 @@ def build_ancient(ancient_id: str, content: str, prior: dict) -> dict:
         ]
         pools_out.append(pool)
     entry = {"id": ancient_id, "name": ANCIENT_NAMES.get(ancient_id, ancient_id)}
-    if p.get("description"):
-        entry["description"] = p["description"]
+    # Prefer the curated prose description, but never ship an unresolved loc key
+    # (dialogue ancients have no pages description) -- fall back to the epithet.
+    carried = p.get("description")
+    desc = (
+        carried
+        if (carried and not _looks_like_loc_key(carried))
+        else epithets.get(ancient_id)
+    )
+    if desc:
+        entry["description"] = desc
     if p.get("selection"):
         entry["selection"] = p["selection"]
     entry["pools"] = pools_out
@@ -281,6 +317,7 @@ def build_ancient(ancient_id: str, content: str, prior: dict) -> dict:
 
 def main() -> None:
     prior = load_existing(DATA_DIR / "ancient_pools.json")
+    epithets = load_epithets()
 
     generated: list[dict] = []
     parsed_out: list[dict] = []
@@ -296,7 +333,7 @@ def main() -> None:
         full_set = parse_ancient_relics(content)
         per_char = parse_per_character_relics(content)
 
-        entry = build_ancient(ancient_id, content, prior)
+        entry = build_ancient(ancient_id, content, prior, epithets)
         covered = {r["id"] for pool in entry["pools"] for r in pool["relics"]}
 
         # The guarantee: generated pools must cover every relic the C# offers.

--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -36,6 +36,9 @@ _INT_FIELDS = (
     "draw_count",
     "discard_count",
     "exhaust_count",
+    # Channeled-orb slot capacity (combat-only, orb characters); the orbs
+    # themselves ride a separate cleaned list. In the transient-unset set.
+    "orb_slots",
     # Live combat damage (DPS) for the spectator view; absent / null outside a
     # fight, cleared by the transient-unset list below when the mod sends null.
     "damage_dealt",
@@ -43,7 +46,17 @@ _INT_FIELDS = (
     "damage_taken",
     "biggest_hit",
 )
-_STR_FIELDS = ("character", "seed", "screen", "sts2_version", "username", "act_name")
+_STR_FIELDS = (
+    "character",
+    "seed",
+    "screen",
+    "sts2_version",
+    "username",
+    "act_name",
+    # whose turn it is in combat: "player" / "enemy". Combat-only, in the
+    # transient-unset set below.
+    "turn_side",
+)
 # `hand` is the live combat hand (card ids); combat-only, so it's in the
 # transient-unset list below. `modifiers` are the run's daily/custom mutators —
 # valid the whole run, so NOT unset.
@@ -245,6 +258,31 @@ def _clean_powers(raw) -> list[dict] | None:
     return out
 
 
+_ORBS_CAP = 12
+
+
+def _clean_orbs(raw) -> list[dict] | None:
+    """The player's channeled orbs in slot order: each {id, passive, evoke} --
+    `passive` the per-turn value, `evoke` the on-evoke value. Combat-only (orb
+    characters); [] is meaningful, so it's in the transient-unset set."""
+    if not isinstance(raw, list):
+        return None
+    out: list[dict] = []
+    for o in raw[:_ORBS_CAP]:
+        if not isinstance(o, dict):
+            continue
+        oid = o.get("id")
+        if not isinstance(oid, str) or not _safe_id(oid[:_MAX_STR]):
+            continue
+        orb: dict = {"id": oid[:_MAX_STR]}
+        for k in ("passive", "evoke"):
+            v = o.get(k)
+            if isinstance(v, (int, float)) and not isinstance(v, bool):
+                orb[k] = int(v)
+        out.append(orb)
+    return out
+
+
 def _clean_players(raw) -> list[dict] | None:
     """Co-op per-seat vitals; the mod sends this only with 2+ players. `is_me`
     marks the local seat so the frontend can highlight it."""
@@ -305,6 +343,15 @@ def _clean_event_ctx(raw) -> dict | None:
                 opt["key"] = o["key"][:_MAX_STR]
             if isinstance(o.get("text"), str):
                 opt["text"] = o["text"][:_OPT_TEXT_CAP]
+            # the resolved consequence text ("Lose 3 HP") plus any card the option
+            # previews (e.g. the card a "lose a card" option will take) or relic it
+            # grants -- the game pre-rolls these, so they're knowable before choosing.
+            if isinstance(o.get("desc"), str) and o["desc"]:
+                opt["desc"] = o["desc"][:_OPT_TEXT_CAP]
+            for ref in ("card", "relic"):
+                v = o.get(ref)
+                if isinstance(v, str) and _safe_id(v[:_MAX_STR]):
+                    opt[ref] = v[:_MAX_STR]
             for flag in ("locked", "proceed", "chosen"):
                 if isinstance(o.get(flag), bool):
                     opt[flag] = o[flag]
@@ -359,6 +406,50 @@ def _clean_shop(raw) -> dict | None:
     return out or None
 
 
+_REST_OPTIONS_CAP = 8
+
+
+def _clean_rest(raw) -> dict | None:
+    """The campfire's options (Rest/Smith/Dig/...): each {id, title, enabled}. `id`
+    is the stable option id, `title` the localized label, `enabled` whether it is
+    selectable. Present only at a rest site; cleared by the transient-unset list
+    when the player leaves the campfire."""
+    if not isinstance(raw, dict):
+        return None
+    opts = raw.get("options")
+    if not isinstance(opts, list):
+        return None
+    out_opts: list[dict] = []
+    for o in opts[:_REST_OPTIONS_CAP]:
+        if not isinstance(o, dict):
+            continue
+        oid = o.get("id")
+        if not isinstance(oid, str) or not oid:
+            continue
+        item: dict = {"id": oid}
+        if isinstance(o.get("title"), str):
+            item["title"] = o["title"]
+        if isinstance(o.get("enabled"), bool):
+            item["enabled"] = o["enabled"]
+        out_opts.append(item)
+    return {"options": out_opts} if out_opts else None
+
+
+def _clean_death(raw) -> dict | None:
+    """The run-ending death: `line` is the killer's already-localized death quote
+    (free text, e.g. "Not quite the top"), `by` the killer's id. Present once the
+    player dies."""
+    if not isinstance(raw, dict):
+        return None
+    out: dict = {}
+    if isinstance(raw.get("line"), str) and raw["line"]:
+        out["line"] = raw["line"][:_MAX_STR]
+    by = raw.get("by")
+    if isinstance(by, str) and _safe_id(by[:_MAX_STR]):
+        out["by"] = by[:_MAX_STR]
+    return out or None
+
+
 # Live combat enemies for the spectator combat panel: per enemy hp/block plus the
 # upcoming intent(s). A move can carry several intents (e.g. attack + buff), so
 # `intents` is a list of {type, dmg?, hits?}; `type` is the codex intent category
@@ -375,7 +466,9 @@ def _clean_intent(o) -> dict | None:
     if not isinstance(t, str) or not t:
         return None
     out: dict = {"type": t[:24]}
-    for k in ("dmg", "hits"):
+    # dmg/hits describe an attack; amount is the magnitude of a non-attack intent
+    # (e.g. the block a defend will gain, or a buff's stacks).
+    for k in ("dmg", "hits", "amount"):
         v = o.get(k)
         if isinstance(v, (int, float)) and not isinstance(v, bool):
             out[k] = int(v)
@@ -410,6 +503,9 @@ def _clean_enemies(raw) -> list[dict] | None:
                 for it in (_clean_intent(i) for i in raw_intents[:_INTENTS_CAP])
                 if it
             ]
+        # enemy buffs/debuffs (vulnerable, weak, strength, ...) -> token icons
+        if epw := _clean_powers(o.get("powers")):
+            en["powers"] = epw
         if en:
             out.append(en)
     return out or None
@@ -512,6 +608,10 @@ async def post_presence(request: Request):
         fields["event"] = ev
     if (shp := _clean_shop(data.get("shop"))) is not None:
         fields["shop"] = shp
+    if (rs := _clean_rest(data.get("rest"))) is not None:
+        fields["rest"] = rs
+    if (dth := _clean_death(data.get("death"))) is not None:
+        fields["death"] = dth
     if (en := _clean_enemies(data.get("enemies"))) is not None:
         fields["enemies"] = en
     # The act's route persists between beats (like the map); loot is per-screen.
@@ -522,6 +622,8 @@ async def post_presence(request: Request):
     # Local player's combat powers ([] is meaningful) + co-op per-seat vitals.
     if (pw := _clean_powers(data.get("player_powers"))) is not None:
         fields["player_powers"] = pw
+    if (orbs := _clean_orbs(data.get("orbs"))) is not None:
+        fields["orbs"] = orbs
     if (pls := _clean_players(data.get("players"))) is not None:
         fields["players"] = pls
 
@@ -534,9 +636,11 @@ async def post_presence(request: Request):
         k
         for k in (
             "turn",
+            "turn_side",
             "fighting",
             "event",
             "shop",
+            "rest",
             "enemies",
             "hand",
             "draw_pile",
@@ -548,6 +652,8 @@ async def post_presence(request: Request):
             "discard_count",
             "exhaust_count",
             "player_powers",
+            "orbs",
+            "orb_slots",
             "damage_dealt",
             "damage_dealt_this_turn",
             "damage_taken",

--- a/backend/app/services/presence_db.py
+++ b/backend/app/services/presence_db.py
@@ -97,6 +97,8 @@ def active(limit: int = 50) -> list[dict]:
                 "reveals": 0,
                 "event": 0,
                 "shop": 0,
+                "rest": 0,
+                "death": 0,
                 "enemies": 0,
                 "hand": 0,
                 "draw_pile": 0,
@@ -106,6 +108,7 @@ def active(limit: int = 50) -> list[dict]:
                 "loot": 0,
                 "players": 0,
                 "player_powers": 0,
+                "orbs": 0,
             },
         )
         .sort([("total_floor", -1), ("updated_at", -1)])

--- a/frontend/app/live/LiveEventShop.tsx
+++ b/frontend/app/live/LiveEventShop.tsx
@@ -34,7 +34,17 @@ function Gold({ cost }: { cost?: number }) {
   return <span className="text-[var(--accent-gold)] tabular-nums font-semibold">{cost}g</span>;
 }
 
-export function LiveEventPanel({ ev, lp }: { ev: LiveEventCtx; lp: string }) {
+export function LiveEventPanel({
+  ev,
+  lp,
+  cards,
+  relics,
+}: {
+  ev: LiveEventCtx;
+  lp: string;
+  cards?: Record<string, CardInfo>;
+  relics?: Record<string, RelicInfo>;
+}) {
   const id = cleanId(ev.id);
   const titleText = ev.title || displayName(`EVENT.${id}`);
   return (
@@ -79,6 +89,56 @@ export function LiveEventPanel({ ev, lp }: { ev: LiveEventCtx; lp: string }) {
                   </span>
                   <span className={`min-w-0 flex-1 ${disabled ? "line-through" : ""}`}>
                     {o.text ? <RichDescriptionSimple text={o.text} /> : o.key || "(option)"}
+                    {o.desc && o.desc !== o.text && (
+                      <span className="mt-0.5 block text-xs text-[var(--text-muted)]">
+                        <RichDescriptionSimple text={o.desc} />
+                      </span>
+                    )}
+                    {(o.card || o.relic) && (
+                      <span className="mt-1.5 flex flex-wrap items-center gap-2">
+                        {o.card && (
+                          <CardPill
+                            cardId={cleanId(o.card)}
+                            cardData={cards ?? {}}
+                            lp={lp}
+                            className="block w-16 shrink-0"
+                          >
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img
+                              src={fullCardUrl(o.card)}
+                              alt=""
+                              className="w-16 rounded shadow"
+                              crossOrigin="anonymous"
+                              onError={(e) => {
+                                (e.target as HTMLImageElement).style.display = "none";
+                              }}
+                            />
+                          </CardPill>
+                        )}
+                        {o.relic && (
+                          <RelicPill
+                            relicId={cleanId(o.relic)}
+                            relicData={relics ?? {}}
+                            lp={lp}
+                            className="block shrink-0"
+                          >
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img
+                              src={imageUrl(
+                                relics?.[cleanId(o.relic)]?.image_url ||
+                                  `/static/images/relics/${cleanId(o.relic).toLowerCase()}.png`,
+                              )}
+                              alt=""
+                              className="h-9 w-9 object-contain"
+                              crossOrigin="anonymous"
+                              onError={(e) => {
+                                (e.target as HTMLImageElement).style.display = "none";
+                              }}
+                            />
+                          </RelicPill>
+                        )}
+                      </span>
+                    )}
                   </span>
                   {o.proceed && !o.chosen && (
                     <span className="text-[10px] text-[var(--text-muted)] shrink-0">leave</span>

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -360,13 +360,19 @@ function TickerRow({
       );
       break;
     }
-    case "victory":
+    case "victory": {
+      // `won` is the encounter id; prefer its clean encounter name over the
+      // raw id fallback (which renders ALL-CAPS like "SLUDGE SPINNER WEAK").
+      const wonName = won
+        ? encounters[cleanId(won)]?.name || monsterName(won, monsters)
+        : "";
       body = (
         <span className="text-emerald-300">
-          {won ? `Won the fight against ${monsterName(won, monsters)}` : "Won the fight"}
+          {wonName ? `Won the fight against ${wonName}` : "Won the fight"}
         </span>
       );
       break;
+    }
     case "choice":
       // An event option the player picked; `v` is the resolved option label.
       body = (
@@ -703,9 +709,14 @@ export default function LivePlayerClient() {
   // EXPERIMENTAL: ?scene=1 renders the game-like battle scene above the panels
   // (localhost prototype; off by default). Read from the URL on the client to
   // avoid the useSearchParams static-bailout for a debug toggle.
-  const [sceneMode, setSceneMode] = useState(false);
+  const [sceneMode, setSceneMode] = useState(true);
+  const [pbpOpen, setPbpOpen] = useState(true);
   useEffect(() => {
-    setSceneMode(new URLSearchParams(window.location.search).get("scene") === "1");
+    // The battle scene is the default view now (no opt-in); `?scene=0` is a
+    // debug opt-out back to the old data panels.
+    setSceneMode(
+      new URLSearchParams(window.location.search).get("scene") !== "0",
+    );
   }, []);
 
   useEffect(() => {
@@ -976,7 +987,14 @@ export default function LivePlayerClient() {
       {p.screen === "combat" && !p.loot && (
         <LiveCombatPanel p={p} cat={cat} lp={lp} lang={lang} />
       )}
-      {p.event && <LiveEventPanel ev={p.event} lp={lp} />}
+      {p.event && (
+        <LiveEventPanel
+          ev={p.event}
+          lp={lp}
+          cards={cat.cards}
+          relics={cat.relics}
+        />
+      )}
       {p.shop && (
         <LiveShopPanel
           shop={p.shop}
@@ -1168,22 +1186,56 @@ export default function LivePlayerClient() {
           The rail is dropped entirely when there's no map. */}
       {/* Four columns on desktop (play-by-play | character + deck | combat
           context | map); stacks to one column on mobile. */}
-      {sceneMode && (
-        <div className="mt-3">
-          <LiveScene p={p} cat={cat} monsters={monsters} lp={lp} lang={lang} />
+      {sceneMode ? (
+        // Scene mode: a collapsible play-by-play (~1/5) beside the battle scene,
+        // which carries the character/combat/deck/map itself.
+        <div className="mt-3 flex items-start gap-3">
+          {pbpOpen ? (
+            <div className="relative w-1/5 min-w-[180px] shrink-0">
+              <button
+                type="button"
+                onClick={() => setPbpOpen(false)}
+                title="Collapse play-by-play"
+                className="absolute right-2 top-2 z-10 text-lg leading-none text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+              >
+                »
+              </button>
+              {playByPlay}
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setPbpOpen(true)}
+              title="Show play-by-play"
+              className="shrink-0 self-stretch rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] px-2 text-sm font-semibold text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+            >
+              «
+            </button>
+          )}
+          <div className="min-w-0 flex-1">
+            <LiveScene
+              p={p}
+              cat={cat}
+              monsters={monsters}
+              encounters={encounters}
+              lp={lp}
+              lang={lang}
+            />
+          </div>
+        </div>
+      ) : (
+        <div className="mt-3 grid grid-cols-1 lg:grid-cols-4 gap-4 items-start">
+          <div className="min-w-0">{playByPlay}</div>
+          <div className="space-y-4 min-w-0">
+            {characterCard}
+            {deckColumn}
+          </div>
+          <div className="space-y-4 min-w-0">{screenPanels}</div>
+          {mapCard && (
+            <div className="lg:sticky lg:top-4 self-start min-w-0">{mapCard}</div>
+          )}
         </div>
       )}
-      <div className="mt-3 grid grid-cols-1 lg:grid-cols-4 gap-4 items-start">
-        <div className="min-w-0">{playByPlay}</div>
-        <div className="space-y-4 min-w-0">
-          {characterCard}
-          {deckColumn}
-        </div>
-        <div className="space-y-4 min-w-0">{screenPanels}</div>
-        {mapCard && (
-          <div className="lg:sticky lg:top-4 self-start min-w-0">{mapCard}</div>
-        )}
-      </div>
     </div>
   );
 }

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -15,6 +15,7 @@ import { useLanguage } from "@/app/contexts/LanguageContext";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { imageUrl, fullCardUrl } from "@/lib/image-url";
 import LiveMap from "../LiveMap";
+import LiveScene from "./LiveScene";
 import { LiveEventPanel, LiveLootPanel, LiveShopPanel } from "../LiveEventShop";
 import {
   CardPill,
@@ -699,6 +700,13 @@ export default function LivePlayerClient() {
   const [cat, setCat] = useState<Catalogs>({ cards: {}, relics: {}, potions: {}, events: {} });
   const monsters = useMonsterMap(true);
   const encounters = useEncounterMap(true);
+  // EXPERIMENTAL: ?scene=1 renders the game-like battle scene above the panels
+  // (localhost prototype; off by default). Read from the URL on the client to
+  // avoid the useSearchParams static-bailout for a debug toggle.
+  const [sceneMode, setSceneMode] = useState(false);
+  useEffect(() => {
+    setSceneMode(new URLSearchParams(window.location.search).get("scene") === "1");
+  }, []);
 
   useEffect(() => {
     cachedFetch<CardInfo[]>(`${API}/api/cards?lang=${lang}`)
@@ -1160,6 +1168,11 @@ export default function LivePlayerClient() {
           The rail is dropped entirely when there's no map. */}
       {/* Four columns on desktop (play-by-play | character + deck | combat
           context | map); stacks to one column on mobile. */}
+      {sceneMode && (
+        <div className="mt-3">
+          <LiveScene p={p} cat={cat} monsters={monsters} lp={lp} lang={lang} />
+        </div>
+      )}
       <div className="mt-3 grid grid-cols-1 lg:grid-cols-4 gap-4 items-start">
         <div className="min-w-0">{playByPlay}</div>
         <div className="space-y-4 min-w-0">

--- a/frontend/app/live/[steamId]/LiveScene.tsx
+++ b/frontend/app/live/[steamId]/LiveScene.tsx
@@ -29,6 +29,7 @@ import {
   type LivePower,
   type MonsterMap,
 } from "../live-shared";
+import { LiveEventPanel, LiveLootPanel, LiveShopPanel } from "../LiveEventShop";
 
 interface Catalogs {
   cards: Record<string, CardInfo>;
@@ -177,6 +178,18 @@ export default function LiveScene({
   const char = (p.character ?? "colorless").toLowerCase();
   const enemies: Enemy[] = (p.enemies ?? []).filter((e) => (e.hp ?? 1) > 0);
   const hand = p.hand ?? [];
+  // The room background for the current screen (combat falls back to the
+  // gradient; not every screen has dedicated art yet).
+  const sceneBg =
+    p.screen === "merchant"
+      ? imageUrl("/static/images/misc/merchant.webp")
+      : p.screen === "treasure"
+        ? imageUrl(
+            "/static/images/renders/backgrounds/treasure_room/chest_room_act_3.png",
+          )
+        : p.event?.id === "NEOW"
+          ? imageUrl("/static/images/renders/backgrounds/neow_room/neow.webp")
+          : "";
 
   return (
     <div className="overflow-hidden rounded-xl border border-[var(--border-subtle)]">
@@ -225,9 +238,27 @@ export default function LiveScene({
         </div>
       </div>
 
-      {/* The arena: player on the left, enemies on the right. */}
-      <div className="relative min-h-[280px] bg-gradient-to-b from-[#1a1320] via-[#120c18] to-[#0c0810] px-6 py-8">
-        <div className="flex items-start justify-between gap-6">
+      {/* The arena: combat shows the battle; other screens render their own
+          scene over the matching room background. */}
+      <div className="relative min-h-[320px] overflow-hidden bg-gradient-to-b from-[#1a1320] via-[#120c18] to-[#0c0810]">
+        {sceneBg && (
+          <>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={sceneBg}
+              alt=""
+              className="absolute inset-0 h-full w-full object-cover opacity-90"
+              crossOrigin="anonymous"
+              onError={(e) => {
+                (e.target as HTMLImageElement).style.display = "none";
+              }}
+            />
+            <div className="absolute inset-0 bg-black/45" />
+          </>
+        )}
+        <div className="relative px-6 py-8">
+          {p.screen === "combat" ? (
+            <div className="flex items-start justify-between gap-6">
           {/* Player token */}
           <div className="flex flex-col items-center gap-2">
             <CharacterIcon
@@ -274,6 +305,38 @@ export default function LiveScene({
               ))
             )}
           </div>
+            </div>
+          ) : p.event ? (
+            <div className="mx-auto max-w-2xl">
+              <LiveEventPanel ev={p.event} lp={lp} />
+            </div>
+          ) : p.shop ? (
+            <div className="mx-auto max-w-3xl">
+              <LiveShopPanel
+                shop={p.shop}
+                cards={cat.cards}
+                relics={cat.relics}
+                potions={cat.potions}
+                lp={lp}
+                lang={lang}
+              />
+            </div>
+          ) : p.loot ? (
+            <div className="mx-auto max-w-2xl">
+              <LiveLootPanel
+                loot={p.loot}
+                cards={cat.cards}
+                relics={cat.relics}
+                potions={cat.potions}
+                lp={lp}
+                lang={lang}
+              />
+            </div>
+          ) : (
+            <div className="py-12 text-center text-sm text-white/70">
+              {p.screen ? `On the ${p.screen} screen` : "Between rooms"}
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/app/live/[steamId]/LiveScene.tsx
+++ b/frontend/app/live/[steamId]/LiveScene.tsx
@@ -7,10 +7,13 @@
 // the hand along the bottom. Combat only for now; other screens fall through to
 // the normal layout. All driven by the same presence fields the panels use.
 
+import { useState } from "react";
 import { imageUrl, fullCardUrl } from "@/lib/image-url";
+import LiveMap from "../LiveMap";
 import {
   CardPill,
   PotionPill,
+  RelicPill,
   cleanId,
   displayName,
   type CardInfo,
@@ -23,8 +26,10 @@ import {
   monsterName,
   parseDeckId,
   withOrdinalKeys,
+  type EncounterMap,
   type Enemy,
   type EnemyIntent,
+  type LiveOrb,
   type LivePlayer,
   type LivePower,
   type MonsterMap,
@@ -75,12 +80,16 @@ function IntentBadge({ intent }: { intent: EnemyIntent }) {
           (e.target as HTMLImageElement).style.visibility = "hidden";
         }}
       />
-      {dmg != null && (
+      {dmg != null ? (
         <span className="text-xs font-bold tabular-nums text-rose-200">
           {dmg}
           {hits}
         </span>
-      )}
+      ) : intent.amount != null ? (
+        <span className="text-xs font-bold tabular-nums text-sky-200">
+          {intent.amount}
+        </span>
+      ) : null}
     </span>
   );
 }
@@ -113,6 +122,47 @@ function PowerRow({ powers }: { powers: LivePower[] }) {
   );
 }
 
+/** The player's channeled orbs: a row of orb icons (filled + empty slots), each
+ * with its passive (per-turn) value. */
+function OrbRow({ orbs, slots }: { orbs: LiveOrb[]; slots?: number | null }) {
+  const total = Math.max(slots ?? 0, orbs.length);
+  if (total <= 0) return null;
+  return (
+    <div className="flex flex-wrap justify-center gap-1">
+      {Array.from({ length: total }).map((_, i) => {
+        const orb = orbs[i];
+        return (
+          <span
+            key={i}
+            className="relative inline-flex"
+            title={orb ? displayName(orb.id) : "Empty orb slot"}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={imageUrl(
+                orb
+                  ? `/static/images/orbs/${cleanId(orb.id).toLowerCase()}_orb.png`
+                  : "/static/images/orbs/empty_orb.png",
+              )}
+              alt=""
+              className="h-7 w-7 object-contain"
+              crossOrigin="anonymous"
+              onError={(e) => {
+                (e.target as HTMLImageElement).style.visibility = "hidden";
+              }}
+            />
+            {orb?.passive != null && (
+              <span className="absolute -bottom-1 -right-1 rounded bg-black/70 px-0.5 text-[9px] font-bold leading-none text-white tabular-nums">
+                {orb.passive}
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
 /** HP bar + block + the optional block shield, under a token. */
 function Vitals({
   hp,
@@ -136,7 +186,13 @@ function Vitals({
       )}
       {(block ?? 0) > 0 && (
         <div className="mt-0.5 flex items-center justify-center gap-1 text-[11px] font-bold text-sky-200">
-          <span className="inline-block h-2.5 w-2.5 rotate-45 bg-sky-400/80" />
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={imageUrl("/static/images/intents/defend.png")}
+            alt="block"
+            className="h-4 w-4 object-contain"
+            crossOrigin="anonymous"
+          />
           {block}
         </div>
       )}
@@ -162,22 +218,72 @@ function HudStat({ icon, children }: { icon: string; children: React.ReactNode }
   );
 }
 
+/** A clickable pile button (image + count) that opens the pile's contents. */
+function PileButton({
+  label,
+  img,
+  count,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  img: string;
+  count?: number | null;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  if (count == null) return null;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={`${label} pile`}
+      className="inline-flex flex-col items-center gap-0.5 hover:opacity-80 disabled:cursor-default disabled:opacity-60"
+    >
+      <span className="inline-flex items-center gap-1 text-sm font-semibold tabular-nums text-[var(--text-secondary)]">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={img} alt={label} className="h-8 w-8 object-contain" crossOrigin="anonymous" />
+        {count}
+      </span>
+    </button>
+  );
+}
+
 export default function LiveScene({
   p,
   cat,
   monsters,
+  encounters,
   lp,
   lang,
 }: {
   p: LivePlayer;
   cat: Catalogs;
   monsters: MonsterMap;
+  encounters: EncounterMap;
   lp: string;
   lang: string;
 }) {
   const char = (p.character ?? "colorless").toLowerCase();
   const enemies: Enemy[] = (p.enemies ?? []).filter((e) => (e.hp ?? 1) > 0);
+  const dead = !!p.death || (p.events ?? []).some((e) => e.k === "death");
   const hand = p.hand ?? [];
+  const hpPct =
+    p.hp != null && p.max_hp
+      ? Math.max(0, Math.min(100, (p.hp / p.max_hp) * 100))
+      : 0;
+  // Deck / pile viewer modal + the map modal (the Deck/Map buttons + the pile
+  // buttons open these). `openCards` holds the title + the card-id list.
+  const [openCards, setOpenCards] = useState<{ title: string; ids: string[] } | null>(
+    null,
+  );
+  const [showMap, setShowMap] = useState(false);
+  const groupCards = (ids: string[]): [string, number][] => {
+    const m = new Map<string, number>();
+    for (const raw of ids) m.set(raw, (m.get(raw) ?? 0) + 1);
+    return [...m.entries()];
+  };
   // The room background for the current screen (combat falls back to the
   // gradient; not every screen has dedicated art yet).
   // Scene background. Merchant/neow have their own room art; everything else
@@ -188,147 +294,227 @@ export default function LiveScene({
   const regionBgs = new Set(["overgrowth", "underdocks", "hive", "glory"]);
   const sceneLayers: string[] =
     p.screen === "merchant"
-      ? [imageUrl("/static/images/misc/merchant.webp")]
+      ? // the room, cropped of its baked-in letterbox so object-cover fills the
+        // whole box; the merchant figure rides as the medallion token instead.
+        ["/rooms/merchant.webp"]
       : p.event?.id === "NEOW"
         ? [imageUrl("/static/images/misc/neow.webp")]
         : regionBgs.has(region)
-          ? ["top", "middle", "bottom"].map((l) =>
-              imageUrl(`/static/images/ui/map_backgrounds/map_${l}_${region}.png`),
-            )
+          ? // the act's room backdrop (also the rest-site environment),
+            // composited from the game's parallax layers, served from /public/rooms
+            [`/rooms/${region}.webp`]
           : [];
 
   return (
-    <div className="overflow-hidden rounded-xl border border-[var(--border-subtle)]">
-      {/* Top HUD bar (the in-game taskbar). */}
-      <div className="flex flex-wrap items-center gap-4 border-b border-[var(--border-subtle)] bg-[var(--bg-card)] px-4 py-2">
-        <span className="text-sm font-bold text-[var(--text-primary)]">
-          {p.act != null ? `Act ${p.act}` : ""}
-          {p.total_floor != null ? ` · Floor ${p.total_floor}` : ""}
+    <div className="flex h-[80vh] flex-col rounded-xl border border-[var(--border-subtle)]">
+      {/* Top bar: character + vitals + potions on the left, the act/boss
+          progress, then the map + deck buttons on the right. */}
+      <div className="relative z-20 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-t-xl border-b border-[var(--border-subtle)] bg-[var(--bg-card)] px-3 py-2">
+        <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full border border-[var(--accent-gold)]/50 bg-[var(--bg-primary)]">
+          <CharacterIcon character={p.character} className="h-[88%] w-[88%]" />
         </span>
-        {p.energy != null && (
-          <HudStat
-            icon={imageUrl(`/static/images/icons/${char}_energy_icon.png`)}
-          >
-            {p.energy}
-            {p.max_energy != null ? `/${p.max_energy}` : ""}
-          </HudStat>
+        {p.ascension != null && p.ascension > 0 && (
+          <span className="rounded bg-[var(--accent-gold)]/15 px-1.5 py-0.5 text-[10px] font-bold text-[var(--accent-gold)] ring-1 ring-[var(--accent-gold)]/30">
+            A{p.ascension}
+          </span>
+        )}
+        {p.hp != null && (
+          <span className="inline-flex items-center gap-1.5">
+            <span className="relative block h-3.5 w-24 overflow-hidden rounded bg-black/40 ring-1 ring-black/30">
+              <span className="block h-full bg-rose-600" style={{ width: `${hpPct}%` }} />
+            </span>
+            <span className="text-xs font-semibold tabular-nums text-rose-200">
+              {p.hp}/{p.max_hp}
+            </span>
+          </span>
         )}
         {p.gold != null && (
           <HudStat icon={imageUrl("/static/images/icons/gold_icon.png")}>
             {p.gold}
           </HudStat>
         )}
-        {p.deck != null && (
-          <span className="text-sm text-[var(--text-secondary)] tabular-nums">
-            Deck {p.deck.length}
-          </span>
+        {(p.potions ?? []).length > 0 && (
+          <div className="flex items-center gap-1">
+            {withOrdinalKeys(p.potions ?? []).map(({ item, key }) => {
+              const pid = cleanId(item);
+              const info = cat.potions[pid];
+              return (
+                <PotionPill
+                  key={key}
+                  potionId={pid}
+                  potionData={cat.potions}
+                  lp={lp}
+                  className="block shrink-0"
+                >
+                  {info?.image_url ? (
+                    <img
+                      src={imageUrl(info.image_url)}
+                      alt={info.name}
+                      className="h-7 w-7 object-contain"
+                      crossOrigin="anonymous"
+                      onError={(e) => {
+                        (e.target as HTMLImageElement).style.display = "none";
+                      }}
+                    />
+                  ) : (
+                    <span className="text-[10px] text-[var(--text-secondary)]">
+                      {displayName(`POTION.${pid}`)}
+                    </span>
+                  )}
+                </PotionPill>
+              );
+            })}
+          </div>
         )}
-        <div className="ml-auto flex items-center gap-3 text-sm text-[var(--text-secondary)] tabular-nums">
-          {p.draw_count != null && (
-            <HudStat icon={imageUrl("/static/images/ui/combat/draw_pile.png")}>
-              {p.draw_count}
-            </HudStat>
-          )}
-          {p.discard_count != null && (
-            <HudStat icon={imageUrl("/static/images/ui/combat/discard_pile.png")}>
-              {p.discard_count}
-            </HudStat>
-          )}
-          {p.exhaust_count != null && (
-            <span className="inline-flex items-center gap-1">
-              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-purple-600 text-[10px] font-bold text-white">
-                {p.exhaust_count}
-              </span>
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs font-semibold tabular-nums text-[var(--text-secondary)]">
+            {p.act != null ? `Act ${p.act}` : ""}
+            {p.total_floor != null ? ` · F${p.total_floor}` : ""}
+          </span>
+          {p.route?.boss?.id && (
+            <span
+              className="inline-flex items-center gap-1"
+              title={`Act boss: ${p.route.boss.name || p.route.boss.id}`}
+            >
+              <span className="text-[var(--text-muted)]">→</span>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={imageUrl(
+                  `/static/images/misc/bosses/${p.route.boss.id.toLowerCase()}.png`,
+                )}
+                alt={p.route.boss.name || "Boss"}
+                className="h-9 w-9 object-contain"
+                crossOrigin="anonymous"
+                onError={(e) => {
+                  (e.target as HTMLImageElement).style.display = "none";
+                }}
+              />
             </span>
+          )}
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          {(p.map?.nodes?.length ?? 0) > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowMap(true)}
+              title="Map"
+              className="shrink-0 hover:opacity-80"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={imageUrl("/static/images/ui/top_bar/top_bar_map.png")}
+                alt="Map"
+                className="h-10 w-10 object-contain"
+                crossOrigin="anonymous"
+              />
+            </button>
+          )}
+          {p.deck != null && (
+            <button
+              type="button"
+              onClick={() => setOpenCards({ title: "Deck", ids: p.deck ?? [] })}
+              title="Deck"
+              className="relative shrink-0 hover:opacity-80"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={imageUrl("/static/images/ui/top_bar/top_bar_deck.png")}
+                alt="Deck"
+                className="h-10 w-10 object-contain"
+                crossOrigin="anonymous"
+              />
+              {p.deck.length > 0 && (
+                <span className="absolute -bottom-1 -right-1 rounded bg-black/70 px-1 text-[10px] font-bold tabular-nums text-white">
+                  {p.deck.length}
+                </span>
+              )}
+            </button>
           )}
         </div>
       </div>
 
+      {/* Relics, listed top-left under the HUD like the in-game relic bar. */}
+      {(p.relics ?? []).length > 0 && (
+        <div className="relative z-30 flex flex-wrap items-center gap-1 border-b border-[var(--border-subtle)] bg-[var(--bg-card)]/60 px-3 py-1.5">
+          {withOrdinalKeys(p.relics ?? []).map(({ item, key }) => {
+            const rid = cleanId(item);
+            const info = cat.relics[rid];
+            return (
+              <RelicPill
+                key={key}
+                relicId={rid}
+                relicData={cat.relics}
+                lp={lp}
+                className="block shrink-0"
+              >
+                {info?.image_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={imageUrl(info.image_url)}
+                    alt={info.name}
+                    className="h-7 w-7 object-contain"
+                    crossOrigin="anonymous"
+                    onError={(e) => {
+                      (e.target as HTMLImageElement).style.display = "none";
+                    }}
+                  />
+                ) : (
+                  <span className="text-[10px] text-[var(--text-secondary)]">
+                    {displayName(`RELIC.${rid}`)}
+                  </span>
+                )}
+              </RelicPill>
+            );
+          })}
+        </div>
+      )}
+
       {/* The arena: combat shows the battle; other screens render their own
           scene over the matching room background. */}
-      <div className="relative min-h-[320px] overflow-hidden bg-gradient-to-b from-[#1a1320] via-[#120c18] to-[#0c0810]">
-        {sceneLayers.map((src) => (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            key={src}
-            src={src}
-            alt=""
-            className="absolute inset-0 h-full w-full object-cover"
-            crossOrigin="anonymous"
-            onError={(e) => {
-              (e.target as HTMLImageElement).style.display = "none";
-            }}
-          />
-        ))}
-        {sceneLayers.length > 0 && (
-          <div className="absolute inset-0 bg-black/30" />
-        )}
-        <div className="relative px-6 py-8">
-          {p.screen === "combat" ? (
-            <div className="flex items-start justify-between gap-6">
-          {/* Player token */}
-          <div className="flex flex-col items-center gap-2">
-            <CharacterIcon
-              character={p.character}
-              className="h-28 w-28 ring-2 ring-[var(--accent-gold)]/60"
+      <div className="relative flex flex-1 items-center bg-gradient-to-b from-[#1a1320] via-[#120c18] to-[#0c0810]">
+        {/* Background layers clipped to the arena; the content lives in a
+            non-clipped sibling so hover previews aren't cut off at the edge. */}
+        <div className="absolute inset-0 overflow-hidden">
+          {sceneLayers.map((src) => (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              key={src}
+              src={src}
+              alt=""
+              className="absolute inset-0 h-full w-full object-cover"
+              crossOrigin="anonymous"
+              onError={(e) => {
+                (e.target as HTMLImageElement).style.display = "none";
+              }}
             />
-            <div className="text-sm font-semibold text-[var(--text-primary)]">
-              {p.username || displayName(`CHARACTER.${p.character ?? ""}`)}
-            </div>
-            <Vitals hp={p.hp} maxHp={p.max_hp} block={p.block} />
-            <PowerRow powers={p.player_powers ?? []} />
-          </div>
-
-          {/* Enemy tokens */}
-          <div className="flex flex-wrap items-start justify-end gap-6">
-            {enemies.length === 0 ? (
-              <div className="self-center text-sm text-[var(--text-muted)]">
-                Waiting for the fight…
+          ))}
+          {sceneLayers.length > 0 && (
+            <div className="absolute inset-0 bg-black/20" />
+          )}
+          {dead && (
+            <div className="absolute inset-0 bg-gradient-to-t from-rose-950/80 via-rose-900/45 to-rose-900/20" />
+          )}
+        </div>
+        <div className="relative w-full px-6 py-8">
+          {dead ? (
+            <div className="mx-auto flex max-w-lg flex-col items-center gap-3 py-10 text-center">
+              <div className="text-xs font-bold uppercase tracking-[0.3em] text-rose-400">
+                Defeated
               </div>
-            ) : (
-              enemies.map((e, i) => (
-                <div
-                  key={(e.id || "enemy") + i}
-                  className="flex flex-col items-center gap-2"
-                >
-                  <div className="min-h-[28px]">
-                    <div className="flex items-end gap-1">
-                      {(e.intents ?? []).map((it, j) => (
-                        <IntentBadge key={j} intent={it} />
-                      ))}
-                    </div>
-                  </div>
-                  <EnemyCircle
-                    id={e.id || ""}
-                    monsters={monsters}
-                    className="h-28 w-28 ring-2 ring-rose-500/50"
-                  />
-                  <div className="max-w-[8rem] truncate text-sm font-semibold text-[var(--text-primary)]">
-                    {e.name || monsterName(e.id || "", monsters)}
-                  </div>
-                  <Vitals hp={e.hp} maxHp={e.max_hp} block={e.block} />
-                  <PowerRow powers={(e as { powers?: LivePower[] }).powers ?? []} />
+              {p.death?.line && (
+                <div className="text-2xl font-semibold italic leading-snug text-rose-200">
+                  “{p.death.line}”
                 </div>
-              ))
-            )}
-          </div>
-            </div>
-          ) : p.event ? (
-            <div className="mx-auto max-w-2xl">
-              <LiveEventPanel ev={p.event} lp={lp} />
-            </div>
-          ) : p.shop ? (
-            <div className="mx-auto max-w-3xl">
-              <LiveShopPanel
-                shop={p.shop}
-                cards={cat.cards}
-                relics={cat.relics}
-                potions={cat.potions}
-                lp={lp}
-                lang={lang}
-              />
+              )}
+              {p.death?.by && (
+                <div className="text-sm text-[var(--text-muted)]">
+                  Slain by {monsterName(p.death.by, monsters)}
+                </div>
+              )}
             </div>
           ) : p.loot ? (
+            // The fight is over once loot is on offer -- show the rewards
+            // instead of the dying enemy sitting at 1 HP.
             <div className="mx-auto max-w-2xl">
               <LiveLootPanel
                 loot={p.loot}
@@ -339,6 +525,126 @@ export default function LiveScene({
                 lang={lang}
               />
             </div>
+          ) : p.screen === "combat" && enemies.length > 0 ? (
+            <div className="flex flex-col items-center gap-8 landscape:flex-row landscape:items-start landscape:justify-between landscape:gap-6 landscape:px-[10%]">
+              {/* Character on the left in landscape; portrait stacks it above the
+                  enemies so the two aren't crammed side by side. */}
+              <div className="flex flex-col items-center gap-2">
+                <span
+                  className={`inline-flex h-28 w-28 items-center justify-center overflow-hidden rounded-full border-2 bg-[var(--bg-primary)] transition ${
+                    p.turn_side === "player"
+                      ? "border-[var(--accent-gold)] ring-4 ring-[var(--accent-gold)]/70 shadow-[0_0_18px_rgba(212,175,55,0.6)]"
+                      : "border-[var(--accent-gold)]/60"
+                  }`}
+                >
+                  <CharacterIcon character={p.character} className="h-[88%] w-[88%]" />
+                </span>
+                <div className="text-sm font-semibold text-[var(--text-primary)]">
+                  {p.username || displayName(`CHARACTER.${p.character ?? ""}`)}
+                </div>
+                <Vitals hp={p.hp} maxHp={p.max_hp} block={p.block} />
+                <PowerRow powers={p.player_powers ?? []} />
+                <OrbRow orbs={p.orbs ?? []} slots={p.orb_slots} />
+              </div>
+
+              {/* Enemy tokens */}
+              <div className="flex flex-wrap items-center justify-center gap-6 landscape:items-start landscape:justify-end">
+                {enemies.map((e, i) => (
+                  <div
+                    key={(e.id || "enemy") + i}
+                    className="flex flex-col items-center gap-2"
+                  >
+                    <div className="min-h-[28px]">
+                      <div className="flex items-end gap-1">
+                        {(e.intents ?? []).map((it, j) => (
+                          <IntentBadge key={j} intent={it} />
+                        ))}
+                      </div>
+                    </div>
+                    <EnemyCircle
+                      id={e.id || ""}
+                      monsters={monsters}
+                      className={`h-28 w-28 ring-2 transition ${
+                        p.turn_side === "enemy"
+                          ? "ring-rose-400 shadow-[0_0_18px_rgba(244,63,94,0.6)]"
+                          : "ring-rose-500/50"
+                      }`}
+                    />
+                    <div className="max-w-[8rem] truncate text-sm font-semibold text-[var(--text-primary)]">
+                      {e.name || monsterName(e.id || "", monsters)}
+                    </div>
+                    <Vitals hp={e.hp} maxHp={e.max_hp} block={e.block} />
+                    <PowerRow powers={e.powers ?? []} />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : p.event ? (
+            <div className="mx-auto max-w-2xl">
+              <LiveEventPanel
+                ev={p.event}
+                lp={lp}
+                cards={cat.cards}
+                relics={cat.relics}
+              />
+            </div>
+          ) : p.shop ? (
+            // Like the in-game merchant: player on the left, shopkeep on the
+            // right, the wares (with prices) between them.
+            <div className="flex items-center justify-between gap-4 px-[5%]">
+              <span className="inline-flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden rounded-full border-2 border-[var(--accent-gold)]/60 bg-[var(--bg-primary)]">
+                <CharacterIcon character={p.character} className="h-[88%] w-[88%]" />
+              </span>
+              <div className="min-w-0 max-w-2xl flex-1">
+                <LiveShopPanel
+                  shop={p.shop}
+                  cards={cat.cards}
+                  relics={cat.relics}
+                  potions={cat.potions}
+                  lp={lp}
+                  lang={lang}
+                />
+              </div>
+              <span className="inline-flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden rounded-full border-2 border-[var(--accent-gold)]/60 bg-[var(--bg-primary)]">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={imageUrl("/static/images/misc/merchant.webp")}
+                  alt="Merchant"
+                  className="h-[88%] w-[88%] object-contain"
+                  crossOrigin="anonymous"
+                />
+              </span>
+            </div>
+          ) : p.screen === "rest" ? (
+            <div className="mx-auto flex max-w-md flex-col items-center gap-3 py-8 text-center">
+              <span className="inline-flex h-24 w-24 items-center justify-center overflow-hidden rounded-full border-2 border-[var(--accent-gold)]/60 bg-[var(--bg-primary)]">
+                <CharacterIcon character={p.character} className="h-[88%] w-[88%]" />
+              </span>
+              <div className="text-base font-semibold text-amber-200">
+                Resting at a campfire
+              </div>
+              {p.hp != null && (
+                <div className="text-sm text-[var(--text-secondary)] tabular-nums">
+                  {p.hp}/{p.max_hp} HP
+                </div>
+              )}
+              {p.rest?.options?.length ? (
+                <div className="flex flex-wrap justify-center gap-2">
+                  {p.rest.options.map((o) => (
+                    <span
+                      key={o.id}
+                      className={`rounded-lg border px-4 py-2 text-sm font-semibold ${
+                        o.enabled === false
+                          ? "border-[var(--border-subtle)] text-[var(--text-muted)] opacity-50"
+                          : "border-[var(--accent-gold)]/50 bg-[var(--bg-card)]/80 text-[var(--text-primary)]"
+                      }`}
+                    >
+                      {o.title || displayName(`REST.${o.id}`)}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </div>
           ) : (
             <div className="py-12 text-center text-sm text-white/70">
               {p.screen ? `On the ${p.screen} screen` : "Between rooms"}
@@ -347,69 +653,181 @@ export default function LiveScene({
         </div>
       </div>
 
-      {/* The hand along the bottom. */}
-      {hand.length > 0 && (
-        <div className="flex flex-wrap items-end justify-center gap-1.5 border-t border-[var(--border-subtle)] bg-[var(--bg-card)] px-4 py-3">
-          {withOrdinalKeys(hand).map(({ item, key }) => {
-            const { id, upgraded } = parseDeckId(item);
-            return (
-              <CardPill
-                key={key}
-                cardId={id}
-                upgraded={upgraded}
-                cardData={cat.cards}
-                lp={lp}
-                className="relative block w-20 shrink-0 transition hover:-translate-y-2"
-              >
+      {/* Bottom bar: draw pile + energy, the hand, then discard + exhaust. */}
+      {(hand.length > 0 ||
+        p.energy != null ||
+        p.draw_count != null ||
+        p.discard_count != null) && (
+        <div className="flex items-end justify-between gap-3 rounded-b-xl border-t border-[var(--border-subtle)] bg-[var(--bg-card)] px-4 py-3">
+          <div className="flex shrink-0 items-center gap-3">
+            <PileButton
+              label="Draw"
+              img={imageUrl("/static/images/ui/combat/draw_pile.png")}
+              count={p.draw_count}
+              onClick={() =>
+                setOpenCards({ title: "Draw pile", ids: p.draw_pile ?? [] })
+              }
+              disabled={!p.draw_pile?.length}
+            />
+            {p.energy != null && (
+              <span className="inline-flex items-center gap-1 text-base font-bold tabular-nums text-[var(--text-primary)]">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
-                  src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
-                  alt={cat.cards[id]?.name || displayName(`CARD.${id}`)}
-                  className="h-auto w-20 rounded-sm"
+                  src={imageUrl(`/static/images/icons/${char}_energy_icon.png`)}
+                  alt="Energy"
+                  className="h-8 w-8 object-contain"
                   crossOrigin="anonymous"
-                  loading="lazy"
+                  onError={(e) => {
+                    const el = e.target as HTMLImageElement;
+                    const fb = imageUrl(
+                      "/static/images/icons/colorless_energy_icon.png",
+                    );
+                    if (el.src !== fb) el.src = fb;
+                  }}
                 />
-              </CardPill>
-            );
-          })}
+                {p.energy}
+                {p.max_energy != null ? `/${p.max_energy}` : ""}
+              </span>
+            )}
+          </div>
+          <div className="flex flex-1 flex-wrap items-end justify-center gap-1.5">
+            {withOrdinalKeys(hand).map(({ item, key }) => {
+              const { id, upgraded } = parseDeckId(item);
+              return (
+                <CardPill
+                  key={key}
+                  cardId={id}
+                  upgraded={upgraded}
+                  cardData={cat.cards}
+                  lp={lp}
+                  className="relative block w-20 shrink-0 transition hover:-translate-y-2"
+                >
+                  <img
+                    src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                    alt={cat.cards[id]?.name || displayName(`CARD.${id}`)}
+                    className="h-auto w-20 rounded-sm"
+                    crossOrigin="anonymous"
+                    loading="lazy"
+                  />
+                </CardPill>
+              );
+            })}
+          </div>
+          <div className="flex shrink-0 items-center gap-3">
+            <PileButton
+              label="Discard"
+              img={imageUrl("/static/images/ui/combat/discard_pile.png")}
+              count={p.discard_count}
+              onClick={() =>
+                setOpenCards({ title: "Discard pile", ids: p.discard_pile ?? [] })
+              }
+              disabled={!p.discard_pile?.length}
+            />
+            <PileButton
+              label="Exhaust"
+              img={imageUrl("/static/images/ui/combat/exhaust_pile.png")}
+              count={p.exhaust_count}
+              onClick={() =>
+                setOpenCards({ title: "Exhaust pile", ids: p.exhaust_pile ?? [] })
+              }
+              disabled={!p.exhaust_pile?.length}
+            />
+          </div>
         </div>
       )}
 
-      {/* Potions, small, under the arena. */}
-      {(p.potions ?? []).length > 0 && (
-        <div className="flex items-center gap-1.5 border-t border-[var(--border-subtle)] bg-[var(--bg-card)] px-4 py-2">
-          <span className="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
-            Potions
-          </span>
-          {withOrdinalKeys(p.potions ?? []).map(({ item, key }) => {
-            const pid = cleanId(item);
-            const info = cat.potions[pid];
-            return (
-              <PotionPill
-                key={key}
-                potionId={pid}
-                potionData={cat.potions}
-                lp={lp}
-                className="block shrink-0"
+      {/* Deck / pile viewer (the Deck button + the pile buttons open this). */}
+      {openCards && (
+        <div
+          className="fixed inset-0 z-[60] flex items-start justify-center overflow-y-auto bg-black/60 p-4"
+          onClick={() => setOpenCards(null)}
+        >
+          <div
+            className="my-8 w-full max-w-3xl rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4"
+            onClick={(ev) => ev.stopPropagation()}
+          >
+            <div className="mb-3 flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-[var(--accent-gold)]">
+                {openCards.title} ({openCards.ids.length})
+              </h3>
+              <button
+                type="button"
+                onClick={() => setOpenCards(null)}
+                aria-label="Close"
+                className="px-1 text-[var(--text-muted)] hover:text-[var(--text-primary)]"
               >
-                {info?.image_url ? (
-                  <img
-                    src={imageUrl(info.image_url)}
-                    alt={info.name}
-                    className="h-8 w-8 object-contain"
-                    crossOrigin="anonymous"
-                    loading="lazy"
-                    onError={(e) => {
-                      (e.target as HTMLImageElement).style.display = "none";
-                    }}
-                  />
-                ) : (
-                  <span className="text-xs text-[var(--text-secondary)]">
-                    {displayName(`POTION.${pid}`)}
-                  </span>
-                )}
-              </PotionPill>
-            );
-          })}
+                ✕
+              </button>
+            </div>
+            {openCards.ids.length === 0 ? (
+              <p className="text-sm text-[var(--text-muted)]">No cards on this beat.</p>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {groupCards(openCards.ids).map(([raw, count]) => {
+                  const { id, upgraded } = parseDeckId(raw);
+                  return (
+                    <CardPill
+                      key={raw}
+                      cardId={id}
+                      upgraded={upgraded}
+                      cardData={cat.cards}
+                      lp={lp}
+                      className="relative block w-24 shrink-0"
+                    >
+                      <img
+                        src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                        alt={cat.cards[id]?.name || displayName(`CARD.${id}`)}
+                        className="h-auto w-24 rounded-sm"
+                        crossOrigin="anonymous"
+                        loading="lazy"
+                      />
+                      {count > 1 && (
+                        <span className="absolute -top-1 -right-1 rounded bg-[var(--accent-gold)] px-1 text-[10px] font-bold text-[var(--bg-primary)]">
+                          ×{count}
+                        </span>
+                      )}
+                    </CardPill>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Map viewer (the Map button opens this). */}
+      {showMap && (
+        <div
+          className="fixed inset-0 z-[60] flex items-start justify-center overflow-y-auto bg-black/60 p-4"
+          onClick={() => setShowMap(false)}
+        >
+          <div
+            className="my-8 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4"
+            onClick={(ev) => ev.stopPropagation()}
+          >
+            <div className="mb-3 flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-[var(--accent-gold)]">
+                Map{p.map?.act != null ? ` · Act ${p.map.act}` : ""}
+              </h3>
+              <button
+                type="button"
+                onClick={() => setShowMap(false)}
+                aria-label="Close"
+                className="px-1 text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+              >
+                ✕
+              </button>
+            </div>
+            <LiveMap
+              map={p.map}
+              path={p.path}
+              pos={p.pos}
+              reveals={p.reveals}
+              route={p.route}
+              monsters={monsters}
+              encounters={encounters}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/frontend/app/live/[steamId]/LiveScene.tsx
+++ b/frontend/app/live/[steamId]/LiveScene.tsx
@@ -180,16 +180,22 @@ export default function LiveScene({
   const hand = p.hand ?? [];
   // The room background for the current screen (combat falls back to the
   // gradient; not every screen has dedicated art yet).
-  const sceneBg =
+  // Scene background. Merchant/neow have their own room art; everything else
+  // (combat, events, treasure, rest) sits in the current act's region, so use
+  // that region's environment — the map parallax layers (top/middle/bottom),
+  // keyed by act_name — to match the in-game look.
+  const region = (p.act_name || "").toLowerCase();
+  const regionBgs = new Set(["overgrowth", "underdocks", "hive", "glory"]);
+  const sceneLayers: string[] =
     p.screen === "merchant"
-      ? imageUrl("/static/images/misc/merchant.webp")
-      : p.screen === "treasure"
-        ? imageUrl(
-            "/static/images/renders/backgrounds/treasure_room/chest_room_act_3.png",
-          )
-        : p.event?.id === "NEOW"
-          ? imageUrl("/static/images/renders/backgrounds/neow_room/neow.webp")
-          : "";
+      ? [imageUrl("/static/images/misc/merchant.webp")]
+      : p.event?.id === "NEOW"
+        ? [imageUrl("/static/images/misc/neow.webp")]
+        : regionBgs.has(region)
+          ? ["top", "middle", "bottom"].map((l) =>
+              imageUrl(`/static/images/ui/map_backgrounds/map_${l}_${region}.png`),
+            )
+          : [];
 
   return (
     <div className="overflow-hidden rounded-xl border border-[var(--border-subtle)]">
@@ -241,20 +247,21 @@ export default function LiveScene({
       {/* The arena: combat shows the battle; other screens render their own
           scene over the matching room background. */}
       <div className="relative min-h-[320px] overflow-hidden bg-gradient-to-b from-[#1a1320] via-[#120c18] to-[#0c0810]">
-        {sceneBg && (
-          <>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={sceneBg}
-              alt=""
-              className="absolute inset-0 h-full w-full object-cover opacity-90"
-              crossOrigin="anonymous"
-              onError={(e) => {
-                (e.target as HTMLImageElement).style.display = "none";
-              }}
-            />
-            <div className="absolute inset-0 bg-black/45" />
-          </>
+        {sceneLayers.map((src) => (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            key={src}
+            src={src}
+            alt=""
+            className="absolute inset-0 h-full w-full object-cover"
+            crossOrigin="anonymous"
+            onError={(e) => {
+              (e.target as HTMLImageElement).style.display = "none";
+            }}
+          />
+        ))}
+        {sceneLayers.length > 0 && (
+          <div className="absolute inset-0 bg-black/30" />
         )}
         <div className="relative px-6 py-8">
           {p.screen === "combat" ? (

--- a/frontend/app/live/[steamId]/LiveScene.tsx
+++ b/frontend/app/live/[steamId]/LiveScene.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+// EXPERIMENTAL game-like battle scene for the live view (opt-in via ?scene=1).
+// Instead of data panels, it recreates the in-game combat layout: a top HUD
+// bar, the player as a token on the left and the enemies as tokens on the
+// right, each with HP / block / powers, the enemies showing their intent, and
+// the hand along the bottom. Combat only for now; other screens fall through to
+// the normal layout. All driven by the same presence fields the panels use.
+
+import { imageUrl, fullCardUrl } from "@/lib/image-url";
+import {
+  CardPill,
+  PotionPill,
+  cleanId,
+  displayName,
+  type CardInfo,
+  type PotionInfo,
+  type RelicInfo,
+} from "../../runs/[hash]/RunPills";
+import {
+  CharacterIcon,
+  EnemyCircle,
+  monsterName,
+  parseDeckId,
+  withOrdinalKeys,
+  type Enemy,
+  type EnemyIntent,
+  type LivePlayer,
+  type LivePower,
+  type MonsterMap,
+} from "../live-shared";
+
+interface Catalogs {
+  cards: Record<string, CardInfo>;
+  relics: Record<string, RelicInfo>;
+  potions: Record<string, PotionInfo>;
+}
+
+// Map an intent category to its icon file (a few names differ from the type).
+const INTENT_FILE: Record<string, string> = {
+  attack: "attack",
+  deathblow: "death_blow",
+  defend: "defend",
+  buff: "buff",
+  heal: "heal",
+  debuff: "debuff",
+  carddebuff: "card_debuff",
+  escape: "escape",
+  sleep: "sleep",
+  status: "status",
+  hidden: "hidden",
+  unknown: "hidden",
+};
+
+function intentSrc(type?: string): string {
+  const key = (type || "unknown").toLowerCase();
+  return imageUrl(`/static/images/intents/${INTENT_FILE[key] || "hidden"}.png`);
+}
+
+/** The enemy's next move: the intent icon with the damage (and hit count) on it. */
+function IntentBadge({ intent }: { intent: EnemyIntent }) {
+  const dmg = intent.dmg != null ? intent.dmg : null;
+  const hits = intent.hits && intent.hits > 1 ? `×${intent.hits}` : "";
+  return (
+    <span className="inline-flex flex-col items-center">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={intentSrc(intent.type)}
+        alt={intent.type || "intent"}
+        title={intent.type || "intent"}
+        className="h-7 w-7 object-contain drop-shadow"
+        crossOrigin="anonymous"
+        onError={(e) => {
+          (e.target as HTMLImageElement).style.visibility = "hidden";
+        }}
+      />
+      {dmg != null && (
+        <span className="text-xs font-bold tabular-nums text-rose-200">
+          {dmg}
+          {hits}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/** Buff/debuff chips as the game's power icons with their stack count. */
+function PowerRow({ powers }: { powers: LivePower[] }) {
+  if (!powers.length) return null;
+  return (
+    <div className="flex flex-wrap justify-center gap-1">
+      {powers.map((pw) => (
+        <span key={pw.id} className="relative inline-flex" title={displayName(pw.id)}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={imageUrl(`/static/images/powers/${pw.id.toLowerCase()}_power.png`)}
+            alt={displayName(pw.id)}
+            className="h-5 w-5 object-contain"
+            crossOrigin="anonymous"
+            onError={(e) => {
+              (e.target as HTMLImageElement).style.visibility = "hidden";
+            }}
+          />
+          {pw.amount != null && pw.amount !== 0 && (
+            <span className="absolute -bottom-1 -right-1 rounded bg-black/70 px-0.5 text-[9px] font-bold leading-none text-white tabular-nums">
+              {pw.amount}
+            </span>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** HP bar + block + the optional block shield, under a token. */
+function Vitals({
+  hp,
+  maxHp,
+  block,
+}: {
+  hp?: number | null;
+  maxHp?: number | null;
+  block?: number | null;
+}) {
+  const pct = hp != null && maxHp ? Math.max(0, Math.min(100, (hp / maxHp) * 100)) : null;
+  return (
+    <div className="w-32 max-w-full">
+      {pct != null && (
+        <div className="relative h-4 rounded bg-black/50 ring-1 ring-black/40">
+          <div className="h-4 rounded bg-rose-600" style={{ width: `${pct}%` }} />
+          <span className="absolute inset-0 flex items-center justify-center text-[10px] font-bold text-white tabular-nums drop-shadow">
+            {hp}/{maxHp}
+          </span>
+        </div>
+      )}
+      {(block ?? 0) > 0 && (
+        <div className="mt-0.5 flex items-center justify-center gap-1 text-[11px] font-bold text-sky-200">
+          <span className="inline-block h-2.5 w-2.5 rotate-45 bg-sky-400/80" />
+          {block}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HudStat({ icon, children }: { icon: string; children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1 text-sm font-semibold tabular-nums text-[var(--text-primary)]">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={icon}
+        alt=""
+        className="h-5 w-5 object-contain"
+        crossOrigin="anonymous"
+        onError={(e) => {
+          (e.target as HTMLImageElement).style.visibility = "hidden";
+        }}
+      />
+      {children}
+    </span>
+  );
+}
+
+export default function LiveScene({
+  p,
+  cat,
+  monsters,
+  lp,
+  lang,
+}: {
+  p: LivePlayer;
+  cat: Catalogs;
+  monsters: MonsterMap;
+  lp: string;
+  lang: string;
+}) {
+  const char = (p.character ?? "colorless").toLowerCase();
+  const enemies: Enemy[] = (p.enemies ?? []).filter((e) => (e.hp ?? 1) > 0);
+  const hand = p.hand ?? [];
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-[var(--border-subtle)]">
+      {/* Top HUD bar (the in-game taskbar). */}
+      <div className="flex flex-wrap items-center gap-4 border-b border-[var(--border-subtle)] bg-[var(--bg-card)] px-4 py-2">
+        <span className="text-sm font-bold text-[var(--text-primary)]">
+          {p.act != null ? `Act ${p.act}` : ""}
+          {p.total_floor != null ? ` · Floor ${p.total_floor}` : ""}
+        </span>
+        {p.energy != null && (
+          <HudStat
+            icon={imageUrl(`/static/images/icons/${char}_energy_icon.png`)}
+          >
+            {p.energy}
+            {p.max_energy != null ? `/${p.max_energy}` : ""}
+          </HudStat>
+        )}
+        {p.gold != null && (
+          <HudStat icon={imageUrl("/static/images/icons/gold_icon.png")}>
+            {p.gold}
+          </HudStat>
+        )}
+        {p.deck != null && (
+          <span className="text-sm text-[var(--text-secondary)] tabular-nums">
+            Deck {p.deck.length}
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-3 text-sm text-[var(--text-secondary)] tabular-nums">
+          {p.draw_count != null && (
+            <HudStat icon={imageUrl("/static/images/ui/combat/draw_pile.png")}>
+              {p.draw_count}
+            </HudStat>
+          )}
+          {p.discard_count != null && (
+            <HudStat icon={imageUrl("/static/images/ui/combat/discard_pile.png")}>
+              {p.discard_count}
+            </HudStat>
+          )}
+          {p.exhaust_count != null && (
+            <span className="inline-flex items-center gap-1">
+              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-purple-600 text-[10px] font-bold text-white">
+                {p.exhaust_count}
+              </span>
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* The arena: player on the left, enemies on the right. */}
+      <div className="relative min-h-[280px] bg-gradient-to-b from-[#1a1320] via-[#120c18] to-[#0c0810] px-6 py-8">
+        <div className="flex items-start justify-between gap-6">
+          {/* Player token */}
+          <div className="flex flex-col items-center gap-2">
+            <CharacterIcon
+              character={p.character}
+              className="h-28 w-28 ring-2 ring-[var(--accent-gold)]/60"
+            />
+            <div className="text-sm font-semibold text-[var(--text-primary)]">
+              {p.username || displayName(`CHARACTER.${p.character ?? ""}`)}
+            </div>
+            <Vitals hp={p.hp} maxHp={p.max_hp} block={p.block} />
+            <PowerRow powers={p.player_powers ?? []} />
+          </div>
+
+          {/* Enemy tokens */}
+          <div className="flex flex-wrap items-start justify-end gap-6">
+            {enemies.length === 0 ? (
+              <div className="self-center text-sm text-[var(--text-muted)]">
+                Waiting for the fight…
+              </div>
+            ) : (
+              enemies.map((e, i) => (
+                <div
+                  key={(e.id || "enemy") + i}
+                  className="flex flex-col items-center gap-2"
+                >
+                  <div className="min-h-[28px]">
+                    <div className="flex items-end gap-1">
+                      {(e.intents ?? []).map((it, j) => (
+                        <IntentBadge key={j} intent={it} />
+                      ))}
+                    </div>
+                  </div>
+                  <EnemyCircle
+                    id={e.id || ""}
+                    monsters={monsters}
+                    className="h-28 w-28 ring-2 ring-rose-500/50"
+                  />
+                  <div className="max-w-[8rem] truncate text-sm font-semibold text-[var(--text-primary)]">
+                    {e.name || monsterName(e.id || "", monsters)}
+                  </div>
+                  <Vitals hp={e.hp} maxHp={e.max_hp} block={e.block} />
+                  <PowerRow powers={(e as { powers?: LivePower[] }).powers ?? []} />
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* The hand along the bottom. */}
+      {hand.length > 0 && (
+        <div className="flex flex-wrap items-end justify-center gap-1.5 border-t border-[var(--border-subtle)] bg-[var(--bg-card)] px-4 py-3">
+          {withOrdinalKeys(hand).map(({ item, key }) => {
+            const { id, upgraded } = parseDeckId(item);
+            return (
+              <CardPill
+                key={key}
+                cardId={id}
+                upgraded={upgraded}
+                cardData={cat.cards}
+                lp={lp}
+                className="relative block w-20 shrink-0 transition hover:-translate-y-2"
+              >
+                <img
+                  src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                  alt={cat.cards[id]?.name || displayName(`CARD.${id}`)}
+                  className="h-auto w-20 rounded-sm"
+                  crossOrigin="anonymous"
+                  loading="lazy"
+                />
+              </CardPill>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Potions, small, under the arena. */}
+      {(p.potions ?? []).length > 0 && (
+        <div className="flex items-center gap-1.5 border-t border-[var(--border-subtle)] bg-[var(--bg-card)] px-4 py-2">
+          <span className="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
+            Potions
+          </span>
+          {withOrdinalKeys(p.potions ?? []).map(({ item, key }) => {
+            const pid = cleanId(item);
+            const info = cat.potions[pid];
+            return (
+              <PotionPill
+                key={key}
+                potionId={pid}
+                potionData={cat.potions}
+                lp={lp}
+                className="block shrink-0"
+              >
+                {info?.image_url ? (
+                  <img
+                    src={imageUrl(info.image_url)}
+                    alt={info.name}
+                    className="h-8 w-8 object-contain"
+                    crossOrigin="anonymous"
+                    loading="lazy"
+                    onError={(e) => {
+                      (e.target as HTMLImageElement).style.display = "none";
+                    }}
+                  />
+                ) : (
+                  <span className="text-xs text-[var(--text-secondary)]">
+                    {displayName(`POTION.${pid}`)}
+                  </span>
+                )}
+              </PotionPill>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -41,6 +41,11 @@ export type Coord = [number, number];
 export interface LiveEventOption {
   key?: string;
   text?: string;
+  // resolved consequence text ("Lose 3 HP"), a card the option previews (e.g. the
+  // card a "lose a card" option will take), and a relic it grants. All optional.
+  desc?: string;
+  card?: string;
+  relic?: string;
   locked?: boolean;
   proceed?: boolean;
   chosen?: boolean;
@@ -65,6 +70,19 @@ export interface LiveShop {
   removal?: { cost?: number; stocked?: boolean };
 }
 
+// Rest-site options (v7), present only at a campfire: the Rest/Smith/Dig/...
+// buttons the player is choosing between. `id` is stable (HEAL/SMITH/...),
+// `title` the localized label, `enabled` whether it is selectable.
+export interface LiveRestOption {
+  id: string;
+  title?: string;
+  enabled?: boolean;
+}
+
+export interface LiveRest {
+  options?: LiveRestOption[];
+}
+
 // Rich combat enemy (v5) for the spectator combat panel: hp/block plus the
 // upcoming intent(s). `intents` is a list because one move can do several things
 // (attack + buff). Each intent's `type` is a codex category; `dmg`/`hits`
@@ -73,6 +91,8 @@ export interface EnemyIntent {
   type: string;
   dmg?: number;
   hits?: number;
+  // magnitude of a non-attack intent (e.g. the block a defend will gain)
+  amount?: number;
 }
 export interface Enemy {
   id?: string;
@@ -81,12 +101,22 @@ export interface Enemy {
   max_hp?: number;
   block?: number;
   intents?: EnemyIntent[];
+  // the enemy's buffs/debuffs (vulnerable, weak, strength, ...) for token icons
+  powers?: LivePower[];
 }
 
 /** A combat buff/debuff on the local player (v6): id + stack amount. */
 export interface LivePower {
   id: string;
   amount?: number;
+}
+
+/** A channeled orb (v7): id + `passive` (per-turn value) and `evoke` (on-evoke
+ * value). Combat-only, orb characters; `orb_slots` is the current capacity. */
+export interface LiveOrb {
+  id: string;
+  passive?: number;
+  evoke?: number;
 }
 
 /** One route node (v6): a boss/ancient/elite/monster/event in the act, with an
@@ -116,6 +146,13 @@ export interface LiveLoot {
   relics?: string[];
   potions?: string[];
   card_removal?: boolean | number;
+}
+
+// Death (v7), present once the run ends in a death. `line` is the killer's
+// already-localized death quote ("Not quite the top"), `by` the killer's id.
+export interface LiveDeath {
+  line?: string;
+  by?: string;
 }
 
 /** Co-op per-seat vitals (v6); `is_me` marks the local player's seat. */
@@ -160,6 +197,7 @@ export interface LivePlayer {
   pos?: Coord | null;
   event?: LiveEventCtx | null;
   shop?: LiveShop | null;
+  rest?: LiveRest | null;
   enemies?: Enemy[] | null;
   // Combat vitals + DPS (v6). `block`/`max_energy` ride the whole run; `energy`,
   // the pile counts, damage, hand, and player_powers are combat-only. See
@@ -179,7 +217,12 @@ export interface LivePlayer {
   discard_pile?: string[];
   exhaust_pile?: string[];
   player_powers?: LivePower[];
+  orbs?: LiveOrb[] | null;
+  orb_slots?: number | null;
+  // whose turn it is in combat: "player" / "enemy" (combat-only)
+  turn_side?: string | null;
   loot?: LiveLoot | null;
+  death?: LiveDeath | null;
   route?: LiveRoute | null;
   reveals?: Reveal[];
   players?: LiveSeat[];

--- a/frontend/app/runs/[hash]/RunPills.tsx
+++ b/frontend/app/runs/[hash]/RunPills.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import Link from "next/link";
 import RichDescription from "@/app/components/RichDescription";
@@ -61,13 +61,21 @@ export function CardPill({
   children?: ReactNode;
 }) {
   const [show, setShow] = useState(false);
+  const [above, setAbove] = useState(true);
+  const ref = useRef<HTMLAnchorElement>(null);
   const { lang } = useLanguage();
   const info = cardData[cardId];
   return (
     <Link
+      ref={ref}
       href={`${lp}/cards/${cardId.toLowerCase()}`}
       className={`relative ${className || ""}`}
-      onMouseEnter={() => setShow(true)}
+      onMouseEnter={() => {
+        // Flip the card preview below when there isn't room above (small
+        // screens / cards near the top, e.g. the deck modal on the live page).
+        setAbove((ref.current?.getBoundingClientRect().top ?? 999) > 240);
+        setShow(true);
+      }}
       onMouseLeave={() => setShow(false)}
     >
       {children ?? (
@@ -85,7 +93,11 @@ export function CardPill({
         // Pop the full rendered card (enchanted and/or upgraded variant when
         // the run says so) instead of the text tooltip. Falls back from the
         // enchanted render to the plain one, then to the portrait art.
-        <span className="pointer-events-none absolute z-50 bottom-full left-1/2 -translate-x-1/2 mb-2 w-40">
+        <span
+          className={`pointer-events-none absolute z-50 left-1/2 w-40 -translate-x-1/2 ${
+            above ? "bottom-full mb-2" : "top-full mt-2"
+          }`}
+        >
           <img
             src={
               enchantment

--- a/markdown-docs/live-presence.md
+++ b/markdown-docs/live-presence.md
@@ -59,6 +59,12 @@ Combat context (v2, absent between fights):
 - `damage_dealt`, `damage_dealt_this_turn`, `damage_taken`, `biggest_hit`: live DPS
 - `player_powers`: the local player's combat buffs/debuffs as `[{id, amount}]`
   (combat-only; `[]` means "in combat, no powers")
+- `orbs`, `orb_slots`: the player's channeled orbs (orb characters). `orbs` is
+  `[{id, passive, evoke}]` in slot order (`passive` = per-turn value, `evoke` =
+  on-evoke value); `orb_slots` is the current slot capacity, so empty slots can be
+  drawn (e.g. 2/3 filled). Combat-only; `[]`/absent for non-orb characters.
+- `turn_side`: whose turn it is in combat -- `"player"` or `"enemy"`; the frontend
+  highlights (glows) the active side's token. Combat-only.
 - `run_time`: elapsed run seconds (freezes at win); present the whole run, distinct
   from the wall-clock `started_at`
 - `modifiers`: bare ids of the run's daily/custom mutators (whole run)
@@ -92,9 +98,13 @@ panel data, each enemy carrying hp/block and its upcoming intent(s):
 `escape`, `summon`, `carddebuff`, `deathblow`, `hidden`, `unknown`); render the game's
 intent icon from it. For attacks, `dmg` is the base per-hit damage and `hits` the strike
 count, so `dmg:16, hits:2` is "16 x2" = 32 incoming (`dmg` is the base value; in-combat
-modifiers like strength/vulnerable aren't folded in). Non-attacks omit `dmg`/`hits`.
+modifiers like strength/vulnerable aren't folded in). Non-attacks omit `dmg`/`hits` but may
+carry `amount` — the magnitude of the move, e.g. the block a `defend` will gain — rendered
+next to the intent icon.
 `name` is the resolved enemy name (fall back to the id lookup if absent), `block` the
-enemy's current block. All fields except the intent `type` are optional. Excluded from
+enemy's current block. Each enemy may also carry `powers` (`[{id, amount}]`, same shape as
+`player_powers`) for its own buffs/debuffs (vulnerable, weak, strength, ...), rendered as
+icons on the token. All fields except the intent `type` are optional. Excluded from
 `/active` (per-player only) and cleared when combat ends (same null-to-clear rule as
 `turn`/`fighting`).
 
@@ -186,6 +196,10 @@ to link to the event page).
 - `title`/`prompt` are resolved localized strings (may be absent on a sparse beat).
 - each option: `key` (stable loc key), `text` (the localized button label), `locked` (greyed
   out / requirement unmet), `proceed` (the leave/continue option), `chosen` (already picked).
+- `desc`, `card`, `relic` (all optional): `desc` is the resolved consequence text with numbers
+  filled in ("Lose 3 HP"); `card` is a card the option previews — the specific card a
+  "lose a card" option will take, knowable because the game pre-rolls and hovers it; `relic`
+  is a relic the option grants. Render the card/relic as images beside the option.
 - Cleared when the player leaves the event (the mod sends `event: null` -> server `$unset`).
   Omitted from `/active`.
 
@@ -211,8 +225,39 @@ the deck. Costs are the live gold price.
 - `removal` is the card-removal service (null if this shop has none). Cleared on leaving
   the shop; omitted from `/active`.
 
-Note the singular `event`/`shop` objects are distinct from the plural `events` ticker
-array above.
+### Live rest (v7, present only at a rest site)
+
+When `screen == "rest"`, the doc carries the campfire's options.
+
+```json
+"rest": {
+  "options": [
+    {"id": "HEAL", "title": "Rest", "enabled": true},
+    {"id": "SMITH", "title": "Smith", "enabled": true}
+  ]
+}
+```
+
+- each option: `id` (stable, e.g. `HEAL`/`SMITH`/`DIG`/...), `title` (the localized button
+  label), `enabled` (false = greyed / unavailable). This is the button state the player is
+  choosing between; the actual rest/smith outcome still arrives via the `rest`/`upgrade`
+  ticker kinds.
+- Cleared when the player leaves the campfire (mod sends `rest: null` -> server `$unset`).
+  Omitted from `/active`.
+
+Note the singular `event`/`shop`/`rest` objects are distinct from the plural `events`
+ticker array above.
+
+### Death (v7, present once the run ends in a death)
+
+```json
+"death": { "line": "Not quite the top", "by": "THE_CHAMP" }
+```
+
+- `line` is the killer's **already-localized** death quote (free text, the line the game
+  shows on the death screen); `by` is the killer's id (for the portrait/name lookup).
+- The frontend renders a red death screen with the quote. Send it on the death beat;
+  it rides until the doc expires. Omitted from `/active`.
 
 ### POST /api/presence
 


### PR DESCRIPTION
Rebuilds `/live` as a game-like battle scene and makes it the **default** view (no opt-in; `?scene=0` falls back to the old data panels).

## Scene
- Rounded character + merchant medallions; per-act room backgrounds (overgrowth/hive/glory/underdocks composited from the game's parallax layers; merchant + rest rooms).
- Top HUD bar: vitals, gold, potions, act + boss, map + deck icon buttons. Bottom bar: draw / energy / hand / discard / exhaust as images. Collapsible play-by-play beside it.
- Combat: block shield + amount, enemy intents incl. defend amounts, enemy buffs/debuffs, the player's channeled orbs, and a glow on whoever's turn it is.
- Event options preview the consequence ("Lose 3 HP"), the card they'll take, and any granted relic. Loot replaces the dying enemy; rest / shop / death scenes; the card hover flips below when cramped.

## Backend (presence ingest)
- New cleaners + whitelist for: rest options, enemy powers, intent amount, death (killer quote + id), orbs/orb_slots, turn_side. Each capped, safe-id guarded, stripped from `/active`.
- Contract documented in `markdown-docs/live-presence.md`.

## Also in this PR
- ancients: the `/ancients` page no longer leaks a raw loc key for dialogue ancients (NEOW/PAEL) -- falls back to the epithet. Needs an `ancient_pools.json` regen to take effect.

The new combat fields ride mod fields that are already deployed; they light up once this backend merges (prod strips them until then).