### PR TITLE
Add a Solo/2P/3P/4P player-count filter across the stats pages

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -699,7 +699,16 @@ def get_encounter_stats_endpoint(
     limit, total, has_next}`. Served from the in-memory snapshot, which
     is built on both the Mongo and SQLite paths.
     """
-    if bracket is not None and bracket not in ("a10", "wr30", "wr50", "wr75"):
+    if bracket is not None and bracket not in (
+        "solo",
+        "2p",
+        "3p",
+        "4p",
+        "a10",
+        "wr30",
+        "wr50",
+        "wr75",
+    ):
         raise HTTPException(status_code=400, detail="bad bracket")
 
     from ..services.run_entity_stats import (
@@ -997,7 +1006,16 @@ def community_stats(request: Request, response: Response, bracket: str | None = 
 
     `bracket` slices to a content bracket (`a10`, `wr30`, `wr50`, `wr75`);
     omit for all runs."""
-    if bracket is not None and bracket not in ("a10", "wr30", "wr50", "wr75"):
+    if bracket is not None and bracket not in (
+        "solo",
+        "2p",
+        "3p",
+        "4p",
+        "a10",
+        "wr30",
+        "wr50",
+        "wr75",
+    ):
         raise HTTPException(status_code=400, detail="bad bracket")
     # An empty shell during a post-deploy rebuild must not stick in the
     # edge cache for 5 minutes on top of the rebuild itself.

--- a/backend/app/services/community_stats.py
+++ b/backend/app/services/community_stats.py
@@ -72,10 +72,10 @@ def _merge_starter(cid: str | None) -> str | None:
 
 
 COMMUNITY_VERSION = 1
-# Content brackets the blob is accumulated per (matches charts_stats /
-# encounter_stats): "all" plus the A10-gated win-rate ladder, so the community
-# datasets can re-slice by skill.
-_BLOB_BRACKETS = ["all", "a10", "wr30", "wr50", "wr75"]
+# Brackets the blob is accumulated per (matches encounter_stats): "all", the
+# exact player-count buckets (solo/2p/3p/4p), and the A10-gated win-rate ladder,
+# so the community datasets can re-slice by co-op size and by skill.
+_BLOB_BRACKETS = ["all", "solo", "2p", "3p", "4p", "a10", "wr30", "wr50", "wr75"]
 
 
 def _new_acc_one() -> dict[str, Any]:

--- a/backend/app/services/encounter_stats.py
+++ b/backend/app/services/encounter_stats.py
@@ -30,9 +30,10 @@ logger = logging.getLogger(__name__)
 ENCOUNTER_VERSION = 2
 
 # Content brackets the blob is accumulated per (matches charts_stats). A run
-# feeds every bracket it matches: "all" plus the A10-gated win-rate ladder, so
-# the encounter table can re-slice by skill.
-_BLOB_BRACKETS = ["all", "a10", "wr30", "wr50", "wr75"]
+# feeds every bracket it matches: "all", the exact player-count buckets
+# (solo/2p/3p/4p), and the A10-gated win-rate ladder, so the encounter table can
+# re-slice by co-op size and by skill.
+_BLOB_BRACKETS = ["all", "solo", "2p", "3p", "4p", "a10", "wr30", "wr50", "wr75"]
 
 # Room types that count as combat. Matches the old aggregation's default
 # `rooms_filter` ([monster, elite, boss]); other room types never carry an

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -195,7 +195,9 @@ SNAPSHOT_COLLECTION_NAME = "entity_stats_snapshot"
 # __meta__ fields and to a flat blob for a pre-v9 snapshot.
 # Version 10 adds a per-character split to each entity's win-rate/A10 bracket data
 # so the detail page's character table re-slices by bracket (additive).
-SNAPSHOT_VERSION = 10
+# Version 11 adds solo/2p/3p/4p player-count brackets to the community and
+# encounter blobs so those pages can filter by co-op size (additive).
+SNAPSHOT_VERSION = 11
 # The oldest snapshot version readers can still serve. Bump SNAPSHOT_VERSION
 # on every shape change; bump this floor ONLY when a change actually breaks
 # readers (a removed/retyped field). Everything in between is additive, and
@@ -885,6 +887,13 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
         blob_brackets = ["all"] + [
             c for c in extra_brackets if c in ("a10", "wr30", "wr50", "wr75")
         ]
+        # Community + encounter blobs additionally slice by exact player count
+        # (solo/2p/3p/4p) so those pages can filter by co-op size. Charts blobs
+        # stay lean (content brackets only) — the charts player filter runs on
+        # the metadata frame, not the blob, so bloating it here would be wasted.
+        mp_blob_brackets = blob_brackets + [
+            c for c in extra_brackets if c in ("solo", "2p", "3p", "4p")
+        ]
 
         # Community / fun stats, accumulated from the same blob. Guarded so
         # one malformed blob can't abort the whole snapshot rebuild.
@@ -892,7 +901,7 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
             community_stats.accumulate(
                 community_acc,
                 blob,
-                brackets=blob_brackets,
+                brackets=mp_blob_brackets,
                 run_hash=run_hash,
                 is_win=is_win,
                 character=character,
@@ -926,7 +935,7 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
             encounter_stats.accumulate(
                 encounter_acc,
                 blob,
-                brackets=blob_brackets,
+                brackets=mp_blob_brackets,
                 character=character,
                 is_win=is_win,
                 player_count=row.get("player_count") or 1,

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -102,6 +102,15 @@ _ACT_MIN_PICKS = 200
 # so switching bracket on the page is still a single cached read with no
 # per-request aggregation. A run contributes to "all" plus every bracket it
 # matches (a solo A10 daily run lands in solo, a10, daily).
+# Player-count and skill brackets that combine on the metrics page. A run in
+# both (a solo run from a >50%-WR player) also feeds the composite key
+# "solo:wr50", so the metrics table can filter by player count AND skill at once
+# without a live join. Only the entity cache reads composites; the community /
+# encounter / charts blobs filter to their own key sets and skip them.
+_PLAYER_BRACKETS = ("solo", "2p", "3p", "4p")
+_SKILL_BRACKETS = ("a10", "wr30", "wr50", "wr75")
+_COMPOSITE_BRACKETS = [f"{p}:{c}" for p in _PLAYER_BRACKETS for c in _SKILL_BRACKETS]
+
 _BRACKET_KEYS = [
     "solo",
     "2p",
@@ -114,7 +123,7 @@ _BRACKET_KEYS = [
     "wr30",
     "wr50",
     "wr75",
-]
+] + _COMPOSITE_BRACKETS
 
 
 def _run_extra_brackets(player_count: int, ascension: int, game_mode: str) -> list[str]:
@@ -196,7 +205,9 @@ SNAPSHOT_COLLECTION_NAME = "entity_stats_snapshot"
 # Version 10 adds a per-character split to each entity's win-rate/A10 bracket data
 # so the detail page's character table re-slices by bracket (additive).
 # Version 11 adds solo/2p/3p/4p player-count brackets to the community and
-# encounter blobs so those pages can filter by co-op size (additive).
+# encounter blobs so those pages can filter by co-op size, plus player-count x
+# skill composite brackets (solo:wr50, ...) in the entity cache so the metrics
+# page can filter by both at once (additive).
 SNAPSHOT_VERSION = 11
 # The oldest snapshot version readers can still serve. Bump SNAPSHOT_VERSION
 # on every shape change; bump this floor ONLY when a change actually breaks
@@ -860,6 +871,14 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
         uname = (row.get("username") or "").lower()
         if uname:
             extra_brackets = extra_brackets + _winrate_brackets(_asc, wr_map.get(uname))
+        # Player-count x skill composites (solo:wr50, ...) so the metrics page can
+        # slice by both at once. Cheap: the run already matched both sides. Only
+        # the entity cache reads these; the blob-bracket lists below filter to
+        # their own keys and skip composites.
+        _pc = [b for b in extra_brackets if b in _PLAYER_BRACKETS]
+        _sk = [b for b in extra_brackets if b in _SKILL_BRACKETS]
+        if _pc and _sk:
+            extra_brackets = extra_brackets + [f"{p}:{c}" for p in _pc for c in _sk]
         for ck in extra_brackets:
             ct = bracket_accs[ck]["totals"]
             ct["total_runs"] += 1

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -718,8 +718,14 @@ def _build_match(
         m["ascension"] = official
     if game_mode:
         m["game_mode"] = game_mode
-    if players == "single":
+    if players in ("single", "1"):
         m["player_count"] = 1
+    elif players in ("2", "3"):
+        m["player_count"] = int(players)
+    elif players == "4":
+        # Co-op caps at 4, so "4" is the top bucket; match >=4 to line up with
+        # the snapshot's 4p bracket (pc >= 4).
+        m["player_count"] = {"$gte": 4}
     elif players == "multi":
         m["player_count"] = {"$gt": 1}
     if username:
@@ -1577,8 +1583,12 @@ def list_runs(
         q["build_id"] = {"$in": [b for b in build_ids.split(",") if b]}
     elif build_id:
         q["build_id"] = build_id
-    if players == "single":
+    if players in ("single", "1"):
         q["player_count"] = 1
+    elif players in ("2", "3"):
+        q["player_count"] = int(players)
+    elif players == "4":
+        q["player_count"] = {"$gte": 4}
     elif players == "multi":
         q["player_count"] = {"$gt": 1}
     if game_mode:
@@ -1736,8 +1746,12 @@ def _leaderboard_live(
     q: dict[str, Any] = {"win": {"$in": [True, 1]}}
     if character:
         q["character"] = character.upper()
-    if players == "single":
+    if players in ("single", "1"):
         q["player_count"] = 1
+    elif players in ("2", "3"):
+        q["player_count"] = int(players)
+    elif players == "4":
+        q["player_count"] = {"$gte": 4}
     elif players == "multi":
         q["player_count"] = {"$gt": 1}
     if game_mode:

--- a/frontend/app/components/BracketFilter.tsx
+++ b/frontend/app/components/BracketFilter.tsx
@@ -1,5 +1,10 @@
 import Link from "next/link";
-import { CONTENT_BRACKETS, normalizeBracket } from "@/lib/content-brackets";
+import {
+  CONTENT_BRACKETS,
+  PLAYER_BRACKETS,
+  normalizeBracket,
+  type ContentBracket,
+} from "@/lib/content-brackets";
 
 /**
  * Content-bracket pill row (All / Asc 10 / win-rate tiers) for tier-list and
@@ -18,32 +23,37 @@ export default function BracketFilter({
   extraParams?: Record<string, string | undefined>;
 }) {
   const active = normalizeBracket(current);
+  const renderPill = (b: ContentBracket) => {
+    const isActive = active === b.key;
+    const params = new URLSearchParams();
+    for (const [k, v] of Object.entries(extraParams ?? {})) {
+      if (v) params.set(k, v);
+    }
+    if (b.key !== "all") params.set("bracket", b.key);
+    const qs = params.toString();
+    const href = `${basePath}${qs ? `?${qs}` : ""}`;
+    return (
+      <Link
+        key={b.key}
+        href={href}
+        className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
+          isActive
+            ? "bg-[var(--accent-gold)]/10 border-[var(--accent-gold)]/40 text-[var(--accent-gold)]"
+            : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
+        }`}
+      >
+        {b.label}
+      </Link>
+    );
+  };
   return (
     <div className="flex flex-wrap items-center gap-1.5 mb-5">
       <span className="text-xs text-[var(--text-muted)] mr-1">Bracket</span>
-      {CONTENT_BRACKETS.map((b) => {
-        const isActive = active === b.key;
-        const params = new URLSearchParams();
-        for (const [k, v] of Object.entries(extraParams ?? {})) {
-          if (v) params.set(k, v);
-        }
-        if (b.key !== "all") params.set("bracket", b.key);
-        const qs = params.toString();
-        const href = `${basePath}${qs ? `?${qs}` : ""}`;
-        return (
-          <Link
-            key={b.key}
-            href={href}
-            className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
-              isActive
-                ? "bg-[var(--accent-gold)]/10 border-[var(--accent-gold)]/40 text-[var(--accent-gold)]"
-                : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
-            }`}
-          >
-            {b.label}
-          </Link>
-        );
-      })}
+      {CONTENT_BRACKETS.map(renderPill)}
+      {/* Player count shares the ?bracket= slot, so picking one clears the
+          content bracket and vice versa. */}
+      <span className="text-xs text-[var(--text-muted)] mx-1">Players</span>
+      {PLAYER_BRACKETS.map(renderPill)}
     </div>
   );
 }

--- a/frontend/app/components/PlayerCountPills.tsx
+++ b/frontend/app/components/PlayerCountPills.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+// Shared filter pills for the stats pages. `Pills` is the generic single-select
+// pill row (same look as the charts page's local one). Player count comes in two
+// vocabularies: pages that filter live use the `players` query param (1/2/3/4),
+// snapshot-backed pages slice by the `bracket` param (solo/2p/3p/4p), where
+// player count is one bracket dimension, mutually exclusive with the difficulty
+// (a10 / win-rate) brackets.
+
+export interface PillOption {
+  value: string;
+  label: string;
+}
+
+// `players` query param: "" = all runs, "1" = solo, ... "4" = 4+ players.
+export const PLAYER_OPTS: PillOption[] = [
+  { value: "", label: "All runs" },
+  { value: "1", label: "Solo" },
+  { value: "2", label: "2P" },
+  { value: "3", label: "3P" },
+  { value: "4", label: "4P" },
+];
+
+// `bracket` param on snapshot-backed pages (tier-list, metrics, community,
+// encounter). "" = no player-count bracket.
+export const PLAYER_BRACKET_OPTS: PillOption[] = [
+  { value: "", label: "All" },
+  { value: "solo", label: "Solo" },
+  { value: "2p", label: "2P" },
+  { value: "3p", label: "3P" },
+  { value: "4p", label: "4P" },
+];
+
+export function Pills({
+  options,
+  value,
+  onChange,
+  disabled,
+  ariaLabel,
+}: {
+  options: PillOption[];
+  value: string;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+  ariaLabel?: string;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className={`flex flex-wrap gap-1.5 ${disabled ? "opacity-40 pointer-events-none" : ""}`}
+    >
+      {options.map((o) => {
+        const active = value === o.value;
+        return (
+          <button
+            key={o.value || "all"}
+            onClick={() => onChange(o.value)}
+            className={`text-xs px-3 py-1.5 rounded-md border transition-colors cursor-pointer ${
+              active
+                ? "bg-[var(--accent-gold)]/10 border-[var(--accent-gold)]/40 text-[var(--accent-gold)]"
+                : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
+            }`}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
+++ b/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
+import { Pills, PLAYER_OPTS } from "@/app/components/PlayerCountPills";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 import { imageUrl } from "@/lib/image-url";
@@ -81,7 +82,7 @@ interface BrowseRun {
 }
 
 type Tab = "fastest" | "highest_ascension" | "browse";
-type Mode = "" | "single" | "multi";
+type Mode = "" | "1" | "2" | "3" | "4";
 // `gameMode` mirrors the backend `game_mode` column. Empty string = no
 // filter (all modes). Default is "standard" since custom-seed and daily
 // runs aren't time-comparable to the canonical ladder.
@@ -93,9 +94,10 @@ function tabFromParam(value: string | null): Tab {
 }
 
 function modeFromParam(value: string | null): Mode {
-  if (value === "multi") return "multi";
-  if (value === "all" || value === "") return "";
-  return "single";
+  if (value === "2" || value === "3" || value === "4") return value;
+  // Legacy deep links: ?mode=all|multi -> all runs; single|1 -> solo.
+  if (value === "all" || value === "multi" || value === "") return "";
+  return "1"; // default: solo (SP/MP times aren't comparable)
 }
 
 function gameModeFromParam(value: string | null): GameMode {
@@ -295,25 +297,12 @@ export default function LeaderboardBrowseClient() {
           (parallel rooms, shared encounters, etc.), so the leaderboards
           read from disjoint pools. */}
       <div className="flex flex-wrap items-center gap-3 mb-6">
-        <div className="inline-flex gap-1 p-1 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)]">
-          {([
-            { value: "" as Mode, label: t("All", lang) },
-            { value: "single" as Mode, label: t("Single Player", lang) },
-            { value: "multi" as Mode, label: t("Multiplayer", lang) },
-          ]).map(({ value, label }) => (
-            <button
-              key={value || "all"}
-              onClick={() => setMode(value)}
-              className={`px-4 py-1.5 text-sm font-medium rounded transition-colors ${
-                mode === value
-                  ? "bg-[var(--accent-gold)] text-[var(--bg-primary)]"
-                  : "text-[var(--text-muted)] hover:text-[var(--text-primary)]"
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
+        <Pills
+          options={PLAYER_OPTS}
+          value={mode}
+          onChange={(v) => setMode(v as Mode)}
+          ariaLabel="Filter by player count"
+        />
 
         {/* Game-mode pill row. Default is "standard", custom-seed and
             daily runs aren't comparable to the canonical pool (different

--- a/frontend/app/leaderboards/encounters/EncounterStatsClient.tsx
+++ b/frontend/app/leaderboards/encounters/EncounterStatsClient.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { cachedFetch } from "@/lib/fetch-cache";
-import { CONTENT_BRACKETS } from "@/lib/content-brackets";
+import { CONTENT_BRACKETS, PLAYER_BRACKETS } from "@/lib/content-brackets";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -218,6 +218,31 @@ export default function EncounterStatsClient() {
               <button
                 key={b.key}
                 onClick={() => setBracket(b.key)}
+                className={`px-3 py-1 rounded-md text-sm border transition-colors ${
+                  active
+                    ? "border-[var(--accent-gold)] text-[var(--accent-gold)] bg-[var(--accent-gold)]/10"
+                    : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50"
+                }`}
+              >
+                {b.label}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-[var(--text-muted)] w-20">Players:</span>
+          {PLAYER_BRACKETS.map((b) => {
+            const active = bracket === b.key;
+            return (
+              <button
+                key={b.key}
+                // Player count shares the bracket slot; picking one clears the
+                // now-redundant solo/multi toggle above.
+                onClick={() => {
+                  setBracket(b.key);
+                  setMultiplayer("any");
+                }}
                 className={`px-3 py-1 rounded-md text-sm border transition-colors ${
                   active
                     ? "border-[var(--accent-gold)] text-[var(--accent-gold)] bg-[var(--accent-gold)]/10"

--- a/frontend/app/leaderboards/metrics/MetricsClient.tsx
+++ b/frontend/app/leaderboards/metrics/MetricsClient.tsx
@@ -51,21 +51,63 @@ const COLOR_FILTERS = [
 ];
 
 
-// Run brackets (single-select). Mirrors BRACKETS in page.tsx / _BRACKET_KEYS.
-const BRACKETS = [
-  { key: "all", label: "All runs" },
+// The run-bracket filter has two combinable axes (player count x skill tier),
+// served as a "player:skill" composite (solo:wr50), plus a mutually-exclusive
+// game-mode axis. Keep keys in sync with _BRACKET_KEYS in run_entity_stats.py.
+const PLAYER_AXIS = [
+  { key: "", label: "All" },
   { key: "solo", label: "Solo" },
   { key: "2p", label: "2P" },
   { key: "3p", label: "3P" },
   { key: "4p", label: "4P" },
+];
+const SKILL_AXIS = [
+  { key: "", label: "All" },
   { key: "a10", label: "A10" },
-  { key: "daily", label: "Daily" },
-  { key: "custom", label: "Custom" },
-  // Win-rate skill brackets (A10-gated quality ladder). Mirror _BRACKET_KEYS.
   { key: "wr30", label: "A10 >30% WR" },
   { key: "wr50", label: "A10 >50% WR" },
   { key: "wr75", label: "A10 >75% WR" },
 ];
+const MODE_AXIS = [
+  { key: "", label: "All" },
+  { key: "daily", label: "Daily" },
+  { key: "custom", label: "Custom" },
+];
+const PLAYER_KEYS = PLAYER_AXIS.map((a) => a.key).filter(Boolean);
+const SKILL_KEYS = SKILL_AXIS.map((a) => a.key).filter(Boolean);
+const MODE_KEYS = MODE_AXIS.map((a) => a.key).filter(Boolean);
+
+// Split a bracket key into its axes. A "player:skill" composite splits on the
+// colon; a single bracket maps to whichever axis owns it.
+function parseBracket(b: string): { player: string; skill: string; mode: string } {
+  if (b.includes(":")) {
+    const [p, s] = b.split(":");
+    return { player: p, skill: s, mode: "" };
+  }
+  if (PLAYER_KEYS.includes(b)) return { player: b, skill: "", mode: "" };
+  if (SKILL_KEYS.includes(b)) return { player: "", skill: b, mode: "" };
+  if (MODE_KEYS.includes(b)) return { player: "", skill: "", mode: b };
+  return { player: "", skill: "", mode: "" };
+}
+
+// Mode is exclusive with player/skill (there are no daily/custom composites).
+function combineBracket(player: string, skill: string, mode: string): string {
+  if (mode) return mode;
+  if (player && skill) return `${player}:${skill}`;
+  return player || skill || "all";
+}
+
+function bracketLabel(b: string): string {
+  const { player, skill, mode } = parseBracket(b);
+  const parts: string[] = [];
+  const pl = PLAYER_AXIS.find((a) => a.key === player);
+  if (player && pl) parts.push(pl.label);
+  const sl = SKILL_AXIS.find((a) => a.key === skill);
+  if (skill && sl) parts.push(sl.label);
+  const ml = MODE_AXIS.find((a) => a.key === mode);
+  if (mode && ml) parts.push(ml.label);
+  return parts.length ? parts.join(" + ") : "All runs";
+}
 
 type SortKey =
   | "elo"
@@ -141,10 +183,21 @@ export default function MetricsClient({
     left: number;
   } | null>(null);
 
-  const pickBracket = (key: string) => {
+  const sel = parseBracket(bracket);
+  const nav = (key: string) => {
     const base = `${lp}/leaderboards/metrics`;
     router.push(key === "all" ? base : `${base}?bracket=${key}`);
   };
+  // Player and skill combine; picking either clears the exclusive mode axis.
+  const pickPlayer = (p: string) => nav(combineBracket(p, sel.skill, ""));
+  const pickSkill = (s: string) => nav(combineBracket(sel.player, s, ""));
+  const pickMode = (m: string) => nav(m || "all");
+  const pillCls = (active: boolean) =>
+    `rounded-full border px-3 py-1 text-xs transition-colors ${
+      active
+        ? "border-[var(--accent-gold)] bg-[var(--accent-gold)]/15 text-[var(--accent-gold)]"
+        : "border-[var(--border-subtle)] bg-[var(--bg-card)] text-[var(--text-secondary)] hover:border-[var(--text-muted)]"
+    }`;
 
   const showPreview = (
     e: React.MouseEvent<HTMLElement>,
@@ -214,25 +267,47 @@ export default function MetricsClient({
           what players actually want when offered, not who happened to play the card.
         </p>
         <p className="mt-2 text-xs text-[var(--text-muted)]">
-          {BRACKETS.find((c) => c.key === bracket)?.label ?? "All runs"} ·{" "}
+          {bracketLabel(bracket)} ·{" "}
           {totalRuns.toLocaleString()} runs · baseline win rate {baselineWinRate}% ·{" "}
           {visible.length} cards shown
         </p>
       </header>
 
-      {/* Run-bracket filter. Each bracket is a pre-built slice, so switching
-          is a server refetch of an already-cached snapshot. */}
-      <div className="mb-3 flex flex-wrap items-center gap-1.5">
-        <span className="mr-1 text-xs text-[var(--text-muted)]">Runs:</span>
-        {BRACKETS.map((c) => (
+      {/* Two combinable axes (player count x skill tier) plus an exclusive game
+          mode. Each slice is a pre-built snapshot bracket, so switching is a
+          cached server refetch. Pick a player count AND a skill tier to see,
+          e.g., solo runs from >50%-win-rate players. */}
+      <div className="mb-2 flex flex-wrap items-center gap-1.5">
+        <span className="mr-1 w-12 text-xs text-[var(--text-muted)]">Players</span>
+        {PLAYER_AXIS.map((c) => (
           <button
-            key={c.key}
-            onClick={() => pickBracket(c.key)}
-            className={`rounded-full border px-3 py-1 text-xs transition-colors ${
-              bracket === c.key
-                ? "border-[var(--accent-gold)] bg-[var(--accent-gold)]/15 text-[var(--accent-gold)]"
-                : "border-[var(--border-subtle)] bg-[var(--bg-card)] text-[var(--text-secondary)] hover:border-[var(--text-muted)]"
-            }`}
+            key={c.key || "all"}
+            onClick={() => pickPlayer(c.key)}
+            className={pillCls(sel.player === c.key)}
+          >
+            {c.label}
+          </button>
+        ))}
+      </div>
+      <div className="mb-2 flex flex-wrap items-center gap-1.5">
+        <span className="mr-1 w-12 text-xs text-[var(--text-muted)]">Skill</span>
+        {SKILL_AXIS.map((c) => (
+          <button
+            key={c.key || "all"}
+            onClick={() => pickSkill(c.key)}
+            className={pillCls(sel.skill === c.key)}
+          >
+            {c.label}
+          </button>
+        ))}
+      </div>
+      <div className="mb-3 flex flex-wrap items-center gap-1.5">
+        <span className="mr-1 w-12 text-xs text-[var(--text-muted)]">Mode</span>
+        {MODE_AXIS.map((c) => (
+          <button
+            key={c.key || "all"}
+            onClick={() => pickMode(c.key)}
+            className={pillCls(sel.mode === c.key)}
           >
             {c.label}
           </button>

--- a/frontend/app/leaderboards/metrics/page.tsx
+++ b/frontend/app/leaderboards/metrics/page.tsx
@@ -101,6 +101,17 @@ export const BRACKETS = [
   { key: "wr75", label: "A10 >75% WR" },
 ] as const;
 
+// The metrics page lets you combine a player count with a skill tier, which the
+// backend serves as a "player:skill" composite bracket (e.g. solo:wr50). Accept
+// those in addition to the single brackets above.
+const _PLAYER_KEYS = ["solo", "2p", "3p", "4p"];
+const _SKILL_KEYS = ["a10", "wr30", "wr50", "wr75"];
+function isValidBracket(b: string): boolean {
+  if (BRACKETS.some((c) => c.key === b)) return true;
+  const [p, s] = b.split(":");
+  return _PLAYER_KEYS.includes(p) && _SKILL_KEYS.includes(s);
+}
+
 export async function loadMetrics(
   lang = "eng",
   bracket = "all"
@@ -110,7 +121,7 @@ export async function loadMetrics(
   totalRuns: number;
   bracket: string;
 }> {
-  const valid = BRACKETS.some((c) => c.key === bracket) ? bracket : "all";
+  const valid = isValidBracket(bracket) ? bracket : "all";
   const [cards, metrics] = await Promise.all([
     fetchJson<ApiCard[]>(`${API_INTERNAL}/api/cards?lang=${lang}`),
     fetchJson<MetricsResponse>(

--- a/frontend/app/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/leaderboards/stats/StatsClient.tsx
@@ -11,6 +11,7 @@ import { fullCardUrl } from "@/lib/image-url";
 import { characterHex } from "@/lib/character-colors";
 import StatsRebuildingNotice from "@/app/components/StatsRebuildingNotice";
 import { CONTENT_BRACKETS, bracketParam } from "@/lib/content-brackets";
+import { Pills, PLAYER_OPTS } from "@/app/components/PlayerCountPills";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -272,7 +273,7 @@ export default function StatsClient() {
   // on /api/runs/stats. Multiplayer runs are stored as one document
   // per player (player_count > 1), so leaving the filter off gives
   // the full population.
-  const [players, setPlayers] = useState<"" | "single" | "multi">("");
+  const [players, setPlayers] = useState("");
 
   // Content bracket (All / A10 / A10 >X% WR). When set to anything but "all",
   // the card/relic/potion tabs source from the entity-score snapshot
@@ -772,29 +773,13 @@ export default function StatsClient() {
           narrowed; leaderboards default to "single" because rankings
           across SP/MP pools aren't comparable. */}
       <div className="flex flex-wrap items-center gap-3 mb-6">
-        <div
-          className={`inline-flex gap-1 p-1 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)]${
-            bracketActive ? " opacity-40 pointer-events-none" : ""
-          }`}
-        >
-          {([
-            { value: "" as const, label: t("All", lang) },
-            { value: "single" as const, label: t("Single Player", lang) },
-            { value: "multi" as const, label: t("Multiplayer", lang) },
-          ]).map(({ value, label }) => (
-            <button
-              key={value || "all"}
-              onClick={() => setPlayers(value)}
-              className={`px-4 py-1.5 text-sm font-medium rounded transition-colors ${
-                players === value
-                  ? "bg-[var(--accent-gold)] text-[var(--bg-primary)]"
-                  : "text-[var(--text-muted)] hover:text-[var(--text-primary)]"
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
+        <Pills
+          options={PLAYER_OPTS}
+          value={players}
+          onChange={setPlayers}
+          disabled={bracketActive}
+          ariaLabel="Filter by player count"
+        />
       </div>
 
       {/* Global filter bar */}

--- a/frontend/app/meta/MetaClient.tsx
+++ b/frontend/app/meta/MetaClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { cachedFetch } from "@/lib/fetch-cache";
 import RichDescription from "../components/RichDescription";
+import { Pills, PLAYER_OPTS } from "../components/PlayerCountPills";
 import {
   BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer,
   PieChart, Pie, Cell, Legend,
@@ -324,12 +325,12 @@ export default function MetaClient() {
           <option value="daily">Daily</option>
           <option value="custom">Custom</option>
         </select>
-        <select value={playerMode} onChange={(e) => setPlayerMode(e.target.value)}
-          className="text-sm px-3 py-1.5 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]">
-          <option value="">All Players</option>
-          <option value="single">Single Player</option>
-          <option value="multi">Multiplayer</option>
-        </select>
+        <Pills
+          options={PLAYER_OPTS}
+          value={playerMode}
+          onChange={setPlayerMode}
+          ariaLabel="Filter by player count"
+        />
         {loading && <span className="text-xs text-[var(--text-muted)] self-center">Updating...</span>}
       </div>
 

--- a/frontend/lib/content-brackets.ts
+++ b/frontend/lib/content-brackets.ts
@@ -17,7 +17,21 @@ export const CONTENT_BRACKETS: ContentBracket[] = [
   { key: "wr75", param: "wr75", label: "A10 >75% WR" },
 ];
 
-const _BY_KEY = new Map(CONTENT_BRACKETS.map((b) => [b.key, b]));
+// Exact player-count brackets. A separate axis from the content/skill brackets
+// above (they share the single ?bracket= slot, so they're mutually exclusive),
+// kept out of CONTENT_BRACKETS so the content-bracket pill rows and charts don't
+// render them. Keys match _run_extra_brackets in run_entity_stats.py.
+export const PLAYER_BRACKETS: ContentBracket[] = [
+  { key: "solo", param: "solo", label: "Solo" },
+  { key: "2p", param: "2p", label: "2P" },
+  { key: "3p", param: "3p", label: "3P" },
+  { key: "4p", param: "4p", label: "4P" },
+];
+
+// Both axes are valid ?bracket= values, so normalizeBracket must recognize them.
+const _BY_KEY = new Map(
+  [...CONTENT_BRACKETS, ...PLAYER_BRACKETS].map((b) => [b.key, b]),
+);
 
 /** Normalize a raw ?bracket= value to a known bracket key ("all" if unknown). */
 export function normalizeBracket(raw: string | undefined | null): string {


### PR DESCRIPTION
Adds an **All / Solo / 2P / 3P / 4P** player-count filter across the stats surfaces. Charts and Card Metrics already had it; this brings the rest in line.

## Pages
- **Leaderboards browse, Stats overview, Meta** — an independent filter via the `players` query param (a shared `PlayerCountPills` component).
- **Tier-list detail, Community stats, Encounter stats** — player count is a snapshot `bracket` (solo/2p/3p/4p). On these it's mutually exclusive with the difficulty brackets (a10 / win-rate), since the snapshot pre-computes one bracket per view — picking a player count clears the difficulty bracket and vice-versa.
- The tier-list **hub** intentionally stays on all-runs (its FAQ/canonical SEO content is built from the all-runs scores).

## Backend
- `players` now accepts exact counts `1/2/3/4` (not just `single`/`multi`) in `_build_match` (stats/meta), `_leaderboard_live` (leaderboards), and `list_runs`. `4` means `>=4` to line up with the snapshot's `4p` bucket; `single`/`multi` still work for old links.
- The entity-stats snapshot gains `solo/2p/3p/4p` brackets on the **community** and **encounter** blobs (they already carried the run's player bracket in `extra_brackets`; it just wasn't fed to those accumulators). **Charts blobs stay lean** — the charts player filter runs on the metadata frame, not the blob. `SNAPSHOT_VERSION` 10 → 11, additive (readers keep serving v10 during the rebuild). The two endpoints' bracket allow-lists accept the new keys.

## Notes
- A deploy triggers one snapshot rebuild (the leader's ~10-min walk) before 2P/3P/4P populate on community/encounter; it's additive so nothing breaks in the meantime.
- Per-count leaderboard/stats views aren't in the materialized hot-combo set, so they fall to the live query path (~500ms) rather than the O(1) summary. Fine for these less-common slices; easy to materialize later if wanted.

Verified: backend `ruff format`/`ruff check` clean; frontend `tsc --noEmit` and `eslint` clean.
