### PR TITLE
Keep modded/unofficial content out of the public stats

### DIFF
--- a/backend/app/routers/exports.py
+++ b/backend/app/routers/exports.py
@@ -45,12 +45,16 @@ OFFICIAL_CHARACTERS = {"IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"}
 
 
 def _official_run_hashes() -> list[str]:
-    """Get hashes of runs with official characters from Mongo."""
+    """Get hashes of official runs from Mongo: an official character AND the
+    official ascension range (A11+ is modded)."""
     from ..services.runs_db_mongo import _get_collection
 
     coll = _get_collection()
     cursor = coll.find(
-        {"character": {"$in": list(OFFICIAL_CHARACTERS)}},
+        {
+            "character": {"$in": list(OFFICIAL_CHARACTERS)},
+            "ascension": {"$gte": 0, "$lte": 10},
+        },
         {"_id": 1},
         no_cursor_timeout=True,
     )

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -130,8 +130,10 @@ def _load_frame() -> list[tuple]:
         from .runs_db_mongo import _get_collection
 
         cursor = _get_collection().find(
-            # Exclude admin-flagged cheated runs (absent field = eligible).
-            {"hidden": {"$ne": True}},
+            # Exclude admin-flagged cheated runs (absent field = eligible) and
+            # clamp to the official ascension range (A11+ is modded, mirroring
+            # _build_match); modded characters already fold into ALL only below.
+            {"hidden": {"$ne": True}, "ascension": {"$gte": 0, "$lte": 10}},
             {
                 "_id": 0,
                 "character": 1,
@@ -178,7 +180,7 @@ def _load_frame() -> list[tuple]:
                 "SELECT character, win, ascension, game_mode, player_count,"
                 " run_time, floors_reached, deck_size, relic_count,"
                 " submitted_at, username, was_abandoned, acts_completed, seed"
-                " FROM runs"
+                " FROM runs WHERE ascension BETWEEN 0 AND 10"
             ):
                 mode = (d["game_mode"] or "standard").lower()
                 rows.append(

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -322,6 +322,59 @@ def _official_relic_ids() -> frozenset[str]:
     return _official_relics_cache
 
 
+_official_potions_cache: frozenset[str] | None = None
+
+
+def _official_potion_ids() -> frozenset[str]:
+    """Uppercase ids of the official potions. Runs can carry modded potion ids;
+    like _official_relic_ids, an empty set (unreadable catalog) means "don't
+    filter" so a transient read failure can't blank the list."""
+    global _official_potions_cache
+    if _official_potions_cache is None:
+        try:
+            from .data_service import load_potions
+
+            _official_potions_cache = frozenset(
+                (p.get("id") or "").upper() for p in load_potions() if p.get("id")
+            )
+        except Exception:
+            _official_potions_cache = frozenset()
+    return _official_potions_cache
+
+
+_official_cards_cache: frozenset[str] | None = None
+
+
+def _official_card_ids() -> frozenset[str]:
+    """Uppercase ids of the official cards (the real card catalog). A card id
+    absent from this set is fully modded (a mod's custom card). Empty set means
+    "don't filter"."""
+    global _official_cards_cache
+    if _official_cards_cache is None:
+        try:
+            from .data_service import load_cards
+
+            _official_cards_cache = frozenset(
+                (c.get("id") or "").upper() for c in load_cards() if c.get("id")
+            )
+        except Exception:
+            _official_cards_cache = frozenset()
+    return _official_cards_cache
+
+
+def _official_entity_ids(entity_type: str) -> frozenset[str]:
+    """The official-catalog id set for a stats entity type (cards/relics/potions).
+    An empty set means "don't filter" (unreadable catalog or an unknown type), so
+    callers use `if official and eid not in official` to fail open."""
+    if entity_type == "cards":
+        return _official_card_ids()
+    if entity_type == "relics":
+        return _official_relic_ids()
+    if entity_type == "potions":
+        return _official_potion_ids()
+    return frozenset()
+
+
 # Card colors that are never a real card-reward choice: curses and status
 # cards are forced into the deck, event/quest cards come from events, and
 # tokens are generated mid-combat. A forced grant isn't a revealed
@@ -1710,6 +1763,10 @@ def get_all_entity_scores(
         if entity_type == "cards"
         else frozenset()
     )
+    # Fully-modded ids (in no official catalog) leak from the run walk, which
+    # only gates ascension + character, not per-entity content. Drop them for
+    # every type; the per-act relic view already does this via _official_relic_ids.
+    official = _official_entity_ids(entity_type)
     # Bracket view (the content brackets: a10 / wr30 / wr50 / wr75 etc.): grade
     # each entity against that bracket's baseline using its nested per-bracket
     # counts, mirroring get_entity_metrics_table. character scoping isn't tracked
@@ -1723,6 +1780,8 @@ def get_all_entity_scores(
         bracket_out: dict[str, dict[str, Any]] = {}
         for (etype, eid), agg in _cache.items():
             if etype != entity_type or eid in excluded:
+                continue
+            if official and eid not in official:
                 continue
             data = (agg.get("brackets") or {}).get(bracket)
             if not data:
@@ -1744,7 +1803,7 @@ def get_all_entity_scores(
     for (etype, eid), agg in _cache.items():
         if etype != entity_type:
             continue
-        if eid in excluded:
+        if eid in excluded or (official and eid not in official):
             continue
         picks = agg["picks"]
         wins = agg["wins"]
@@ -1870,11 +1929,13 @@ def get_entity_metrics_table(entity_type: str, bracket: str = "all") -> dict[str
 
     rows: list[dict[str, Any]] = []
     excluded_cards = _excluded_card_ids() if entity_type == "cards" else frozenset()
+    official = _official_entity_ids(entity_type)
     for (etype, eid), agg in _cache.items():
         if etype != entity_type:
             continue
-        # Drop curses/status/event/token cards: not reward-pickable.
-        if eid in excluded_cards:
+        # Drop curses/status/event/token cards (not reward-pickable) and
+        # fully-modded ids (in no official catalog) of any type.
+        if eid in excluded_cards or (official and eid not in official):
             continue
         if use_bracket:
             # Bracket views stay merged (no base/upg split is tracked per bracket).
@@ -1968,9 +2029,17 @@ def get_top_entities_for_character(
     _maybe_rebuild()
     char = character.upper()
     baseline = _type_baseline(entity_type)
+    official = _official_entity_ids(entity_type)
+    excluded = (
+        _excluded_card_ids() | _starter_card_ids() | _token_card_ids()
+        if entity_type == "cards"
+        else frozenset()
+    )
     rows: list[dict[str, Any]] = []
     for (etype, eid), agg in _cache.items():
         if etype != entity_type:
+            continue
+        if eid in excluded or (official and eid not in official):
             continue
         cstats = agg["by_character"].get(char)
         if not cstats or cstats["picks"] <= 0:
@@ -2000,6 +2069,11 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
     # Tokens can't be obtained in the official game, so any aggregate for them is
     # mod-only noise. Report no data (the endpoint renders a zero-filled stub).
     if entity_type == "cards" and entity_id.upper() in _token_card_ids():
+        return None
+    # Same for a fully-modded id (in no official catalog). Fail open on an
+    # unreadable catalog so a transient read failure can't blank real entities.
+    official = _official_entity_ids(entity_type)
+    if official and entity_id.upper() not in official:
         return None
     _maybe_rebuild()
     key = (entity_type, entity_id.upper())

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1498,7 +1498,16 @@ def get_user_winrates() -> dict[str, list[int]]:
         return cached
     coll = _get_collection()
     pipeline = [
-        {"$match": {"username_lower": {"$nin": [None, ""]}}},
+        # Official content only: A11+ and modded-character runs aren't real skill
+        # signal, so they must not count toward the win rate that gates the
+        # winrate:xx brackets on /list and the leaderboards.
+        {
+            "$match": {
+                "username_lower": {"$nin": [None, ""]},
+                "ascension": {"$gte": 0, "$lte": 10},
+                "character": {"$in": list(OFFICIAL_CHARACTERS)},
+            }
+        },
         {
             "$group": {
                 "_id": "$username_lower",
@@ -1767,6 +1776,10 @@ def _leaderboard_live(
     q: dict[str, Any] = {"win": {"$in": [True, 1]}, "hidden": {"$ne": True}}
     if character:
         q["character"] = character.upper()
+    else:
+        # Default (all-character) board: official characters only, so modded
+        # characters can't appear on the public leaderboard.
+        q["character"] = {"$in": list(OFFICIAL_CHARACTERS)}
     if players in ("single", "1"):
         q["player_count"] = 1
     elif players in ("2", "3"):
@@ -1777,8 +1790,12 @@ def _leaderboard_live(
         q["player_count"] = {"$gt": 1}
     if game_mode:
         q["game_mode"] = game_mode
+    # Clamp to the official ascension range (A10 is the game's cap); A11+ runs are
+    # modded and must never top the ladder. Merge an explicit ascension_min in.
     if ascension_min is not None:
-        q["ascension"] = {"$gte": ascension_min}
+        q["ascension"] = {"$gte": max(int(ascension_min), 0), "$lte": 10}
+    else:
+        q["ascension"] = {"$gte": 0, "$lte": 10}
     if winrate_min is not None:
         # Skill bracket: restrict to runs whose submitter's overall win rate
         # clears the threshold (same per-user map + floor as the browse filter).
@@ -2029,6 +2046,9 @@ def get_daily_leaderboard(username: str | None = None) -> dict:
         "win": {"$in": [True, 1]},
         "game_mode": "daily",
         "seed": _today_daily_seed_match(),
+        # Official content only, like the other ladders (A10 cap, real characters).
+        "ascension": {"$gte": 0, "$lte": 10},
+        "character": {"$in": list(OFFICIAL_CHARACTERS)},
     }
 
     top_10 = list(coll.find(base, _projection_row()).sort("run_time", 1).limit(10))


### PR DESCRIPTION
Fixes the modded/unofficial-content leaks from the stats audit. The pattern everywhere was "official character + A0-10 gates the run," but per-entity content inside an otherwise-official run leaked, and the leaderboards didn't even clamp ascension. This applies the official-content guards the stats path already uses, consistently.

## Leaderboards (highest impact — visible on `/leaderboards`)
`_leaderboard_live` and `get_daily_leaderboard` now clamp ascension to **0-10** and restrict the default (all-character) board to **official characters**. So `?category=highest_ascension` stops being topped by A11+ modded runs, and modded characters/A11+ no longer appear on the public ladders. Per-character requests still work; the materialized leaderboard summary inherits this via `_leaderboard_live`.

## Entity stats (raw JSON API + in-game mod)
`get_all_entity_scores`, `get_entity_metrics_table`, `get_top_entities_for_character`, and per-entity `get_entity_stats` filtered only cards' non-reward colors. Added `_official_card_ids()` and `_official_potion_ids()` (mirroring the existing `_official_relic_ids()`), plus an `_official_entity_ids(type)` dispatcher, and applied it to all three types on every read path — so `/scores/{relics,potions}`, `/metrics/{relics,potions}`, the character "top picked" lists, and per-entity `/stats` drop modded relic/potion ids and fully-modded card ids. Fails open on an unreadable catalog. Matches the already-shipped token guard + the per-act relic view.

## Charts
`_load_frame` drops A11+ runs (Mongo `$gte:0,$lte:10` and the SQLite `WHERE`), so every frame chart is official-only. Modded characters already fold into ALL.

## Win-rate map + bulk export
`get_user_winrates` (which powers the `winrate:xx` brackets on `/list` and the leaderboards) and `_official_run_hashes` (the bulk `/api/exports/runs`) now drop A11+ and modded-character runs.

## Deferred to a follow-up
These hinge on the "does *any* modded content disqualify a whole run" policy call and/or need an admin bypass, so I left them out of this pass (tracked): single-run/seed **rank denominators**, the **`/list` run browser**, the **profile win-rate comparison**, and the **community spotlights / rest-site allow-list / live presence**.

Verified: `ruff format`/`ruff check` clean, all files compile, and the catalog-filter logic spot-checked (official kept, modded dropped, tokens still handled by the token guard). No snapshot version bump — all changes are read-time / query-level.
