### PR TITLE
Stop reporting per-card stats for tokens

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -341,6 +341,32 @@ def _excluded_card_ids() -> frozenset[str]:
     return _excluded_card_ids_cache
 
 
+_token_card_ids_cache: frozenset[str] | None = None
+
+
+def _token_card_ids() -> frozenset[str]:
+    """Token card ids (color "token": Shiv, Soul, Giant Rock, the Minion cards,
+    ...). Tokens are generated mid-combat and can't be obtained in the official
+    game, so any per-entity stats for them come only from modded runs and are
+    meaningless. Empty if the card data can't be read."""
+    global _token_card_ids_cache
+    if _token_card_ids_cache is None:
+        try:
+            from .data_service import load_cards
+
+            _token_card_ids_cache = frozenset(
+                c["id"]
+                for c in load_cards()
+                if c.get("id") and (c.get("color") or "").lower() == "token"
+            )
+        except Exception:
+            logger.warning(
+                "could not load card colors for token exclusion", exc_info=True
+            )
+            _token_card_ids_cache = frozenset()
+    return _token_card_ids_cache
+
+
 _starter_card_ids_cache: frozenset[str] | None = None
 
 
@@ -1943,6 +1969,10 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
     blocks while the initial build runs (a few seconds at current run
     counts); subsequent calls within the TTL window are O(1).
     """
+    # Tokens can't be obtained in the official game, so any aggregate for them is
+    # mod-only noise. Report no data (the endpoint renders a zero-filled stub).
+    if entity_type == "cards" and entity_id.upper() in _token_card_ids():
+        return None
     _maybe_rebuild()
     key = (entity_type, entity_id.upper())
     agg = _cache.get(key)


### PR DESCRIPTION
Token cards show picks/wins on their card page even though they can't be obtained in the official game. On prod, Shiv, Soul, Giant Rock (Boulder), Fuel, Mind Rot, Sloth, Sovereign Blade, and the Minion cards all report nonzero picks/wins — all mod-only noise (they're generated mid-combat, never a reward or deck card in the base game).

The scores and metrics tables already drop non-reward colors via `_excluded_card_ids()`, but the per-entity `/stats/{entity_type}/{entity_id}` path (the card page's Stats tab, via `EntityRunStats`) didn't. This adds a token-color exclusion there.

- New `_token_card_ids()` (color `token`, loaded once from the card data), mirroring `_excluded_card_ids()`.
- `get_entity_stats` returns `None` for a token card, so the endpoint renders its existing zero-filled "no runs yet" stub.

Scoped to tokens on purpose — curses and status cards are obtainable in the official game (Wounds, Dazed, event curses), so I left their per-entity stats alone. Backend-only; no snapshot or frontend change.
