### PR TITLE
Show Osty (and any pet) on the live combat scene (#556)

### DIFF
--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -285,7 +285,9 @@ def _clean_orbs(raw) -> list[dict] | None:
 
 def _clean_players(raw) -> list[dict] | None:
     """Co-op per-seat vitals; the mod sends this only with 2+ players. `is_me`
-    marks the local seat so the frontend can highlight it."""
+    marks the local seat so the frontend can highlight it. `energy`/`ended_turn`
+    are combat turn state (0/false outside combat): combined with the global
+    `turn_side`, they show who is still taking their turn vs already locked in."""
     if not isinstance(raw, list):
         return None
     out: list[dict] = []
@@ -300,13 +302,45 @@ def _clean_players(raw) -> list[dict] | None:
                 "max_hp": _as_int(p.get("max_hp")),
                 "block": _as_int(p.get("block")),
                 "gold": _as_int(p.get("gold")),
+                "energy": _as_int(p.get("energy")),
                 "alive": bool(p.get("alive")),
+                "ended_turn": bool(p.get("ended_turn")),
                 "deck_size": _as_int(p.get("deck_size")),
                 "relic_count": _as_int(p.get("relic_count")),
                 "potion_count": _as_int(p.get("potion_count")),
                 "is_me": bool(p.get("is_me")),
             }
         )
+    return out
+
+
+_PETS_CAP = 8
+
+
+def _clean_pets(raw) -> list[dict] | None:
+    """Friendly summons in combat (the Necrobinder's Osty and any future pet):
+    id/name + vitals plus `owner`, an index into `players` so a co-op pet can
+    hang off the right seat (0 in single-player). Combat-only, so it is cleared
+    with the other combat fields when a fight ends."""
+    if not isinstance(raw, list):
+        return None
+    out: list[dict] = []
+    for o in raw[:_PETS_CAP]:
+        if not isinstance(o, dict):
+            continue
+        pet: dict = {
+            "hp": _as_int(o.get("hp")),
+            "max_hp": _as_int(o.get("max_hp")),
+            "block": _as_int(o.get("block")),
+            "owner": _as_int(o.get("owner")),
+            "alive": bool(o.get("alive")),
+        }
+        pid = o.get("id")
+        if isinstance(pid, str) and _safe_id(pid[:_MAX_STR]):
+            pet["id"] = pid[:_MAX_STR]
+        if isinstance(o.get("name"), str) and o["name"]:
+            pet["name"] = o["name"][:_MAX_STR]
+        out.append(pet)
     return out
 
 
@@ -626,6 +660,8 @@ async def post_presence(request: Request):
         fields["orbs"] = orbs
     if (pls := _clean_players(data.get("players"))) is not None:
         fields["players"] = pls
+    if (pets := _clean_pets(data.get("pets"))) is not None:
+        fields["pets"] = pets
 
     # Transient fields: when the mod sends these as explicit null (combat ended / left the
     # screen), clear them rather than leaving stale values. pos is NOT in this set on
@@ -654,6 +690,7 @@ async def post_presence(request: Request):
             "player_powers",
             "orbs",
             "orb_slots",
+            "pets",
             "damage_dealt",
             "damage_dealt_this_turn",
             "damage_taken",

--- a/backend/app/services/presence_db.py
+++ b/backend/app/services/presence_db.py
@@ -109,6 +109,7 @@ def active(limit: int = 50) -> list[dict]:
                 "players": 0,
                 "player_powers": 0,
                 "orbs": 0,
+                "pets": 0,
             },
         )
         .sort([("total_floor", -1), ("updated_at", -1)])

--- a/frontend/app/live/[steamId]/LiveScene.tsx
+++ b/frontend/app/live/[steamId]/LiveScene.tsx
@@ -31,6 +31,7 @@ import {
   type Enemy,
   type EnemyIntent,
   type LiveOrb,
+  type LivePet,
   type LivePlayer,
   type LivePower,
   type MonsterMap,
@@ -199,6 +200,31 @@ function Vitals({
           {block}
         </div>
       )}
+    </div>
+  );
+}
+
+/** Friendly summons beside the player token (the Necrobinder's Osty and any
+ * future pet): portrait + name + HP, so a spectator can see the summon's health.
+ * Dead pets drop off. `owner` co-op matching is left to the caller. */
+function PetRow({ pets, monsters }: { pets: LivePet[]; monsters: MonsterMap }) {
+  const live = pets.filter((pt) => pt && pt.alive !== false && (pt.id || pt.name));
+  if (!live.length) return null;
+  return (
+    <div className="mt-1 flex flex-wrap items-start justify-center gap-3">
+      {live.map((pt, i) => (
+        <div key={(pt.id || pt.name || "pet") + i} className="flex flex-col items-center gap-1">
+          <EnemyCircle
+            id={pt.id || ""}
+            monsters={monsters}
+            className="h-16 w-16 ring-2 ring-emerald-400/60"
+          />
+          <div className="max-w-[6rem] truncate text-xs font-medium text-emerald-200">
+            {pt.name || (pt.id ? monsterName(pt.id, monsters) : "Pet")}
+          </div>
+          <Vitals hp={pt.hp} maxHp={pt.max_hp} block={pt.block} />
+        </div>
+      ))}
     </div>
   );
 }
@@ -553,6 +579,7 @@ export default function LiveScene({
                 <Vitals hp={p.hp} maxHp={p.max_hp} block={p.block} />
                 <PowerRow powers={p.player_powers ?? []} />
                 <OrbRow orbs={p.orbs ?? []} slots={p.orb_slots} />
+                <PetRow pets={p.pets ?? []} monsters={monsters} />
               </div>
 
               {/* Enemy tokens */}

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -155,18 +155,34 @@ export interface LiveDeath {
   by?: string;
 }
 
-/** Co-op per-seat vitals (v6); `is_me` marks the local player's seat. */
+/** Co-op per-seat vitals (v6); `is_me` marks the local player's seat. `energy`
+ * and `ended_turn` (v8) are combat turn state (0/false outside combat): with the
+ * global `turn_side`, they show who is still going vs already locked in. */
 export interface LiveSeat {
   character?: string | null;
   hp?: number;
   max_hp?: number;
   block?: number;
   gold?: number;
+  energy?: number;
   alive?: boolean;
+  ended_turn?: boolean;
   deck_size?: number;
   relic_count?: number;
   potion_count?: number;
   is_me?: boolean;
+}
+
+/** A friendly summon in combat (v8): the Necrobinder's Osty and any future pet.
+ * `owner` indexes into `players` (0 in single-player). Combat-only. */
+export interface LivePet {
+  id?: string;
+  name?: string;
+  hp?: number;
+  max_hp?: number;
+  block?: number;
+  alive?: boolean;
+  owner?: number;
 }
 
 export interface LivePlayer {
@@ -226,6 +242,8 @@ export interface LivePlayer {
   route?: LiveRoute | null;
   reveals?: Reveal[];
   players?: LiveSeat[];
+  // Friendly summons in combat (Necrobinder's Osty, etc.), combat-only (v8).
+  pets?: LivePet[] | null;
   run_time?: number | null;
   modifiers?: string[];
   act_name?: string | null;

--- a/markdown-docs/live-presence.md
+++ b/markdown-docs/live-presence.md
@@ -259,6 +259,37 @@ ticker array above.
 - The frontend renders a red death screen with the quote. Send it on the death beat;
   it rides until the doc expires. Omitted from `/active`.
 
+### Co-op turn state + pets (v8)
+
+Two combat additions for co-op and summoner runs.
+
+`players[]` (co-op only, run-level) now also carries per-seat combat turn state:
+
+```json
+"players": [
+  {"character": "NECROBINDER", "hp": 60, "max_hp": 70, "block": 0, "gold": 120,
+   "energy": 3, "alive": true, "ended_turn": false, "deck_size": 22,
+   "relic_count": 5, "potion_count": 1, "is_me": true}
+]
+```
+
+- `energy` and `ended_turn` are 0/false outside combat. Combine `ended_turn` with the
+  global `turn_side` (`player`/`enemy`): during the player side, a seat with
+  `ended_turn: false` is still taking its turn, `true` means locked in and waiting.
+
+`pets[]` (present only while a pet is out in combat, transient) is the friendly summons:
+
+```json
+"pets": [
+  {"id": "OSTY", "name": "Osty", "hp": 18, "max_hp": 30, "block": 0, "alive": true, "owner": 0}
+]
+```
+
+- `owner` indexes into `players[]` (0 in single-player), so a co-op pet attaches to the
+  right seat. ids are bare (`OSTY`). Combat-only: cleared (`$unset`) when a fight ends.
+  Omitted from `/active` (detail endpoint only). It is generic, so it picks up any future
+  pet, not just Osty.
+
 ### POST /api/presence
 
 Mod-only; requires the Steam JWT (`Authorization: Bearer`). The frontend never calls it.


### PR DESCRIPTION
Closes #556.

Necrobinder's Osty (and any future summon) now shows on the live combat scene as a token with its name and HP, so a spectator can see the summon's health.

The mod half already shipped: it emits a top-level `pets[]` in combat (id/name/hp/max_hp/block/alive + `owner`, an index into `players[]`), plus per-seat `energy`/`ended_turn` on the co-op `players[]`. Osty never showed before because it lives on the allies side, not in `enemies[]`.

**Backend**
- Added `_clean_pets` and wired it into the ingest (both `pets` and the new `players` sub-fields were dropped by the whitelist). `pets` is combat-only, so it joins the transient `unset` list and stays off the `/active` roster projection.
- Added `energy`/`ended_turn` to the existing co-op seat cleaner.
- Reused the path-safety id check on the pet id.

**Frontend**
- The combat scene renders a pet token (portrait + name + HP) under the player token, styled with a friendly (emerald) ring to set it apart from enemies. Dead pets drop off.

**Notes**
- Scoped to the default battle scene (the pet shows under the watched player). The co-op owner-to-seat matching is carried in the data (`owner`) but the scene centers one player, so pets render under that player for now.
- Documented `pets` and the co-op turn state as v8 in `markdown-docs/live-presence.md`.
- Backend cleaners are unit-verified (OSTY kept, unsafe id dropped, junk dropped). The live token needs a real Necrobinder run to confirm the portrait/HP, since I can't drive the game from here.