### PR TITLE
Restore the Withering Presence and Tainted power icons

### DIFF
--- a/data/deu/powers.json
+++ b/data/deu/powers.json
@@ -2287,7 +2287,7 @@
     "type": "Debuff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/tainted_power.webp"
   },
   {
     "id": "TANGLED",
@@ -2557,7 +2557,7 @@
     "type": "Buff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/withering_presence_power.webp"
   },
   {
     "id": "WRAITH_FORM",

--- a/data/eng/powers.json
+++ b/data/eng/powers.json
@@ -2287,7 +2287,7 @@
     "type": "Debuff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/tainted_power.webp"
   },
   {
     "id": "TANGLED",
@@ -2557,7 +2557,7 @@
     "type": "Buff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/withering_presence_power.webp"
   },
   {
     "id": "WRAITH_FORM",

--- a/data/esp/powers.json
+++ b/data/esp/powers.json
@@ -2287,7 +2287,7 @@
     "type": "Debuff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/tainted_power.webp"
   },
   {
     "id": "TANGLED",
@@ -2557,7 +2557,7 @@
     "type": "Buff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/withering_presence_power.webp"
   },
   {
     "id": "WRAITH_FORM",

--- a/data/fra/powers.json
+++ b/data/fra/powers.json
@@ -2287,7 +2287,7 @@
     "type": "Debuff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/tainted_power.webp"
   },
   {
     "id": "TANGLED",
@@ -2557,7 +2557,7 @@
     "type": "Buff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/withering_presence_power.webp"
   },
   {
     "id": "WRAITH_FORM",

--- a/data/ita/powers.json
+++ b/data/ita/powers.json
@@ -2287,7 +2287,7 @@
     "type": "Debuff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/tainted_power.webp"
   },
   {
     "id": "TANGLED",
@@ -2557,7 +2557,7 @@
     "type": "Buff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/withering_presence_power.webp"
   },
   {
     "id": "WRAITH_FORM",

--- a/data/jpn/powers.json
+++ b/data/jpn/powers.json
@@ -2287,7 +2287,7 @@
     "type": "Debuff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/tainted_power.webp"
   },
   {
     "id": "TANGLED",
@@ -2557,7 +2557,7 @@
     "type": "Buff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/withering_presence_power.webp"
   },
   {
     "id": "WRAITH_FORM",

--- a/data/kor/powers.json
+++ b/data/kor/powers.json
@@ -2287,7 +2287,7 @@
     "type": "Debuff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/tainted_power.webp"
   },
   {
     "id": "TANGLED",
@@ -2557,7 +2557,7 @@
     "type": "Buff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/withering_presence_power.webp"
   },
   {
     "id": "WRAITH_FORM",

--- a/data/pol/powers.json
+++ b/data/pol/powers.json
@@ -2287,7 +2287,7 @@
     "type": "Debuff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/tainted_power.webp"
   },
   {
     "id": "TANGLED",
@@ -2557,7 +2557,7 @@
     "type": "Buff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/withering_presence_power.webp"
   },
   {
     "id": "WRAITH_FORM",

--- a/data/ptb/powers.json
+++ b/data/ptb/powers.json
@@ -2287,7 +2287,7 @@
     "type": "Debuff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/tainted_power.webp"
   },
   {
     "id": "TANGLED",
@@ -2557,7 +2557,7 @@
     "type": "Buff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/withering_presence_power.webp"
   },
   {
     "id": "WRAITH_FORM",

--- a/data/rus/powers.json
+++ b/data/rus/powers.json
@@ -2287,7 +2287,7 @@
     "type": "Debuff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/tainted_power.webp"
   },
   {
     "id": "TANGLED",
@@ -2557,7 +2557,7 @@
     "type": "Buff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/withering_presence_power.webp"
   },
   {
     "id": "WRAITH_FORM",

--- a/data/spa/powers.json
+++ b/data/spa/powers.json
@@ -2287,7 +2287,7 @@
     "type": "Debuff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/tainted_power.webp"
   },
   {
     "id": "TANGLED",
@@ -2557,7 +2557,7 @@
     "type": "Buff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/withering_presence_power.webp"
   },
   {
     "id": "WRAITH_FORM",

--- a/data/tha/powers.json
+++ b/data/tha/powers.json
@@ -2287,7 +2287,7 @@
     "type": "Debuff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/tainted_power.webp"
   },
   {
     "id": "TANGLED",
@@ -2557,7 +2557,7 @@
     "type": "Buff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/withering_presence_power.webp"
   },
   {
     "id": "WRAITH_FORM",

--- a/data/tur/powers.json
+++ b/data/tur/powers.json
@@ -2287,7 +2287,7 @@
     "type": "Debuff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/tainted_power.webp"
   },
   {
     "id": "TANGLED",
@@ -2557,7 +2557,7 @@
     "type": "Buff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/withering_presence_power.webp"
   },
   {
     "id": "WRAITH_FORM",

--- a/data/zhs/powers.json
+++ b/data/zhs/powers.json
@@ -2287,7 +2287,7 @@
     "type": "Debuff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/tainted_power.webp"
   },
   {
     "id": "TANGLED",
@@ -2557,7 +2557,7 @@
     "type": "Buff",
     "stack_type": "Counter",
     "allow_negative": null,
-    "image_url": null
+    "image_url": "/static/images/powers/withering_presence_power.webp"
   },
   {
     "id": "WRAITH_FORM",


### PR DESCRIPTION
Withering Presence shows no icon on the site. Its icon file exists (`backend/static/images/powers/withering_presence_power.webp`), but its `powers.json` `image_url` was `null`.

Cause: the data was regenerated before that icon landed in the stable image tree, so `resolve_image_url` returned nothing for it that run. It resolves correctly now (verified: `resolve_image_url("powers", "withering_presence_power")` → `/static/images/powers/withering_presence_power.webp`), the data just went stale.

`TAINTED` had the identical problem (icon present, `image_url` null) — they're the only two powers whose icon existed but wasn't linked, so I fixed both. Set the icon URLs the parser yields today, across all 14 languages. Each file changes exactly the two `image_url` lines; a future full data regen reproduces the same values, so nothing drifts.

Backend/data only. Beta already had these icons wired (per-version beta assets), so this is the stable/main channel catching up.
