### PR TITLE
Reorder the homepage character bar

### DIFF
--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -23,9 +23,9 @@ interface Translations {
 const CHARACTERS = [
   { id: "ironclad", cssColor: "var(--color-ironclad)" },
   { id: "silent", cssColor: "var(--color-silent)" },
-  { id: "defect", cssColor: "var(--color-defect)" },
-  { id: "necrobinder", cssColor: "var(--color-necrobinder)" },
   { id: "regent", cssColor: "var(--color-regent)" },
+  { id: "necrobinder", cssColor: "var(--color-necrobinder)" },
+  { id: "defect", cssColor: "var(--color-defect)" },
 ];
 
 const FALLBACK_DESCS: Record<string, string> = {


### PR DESCRIPTION
Change the top character bar to **Ironclad, Silent, Regent, Necrobinder, Defect** (swaps Defect and Regent from the old order).

The bar renders `CHARACTERS` in array order with no sort, so this is a straight reorder of that array — two lines, no logic change.