### PR TITLE
Run the snapshot rebuild before charts prewarm, not after

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1187,20 +1187,12 @@ def start_stats_refresher() -> None:
         _cyc0 = time.time()
         logger.info("refresh cycle: starting (leader)")
 
-        # Warm the /charts page FIRST so the default no-filter view of each chart
-        # is in Redis within seconds of a deploy, instead of waiting behind the
-        # entity-stats snapshot walk below (which can run for minutes). Frame
-        # charts warm immediately; blob charts that still need the snapshot come
-        # back "building" and re-warm on the next cycle. One worker, shared cache.
-        try:
-            if app_cache.enabled():
-                from .charts import prewarm_charts
-
-                prewarm_charts()
-        except Exception:
-            logger.warning("charts prewarm failed", exc_info=True)
-        logger.info("refresh cycle: charts prewarm done at %.1fs", time.time() - _cyc0)
-
+        # The entity-stats snapshot rebuild below is the critical product data
+        # (tier list / Codex Score / metrics), so it runs FIRST and nothing may
+        # starve it. Charts prewarm — which loads the full ~740k-run frame from
+        # Mongo and can run long under DB load — is deferred to the END of the
+        # cycle. This reverses PR #567's ordering: putting prewarm first let it
+        # block the snapshot rebuild indefinitely, so the snapshot never advanced.
         try:
             refresh_stats_summary()
         except Exception:
@@ -1250,6 +1242,19 @@ def start_stats_refresher() -> None:
                     )
         except Exception:
             logger.warning("entity-scores cache warm failed", exc_info=True)
+
+        # Charts prewarm LAST — it loads the full run frame from Mongo and can run
+        # for a while under load, so it must never delay the snapshot rebuild
+        # above. Trade-off: /charts warms a bit later after a deploy; the snapshot
+        # actually completing is the priority.
+        try:
+            if app_cache.enabled():
+                from .charts import prewarm_charts
+
+                prewarm_charts()
+        except Exception:
+            logger.warning("charts prewarm failed", exc_info=True)
+        logger.info("refresh cycle: charts prewarm done at %.1fs", time.time() - _cyc0)
 
     threading.Thread(target=_loop, daemon=True, name="stats-refresher").start()
 


### PR DESCRIPTION
## Root cause (finally pinned down)

The instrumentation from #583 gave the definitive answer — the leader logs:
```
refresh cycle: starting (leader)
```
…and then **nothing**. It hangs in the very first cycle step, `prewarm_charts()`, and never reaches the entity-stats snapshot rebuild. That's why prod has been frozen serving a stale snapshot (v10) with tier-list/metrics/composites broken.

`prewarm_charts()` loads the full ~740k-run charts frame from Mongo, and under the current DB load (heavy presence write traffic) that runs long enough to **starve the snapshot rebuild indefinitely**.

This is a regression from **PR #567**, which moved `prewarm_charts` to the *front* of the refresh cycle (so /charts warmed fast after a deploy). That reordering let prewarm block the snapshot rebuild that used to run first — which is exactly why the snapshot stopped advancing.

## Fix
Move `prewarm_charts` back to the **end** of the cycle. The snapshot rebuild (the critical product data) runs first and can't be starved. /charts warms a little later after a deploy as the trade-off — far better than the snapshot never rebuilding.

One-file reorder, ruff + compile clean. After deploy, the logs should show the full sequence through `snapshot rebuilt: N entities across M runs`, the snapshot advances to 13, and the composite tier-list/metrics combos populate.