### PR TITLE
Add an admin giveaway lookup for resolving SteamID64s

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -349,6 +349,80 @@ async def users_set_partner(request: Request, user_id: str):
     return result
 
 
+# Cap the batch so one paste can't fan out into thousands of outbound Steam
+# requests. Plenty for a giveaway entrant list.
+_STEAM_RESOLVE_CAP = 300
+
+
+@router.post("/steam/resolve")
+async def steam_resolve(request: Request):
+    """Resolve a batch of raw SteamID64s for the giveaway tool. Each id is
+    validated, looked up against Steam's public profile XML (persona + avatar,
+    works for anyone with a public profile), and cross-checked against our
+    accounts (member? run count?). Input order is preserved and duplicates are
+    collapsed; the batch is capped at _STEAM_RESOLVE_CAP."""
+    _audit(request)
+    from fastapi import HTTPException
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    raw = body.get("steam_ids") if isinstance(body, dict) else None
+    if not isinstance(raw, list):
+        raise HTTPException(status_code=422, detail="steam_ids must be a list")
+
+    # Dedupe preserving first-seen order, then cap.
+    seen: list[str] = []
+    for item in raw:
+        sid = str(item).strip()
+        if sid and sid not in seen:
+            seen.append(sid)
+        if len(seen) >= _STEAM_RESOLVE_CAP:
+            break
+
+    from ..services import steam_profile
+
+    valid = [s for s in seen if steam_profile.is_valid_steamid64(s)]
+    profiles = await steam_profile.resolve_many(valid)
+
+    members: dict = {}
+    try:
+        from ..services.users_db import admin_members_by_steam_ids
+
+        members = admin_members_by_steam_ids(valid)
+    except Exception:
+        # A Mongo hiccup shouldn't sink the whole lookup; entrants still resolve
+        # to Steam profiles, just without the member/run-count annotation.
+        logger.warning("giveaway member lookup failed", exc_info=True)
+
+    results = []
+    resolved = 0
+    for sid in seen:
+        prof = profiles.get(sid)
+        if prof:
+            resolved += 1
+        results.append(
+            {
+                "steam_id": sid,
+                "valid": steam_profile.is_valid_steamid64(sid),
+                "steam": prof,
+                "member": members.get(sid),
+            }
+        )
+
+    return {
+        "results": results,
+        "counts": {
+            "total": len(seen),
+            "valid": len(valid),
+            "invalid": len(seen) - len(valid),
+            "resolved": resolved,
+            "members": len(members),
+        },
+    }
+
+
 @router.get("/feedback")
 def feedback_inbox(request: Request, include_resolved: bool = False, limit: int = 50):
     """The feedback inbox: site feedback and QA card reports, newest first.

--- a/backend/app/services/steam_profile.py
+++ b/backend/app/services/steam_profile.py
@@ -1,0 +1,112 @@
+"""Resolve a SteamID64 to its public Steam Community profile.
+
+Uses the keyless public profile XML (``steamcommunity.com/profiles/<id>/?xml=1``)
+- the same source ``auth_steam`` reads persona names from at sign-in - so it
+needs no Steam Web API key and works for any *public* profile, whether or not
+that person has an account on this site. Private or nonexistent profiles resolve
+to ``None`` (their XML is an ``<error>`` document with no ``<steamID>``).
+
+The giveaway admin tool calls :func:`resolve_many` to turn a pasted list of
+entrant ids into names + avatars.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+import httpx
+
+logger = logging.getLogger("spire-codex.steam-profile")
+
+# Base of the individual-account SteamID64 range (76561197960265728). Every real
+# player id is >= this; anything below is a group/other-type id or a typo.
+_STEAMID64_MIN = 76561197960265728
+_TIMEOUT = 10.0
+_CONCURRENCY = 8
+_CACHE_TTL = 900.0  # 15 min; personas/avatars change rarely, batches repeat
+
+# steam_id -> (expires_at, profile-or-None). None is cached too, so a private or
+# missing profile isn't re-fetched every time the operator re-resolves a list.
+_cache: dict[str, tuple[float, dict | None]] = {}
+
+
+def is_valid_steamid64(value: str) -> bool:
+    """True for a syntactically valid individual SteamID64 (17 digits, in the
+    individual-account range). Does not confirm the account actually exists."""
+    v = (value or "").strip()
+    return v.isdigit() and len(v) == 17 and int(v) >= _STEAMID64_MIN
+
+
+def _extract(body: str, tag: str) -> str | None:
+    open_tag, close_tag = f"<{tag}>", f"</{tag}>"
+    start = body.find(open_tag)
+    if start < 0:
+        return None
+    start += len(open_tag)
+    end = body.find(close_tag, start)
+    if end < 0:
+        return None
+    raw = body[start:end].strip()
+    if raw.startswith("<![CDATA[") and raw.endswith("]]>"):
+        raw = raw[len("<![CDATA[") : -len("]]>")].strip()
+    return raw or None
+
+
+def _parse_profile(steam_id: str, body: str) -> dict | None:
+    # The error document (private / nonexistent) carries no <steamID>, so a
+    # missing persona is how we tell "couldn't resolve" from a real profile.
+    persona = _extract(body, "steamID")
+    if not persona:
+        return None
+    return {
+        "steam_id": steam_id,
+        "persona": persona,
+        "avatar": _extract(body, "avatarFull") or _extract(body, "avatarMedium"),
+        "profile_url": f"https://steamcommunity.com/profiles/{steam_id}",
+        "privacy": _extract(body, "privacyState"),
+    }
+
+
+async def _fetch_one(client: httpx.AsyncClient, steam_id: str) -> dict | None:
+    now = time.time()
+    hit = _cache.get(steam_id)
+    if hit and hit[0] > now:
+        return hit[1]
+    try:
+        resp = await client.get(
+            f"https://steamcommunity.com/profiles/{steam_id}/?xml=1"
+        )
+        profile = _parse_profile(steam_id, resp.text)
+    except Exception as exc:
+        # Transient (timeout / network): return None without caching, so a retry
+        # can still succeed instead of being pinned to a failure for 15 minutes.
+        logger.warning("steam profile fetch failed for %s: %s", steam_id, exc)
+        return None
+    _cache[steam_id] = (now + _CACHE_TTL, profile)
+    return profile
+
+
+async def resolve_many(steam_ids: list[str]) -> dict[str, dict | None]:
+    """Resolve valid SteamID64s to profiles, bounded-concurrently. Returns a map
+    keyed by steam_id; a value of ``None`` means the profile is private, hidden,
+    or does not exist. Invalid ids are dropped (they never appear in the map)."""
+    ids = [
+        s for s in dict.fromkeys(x.strip() for x in steam_ids) if is_valid_steamid64(s)
+    ]
+    if not ids:
+        return {}
+    sem = asyncio.Semaphore(_CONCURRENCY)
+    out: dict[str, dict | None] = {}
+
+    async with httpx.AsyncClient(
+        timeout=_TIMEOUT, headers={"User-Agent": "spire-codex-admin"}
+    ) as client:
+
+        async def worker(sid: str) -> None:
+            async with sem:
+                out[sid] = await _fetch_one(client, sid)
+
+        await asyncio.gather(*(worker(sid) for sid in ids))
+    return out

