### PR TITLE
live: fix missing power icons (doubled _power suffix)

### DIFF
--- a/frontend/app/live/[steamId]/LiveScene.tsx
+++ b/frontend/app/live/[steamId]/LiveScene.tsx
@@ -104,7 +104,9 @@ function PowerRow({ powers }: { powers: LivePower[] }) {
         <span key={pw.id} className="relative inline-flex" title={displayName(pw.id)}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src={imageUrl(`/static/images/powers/${pw.id.toLowerCase()}_power.png`)}
+            // power ids already end in _POWER (e.g. DEXTERITY_POWER), and the
+            // asset is dexterity_power.png -- so no extra _power suffix.
+            src={imageUrl(`/static/images/powers/${pw.id.toLowerCase()}.png`)}
             alt={displayName(pw.id)}
             className="h-5 w-5 object-contain"
             crossOrigin="anonymous"


### PR DESCRIPTION
On the live battle scene, player/enemy powers showed their amount but no icon. The mod's power ids already end in `_POWER` (e.g. `DEXTERITY_POWER`) and the asset is `dexterity_power.png`, but `PowerRow` appended an extra `_power`, building `dexterity_power_power.png` -> 404. Drops the extra suffix (`{id}.png`). Verified against the CDN: `dexterity_power.png`/`vulnerable_power.png`/`weak_power.png` are 200, the doubled form 404s.