### PR TITLE
Show the previous-floor hover on the live map (#554)

### DIFF
--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -233,6 +233,58 @@ def _clean_loot(raw) -> dict | None:
     return out or None
 
 
+_FLOOR_HISTORY_CAP = 64  # a full run is < 60 floors
+_FLOOR_REWARDS_CAP = 24  # matches the mod-side per-floor cap
+_KIND_OK = {"card", "relic", "potion"}
+
+
+def _floor_rewards(raw) -> list[dict]:
+    """The taken / skipped items on a cleared floor: {kind, id} pairs. The ids
+    flow into image/CDN URLs on the frontend, so drop anything that fails the
+    path-safety check, same as the loot cleaner."""
+    out = []
+    if isinstance(raw, list):
+        for o in raw[:_FLOOR_REWARDS_CAP]:
+            if not isinstance(o, dict):
+                continue
+            kind, rid = o.get("kind"), o.get("id")
+            if kind in _KIND_OK and isinstance(rid, str) and _safe_id(rid[:_MAX_STR]):
+                out.append({"kind": kind, "id": rid[:_MAX_STR]})
+    return out
+
+
+def _clean_floor_history(raw) -> list[dict] | None:
+    """Per-cleared-floor summary for the map's previous-node hover: the same data
+    the game shows on a visited node (room/enemy, turns, damage, HP + gold, and
+    the rewards taken vs skipped). Run-level and sent every beat, so it is never
+    unset (unlike the combat-only fields)."""
+    if not isinstance(raw, list):
+        return None
+    out: list[dict] = []
+    for o in raw[:_FLOOR_HISTORY_CAP]:
+        if not isinstance(o, dict):
+            continue
+        f: dict = {
+            "floor": _as_int(o.get("floor")),
+            "act": _as_int(o.get("act")),
+            "type": str(o.get("type", "unknown"))[:24],
+            "hp": _as_int(o.get("hp")),
+            "max_hp": _as_int(o.get("max_hp")),
+            "gold": _as_int(o.get("gold")),
+        }
+        eid = o.get("encounter_id")
+        if isinstance(eid, str) and _safe_id(eid[:_MAX_STR]):
+            f["encounter_id"] = eid[:_MAX_STR]
+        for k in ("turns", "damage_taken", "healed", "gold_spent", "gold_gained"):
+            v = o.get(k)
+            if isinstance(v, int) and not isinstance(v, bool):
+                f[k] = int(v)
+        f["rewards"] = _floor_rewards(o.get("rewards"))
+        f["skipped"] = _floor_rewards(o.get("skipped"))
+        out.append(f)
+    return out
+
+
 _POWERS_CAP = 40
 _COOP_CAP = 4
 
@@ -619,6 +671,10 @@ async def post_presence(request: Request):
         fields["route"] = rt
     if (lt := _clean_loot(data.get("loot"))) is not None:
         fields["loot"] = lt
+    # Per-cleared-floor history for the map's previous-node hover. Run-level: it
+    # rides every beat and persists for the whole run, so it is NOT in `unset`.
+    if (fh := _clean_floor_history(data.get("floor_history"))) is not None:
+        fields["floor_history"] = fh
     # Local player's combat powers ([] is meaningful) + co-op per-seat vitals.
     if (pw := _clean_powers(data.get("player_powers"))) is not None:
         fields["player_powers"] = pw

--- a/backend/app/services/presence_db.py
+++ b/backend/app/services/presence_db.py
@@ -79,7 +79,8 @@ def end(steam_id: str) -> None:
 def active(limit: int = 50) -> list[dict]:
     """Fresh live players, deepest run first. Excludes the heavy per-run detail
     (deck/relics/potions, the event window, the map node/edge graph, the combat
-    hand, the act route, loot, co-op seats, and the local player's powers): the
+    hand, the act route, loot, floor history, co-op seats, and the local player's
+    powers): the
     per-player endpoint serves those for the live run view. Keeps path/pos so the
     roster can show a player's position on a mini progress indicator. The light
     scalars (run_time/block/energy/damage/pile counts) stay for a richer card."""
@@ -106,6 +107,7 @@ def active(limit: int = 50) -> list[dict]:
                 "exhaust_pile": 0,
                 "route": 0,
                 "loot": 0,
+                "floor_history": 0,
                 "players": 0,
                 "player_powers": 0,
                 "orbs": 0,

--- a/frontend/app/live/LiveMap.tsx
+++ b/frontend/app/live/LiveMap.tsx
@@ -14,15 +14,25 @@
 // resolved encounter -> representative monster -> portrait. The game binds an
 // encounter to a node only on entry, so an unvisited node's enemy is genuinely
 // unknowable; unrevealed nodes keep the type glyph.
+//
+// Hovering a previous (visited) node shows that floor's summary card, mirroring
+// the game's own node hover: HP/gold, room/enemy, damage/turns, and the rewards
+// taken vs skipped. Data comes from `floor_history` (v8), matched to nodes by
+// visit order within the act.
 
 import { imageUrl } from "@/lib/image-url";
-import type {
-  Coord,
-  EncounterMap,
-  LiveMapData,
-  LiveRoute,
-  MonsterMap,
-  Reveal,
+import { useState } from "react";
+import { cleanId, displayName } from "../runs/[hash]/RunPills";
+import {
+  safeId,
+  type Coord,
+  type EncounterMap,
+  type FloorReward,
+  type FloorSummary,
+  type LiveMapData,
+  type LiveRoute,
+  type MonsterMap,
+  type Reveal,
 } from "./live-shared";
 
 // Per-node-type styling. Types arrive lowercase; an unrecognized type falls
@@ -44,6 +54,20 @@ function styleFor(type: string) {
   return NODE_STYLE[type] ?? NODE_STYLE.node;
 }
 
+// Room-type -> human label for the floor hover. Combat types get an "Enemy:" /
+// "Elite:" / "Boss:" prefix in the card; the rest use the label directly.
+const ROOM_LABEL: Record<string, string> = {
+  monster: "Enemy",
+  elite: "Elite",
+  boss: "Boss",
+  shop: "Shop",
+  treasure: "Treasure",
+  restsite: "Rest Site",
+  event: "Event",
+  ancient: "Ancient",
+  unknown: "Unknown",
+};
+
 const COL = 44; // horizontal spacing between lanes
 const ROW = 44; // vertical spacing between depths
 const PAD = 22;
@@ -51,6 +75,131 @@ const R = 13; // node radius
 
 function key(col: number, row: number): string {
   return `${col},${row}`;
+}
+
+function hideImg(e: React.SyntheticEvent<HTMLImageElement>) {
+  (e.target as HTMLImageElement).style.display = "none";
+}
+
+// One taken/skipped item: a small icon (best-effort by convention, hidden on a
+// 404) plus its prettified name.
+function RewardRow({ item }: { item: FloorReward }) {
+  const id = cleanId(item.id);
+  const src =
+    !safeId(id)
+      ? ""
+      : item.kind === "card"
+        ? imageUrl(`/static/images/cards/${id.toLowerCase()}.webp`)
+        : item.kind === "relic"
+          ? imageUrl(`/static/images/relics/${id.toLowerCase()}.png`)
+          : imageUrl(`/static/images/potions/${id.toLowerCase()}.png`);
+  return (
+    <li className="flex items-center gap-1.5">
+      {src ? (
+        <img
+          src={src}
+          alt=""
+          className="h-4 w-4 shrink-0 object-contain"
+          crossOrigin="anonymous"
+          onError={hideImg}
+        />
+      ) : (
+        <span className="h-4 w-4 shrink-0" />
+      )}
+      <span className="truncate text-[var(--text-secondary)]">{displayName(id)}</span>
+    </li>
+  );
+}
+
+function RewardList({
+  label,
+  items,
+  gold,
+  tone,
+}: {
+  label: string;
+  items?: FloorReward[];
+  gold?: number;
+  tone: "reward" | "skip";
+}) {
+  if (!items?.length && !gold) return null;
+  return (
+    <div className="mt-1.5">
+      <div
+        className={`text-[10px] font-bold uppercase tracking-wide ${
+          tone === "reward" ? "text-[var(--accent-gold)]" : "text-[var(--text-muted)]"
+        }`}
+      >
+        {label}
+      </div>
+      <ul className="mt-0.5 space-y-0.5">
+        {gold ? (
+          <li className="flex items-center gap-1.5">
+            <img
+              src={imageUrl("/static/images/icons/gold_icon.png")}
+              alt=""
+              className="h-4 w-4 shrink-0 object-contain"
+              crossOrigin="anonymous"
+              onError={hideImg}
+            />
+            <span className="tabular-nums text-amber-300">{gold} Gold</span>
+          </li>
+        ) : null}
+        {(items ?? []).map((it, i) => (
+          <RewardRow key={`${it.kind}-${it.id}-${i}`} item={it} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// The floating card shown when hovering a visited node: mirrors the game's own
+// previous-floor hover.
+function FloorCard({ f, encounters }: { f: FloorSummary; encounters?: EncounterMap }) {
+  const isCombat = f.type === "monster" || f.type === "elite" || f.type === "boss";
+  const encName = f.encounter_id
+    ? encounters?.[f.encounter_id]?.name || displayName(f.encounter_id)
+    : null;
+  return (
+    <div>
+      <div className="text-sm font-bold text-[var(--accent-gold)]">Floor {f.floor}</div>
+      <div className="mt-0.5 flex gap-3 text-[11px] tabular-nums">
+        <span className="text-rose-300">
+          {f.hp}/{f.max_hp} HP
+        </span>
+        <span className="text-amber-300">{f.gold} Gold</span>
+      </div>
+
+      <div className="mt-1 text-[11px]">
+        {isCombat ? (
+          <>
+            <div className="text-[var(--text-primary)]">
+              {ROOM_LABEL[f.type] ?? "Enemy"}: {encName ?? "Enemy"}
+            </div>
+            {f.damage_taken ? (
+              <div className="tabular-nums text-rose-300">{f.damage_taken} Damage</div>
+            ) : null}
+            {f.turns != null ? (
+              <div className="tabular-nums text-[var(--text-muted)]">{f.turns} Turns</div>
+            ) : null}
+          </>
+        ) : f.type === "event" && encName ? (
+          <div className="text-[var(--text-secondary)]">{encName}</div>
+        ) : (
+          <div className="text-[var(--text-secondary)]">{ROOM_LABEL[f.type] ?? "Room"}</div>
+        )}
+        {f.healed ? (
+          <div className="tabular-nums text-emerald-300">{f.healed} Healed</div>
+        ) : null}
+        {f.gold_spent ? (
+          <div className="tabular-nums text-amber-300/80">Spent {f.gold_spent} Gold</div>
+        ) : null}
+      </div>
+
+      <RewardList label="Rewards" items={f.rewards} gold={f.gold_gained} tone="reward" />
+      <RewardList label="Skipped" items={f.skipped} tone="skip" />
+    </div>
+  );
 }
 
 export default function LiveMap({
@@ -61,6 +210,7 @@ export default function LiveMap({
   route,
   monsters,
   encounters,
+  floorHistory,
 }: {
   map?: LiveMapData | null;
   path?: Coord[];
@@ -69,7 +219,10 @@ export default function LiveMap({
   route?: LiveRoute | null;
   monsters?: MonsterMap;
   encounters?: EncounterMap;
+  floorHistory?: FloorSummary[];
 }) {
+  const [hovered, setHovered] = useState<{ c: number; r: number } | null>(null);
+
   const nodes = map?.nodes ?? [];
   if (!nodes.length) return null;
 
@@ -91,6 +244,26 @@ export default function LiveMap({
   // (col,row) -> [col, row, resolved room_type, encounter id|null] for visited nodes.
   const revealMap = new Map<string, Reveal>();
   for (const rv of reveals ?? []) revealMap.set(key(rv[0], rv[1]), rv);
+
+  // Match floor_history entries to visited rows. floor_history has no grid
+  // coords, but the player clears exactly one node per depth, so within this act
+  // the entries (sorted by floor) line up with the visited rows in ascending
+  // order. The floor being stood on has no entry, so the deepest visited row
+  // naturally falls off the end -- exactly right (no card on the current node).
+  const actNo = map?.act;
+  const actHist = (floorHistory ?? [])
+    .filter((f) => actNo == null || f.act === actNo)
+    .slice()
+    .sort((a, b) => a.floor - b.floor);
+  const visitedRows = Array.from(new Set((path ?? []).map(([, r]) => r))).sort(
+    (a, b) => a - b,
+  );
+  const rowFloor = new Map<number, FloorSummary>();
+  visitedRows.forEach((r, i) => {
+    if (actHist[i]) rowFloor.set(r, actHist[i]);
+  });
+  const floorAt = (c: number, r: number): FloorSummary | undefined =>
+    onPath(c, r) ? rowFloor.get(r) : undefined;
 
   // The portrait for a node, or null to fall back to the type glyph: a visited
   // node resolves encounter -> first monster -> image; the boss/ancient resolve
@@ -126,15 +299,27 @@ export default function LiveMap({
     return effType;
   }
 
+  const hoverFloor = hovered ? floorAt(hovered.c, hovered.r) : undefined;
+  // Tooltip anchor as a percentage of the SVG box (the wrapper matches the
+  // rendered svg, so this holds even when max-w-full scales it down).
+  const lx = hovered ? (x(hovered.c) / width) * 100 : 0;
+  const ty = hovered ? (y(hovered.r) / height) * 100 : 0;
+  const anchorRight = lx > 55; // right-side node -> grow the card leftward
+  const below = ty < 40; // near the top -> drop the card below the node
+  const tipTransform = `translate(${anchorRight ? "-100%" : "0"}, ${
+    below ? "14px" : "calc(-100% - 14px)"
+  })`;
+
   return (
-    <div className="overflow-auto">
+    <div className="relative inline-block max-w-full">
       <svg
         width={width}
         height={height}
         viewBox={`0 0 ${width} ${height}`}
-        className="max-w-full"
+        className="block max-w-full"
         role="img"
         aria-label="Act map showing the player's route"
+        onMouseLeave={() => setHovered(null)}
       >
         {edges.map(([c, r, cc, cr], i) => {
           const lit = onPath(c, r) && onPath(cc, cr);
@@ -159,8 +344,13 @@ export default function LiveMap({
           const seen = onPath(c, r);
           const portrait = portraitFor(c, r, type);
           const dim = !(seen || here);
+          const hasFloor = !!floorAt(c, r);
           return (
-            <g key={`n-${c}-${r}`}>
+            <g
+              key={`n-${c}-${r}`}
+              onMouseEnter={() => setHovered({ c, r })}
+              style={{ cursor: hasFloor ? "help" : "default" }}
+            >
               {here && (
                 <circle cx={x(c)} cy={y(r)} r={R + 4} fill="none" stroke="var(--accent-gold)" strokeWidth={2}>
                   <animate attributeName="r" values={`${R + 2};${R + 6};${R + 2}`} dur="1.4s" repeatCount="indefinite" />
@@ -222,6 +412,14 @@ export default function LiveMap({
           );
         })}
       </svg>
+      {hovered && hoverFloor && (
+        <div
+          className="pointer-events-none absolute z-50 w-56 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] px-3 py-2 text-xs shadow-xl"
+          style={{ left: `${lx}%`, top: `${ty}%`, transform: tipTransform }}
+        >
+          <FloorCard f={hoverFloor} encounters={encounters} />
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -847,6 +847,7 @@ export default function LivePlayerClient() {
           route={p.route}
           monsters={monsters}
           encounters={encounters}
+          floorHistory={p.floor_history}
         />
       </div>
     ) : null;

--- a/frontend/app/live/[steamId]/LiveScene.tsx
+++ b/frontend/app/live/[steamId]/LiveScene.tsx
@@ -834,6 +834,7 @@ export default function LiveScene({
               route={p.route}
               monsters={monsters}
               encounters={encounters}
+              floorHistory={p.floor_history}
             />
           </div>
         </div>

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -155,6 +155,31 @@ export interface LiveDeath {
   by?: string;
 }
 
+// Floor history (v8): the live mirror of the game's "previous floor" node hover.
+// One entry per cleared floor (excludes the floor you're standing on), covering
+// the whole run. `rewards` were taken, `skipped` were offered and left behind.
+// ids are bare (no CARD./RELIC. prefix). Contract: markdown-docs/live-presence.md.
+export interface FloorReward {
+  kind: "card" | "relic" | "potion";
+  id: string;
+}
+export interface FloorSummary {
+  floor: number;
+  act: number;
+  type: string; // monster|elite|boss|shop|treasure|restsite|event|ancient|unknown
+  encounter_id?: string; // bare enemy/event id; absent for shop/rest/treasure
+  hp: number;
+  max_hp: number;
+  gold: number;
+  turns?: number; // combat only
+  damage_taken?: number;
+  healed?: number;
+  gold_spent?: number;
+  gold_gained?: number;
+  rewards?: FloorReward[];
+  skipped?: FloorReward[];
+}
+
 /** Co-op per-seat vitals (v6); `is_me` marks the local player's seat. */
 export interface LiveSeat {
   character?: string | null;
@@ -223,6 +248,8 @@ export interface LivePlayer {
   turn_side?: string | null;
   loot?: LiveLoot | null;
   death?: LiveDeath | null;
+  // Per-cleared-floor history for the map's previous-node hover (v8).
+  floor_history?: FloorSummary[];
   route?: LiveRoute | null;
   reveals?: Reveal[];
   players?: LiveSeat[];

--- a/markdown-docs/live-presence.md
+++ b/markdown-docs/live-presence.md
@@ -259,6 +259,35 @@ ticker array above.
 - The frontend renders a red death screen with the quote. Send it on the death beat;
   it rides until the doc expires. Omitted from `/active`.
 
+### Floor history (v8, the map's previous-node hover)
+
+The live mirror of what the game shows when you hover a visited node on the map: one
+entry per cleared floor, for the whole run. `floor_history` accumulates (a full run is
+< 60 floors) and **excludes the floor being stood on**. Run-level, so it rides every beat
+and is never `$unset` (the doc is dropped when the run ends).
+
+```json
+"floor_history": [
+  {
+    "floor": 4, "act": 1, "type": "monster", "encounter_id": "SHRINKER_BEETLE",
+    "hp": 45, "max_hp": 70, "gold": 54, "turns": 4, "damage_taken": 4,
+    "rewards": [{"kind": "card", "id": "HAZE"}],
+    "skipped": [{"kind": "card", "id": "SPEEDSTER"}, {"kind": "card", "id": "ANTICIPATE"}]
+  }
+]
+```
+
+- `floor` is the global run floor (1-based, cumulative across acts); `act` is 1-indexed;
+  `type` is `monster|elite|boss|shop|treasure|restsite|event|ancient|unknown`.
+- `encounter_id` (bare id, resolve to a title) is present on combat/event floors, omitted
+  for shop/rest/treasure. `turns`/`damage_taken`/`healed`/`gold_spent`/`gold_gained` are
+  omitted when 0.
+- `rewards` were taken this floor, `skipped` were offered and left behind; each is
+  `{kind: card|relic|potion, id}` with bare ids (per-floor list capped at 24).
+- The frontend matches entries to map nodes by visit order within the act (the player
+  clears one node per depth), and shows the card on hover of a **visited** node only.
+  Omitted from `/active` (detail endpoint only).
+
 ### POST /api/presence
 
 Mod-only; requires the Steam JWT (`Authorization: Bearer`). The frontend never calls it.


### PR DESCRIPTION
Closes #554.

When you hover a previous (visited) node on the live map, it now shows the same summary the game shows on a visited node: HP/gold, room or enemy, damage taken and turns for fights, and the rewards taken vs the cards/relics/potions skipped.

The mod half already shipped: it emits `floor_history` on the presence heartbeat (one entry per cleared floor, run-level, excludes the floor you are standing on). This wires up the website side.

**Backend**
- Added `_clean_floor_history` to the presence ingest. The field was being dropped by the whitelist. Wired it after `loot`, and kept it out of the transient `unset` list since it is run-level, not combat-only.
- Reused the existing path-safety id check so a bad reward id can't build a traversal URL.
- Kept `floor_history` off the `/active` roster projection (it is detail-only, keeps the roster small).

**Frontend**
- `LiveMap` shows a floating floor card on hover of a visited node. Entries are matched to nodes by visit order within the act (the player clears one node per depth), so the current node shows nothing, exactly like the game's "previous floor" hover.
- Reward/skip items resolve to prettified names with a best-effort icon (hidden on a 404), gold shown as "N Gold".

**Notes**
- Documented the field as v8 in `markdown-docs/live-presence.md`.
- Backend cleaner is unit-verified (combat/shop/rest floors, unsafe ids dropped, junk coerced). The node-to-floor matching needs a live run to confirm the floor numbers and the rewards/skipped split line up, since I can't drive the game from here.