### PR TITLE
Serve beta card render URLs on the beta channel

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -13,6 +13,28 @@ CARD_FULL_BASE = os.getenv(
 ).rstrip("/")
 
 
+def _full_render_base() -> str:
+    """CDN base for full card renders on the current request's channel: the
+    stable set by default, or the current beta archive
+    (cards-full/beta/<version>) when the beta channel is active. Falls back to
+    stable if the beta version can't be resolved (or CARD_FULL_BASE points
+    somewhere non-standard), so a render URL is never broken; background threads
+    read stable."""
+    if not CARD_FULL_BASE.endswith("/stable"):
+        return CARD_FULL_BASE
+    try:
+        from ..services.data_service import get_beta_version, get_channel
+
+        if get_channel() == "beta":
+            version = (get_beta_version() or "").lstrip("v")
+            if version:
+                root = CARD_FULL_BASE[: -len("/stable")]
+                return f"{root}/beta/{version}"
+    except Exception:
+        pass
+    return CARD_FULL_BASE
+
+
 class PowerApplied(BaseModel):
     power: str
     power_key: str | None = None
@@ -80,7 +102,7 @@ class Card(BaseModel):
         ancients). `null` when there's no render (mad_science)."""
         if self.id.lower() == "mad_science":
             return None
-        return f"{CARD_FULL_BASE}/{self.id.lower()}.webp"
+        return f"{_full_render_base()}/{self.id.lower()}.webp"
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -89,7 +111,7 @@ class Card(BaseModel):
         has no upgrade."""
         if not self.upgrade or self.id.lower() == "mad_science":
             return None
-        return f"{CARD_FULL_BASE}/{self.id.lower()}_upg.webp"
+        return f"{_full_render_base()}/{self.id.lower()}_upg.webp"
 
 
 class CharacterDialogueLine(BaseModel):


### PR DESCRIPTION
The proper backend home for the beta card-render fix (the Discord bot currently works around it client-side, commit 8fa0ad1).

`Card.image_url_card` / `image_url_card_upg` hardcoded the stable render base (`cards-full/stable/<id>.webp`), so on `?channel=beta` a beta card still returned a stable URL — and a beta-only card like **Cacophony** pointed at a stable render that doesn't exist.

This makes the render base **channel-aware**: on the beta channel it resolves the current beta version (`get_beta_version()`, e.g. `v0.108.0`) and points at `cards-full/beta/0.108.0/<id>.webp` for both the base and `_upg` renders. It falls back to stable if the version can't be read (and background threads read stable), so a URL never breaks.

Verified locally with the channel ContextVar set to beta:
- beta -> `https://cdn.spire-codex.com/cards-full/beta/0.108.0/cacophony.webp` (+ `_upg`) — matches the CDN files that return 200
- stable -> `.../cards-full/stable/cacophony.webp`
- edge cases (`mad_science`, no-upgrade cards) still return `null`

Now every API client (the bot, and anyone reading the fields) gets correct beta renders straight from the API, so the bot's workaround becomes redundant — it was written to stay harmless once this lands, so no coordination needed. One file, `ruff` clean.

Note: scoped to channel-awareness, matching the existing eng-only behavior of these fields (they were never lang-segmented). Localized beta renders would be a separate enhancement.
