### PR TITLE
Keep live map node circles above the connector lines

### DIFF
--- a/frontend/app/live/LiveMap.tsx
+++ b/frontend/app/live/LiveMap.tsx
@@ -353,6 +353,11 @@ export default function LiveMap({
               onMouseEnter={() => setHovered({ c, r })}
               style={{ cursor: hasFloor ? "help" : "default" }}
             >
+              {/* Opaque backing so the connector lines never show through a
+                  node -- dim/unvisited nodes are drawn at 0.55 opacity, which
+                  otherwise lets the white edges bleed through and look like
+                  they sit on top of the circle. */}
+              <circle cx={x(c)} cy={y(r)} r={R} fill="var(--bg-primary)" />
               {here && (
                 <circle cx={x(c)} cy={y(r)} r={R + 4} fill="none" stroke="var(--accent-gold)" strokeWidth={2}>
                   <animate attributeName="r" values={`${R + 2};${R + 6};${R + 2}`} dur="1.4s" repeatCount="indefinite" />


### PR DESCRIPTION
Follow-up to the connector-visibility change (#559): the thicker white connectors were showing through the map node circles.

The nodes are already drawn after the edges (so they're on top in SVG document order), but dim/unvisited nodes render at 0.55 opacity, which let the white lines bleed through and read as if they sat on top of the circle. Added an opaque backing circle (`var(--bg-primary)`) behind each node so the connectors never show through, dim or not.