### PR TITLE
Capture starting Plating for enemies that apply it in a helper

### DIFF
--- a/backend/app/parsers/monster_parser.py
+++ b/backend/app/parsers/monster_parser.py
@@ -1042,6 +1042,37 @@ def parse_single_monster(
                 depth -= 1
             i += 1
         init_block = content[start : i - 1]
+    # AfterAddedToRoom often delegates its combat-start setup to a private helper
+    # rather than writing every PowerCmd.Apply inline. Lagavulin Matriarch, for
+    # instance, calls `await Sleep();` and applies its innate Plating inside
+    # Sleep(). Follow local same-class method calls (await Foo(...) where Foo is a
+    # method defined in this file, not base.X / Cmd.X) so those applied powers are
+    # captured too. Bounded to a couple of levels with a visited set.
+    scan_block = init_block
+    seen_helpers: set[str] = set()
+    frontier = [init_block]
+    hops = 0
+    while frontier and hops < 8:
+        block = frontier.pop()
+        for call in re.finditer(r"\bawait\s+(\w+)\s*\(", block):
+            helper = call.group(1)
+            if helper in seen_helpers or helper == "AfterAddedToRoom":
+                continue
+            # Only follow methods actually DEFINED in this class (a private/
+            # protected/etc. helper); the modifier prefix excludes bare framework
+            # calls and `await base.X()` (which has no local definition here).
+            helper_body = _extract_method_body(
+                content,
+                r"(?:private|protected|internal|public)[^\n;{]*\b"
+                + re.escape(helper)
+                + r"\s*\(",
+            )
+            if helper_body is None:
+                continue
+            seen_helpers.add(helper)
+            scan_block += "\n" + helper_body
+            frontier.append(helper_body)
+            hops += 1
     # v0.104+ added an optional context arg before the target, same as the
     # move-effects regex above:
     #   OLD:  PowerCmd.Apply<ArtifactPower>(base.Creature, 3m, ...)
@@ -1054,7 +1085,7 @@ def parse_single_monster(
     # no `<Power>` token and is still not captured here.
     for pm in re.finditer(
         r"PowerCmd\.Apply<(\w+)>\(\s*(?:new\s+\w+\([^)]*\)\s*,\s*)?[\w.]+\s*,\s*(\w+?)m?\b",
-        init_block,
+        scan_block,
     ):
         power_name = pm.group(1).replace("Power", "")
         amount_ref = pm.group(2)

--- a/data-beta/v0.108.0/deu/monsters.json
+++ b/data-beta/v0.108.0/deu/monsters.json
@@ -4575,7 +4575,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data-beta/v0.108.0/eng/monsters.json
+++ b/data-beta/v0.108.0/eng/monsters.json
@@ -4575,7 +4575,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data-beta/v0.108.0/esp/monsters.json
+++ b/data-beta/v0.108.0/esp/monsters.json
@@ -4575,7 +4575,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data-beta/v0.108.0/fra/monsters.json
+++ b/data-beta/v0.108.0/fra/monsters.json
@@ -4575,7 +4575,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data-beta/v0.108.0/ita/monsters.json
+++ b/data-beta/v0.108.0/ita/monsters.json
@@ -4575,7 +4575,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data-beta/v0.108.0/jpn/monsters.json
+++ b/data-beta/v0.108.0/jpn/monsters.json
@@ -4575,7 +4575,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data-beta/v0.108.0/kor/monsters.json
+++ b/data-beta/v0.108.0/kor/monsters.json
@@ -4575,7 +4575,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data-beta/v0.108.0/pol/monsters.json
+++ b/data-beta/v0.108.0/pol/monsters.json
@@ -4575,7 +4575,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data-beta/v0.108.0/ptb/monsters.json
+++ b/data-beta/v0.108.0/ptb/monsters.json
@@ -4575,7 +4575,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data-beta/v0.108.0/rus/monsters.json
+++ b/data-beta/v0.108.0/rus/monsters.json
@@ -4575,7 +4575,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data-beta/v0.108.0/spa/monsters.json
+++ b/data-beta/v0.108.0/spa/monsters.json
@@ -4575,7 +4575,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data-beta/v0.108.0/tha/monsters.json
+++ b/data-beta/v0.108.0/tha/monsters.json
@@ -4575,7 +4575,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data-beta/v0.108.0/tur/monsters.json
+++ b/data-beta/v0.108.0/tur/monsters.json
@@ -4575,7 +4575,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data-beta/v0.108.0/zhs/monsters.json
+++ b/data-beta/v0.108.0/zhs/monsters.json
@@ -4575,7 +4575,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data/deu/monsters.json
+++ b/data/deu/monsters.json
@@ -4572,7 +4572,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data/eng/monsters.json
+++ b/data/eng/monsters.json
@@ -4572,7 +4572,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data/esp/monsters.json
+++ b/data/esp/monsters.json
@@ -4572,7 +4572,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data/fra/monsters.json
+++ b/data/fra/monsters.json
@@ -4572,7 +4572,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data/ita/monsters.json
+++ b/data/ita/monsters.json
@@ -4572,7 +4572,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data/jpn/monsters.json
+++ b/data/jpn/monsters.json
@@ -4572,7 +4572,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data/kor/monsters.json
+++ b/data/kor/monsters.json
@@ -4572,7 +4572,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data/pol/monsters.json
+++ b/data/pol/monsters.json
@@ -4572,7 +4572,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data/ptb/monsters.json
+++ b/data/ptb/monsters.json
@@ -4572,7 +4572,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data/rus/monsters.json
+++ b/data/rus/monsters.json
@@ -4572,7 +4572,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data/spa/monsters.json
+++ b/data/spa/monsters.json
@@ -4572,7 +4572,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data/tha/monsters.json
+++ b/data/tha/monsters.json
@@ -4572,7 +4572,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data/tur/monsters.json
+++ b/data/tur/monsters.json
@@ -4572,7 +4572,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",

--- a/data/zhs/monsters.json
+++ b/data/zhs/monsters.json
@@ -4572,7 +4572,16 @@
         "is_weak": false
       }
     ],
