### PR TITLE
Let the tier list combine player count and skill brackets

### DIFF
--- a/frontend/app/components/BracketFilter.tsx
+++ b/frontend/app/components/BracketFilter.tsx
@@ -3,57 +3,106 @@ import {
   CONTENT_BRACKETS,
   PLAYER_BRACKETS,
   normalizeBracket,
+  splitBracket,
+  combineBracket,
   type ContentBracket,
 } from "@/lib/content-brackets";
 
 /**
- * Content-bracket pill row (All / Asc 10 / win-rate tiers) for tier-list and
- * other run-derived pages. Server component: each bracket is its own indexable
- * URL. `extraParams` carries the page's other filters (color/pool/sort/act) so
- * switching bracket preserves them; "all" omits the param to keep the canonical
- * URL clean.
+ * Bracket pill rows (All / Asc 10 / win-rate tiers, plus player count) for
+ * tier-list and other run-derived pages. Server component: each bracket is its
+ * own indexable URL. `extraParams` carries the page's other filters
+ * (color/pool/sort/act) so switching bracket preserves them; "all" omits the
+ * param to keep the canonical URL clean.
+ *
+ * `composite`: when the page's data source materializes player x skill
+ * composites (the entity cache behind the tier list / metrics), the two rows
+ * COMBINE — e.g. Solo + A10 together. Otherwise the two rows share the single
+ * ?bracket= slot and are mutually exclusive (blob-backed pages like community
+ * stats, which have no composites).
  */
 export default function BracketFilter({
   basePath,
   current,
   extraParams,
+  composite,
 }: {
   basePath: string;
   current: string;
   extraParams?: Record<string, string | undefined>;
+  composite?: boolean;
 }) {
   const active = normalizeBracket(current);
-  const renderPill = (b: ContentBracket) => {
-    const isActive = active === b.key;
+  const { player, skill } = splitBracket(active);
+
+  const hrefFor = (bracketValue: string) => {
     const params = new URLSearchParams();
     for (const [k, v] of Object.entries(extraParams ?? {})) {
       if (v) params.set(k, v);
     }
-    if (b.key !== "all") params.set("bracket", b.key);
+    if (bracketValue !== "all") params.set("bracket", bracketValue);
     const qs = params.toString();
-    const href = `${basePath}${qs ? `?${qs}` : ""}`;
-    return (
-      <Link
-        key={b.key}
-        href={href}
-        className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
-          isActive
-            ? "bg-[var(--accent-gold)]/10 border-[var(--accent-gold)]/40 text-[var(--accent-gold)]"
-            : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
-        }`}
-      >
+    return `${basePath}${qs ? `?${qs}` : ""}`;
+  };
+
+  const pillCls = (isActive: boolean) =>
+    `text-xs px-3 py-1.5 rounded-md border transition-colors ${
+      isActive
+        ? "bg-[var(--accent-gold)]/10 border-[var(--accent-gold)]/40 text-[var(--accent-gold)]"
+        : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
+    }`;
+
+  if (!composite) {
+    // Mutually-exclusive: each pill sets ?bracket=<its key>.
+    const renderPill = (b: ContentBracket) => (
+      <Link key={b.key} href={hrefFor(b.key)} className={pillCls(active === b.key)}>
         {b.label}
       </Link>
     );
-  };
+    return (
+      <div className="flex flex-wrap items-center gap-1.5 mb-5">
+        <span className="text-xs text-[var(--text-muted)] mr-1">Bracket</span>
+        {CONTENT_BRACKETS.map(renderPill)}
+        {/* Player count shares the ?bracket= slot, so picking one clears the
+            content bracket and vice versa. */}
+        <span className="text-xs text-[var(--text-muted)] mx-1">Players</span>
+        {PLAYER_BRACKETS.map(renderPill)}
+      </div>
+    );
+  }
+
+  // Composite: each skill pill keeps the current player and vice versa, so the
+  // two axes combine into a player:skill bracket.
+  const playerOpts = [{ key: "", label: "All" }, ...PLAYER_BRACKETS];
   return (
-    <div className="flex flex-wrap items-center gap-1.5 mb-5">
-      <span className="text-xs text-[var(--text-muted)] mr-1">Bracket</span>
-      {CONTENT_BRACKETS.map(renderPill)}
-      {/* Player count shares the ?bracket= slot, so picking one clears the
-          content bracket and vice versa. */}
-      <span className="text-xs text-[var(--text-muted)] mx-1">Players</span>
-      {PLAYER_BRACKETS.map(renderPill)}
+    <div className="mb-5 space-y-1.5">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="w-14 text-xs text-[var(--text-muted)]">Bracket</span>
+        {CONTENT_BRACKETS.map((b) => {
+          const targetSkill = b.key === "all" ? "" : b.key;
+          return (
+            <Link
+              key={b.key}
+              href={hrefFor(combineBracket(player, targetSkill))}
+              className={pillCls(skill === targetSkill)}
+            >
+              {b.label}
+            </Link>
+          );
+        })}
+      </div>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="w-14 text-xs text-[var(--text-muted)]">Players</span>
+        {playerOpts.map((b) => (
+          <Link
+            key={b.key || "all"}
+            href={hrefFor(combineBracket(b.key, skill))}
+            className={pillCls(player === b.key)}
+          >
+            {b.label}
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/app/tier-list/cards/page.tsx
+++ b/frontend/app/tier-list/cards/page.tsx
@@ -303,6 +303,7 @@ export default async function CardsTierListPage({ searchParams }: PageProps) {
         basePath="/tier-list/cards"
         current={bracket}
         extraParams={{ color, sort: sort === "elo" ? "elo" : undefined }}
+        composite
       />
 
       <TierList route="cards" entities={entities} valueLabel={sort === "elo" ? "Elo" : "Score"} />

--- a/frontend/app/tier-list/potions/page.tsx
+++ b/frontend/app/tier-list/potions/page.tsx
@@ -117,7 +117,7 @@ export default async function PotionsTierListPage({ searchParams }: PageProps) {
       </p>
 
       {/* Content bracket: grade against all runs, A10, or win-rate skill tiers. */}
-      <BracketFilter basePath="/tier-list/potions" current={bracket} />
+      <BracketFilter basePath="/tier-list/potions" current={bracket} composite />
 
       <TierList route="potions" entities={entities} />
     </div>

--- a/frontend/app/tier-list/relics/page.tsx
+++ b/frontend/app/tier-list/relics/page.tsx
@@ -272,6 +272,7 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
         basePath="/tier-list/relics"
         current={bracket}
         extraParams={{ pool, rarity, act }}
+        composite
       />
 
       <TierList route="relics" entities={entities} />

--- a/frontend/lib/content-brackets.ts
+++ b/frontend/lib/content-brackets.ts
@@ -33,14 +33,60 @@ const _BY_KEY = new Map(
   [...CONTENT_BRACKETS, ...PLAYER_BRACKETS].map((b) => [b.key, b]),
 );
 
-/** Normalize a raw ?bracket= value to a known bracket key ("all" if unknown). */
-export function normalizeBracket(raw: string | undefined | null): string {
-  return raw && _BY_KEY.has(raw) ? raw : "all";
+const _PLAYER_KEYS = new Set(PLAYER_BRACKETS.map((b) => b.key));
+const _SKILL_KEYS = new Set(
+  CONTENT_BRACKETS.filter((b) => b.key !== "all").map((b) => b.key),
+);
+
+/**
+ * A "player:skill" composite (e.g. "solo:wr50") combines a player-count bracket
+ * with a content/skill bracket. Only the entity cache (tier list + metrics)
+ * materializes these, so BracketFilter offers them only in composite mode.
+ */
+export function isCompositeBracket(raw: string | undefined | null): boolean {
+  if (!raw || !raw.includes(":")) return false;
+  const [p, s] = raw.split(":");
+  return _PLAYER_KEYS.has(p) && _SKILL_KEYS.has(s);
 }
 
-/** The ?bracket= API value for a bracket key (null = all runs, no param). */
+/** Split a bracket value into its player + skill axes. A single bracket maps to
+ * whichever axis owns it; "all"/unknown gives both empty. */
+export function splitBracket(raw: string | undefined | null): {
+  player: string;
+  skill: string;
+} {
+  const b = normalizeBracket(raw);
+  if (isCompositeBracket(b)) {
+    const [player, skill] = b.split(":");
+    return { player, skill };
+  }
+  if (_PLAYER_KEYS.has(b)) return { player: b, skill: "" };
+  if (_SKILL_KEYS.has(b)) return { player: "", skill: b };
+  return { player: "", skill: "" };
+}
+
+/** Combine a player + skill selection into one ?bracket= value. */
+export function combineBracket(player: string, skill: string): string {
+  if (player && skill) return `${player}:${skill}`;
+  return player || skill || "all";
+}
+
+/** Normalize a raw ?bracket= value to a known bracket key or a player:skill
+ * composite ("all" if unknown). */
+export function normalizeBracket(raw: string | undefined | null): string {
+  if (!raw) return "all";
+  if (_BY_KEY.has(raw)) return raw;
+  if (isCompositeBracket(raw)) return raw;
+  return "all";
+}
+
+/** The ?bracket= API value for a bracket key (null = all runs, no param). A
+ * composite passes through unchanged (its API value is the composite itself). */
 export function bracketParam(key: string | undefined | null): string | null {
-  return _BY_KEY.get(normalizeBracket(key))?.param ?? null;
+  const n = normalizeBracket(key);
+  if (n === "all") return null;
+  if (isCompositeBracket(n)) return n;
+  return _BY_KEY.get(n)?.param ?? null;
 }
 
 /**


### PR DESCRIPTION
On the tier list, the Bracket and Players rows shared the single `?bracket=` slot, so picking a player count cleared the skill bracket and vice versa. This lets you toggle both — e.g. **Solo + A10** together.

It works because the tier-list detail pages read the same entity-cache scores as the metrics page, which already materializes the `player:skill` composites (`solo:wr50`, ...) from #570. So this is **frontend-only** — no backend or snapshot change.

- `BracketFilter` gains a `composite` prop: two combinable rows where each skill pill keeps the current player and each player pill keeps the current skill (building a `player:skill` bracket). Without the prop it stays mutually-exclusive as before. Still a server component, so each combination is its own indexable URL.
- `content-brackets.ts`: `normalizeBracket` / `bracketParam` now pass a `player:skill` composite through (previously coerced to "all"), plus `splitBracket` / `combineBracket` / `isCompositeBracket` helpers.
- The cards / relics / potions tier-list pages pass `composite`.

Blob-backed pages like **community stats** keep the mutually-exclusive rows — their snapshot has the single solo/2p/3p/4p and skill brackets but not the composites (adding those would be a snapshot change; happy to do it if you want community/encounter combinable too).

Verified: `tsc --noEmit` clean, `eslint` clean on the changed files (the one warning is a pre-existing unused import).
