### PR TITLE
Land the orphaned entity-page fixes (hero prose, chips-only, Quest filter)

### DIFF
--- a/frontend/app/achievements/[id]/AchievementDetail.tsx
+++ b/frontend/app/achievements/[id]/AchievementDetail.tsx
@@ -104,6 +104,7 @@ export default function AchievementDetail({ initialAchievement }: { initialAchie
               <span>Achievement</span>
             </p>
             <h1>{achievement.name}</h1>
+            <EntityProse kind="achievement" achievement={achievement} lead />
           </div>
 
           {/* Sticky ToC */}
@@ -126,9 +127,6 @@ export default function AchievementDetail({ initialAchievement }: { initialAchie
             <div className="desc-quote">
               <RichDescription text={achievement.description} />
             </div>
-
-            {/* Programmatic prose block for SEO */}
-            <EntityProse kind="achievement" achievement={achievement} />
           </section>
 
           {/* Version history + localized names */}

--- a/frontend/app/acts/[id]/ActDetail.tsx
+++ b/frontend/app/acts/[id]/ActDetail.tsx
@@ -80,12 +80,6 @@ export default function ActDetail({ initialAct }: { initialAct?: Act | null } = 
 
   const titleCase = (s: string) => s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 
-  const summaryBits: string[] = [];
-  if (act.num_rooms) summaryBits.push(`${act.num_rooms} rooms`);
-  if (act.bosses.length > 0) summaryBits.push(`${act.bosses.length} bosses`);
-  if (act.encounters.length > 0) summaryBits.push(`${act.encounters.length} encounters`);
-  if (act.events.length > 0) summaryBits.push(`${act.events.length} events`);
-
   const tocItems: { id: string; label: string }[] = [
     ...(act.bosses.length > 0 ? [{ id: "bosses", label: "Bosses" }] : []),
     ...(act.encounters.length > 0 ? [{ id: "encounters", label: "Encounters" }] : []),
@@ -117,7 +111,7 @@ export default function ActDetail({ initialAct }: { initialAct?: Act | null } = 
               )}
             </p>
             <h1>{act.name}</h1>
-            {summaryBits.length > 0 && <p className="lede">{summaryBits.join(" · ")}</p>}
+            <EntityProse kind="act" act={act} lead />
           </div>
 
           {/* Sticky ToC */}
@@ -200,9 +194,6 @@ export default function ActDetail({ initialAct }: { initialAct?: Act | null } = 
             <LocalizedNames entityType="acts" entityId={id} />
             <EntityHistory entityType="acts" entityId={id} />
           </section>
-
-          {/* Programmatic prose block for SEO */}
-          <EntityProse kind="act" act={act} />
         </main>
       </div>
     </div>

--- a/frontend/app/afflictions/[id]/AfflictionDetail.tsx
+++ b/frontend/app/afflictions/[id]/AfflictionDetail.tsx
@@ -53,11 +53,6 @@ export default function AfflictionDetail({ initialAffliction }: { initialAfflict
     );
   }
 
-  // Plain-text lede: the effect with rich [tags] + whitespace stripped.
-  const ledeText = affliction.description
-    ? affliction.description.replace(/\[[^\]]*\]/g, "").replace(/\s+/g, " ").trim()
-    : "";
-
   return (
     <div className="card-rvmp">
       <div className="cd-top">
@@ -80,7 +75,7 @@ export default function AfflictionDetail({ initialAffliction }: { initialAfflict
               )}
             </p>
             <h1>{affliction.name}</h1>
-            {ledeText && <p className="lede">{ledeText}</p>}
+            <EntityProse kind="affliction" affliction={affliction} lead />
           </div>
 
           <section id="description">
@@ -88,9 +83,6 @@ export default function AfflictionDetail({ initialAffliction }: { initialAfflict
             <div className="desc-quote">
               <RichDescription text={affliction.description} />
             </div>
-
-            {/* Programmatic prose block for SEO */}
-            <EntityProse kind="affliction" affliction={affliction} />
           </section>
 
           {affliction.extra_card_text && (

--- a/frontend/app/ascensions/[id]/AscensionDetail.tsx
+++ b/frontend/app/ascensions/[id]/AscensionDetail.tsx
@@ -117,7 +117,7 @@ export default function AscensionDetail({ initialAscension }: { initialAscension
               <span>Level {ascension.level}</span>
             </p>
             <h1>{ascension.name}</h1>
-            <p className="lede">Ascension Level {ascension.level}</p>
+            <EntityProse kind="ascension" ascension={ascension} lead />
           </div>
 
           {/* Sticky ToC */}
@@ -140,9 +140,6 @@ export default function AscensionDetail({ initialAscension }: { initialAscension
             <div className="desc-quote">
               <RichDescription text={ascension.description} />
             </div>
-
-            {/* Programmatic prose block for SEO */}
-            <EntityProse kind="ascension" ascension={ascension} />
           </section>
 
           {/* Prev/Next navigation */}

--- a/frontend/app/card-revamp.css
+++ b/frontend/app/card-revamp.css
@@ -58,6 +58,11 @@
   line-height: 1.04; margin: 12px 0 0; text-wrap: balance; color: var(--text); }
 .card-rvmp .hero h1 .up { color: var(--good); }
 .card-rvmp .lede { color: var(--text-2); font-size: 18px; margin: 14px 0 0; max-width: 60ch; }
+/* Programmatic overview prose rendered as a hero lead (EntityProse lead mode).
+   Sits under the H1 in place of the old token-stripped description lede. */
+.card-rvmp .entity-lead { margin: 14px 0 0; max-width: 64ch; font-size: 15px; line-height: 1.65; color: var(--text-2); }
+.card-rvmp .entity-lead p { margin: 0 0 10px; }
+.card-rvmp .entity-lead p:last-child { margin-bottom: 0; }
 
 /* ── sticky ToC ── */
 .card-rvmp .toc { position: sticky; top: 64px; z-index: 20; margin: 28px 0 0; padding: 10px 0;
@@ -209,6 +214,10 @@
   flex-wrap: wrap; justify-content: flex-end; align-items: center; }
 .card-rvmp .kw { display: inline-block; font-size: 11.5px; border: 1px solid var(--border-2); border-radius: 3px;
   padding: 1px 7px; color: var(--gold); }
+/* keyword chips shown inline in the description box */
+.card-rvmp .kw-row { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 14px; }
+a.kw { text-decoration: none; }
+.card-rvmp a.kw:hover { border-color: var(--gold); }
 
 /* mini community block */
 .card-rvmp .mini { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 13px 15px; }

--- a/frontend/app/cards/CardsClient.tsx
+++ b/frontend/app/cards/CardsClient.tsx
@@ -37,6 +37,7 @@ const typeOptions = [
   { label: "Attack", value: "Attack" },
   { label: "Skill", value: "Skill" },
   { label: "Power", value: "Power" },
+  { label: "Quest", value: "Quest" },
   { label: "Status", value: "Status" },
   { label: "Curse", value: "Curse" },
 ];

--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -345,11 +345,6 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
     card.target && card.target !== "None" && card.target !== "Self"
       ? card.target.replace(/([A-Z])/g, " $1").trim()
       : null;
-  // Plain-text lede from the card effect (rich tags + newlines stripped).
-  const ledeText = descText
-    ? descText.replace(/\[[^\]]*\]/g, "").replace(/\s+/g, " ").trim()
-    : "";
-
   const enchActive = selectedEnch !== "none" && cardEnchantments.includes(selectedEnch);
   // Infobox render: enchanted render > raw artwork (detail / beta / variant /
   // failed full render) > full engine render. Mirrors the old image logic while
@@ -411,7 +406,9 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
               {card.name}
               {isUpgraded && <span className="up">+</span>}
             </h1>
-            {ledeText && <p className="lede">{ledeText}</p>}
+            {/* Overview prose as the hero lead (replaces the old token-stripped
+                description lede, which rendered blanks like "Gain ."). */}
+            <EntityProse kind="card" card={card} lead />
           </div>
 
           {/* Sticky ToC */}
@@ -549,6 +546,27 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
               </>
             )}
 
+            {/* Keywords this card uses (Exhaust, Ethereal, Sly, ...) shown in
+                the description box, linked to their glossary pages. */}
+            {displayKeywords.length > 0 && (
+              <div className="kw-row">
+                {displayKeywords.map((kw) => {
+                  const data = keywordData[kw.toLowerCase()];
+                  const tip = data?.description || keywordTooltips[kw] || "";
+                  return (
+                    <HoverTooltip key={kw} title={data?.name || kw} content={tip}>
+                      <Link
+                        href={`${lp}/keywords/${(data?.id || kw).toLowerCase()}`}
+                        className="kw"
+                      >
+                        {data?.name || kw}
+                      </Link>
+                    </HoverTooltip>
+                  );
+                })}
+              </div>
+            )}
+
             {/* Powers applied */}
             {card.powers_applied && card.powers_applied.length > 0 && (
               <>
@@ -575,8 +593,6 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
               </>
             )}
 
-            {/* Programmatic prose block for SEO */}
-            <EntityProse kind="card" card={card} />
           </section>
 
           {/* Relations */}

--- a/frontend/app/characters/[id]/CharacterDetail.tsx
+++ b/frontend/app/characters/[id]/CharacterDetail.tsx
@@ -313,11 +313,6 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
     Ancient: "bg-red-600/30 text-red-300",
   };
 
-  // Plain-text lede from the character description (rich tags + newlines stripped).
-  const ledeText = char.description
-    ? char.description.replace(/\[[^\]]*\]/g, "").replace(/\s+/g, " ").trim()
-    : "";
-
   const hasDeck = char.starting_deck.length > 0;
   const hasStartRelics = char.starting_relics.length > 0;
   const hasCommunity =
@@ -378,7 +373,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
               )}
             </p>
             <h1>{char.name}</h1>
-            {ledeText && <p className="lede">{ledeText}</p>}
+            <EntityProse kind="character" character={char} lead />
           </div>
 
           {/* Sticky ToC */}
@@ -401,9 +396,6 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
             <div className="desc-quote">
               <RichDescription text={char.description} />
             </div>
-
-            {/* Programmatic prose block for SEO */}
-            <EntityProse kind="character" character={char} />
           </section>
 
           {/* Starting Deck */}

--- a/frontend/app/components/EntityProse.tsx
+++ b/frontend/app/components/EntityProse.tsx
@@ -63,7 +63,7 @@ interface AfflictionProseProps { kind: "affliction"; affliction: Affliction; }
 interface AchievementProseProps { kind: "achievement"; achievement: Achievement; }
 interface ActProseProps { kind: "act"; act: Act; }
 interface AscensionProseProps { kind: "ascension"; ascension: Ascension; }
-type Props =
+type Props = (
   | RelicProseProps
   | PotionProseProps
   | PowerProseProps
@@ -80,7 +80,13 @@ type Props =
   | AfflictionProseProps
   | AchievementProseProps
   | ActProseProps
-  | AscensionProseProps;
+  | AscensionProseProps
+) & {
+  // When true the prose renders as a hero lead (no top rule) instead of the
+  // default bottom block. Entity detail pages pass this to put the overview
+  // right under the H1; relics/potions/powers omit it (bottom of overview tab).
+  lead?: boolean;
+};
 
 // "a"/"an" by leading vowel sound (good enough for our vocabulary).
 function article(word: string): string {
@@ -113,7 +119,7 @@ export default function EntityProse(props: Props) {
     if (!isEnglish) {
       // Non-English: single sentence using ONLY localized API fields.
       // No English connective text → no duplicate-content signal.
-      return <Prose sentences={[`${name} · ${rarity} · ${pool}`]} />;
+      return <Prose lead={props.lead} sentences={[`${name} · ${rarity} · ${pool}`]} />;
     }
 
     const sentences: string[] = [];
@@ -130,7 +136,7 @@ export default function EntityProse(props: Props) {
     sentences.push(
       `Like every relic in Slay the Spire 2, ${name} is preserved across combats unless removed by an event.`
     );
-    return <Prose sentences={sentences} />;
+    return <Prose lead={props.lead} sentences={sentences} />;
   }
 
   if (props.kind === "potion") {
@@ -140,7 +146,7 @@ export default function EntityProse(props: Props) {
     const pool = (p as Potion & { pool?: string | null }).pool;
 
     if (!isEnglish) {
-      return <Prose sentences={[`${name} · ${rarity}${pool ? ` · ${pool}` : ""}`]} />;
+      return <Prose lead={props.lead} sentences={[`${name} · ${rarity}${pool ? ` · ${pool}` : ""}`]} />;
     }
 
     const sentences: string[] = [];
@@ -151,7 +157,7 @@ export default function EntityProse(props: Props) {
     sentences.push(
       `${name} can be saved between combats and used at any point during your turn. Effects trigger immediately and the potion is consumed.`
     );
-    return <Prose sentences={sentences} />;
+    return <Prose lead={props.lead} sentences={sentences} />;
   }
 
   if (props.kind === "card") {
@@ -161,7 +167,7 @@ export default function EntityProse(props: Props) {
       ironclad: "Ironclad", silent: "Silent", defect: "Defect", necrobinder: "Necrobinder", regent: "Regent",
     };
     if (!isEnglish) {
-      return <Prose sentences={[`${name} · ${c.rarity} · ${c.type}`]} />;
+      return <Prose lead={props.lead} sentences={[`${name} · ${c.rarity} · ${c.type}`]} />;
     }
     const who = pools[c.color] ? ` for the ${pools[c.color]}` : "";
     const cost = c.is_x_cost ? "X" : `${c.cost}`;
@@ -178,14 +184,14 @@ export default function EntityProse(props: Props) {
     if (c.keywords && c.keywords.length) {
       sentences.push(`It carries the ${listWords(c.keywords)} keyword${c.keywords.length > 1 ? "s" : ""}.`);
     }
-    return <Prose sentences={sentences} />;
+    return <Prose lead={props.lead} sentences={sentences} />;
   }
 
   if (props.kind === "enchantment") {
     const e = props.enchantment;
     const name = e.name;
     if (!isEnglish) {
-      return <Prose sentences={[`${name}${e.card_type ? ` · ${e.card_type}` : ""}`]} />;
+      return <Prose lead={props.lead} sentences={[`${name}${e.card_type ? ` · ${e.card_type}` : ""}`]} />;
     }
     const sentences: string[] = [];
     sentences.push(
@@ -196,14 +202,14 @@ export default function EntityProse(props: Props) {
         ? `${name} stacks, so a single card can hold more than one for a compounding effect.`
         : `${name} does not stack; a card can carry it only once.`,
     );
-    return <Prose sentences={sentences} />;
+    return <Prose lead={props.lead} sentences={sentences} />;
   }
 
   if (props.kind === "character") {
     const ch = props.character;
     const name = ch.name;
     if (!isEnglish) {
-      return <Prose sentences={[`${name}${ch.starting_hp != null ? ` · ${ch.starting_hp} HP` : ""}`]} />;
+      return <Prose lead={props.lead} sentences={[`${name}${ch.starting_hp != null ? ` · ${ch.starting_hp} HP` : ""}`]} />;
     }
     const sentences: string[] = [];
     const stats: string[] = [];
@@ -221,13 +227,13 @@ export default function EntityProse(props: Props) {
     }
     if (ch.orb_slots) sentences.push(`${name} channels orbs, with ${ch.orb_slots} orb slot${ch.orb_slots === 1 ? "" : "s"} to start.`);
     if (ch.unlocks_after) sentences.push(`${name} unlocks after ${ch.unlocks_after}.`);
-    return <Prose sentences={sentences} />;
+    return <Prose lead={props.lead} sentences={sentences} />;
   }
 
   if (props.kind === "orb") {
     const o = props.orb;
     const name = o.name;
-    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    if (!isEnglish) return <Prose lead={props.lead} sentences={[`${name}`]} />;
     const cards = o.channeled_by_cards?.length || 0;
     const relics = o.channeled_by_relics?.length || 0;
     const sentences: string[] = [];
@@ -238,13 +244,13 @@ export default function EntityProse(props: Props) {
       if (relics) src.push(`${relics} relic${relics === 1 ? "" : "s"}`);
       sentences.push(`${name} is channeled by ${listWords(src)} in the game.`);
     }
-    return <Prose sentences={sentences} />;
+    return <Prose lead={props.lead} sentences={sentences} />;
   }
 
   if (props.kind === "event") {
     const ev = props.event;
     const name = ev.name;
-    if (!isEnglish) return <Prose sentences={[`${name}${ev.act ? ` · ${ev.act}` : ""}`]} />;
+    if (!isEnglish) return <Prose lead={props.lead} sentences={[`${name}${ev.act ? ` · ${ev.act}` : ""}`]} />;
     const sentences: string[] = [];
     const typeWord = ev.type && ev.type.toLowerCase() !== "event" ? `${ev.type.toLowerCase()} event` : "event";
     sentences.push(`${name} is ${article(typeWord)} ${typeWord} in Slay the Spire 2${ev.act ? `, encountered in ${ev.act}` : ""}.`);
@@ -253,13 +259,13 @@ export default function EntityProse(props: Props) {
     if (ev.relics && ev.relics.length) {
       sentences.push(`It can reward the ${listWords(ev.relics.map(titleCaseId))} relic${ev.relics.length > 1 ? "s" : ""}.`);
     }
-    return <Prose sentences={sentences} />;
+    return <Prose lead={props.lead} sentences={sentences} />;
   }
 
   if (props.kind === "encounter") {
     const en = props.encounter;
     const name = en.name;
-    if (!isEnglish) return <Prose sentences={[`${name}${en.room_type ? ` · ${en.room_type}` : ""}`]} />;
+    if (!isEnglish) return <Prose lead={props.lead} sentences={[`${name}${en.room_type ? ` · ${en.room_type}` : ""}`]} />;
     const room = (en.room_type || "combat").toLowerCase();
     const monsters = (en.monsters || []).map((mm) => mm.name);
     let s1 = `${name} is ${article(room)} ${room} encounter in Slay the Spire 2${en.act ? `, fought in ${en.act}` : ""}`;
@@ -269,12 +275,12 @@ export default function EntityProse(props: Props) {
     }
     const sentences: string[] = [s1 + "."];
     if (en.is_weak) sentences.push(`It is flagged as one of the weaker fights for its act.`);
-    return <Prose sentences={sentences} />;
+    return <Prose lead={props.lead} sentences={sentences} />;
   }
 
   if (props.kind === "keyword") {
     const name = props.keyword.name;
-    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    if (!isEnglish) return <Prose lead={props.lead} sentences={[`${name}`]} />;
     return (
       <Prose
         sentences={[
@@ -287,7 +293,7 @@ export default function EntityProse(props: Props) {
 
   if (props.kind === "intent") {
     const name = props.intent.name;
-    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    if (!isEnglish) return <Prose lead={props.lead} sentences={[`${name}`]} />;
     return (
       <Prose
         sentences={[
@@ -300,7 +306,7 @@ export default function EntityProse(props: Props) {
 
   if (props.kind === "modifier") {
     const name = props.modifier.name;
-    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    if (!isEnglish) return <Prose lead={props.lead} sentences={[`${name}`]} />;
     return (
       <Prose
         sentences={[
@@ -314,7 +320,7 @@ export default function EntityProse(props: Props) {
   if (props.kind === "affliction") {
     const af = props.affliction;
     const name = af.name;
-    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    if (!isEnglish) return <Prose lead={props.lead} sentences={[`${name}`]} />;
     const sentences: string[] = [];
     sentences.push(`${name} is an affliction in Slay the Spire 2, a lasting negative effect that follows your character rather than a single card or combat.`);
     sentences.push(
@@ -322,12 +328,12 @@ export default function EntityProse(props: Props) {
         ? `${name} can stack, so repeated sources make it progressively worse.`
         : `${name} does not stack; picking it up again has no added effect.`,
     );
-    return <Prose sentences={sentences} />;
+    return <Prose lead={props.lead} sentences={sentences} />;
   }
 
   if (props.kind === "achievement") {
     const name = props.achievement.name;
-    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    if (!isEnglish) return <Prose lead={props.lead} sentences={[`${name}`]} />;
     return (
       <Prose
         sentences={[
@@ -341,7 +347,7 @@ export default function EntityProse(props: Props) {
   if (props.kind === "act") {
     const ac = props.act;
     const name = ac.name;
-    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    if (!isEnglish) return <Prose lead={props.lead} sentences={[`${name}`]} />;
     const sentences: string[] = [];
     let s1 = `${name} is an act in Slay the Spire 2`;
     if (ac.num_rooms) s1 += `, spanning around ${ac.num_rooms} rooms from entrance to boss`;
@@ -351,13 +357,13 @@ export default function EntityProse(props: Props) {
     if (ac.encounters?.length) counts.push(`${ac.encounters.length} combat encounter${ac.encounters.length === 1 ? "" : "s"}`);
     if (ac.events?.length) counts.push(`${ac.events.length} event${ac.events.length === 1 ? "" : "s"}`);
     if (counts.length) sentences.push(`It includes ${listWords(counts)}.`);
-    return <Prose sentences={sentences} />;
+    return <Prose lead={props.lead} sentences={sentences} />;
   }
 
   if (props.kind === "ascension") {
     const as = props.ascension;
     const name = as.name;
-    if (!isEnglish) return <Prose sentences={[`${name}`]} />;
+    if (!isEnglish) return <Prose lead={props.lead} sentences={[`${name}`]} />;
     const sentences: string[] =
       as.level > 0
         ? [
@@ -368,7 +374,7 @@ export default function EntityProse(props: Props) {
             `${name} is the base difficulty in Slay the Spire 2, played without any Ascension modifiers.`,
             `Clearing a run here unlocks Ascension 1, the first of the stacking difficulty levels.`,
           ];
-    return <Prose sentences={sentences} />;
+    return <Prose lead={props.lead} sentences={sentences} />;
   }
 
   if (props.kind === "monster") {
@@ -459,7 +465,7 @@ export default function EntityProse(props: Props) {
   const stack = pw.stack_type || "Counter";
 
   if (!isEnglish) {
-    return <Prose sentences={[`${name} · ${type} · ${stack}`]} />;
+    return <Prose lead={props.lead} sentences={[`${name} · ${type} · ${stack}`]} />;
   }
 
   const sentences: string[] = [];
@@ -486,14 +492,14 @@ export default function EntityProse(props: Props) {
       `${name} is not directly applied by any cards in the player's pool, it appears via enemy moves, relics, or events.`
     );
   }
-  return <Prose sentences={sentences} />;
+  return <Prose lead={props.lead} sentences={sentences} />;
 }
 
 function Prose({ sentences, lead }: { sentences: string[]; lead?: boolean }) {
   // lead: rendered as an intro right under a page hero (no top border/rule).
   if (lead) {
     return (
-      <section className="mon-lead">
+      <section className="entity-lead">
         {sentences.map((s, i) => (
           <p key={i}>{s}</p>
         ))}

--- a/frontend/app/enchantments/[id]/EnchantmentDetail.tsx
+++ b/frontend/app/enchantments/[id]/EnchantmentDetail.tsx
@@ -97,10 +97,6 @@ export default function EnchantmentDetail({
   }
 
   const cardTypes = enchantment.card_type ? enchantment.card_type.split(", ") : [];
-  // Plain-text lede from the enchantment effect (rich tags + newlines stripped).
-  const ledeText = enchantment.description
-    ? enchantment.description.replace(/\[[^\]]*\]/g, "").replace(/\s+/g, " ").trim()
-    : "";
 
   const tocItems: { id: string; label: string }[] = [
     { id: "description", label: t("Description", lang) },
@@ -138,7 +134,7 @@ export default function EnchantmentDetail({
               )}
             </p>
             <h1>{enchantment.name}</h1>
-            {ledeText && <p className="lede">{ledeText}</p>}
+            <EntityProse kind="enchantment" enchantment={enchantment} lead />
           </div>
 
           {/* Sticky ToC */}
@@ -170,9 +166,6 @@ export default function EnchantmentDetail({
                 </div>
               </>
             )}
-
-            {/* Programmatic prose block for SEO */}
-            <EntityProse kind="enchantment" enchantment={enchantment} />
           </section>
 
           {/* Cards it can apply to */}

--- a/frontend/app/encounters/[id]/EncounterDetail.tsx
+++ b/frontend/app/encounters/[id]/EncounterDetail.tsx
@@ -132,6 +132,7 @@ export default function EncounterDetail({ initialEncounter }: { initialEncounter
               </span>
             </p>
             <h1>{encounter.name}</h1>
+            <EntityProse kind="encounter" encounter={encounter} lead />
           </div>
 
           {/* Sticky ToC */}
@@ -180,9 +181,6 @@ export default function EncounterDetail({ initialEncounter }: { initialEncounter
             <LocalizedNames entityType="encounters" entityId={id} />
             <EntityHistory entityType="encounters" entityId={id} />
           </section>
-
-          {/* Programmatic prose block for SEO */}
-          <EntityProse kind="encounter" encounter={encounter} />
         </main>
 
         {/* ===== INFOBOX column (sticky) ===== */}

--- a/frontend/app/events/[id]/EventDetail.tsx
+++ b/frontend/app/events/[id]/EventDetail.tsx
@@ -150,10 +150,6 @@ export default function EventDetail({
     (event.pages && event.pages.length > 1);
   const hasRelics = event.relics && event.relics.length > 0;
   const hasDialogue = event.dialogue && Object.keys(event.dialogue).length > 0;
-  // Plain-text lede from the event description (rich tags + newlines stripped).
-  const ledeText = event.description
-    ? event.description.replace(/\[[^\]]*\]/g, "").replace(/\s+/g, " ").trim()
-    : "";
 
   const tocItems: { id: string; label: string }[] = [
     { id: "description", label: t("Description", lang) },
@@ -197,7 +193,7 @@ export default function EventDetail({
             </p>
             <h1>{event.name}</h1>
             {event.epithet && <p className="epithet">{event.epithet}</p>}
-            {ledeText && <p className="lede">{ledeText}</p>}
+            <EntityProse kind="event" event={event} lead />
           </div>
 
           {/* Sticky ToC */}
@@ -231,9 +227,6 @@ export default function EventDetail({
                 <RichDescription text={event.description} />
               </div>
             )}
-
-            {/* Programmatic prose block for SEO */}
-            <EntityProse kind="event" event={event} />
           </section>
 
           {/* Choices & outcomes */}

--- a/frontend/app/intents/[id]/IntentDetail.tsx
+++ b/frontend/app/intents/[id]/IntentDetail.tsx
@@ -54,11 +54,6 @@ export default function IntentDetail({ initialIntent }: { initialIntent?: Intent
     );
   }
 
-  // Plain-text lede: the effect with rich [tags] + whitespace stripped.
-  const ledeText = intent.description
-    ? intent.description.replace(/\[[^\]]*\]/g, "").replace(/\s+/g, " ").trim()
-    : "";
-
   return (
     <div className="card-rvmp">
       <div className="cd-top">
@@ -75,7 +70,7 @@ export default function IntentDetail({ initialIntent }: { initialIntent?: Intent
               <span>{t("Intent", lang)}</span>
             </p>
             <h1>{intent.name}</h1>
-            {ledeText && <p className="lede">{ledeText}</p>}
+            <EntityProse kind="intent" intent={intent} lead />
           </div>
 
           <section id="description">
@@ -83,9 +78,6 @@ export default function IntentDetail({ initialIntent }: { initialIntent?: Intent
             <div className="desc-quote">
               <RichDescription text={intent.description} />
             </div>
-
-            {/* Programmatic prose block for SEO */}
-            <EntityProse kind="intent" intent={intent} />
           </section>
 
           <section id="history">

--- a/frontend/app/keywords/[id]/KeywordDetail.tsx
+++ b/frontend/app/keywords/[id]/KeywordDetail.tsx
@@ -164,6 +164,7 @@ export default function KeywordDetail({ initialResult }: { initialResult?: Initi
             <div className="lede">
               <RichDescription text={keyword.description} />
             </div>
+            <EntityProse kind="keyword" keyword={keyword} lead />
           </div>
 
           <section id="cards">
@@ -188,9 +189,6 @@ export default function KeywordDetail({ initialResult }: { initialResult?: Initi
             />
 
             <FullCardGrid cards={filtered} />
-
-            {/* Programmatic prose block for SEO */}
-            <EntityProse kind="keyword" keyword={keyword} />
           </section>
         </main>
       </div>

--- a/frontend/app/modifiers/[id]/ModifierDetail.tsx
+++ b/frontend/app/modifiers/[id]/ModifierDetail.tsx
@@ -53,11 +53,6 @@ export default function ModifierDetail({ initialModifier }: { initialModifier?: 
     );
   }
 
-  // Plain-text lede: the effect with rich [tags] + whitespace stripped.
-  const ledeText = modifier.description
-    ? modifier.description.replace(/\[[^\]]*\]/g, "").replace(/\s+/g, " ").trim()
-    : "";
-
   return (
     <div className="card-rvmp">
       <div className="cd-top">
@@ -74,7 +69,7 @@ export default function ModifierDetail({ initialModifier }: { initialModifier?: 
               <span>{t("Modifier", lang)}</span>
             </p>
             <h1>{modifier.name}</h1>
-            {ledeText && <p className="lede">{ledeText}</p>}
+            <EntityProse kind="modifier" modifier={modifier} lead />
           </div>
 
           <section id="description">
@@ -82,9 +77,6 @@ export default function ModifierDetail({ initialModifier }: { initialModifier?: 
             <div className="desc-quote">
               <RichDescription text={modifier.description} />
             </div>
-
-            {/* Programmatic prose block for SEO */}
-            <EntityProse kind="modifier" modifier={modifier} />
           </section>
 
           <section id="history">

--- a/frontend/app/monster-encounter-extra.css
+++ b/frontend/app/monster-encounter-extra.css
@@ -43,11 +43,6 @@
   border: 1px solid var(--border-2); color: var(--text-2); }
 .card-rvmp .chip .cn { color: var(--text); }
 
-/* ── monster overview lead prose (rendered right under the hero) ── */
-.card-rvmp .mon-lead { max-width: 64ch; margin: 2px 0 8px; font-size: 15px; line-height: 1.65; color: var(--text-2); }
-.card-rvmp .mon-lead p { margin: 0 0 10px; }
-.card-rvmp .mon-lead p:last-child { margin-bottom: 0; }
-
 /* ── readable per-move effect line (English only, sits above the numeric rows) ── */
 .card-rvmp .move-effect { font-size: 14px; line-height: 1.5; color: var(--text-2); margin: 0 0 10px; }
 

--- a/frontend/app/monsters/[id]/MonsterDetail.tsx
+++ b/frontend/app/monsters/[id]/MonsterDetail.tsx
@@ -549,9 +549,10 @@ export default function MonsterDetail({
                 </>
               )}
 
-              {/* Attack Pattern — text description plus a visible move sequence.
-                  The sequence chips use localized move names, so they render in
-                  every language even when the English description is thin. */}
+              {/* Attack Pattern — the localized move-name sequence (chips with
+                  arrows). Falls back to the text description only when there
+                  aren't enough steps to form a chip sequence, so the two never
+                  duplicate each other. */}
               {monster.attack_pattern && (() => {
                 const steps = patternSteps(monster.attack_pattern!, monster.moves || []);
                 const desc = monster.attack_pattern!.description;
@@ -559,8 +560,7 @@ export default function MonsterDetail({
                 return (
                   <>
                     <h3 className="subh">Attack Pattern</h3>
-                    {desc && <p className="desc-body">{desc}</p>}
-                    {steps.length > 1 && (
+                    {steps.length > 1 ? (
                       <div className="atk-seq">
                         {steps.map((s, i) => (
                           <span key={i} className="atk-step-wrap">
@@ -572,6 +572,8 @@ export default function MonsterDetail({
                           <span className="atk-repeat" title={t("Repeats", lang)}>↻</span>
                         )}
                       </div>
+                    ) : (
+                      desc && <p className="desc-body">{desc}</p>
                     )}
                   </>
                 );

--- a/frontend/app/orbs/[id]/OrbDetail.tsx
+++ b/frontend/app/orbs/[id]/OrbDetail.tsx
@@ -54,10 +54,6 @@ export default function OrbDetail({ initialOrb }: { initialOrb?: Orb | null } = 
     );
   }
 
-  // Plain-text lede: the effect with rich [tags] + whitespace stripped.
-  const ledeText = orb.description
-    ? orb.description.replace(/\[[^\]]*\]/g, "").replace(/\s+/g, " ").trim()
-    : "";
   const relGroups = [
     { label: `Cards that Channel ${orb.name}`, items: orb.channeled_by_cards, route: "cards" },
     { label: `Relics that Channel ${orb.name}`, items: orb.channeled_by_relics, route: "relics" },
@@ -80,7 +76,7 @@ export default function OrbDetail({ initialOrb }: { initialOrb?: Orb | null } = 
               <span>{t("Orb", lang)}</span>
             </p>
             <h1>{orb.name}</h1>
-            {ledeText && <p className="lede">{ledeText}</p>}
+            <EntityProse kind="orb" orb={orb} lead />
           </div>
 
           <section id="description">
@@ -88,9 +84,6 @@ export default function OrbDetail({ initialOrb }: { initialOrb?: Orb | null } = 
             <div className="desc-quote">
               <RichDescription text={orb.description} />
             </div>
-
-            {/* Programmatic prose block for SEO */}
-            <EntityProse kind="orb" orb={orb} />
           </section>
 
           {hasRelations && (


### PR DESCRIPTION
These commits were pushed to `seo/entity-title-tags` **after** #594 had already merged, so they never reached `main`. Re-basing them here off current `main`.

What's in it:
- **Attack pattern shows only the pill sequence** — drops the duplicate text line (`Ebb → Eye Lasers → … → repeat`) that still renders alongside the chips on prod. Text stays as a fallback only when there are too few moves to form a sequence.
- **Overview prose moved into the hero** on every entity page, replacing the old token-stripped `.lede` (the one that rendered `"Gain ."` on cards like Adrenaline). So e.g. `/cards/hidden_gem` gets its "Hidden Gem is a Rare Skill card…" line in the hero. The real description still renders in the body.
- **Keyword chips in the card description box**, and the keyword pages keep their real definition.
- **Quest type filter on `/cards`** — Quest is a real card type (Byrdonis Egg, Lantern Key, Spoils Map) that was missing from the filter.

Same changes I'd verified before; `tsc` clean against current main.