### PR TITLE
Fix admin hide/delete for single-player runs (match by _id too)

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -202,8 +202,13 @@ def runs_search(
 
     limit = max(1, min(limit, 100))
     if run_hash:
-        docs = list(get_database()["runs"].find({"run_hash": run_hash.strip()}))
+        # Single-player runs key on _id (= the run hash) with no run_hash field;
+        # multiplayer runs share a run_hash field across per-player docs. Match
+        # either, and expose the hash as run_hash for the UI.
+        h = run_hash.strip()
+        docs = list(get_database()["runs"].find({"$or": [{"_id": h}, {"run_hash": h}]}))
         for d in docs:
+            d["run_hash"] = d.get("run_hash") or d.pop("_id", None)
             d.pop("_id", None)
             d.pop("raw", None)
         return {"runs": docs, "total": len(docs)}
@@ -219,7 +224,8 @@ def runs_search(
             coll.find(
                 q,
                 {
-                    "_id": 0,
+                    # _id is the run hash for single-player; multiplayer docs also
+                    # carry a run_hash field. Keep both and resolve below.
                     "run_hash": 1,
                     "run_time": 1,
                     "character": 1,
@@ -235,6 +241,9 @@ def runs_search(
         )
         runs = list(cursor)
         for d in runs:
+            # Expose the hash as run_hash so the admin UI can hide/delete these.
+            d["run_hash"] = d.get("run_hash") or d.pop("_id", None)
+            d.pop("_id", None)
             sa = d.get("submitted_at")
             if hasattr(sa, "isoformat"):
                 d["submitted_at"] = sa.isoformat()

--- a/backend/app/services/admin_db.py
+++ b/backend/app/services/admin_db.py
@@ -143,7 +143,14 @@ def delete_run(run_hash: str, runs_dir: Path) -> dict[str, Any]:
     removal on their next scheduled rebuild."""
     deleted_docs = 0
     if _enabled():
-        deleted_docs = _db()["runs"].delete_many({"run_hash": run_hash}).deleted_count
+        # Single-player runs key on _id (= run hash) with no run_hash field;
+        # multiplayer runs share a run_hash field. Match either so the doc is
+        # actually removed, not just the blob file.
+        deleted_docs = (
+            _db()["runs"]
+            .delete_many({"$or": [{"_id": run_hash}, {"run_hash": run_hash}]})
+            .deleted_count
+        )
     file_removed = False
     blob = runs_dir / f"{run_hash}.json"
     try:

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1679,7 +1679,11 @@ def set_run_hidden(run_hash: str, hidden: bool) -> dict:
     clear the run on their next ~60s rebuild. Returns how many docs changed."""
     coll = _get_collection()
     update = {"$set": {"hidden": True}} if hidden else {"$unset": {"hidden": ""}}
-    result = coll.update_many({"run_hash": run_hash}, update)
+    # Single-player runs key on _id (= run hash) with no run_hash field;
+    # multiplayer runs share a run_hash field across per-player docs. Match either.
+    result = coll.update_many(
+        {"$or": [{"_id": run_hash}, {"run_hash": run_hash}]}, update
+    )
     return {"matched": result.matched_count, "modified": result.modified_count}
 
 


### PR DESCRIPTION
The "Fast wins <5m" review queue had no way to hide runs.

Root cause: single-player runs key on `_id` (= the run hash) with **no separate `run_hash` field**; only multiplayer runs carry a shared `run_hash` field. But the admin paths keyed only on a `run_hash` field:
- the fast-win query projected `{"_id": 0, "run_hash": 1}`, so every row came back **without a run_hash** and the Hide/Delete buttons (gated on `r.run_hash`) never rendered;
- `set_run_hidden` and `admin_db.delete_run` (and the by-hash search) filtered on `{"run_hash": h}`, which matches **nothing** for a solo run — so even if a button showed, hiding silently no-op'd (and delete removed only the blob file, not the Mongo doc).

Fix:
- fast-win + by-hash searches surface the hash from `_id` (or the `run_hash` field for MP) as `run_hash`, so the rows carry it and the buttons render;
- `set_run_hidden` and `delete_run` now match `{$or: [{_id: h}, {run_hash: h}]}`, so both single-player and multiplayer runs are actually hidden/deleted.

Backend-only, ruff clean. This makes the cheater-hiding flow from #568 actually work on the (mostly single-player) fast-win cheats.