### PR TITLE
Bump snapshot version to 12 to rebuild the composite brackets

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -205,10 +205,13 @@ SNAPSHOT_COLLECTION_NAME = "entity_stats_snapshot"
 # Version 10 adds a per-character split to each entity's win-rate/A10 bracket data
 # so the detail page's character table re-slices by bracket (additive).
 # Version 11 adds solo/2p/3p/4p player-count brackets to the community and
-# encounter blobs so those pages can filter by co-op size, plus player-count x
-# skill composite brackets (solo:wr50, ...) in the entity cache so the metrics
-# page can filter by both at once (additive).
-SNAPSHOT_VERSION = 11
+# encounter blobs so those pages can filter by co-op size.
+# Version 12 adds player-count x skill composite brackets (solo:wr50, ...) to the
+# entity cache so the metrics table and tier list can filter by both at once.
+# These landed in the same deploy as v11 but reused version 11, so the leader
+# considered its (composite-less) v11 snapshot current and never rebuilt them in;
+# the bump forces the rebuild.
+SNAPSHOT_VERSION = 12
 # The oldest snapshot version readers can still serve. Bump SNAPSHOT_VERSION
 # on every shape change; bump this floor ONLY when a change actually breaks
 # readers (a removed/retyped field). Everything in between is additive, and


### PR DESCRIPTION
**Why the tier list "players + bracket" combine shows nothing:** the composite data was never built into the prod snapshot.

I traced it end to end. The composite accumulation code (from #570) is correct — it's placed before the totals loop and the entity-cache loop, and the serializer iterates every bracket. And the snapshot did rebuild (the community/encounter player brackets work). But every composite (`solo:wr50`, `solo:a10`, ...) returns **0 entities / 0 runs** on `/api/runs/scores` and `/api/runs/metrics`.

Root cause: the composite brackets were added **additively but reused `SNAPSHOT_VERSION = 11`** (the same version the player-count blob brackets bumped to, in the same deploy). `refresh_entity_stats_snapshot` skips the rebuild when the existing snapshot's `snapshot_version == SNAPSHOT_VERSION` and it's fresh — so the leader treated its composite-less v11 snapshot as current and never rebuilt the composites in. A shape change (new bracket keys) needs its own bump; #570's composite commit missed it.

Fix: bump `SNAPSHOT_VERSION` 11 → 12. On deploy the leader sees v11 ≠ v12, skips the freshness check, and rebuilds once with the (already-correct) composite code. The tier-list/metrics "players + skill" combinations then return data.

One-line change (+ comment), ruff clean. #575 (the tier-list UI) was fine — it just had no data to show.