### PR TITLE
Remove the placeholder legal note from the giveaway page

### DIFF
--- a/frontend/app/giveaway/GiveawayClient.tsx
+++ b/frontend/app/giveaway/GiveawayClient.tsx
@@ -297,10 +297,6 @@ Santa Rosa, CA 95406`}
           This promotion is in no way sponsored, endorsed, administered by, or associated with
           Valve, Steam, Mega Crit, Overwolf, or Artovision.
         </p>
-        <p className="text-[var(--text-muted)]">
-          [ Placeholder: add a privacy note, governing law / state, and any other terms your
-          jurisdiction requires before publishing. ]
-        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
The giveaway page merged (#520) with a placeholder standing in for the legal note:

> [ Placeholder: add a privacy note, governing law / state, and any other terms your jurisdiction requires before publishing. ]

This drops that paragraph so it doesn't show on the live page. Nothing else changes. The Steam/Mega Crit/Overwolf/Artovision non-affiliation line right above it stays.