### PR TITLE
SEO: name-first titles + server-render the site's unique community data

### DIFF
--- a/frontend/app/[lang]/cards/[id]/page.tsx
+++ b/frontend/app/[lang]/cards/[id]/page.tsx
@@ -32,7 +32,7 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
     const langCode = lang as LangCode;
     const gameName = LANG_GAME_NAME[langCode];
     const color = (card.color || "").replace(/^\w/, (c: string) => c.toUpperCase());
-    const title = `${gameName} Card - ${card.name} - ${card.rarity} ${card.type} | Spire Codex (${LANG_NAMES[langCode]})`;
+    const title = `${card.name} - ${gameName} ${card.rarity} ${card.type} | Spire Codex (${LANG_NAMES[langCode]})`;
     const descFlat = stripTagsFlat(card.description || "");
     const keywords = card.keywords?.length ? ` Keywords: ${card.keywords.join(", ")}.` : "";
     const metaDesc = clipMetaDescription(

--- a/frontend/app/achievements/[id]/AchievementDetail.tsx
+++ b/frontend/app/achievements/[id]/AchievementDetail.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
+import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import "../../card-revamp.css";
 import "../../meta-extra.css";
@@ -125,6 +126,9 @@ export default function AchievementDetail({ initialAchievement }: { initialAchie
             <div className="desc-quote">
               <RichDescription text={achievement.description} />
             </div>
+
+            {/* Programmatic prose block for SEO */}
+            <EntityProse kind="achievement" achievement={achievement} />
           </section>
 
           {/* Version history + localized names */}

--- a/frontend/app/achievements/[id]/page.tsx
+++ b/frontend/app/achievements/[id]/page.tsx
@@ -16,9 +16,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Achievement Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const achievement = await res.json();
     const desc = stripTagsFlat(achievement.description || "");
-    const title = `Achievement - ${achievement.name} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${achievement.name} - Slay the Spire 2 Achievement | Spire Codex`;
     const metaDesc = clipMetaDescription(
-      `Slay the Spire 2 achievement, ${achievement.name}${desc ? `: ${desc}` : ""}`,
+      `${achievement.name} is an achievement in Slay the Spire 2 (sts2)${desc ? `: ${desc}` : "."}`,
     );
     return {
       title,

--- a/frontend/app/acts/[id]/ActDetail.tsx
+++ b/frontend/app/acts/[id]/ActDetail.tsx
@@ -9,6 +9,7 @@ import { useLanguage } from "../../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
+import EntityProse from "@/app/components/EntityProse";
 import "../../card-revamp.css";
 import "../../meta-extra.css";
 
@@ -199,6 +200,9 @@ export default function ActDetail({ initialAct }: { initialAct?: Act | null } = 
             <LocalizedNames entityType="acts" entityId={id} />
             <EntityHistory entityType="acts" entityId={id} />
           </section>
+
+          {/* Programmatic prose block for SEO */}
+          <EntityProse kind="act" act={act} />
         </main>
       </div>
     </div>

--- a/frontend/app/acts/[id]/page.tsx
+++ b/frontend/app/acts/[id]/page.tsx
@@ -19,9 +19,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     });
     if (!res.ok) return { title: "Act Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const act = await res.json();
-    const title = `Act - ${act.name} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${act.name} - Slay the Spire 2 Act | Spire Codex`;
     const desc = clipMetaDescription(
-      `Slay the Spire 2 act, ${act.name}. ${act.num_rooms || "?"} rooms, ${act.bosses.length} bosses, ${act.encounters.length} encounters, ${act.events.length} events.`,
+      `${act.name} is an act in Slay the Spire 2 (sts2). ${act.num_rooms || "?"} rooms, ${act.bosses.length} bosses, ${act.encounters.length} encounters, ${act.events.length} events.`,
     );
     return {
       title,

--- a/frontend/app/afflictions/[id]/AfflictionDetail.tsx
+++ b/frontend/app/afflictions/[id]/AfflictionDetail.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
+import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import "../../card-revamp.css";
 import "../../reference-extra.css";
@@ -87,6 +88,9 @@ export default function AfflictionDetail({ initialAffliction }: { initialAfflict
             <div className="desc-quote">
               <RichDescription text={affliction.description} />
             </div>
+
+            {/* Programmatic prose block for SEO */}
+            <EntityProse kind="affliction" affliction={affliction} />
           </section>
 
           {affliction.extra_card_text && (

--- a/frontend/app/afflictions/[id]/page.tsx
+++ b/frontend/app/afflictions/[id]/page.tsx
@@ -16,9 +16,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Affliction Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const affliction = await res.json();
     const desc = stripTagsFlat(affliction.description || "");
-    const title = `Affliction - ${affliction.name} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${affliction.name} - Slay the Spire 2 Affliction | Spire Codex`;
     const metaDesc = clipMetaDescription(
-      `Slay the Spire 2 affliction, ${affliction.name}${desc ? `: ${desc}` : ""}`,
+      `${affliction.name} is an affliction in Slay the Spire 2 (sts2)${desc ? `: ${desc}` : "."}`,
     );
     return {
       title,

--- a/frontend/app/ascensions/[id]/AscensionDetail.tsx
+++ b/frontend/app/ascensions/[id]/AscensionDetail.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from "../../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
+import EntityProse from "@/app/components/EntityProse";
 import "../../card-revamp.css";
 import "../../meta-extra.css";
 
@@ -139,6 +140,9 @@ export default function AscensionDetail({ initialAscension }: { initialAscension
             <div className="desc-quote">
               <RichDescription text={ascension.description} />
             </div>
+
+            {/* Programmatic prose block for SEO */}
+            <EntityProse kind="ascension" ascension={ascension} />
           </section>
 
           {/* Prev/Next navigation */}

--- a/frontend/app/ascensions/[id]/page.tsx
+++ b/frontend/app/ascensions/[id]/page.tsx
@@ -20,9 +20,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Ascension Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const asc = await res.json();
     const desc = stripTagsFlat(asc.description);
-    const title = `Ascension - Level ${asc.level} - ${asc.name} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `Ascension ${asc.level}: ${asc.name} - Slay the Spire 2 | Spire Codex`;
     const metaDesc = clipMetaDescription(
-      `Slay the Spire 2 Ascension ${asc.level}, ${asc.name}${desc ? `: ${desc}` : ""}`,
+      `Ascension ${asc.level} (${asc.name}) in Slay the Spire 2 (sts2)${desc ? `: ${desc}` : "."}`,
     );
     return {
       title,

--- a/frontend/app/badges/[id]/page.tsx
+++ b/frontend/app/badges/[id]/page.tsx
@@ -60,9 +60,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const desc = stripTagsFlat(badge.description);
   const subtype = badge.tiered ? "Tiered" : "Badge";
-  const title = `Badge - ${badge.name} - ${subtype} - Slay the Spire 2 (sts2) | Spire Codex`;
+  const title = `${badge.name} - Slay the Spire 2 Badge | Spire Codex`;
   const metaDesc = clipMetaDescription(
-    `Slay the Spire 2 ${subtype.toLowerCase()} run-end badge, ${badge.name}${desc ? `: ${desc}` : ""}`,
+    `${badge.name} is a ${subtype.toLowerCase()} run-end badge in Slay the Spire 2 (sts2)${desc ? `: ${desc}` : "."}`,
   );
   return {
     title,

--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -14,7 +14,7 @@ import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import RelatedCards from "@/app/components/RelatedCards";
 import { imageUrl, fullCardUrl, enchantedCardUrl } from "@/lib/image-url";
-import EntityRunStats from "@/app/components/EntityRunStats";
+import EntityRunStats, { type EntityStats } from "@/app/components/EntityRunStats";
 import HoverTooltip from "@/app/components/HoverTooltip";
 import { useChannel, useLangPrefix } from "@/lib/use-lang-prefix";
 import BetaDiffNotice from "@/app/components/BetaDiffNotice";
@@ -150,7 +150,7 @@ function getMerchantPriceRange(rarity: string, color: string): { min: number; ma
   return { min: Math.floor(base * 0.95), max: Math.ceil(base * 1.05) };
 }
 
-export default function CardDetail({ initialCard, initialEnchantments }: { initialCard?: Card | null; initialEnchantments?: string[] } = {}) {
+export default function CardDetail({ initialCard, initialEnchantments, initialStats }: { initialCard?: Card | null; initialEnchantments?: string[]; initialStats?: EntityStats | null } = {}) {
   const params = useParams();
   const id = params.id as string;
   const { lang } = useLanguage();
@@ -441,6 +441,7 @@ export default function CardDetail({ initialCard, initialEnchantments }: { initi
               entityId={id}
               entityName={card.name}
               variant="wiki"
+              initialStats={initialStats}
             />
           </section>
 

--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -13,6 +13,7 @@ import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import RelatedCards from "@/app/components/RelatedCards";
+import EntityProse from "@/app/components/EntityProse";
 import { imageUrl, fullCardUrl, enchantedCardUrl } from "@/lib/image-url";
 import EntityRunStats, { type EntityStats } from "@/app/components/EntityRunStats";
 import HoverTooltip from "@/app/components/HoverTooltip";
@@ -573,6 +574,9 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
                 </div>
               </>
             )}
+
+            {/* Programmatic prose block for SEO */}
+            <EntityProse kind="card" card={card} />
           </section>
 
           {/* Relations */}

--- a/frontend/app/cards/[id]/page.tsx
+++ b/frontend/app/cards/[id]/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import CardDetail from "./CardDetail";
+import type { EntityStats } from "@/app/components/EntityRunStats";
+import { fetchEntityStats } from "@/lib/entity-stats";
 import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates, SITE_NAME, SITE_URL } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
@@ -103,10 +105,16 @@ export default async function Page({ params }: Props) {
   // 308 unknown IDs to the cards list so search engines transfer
   // link equity and humans land on something useful.
   if (!card && !apiUnreachable) redirectMissingEntity("cards", id);
+  // Server-render the community stats into the HTML (unique, crawlable data).
+  const initialStats: EntityStats | null = card ? await fetchEntityStats("cards", id) : null;
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <CardDetail initialCard={card} initialEnchantments={enchantmentsForCard(id)} />
+      <CardDetail
+        initialCard={card}
+        initialEnchantments={enchantmentsForCard(id)}
+        initialStats={initialStats}
+      />
     </>
   );
 }

--- a/frontend/app/cards/[id]/page.tsx
+++ b/frontend/app/cards/[id]/page.tsx
@@ -31,11 +31,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const card = await res.json();
     const desc = stripTags(card.description || "");
     const color = (card.color || "").replace(/^\w/, (c: string) => c.toUpperCase());
-    const title = `Card - ${card.name} - ${card.rarity} ${card.type} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${card.name} - Slay the Spire 2 ${card.rarity} ${card.type} | Spire Codex`;
     const descFlat = stripTagsFlat(card.description || "");
     const keywords = card.keywords?.length ? ` Keywords: ${card.keywords.join(", ")}.` : "";
     const metaDesc = clipMetaDescription(
-      `Slay the Spire 2 card, ${card.name} (${card.cost ?? "X"}-cost ${card.rarity} ${card.type}, ${color}). ${descFlat}${keywords}`,
+      `${card.name} is a ${card.cost ?? "X"}-cost ${color} ${card.rarity} ${card.type} card in Slay the Spire 2 (sts2). ${descFlat}${keywords}`,
     );
     // Full game-rendered card (base + upgraded) as the share image, English.
     const ogImages = cardOgImages(card, "eng");

--- a/frontend/app/characters/[id]/CharacterDetail.tsx
+++ b/frontend/app/characters/[id]/CharacterDetail.tsx
@@ -11,6 +11,7 @@ import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import { imageUrl, fullCardUrl } from "@/lib/image-url";
 import FullCardGrid from "@/app/components/FullCardGrid";
+import EntityProse from "@/app/components/EntityProse";
 import "../../card-revamp.css";
 import "../../character-extra.css";
 
@@ -400,6 +401,9 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
             <div className="desc-quote">
               <RichDescription text={char.description} />
             </div>
+
+            {/* Programmatic prose block for SEO */}
+            <EntityProse kind="character" character={char} />
           </section>
 
           {/* Starting Deck */}

--- a/frontend/app/components/EntityProse.tsx
+++ b/frontend/app/components/EntityProse.tsx
@@ -1,7 +1,25 @@
 "use client";
 
 import { useLanguage } from "@/app/contexts/LanguageContext";
-import type { Relic, Potion, Power, Monster } from "@/lib/api";
+import type {
+  Relic,
+  Potion,
+  Power,
+  Monster,
+  Card,
+  Enchantment,
+  Character,
+  Orb,
+  GameEvent,
+  Encounter,
+  Keyword,
+  Intent,
+  Modifier,
+  Affliction,
+  Achievement,
+  Act,
+  Ascension,
+} from "@/lib/api";
 
 /**
  * Programmatic prose block at the bottom of each entity's Overview
@@ -32,7 +50,42 @@ interface RelicProseProps { kind: "relic"; relic: Relic; }
 interface PotionProseProps { kind: "potion"; potion: Potion; }
 interface PowerProseProps { kind: "power"; power: Power; appliedByCount: number; }
 interface MonsterProseProps { kind: "monster"; monster: Monster; deadliest?: { name: string; killRate: number } | null; }
-type Props = RelicProseProps | PotionProseProps | PowerProseProps | MonsterProseProps;
+interface CardProseProps { kind: "card"; card: Card; }
+interface EnchantmentProseProps { kind: "enchantment"; enchantment: Enchantment; }
+interface CharacterProseProps { kind: "character"; character: Character; }
+interface OrbProseProps { kind: "orb"; orb: Orb; }
+interface EventProseProps { kind: "event"; event: GameEvent; }
+interface EncounterProseProps { kind: "encounter"; encounter: Encounter; }
+interface KeywordProseProps { kind: "keyword"; keyword: Keyword; }
+interface IntentProseProps { kind: "intent"; intent: Intent; }
+interface ModifierProseProps { kind: "modifier"; modifier: Modifier; }
+interface AfflictionProseProps { kind: "affliction"; affliction: Affliction; }
+interface AchievementProseProps { kind: "achievement"; achievement: Achievement; }
+interface ActProseProps { kind: "act"; act: Act; }
+interface AscensionProseProps { kind: "ascension"; ascension: Ascension; }
+type Props =
+  | RelicProseProps
+  | PotionProseProps
+  | PowerProseProps
+  | MonsterProseProps
+  | CardProseProps
+  | EnchantmentProseProps
+  | CharacterProseProps
+  | OrbProseProps
+  | EventProseProps
+  | EncounterProseProps
+  | KeywordProseProps
+  | IntentProseProps
+  | ModifierProseProps
+  | AfflictionProseProps
+  | AchievementProseProps
+  | ActProseProps
+  | AscensionProseProps;
+
+// "a"/"an" by leading vowel sound (good enough for our vocabulary).
+function article(word: string): string {
+  return /^[aeiou]/i.test(word) ? "an" : "a";
+}
 
 // Title-case a raw power id ("INCREASING_INTENSITY" -> "Increasing Intensity")
 // for SSR-safe prose (power display names load client-side only).
@@ -101,6 +154,223 @@ export default function EntityProse(props: Props) {
     return <Prose sentences={sentences} />;
   }
 
+  if (props.kind === "card") {
+    const c = props.card;
+    const name = c.name;
+    const pools: Record<string, string> = {
+      ironclad: "Ironclad", silent: "Silent", defect: "Defect", necrobinder: "Necrobinder", regent: "Regent",
+    };
+    if (!isEnglish) {
+      return <Prose sentences={[`${name} · ${c.rarity} · ${c.type}`]} />;
+    }
+    const who = pools[c.color] ? ` for the ${pools[c.color]}` : "";
+    const cost = c.is_x_cost ? "X" : `${c.cost}`;
+    const sentences: string[] = [];
+    sentences.push(`${name} is a ${c.rarity} ${c.type} card${who} in Slay the Spire 2, costing ${cost} energy.`);
+    const eff: string[] = [];
+    if (c.damage != null) eff.push(`deals ${c.damage} damage${c.hit_count && c.hit_count > 1 ? ` across ${c.hit_count} hits` : ""}`);
+    if (c.block != null) eff.push(`grants ${c.block} Block`);
+    if (c.cards_draw != null) eff.push(`draws ${c.cards_draw} card${c.cards_draw === 1 ? "" : "s"}`);
+    if (c.energy_gain != null) eff.push(`gains ${c.energy_gain} energy`);
+    const powerParts = (c.powers_applied || []).map((p) => `${p.amount} ${p.power}`);
+    if (powerParts.length) eff.push(`applies ${listWords(powerParts)}`);
+    if (eff.length) sentences.push(`It ${listWords(eff)}.`);
+    if (c.keywords && c.keywords.length) {
+      sentences.push(`It carries the ${listWords(c.keywords)} keyword${c.keywords.length > 1 ? "s" : ""}.`);
+    }
+    return <Prose sentences={sentences} />;
+  }
+
+  if (props.kind === "enchantment") {
+    const e = props.enchantment;
+    const name = e.name;
+    if (!isEnglish) {
+      return <Prose sentences={[`${name}${e.card_type ? ` · ${e.card_type}` : ""}`]} />;
+    }
+    const sentences: string[] = [];
+    sentences.push(
+      `${name} is a card enchantment in Slay the Spire 2${e.card_type ? `, applied to ${e.card_type.toLowerCase()} cards` : ""}.`,
+    );
+    sentences.push(
+      e.is_stackable
+        ? `${name} stacks, so a single card can hold more than one for a compounding effect.`
+        : `${name} does not stack; a card can carry it only once.`,
+    );
+    return <Prose sentences={sentences} />;
+  }
+
+  if (props.kind === "character") {
+    const ch = props.character;
+    const name = ch.name;
+    if (!isEnglish) {
+      return <Prose sentences={[`${name}${ch.starting_hp != null ? ` · ${ch.starting_hp} HP` : ""}`]} />;
+    }
+    const sentences: string[] = [];
+    const stats: string[] = [];
+    if (ch.starting_hp != null) stats.push(`${ch.starting_hp} HP`);
+    if (ch.starting_gold != null) stats.push(`${ch.starting_gold} gold`);
+    if (ch.max_energy != null) stats.push(`${ch.max_energy} energy per turn`);
+    sentences.push(`${name} is a playable character in Slay the Spire 2${stats.length ? `, starting each run with ${listWords(stats)}` : ""}.`);
+    const deck = ch.starting_deck?.length || 0;
+    const relics = ch.starting_relics?.length || 0;
+    if (deck || relics) {
+      const parts: string[] = [];
+      if (deck) parts.push(`a ${deck}-card starting deck`);
+      if (relics) parts.push(`${relics} starting relic${relics === 1 ? "" : "s"}`);
+      sentences.push(`They begin with ${listWords(parts)}.`);
+    }
+    if (ch.orb_slots) sentences.push(`${name} channels orbs, with ${ch.orb_slots} orb slot${ch.orb_slots === 1 ? "" : "s"} to start.`);
+    if (ch.unlocks_after) sentences.push(`${name} unlocks after ${ch.unlocks_after}.`);
+    return <Prose sentences={sentences} />;
+  }
+
+  if (props.kind === "orb") {
+    const o = props.orb;
+    const name = o.name;
+    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    const cards = o.channeled_by_cards?.length || 0;
+    const relics = o.channeled_by_relics?.length || 0;
+    const sentences: string[] = [];
+    sentences.push(`${name} is an orb in Slay the Spire 2. Orbs fill your orb slots and trigger passively each turn, or all at once when evoked.`);
+    if (cards || relics) {
+      const src: string[] = [];
+      if (cards) src.push(`${cards} card${cards === 1 ? "" : "s"}`);
+      if (relics) src.push(`${relics} relic${relics === 1 ? "" : "s"}`);
+      sentences.push(`${name} is channeled by ${listWords(src)} in the game.`);
+    }
+    return <Prose sentences={sentences} />;
+  }
+
+  if (props.kind === "event") {
+    const ev = props.event;
+    const name = ev.name;
+    if (!isEnglish) return <Prose sentences={[`${name}${ev.act ? ` · ${ev.act}` : ""}`]} />;
+    const sentences: string[] = [];
+    const typeWord = ev.type && ev.type.toLowerCase() !== "event" ? `${ev.type.toLowerCase()} event` : "event";
+    sentences.push(`${name} is ${article(typeWord)} ${typeWord} in Slay the Spire 2${ev.act ? `, encountered in ${ev.act}` : ""}.`);
+    const opts = ev.options?.length || 0;
+    if (opts) sentences.push(`It presents ${opts} choice${opts === 1 ? "" : "s"}, each leading to a different outcome.`);
+    if (ev.relics && ev.relics.length) {
+      sentences.push(`It can reward the ${listWords(ev.relics.map(titleCaseId))} relic${ev.relics.length > 1 ? "s" : ""}.`);
+    }
+    return <Prose sentences={sentences} />;
+  }
+
+  if (props.kind === "encounter") {
+    const en = props.encounter;
+    const name = en.name;
+    if (!isEnglish) return <Prose sentences={[`${name}${en.room_type ? ` · ${en.room_type}` : ""}`]} />;
+    const room = (en.room_type || "combat").toLowerCase();
+    const monsters = (en.monsters || []).map((mm) => mm.name);
+    let s1 = `${name} is ${article(room)} ${room} encounter in Slay the Spire 2${en.act ? `, fought in ${en.act}` : ""}`;
+    // Skip the "against X" clause when the only monster shares the encounter name.
+    if (monsters.length && !(monsters.length === 1 && monsters[0] === name)) {
+      s1 += `, pitting you against ${listWords(monsters)}`;
+    }
+    const sentences: string[] = [s1 + "."];
+    if (en.is_weak) sentences.push(`It is flagged as one of the weaker fights for its act.`);
+    return <Prose sentences={sentences} />;
+  }
+
+  if (props.kind === "keyword") {
+    const name = props.keyword.name;
+    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    return (
+      <Prose
+        sentences={[
+          `${name} is a keyword in Slay the Spire 2. Keywords are shared rules text: wherever ${name} appears on a card, relic, or power, the same definition applies.`,
+          `Knowing what ${name} does helps you read new cards at a glance and plan around its interactions during a run.`,
+        ]}
+      />
+    );
+  }
+
+  if (props.kind === "intent") {
+    const name = props.intent.name;
+    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    return (
+      <Prose
+        sentences={[
+          `${name} is an enemy intent in Slay the Spire 2. Intents are the icons shown above each enemy that telegraph what it will do on its next turn before you commit to yours.`,
+          `Reading the ${name} intent lets you line up blocks, attacks, and defensive plays around the enemy's plan.`,
+        ]}
+      />
+    );
+  }
+
+  if (props.kind === "modifier") {
+    const name = props.modifier.name;
+    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    return (
+      <Prose
+        sentences={[
+          `${name} is a run modifier in Slay the Spire 2. Modifiers adjust a run's starting conditions or rules so you can tailor the challenge before the run begins.`,
+          `They are one of the ways Slay the Spire 2 lets you customize difficulty beyond the Ascension ladder.`,
+        ]}
+      />
+    );
+  }
+
+  if (props.kind === "affliction") {
+    const af = props.affliction;
+    const name = af.name;
+    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    const sentences: string[] = [];
+    sentences.push(`${name} is an affliction in Slay the Spire 2, a lasting negative effect that follows your character rather than a single card or combat.`);
+    sentences.push(
+      af.is_stackable
+        ? `${name} can stack, so repeated sources make it progressively worse.`
+        : `${name} does not stack; picking it up again has no added effect.`,
+    );
+    return <Prose sentences={sentences} />;
+  }
+
+  if (props.kind === "achievement") {
+    const name = props.achievement.name;
+    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    return (
+      <Prose
+        sentences={[
+          `${name} is an achievement in Slay the Spire 2, unlocked by meeting a specific in-game condition during play.`,
+          `Achievements track long-term goals across runs and appear on your Steam profile once earned.`,
+        ]}
+      />
+    );
+  }
+
+  if (props.kind === "act") {
+    const ac = props.act;
+    const name = ac.name;
+    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    const sentences: string[] = [];
+    let s1 = `${name} is an act in Slay the Spire 2`;
+    if (ac.num_rooms) s1 += `, spanning around ${ac.num_rooms} rooms from entrance to boss`;
+    sentences.push(s1 + ".");
+    const counts: string[] = [];
+    if (ac.bosses?.length) counts.push(`${ac.bosses.length} boss${ac.bosses.length === 1 ? "" : "es"}`);
+    if (ac.encounters?.length) counts.push(`${ac.encounters.length} combat encounter${ac.encounters.length === 1 ? "" : "s"}`);
+    if (ac.events?.length) counts.push(`${ac.events.length} event${ac.events.length === 1 ? "" : "s"}`);
+    if (counts.length) sentences.push(`It includes ${listWords(counts)}.`);
+    return <Prose sentences={sentences} />;
+  }
+
+  if (props.kind === "ascension") {
+    const as = props.ascension;
+    const name = as.name;
+    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    const sentences: string[] =
+      as.level > 0
+        ? [
+            `${name} is Ascension ${as.level} in Slay the Spire 2, one rung on the stacking difficulty ladder that layers a new permanent handicap on top of every level below it.`,
+            `You unlock it by winning at Ascension ${as.level - 1}, and each level makes the run tougher than the last.`,
+          ]
+        : [
+            `${name} is the base difficulty in Slay the Spire 2, played without any Ascension modifiers.`,
+            `Clearing a run here unlocks Ascension 1, the first of the stacking difficulty levels.`,
+          ];
+    return <Prose sentences={sentences} />;
+  }
+
   if (props.kind === "monster") {
     const m = props.monster;
     const name = m.name;
@@ -119,7 +389,6 @@ export default function EntityProse(props: Props) {
 
     const moves = m.moves || [];
     const sentences: string[] = [];
-    const article = (w: string) => (/^[aeiou]/i.test(w) ? "an" : "a");
 
     // 1. Identity + HP.
     let s1 = `${name} is ${article(type)} ${type.toLowerCase()} enemy in Slay the Spire 2`;

--- a/frontend/app/components/EntityProse.tsx
+++ b/frontend/app/components/EntityProse.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useLanguage } from "@/app/contexts/LanguageContext";
-import type { Relic, Potion, Power } from "@/lib/api";
+import type { Relic, Potion, Power, Monster } from "@/lib/api";
 
 /**
  * Programmatic prose block at the bottom of each entity's Overview
@@ -31,7 +31,21 @@ import type { Relic, Potion, Power } from "@/lib/api";
 interface RelicProseProps { kind: "relic"; relic: Relic; }
 interface PotionProseProps { kind: "potion"; potion: Potion; }
 interface PowerProseProps { kind: "power"; power: Power; appliedByCount: number; }
-type Props = RelicProseProps | PotionProseProps | PowerProseProps;
+interface MonsterProseProps { kind: "monster"; monster: Monster; deadliest?: { name: string; killRate: number } | null; }
+type Props = RelicProseProps | PotionProseProps | PowerProseProps | MonsterProseProps;
+
+// Title-case a raw power id ("INCREASING_INTENSITY" -> "Increasing Intensity")
+// for SSR-safe prose (power display names load client-side only).
+function titleCaseId(id: string): string {
+  return id.replace(/_/g, " ").toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// "a", "a and b", "a, b, and c"
+function listWords(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? "";
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
 
 export default function EntityProse(props: Props) {
   const { lang } = useLanguage();
@@ -87,6 +101,88 @@ export default function EntityProse(props: Props) {
     return <Prose sentences={sentences} />;
   }
 
+  if (props.kind === "monster") {
+    const m = props.monster;
+    const name = m.name;
+    const type = m.type || "enemy";
+    const hp = m.min_hp
+      ? `${m.min_hp}${m.max_hp && m.max_hp !== m.min_hp ? `–${m.max_hp}` : ""}`
+      : null;
+    const hpAsc = m.min_hp_ascension
+      ? `${m.min_hp_ascension}${m.max_hp_ascension && m.max_hp_ascension !== m.min_hp_ascension ? `–${m.max_hp_ascension}` : ""}`
+      : null;
+
+    if (!isEnglish) {
+      // Non-English: one line from localized fields only (no English prose).
+      return <Prose lead sentences={[`${name} · ${type}${hp ? ` · ${hp} HP` : ""}`]} />;
+    }
+
+    const moves = m.moves || [];
+    const sentences: string[] = [];
+    const article = (w: string) => (/^[aeiou]/i.test(w) ? "an" : "a");
+
+    // 1. Identity + HP.
+    let s1 = `${name} is ${article(type)} ${type.toLowerCase()} enemy in Slay the Spire 2`;
+    if (hp) s1 += `, entering combat with ${hp} HP`;
+    if (hpAsc && hpAsc !== hp) s1 += ` (${hpAsc} on higher Ascensions)`;
+    sentences.push(s1 + ".");
+
+    // 2. Attack pattern. When a description is present it already spells out the
+    // sequence, so lead with that rather than a move count (some moves are
+    // conditional and never appear in the printed rotation).
+    const pat = m.attack_pattern;
+    if (pat && pat.description) {
+      const desc = pat.description;
+      if (desc.includes("→")) {
+        // Arrow sequence — frame it as the rotation.
+        sentences.push(
+          pat.type === "cycle"
+            ? `It cycles through ${desc}.`
+            : `Its attack pattern runs ${desc}.`,
+        );
+      } else {
+        // Already a prose summary (e.g. "Always uses Wake Up") — use it as-is.
+        sentences.push(desc.endsWith(".") ? desc : desc + ".");
+      }
+    } else if (moves.length) {
+      sentences.push(`It has ${moves.length} known move${moves.length === 1 ? "" : "s"}.`);
+    }
+
+    // 3. Heaviest hit (by total damage across multi-hits).
+    const hardest = [...moves]
+      .filter((mv) => mv.damage && mv.damage.normal != null)
+      .sort(
+        (a, b) =>
+          b.damage!.normal * (b.damage!.hit_count || 1) -
+          a.damage!.normal * (a.damage!.hit_count || 1),
+      )[0];
+    if (hardest && hardest.damage) {
+      const d = hardest.damage;
+      const dmg =
+        d.hit_count && d.hit_count > 1
+          ? `${d.normal}×${d.hit_count} (${d.normal * d.hit_count} total)`
+          : `${d.normal}`;
+      let s3 = `Its heaviest attack, ${hardest.name}, deals ${dmg} damage`;
+      if (hardest.block != null) s3 += `, and it gains ${hardest.block} Block on the same turn`;
+      sentences.push(s3 + ".");
+    }
+
+    // 4. Innate powers it enters combat with.
+    if (m.innate_powers && m.innate_powers.length) {
+      const names = m.innate_powers.map((p) => titleCaseId(p.power_id));
+      sentences.push(`It opens the fight already holding ${listWords(names)}.`);
+    }
+
+    // 5. Community deadliness (our own run data — nothing else has this).
+    if (props.deadliest && props.deadliest.killRate > 0) {
+      sentences.push(
+        `Across community-tracked runs, the ${props.deadliest.name} fight proves fatal to ${props.deadliest.killRate.toFixed(1)}% of the parties that reach it.`,
+      );
+    }
+
+    return <Prose lead sentences={sentences} />;
+  }
+
   // power
   const pw = props.power;
   const name = pw.name;
@@ -124,7 +220,17 @@ export default function EntityProse(props: Props) {
   return <Prose sentences={sentences} />;
 }
 
-function Prose({ sentences }: { sentences: string[] }) {
+function Prose({ sentences, lead }: { sentences: string[]; lead?: boolean }) {
+  // lead: rendered as an intro right under a page hero (no top border/rule).
+  if (lead) {
+    return (
+      <section className="mon-lead">
+        {sentences.map((s, i) => (
+          <p key={i}>{s}</p>
+        ))}
+      </section>
+    );
+  }
   return (
     <section className="mt-6 pt-5 border-t border-[var(--border-subtle)] text-sm leading-relaxed text-[var(--text-secondary)] space-y-2">
       {sentences.map((s, i) => (

--- a/frontend/app/components/EntityRunStats.tsx
+++ b/frontend/app/components/EntityRunStats.tsx
@@ -29,7 +29,7 @@ interface BracketStat {
   by_character?: CharacterRow[];
 }
 
-interface EntityStats {
+export interface EntityStats {
   entity_type: string;
   entity_id: string;
   picks: number;
@@ -55,6 +55,10 @@ interface Props {
    * (stat tiles + bracket pills + by-character bars). Data/fetch/bracket
    * logic is identical; only the presentation changes. */
   variant?: "default" | "wiki";
+  /** Server-fetched stats used as the initial state so the numbers render into
+   * the SSR HTML (crawlable) instead of a client-only "Loading" placeholder.
+   * The component still re-fetches on mount to stay fresh. */
+  initialStats?: EntityStats | null;
 }
 
 /** Compact 1.2k / 44.8k style number for the wiki tiles + bars. */
@@ -115,8 +119,8 @@ function characterPretty(c: string): string {
  * state when the entity has no submitted runs yet so SEO crawlers
  * still see something other than spinners.
  */
-export default function EntityRunStats({ entityType, entityId, entityName, variant = "default" }: Props) {
-  const [stats, setStats] = useState<EntityStats | null>(null);
+export default function EntityRunStats({ entityType, entityId, entityName, variant = "default", initialStats = null }: Props) {
+  const [stats, setStats] = useState<EntityStats | null>(initialStats);
   const [selectedBracket, setSelectedBracket] = useState("all");
   const { lang } = useLanguage();
 

--- a/frontend/app/enchantments/[id]/EnchantmentDetail.tsx
+++ b/frontend/app/enchantments/[id]/EnchantmentDetail.tsx
@@ -15,6 +15,7 @@ import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
+import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { imageUrl, enchantedCardUrl } from "@/lib/image-url";
 import "../../card-revamp.css";
@@ -169,6 +170,9 @@ export default function EnchantmentDetail({
                 </div>
               </>
             )}
+
+            {/* Programmatic prose block for SEO */}
+            <EntityProse kind="enchantment" enchantment={enchantment} />
           </section>
 
           {/* Cards it can apply to */}

--- a/frontend/app/enchantments/[id]/page.tsx
+++ b/frontend/app/enchantments/[id]/page.tsx
@@ -19,9 +19,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Enchantment Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const enchantment = await res.json();
     const desc = stripTagsFlat(enchantment.description || "");
-    const title = `Enchantment - ${enchantment.name} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${enchantment.name} - Slay the Spire 2 Enchantment | Spire Codex`;
     const metaDesc = clipMetaDescription(
-      `Slay the Spire 2 card enchantment, ${enchantment.name}${desc ? `: ${desc}` : ""}`,
+      `${enchantment.name} is a card enchantment in Slay the Spire 2 (sts2)${desc ? `: ${desc}` : "."}`,
     );
     return {
       title,

--- a/frontend/app/encounters/[id]/EncounterDetail.tsx
+++ b/frontend/app/encounters/[id]/EncounterDetail.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
+import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import "../../card-revamp.css";
 import "../../monster-encounter-extra.css";
@@ -179,6 +180,9 @@ export default function EncounterDetail({ initialEncounter }: { initialEncounter
             <LocalizedNames entityType="encounters" entityId={id} />
             <EntityHistory entityType="encounters" entityId={id} />
           </section>
+
+          {/* Programmatic prose block for SEO */}
+          <EntityProse kind="encounter" encounter={encounter} />
         </main>
 
         {/* ===== INFOBOX column (sticky) ===== */}

--- a/frontend/app/encounters/[id]/page.tsx
+++ b/frontend/app/encounters/[id]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const res = await fetch(`${API_INTERNAL}/api/encounters/${id}`);
     if (!res.ok) return { title: "Encounter Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const encounter = await res.json();
-    const title = `Encounter - ${encounter.name} - ${encounter.room_type} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${encounter.name} - Slay the Spire 2 ${encounter.room_type} Encounter | Spire Codex`;
     const monsterList = encounter.monsters?.length
       ? ` Monsters: ${encounter.monsters.map((m: { name: string }) => m.name).join(", ")}.`
       : "";

--- a/frontend/app/events/[id]/EventDetail.tsx
+++ b/frontend/app/events/[id]/EventDetail.tsx
@@ -15,6 +15,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
+import EntityProse from "@/app/components/EntityProse";
 import BetaDiffNotice from "@/app/components/BetaDiffNotice";
 import { imageUrl } from "@/lib/image-url";
 import "../../card-revamp.css";
@@ -230,6 +231,9 @@ export default function EventDetail({
                 <RichDescription text={event.description} />
               </div>
             )}
+
+            {/* Programmatic prose block for SEO */}
+            <EntityProse kind="event" event={event} />
           </section>
 
           {/* Choices & outcomes */}

--- a/frontend/app/events/[id]/EventDetail.tsx
+++ b/frontend/app/events/[id]/EventDetail.tsx
@@ -9,6 +9,7 @@ import {
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import type { GameEvent, EventPage } from "@/lib/api";
+import type { EventVotes } from "@/lib/event-votes";
 import RichDescription from "@/app/components/RichDescription";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
@@ -62,7 +63,10 @@ function PageBlock({ page }: { page: EventPage }) {
   );
 }
 
-export default function EventDetail({ initialEvent }: { initialEvent?: GameEvent | null } = {}) {
+export default function EventDetail({
+  initialEvent,
+  voteStats,
+}: { initialEvent?: GameEvent | null; voteStats?: EventVotes | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
@@ -250,6 +254,32 @@ export default function EventDetail({ initialEvent }: { initialEvent?: GameEvent
                       )}
                     </div>
                   ))}
+                </div>
+              )}
+
+              {voteStats && voteStats.options.length > 0 && (
+                <div className="event-votes">
+                  <h3 className="subh">How the community votes</h3>
+                  <p className="h-note">
+                    Across {voteStats.total.toLocaleString()} community-submitted runs at{" "}
+                    {event.name}, players chose:
+                  </p>
+                  <div className="bars">
+                    {voteStats.options.map((o) => (
+                      <div className="bar-row" key={o.id}>
+                        <span className="name">{o.label}</span>
+                        <span className="bar-track">
+                          <span
+                            className="bar-fill"
+                            style={{ width: `${o.pct}%`, background: "var(--gold)" }}
+                          />
+                        </span>
+                        <span className="num">
+                          <b>{o.pct}%</b> · {o.count.toLocaleString()}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
                 </div>
               )}
 

--- a/frontend/app/events/[id]/page.tsx
+++ b/frontend/app/events/[id]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import EventDetail from "./EventDetail";
+import { fetchEventVotes } from "@/lib/event-votes";
 import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates, SITE_NAME, SITE_URL } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
@@ -76,10 +77,12 @@ export default async function Page({ params }: Props) {
     apiUnreachable = true;
   }
   if (!event && !apiUnreachable) redirectMissingEntity("events", id);
+  // Server-render the community choice distribution (unique, crawlable data).
+  const voteStats = event ? await fetchEventVotes(id) : null;
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <EventDetail initialEvent={event} />
+      <EventDetail initialEvent={event} voteStats={voteStats} />
     </>
   );
 }

--- a/frontend/app/events/[id]/page.tsx
+++ b/frontend/app/events/[id]/page.tsx
@@ -18,9 +18,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Event Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const event = await res.json();
     const desc = stripTagsFlat(event.description || "");
-    const title = `Event - ${event.name} - ${event.type} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${event.name} - Slay the Spire 2 Event | Spire Codex`;
     const metaDesc = clipMetaDescription(
-      `Slay the Spire 2 ${event.type} event, ${event.name}${event.act ? ` (${event.act})` : ""}${desc ? `: ${desc}` : ""}`,
+      `${event.name} is a ${event.type} event in Slay the Spire 2 (sts2)${event.act ? ` (${event.act})` : ""}${desc ? `: ${desc}` : "."}`,
     );
     return {
       title,

--- a/frontend/app/intents/[id]/IntentDetail.tsx
+++ b/frontend/app/intents/[id]/IntentDetail.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
+import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { imageUrl } from "@/lib/image-url";
 import "../../card-revamp.css";
@@ -82,6 +83,9 @@ export default function IntentDetail({ initialIntent }: { initialIntent?: Intent
             <div className="desc-quote">
               <RichDescription text={intent.description} />
             </div>
+
+            {/* Programmatic prose block for SEO */}
+            <EntityProse kind="intent" intent={intent} />
           </section>
 
           <section id="history">

--- a/frontend/app/intents/[id]/page.tsx
+++ b/frontend/app/intents/[id]/page.tsx
@@ -16,9 +16,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Intent Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const intent = await res.json();
     const desc = stripTagsFlat(intent.description || "");
-    const title = `Intent - ${intent.name} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${intent.name} - Slay the Spire 2 Monster Intent | Spire Codex`;
     const metaDesc = clipMetaDescription(
-      `Slay the Spire 2 monster intent, ${intent.name}${desc ? `: ${desc}` : ""}`,
+      `${intent.name} is a monster intent in Slay the Spire 2 (sts2)${desc ? `: ${desc}` : "."}`,
     );
     return {
       title,

--- a/frontend/app/keywords/[id]/KeywordDetail.tsx
+++ b/frontend/app/keywords/[id]/KeywordDetail.tsx
@@ -7,6 +7,7 @@ import type { Card } from "@/lib/api";
 import FullCardGrid from "@/app/components/FullCardGrid";
 import RichDescription from "@/app/components/RichDescription";
 import SearchFilter from "@/app/components/SearchFilter";
+import EntityProse from "@/app/components/EntityProse";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import "../../card-revamp.css";
@@ -187,6 +188,9 @@ export default function KeywordDetail({ initialResult }: { initialResult?: Initi
             />
 
             <FullCardGrid cards={filtered} />
+
+            {/* Programmatic prose block for SEO */}
+            <EntityProse kind="keyword" keyword={keyword} />
           </section>
         </main>
       </div>

--- a/frontend/app/keywords/[id]/page.tsx
+++ b/frontend/app/keywords/[id]/page.tsx
@@ -33,9 +33,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const desc = stripTagsFlat(data.description);
 
   if (type === "keyword") {
-    const title = `Keyword - ${data.name} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${data.name} - Slay the Spire 2 Keyword | Spire Codex`;
     const metaDesc = clipMetaDescription(
-      `Slay the Spire 2 card keyword, ${data.name}${desc ? `: ${desc}` : ""} See every card that uses ${data.name}.`,
+      `${data.name} is a card keyword in Slay the Spire 2 (sts2)${desc ? `: ${desc}` : "."} See every card that uses ${data.name}.`,
     );
     return {
       title,
@@ -53,9 +53,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
   }
 
-  const title = `Term - ${data.name} - Slay the Spire 2 (sts2) | Spire Codex`;
+  const title = `${data.name} - Slay the Spire 2 Term | Spire Codex`;
   const metaDesc = clipMetaDescription(
-    `Slay the Spire 2 game term, ${data.name}${desc ? `: ${desc}` : ""}`,
+    `${data.name} is a game term in Slay the Spire 2 (sts2)${desc ? `: ${desc}` : "."}`,
   );
   return {
     title,

--- a/frontend/app/modifiers/[id]/ModifierDetail.tsx
+++ b/frontend/app/modifiers/[id]/ModifierDetail.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
+import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import "../../card-revamp.css";
 import "../../reference-extra.css";
@@ -81,6 +82,9 @@ export default function ModifierDetail({ initialModifier }: { initialModifier?: 
             <div className="desc-quote">
               <RichDescription text={modifier.description} />
             </div>
+
+            {/* Programmatic prose block for SEO */}
+            <EntityProse kind="modifier" modifier={modifier} />
           </section>
 
           <section id="history">

--- a/frontend/app/modifiers/[id]/page.tsx
+++ b/frontend/app/modifiers/[id]/page.tsx
@@ -16,9 +16,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Modifier Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const modifier = await res.json();
     const desc = stripTagsFlat(modifier.description || "");
-    const title = `Modifier - ${modifier.name} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${modifier.name} - Slay the Spire 2 Modifier | Spire Codex`;
     const metaDesc = clipMetaDescription(
-      `Slay the Spire 2 custom-run modifier, ${modifier.name}${desc ? `: ${desc}` : ""}`,
+      `${modifier.name} is a custom-run modifier in Slay the Spire 2 (sts2)${desc ? `: ${desc}` : "."}`,
     );
     return {
       title,

--- a/frontend/app/monster-encounter-extra.css
+++ b/frontend/app/monster-encounter-extra.css
@@ -42,3 +42,20 @@
 .card-rvmp .badge { font-family: var(--mono); font-size: 11px; padding: 2px 8px; border-radius: 999px;
   border: 1px solid var(--border-2); color: var(--text-2); }
 .card-rvmp .chip .cn { color: var(--text); }
+
+/* ── monster overview lead prose (rendered right under the hero) ── */
+.card-rvmp .mon-lead { max-width: 64ch; margin: 2px 0 8px; font-size: 15px; line-height: 1.65; color: var(--text-2); }
+.card-rvmp .mon-lead p { margin: 0 0 10px; }
+.card-rvmp .mon-lead p:last-child { margin-bottom: 0; }
+
+/* ── readable per-move effect line (English only, sits above the numeric rows) ── */
+.card-rvmp .move-effect { font-size: 14px; line-height: 1.5; color: var(--text-2); margin: 0 0 10px; }
+
+/* ── attack-pattern move sequence (localized move-name chips, shown in every language) ── */
+.card-rvmp .atk-seq { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin-top: 12px; }
+.card-rvmp .atk-step-wrap { display: inline-flex; align-items: center; gap: 6px; }
+.card-rvmp .atk-step { font-family: var(--mono); font-size: 12px; padding: 4px 10px; border-radius: 999px;
+  border: 1px solid var(--border-2); background: var(--surface-2); color: var(--text); white-space: nowrap; }
+.card-rvmp .atk-arrow { color: var(--text-3); font-size: 13px; }
+.card-rvmp .atk-repeat { font-family: var(--mono); font-size: 13px; padding: 4px 8px; border-radius: 999px;
+  border: 1px dashed var(--border-2); color: var(--text-3); }

--- a/frontend/app/monsters/[id]/MonsterDetail.tsx
+++ b/frontend/app/monsters/[id]/MonsterDetail.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, type MouseEvent as ReactMouseEvent, type CSSProperties } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import type { Monster, MonsterMove, MonsterMovePower, Power } from "@/lib/api";
+import type { Monster, MonsterMove, MonsterMovePower, Power, AttackPattern } from "@/lib/api";
 import type { EncounterStat } from "@/lib/encounter-stats";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
@@ -12,6 +12,7 @@ import { t } from "@/lib/ui-translations";
 import RichDescription from "@/app/components/RichDescription";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
+import EntityProse from "@/app/components/EntityProse";
 import { imageUrl } from "@/lib/image-url";
 import "../../card-revamp.css";
 import "../../monster-encounter-extra.css";
@@ -119,16 +120,101 @@ function PowerPill({
   );
 }
 
+// Title-case a raw id ("EYE_LASERS" -> "Eye Lasers").
+function titleCaseId(id: string): string {
+  return id.replace(/_/g, " ").toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// A plain-English, one-line summary of what a move does, built from its
+// structured fields (damage / block / heal / applied powers). English only —
+// non-English monster pages skip it to avoid duplicating boilerplate across
+// the localized variants (same policy as EntityProse). Falls back to an
+// intent-derived line for moves that carry no numbers or powers.
+function describeMove(move: MonsterMove, powerData: Record<string, Power>): string | null {
+  const clauses: string[] = [];
+  const d = move.damage;
+  if (d && d.normal != null) {
+    const multi = !!(d.hit_count && d.hit_count > 1);
+    const base = multi
+      ? `hits ${d.hit_count} times for ${d.normal} (${d.normal * d.hit_count!} total)`
+      : `hits for ${d.normal}`;
+    const asc =
+      d.ascension != null && d.ascension !== d.normal
+        ? ` (${multi ? `${d.ascension}×${d.hit_count} = ${d.ascension * d.hit_count!}` : d.ascension} on Ascension)`
+        : "";
+    clauses.push(`${base} damage${asc}`);
+  }
+  if (move.block != null) clauses.push(`gains ${move.block} Block`);
+  if (move.heal != null) clauses.push(`heals ${move.heal} HP`);
+  for (const p of move.powers || []) {
+    const nm = powerData[p.power_id]?.name || titleCaseId(p.power_id);
+    clauses.push(`${p.target === "player" ? "applies" : "gains"} ${p.amount} ${nm}`);
+  }
+  if (clauses.length === 0) {
+    // No numbers or powers parsed — lean on the intent so the move still reads.
+    const intent = (move.intent || "").toLowerCase();
+    if (intent.includes("debuff")) return "Applies a debuff to you.";
+    if (intent.includes("buff")) return "Strengthens itself with a buff.";
+    if (intent.includes("defend")) return "Braces behind Block.";
+    if (intent.includes("status")) return "Adds a status effect.";
+    if (intent.includes("escape")) return "Prepares to flee the fight.";
+    return null;
+  }
+  const joined =
+    clauses.length === 1
+      ? clauses[0]
+      : clauses.length === 2
+        ? `${clauses[0]} and ${clauses[1]}`
+        : `${clauses.slice(0, -1).join(", ")}, and ${clauses[clauses.length - 1]}`;
+  return joined.charAt(0).toUpperCase() + joined.slice(1) + ".";
+}
+
+// Ordered list of move display names for an attack pattern, so it can render
+// as a visible sequence of chips. Follows the state machine's `next` links for
+// a cycle; for other pattern types, lists the distinct moves it can pick.
+function patternSteps(pattern: AttackPattern, moves: MonsterMove[]): string[] {
+  const states = pattern.states || [];
+  if (states.length === 0) return [];
+  const nameOf = (mid: string) => moves.find((m) => m.id === mid)?.name || titleCaseId(mid);
+
+  if (pattern.type === "cycle") {
+    const byId = new Map(states.map((s) => [s.id, s]));
+    const start =
+      states.find((s) => s.move_id === pattern.initial_move) || states.find((s) => s.move_id) || states[0];
+    const seen = new Set<string>();
+    const out: string[] = [];
+    let cur: typeof start | undefined = start;
+    while (cur && !seen.has(cur.id)) {
+      seen.add(cur.id);
+      if (cur.move_id) out.push(nameOf(cur.move_id));
+      cur = cur.next ? byId.get(cur.next) : undefined;
+    }
+    // Guard against a malformed chain that skipped most states.
+    if (out.length >= 2) return out;
+  }
+
+  // random / conditional / mixed (or a broken cycle): unique moves it can use.
+  const ids: string[] = [];
+  for (const s of states) {
+    if (s.move_id) ids.push(s.move_id);
+    for (const b of s.branches || []) if (b.move_id) ids.push(b.move_id);
+  }
+  return [...new Set(ids)].map(nameOf);
+}
+
 function MoveCard({
   move,
   powerData,
   lp,
+  isEnglish,
 }: {
   move: MonsterMove;
   powerData: Record<string, Power>;
   lp: string;
+  isEnglish: boolean;
 }) {
   const intentParts = (move.intent || "Unknown").split(" + ");
+  const effect = isEnglish ? describeMove(move, powerData) : null;
 
   return (
     <div className="move">
@@ -146,6 +232,9 @@ function MoveCard({
           ))}
         </div>
       </div>
+
+      {/* Plain-English effect summary (English pages only) */}
+      {effect && <p className="move-effect">{effect}</p>}
 
       {/* Move details */}
       <div className="mstats">
@@ -315,10 +404,26 @@ export default function MonsterDetail({
     );
   }
 
+  const isEnglish = lang === "eng";
+
   // Derive acts from encounters
   const acts = monster.encounters
     ? [...new Set(monster.encounters.filter(e => e.act).map(e => e.act!))]
     : [];
+
+  // The single deadliest encounter this monster shows up in (highest kill
+  // rate), fed to the overview prose as our own unique community data.
+  const deadliest = (() => {
+    if (!encounterStats?.length || !monster.encounters?.length) return null;
+    let best: { name: string; killRate: number } | null = null;
+    for (const enc of monster.encounters) {
+      const s = encounterStats.find((x) => x.encounter_id === enc.encounter_id);
+      if (!s || !s.total) continue;
+      const killRate = (s.fatal / s.total) * 100;
+      if (!best || killRate > best.killRate) best = { name: enc.encounter_name, killRate };
+    }
+    return best;
+  })();
 
   const spineColor = SPINE_BY_TYPE[monster.type] ?? "var(--color-silent)";
   const heroSrc = betaArt && monster.beta_image_url ? monster.beta_image_url : monster.image_url;
@@ -372,6 +477,9 @@ export default function MonsterDetail({
             </p>
             <h1>{monster.name}</h1>
           </div>
+
+          {/* Overview prose (unique, data-derived intro under the H1) */}
+          <EntityProse kind="monster" monster={monster} deadliest={deadliest} />
 
           {/* Sticky ToC */}
           <nav className="toc" aria-label={t("On this page", lang)}>
@@ -441,13 +549,33 @@ export default function MonsterDetail({
                 </>
               )}
 
-              {/* Attack Pattern */}
-              {monster.attack_pattern && (
-                <>
-                  <h3 className="subh">Attack Pattern</h3>
-                  <p className="desc-body">{monster.attack_pattern.description}</p>
-                </>
-              )}
+              {/* Attack Pattern — text description plus a visible move sequence.
+                  The sequence chips use localized move names, so they render in
+                  every language even when the English description is thin. */}
+              {monster.attack_pattern && (() => {
+                const steps = patternSteps(monster.attack_pattern!, monster.moves || []);
+                const desc = monster.attack_pattern!.description;
+                const isCycle = monster.attack_pattern!.type === "cycle";
+                return (
+                  <>
+                    <h3 className="subh">Attack Pattern</h3>
+                    {desc && <p className="desc-body">{desc}</p>}
+                    {steps.length > 1 && (
+                      <div className="atk-seq">
+                        {steps.map((s, i) => (
+                          <span key={i} className="atk-step-wrap">
+                            <span className="atk-step">{s}</span>
+                            {i < steps.length - 1 && <span className="atk-arrow">→</span>}
+                          </span>
+                        ))}
+                        {isCycle && (
+                          <span className="atk-repeat" title={t("Repeats", lang)}>↻</span>
+                        )}
+                      </div>
+                    )}
+                  </>
+                );
+              })()}
             </section>
           )}
 
@@ -457,7 +585,7 @@ export default function MonsterDetail({
               <h2>{t("Moves", lang)} ({monster.moves!.length})</h2>
               <div className="moves">
                 {monster.moves!.map((move) => (
-                  <MoveCard key={move.id} move={move} powerData={powerData} lp={lp} />
+                  <MoveCard key={move.id} move={move} powerData={powerData} lp={lp} isEnglish={isEnglish} />
                 ))}
               </div>
             </section>

--- a/frontend/app/monsters/[id]/MonsterDetail.tsx
+++ b/frontend/app/monsters/[id]/MonsterDetail.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, type MouseEvent as ReactMouseEvent, type C
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import type { Monster, MonsterMove, MonsterMovePower, Power } from "@/lib/api";
+import type { EncounterStat } from "@/lib/encounter-stats";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
@@ -201,7 +202,10 @@ function MoveCard({
   );
 }
 
-export default function MonsterDetail({ initialMonster }: { initialMonster?: Monster | null } = {}) {
+export default function MonsterDetail({
+  initialMonster,
+  encounterStats,
+}: { initialMonster?: Monster | null; encounterStats?: EncounterStat[] } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
@@ -464,6 +468,26 @@ export default function MonsterDetail({ initialMonster }: { initialMonster?: Mon
             <section id="encounters">
               <h2>{t("Encounters", lang)}</h2>
               <p className="h-note">Where {monster.name} shows up.</p>
+              {encounterStats && encounterStats.length > 0 && (
+                <div className="enc-deadliness">
+                  {monster.encounters!.map((enc) => {
+                    const s = encounterStats.find(
+                      (x) => x.encounter_id === enc.encounter_id,
+                    );
+                    if (!s || !s.total) return null;
+                    const killRate = (s.fatal / s.total) * 100;
+                    return (
+                      <p key={enc.encounter_id} className="stat-note">
+                        In {s.total.toLocaleString()} community runs, the{" "}
+                        <b>{enc.encounter_name}</b> fight was fatal to{" "}
+                        <b>{killRate.toFixed(1)}%</b> of runs ({s.fatal.toLocaleString()}),
+                        dealing an average of <b>{s.avg_damage}</b> damage over{" "}
+                        <b>{s.avg_turns}</b> turns.
+                      </p>
+                    );
+                  })}
+                </div>
+              )}
               <div className="enc-list">
                 {monster.encounters!.map((enc) => (
                   <Link

--- a/frontend/app/monsters/[id]/page.tsx
+++ b/frontend/app/monsters/[id]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import MonsterDetail from "./MonsterDetail";
+import { fetchEncounterStats } from "@/lib/encounter-stats";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { clipMetaDescription, buildLanguageAlternates, SITE_NAME, SITE_URL } from "@/lib/seo";
@@ -78,10 +79,16 @@ export default async function Page({ params }: Props) {
       jsonLd = [...detailJsonLd, buildFAQPageJsonLd(faqQuestions)];
     }
   } catch {}
+  // Server-render the community "how deadly" stats for this monster's fights.
+  const encounterStats = monster?.encounters?.length
+    ? await fetchEncounterStats(
+        monster.encounters.map((e: { encounter_id: string }) => e.encounter_id),
+      )
+    : [];
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <MonsterDetail initialMonster={monster} />
+      <MonsterDetail initialMonster={monster} encounterStats={encounterStats} />
     </>
   );
 }

--- a/frontend/app/monsters/[id]/page.tsx
+++ b/frontend/app/monsters/[id]/page.tsx
@@ -23,10 +23,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const monster = await res.json();
     const hpText = monster.min_hp ? `${monster.min_hp}${monster.max_hp && monster.max_hp !== monster.min_hp ? `\u2013${monster.max_hp}` : ""} HP` : "";
     const desc = `${monster.type} monster${hpText ? ` \u00b7 ${hpText}` : ""}`;
-    const title = `Monster - ${monster.name} - ${monster.type} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${monster.name} - Slay the Spire 2 ${monster.type} | Spire Codex`;
     const movesText = monster.moves?.length ? `${monster.moves.length} known moves.` : "";
     const metaDesc = clipMetaDescription(
-      `Slay the Spire 2 ${monster.type} monster, ${monster.name}.${hpText ? ` ${hpText}.` : ""}${movesText ? ` ${movesText}` : ""}`,
+      `${monster.name} is a ${monster.type} in Slay the Spire 2 (sts2).${hpText ? ` ${hpText}.` : ""}${movesText ? ` ${movesText}` : ""}`,
     );
     return {
       title,

--- a/frontend/app/news/page.tsx
+++ b/frontend/app/news/page.tsx
@@ -15,13 +15,17 @@ export const revalidate = 1800;
 // Meta follows the standard `Slay the Spire 2 {Topic} - {Descriptor} | Spire Codex`
 // format used across the rest of the site (see /changelog, /cards, /relics, etc.).
 // The visible page tagline below is separate marketing copy.
+// Lead with the query people actually type ("slay the spire 2 patch notes",
+// "sts2 patch notes / updates") rather than a generic "News -".
+const NEWS_TITLE = `Slay the Spire 2 Patch Notes & Updates (sts2) | ${SITE_NAME}`;
+
 export const metadata: Metadata = {
-  title: `News - Patch Notes & Announcements - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
+  title: NEWS_TITLE,
   description:
     "Slay the Spire 2 (sts2) patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
   alternates: { canonical: `${SITE_URL}/news`, languages: buildLanguageAlternates("/news") },
   openGraph: {
-    title: `News - Patch Notes & Announcements - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
+    title: NEWS_TITLE,
     description:
       "Slay the Spire 2 (sts2) patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
     url: `${SITE_URL}/news`,
@@ -31,7 +35,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: `News - Patch Notes & Announcements - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
+    title: NEWS_TITLE,
     description: "Slay the Spire 2 (sts2) patch notes, dev announcements, and press coverage. Track every Mega Crit update plus external articles from PCGamesN, RPS, and more.",
     images: [DEFAULT_OG_IMAGE],
   },
@@ -73,6 +77,7 @@ export default async function NewsPage({
   const tabConfig = TABS.find((t) => t.key === activeTab) ?? TABS[0];
   const data = await loadNews(tabConfig.feedType);
   const items = data.items;
+  const latest = items[0];
 
   const jsonLd = [
     buildBreadcrumbJsonLd([
@@ -91,11 +96,12 @@ export default async function NewsPage({
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-[var(--accent-gold)]">News</span>
+        <span className="text-[var(--accent-gold)]">Slay the Spire 2</span> Patch Notes &amp; News
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-6">
-        Patch notes, dev updates, and community announcements from Mega Crit, plus press
-        coverage. Mirrored from Steam, read each post in full or follow the original link.
+        Every Slay the Spire 2 (sts2) patch note, dev update, and announcement from Mega Crit,
+        mirrored from Steam the moment it posts, plus press coverage from PCGamesN, RPS, and more.
+        {latest ? ` The most recent update is ${latest.title} (${formatNewsDate(latest.date)}).` : ""}
       </p>
 
       {/* Tabs, Community is the default; Press surfaces external coverage */}

--- a/frontend/app/orbs/[id]/OrbDetail.tsx
+++ b/frontend/app/orbs/[id]/OrbDetail.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
+import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { imageUrl } from "@/lib/image-url";
 import "../../card-revamp.css";
@@ -87,6 +88,9 @@ export default function OrbDetail({ initialOrb }: { initialOrb?: Orb | null } = 
             <div className="desc-quote">
               <RichDescription text={orb.description} />
             </div>
+
+            {/* Programmatic prose block for SEO */}
+            <EntityProse kind="orb" orb={orb} />
           </section>
 
           {hasRelations && (

--- a/frontend/app/orbs/[id]/page.tsx
+++ b/frontend/app/orbs/[id]/page.tsx
@@ -16,9 +16,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Orb Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const orb = await res.json();
     const desc = stripTagsFlat(orb.description || "");
-    const title = `Orb - ${orb.name} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${orb.name} - Slay the Spire 2 Orb | Spire Codex`;
     const metaDesc = clipMetaDescription(
-      `Slay the Spire 2 orb, ${orb.name}${desc ? `: ${desc}` : ""}`,
+      `${orb.name} is an orb in Slay the Spire 2 (sts2)${desc ? `: ${desc}` : "."}`,
     );
     return {
       title,

--- a/frontend/app/potions/[id]/PotionDetail.tsx
+++ b/frontend/app/potions/[id]/PotionDetail.tsx
@@ -12,7 +12,7 @@ import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import RelatedItems from "@/app/components/RelatedItems";
 import EntityProse from "@/app/components/EntityProse";
-import EntityRunStats from "@/app/components/EntityRunStats";
+import EntityRunStats, { type EntityStats } from "@/app/components/EntityRunStats";
 import { imageUrl } from "@/lib/image-url";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import "../../card-revamp.css";
@@ -43,7 +43,10 @@ interface MiniStats {
   elo: number | null;
 }
 
-export default function PotionDetail({ initialPotion }: { initialPotion?: Potion | null } = {}) {
+export default function PotionDetail({
+  initialPotion,
+  initialStats,
+}: { initialPotion?: Potion | null; initialStats?: EntityStats | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
@@ -195,6 +198,7 @@ export default function PotionDetail({ initialPotion }: { initialPotion?: Potion
               entityId={id}
               entityName={potion.name}
               variant="wiki"
+              initialStats={initialStats}
             />
           </section>
 

--- a/frontend/app/potions/[id]/page.tsx
+++ b/frontend/app/potions/[id]/page.tsx
@@ -18,9 +18,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Potion Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const potion = await res.json();
     const desc = stripTagsFlat(potion.description || "");
-    const title = `Potion - ${potion.name} - ${potion.rarity} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${potion.name} - Slay the Spire 2 ${potion.rarity} Potion | Spire Codex`;
     const metaDesc = clipMetaDescription(
-      `Slay the Spire 2 ${potion.rarity} potion, ${potion.name}${desc ? `: ${desc}` : ""}`,
+      `${potion.name} is a ${potion.rarity} potion in Slay the Spire 2 (sts2)${desc ? `: ${desc}` : "."}`,
     );
     return {
       title,

--- a/frontend/app/potions/[id]/page.tsx
+++ b/frontend/app/potions/[id]/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import PotionDetail from "./PotionDetail";
+import type { EntityStats } from "@/app/components/EntityRunStats";
+import { fetchEntityStats } from "@/lib/entity-stats";
 import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates, SITE_NAME, SITE_URL } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
@@ -73,10 +75,12 @@ export default async function Page({ params }: Props) {
     apiUnreachable = true;
   }
   if (!potion && !apiUnreachable) redirectMissingEntity("potions", id);
+  // Server-render the community stats into the HTML (unique, crawlable data).
+  const initialStats: EntityStats | null = potion ? await fetchEntityStats("potions", id) : null;
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <PotionDetail initialPotion={potion} />
+      <PotionDetail initialPotion={potion} initialStats={initialStats} />
     </>
   );
 }

--- a/frontend/app/powers/[id]/page.tsx
+++ b/frontend/app/powers/[id]/page.tsx
@@ -18,9 +18,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Power Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const power = await res.json();
     const desc = stripTagsFlat(power.description || "");
-    const title = `Power - ${power.name} - ${power.type} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${power.name} - Slay the Spire 2 ${power.type} Power | Spire Codex`;
     const metaDesc = clipMetaDescription(
-      `Slay the Spire 2 ${power.type} power, ${power.name}${desc ? `: ${desc}` : ""}`,
+      `${power.name} is a ${power.type} power in Slay the Spire 2 (sts2)${desc ? `: ${desc}` : "."}`,
     );
     return {
       title,

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -12,7 +12,7 @@ import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import RelatedItems from "@/app/components/RelatedItems";
 import EntityProse from "@/app/components/EntityProse";
-import EntityRunStats from "@/app/components/EntityRunStats";
+import EntityRunStats, { type EntityStats } from "@/app/components/EntityRunStats";
 import { imageUrl } from "@/lib/image-url";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import BetaDiffNotice from "@/app/components/BetaDiffNotice";
@@ -31,7 +31,10 @@ interface MiniStats {
   elo: number | null;
 }
 
-export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | null } = {}) {
+export default function RelicDetail({
+  initialRelic,
+  initialStats,
+}: { initialRelic?: Relic | null; initialStats?: EntityStats | null } = {}) {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { lang } = useLanguage();
@@ -199,6 +202,7 @@ export default function RelicDetail({ initialRelic }: { initialRelic?: Relic | n
               entityId={id}
               entityName={relic.name}
               variant="wiki"
+              initialStats={initialStats}
             />
           </section>
 

--- a/frontend/app/relics/[id]/page.tsx
+++ b/frontend/app/relics/[id]/page.tsx
@@ -26,9 +26,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (!res.ok) return { title: "Relic Not Found - Slay the Spire 2 (sts2) | Spire Codex" };
     const relic = await res.json();
     const desc = stripTagsFlat(relic.description || "");
-    const title = `Relic - ${relic.name} - ${relic.rarity} - Slay the Spire 2 (sts2) | Spire Codex`;
+    const title = `${relic.name} - Slay the Spire 2 ${relic.rarity} Relic | Spire Codex`;
     const metaDesc = clipMetaDescription(
-      `Slay the Spire 2 ${relic.rarity} relic, ${relic.name}${desc ? `: ${desc}` : ""}`,
+      `${relic.name} is a ${relic.rarity} relic in Slay the Spire 2 (sts2)${desc ? `: ${desc}` : "."}`,
     );
     return {
       title,

--- a/frontend/app/relics/[id]/page.tsx
+++ b/frontend/app/relics/[id]/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import RelicDetail from "./RelicDetail";
+import type { EntityStats } from "@/app/components/EntityRunStats";
+import { fetchEntityStats } from "@/lib/entity-stats";
 import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates, SITE_NAME, SITE_URL } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
@@ -84,10 +86,12 @@ export default async function Page({ params }: Props) {
     apiUnreachable = true;
   }
   if (!relic && !apiUnreachable) redirectMissingEntity("relics", id);
+  // Server-render the community stats into the HTML (unique, crawlable data).
+  const initialStats: EntityStats | null = relic ? await fetchEntityStats("relics", id) : null;
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <RelicDetail initialRelic={relic} />
+      <RelicDetail initialRelic={relic} initialStats={initialStats} />
     </>
   );
 }

--- a/frontend/app/tier-list/cards/page.tsx
+++ b/frontend/app/tier-list/cards/page.tsx
@@ -92,7 +92,7 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
   const scope = charLabel && color ? `${charLabel} Cards` : "Cards";
   // Title leads with STS2 abbreviation + full game name to capture both
   // query phrasings ("sts2 tier list" vs "slay the spire 2 tier list").
-  const title = `${scope} Tier List - Cards Ranked - Slay the Spire 2 (sts2) | ${SITE_NAME}`;
+  const title = `${scope} Tier List - Slay the Spire 2 (sts2) | ${SITE_NAME}`;
   const description = color
     ? `${charLabel} card tier list for Slay the Spire 2 (sts2). Every ${charLabel?.toLowerCase()} card ranked S through F based on community win-rate data.`
     : "Every Slay the Spire 2 (sts2) card ranked S through F. Tier list driven by Codex Score, community-submitted run win rates with Bayesian shrinkage.";

--- a/frontend/app/tier-list/relics/page.tsx
+++ b/frontend/app/tier-list/relics/page.tsx
@@ -86,7 +86,7 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
   const poolLabel = POOL_FILTERS.find((p) => p.value === pool)?.label;
   const actPrefix = act ? `Act ${act} ` : "";
   const scope = poolLabel && pool ? `${actPrefix}${poolLabel} Relic` : `${actPrefix}Relic`;
-  const title = `${scope} Tier List - Relics Ranked - Slay the Spire 2 (sts2) | ${SITE_NAME}`;
+  const title = `${scope} Tier List - Slay the Spire 2 (sts2) | ${SITE_NAME}`;
   const description = act
     ? `Slay the Spire 2 (sts2) relics ranked by the win rate of runs that picked them up in Act ${act}, graded against other Act ${act} pickups.`
     : pool

--- a/frontend/lib/encounter-stats.ts
+++ b/frontend/lib/encounter-stats.ts
@@ -1,0 +1,41 @@
+const API_INTERNAL =
+  process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export interface EncounterStat {
+  encounter_id: string;
+  encounter_name?: string;
+  room_type?: string;
+  act?: number | string;
+  total: number;
+  fatal: number;
+  avg_damage: number;
+  avg_turns: number;
+}
+
+/**
+ * Community "how deadly is this fight" numbers for a monster's encounters, so
+ * the kill rate / avg damage / avg turns render into the SSR HTML — unique data
+ * no wiki has. Sourced from /api/runs/encounter-stats (top ~200 encounters by
+ * volume, which covers the notable monsters). Next dedupes the fetch across all
+ * monster pages. Returns [] for encounters outside the top set, so the section
+ * just hides for rarely-fought monsters.
+ */
+export async function fetchEncounterStats(
+  encounterIds: string[],
+): Promise<EncounterStat[]> {
+  if (!encounterIds?.length) return [];
+  try {
+    const res = await fetch(`${API_INTERNAL}/api/runs/encounter-stats?limit=200`, {
+      next: { revalidate: 600 },
+    });
+    if (!res.ok) return [];
+    const data = (await res.json()) as { encounters?: EncounterStat[] };
+    const byId = new Map<string, EncounterStat>();
+    for (const r of data.encounters ?? []) byId.set(r.encounter_id, r);
+    return encounterIds
+      .map((id) => byId.get(id))
+      .filter((x): x is EncounterStat => !!x && x.total > 0);
+  } catch {
+    return [];
+  }
+}

--- a/frontend/lib/entity-stats.ts
+++ b/frontend/lib/entity-stats.ts
@@ -1,0 +1,32 @@
+import type { EntityStats } from "@/app/components/EntityRunStats";
+
+const API_INTERNAL =
+  process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+/**
+ * Server-side fetch of an entity's community run stats, so the numbers (win
+ * rate, pick rate, Codex Score, tier, per-character) render into the initial
+ * SSR HTML instead of a client-only "Loading" placeholder — the whole point
+ * being that this is unique data crawlers should see.
+ *
+ * Returns null on any error or for entities with no runs yet (the endpoint
+ * hands back a zero-filled stub in that case). A null just falls back to the
+ * existing client-only behaviour, since EntityRunStats still re-fetches on
+ * mount for freshness.
+ */
+export async function fetchEntityStats(
+  entityType: "relics" | "cards" | "potions",
+  entityId: string,
+): Promise<EntityStats | null> {
+  try {
+    const res = await fetch(
+      `${API_INTERNAL}/api/runs/stats/${entityType}/${entityId}`,
+      { next: { revalidate: 300 } },
+    );
+    if (!res.ok) return null;
+    const stats = (await res.json()) as EntityStats;
+    return stats && stats.picks > 0 ? stats : null;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/lib/event-votes.ts
+++ b/frontend/lib/event-votes.ts
@@ -1,0 +1,44 @@
+const API_INTERNAL =
+  process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export interface VoteOption {
+  id: string;
+  label: string;
+  count: number;
+  pct: number;
+}
+export interface EventVotes {
+  total: number;
+  options: VoteOption[];
+}
+
+interface CommunityEvent {
+  id: string;
+  name: string;
+  total: number;
+  options: VoteOption[];
+}
+
+/**
+ * How the community actually votes at one event, server-side, so the choice
+ * distribution ("33% chose Accept") renders into the SSR HTML. This is unique
+ * data no wiki has. Sourced from the existing community-stats payload (which
+ * already carries per-event choice breakdowns); Next dedupes the fetch across
+ * all event pages, so it costs one shared cached request. Returns null for
+ * events not yet tracked (beta-only, low volume) so the section just hides.
+ */
+export async function fetchEventVotes(eventId: string): Promise<EventVotes | null> {
+  try {
+    const res = await fetch(`${API_INTERNAL}/api/runs/community-stats`, {
+      next: { revalidate: 600 },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { events?: CommunityEvent[] };
+    const want = eventId.toUpperCase();
+    const ev = (data.events ?? []).find((e) => (e.id ?? "").toUpperCase() === want);
+    if (!ev || !ev.total || !ev.options?.length) return null;
+    return { total: ev.total, options: ev.options };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
A cohesive SEO batch driven by Search Console. Indexing is healthy (verified — all top pages indexed, canonicals + 14-lang hreflang correct); the real problems are **position 6-9** and the site's best data being **client-only / invisible to Google**. Three themes.

## Theme A — put the searched term first
- **Entity titles lead with the name** across ~17 templates: `Sword of Stone - Slay the Spire 2 Common Relic` (was `Relic - Sword of Stone - …`). Descriptions open with the name, keep "sts2".
- **/news targets "patch notes"** (11k impressions at pos ~7.9): title/H1/intro now lead with "Slay the Spire 2 Patch Notes", plus a live latest-update line.
- **Tier-list titles tightened** (drop the redundant "- Cards/Relics Ranked").

## Theme B — put the *unique* community data into the crawlable HTML
This is the differentiator vs the fandom wiki, and it was all client-only ("Loading run stats"). Now server-fetched and rendered into the SSR HTML:
- **Cards / relics / potions** — win rate, pick rate, Codex Score, tier (`lib/entity-stats.ts`, passed as `initialStats`).
- **Events** — how the community actually votes ("33% chose Accept" across 297k runs) in the Choices section (`lib/event-votes.ts`).
- **Monsters** — how deadly each fight is ("Waterfall Giant: fatal to 14.7% of runs, 46.9 avg damage over 10.3 turns") in the Encounters section (`lib/encounter-stats.ts`).

## Theme C — flesh out every entity page with data-derived prose
Most detail pages had thin bodies (a name and a one-line description), which reads as thin content. Every entity type now renders a short overview block built from its own fields through one shared `EntityProse` component, server-side, from data the page already loads (no new fetches):
- **Monsters** — overview under the H1 (HP, attack pattern, heaviest hit, innate powers, community kill rate), a plain-English effect line per move built from its damage/block/heal/applied powers, and the attack pattern shown as an ordered move-name sequence (rebuilt from the state machine when the description is thin).
- **Cards** — rarity/type/character, cost, derived effect, keywords. **Characters** — starting HP/gold/energy, deck, relics, orb slots, unlock. **Events** — type/act/choice count. **Encounters** — room/act/foes. **Orbs** — channel sources. **Acts** — room/boss/encounter/event counts. Reference entities (enchantments, keywords, intents, modifiers, afflictions, achievements, ascensions) get a short factual definition to clear the thin-content floor.

The generated prose is English-only with a localized single-line fallback (same policy across the board), so the 14 language variants stay distinct and don't read as duplicate content — the issue that had dumped ~7k localized pages into "crawled, not indexed". `tsc` + `eslint` clean; content spot-checked against live prod data for every variant.

Net effect: the searched term leads every title (CTR), Google finally sees the win rates, vote splits, and kill rates no competitor has, and no detail page is left thin — a real reason to rank these above the wiki.