### PR TITLE
Fix the run export 500 on legacy string submitted_at

### DIFF
--- a/backend/app/routers/exports.py
+++ b/backend/app/routers/exports.py
@@ -67,8 +67,20 @@ def _parse_iso(value: str, field: str) -> datetime:
 
 def _encode_cursor(submitted_at, run_hash: str) -> str:
     """Encode a keyset position as an opaque, URL-safe token. Runs missing a
-    submitted_at sort first, encoded with an empty timestamp."""
-    sa = submitted_at.isoformat() if submitted_at is not None else ""
+    submitted_at sort first, encoded with an empty timestamp.
+
+    submitted_at is normally a datetime (or None). Legacy runs imported from the
+    old SQLite store can still hold it as a string, which has no isoformat() and
+    used to crash here, 500-ing the whole page. Coerce anything non-datetime to
+    text so a page boundary never raises. tools/backfill_run_submitted_at.py
+    converts those strings to real dates so the keyset walk covers the whole
+    corpus; until it runs, such a boundary just reads as its raw timestamp."""
+    if submitted_at is None:
+        sa = ""
+    elif hasattr(submitted_at, "isoformat"):
+        sa = submitted_at.isoformat()
+    else:
+        sa = str(submitted_at)
     return base64.urlsafe_b64encode(f"{sa}|{run_hash}".encode("utf-8")).decode("ascii")
 
 

--- a/tools/backfill_run_submitted_at.py
+++ b/tools/backfill_run_submitted_at.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Backfill: normalize legacy string ``submitted_at`` values on run docs to dates.
+
+The keyset run export (GET /api/exports/runs) orders runs by
+``(submitted_at, _id)`` and encodes each page boundary from ``submitted_at``.
+Runs imported from the old SQLite store kept ``submitted_at`` as a *string*,
+which sorts ahead of the real date-typed runs (BSON orders string before date)
+and used to crash cursor encoding. Converting them to real BSON dates puts the
+whole corpus in one clean order so a paged export walks every run.
+
+Safe to re-run: it only touches docs whose ``submitted_at`` is still a string.
+The runs validator is ``moderate``, so it spares these currently-invalid docs
+and the $set is allowed.
+
+Dry-run by default; pass --apply to write. Reads MONGO_URL from the env:
+
+    MONGO_URL='mongodb://app:<pass>@<host>:27017/spire_codex?authSource=admin' \\
+        python tools/backfill_run_submitted_at.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+
+try:
+    from pymongo import MongoClient, UpdateOne
+except ImportError:
+    print("pymongo is required (pip install pymongo)", file=sys.stderr)
+    raise
+
+
+def _parse(value: str) -> datetime | None:
+    """Parse a legacy submitted_at string into an aware UTC datetime, or None if
+    it can't be parsed. SQLite CURRENT_TIMESTAMP is 'YYYY-MM-DD HH:MM:SS' (UTC),
+    which datetime.fromisoformat accepts."""
+    try:
+        dt = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--apply", action="store_true", help="write changes (default: dry-run)"
+    )
+    p.add_argument("--batch", type=int, default=1000, help="bulk-write batch size")
+    args = p.parse_args()
+
+    mongo_url = os.environ.get("MONGO_URL")
+    if not mongo_url:
+        print("MONGO_URL env var required", file=sys.stderr)
+        return 1
+
+    coll = MongoClient(mongo_url).get_default_database().runs
+    query = {"submitted_at": {"$type": "string"}}
+    total = coll.count_documents(query)
+    print(f"{total} run(s) with a string submitted_at")
+    if total == 0:
+        return 0
+
+    converted = skipped = 0
+    ops: list[UpdateOne] = []
+    for doc in coll.find(query, {"submitted_at": 1}):
+        dt = _parse(doc["submitted_at"])
+        if dt is None:
+            skipped += 1
+            continue
+        converted += 1
+        if args.apply:
+            ops.append(UpdateOne({"_id": doc["_id"]}, {"$set": {"submitted_at": dt}}))
+            if len(ops) >= args.batch:
+                coll.bulk_write(ops, ordered=False)
+                ops = []
+    if args.apply and ops:
+        coll.bulk_write(ops, ordered=False)
+
+    verb = "converted" if args.apply else "would convert"
+    print(f"{verb}: {converted}   unparseable (left as-is): {skipped}")
+    if not args.apply:
+        print("dry-run only; re-run with --apply to write")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`GET /api/exports/runs?limit=1` was returning **500** on prod. Root cause: the keyset export encodes each page boundary from `submitted_at` via `.isoformat()`, but runs imported from the old SQLite store still hold `submitted_at` as a **string** (no `isoformat`). Those legacy runs sort first in ascending `(submitted_at, _id)` order, so the very first page always landed on one and crashed.

Confirmed against prod:
- `?limit=1` -> 500 in ~0.15s (fast crash, not a timeout)
- `?limit=1&start=2026-07-01T00:00:00Z` -> 200 with a valid `X-Next-Cursor` (the window only matches date-typed runs, so it skips the legacy strings)

## Changes
- **`_encode_cursor`** now coerces any non-datetime `submitted_at` to text instead of calling `.isoformat()` on it, so a page boundary can't 500 the endpoint. This alone gets `?limit=` responding again on deploy.
- **`tools/backfill_run_submitted_at.py`** converts the legacy string values to real BSON dates. Dry-run by default (`--apply` to write); safe to re-run (only touches `{submitted_at: {$type: "string"}}`, which the `moderate` validator spares). Once it runs, every run shares one clean `(submitted_at, _id)` order so a paged bootstrap walks the whole corpus instead of skipping the legacy block.

The backfill is a data migration, so it's yours to run against prod when ready:
```
MONGO_URL=... python tools/backfill_run_submitted_at.py          # dry-run, reports counts
MONGO_URL=... python tools/backfill_run_submitted_at.py --apply  # write
```

(Separately, the bare unbounded `/api/exports/runs` with no `limit` is still a heavy full-corpus dump that can time out at the gateway — the paged form is the intended path for large pulls.)