### PR TITLE
Make the live map node connectors more visible (#554)

### DIFF
--- a/frontend/app/live/LiveMap.tsx
+++ b/frontend/app/live/LiveMap.tsx
@@ -330,9 +330,11 @@ export default function LiveMap({
               y1={y(r)}
               x2={x(cc)}
               y2={y(cr)}
-              stroke={lit ? "var(--accent-gold)" : "var(--border-subtle)"}
-              strokeWidth={lit ? 2 : 1}
-              strokeOpacity={lit ? 0.9 : 0.5}
+              // White + thicker so the node connectors read clearly against the
+              // dark map (the traveled route stays gold and a touch heavier).
+              stroke={lit ? "var(--accent-gold)" : "#ffffff"}
+              strokeWidth={lit ? 3 : 2}
+              strokeOpacity={lit ? 0.95 : 0.7}
             />
           );
         })}


### PR DESCRIPTION
Follow-up to #557, addressing the "increase the node connector visibility for a11y" part of #554.

The faint grey connector lines between map nodes were hard to see against the dark map. Made the unlit connectors white and thicker (width 1 -> 2, opacity 0.5 -> 0.7), and bumped the traveled route a touch too (width 2 -> 3). The gold route highlight stays gold.