### PR TITLE
live: hotfix the death screen showing for every fight

### DIFF
--- a/frontend/app/live/[steamId]/LiveScene.tsx
+++ b/frontend/app/live/[steamId]/LiveScene.tsx
@@ -9,6 +9,7 @@
 
 import { useState } from "react";
 import { imageUrl, fullCardUrl } from "@/lib/image-url";
+import { RichDescriptionSimple } from "@/app/components/RichDescription";
 import LiveMap from "../LiveMap";
 import {
   CardPill,
@@ -267,7 +268,12 @@ export default function LiveScene({
 }) {
   const char = (p.character ?? "colorless").toLowerCase();
   const enemies: Enemy[] = (p.enemies ?? []).filter((e) => (e.hp ?? 1) > 0);
-  const dead = !!p.death || (p.events ?? []).some((e) => e.k === "death");
+  // Dead only on an actual death signal: a death ticker event or HP at 0.
+  // `p.death` (the killer's line) rides every beat once it exists, so it is NOT
+  // a death signal on its own -- it's just the quote to show when dead.
+  const dead =
+    (p.events ?? []).some((e) => e.k === "death") ||
+    (p.hp != null && p.hp <= 0);
   const hand = p.hand ?? [];
   const hpPct =
     p.hp != null && p.max_hp
@@ -503,7 +509,7 @@ export default function LiveScene({
               </div>
               {p.death?.line && (
                 <div className="text-2xl font-semibold italic leading-snug text-rose-200">
-                  “{p.death.line}”
+                  “<RichDescriptionSimple text={p.death.line} />”
                 </div>
               )}
               {p.death?.by && (


### PR DESCRIPTION
Hotfix -- the death screen is currently showing on **every** live fight on prod.

Once #548's `death` ingest deployed, the mod's `death` field (the killer's line) rides every combat beat, so the death screen -- which triggered on `!!p.death` -- flips every live fight to "Defeated" (verified: an alive player at 58 HP renders the death screen). Now it triggers on an actual death signal (a death ticker event or HP at 0); `p.death` is just the quote shown when dead. Also renders the line through `RichDescriptionSimple` so its `[gold]...[/gold]` BBCode renders instead of raw.

(This fix was committed to #549's branch a moment too late -- after it merged -- so it orphaned; this re-lands it off main.)