--- a/backend/app/services/users_db.py
+++ b/backend/app/services/users_db.py
@@ -745,6 +745,34 @@ def admin_list_users(q: str | None = None, page: int = 1, limit: int = 50) -> di
     }
 
 
+def admin_members_by_steam_ids(steam_ids: list[str]) -> dict[str, dict]:
+    """Map the given SteamID64s to the site accounts that own them. Only ids that
+    belong to a user appear in the returned map; each value carries the account
+    id, username, partner flag, and run count. The giveaway lookup uses this to
+    flag which pasted entrants are members - one indexed `$in` query plus the
+    shared run-count aggregate, not N find_ones."""
+    ids = [s for s in dict.fromkeys(steam_ids) if s]
+    if not ids:
+        return {}
+    coll = _get_collection()
+    users = []
+    for d in coll.find({"steam_id": {"$in": ids}}, _ADMIN_USER_FIELDS):
+        d["_id"] = str(d["_id"])
+        users.append(d)
+    _attach_run_counts(users)
+    out: dict[str, dict] = {}
+    for u in users:
+        sid = u.get("steam_id")
+        if sid:
+            out[sid] = {
+                "user_id": u["_id"],
+                "username": u.get("username"),
+                "is_partner": bool(u.get("is_partner")),
+                "run_count": u.get("run_count", 0),
+            }
+    return out
+
+
 def admin_set_username(user_id: str, new_name: str) -> dict:
     """Rename an account as an admin: enforces sanitization and uniqueness but
     skips the per-day self-service cap, and re-stamps the name on the runs."""

