### PR TITLE
Hide the uninstall-feedback endpoint from the API docs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -576,7 +576,7 @@ app.include_router(images.router)
 app.include_router(changelogs.router)
 # Hidden from the OpenAPI schema (/docs): feedback intake endpoints.
 app.include_router(feedback.router, include_in_schema=False)
-app.include_router(uninstall.router)
+app.include_router(uninstall.router, include_in_schema=False)
 app.include_router(qa_feedback.router, include_in_schema=False)
 app.include_router(acts.router)
 app.include_router(ascensions.router)


### PR DESCRIPTION
Follow-up to #595: also sets `include_in_schema=False` on the `uninstall` router so `/api/uninstall-feedback` drops out of `/docs` and `/openapi.json` alongside the other feedback endpoints. Behavior is unchanged.