### PR TITLE
community-stats: filter modded relics out of ancient_offers

### DIFF
--- a/backend/app/services/community_stats.py
+++ b/backend/app/services/community_stats.py
@@ -569,7 +569,10 @@ def _finalize_one(acc: dict[str, Any]) -> dict[str, Any]:
                 "take_rate": _pct(rec[0], rec[1]),
             }
             for rid, rec in acc["ancient"].items()
+            # Official relics only: modded relic ids aren't in the catalog, so
+            # drop them (matches _ranked; skipped if the catalog failed to load).
             if rec[1] >= MIN_ANCIENT_OFFERS
+            and (not names["relics"] or rid in names["relics"])
         },
         "most_removed": _ranked(removed, names["cards"], _TOP_N),
         "hopper_stolen": _ranked(acc.get("stolen") or {}, names["cards"], 10),


### PR DESCRIPTION
On https://spire-codex.com/community-stats, every dataset the page renders already drops modded ids via the catalog filter (`_ranked` / by_character / events / `ancient_picks`). The one gap was `ancient_offers` -- the complete per-relic ancient take-rate dump behind the in-game tip -- which iterated the raw accumulator with only an offer-count gate, so modded relic ids leaked into **every** bracket's tip data. This adds the same catalog check (keep only relics in `names["relics"]`; skipped if the catalog failed to load, matching `_ranked`).

Needs a community-stats snapshot regen to take effect on existing data.