--- a/frontend/app/admin/users/GiveawayLookup.tsx
+++ b/frontend/app/admin/users/GiveawayLookup.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+// Giveaway helper folded into the Users page: paste a list of SteamID64s (one
+// per line, or comma/space separated), resolve each to its Steam profile
+// (persona + avatar, works for anyone with a public profile) and flag which are
+// site members with run counts, then optionally pick a random winner. Lives here
+// rather than on its own route so all account tooling stays under /admin/users.
+
+import { useMemo, useState } from "react";
+import { adminFetch } from "../shared";
+
+interface SteamProfile {
+  steam_id: string;
+  persona: string;
+  avatar: string | null;
+  profile_url: string;
+  privacy: string | null;
+}
+
+interface MemberInfo {
+  user_id: string;
+  username: string | null;
+  is_partner: boolean;
+  run_count: number;
+}
+
+interface ResolveRow {
+  steam_id: string;
+  valid: boolean;
+  steam: SteamProfile | null;
+  member: MemberInfo | null;
+}
+
+interface ResolveResponse {
+  results: ResolveRow[];
+  counts: {
+    total: number;
+    valid: number;
+    invalid: number;
+    resolved: number;
+    members: number;
+  };
+}
+
+function parseIds(text: string): string[] {
+  return text
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+const badge = "px-1.5 py-0.5 rounded text-[10px] font-bold border";
+
+export default function GiveawayLookup() {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState("");
+  const [rows, setRows] = useState<ResolveRow[]>([]);
+  const [counts, setCounts] = useState<ResolveResponse["counts"] | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+  const [membersOnly, setMembersOnly] = useState(false);
+  const [winnerId, setWinnerId] = useState<string | null>(null);
+
+  const eligible = useMemo(
+    () => rows.filter((r) => r.valid && r.steam && (!membersOnly || r.member)),
+    [rows, membersOnly],
+  );
+  const winner = rows.find((r) => r.steam_id === winnerId) ?? null;
+
+  async function resolve() {
+    const ids = parseIds(text);
+    if (!ids.length) {
+      setNote("Paste at least one SteamID64.");
+      return;
+    }
+    setBusy(true);
+    setNote(null);
+    setWinnerId(null);
+    try {
+      const data = await adminFetch<ResolveResponse>("/api/admin/steam/resolve", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ steam_ids: ids }),
+      });
+      setRows(data.results ?? []);
+      setCounts(data.counts ?? null);
+      if (!(data.results ?? []).length) setNote("Nothing to resolve.");
+    } catch (e) {
+      setNote(String((e as Error)?.message || e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function pickWinner() {
+    if (!eligible.length) {
+      setNote(
+        membersOnly
+          ? "No resolved site members to pick from."
+          : "No resolved entrants to pick from.",
+      );
+      return;
+    }
+    const chosen = eligible[Math.floor(Math.random() * eligible.length)];
+    setWinnerId(chosen.steam_id);
+    setNote(null);
+  }
+
+  const inputClass =
+    "px-3 py-2 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]/50";
+  const actionBtn =
+    "px-2.5 py-1 rounded text-xs font-semibold border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-card)]";
+
+  return (
+    <div className="mb-6 rounded-lg border border-[var(--border-subtle)]">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center gap-2 px-4 py-2.5 text-left text-sm font-semibold text-[var(--text-primary)]"
+      >
+        <span className="text-[var(--text-muted)]">{open ? "▾" : "▸"}</span>
+        Giveaway lookup
+        <span className="font-normal text-xs text-[var(--text-muted)]">
+          resolve SteamID64s and pick a winner
+        </span>
+      </button>
+
+      {open && (
+        <div className="px-4 pb-4">
+          <textarea
+            className={`${inputClass} w-full h-28 font-mono resize-y`}
+            placeholder={"Paste SteamID64s (one per line, or comma/space separated)\n76561198000000000\n76561198000000001"}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+          />
+          <div className="flex flex-wrap items-center gap-3 mt-2">
+            <button
+              onClick={resolve}
+              disabled={busy}
+              className="px-4 py-1.5 rounded-lg bg-[var(--accent-gold)] text-[var(--bg-primary)] text-sm font-semibold hover:opacity-90 disabled:opacity-50"
+            >
+              {busy ? "Resolving..." : "Resolve"}
+            </button>
+            <button
+              onClick={pickWinner}
+              disabled={busy || !eligible.length}
+              className={`${actionBtn} disabled:opacity-40`}
+            >
+              🎲 Pick random winner
+            </button>
+            <label className="flex items-center gap-1.5 text-xs text-[var(--text-secondary)] select-none">
+              <input
+                type="checkbox"
+                checked={membersOnly}
+                onChange={(e) => setMembersOnly(e.target.checked)}
+              />
+              Members only ({rows.filter((r) => r.member).length})
+            </label>
+            {counts && (
+              <span className="ml-auto text-xs text-[var(--text-muted)] tabular-nums">
+                {counts.total} entrant{counts.total === 1 ? "" : "s"} · {counts.resolved}{" "}
+                resolved · {counts.members} member{counts.members === 1 ? "" : "s"}
+                {counts.invalid ? ` · ${counts.invalid} invalid` : ""}
+              </span>
+            )}
+          </div>
+
+          {note && (
+            <p className="mt-3 text-sm text-[var(--text-secondary)]">{note}</p>
+          )}
+
+          {winner && winner.steam && (
+            <div className="mt-3 flex items-center gap-3 px-3 py-2 rounded-lg border border-[var(--accent-gold)]/40 bg-[var(--accent-gold)]/10">
+              <span className="text-lg">🏆</span>
+              {winner.steam.avatar && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={winner.steam.avatar}
+                  alt=""
+                  className="w-8 h-8 rounded"
+                />
+              )}
+              <span className="text-sm text-[var(--text-primary)]">
+                Winner: <b>{winner.steam.persona}</b>
+                {winner.member?.username ? ` (@${winner.member.username})` : ""}
+              </span>
+              <a
+                href={winner.steam.profile_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ml-auto text-xs text-[var(--accent-gold)] hover:underline"
+              >
+                Steam profile →
+              </a>
+            </div>
+          )}
+
+          {rows.length > 0 && (
+            <div className="mt-3 overflow-x-auto rounded-lg border border-[var(--border-subtle)]">
+              <table className="w-full text-sm">
+                <thead className="bg-[var(--bg-card)] text-left text-xs uppercase tracking-wider text-[var(--text-muted)]">
+                  <tr>
+                    <th className="px-3 py-2">Steam profile</th>
+                    <th className="px-3 py-2">SteamID64</th>
+                    <th className="px-3 py-2">Site account</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((r) => {
+                    const isWinner = r.steam_id === winnerId;
+                    return (
+                      <tr
+                        key={r.steam_id}
+                        className={`border-t border-[var(--border-subtle)] ${
+                          isWinner ? "bg-[var(--accent-gold)]/10" : ""
+                        }`}
+                      >
+                        <td className="px-3 py-2">
+                          {r.steam ? (
+                            <a
+                              href={r.steam.profile_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="flex items-center gap-2 hover:underline"
+                            >
+                              {r.steam.avatar && (
+                                // eslint-disable-next-line @next/next/no-img-element
+                                <img
+                                  src={r.steam.avatar}
+                                  alt=""
+                                  className="w-7 h-7 rounded"
+                                />
+                              )}
+                              <span className="text-[var(--text-primary)]">
+                                {r.steam.persona}
+                              </span>
+                            </a>
+                          ) : (
+                            <span
+                              className={`${badge} bg-rose-950/50 text-rose-300 border-rose-900/50`}
+                            >
+                              {r.valid ? "private / not found" : "invalid id"}
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-3 py-2 font-mono text-[11px] text-[var(--text-muted)]">
+                          {r.steam_id}
+                        </td>
+                        <td className="px-3 py-2">
+                          {r.member ? (
+                            <span className="flex flex-wrap items-center gap-1">
+                              <span
+                                className={`${badge} bg-emerald-950/50 text-emerald-300 border-emerald-900/50`}
+                              >
+                                Member
+                              </span>
+                              <span className="text-[var(--text-secondary)]">
+                                {r.member.username ?? "-"} · {r.member.run_count} run
+                                {r.member.run_count === 1 ? "" : "s"}
+                              </span>
+                              {r.member.is_partner && (
+                                <span
+                                  className={`${badge} bg-amber-950/50 text-amber-300 border-amber-900/50`}
+                                >
+                                  Partner
+                                </span>
+                              )}
+                            </span>
+                          ) : (
+                            <span className="text-xs text-[var(--text-muted)]">
+                              not a member
+                            </span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/admin/users/UsersClient.tsx
+++ b/frontend/app/admin/users/UsersClient.tsx
@@ -6,6 +6,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { AdminShell, adminFetch } from "../shared";
+import GiveawayLookup from "./GiveawayLookup";
 
 interface UserRow {
   _id: string;
@@ -203,6 +204,7 @@ export default function UsersClient() {
 
   return (
     <AdminShell title="Users" subtitle="search, rename, delete, merge">
+      <GiveawayLookup />
       <div className="flex flex-wrap gap-2 mb-4">
         <input
           className={`${inputClass} w-80`}


### PR DESCRIPTION
Adds a giveaway lookup to the Users admin page for turning a list of entrant SteamID64s into real people.

## What it does
- Paste SteamID64s (one per line, or comma/space separated) into a collapsible "Giveaway lookup" panel on `/admin/users`.
- Each id resolves to its Steam profile (persona + avatar, linked) via Steam's keyless public profile XML, so it works for anyone with a public profile, member or not.
- Each entrant is cross-checked against our accounts and flagged as a site member with their username and run count.
- A "Pick random winner" button (with a "Members only" filter) highlights a winner and shows a banner.
- Invalid ids and private/hidden profiles are flagged in the table rather than silently dropped.

## Backend
- New `services/steam_profile.py`: `is_valid_steamid64()` plus `resolve_many()` with bounded concurrency, per-id timeouts, and a 15-minute cache. Private or missing profiles come back as `null`.
- New `admin_members_by_steam_ids()` in `users_db.py`: one indexed `$in` query plus the existing run-count aggregate.
- New `POST /api/admin/steam/resolve`, guarded by the router-level `require_admin` like the rest of the admin API. Dedupes and caps the batch at 300.

The winner pick is client-side random for now (re-rollable, nothing logged); easy to move server-side later if I want an auditable draw.
