### PR TITLE
Index run_hash so admin hide/delete/search by hash is instant

### DIFF
--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -165,6 +165,12 @@ def _ensure_indexes(coll) -> None:
     # /api/runs/list hot shapes: filter+sort compounds so Mongo never
     # in-memory-sorts a 40k-doc subset, plus seed for anchored prefix search.
     coll.create_index([("seed", ASCENDING)])
+    # Admin hide/delete/search look runs up by hash. _id IS the hash for
+    # single-player runs; multiplayer runs carry a shared run_hash field. Index
+    # it (sparse — only MP docs have the field) so the admin lookup
+    # $or: [{_id}, {run_hash}] is an index union instead of a full scan of the
+    # ~740k-doc collection.
+    coll.create_index([("run_hash", ASCENDING)], sparse=True)
     coll.create_index([("run_time", ASCENDING)])
     coll.create_index([("ascension", DESCENDING), ("run_time", ASCENDING)])
     coll.create_index([("character", ASCENDING), ("submitted_at", DESCENDING)])


### PR DESCRIPTION
The admin "look up a run by hash → hide/delete" flow is slow (seconds) — hiding `e7ad725372d1af64` "took forever."

Cause: those operations match on the `run_hash` field, which is **unindexed**, so every lookup is a **full collection scan of the ~740k-doc runs collection**. (`_id` is the hash for single-player runs and is indexed; multiplayer runs carry a shared `run_hash` field.)

Fix: add a **sparse index on `run_hash`**. With it, the `$or: [{_id}, {run_hash}]` lookup used by the hide/delete/search fix (#577) becomes an index union instead of a scan — instant. Sparse because only multiplayer docs have the field, so the index is small and cheap to build.

One line, ruff clean. The index builds on startup via `_ensure_indexes` (idempotent).

Note: this + #577 both need the prod backend to actually **deploy** to take effect — the CI built the images but the deploy/restart step is separate and hasn't run, which is also why hiding is still slow and single-player hides don't stick on live right now.