### PR TITLE
Admin: live-player views + PT-based DAU with a hover tooltip

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -134,13 +134,15 @@ def _dau_info() -> dict:
             )
         )
         series = [{"day": r["_id"], "count": r["count"]} for r in reversed(rows)]
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        # Day strings are bucketed in Pacific time by the telemetry ping; read
+        # "today" and the rolling windows in the same zone so they line up.
+        from .telemetry import DAU_TZ
+
+        today = datetime.now(DAU_TZ).strftime("%Y-%m-%d")
         today_count = next((r["count"] for r in series if r["day"] == today), 0)
 
         def _distinct_since(days: int) -> int:
-            cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime(
-                "%Y-%m-%d"
-            )
+            cutoff = (datetime.now(DAU_TZ) - timedelta(days=days)).strftime("%Y-%m-%d")
             res = list(
                 coll.aggregate(
                     [
@@ -175,6 +177,20 @@ def overview(request: Request):
         "redis": app_cache.info(),
         "dau": _dau_info(),
         "environment": os.environ.get("ENVIRONMENT", "development"),
+    }
+
+
+@router.get("/live")
+def live(request: Request):
+    """Live players: the current roster (identity, depth, current-session
+    length) and the all-time live-hours leaderboard. Both from the presence
+    layer; polled more often than /overview since it changes by the second."""
+    _audit(request)
+    from ..services import presence_db
+
+    return {
+        "current": presence_db.current_summary(50),
+        "all_time": presence_db.top_live_totals(20),
     }
 
 

--- a/backend/app/routers/telemetry.py
+++ b/backend/app/routers/telemetry.py
@@ -17,10 +17,16 @@ from __future__ import annotations
 import hashlib
 import os
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, HTTPException, Request
 
 router = APIRouter(prefix="/api/telemetry", tags=["Telemetry"])
+
+# DAU day boundaries follow Pacific time (the operator's local day), so "active
+# today" rolls over at PT midnight rather than UTC. The stored day is a plain
+# YYYY-MM-DD string; admin._dau_info reads it back with the same zone.
+DAU_TZ = ZoneInfo("America/Los_Angeles")
 
 DAU_TTL_DAYS = 120
 _MAX_STR = 64
@@ -76,7 +82,7 @@ async def ping(request: Request):
         data = {}
 
     now = datetime.now(timezone.utc)
-    day = now.strftime("%Y-%m-%d")
+    day = now.astimezone(DAU_TZ).strftime("%Y-%m-%d")
     uid = _hash_steam_id(steam_id)
     _dau_coll().update_one(
         {"_id": f"{day}:{uid}"},

--- a/backend/app/services/presence_db.py
+++ b/backend/app/services/presence_db.py
@@ -31,7 +31,14 @@ from typing import Any
 
 PRESENCE_TTL_SECONDS = 90
 
+# Cap on the gap credited to a player's all-time live total per heartbeat. The
+# mod beats ~every 30s; anything longer (a missed beat streak, or a crash/quit
+# and a later return) is treated as a break and not counted, so the total
+# tracks real continuous play rather than wall-clock between sessions.
+CREDIT_CAP_SECONDS = 150
+
 _coll = None  # lazy — set by _presence_coll
+_totals_coll = None  # lazy — set by _live_totals_coll
 
 
 def _presence_coll():
@@ -44,6 +51,19 @@ def _presence_coll():
         coll.create_index("updated_at", expireAfterSeconds=PRESENCE_TTL_SECONDS)
         _coll = coll
     return _coll
+
+
+def _live_totals_coll():
+    """Permanent per-player accumulator of live seconds (no TTL), keyed by
+    steam_id like the presence doc. Fed by _credit_live_time on each heartbeat."""
+    global _totals_coll
+    if _totals_coll is None:
+        from .runs_db_mongo import get_database
+
+        coll = get_database().live_totals
+        coll.create_index("total_seconds")
+        _totals_coll = coll
+    return _totals_coll
 
 
 # Rolling per-player window of ticker events ("played X", "fighting Y"); old entries
@@ -70,6 +90,39 @@ def heartbeat(
     if events:
         update["$push"] = {"events": {"$each": events, "$slice": -EVENT_WINDOW}}
     _presence_coll().update_one({"_id": steam_id}, update, upsert=True)
+    _credit_live_time(steam_id, fields.get("username"), now)
+
+
+def _credit_live_time(steam_id: str, username: str | None, now: datetime) -> None:
+    """Add the time since this player's previous heartbeat to their all-time live
+    total. Best-effort: accounting never breaks a heartbeat. Gaps longer than
+    CREDIT_CAP_SECONDS (a crash/quit and a later return) aren't counted, so the
+    total reflects real continuous play. Because credit accrues per beat, it
+    captures sessions that end by crash/TTL, not just clean stops."""
+    try:
+        from pymongo import ReturnDocument
+
+        set_fields: dict[str, Any] = {"last_seen": now}
+        if username:
+            set_fields["username"] = username
+        prev = _live_totals_coll().find_one_and_update(
+            {"_id": steam_id},
+            {
+                "$set": set_fields,
+                "$setOnInsert": {"first_seen": now, "total_seconds": 0},
+            },
+            upsert=True,
+            return_document=ReturnDocument.BEFORE,
+        )
+        last = (prev or {}).get("last_seen")
+        if isinstance(last, datetime):
+            delta = (now - last.replace(tzinfo=timezone.utc)).total_seconds()
+            if 0 < delta <= CREDIT_CAP_SECONDS:
+                _live_totals_coll().update_one(
+                    {"_id": steam_id}, {"$inc": {"total_seconds": int(delta)}}
+                )
+    except Exception:
+        pass
 
 
 def end(steam_id: str) -> None:
@@ -125,6 +178,79 @@ def get(steam_id: str) -> dict | None:
     cutoff = datetime.now(timezone.utc) - timedelta(seconds=PRESENCE_TTL_SECONDS)
     d = _presence_coll().find_one({"_id": steam_id, "updated_at": {"$gte": cutoff}})
     return _public(d) if d else None
+
+
+def current_summary(limit: int = 50) -> list[dict]:
+    """Live roster for the admin view: who's playing, their depth, and how long
+    the current session has run (seconds). Deepest run first. Empty on error."""
+    try:
+        now = datetime.now(timezone.utc)
+        cutoff = now - timedelta(seconds=PRESENCE_TTL_SECONDS)
+        docs = (
+            _presence_coll()
+            .find(
+                {"updated_at": {"$gte": cutoff}},
+                {
+                    "username": 1,
+                    "character": 1,
+                    "ascension": 1,
+                    "total_floor": 1,
+                    "act": 1,
+                    "started_at": 1,
+                },
+            )
+            .sort([("total_floor", -1), ("updated_at", -1)])
+            .limit(limit)
+        )
+        out: list[dict] = []
+        for d in docs:
+            started = d.get("started_at")
+            secs = (
+                int((now - started.replace(tzinfo=timezone.utc)).total_seconds())
+                if isinstance(started, datetime)
+                else None
+            )
+            out.append(
+                {
+                    "steam_id": str(d.get("_id")),
+                    "username": d.get("username"),
+                    "character": d.get("character"),
+                    "ascension": d.get("ascension"),
+                    "total_floor": d.get("total_floor"),
+                    "act": d.get("act"),
+                    "session_seconds": secs,
+                }
+            )
+        return out
+    except Exception:
+        return []
+
+
+def top_live_totals(limit: int = 20) -> list[dict]:
+    """All-time cumulative live seconds per player, highest first. Empty on error."""
+    try:
+        rows = (
+            _live_totals_coll()
+            .find({}, {"username": 1, "total_seconds": 1, "last_seen": 1})
+            .sort("total_seconds", -1)
+            .limit(limit)
+        )
+        out: list[dict] = []
+        for r in rows:
+            last = r.get("last_seen")
+            out.append(
+                {
+                    "steam_id": str(r.get("_id")),
+                    "username": r.get("username"),
+                    "total_seconds": int(r.get("total_seconds") or 0),
+                    "last_seen": last.replace(tzinfo=timezone.utc).isoformat()
+                    if isinstance(last, datetime)
+                    else None,
+                }
+            )
+        return out
+    except Exception:
+        return []
 
 
 def _public(d: dict) -> dict:

--- a/frontend/app/admin/AdminClient.tsx
+++ b/frontend/app/admin/AdminClient.tsx
@@ -35,6 +35,26 @@ interface Overview {
   environment: string;
 }
 
+interface LivePlayer {
+  steam_id: string;
+  username?: string | null;
+  character?: string | null;
+  ascension?: number | null;
+  total_floor?: number | null;
+  act?: string | null;
+  session_seconds?: number | null;
+}
+interface LiveTotal {
+  steam_id: string;
+  username?: string | null;
+  total_seconds: number;
+  last_seen?: string | null;
+}
+interface Live {
+  current: LivePlayer[];
+  all_time: LiveTotal[];
+}
+
 function fmtAge(seconds?: number | null): string {
   if (seconds == null) return "unknown";
   if (seconds < 90) return `${seconds}s ago`;
@@ -42,14 +62,49 @@ function fmtAge(seconds?: number | null): string {
   return `${(seconds / 3600).toFixed(1)}h ago`;
 }
 
+function fmtDuration(seconds?: number | null): string {
+  if (seconds == null || seconds < 0) return "-";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m`;
+  return `${seconds}s`;
+}
+
+function fmtHours(seconds: number): string {
+  const h = seconds / 3600;
+  return h >= 10 ? `${Math.round(h).toLocaleString()}h` : `${h.toFixed(1)}h`;
+}
+
+function playerName(p: { username?: string | null; steam_id: string }): string {
+  return p.username || `steam:${p.steam_id.slice(-6)}`;
+}
+
 export default function AdminClient() {
   const [data, setData] = useState<Overview | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [live, setLive] = useState<Live | null>(null);
+  const [hoverDau, setHoverDau] = useState<number | null>(null);
 
   useEffect(() => {
     adminFetch<Overview>("/api/admin/overview")
       .then(setData)
       .catch((e) => setError(String(e?.message || e)));
+  }, []);
+
+  // Live roster changes by the second, so poll it on its own cadence.
+  useEffect(() => {
+    let alive = true;
+    const load = () =>
+      adminFetch<Live>("/api/admin/live")
+        .then((d) => alive && setLive(d))
+        .catch(() => {});
+    load();
+    const id = setInterval(load, 20000);
+    return () => {
+      alive = false;
+      clearInterval(id);
+    };
   }, []);
 
   const r = data?.runs ?? {};
@@ -144,18 +199,31 @@ export default function AdminClient() {
           </div>
           {(data.dau?.series?.length ?? 0) > 0 && (
             <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
-              <div className="text-xs uppercase tracking-wider text-[var(--text-muted)] mb-2">
-                Daily active, last {data.dau!.series!.length} days
+              <div className="flex items-baseline justify-between mb-2 gap-3">
+                <span className="text-xs uppercase tracking-wider text-[var(--text-muted)]">
+                  Daily active, last {data.dau!.series!.length} days · Pacific
+                </span>
+                <span className="text-xs tabular-nums text-[var(--text-secondary)]">
+                  {hoverDau != null && data.dau!.series![hoverDau]
+                    ? `${data.dau!.series![hoverDau].day}: ${data.dau!.series![hoverDau].count.toLocaleString()} active`
+                    : "hover a bar for the count"}
+                </span>
               </div>
               <div className="flex items-end gap-1 h-20">
                 {(() => {
                   const series = data.dau!.series!;
                   const max = Math.max(1, ...series.map((d) => d.count));
-                  return series.map((d) => (
+                  return series.map((d, i) => (
                     <div
                       key={d.day}
-                      title={`${d.day}: ${d.count}`}
-                      className="flex-1 rounded-t bg-[var(--accent-gold)]/60"
+                      onMouseEnter={() => setHoverDau(i)}
+                      onMouseLeave={() => setHoverDau((h) => (h === i ? null : h))}
+                      title={`${d.day}: ${d.count} active`}
+                      className={`flex-1 rounded-t cursor-default transition-colors ${
+                        hoverDau === i
+                          ? "bg-[var(--accent-gold)]"
+                          : "bg-[var(--accent-gold)]/60"
+                      }`}
                       style={{ height: `${Math.max(4, Math.round((d.count / max) * 100))}%` }}
                     />
                   ));
@@ -163,6 +231,111 @@ export default function AdminClient() {
               </div>
             </div>
           )}
+
+          {/* Live players — from the presence layer, polled ~20s */}
+          <h2 className="text-lg font-semibold text-[var(--accent-gold)] mt-8 mb-3">
+            Live players
+          </h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4 md:col-span-2">
+              <div className="flex items-baseline justify-between mb-3 gap-3">
+                <span className="text-xs uppercase tracking-wider text-[var(--text-muted)]">
+                  Currently live
+                </span>
+                <span className="text-xs text-[var(--text-secondary)]">
+                  {(live?.current?.length ?? 0).toLocaleString()} playing now
+                </span>
+              </div>
+              {live && live.current.length > 0 ? (
+                <div className="divide-y divide-[var(--border-subtle)]">
+                  {live.current.map((p) => (
+                    <div
+                      key={p.steam_id}
+                      className="flex items-center gap-3 py-2 text-sm"
+                    >
+                      <span className="text-[var(--text-primary)] truncate">
+                        {playerName(p)}
+                      </span>
+                      <span className="text-xs text-[var(--text-muted)] truncate">
+                        {[
+                          p.character,
+                          p.ascension != null ? `A${p.ascension}` : null,
+                          p.total_floor != null ? `Floor ${p.total_floor}` : null,
+                        ]
+                          .filter(Boolean)
+                          .join(" · ")}
+                      </span>
+                      <span className="ml-auto tabular-nums text-[var(--text-secondary)]">
+                        {fmtDuration(p.session_seconds)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-[var(--text-muted)]">
+                  Nobody&apos;s playing right now.
+                </p>
+              )}
+            </div>
+
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+              <div className="text-xs uppercase tracking-wider text-[var(--text-muted)] mb-3">
+                Longest sessions (live now)
+              </div>
+              {live && live.current.length > 0 ? (
+                <div className="divide-y divide-[var(--border-subtle)]">
+                  {[...live.current]
+                    .sort((a, b) => (b.session_seconds ?? 0) - (a.session_seconds ?? 0))
+                    .slice(0, 8)
+                    .map((p) => (
+                      <div
+                        key={p.steam_id}
+                        className="flex items-center justify-between gap-3 py-2 text-sm"
+                      >
+                        <span className="text-[var(--text-primary)] truncate">
+                          {playerName(p)}
+                        </span>
+                        <span className="tabular-nums text-[var(--text-secondary)]">
+                          {fmtDuration(p.session_seconds)}
+                        </span>
+                      </div>
+                    ))}
+                </div>
+              ) : (
+                <p className="text-sm text-[var(--text-muted)]">&mdash;</p>
+              )}
+            </div>
+
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+              <div className="text-xs uppercase tracking-wider text-[var(--text-muted)] mb-3">
+                All-time live hours
+              </div>
+              {live && live.all_time.length > 0 ? (
+                <div className="divide-y divide-[var(--border-subtle)]">
+                  {live.all_time.slice(0, 10).map((p, i) => (
+                    <div
+                      key={p.steam_id}
+                      className="flex items-center justify-between gap-3 py-2 text-sm"
+                    >
+                      <span className="text-[var(--text-primary)] truncate">
+                        <span className="mr-2 tabular-nums text-[var(--text-muted)]">
+                          {i + 1}
+                        </span>
+                        {playerName(p)}
+                      </span>
+                      <span className="tabular-nums text-[var(--text-secondary)]">
+                        {fmtHours(p.total_seconds)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-[var(--text-muted)]">
+                  No live time recorded yet.
+                </p>
+              )}
+            </div>
+          </div>
         </>
       )}
     </AdminShell>


### PR DESCRIPTION
Adds a "Live players" block to the admin Overview and fixes the mod-DAU chart.

## DAU
- **Resets in PT, not UTC.** The telemetry `/ping` buckets the day in `America/Los_Angeles`, and `admin._dau_info` reads today/7d/30d in the same zone, so "active today" rolls over at PT midnight. Applies to new pings going forward; the day or two of UTC-bucketed history rolls off with the 14-day window (no migration).
- **You can read the counts now.** The bar chart shows `day: N active` in the header on hover and highlights the hovered bar, instead of relying on the slow native tooltip.

## Live players (new)
- **All-time live time is now tracked.** Each presence heartbeat credits the elapsed time since that player's previous beat into a new `live_totals` collection. Gaps past a cap aren't counted, so a crash/quit + later return doesn't inflate the total — and because credit accrues per beat, it captures sessions that end by crash/TTL, not just clean stops.
- **New `GET /api/admin/live`** returns the current roster (identity, depth, current-session length) and the all-time live-hours leaderboard.
- **Overview renders three panels**, polled every 20s: **Currently live** (deepest run first), **Longest sessions (live now)**, and **All-time live hours**.

Everything is admin-gated (router-level `require_admin`) and best-effort on the backend (accounting never breaks a heartbeat; the live endpoint degrades to empty lists without Mongo). `ruff` + `tsc` + `eslint` clean.