### PR TITLE
Feedback: community mini-stats follow the bracket; deadliest by deaths-per-encounter

### DIFF
--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -37,12 +37,15 @@ const SPINE_COLOR: Record<string, string> = {
 
 // Headline figures for the infobox mini-stats block. Same endpoint EntityRunStats
 // fetches, so cachedFetch dedupes it (no extra request).
-interface MiniStats {
+interface MiniBracket {
   picks: number;
   win_rate: number;
   pick_rate: number;
   score: number | null;
   elo: number | null;
+}
+interface MiniStats extends MiniBracket {
+  brackets?: Record<string, MiniBracket>;
 }
 
 const typeIcons: Record<string, string> = {
@@ -171,6 +174,9 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
   // Scroll-spy: which section the ToC highlights.
   const [activeSection, setActiveSection] = useState<string>("performance");
   const [miniStats, setMiniStats] = useState<MiniStats | null>(null);
+  // Bracket shared with EntityRunStats so the infobox mini-stats track the
+  // pill the user picked in the Community section.
+  const [statsBracket, setStatsBracket] = useState("all");
   const [powerData, setPowerData] = useState<Record<string, { id: string; name: string; description: string; type: string; image_url: string | null }>>({});
   const [keywordData, setKeywordData] = useState<Record<string, { id: string; name: string; description: string }>>({});
   const [glossaryData, setGlossaryData] = useState<Record<string, { id: string; name: string; description: string }>>({});
@@ -440,6 +446,8 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
               entityName={card.name}
               variant="wiki"
               initialStats={initialStats}
+              bracket={statsBracket}
+              onBracketChange={setStatsBracket}
             />
           </section>
 
@@ -809,39 +817,44 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
               </dl>
             </div>
 
-            {/* Community mini-stats */}
-            {miniStats && miniStats.picks > 0 && (
-              <div className="mini">
-                <div className="mh">{t("Community", lang)}</div>
-                <div className="mg">
-                  <div>
-                    <div
-                      className="mv"
-                      style={{ color: miniStats.win_rate >= 50 ? "var(--good)" : "var(--warn)" }}
-                    >
-                      {miniStats.win_rate}%
-                    </div>
-                    <div className="ml">{t("Win rate", lang)}</div>
-                  </div>
-                  <div>
-                    <div className="mv">{miniStats.pick_rate}%</div>
-                    <div className="ml">{t("Pick rate", lang)}</div>
-                  </div>
-                  {miniStats.score != null && (
+            {/* Community mini-stats — scoped to the bracket picked in the
+                Community section (falls back to the all-runs figures). */}
+            {(() => {
+              const mini = miniStats?.brackets?.[statsBracket] ?? miniStats;
+              if (!mini || mini.picks <= 0) return null;
+              return (
+                <div className="mini">
+                  <div className="mh">{t("Community", lang)}</div>
+                  <div className="mg">
                     <div>
-                      <div className="mv">{miniStats.score}</div>
-                      <div className="ml">{t("Codex Score", lang)}</div>
+                      <div
+                        className="mv"
+                        style={{ color: mini.win_rate >= 50 ? "var(--good)" : "var(--warn)" }}
+                      >
+                        {mini.win_rate}%
+                      </div>
+                      <div className="ml">{t("Win rate", lang)}</div>
                     </div>
-                  )}
-                  {miniStats.elo != null && (
                     <div>
-                      <div className="mv">{Math.round(miniStats.elo)}</div>
-                      <div className="ml">Elo</div>
+                      <div className="mv">{mini.pick_rate}%</div>
+                      <div className="ml">{t("Pick rate", lang)}</div>
                     </div>
-                  )}
+                    {mini.score != null && (
+                      <div>
+                        <div className="mv">{mini.score}</div>
+                        <div className="ml">{t("Codex Score", lang)}</div>
+                      </div>
+                    )}
+                    {mini.elo != null && (
+                      <div>
+                        <div className="mv">{Math.round(mini.elo)}</div>
+                        <div className="ml">Elo</div>
+                      </div>
+                    )}
+                  </div>
                 </div>
-              </div>
-            )}
+              );
+            })()}
           </div>
         </aside>
       </div>

--- a/frontend/app/components/EntityRunStats.tsx
+++ b/frontend/app/components/EntityRunStats.tsx
@@ -59,6 +59,11 @@ interface Props {
    * the SSR HTML (crawlable) instead of a client-only "Loading" placeholder.
    * The component still re-fetches on mount to stay fresh. */
   initialStats?: EntityStats | null;
+  /** Controlled bracket: when provided, the pills drive this value instead of
+   * internal state, so a parent (e.g. the card page's infobox mini-stats) can
+   * scope to the same bracket the user picked. Uncontrolled if omitted. */
+  bracket?: string;
+  onBracketChange?: (b: string) => void;
 }
 
 /** Compact 1.2k / 44.8k style number for the wiki tiles + bars. */
@@ -119,9 +124,12 @@ function characterPretty(c: string): string {
  * state when the entity has no submitted runs yet so SEO crawlers
  * still see something other than spinners.
  */
-export default function EntityRunStats({ entityType, entityId, entityName, variant = "default", initialStats = null }: Props) {
+export default function EntityRunStats({ entityType, entityId, entityName, variant = "default", initialStats = null, bracket, onBracketChange }: Props) {
   const [stats, setStats] = useState<EntityStats | null>(initialStats);
-  const [selectedBracket, setSelectedBracket] = useState("all");
+  const [internalBracket, setInternalBracket] = useState("all");
+  // Controlled when a parent passes `bracket`; internal otherwise.
+  const selectedBracket = bracket ?? internalBracket;
+  const setSelectedBracket = onBracketChange ?? setInternalBracket;
   const { lang } = useLanguage();
 
   useEffect(() => {

--- a/frontend/app/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/leaderboards/stats/StatsClient.tsx
@@ -904,7 +904,7 @@ export default function StatsClient() {
               lang={lang}
             />
           )}
-          {tab === "encounters" && <EncountersTab stats={stats} lp={lp} lang={lang} />}
+          {tab === "encounters" && <EncountersTab lp={lp} lang={lang} />}
         </>
       )}
     </div>
@@ -1579,52 +1579,92 @@ function PotionsTab({
 
 /* ------------------------- Encounters ------------------------- */
 
-function EncountersTab({ stats, lp, lang }: { stats: CommunityStats; lp: string; lang: string }) {
-  if (!stats.deadliest || stats.deadliest.length === 0) {
+interface EncStatRow {
+  encounter_id: string;
+  total: number;
+  fatal: number;
+  room_type?: string;
+  act?: number | string;
+}
+
+function EncountersTab({ lp, lang }: { lp: string; lang: string }) {
+  const [rows, setRows] = useState<EncStatRow[] | null>(null);
+  useEffect(() => {
+    cachedFetch<{ encounters: EncStatRow[] }>(`${API}/api/runs/encounter-stats?limit=200`)
+      .then((d) => setRows(d.encounters || []))
+      .catch(() => setRows([]));
+  }, []);
+
+  // Rank by deaths *per encounter* (share of parties that die to a fight), not
+  // raw death count — so rare-but-lethal bosses like Aeonglass rise to the top
+  // instead of being buried under the common early fights. The min-sample gate
+  // keeps a handful of unlucky runs from topping the list.
+  const MIN_FACED = 200;
+  const ranked = (rows ?? [])
+    .filter((e) => e.total >= MIN_FACED)
+    .map((e) => ({ ...e, rate: (e.fatal / e.total) * 100 }))
+    .sort((a, b) => b.rate - a.rate)
+    .slice(0, 30);
+
+  if (rows === null) {
+    return (
+      <div className="bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] p-5 text-center text-sm text-[var(--text-muted)]">
+        {t("Loading…", lang)}
+      </div>
+    );
+  }
+  if (ranked.length === 0) {
     return (
       <div className="bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] p-5 text-center text-sm text-[var(--text-muted)]">
         {t("No deadly encounters recorded.", lang)}
       </div>
     );
   }
-  const max = Math.max(1, ...stats.deadliest.map((d) => d.count));
+  const maxRate = Math.max(1, ...ranked.map((r) => r.rate));
   return (
     <div className="bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] p-5">
-      <h2 className="text-sm font-semibold text-[var(--text-muted)] uppercase tracking-wide mb-3">
+      <h2 className="text-sm font-semibold text-[var(--text-muted)] uppercase tracking-wide mb-1">
         {t("Deadliest Encounters", lang)}
       </h2>
+      <p className="text-xs text-[var(--text-muted)] mb-3">
+        {t("Ranked by deaths per encounter — the share of parties that die to a fight, not raw death count.", lang)}
+      </p>
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-[var(--border-subtle)] text-[var(--text-muted)] text-xs">
             <th className="text-left py-2 font-medium w-10">#</th>
             <th className="text-left py-2 font-medium">{t("Encounter", lang)}</th>
-            <th className="text-right py-2 font-medium">{t("Deaths", lang)}</th>
-            <th className="py-2 font-medium w-48"></th>
+            <th className="text-right py-2 font-medium">{t("Per encounter", lang)}</th>
+            <th className="text-right py-2 font-medium">{t("Deaths / faced", lang)}</th>
+            <th className="py-2 font-medium w-40"></th>
           </tr>
         </thead>
         <tbody>
-          {stats.deadliest.map((d, i) => (
+          {ranked.map((r, i) => (
             <tr
-              key={d.encounter}
+              key={r.encounter_id}
               className="border-b border-[var(--border-subtle)] last:border-0 hover:bg-[var(--bg-card-hover)]/60 transition-colors"
             >
               <td className="py-2 text-[var(--text-muted)] tabular-nums">{i + 1}</td>
               <td className="py-2">
                 <Link
-                  href={`${lp}/encounters/${d.encounter.toLowerCase()}`}
+                  href={`${lp}/encounters/${r.encounter_id.toLowerCase()}`}
                   className="text-[var(--text-primary)] hover:text-[var(--accent-gold)] font-medium transition-colors"
                 >
-                  {displayName(`ENCOUNTER.${d.encounter}`)}
+                  {displayName(`ENCOUNTER.${r.encounter_id}`)}
                 </Link>
               </td>
               <td className="py-2 text-right text-red-400 tabular-nums font-semibold">
-                {d.count}
+                {r.rate.toFixed(1)}%
+              </td>
+              <td className="py-2 text-right text-[var(--text-secondary)] tabular-nums text-xs">
+                {r.fatal.toLocaleString()} / {r.total.toLocaleString()}
               </td>
               <td className="py-2 pl-4">
                 <div className="h-1.5 rounded-full bg-[var(--bg-primary)] overflow-hidden">
                   <div
                     className="h-full rounded-full bg-red-400/70"
-                    style={{ width: `${(d.count / max) * 100}%` }}
+                    style={{ width: `${(r.rate / maxRate) * 100}%` }}
                   />
                 </div>
               </td>

--- a/frontend/app/potions/[id]/PotionDetail.tsx
+++ b/frontend/app/potions/[id]/PotionDetail.tsx
@@ -35,12 +35,15 @@ function getPotionMerchantPriceRange(rarity: string): { min: number; max: number
 
 // Headline figures for the infobox mini-stats block. Same endpoint
 // EntityRunStats fetches, so cachedFetch dedupes it (no extra request).
-interface MiniStats {
+interface MiniBracket {
   picks: number;
   win_rate: number;
   pick_rate: number;
   score: number | null;
   elo: number | null;
+}
+interface MiniStats extends MiniBracket {
+  brackets?: Record<string, MiniBracket>;
 }
 
 export default function PotionDetail({
@@ -57,6 +60,9 @@ export default function PotionDetail({
   // Scroll-spy: which section the ToC highlights.
   const [activeSection, setActiveSection] = useState<string>("performance");
   const [miniStats, setMiniStats] = useState<MiniStats | null>(null);
+  // Bracket shared with EntityRunStats so the infobox mini-stats track the
+  // pill the user picked in the Community section.
+  const [statsBracket, setStatsBracket] = useState("all");
 
   useEffect(() => {
     if (!id) return;
@@ -199,6 +205,8 @@ export default function PotionDetail({
               entityName={potion.name}
               variant="wiki"
               initialStats={initialStats}
+              bracket={statsBracket}
+              onBracketChange={setStatsBracket}
             />
           </section>
 
@@ -295,39 +303,44 @@ export default function PotionDetail({
               </dl>
             </div>
 
-            {/* Community mini-stats */}
-            {miniStats && miniStats.picks > 0 && (
-              <div className="mini">
-                <div className="mh">{t("Community", lang)}</div>
-                <div className="mg">
-                  <div>
-                    <div
-                      className="mv"
-                      style={{ color: miniStats.win_rate >= 50 ? "var(--good)" : "var(--warn)" }}
-                    >
-                      {miniStats.win_rate}%
-                    </div>
-                    <div className="ml">{t("Win rate", lang)}</div>
-                  </div>
-                  <div>
-                    <div className="mv">{miniStats.pick_rate}%</div>
-                    <div className="ml">{t("Pick rate", lang)}</div>
-                  </div>
-                  {miniStats.score != null && (
+            {/* Community mini-stats — scoped to the bracket picked in the
+                Community section (falls back to the all-runs figures). */}
+            {(() => {
+              const mini = miniStats?.brackets?.[statsBracket] ?? miniStats;
+              if (!mini || mini.picks <= 0) return null;
+              return (
+                <div className="mini">
+                  <div className="mh">{t("Community", lang)}</div>
+                  <div className="mg">
                     <div>
-                      <div className="mv">{miniStats.score}</div>
-                      <div className="ml">{t("Codex Score", lang)}</div>
+                      <div
+                        className="mv"
+                        style={{ color: mini.win_rate >= 50 ? "var(--good)" : "var(--warn)" }}
+                      >
+                        {mini.win_rate}%
+                      </div>
+                      <div className="ml">{t("Win rate", lang)}</div>
                     </div>
-                  )}
-                  {miniStats.elo != null && (
                     <div>
-                      <div className="mv">{Math.round(miniStats.elo)}</div>
-                      <div className="ml">Elo</div>
+                      <div className="mv">{mini.pick_rate}%</div>
+                      <div className="ml">{t("Pick rate", lang)}</div>
                     </div>
-                  )}
+                    {mini.score != null && (
+                      <div>
+                        <div className="mv">{mini.score}</div>
+                        <div className="ml">{t("Codex Score", lang)}</div>
+                      </div>
+                    )}
+                    {mini.elo != null && (
+                      <div>
+                        <div className="mv">{Math.round(mini.elo)}</div>
+                        <div className="ml">Elo</div>
+                      </div>
+                    )}
+                  </div>
                 </div>
-              </div>
-            )}
+              );
+            })()}
           </div>
         </aside>
       </div>

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -23,12 +23,15 @@ const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 // Headline figures for the infobox mini-stats block. Same endpoint
 // EntityRunStats fetches, so cachedFetch dedupes it (no extra request).
-interface MiniStats {
+interface MiniBracket {
   picks: number;
   win_rate: number;
   pick_rate: number;
   score: number | null;
   elo: number | null;
+}
+interface MiniStats extends MiniBracket {
+  brackets?: Record<string, MiniBracket>;
 }
 
 export default function RelicDetail({
@@ -47,6 +50,9 @@ export default function RelicDetail({
   // Scroll-spy: which section the ToC highlights.
   const [activeSection, setActiveSection] = useState<string>("performance");
   const [miniStats, setMiniStats] = useState<MiniStats | null>(null);
+  // Bracket shared with EntityRunStats so the infobox mini-stats track the
+  // pill the user picked in the Community section.
+  const [statsBracket, setStatsBracket] = useState("all");
 
   useEffect(() => {
     if (!id) return;
@@ -203,6 +209,8 @@ export default function RelicDetail({
               entityName={relic.name}
               variant="wiki"
               initialStats={initialStats}
+              bracket={statsBracket}
+              onBracketChange={setStatsBracket}
             />
           </section>
 
@@ -355,39 +363,44 @@ export default function RelicDetail({
               </dl>
             </div>
 
-            {/* Community mini-stats */}
-            {miniStats && miniStats.picks > 0 && (
-              <div className="mini">
-                <div className="mh">{t("Community", lang)}</div>
-                <div className="mg">
-                  <div>
-                    <div
-                      className="mv"
-                      style={{ color: miniStats.win_rate >= 50 ? "var(--good)" : "var(--warn)" }}
-                    >
-                      {miniStats.win_rate}%
-                    </div>
-                    <div className="ml">{t("Win rate", lang)}</div>
-                  </div>
-                  <div>
-                    <div className="mv">{miniStats.pick_rate}%</div>
-                    <div className="ml">{t("Pick rate", lang)}</div>
-                  </div>
-                  {miniStats.score != null && (
+            {/* Community mini-stats — scoped to the bracket picked in the
+                Community section (falls back to the all-runs figures). */}
+            {(() => {
+              const mini = miniStats?.brackets?.[statsBracket] ?? miniStats;
+              if (!mini || mini.picks <= 0) return null;
+              return (
+                <div className="mini">
+                  <div className="mh">{t("Community", lang)}</div>
+                  <div className="mg">
                     <div>
-                      <div className="mv">{miniStats.score}</div>
-                      <div className="ml">{t("Codex Score", lang)}</div>
+                      <div
+                        className="mv"
+                        style={{ color: mini.win_rate >= 50 ? "var(--good)" : "var(--warn)" }}
+                      >
+                        {mini.win_rate}%
+                      </div>
+                      <div className="ml">{t("Win rate", lang)}</div>
                     </div>
-                  )}
-                  {miniStats.elo != null && (
                     <div>
-                      <div className="mv">{Math.round(miniStats.elo)}</div>
-                      <div className="ml">Elo</div>
+                      <div className="mv">{mini.pick_rate}%</div>
+                      <div className="ml">{t("Pick rate", lang)}</div>
                     </div>
-                  )}
+                    {mini.score != null && (
+                      <div>
+                        <div className="mv">{mini.score}</div>
+                        <div className="ml">{t("Codex Score", lang)}</div>
+                      </div>
+                    )}
+                    {mini.elo != null && (
+                      <div>
+                        <div className="mv">{Math.round(mini.elo)}</div>
+                        <div className="ml">Elo</div>
+                      </div>
+                    )}
+                  </div>
                 </div>
-              </div>
-            )}
+              );
+            })()}
           </div>
         </aside>
       </div>


### PR DESCRIPTION
Two of the feedback items.

## Community mini-stats follow the bracket toggle
On card/relic/potion pages, the right-column "Community" mini-stats ignored the bracket pills (all/A10/…) in the main Community section — they always showed all-runs numbers. `EntityRunStats` now accepts an optional controlled `bracket` + `onBracketChange`; each detail page lifts that state and scopes its infobox block to the same bracket (falling back to all-runs when a bracket has no data). So toggling on the left updates the right.

## Deadliest encounters → deaths per encounter
The Encounters tab on `/leaderboards/stats` ranked by raw death count, so common early fights dominated and lethal-but-rare bosses never showed. It now ranks by **fatality rate** (deaths ÷ times faced) from the per-encounter stats, with a 200-run minimum sample. That puts the real killers on top — Aeonglass lands at ~25.5% (12,597 / 49,337) — and shows the deaths/faced sample next to the rate.

`tsc` + `eslint` clean.