### PR TITLE
Show scroll-box packs in the live loot panel (#555)

### DIFF
--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -168,6 +168,7 @@ def _clean_reveals(raw) -> list | None:
 # per act like the map; loot is transient, cleared when the player leaves the
 # reward screen.
 _LOOT_CAP = 20
+_PACKS_CAP = 8  # scroll-box offers 2 bundles; cap generously
 _ROUTE_CAP = 30
 
 
@@ -225,6 +226,24 @@ def _clean_loot(raw) -> dict | None:
                 for x in lst[:_LOOT_CAP]
                 if isinstance(x, (str, int)) and _safe_id(s := str(x)[:_MAX_STR])
             ]
+    # Scroll-box bundles (ScrollBoxes relic): a list of packs, each a list of
+    # bare card ids. Present only on the choose-a-bundle screen; the mod keeps
+    # these out of `cards`, so the frontend hides the flat card row when set.
+    packs = raw.get("packs")
+    if isinstance(packs, list):
+        cleaned = []
+        for pack in packs[:_PACKS_CAP]:
+            if not isinstance(pack, list):
+                continue
+            ids = [
+                s
+                for x in pack[:_LOOT_CAP]
+                if isinstance(x, (str, int)) and _safe_id(s := str(x)[:_MAX_STR])
+            ]
+            if ids:
+                cleaned.append(ids)
+        if cleaned:
+            out["packs"] = cleaned
     cr = raw.get("card_removal")
     if isinstance(cr, bool):
         out["card_removal"] = cr

--- a/frontend/app/live/LiveEventShop.tsx
+++ b/frontend/app/live/LiveEventShop.tsx
@@ -316,12 +316,14 @@ export function LiveLootPanel({
   const cardIds = loot.cards ?? [];
   const relicIds = loot.relics ?? [];
   const potionIds = loot.potions ?? [];
+  const packs = loot.packs ?? [];
   const hasGold = loot.gold != null && loot.gold > 0;
   const removal = !!loot.card_removal;
   if (
     !cardIds.length &&
     !relicIds.length &&
     !potionIds.length &&
+    !packs.length &&
     !hasGold &&
     !removal
   ) {
@@ -373,9 +375,44 @@ export function LiveLootPanel({
           })}
         </div>
       )}
-      {(cardIds.length > 0 || relicIds.length > 0) && (
+      {packs.length > 0 && (
+        <div className="space-y-2">
+          {packs.map((pack, pi) => (
+            <div key={`pack-${pi}`}>
+              <div className="mb-1 text-[10px] font-bold uppercase tracking-wide text-amber-300/80">
+                Pack {pi + 1}
+              </div>
+              <div className="flex flex-wrap items-start gap-1.5">
+                {withOrdinalKeys(pack).map(({ item, key }) => {
+                  const { id, upgraded } = parseDeckId(item);
+                  return (
+                    <CardPill
+                      key={`pk${pi}-${key}`}
+                      cardId={id}
+                      upgraded={upgraded}
+                      cardData={cards}
+                      lp={lp}
+                      className="relative block w-16 shrink-0"
+                    >
+                      <img
+                        src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                        alt={cards[id]?.name || displayName(`CARD.${id}`)}
+                        className="h-auto w-16 rounded-sm"
+                        crossOrigin="anonymous"
+                        loading="lazy"
+                      />
+                    </CardPill>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      {((!packs.length && cardIds.length > 0) || relicIds.length > 0) && (
         <div className="flex flex-wrap items-start gap-1.5">
-          {withOrdinalKeys(cardIds).map(({ item, key }) => {
+          {!packs.length &&
+            withOrdinalKeys(cardIds).map(({ item, key }) => {
             const { id, upgraded } = parseDeckId(item);
             return (
               <CardPill

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -145,6 +145,10 @@ export interface LiveLoot {
   cards?: string[];
   relics?: string[];
   potions?: string[];
+  // Scroll-box bundles (v8): each pack is a list of card ids the player picks
+  // one whole pack from. Present only on the choose-a-bundle screen; when set,
+  // `cards` is empty and the panel shows the packs instead of the flat row.
+  packs?: string[][];
   card_removal?: boolean | number;
 }
 

--- a/markdown-docs/live-presence.md
+++ b/markdown-docs/live-presence.md
@@ -75,7 +75,10 @@ is_me}]`; `is_me` marks the local seat.
 
 `loot` (v6, present on the combat/reward screen, transient): the rewards on offer —
 `{gold, cards: [ids], relics: [ids], potions: [ids], card_removal}` (`card_removal`
-is a bool/count for the removal option).
+is a bool/count for the removal option). On a **scroll-box bundle** screen
+(ScrollBoxes relic, v8) `loot` also carries `packs: [[ids], [ids]]` — each pack a
+list of card ids the player picks one whole pack from; `cards` is empty then, so
+the frontend renders the packs as labelled groups instead of the flat card row.
 
 `route` (v6, the act's structure, persists per act like the map): `{boss, ancient,
 elites: [], monsters: [], events: []}`. Each node is `{id, name?, room_type?}` plus


### PR DESCRIPTION
Closes #555. Wires up the website side now that the mod emits `loot.packs`.

On a **choose-a-bundle** screen (the ScrollBoxes Ancient relic), the mod sends `loot.packs` — a list of packs, each a list of card ids the player picks one whole pack from — and keeps those cards out of `loot.cards`.

**Backend** (`_clean_loot`): accept `packs` as a list of lists of ids, with the same path-safe id check as the other loot ids, capped (8 packs, `_LOOT_CAP` per pack).

**Frontend** (`LiveLootPanel`): when `packs` is present, render each pack as its own labelled group ("Pack 1 / Pack 2") using the existing `CardPill`, and hide the flat card row (it's empty on a bundle screen anyway). Gold / relics / potions / removal render as before.

Documented as v8 in `markdown-docs/live-presence.md`.

Backend cleaner is unit-verified (valid packs kept, junk dropped, path-unsafe ids stripped, no `packs` field when absent); tsc + ruff clean. The live view needs a ScrollBoxes bundle screen to confirm end-to-end — that's an Ancient relic so it's the hardest of the three to trigger on demand.