### PR TITLE
Let admins hide cheated runs from the rankings

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -187,10 +187,14 @@ def runs_search(
     username: str | None = None,
     seed: str | None = None,
     run_hash: str | None = None,
+    max_win_seconds: int | None = None,
     limit: int = 25,
 ):
-    """Find submitted runs to inspect or delete. run_hash wins when given;
-    otherwise username/seed filter the normal listing, newest first."""
+    """Find submitted runs to inspect, hide, or delete. run_hash wins when given.
+    max_win_seconds surfaces the cheater review queue: wins faster than that many
+    seconds, fastest first, with already-hidden runs included so you can see
+    what's flagged. Otherwise username/seed filter the normal listing, newest
+    first. Admin searches include hidden runs (they carry a `hidden` flag)."""
     _audit(request)
     if not os.environ.get("MONGO_URL", "").strip():
         return {"runs": [], "total": 0}
@@ -203,12 +207,45 @@ def runs_search(
             d.pop("_id", None)
             d.pop("raw", None)
         return {"runs": docs, "total": len(docs)}
+    if max_win_seconds is not None:
+        # The review queue: implausibly fast "wins", fastest first, hidden ones
+        # included so an admin can tell what's already been flagged.
+        coll = get_database()["runs"]
+        q = {
+            "win": {"$in": [True, 1]},
+            "run_time": {"$gt": 0, "$lt": int(max_win_seconds)},
+        }
+        cursor = (
+            coll.find(
+                q,
+                {
+                    "_id": 0,
+                    "run_hash": 1,
+                    "run_time": 1,
+                    "character": 1,
+                    "ascension": 1,
+                    "username": 1,
+                    "win": 1,
+                    "hidden": 1,
+                    "submitted_at": 1,
+                },
+            )
+            .sort([("run_time", 1)])
+            .limit(limit)
+        )
+        runs = list(cursor)
+        for d in runs:
+            sa = d.get("submitted_at")
+            if hasattr(sa, "isoformat"):
+                d["submitted_at"] = sa.isoformat()
+        return {"runs": runs, "total": len(runs)}
     result = list_runs(
         username=(username or "").strip() or None,
         seed=(seed or "").strip() or None,
         sort="newest",
         page=1,
         limit=limit,
+        include_hidden=True,
     )
     return result
 
@@ -234,6 +271,33 @@ def runs_delete(request: Request, run_hash: str):
         result["file_removed"],
     )
     return {"run_hash": run_hash, **result}
