### PR TITLE
Log refresh-cycle steps and snapshot-rebuild phases

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1182,6 +1182,11 @@ def start_stats_refresher() -> None:
         )
         from ..services.run_entity_stats import refresh_entity_stats_snapshot
 
+        # Per-step timing: a rebuild that never completes shows up here as a step
+        # whose "done" log never arrives, so we can see which step starves it.
+        _cyc0 = time.time()
+        logger.info("refresh cycle: starting (leader)")
+
         # Warm the /charts page FIRST so the default no-filter view of each chart
         # is in Redis within seconds of a deploy, instead of waiting behind the
         # entity-stats snapshot walk below (which can run for minutes). Frame
@@ -1194,11 +1199,13 @@ def start_stats_refresher() -> None:
                 prewarm_charts()
         except Exception:
             logger.warning("charts prewarm failed", exc_info=True)
+        logger.info("refresh cycle: charts prewarm done at %.1fs", time.time() - _cyc0)
 
         try:
             refresh_stats_summary()
         except Exception:
             logger.warning("stats summary refresh failed", exc_info=True)
+        logger.info("refresh cycle: stats summary done at %.1fs", time.time() - _cyc0)
         # Pre-compute the default (category, character) ladder
         # views into leaderboard_summary. Reads for the common
         # combos become O(1) find_one instead of a 500ms
@@ -1207,6 +1214,11 @@ def start_stats_refresher() -> None:
             refresh_leaderboard_summary()
         except Exception:
             logger.warning("leaderboard summary refresh failed", exc_info=True)
+        logger.info(
+            "refresh cycle: leaderboard summary done at %.1fs, entering snapshot "
+            "rebuild",
+            time.time() - _cyc0,
+        )
         # Rebuild the shared entity-stats snapshot (tier-list
         # / Codex Score source) on the same leader-only loop.
         # Internally throttled, so this is a no-op find_one

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -839,6 +839,12 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
     (solo/2p/3p/4p/a10/daily/custom); those land nested under each entity's
     ``brackets`` key, and `bracket_meta` carries their baselines + totals.
     """
+    # Phase timing so a stalled rebuild is diagnosable from the logs (the walk is
+    # otherwise silent until it completes). Which phase the last log names tells
+    # us where a rebuild that never finishes is stuck.
+    _t0 = time.time()
+    logger.info("snapshot rebuild: starting (loading run rows from the DB)")
+
     new_cache: dict[tuple[str, str], dict[str, Any]] = {}
     new_totals = {"total_runs": 0, "total_wins": 0}
 
@@ -908,6 +914,12 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
                 "player_count, ascension, game_mode, killed_by, username FROM runs"
             ).fetchall()
             rows = [dict(r) for r in rows]
+
+    logger.info(
+        "snapshot rebuild: loaded %d run rows in %.1fs, now walking blob files",
+        len(rows),
+        time.time() - _t0,
+    )
 
     official_chars = _official_character_ids()
 
@@ -1221,6 +1233,13 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
                     picked_ids,
                     skipped_ids,
                 )
+
+    logger.info(
+        "snapshot rebuild: blob walk done in %.1fs (%d entities), finalizing "
+        "(Codex Elo fits + bracket serialization)",
+        time.time() - _t0,
+        len(new_cache),
+    )
 
     # Fold the card-reward pick stats + fitted Codex Elo into the cache.
     # Cards that were offered but never decked still get an entry (picks=0


### PR DESCRIPTION
The entity-stats snapshot rebuild is silent until it completes, so a rebuild that never finishes (prod is stuck serving snapshot v10, and no error is logged) can't be diagnosed from the logs.

Adds INFO logging only — no behavior change:
- **Refresh cycle** (`_run_refresh_cycle`): times each step — `charts prewarm done at Xs`, `stats summary done at Xs`, `leaderboard summary done at Xs, entering snapshot rebuild`.
- **Snapshot rebuild** (`_build_cache_data`): logs each phase — `starting (loading run rows from the DB)`, `loaded N run rows in Xs, now walking blob files`, `blob walk done in Xs (N entities), finalizing`. Plus the existing `snapshot rebuilt: N entities across M runs` on completion.

After deploying this, the logs will show exactly where the stalled rebuild stops — whichever phase's "done" line never appears is the culprit. My working theory is the `list(coll.find({}))` full pull of ~740k run docs crawling under Mongo write-contention (heavy presence traffic), which these logs will confirm or refute.

ruff + compile clean.