### PR TITLE
Skip the Elo pairwise build for composite brackets so the snapshot rebuilds

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -110,6 +110,12 @@ _ACT_MIN_PICKS = 200
 _PLAYER_BRACKETS = ("solo", "2p", "3p", "4p")
 _SKILL_BRACKETS = ("a10", "wr30", "wr50", "wr75")
 _COMPOSITE_BRACKETS = [f"{p}:{c}" for p in _PLAYER_BRACKETS for c in _SKILL_BRACKETS]
+# Fast membership test in the hot per-run walk. Composite brackets skip the
+# expensive reward-pairwise / Codex Elo machinery (see the card-reward loop):
+# it's the heaviest part of the walk, and the composite tier-list / metrics
+# views only surface Score + Win%, not the reward-preference Elo / Pick% (which
+# are too thin sliced this finely to mean anything).
+_COMPOSITE_BRACKETS_SET = frozenset(_COMPOSITE_BRACKETS)
 
 _BRACKET_KEYS = [
     "solo",
@@ -211,7 +217,11 @@ SNAPSHOT_COLLECTION_NAME = "entity_stats_snapshot"
 # These landed in the same deploy as v11 but reused version 11, so the leader
 # considered its (composite-less) v11 snapshot current and never rebuilt them in;
 # the bump forces the rebuild.
-SNAPSHOT_VERSION = 12
+# Version 13: composites skip the reward-pairwise / Codex Elo build (they keep
+# Score + Win% only). The full-Elo v12 build over 26 brackets x ~740k runs was
+# too heavy to finish, so the snapshot never advanced past v10; this cuts the
+# walk back to a healthy duration. The bump forces the (now cheap) rebuild.
+SNAPSHOT_VERSION = 13
 # The oldest snapshot version readers can still serve. Bump SNAPSHOT_VERSION
 # on every shape change; bump this floor ONLY when a change actually breaks
 # readers (a removed/retyped field). Everything in between is additive, and
@@ -1199,6 +1209,11 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
                 pick_counts, pair_wins, act_index, picked_ids, skipped_ids
             )
             for ck in extra_brackets:
+                # Composite (player x skill) brackets skip the pairwise/Elo work
+                # — the heaviest part of the walk. They keep Score + Win% from
+                # the picks/wins loop above; their views don't show reward Elo.
+                if ck in _COMPOSITE_BRACKETS_SET:
+                    continue
                 _accumulate_screen(
                     bracket_accs[ck]["pick_counts"],
                     bracket_accs[ck]["pair_wins"],


### PR DESCRIPTION
## Why the tier-list "players + skill" combine (and metrics composite) show nothing

Diagnosed from prod: the backend is running the composite code (v12), but the stats snapshot is **stuck at version 10** — `/api/runs/snapshot-status` reports `version: 10, want_version: 12`, and the logs show `serving entity-stats snapshot version 10 while 12 rebuilds`. No crash, no OOM, single stable container — the rebuild **walk simply never finishes**.

Cause: the 16 player×skill composite brackets (`solo:wr50`, ...) each built the full **reward pairwise matrix + Codex Elo** (a 200-iteration Bradley-Terry fit), on top of the 10 base brackets, over **~740k runs**. That's ~2.6× the per-run bracket work of the last snapshot that successfully built (v10, 10 brackets), and it pushed the walk past the point where it completes — so the snapshot never advanced and every composite bracket stayed empty.

## Fix
Composites skip the pairwise/Elo machinery (the heaviest part of the walk). They keep their picks/wins, so **Score and Win% still work** on the tier list and metrics; they just carry no Codex Elo — which those composite views don't display anyway (reward-preference Elo sliced by player×skill is too thin to mean anything). Non-composite brackets keep full Elo, untouched.

`SNAPSHOT_VERSION` → 13 to force the now-cheap rebuild.

## Verified locally
Ran the actual cache build: it completes, composite brackets carry picks/wins with `elo=None` (e.g. `solo:a10` on ACROBATICS → picks=38, wins=16), and non-composite brackets (a10/wr50) still carry Elo. ruff + compile clean.

Once deployed, the walk finishes, the snapshot advances to 13, and the composite combinations populate (the earlier tier-list UI work #575 was fine — it just had no data).