### PR TITLE
Fix the beta /api/cards 500 on cards with fractional vars

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -60,7 +60,7 @@ class Card(BaseModel):
     keywords_key: list[str] | None = None
     tags: list[str] | None = None
     spawns_cards: list[str] | None = None
-    vars: dict[str, int] | None = None
+    vars: dict[str, int | float] | None = None
     upgrade: dict[str, str | int | None] | None = None
     upgrade_description: str | None = None
     image_url: str | None = None


### PR DESCRIPTION
`GET /api/cards?channel=beta` returns 500, so the beta cards gallery can't load.

Root cause: the new v0.108.0 card **Tank** has fractional `vars` — `DamageIncrease: 1.5`, `DamageDecrease: 0.5` (its "take 50% more / allies take 50% less damage"). The `Card` model typed `vars` as `dict[str, int]`, so Tank fails validation. The list endpoint validates *every* card against the model, so that one card 500s the whole beta list (the detail endpoint only validates the one card you request, which is why individual beta cards mostly loaded).

Fix: widen `vars` to `dict[str, int | float]`. Pydantic v2's smart union keeps whole numbers as ints (verified: `BLADE_SYMPHONY` `Cards: 2` stays `int`) and only stores Tank's values as floats.

Verified: all 592 beta cards across all 14 languages now validate (0 failures). Main cards are unaffected — they're all-integer vars, which validate under `int | float` unchanged.

Once this deploys, the beta cards gallery loads again, and beta cards show with their full metadata (all of them already carry the `upgrade` block, so the original + upgraded toggle works — the data was never the problem, the list just couldn't load).