-    "innate_powers": null,
+    "innate_powers": [
+      {
+        "power_id": "PLATING",
+        "amount": 12
+      },
+      {
+        "power_id": "ASLEEP",
+        "amount": 3
+      }
+    ],
     "attack_pattern": {
       "type": "conditional",
       "initial_move": "SLEEP",


### PR DESCRIPTION
Bug report (via Knowledge Demon): Lagavulin Matriarch's page shows no indication of its starting Plating.

## Root cause
The monster parser scans `AfterAddedToRoom()` for `PowerCmd.Apply<...>` calls to build `innate_powers`. **Frog Knight** applies its Plating inline there, so it was captured. **Lagavulin Matriarch** delegates to a private helper — `AfterAddedToRoom()` calls `await Sleep()`, and the Plating is applied inside `Sleep()` — so the scan, which only looked at the literal `AfterAddedToRoom` body, missed it. (So the report's "Frog Knight also has no indication" was already fixed; the real gap was Lagavulin.)

The frontend already renders `innate_powers` — the field was just null.

## Fix
The parser now follows local same-class method calls from `AfterAddedToRoom` (`await Foo(...)` where `Foo` is a method defined in this class, not `base.X` / `Cmd.X`) into their bodies before scanning, so powers applied one hop away are caught. Bounded with a visited set.

## Validation
I ran the old and new parser against the **same** decompiled source and diffed `innate_powers` across every monster:
- **Exactly one monster changes**: `LAGAVULIN_MATRIARCH` → `Plating 12` and `Asleep 3` (both genuinely applied at combat start in `Sleep()`; both are real catalog powers that render).
- **Zero regressions** — every other monster (including the 45 that already had innate_powers) is byte-identical.

Data regenerated for all 14 languages on both the stable and beta channels (the value is language-independent — `power_id`/`amount` only). One parser file + 28 `monsters.json`.