+
+
+@router.post("/runs/{run_hash}/hide")
+async def runs_set_hidden(request: Request, run_hash: str):
+    """Flag (or unflag) a run as ineligible so it drops out of the leaderboards,
+    /charts, the stats, and the run browser. Body: {"hidden": bool} (defaults to
+    true). Reversible - the run is kept, just filtered. Materialized leaderboard
+    and stats summaries clear it on their next ~60s rebuild."""
+    _audit(request)
+    from fastapi import HTTPException
+
+    if not os.environ.get("MONGO_URL", "").strip():
+        raise HTTPException(status_code=503, detail="run hiding needs MongoDB")
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    hidden = bool(body.get("hidden", True))
+    from ..services.runs_db_mongo import set_run_hidden
+    from .runs import _load_run_blob
+
+    result = set_run_hidden(run_hash.strip(), hidden)
+    # Evict the in-process blob LRU so this worker stops serving the run's
+    # detail immediately; other workers age it out on their own.
+    _load_run_blob.cache_clear()
+    logger.info("admin set hidden=%s on run %s: %s", hidden, run_hash, result)
+    return {"run_hash": run_hash, "hidden": hidden, **result}
 
 
 # ── Users ───────────────────────────────────────────────────────────────

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -130,7 +130,8 @@ def _load_frame() -> list[tuple]:
         from .runs_db_mongo import _get_collection
 
         cursor = _get_collection().find(
-            {},
+            # Exclude admin-flagged cheated runs (absent field = eligible).
+            {"hidden": {"$ne": True}},
             {
                 "_id": 0,
                 "character": 1,

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -725,6 +725,8 @@ def _build_match(
     if username:
         # Case-insensitive, exact (anchored) match on the normalized field.
         m["username_lower"] = username.lower()
+    # Drop admin-flagged cheated runs from every stat (absent field = eligible).
+    m["hidden"] = {"$ne": True}
     return m
 
 
@@ -1445,6 +1447,7 @@ def _projection_row() -> dict:
         "username": 1,
         "submitted_at": 1,
         "build_id": 1,
+        "hidden": 1,
     }
 
 
@@ -1526,10 +1529,16 @@ def list_runs(
     today: bool = False,
     page: int = 1,
     limit: int = 50,
+    include_hidden: bool = False,
 ) -> dict:
-    """Paginated, filterable run list. Mirrors the /api/runs/list SQLite path."""
+    """Paginated, filterable run list. Mirrors the /api/runs/list SQLite path.
+
+    include_hidden is for the admin console only; public callers leave it False
+    so admin-flagged cheated runs stay out of the run browser."""
     coll = _get_collection()
     q: dict[str, Any] = {}
+    if not include_hidden:
+        q["hidden"] = {"$ne": True}
     if character:
         q["character"] = character.upper()
     if win == "true":
@@ -1644,6 +1653,17 @@ def list_runs(
 
 
 @_instrument("leaderboard")
+def set_run_hidden(run_hash: str, hidden: bool) -> dict:
+    """Flag or unflag every doc sharing this run_hash as ineligible. Hidden runs
+    stay in the collection but drop out of leaderboards, /charts, the stats, and
+    the run list on the next read. The materialized leaderboard/stats summaries
+    clear the run on their next ~60s rebuild. Returns how many docs changed."""
+    coll = _get_collection()
+    update = {"$set": {"hidden": True}} if hidden else {"$unset": {"hidden": ""}}
+    result = coll.update_many({"run_hash": run_hash}, update)
+    return {"matched": result.matched_count, "modified": result.modified_count}
+
+
 def leaderboard(
     category: str = "fastest",
     character: str | None = None,
@@ -1733,7 +1753,8 @@ def _leaderboard_live(
     """
     coll = _get_collection()
     # ETL'd docs store win as 0/1 int; submit_run stores bool. Match both.
-    q: dict[str, Any] = {"win": {"$in": [True, 1]}}
+    # Exclude admin-flagged cheated runs (absent field = eligible).
+    q: dict[str, Any] = {"win": {"$in": [True, 1]}, "hidden": {"$ne": True}}
     if character:
         q["character"] = character.upper()
     if players == "single":

--- a/frontend/app/admin/runs/RunsClient.tsx
+++ b/frontend/app/admin/runs/RunsClient.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-// Run admin: search by username / seed / hash, inspect, delete. Deletion
-// removes the Mongo docs and the blob file immediately; aggregates drop
-// the run on their next rebuild.
+// Run admin: search by username / seed / hash, inspect, hide, or delete.
+// "Hide" flags a run as ineligible (reversible) so it drops out of the
+// leaderboards, /charts, and the run browser without deleting it. "Fast wins"
+// surfaces the cheater review queue - implausibly fast wins, fastest first.
 
 import { useState } from "react";
 import Link from "next/link";
@@ -14,10 +15,22 @@ interface RunRow {
   character?: string | null;
   ascension?: number | null;
   win?: boolean | number | null;
+  run_time?: number | null;
+  hidden?: boolean | null;
   player_count?: number | null;
   build_id?: string | null;
   submitted_at?: string | null;
   seed?: string | null;
+}
+
+// Wins faster than this many seconds are flagged for review - no legit full run
+// wins this fast. Powers the "Fast wins" review-queue button.
+const FAST_WIN_SECONDS = 300;
+
+function fmtTime(sec?: number | null): string {
+  if (typeof sec !== "number" || sec <= 0) return "-";
+  const m = Math.floor(sec / 60);
+  return `${m}m${String(sec % 60).padStart(2, "0")}s`;
 }
 
 export default function RunsClient() {
@@ -48,6 +61,46 @@ export default function RunsClient() {
     }
   }
 
+  async function findFastWins() {
+    setBusy(true);
+    setNote(null);
+    try {
+      const data = await adminFetch<{ runs: RunRow[] }>(
+        `/api/admin/runs/search?max_win_seconds=${FAST_WIN_SECONDS}&limit=100`,
+      );
+      setRows(data.runs ?? []);
+      setNote(
+        (data.runs ?? []).length
+          ? `Wins under ${FAST_WIN_SECONDS / 60} min, fastest first. Hide the fake ones.`
+          : "No suspiciously fast wins found.",
+      );
+    } catch (e) {
+      setNote(String((e as Error)?.message || e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function setHidden(runHash: string, hidden: boolean) {
+    try {
+      await adminFetch(`/api/admin/runs/${runHash}/hide`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ hidden }),
+      });
+      setRows((prev) =>
+        prev.map((r) => (r.run_hash === runHash ? { ...r, hidden } : r)),
+      );
+      setNote(
+        hidden
+          ? `Hid ${runHash.slice(0, 12)}... - it drops from rankings on the next rebuild.`
+          : `Restored ${runHash.slice(0, 12)}...`,
+      );
+    } catch (e) {
+      setNote(String((e as Error)?.message || e));
+    }
+  }
+
   async function remove(runHash: string) {
     if (!window.confirm(`Delete run ${runHash}? This removes it permanently.`)) return;
     try {
@@ -66,7 +119,7 @@ export default function RunsClient() {
     "px-3 py-1.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]/50";
 
   return (
-    <AdminShell title="Runs" subtitle="search, inspect, delete">
+    <AdminShell title="Runs" subtitle="search, inspect, hide, delete">
       <div className="flex flex-wrap gap-2 mb-4">
         <input className={inputClass} placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
         <input className={inputClass} placeholder="Seed" value={seed} onChange={(e) => setSeed(e.target.value)} />
@@ -77,6 +130,14 @@ export default function RunsClient() {
           className="px-4 py-1.5 rounded-lg bg-[var(--accent-gold)] text-[var(--bg-primary)] text-sm font-semibold hover:opacity-90 disabled:opacity-50"
         >
           {busy ? "Searching..." : "Search"}
+        </button>
+        <button
+          onClick={findFastWins}
+          disabled={busy}
+          className="px-4 py-1.5 rounded-lg border border-[var(--border-subtle)] text-sm font-semibold text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-card)] disabled:opacity-50"
+          title="Show wins under 5 minutes, fastest first - the cheater review queue"
+        >
+          Fast wins &lt;5m
         </button>
       </div>
 
@@ -92,6 +153,7 @@ export default function RunsClient() {
                 <th className="px-3 py-2">Character</th>
                 <th className="px-3 py-2">Asc</th>
                 <th className="px-3 py-2">Win</th>
+                <th className="px-3 py-2">Time</th>
                 <th className="px-3 py-2">Build</th>
                 <th className="px-3 py-2">Submitted</th>
                 <th className="px-3 py-2"></th>
@@ -99,31 +161,50 @@ export default function RunsClient() {
             </thead>
             <tbody>
               {rows.map((r) => (
-                <tr key={r.run_hash} className="border-t border-[var(--border-subtle)]">
+                <tr
+                  key={r.run_hash}
+                  className={`border-t border-[var(--border-subtle)] ${r.hidden ? "opacity-50" : ""}`}
+                >
                   <td className="px-3 py-2 font-mono text-xs">
                     {r.run_hash ? (
                       <Link href={`/runs/${r.run_hash}`} className="text-[var(--accent-gold)] hover:underline">
                         {r.run_hash.slice(0, 12)}...
                       </Link>
                     ) : "-"}
+                    {r.hidden && (
+                      <span className="ml-1.5 px-1.5 py-0.5 rounded text-[10px] font-bold border bg-rose-950/50 text-rose-300 border-rose-900/50">
+                        hidden
+                      </span>
+                    )}
                   </td>
                   <td className="px-3 py-2">{r.username ?? "-"}</td>
                   <td className="px-3 py-2">{(r.character ?? "-").replace("CHARACTER.", "")}</td>
                   <td className="px-3 py-2 tabular-nums">{r.ascension ?? "-"}</td>
                   <td className="px-3 py-2">{r.win ? "yes" : "no"}</td>
+                  <td className="px-3 py-2 tabular-nums text-xs">{fmtTime(r.run_time)}</td>
                   <td className="px-3 py-2 text-xs">{r.build_id ?? "-"}</td>
                   <td className="px-3 py-2 text-xs">
                     {r.submitted_at ? new Date(r.submitted_at).toLocaleString() : "-"}
                   </td>
-                  <td className="px-3 py-2 text-right">
-                    {r.run_hash && (
-                      <button
-                        onClick={() => remove(r.run_hash!)}
-                        className="px-2.5 py-1 rounded text-xs font-semibold bg-rose-950/60 text-rose-300 border border-rose-900/40 hover:bg-rose-900/60"
-                      >
-                        Delete
-                      </button>
-                    )}
+                  <td className="px-3 py-2">
+                    <div className="flex justify-end gap-1.5">
+                      {r.run_hash && (
+                        <button
+                          onClick={() => setHidden(r.run_hash!, !r.hidden)}
+                          className="px-2.5 py-1 rounded text-xs font-semibold border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-card)]"
+                        >
+                          {r.hidden ? "Unhide" : "Hide"}
+                        </button>
+                      )}
+                      {r.run_hash && (
+                        <button
+                          onClick={() => remove(r.run_hash!)}
+                          className="px-2.5 py-1 rounded text-xs font-semibold bg-rose-950/60 text-rose-300 border border-rose-900/40 hover:bg-rose-900/60"
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </div>
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
The `fastest` leaderboard is topped by cheated runs (a 17-second "win", several sub-minute a10 wins). No legit full run wins that fast. This adds a way to flag those so they drop out of the public rankings, without deleting them.

## What it does
- **Reversible `hidden` flag** on runs. A hidden run stays in the collection but is filtered out of the leaderboards, `/charts`, the stats, and the public run browser.
- **Admin toggle**: `/admin/runs` gets a Hide / Unhide button per run, and shows each run's time so the fakes are obvious.
- **Review queue**: a "Fast wins <5m" button lists wins under 5 minutes, fastest first, with already-hidden ones marked, so I can find and flag cheaters quickly. (Manual by design; nothing is auto-hidden.)

## Where the filter is applied
- `_leaderboard_live` (covers both the live and materialized leaderboard paths)
- `_build_match` (covers `get_stats` and the materialized stats summary)
- `list_runs` (public run browser; the admin console passes `include_hidden` so it still sees flagged runs)
- the `/charts` in-memory run frame

New `POST /api/admin/runs/{run_hash}/hide` (body `{"hidden": bool}`) backs the toggle, guarded by the router-level `require_admin` like the rest of the admin API. Hiding takes effect immediately on the live paths; the materialized leaderboard/stats summaries clear the run on their next ~60s rebuild.

## Not covered (Mongo-only, and follow-ups)
- The flag lives on the Mongo doc, so this is the Mongo path only (the SQLite fallback has no such column).
- The community-stats "fastest win" spotlight and the tier-list snapshot walk run *files* rather than querying Mongo, so they don't consult the flag yet. Happy to extend those in a follow-up if you want them covered too. The seed leaderboard and single-run rank lookups also aren't filtered yet.
