### PR TITLE
Backfill Aeonglass Eye Lasers hit count (re-land, orphaned off #601)

### DIFF
--- a/data/deu/monsters.json
+++ b/data/deu/monsters.json
@@ -24,7 +24,8 @@
         "intent": "Attack",
         "damage": {
           "normal": 11,
-          "ascension": 12
+          "ascension": 12,
+          "hit_count": 2
         }
       },
       {
@@ -40,7 +41,8 @@
       },
       "EyeLasers": {
         "normal": 11,
-        "ascension": 12
+        "ascension": 12,
+        "hit_count": 2
       }
     },
     "block_values": {

--- a/data/eng/monsters.json
+++ b/data/eng/monsters.json
@@ -24,7 +24,8 @@
         "intent": "Attack",
         "damage": {
           "normal": 11,
-          "ascension": 12
+          "ascension": 12,
+          "hit_count": 2
         }
       },
       {
@@ -40,7 +41,8 @@
       },
       "EyeLasers": {
         "normal": 11,
-        "ascension": 12
+        "ascension": 12,
+        "hit_count": 2
       }
     },
     "block_values": {

--- a/data/esp/monsters.json
+++ b/data/esp/monsters.json
@@ -24,7 +24,8 @@
         "intent": "Attack",
         "damage": {
           "normal": 11,
-          "ascension": 12
+          "ascension": 12,
+          "hit_count": 2
         }
       },
       {
@@ -40,7 +41,8 @@
       },
       "EyeLasers": {
         "normal": 11,
-        "ascension": 12
+        "ascension": 12,
+        "hit_count": 2
       }
     },
     "block_values": {

--- a/data/fra/monsters.json
+++ b/data/fra/monsters.json
@@ -24,7 +24,8 @@
         "intent": "Attack",
         "damage": {
           "normal": 11,
-          "ascension": 12
+          "ascension": 12,
+          "hit_count": 2
         }
       },
       {
@@ -40,7 +41,8 @@
       },
       "EyeLasers": {
         "normal": 11,
-        "ascension": 12
+        "ascension": 12,
+        "hit_count": 2
       }
     },
     "block_values": {

--- a/data/ita/monsters.json
+++ b/data/ita/monsters.json
@@ -24,7 +24,8 @@
         "intent": "Attack",
         "damage": {
           "normal": 11,
-          "ascension": 12
+          "ascension": 12,
+          "hit_count": 2
         }
       },
       {
@@ -40,7 +41,8 @@
       },
       "EyeLasers": {
         "normal": 11,
-        "ascension": 12
+        "ascension": 12,
+        "hit_count": 2
       }
     },
     "block_values": {

--- a/data/jpn/monsters.json
+++ b/data/jpn/monsters.json
@@ -24,7 +24,8 @@
         "intent": "Attack",
         "damage": {
           "normal": 11,
-          "ascension": 12
+          "ascension": 12,
+          "hit_count": 2
         }
       },
       {
@@ -40,7 +41,8 @@
       },
       "EyeLasers": {
         "normal": 11,
-        "ascension": 12
+        "ascension": 12,
+        "hit_count": 2
       }
     },
     "block_values": {

--- a/data/kor/monsters.json
+++ b/data/kor/monsters.json
@@ -24,7 +24,8 @@
         "intent": "Attack",
         "damage": {
           "normal": 11,
-          "ascension": 12
+          "ascension": 12,
+          "hit_count": 2
         }
       },
       {
@@ -40,7 +41,8 @@
       },
       "EyeLasers": {
         "normal": 11,
-        "ascension": 12
+        "ascension": 12,
+        "hit_count": 2
       }
     },
     "block_values": {

--- a/data/pol/monsters.json
+++ b/data/pol/monsters.json
@@ -24,7 +24,8 @@
         "intent": "Attack",
         "damage": {
           "normal": 11,
-          "ascension": 12
+          "ascension": 12,
+          "hit_count": 2
         }
       },
       {
@@ -40,7 +41,8 @@
       },
       "EyeLasers": {
         "normal": 11,
-        "ascension": 12
+        "ascension": 12,
+        "hit_count": 2
       }
     },
     "block_values": {

--- a/data/ptb/monsters.json
+++ b/data/ptb/monsters.json
@@ -24,7 +24,8 @@
         "intent": "Attack",
         "damage": {
           "normal": 11,
-          "ascension": 12
+          "ascension": 12,
+          "hit_count": 2
         }
       },
       {
@@ -40,7 +41,8 @@
       },
       "EyeLasers": {
         "normal": 11,
-        "ascension": 12
+        "ascension": 12,
+        "hit_count": 2
       }
     },
     "block_values": {

--- a/data/rus/monsters.json
+++ b/data/rus/monsters.json
@@ -24,7 +24,8 @@
         "intent": "Attack",
         "damage": {
           "normal": 11,
-          "ascension": 12
+          "ascension": 12,
+          "hit_count": 2
         }
       },
       {
@@ -40,7 +41,8 @@
       },
       "EyeLasers": {
         "normal": 11,
-        "ascension": 12
+        "ascension": 12,
+        "hit_count": 2
       }
     },
     "block_values": {

--- a/data/spa/monsters.json
+++ b/data/spa/monsters.json
@@ -24,7 +24,8 @@
         "intent": "Attack",
         "damage": {
           "normal": 11,
-          "ascension": 12
+          "ascension": 12,
+          "hit_count": 2
         }
       },
       {
@@ -40,7 +41,8 @@
       },
       "EyeLasers": {
         "normal": 11,
-        "ascension": 12
+        "ascension": 12,
+        "hit_count": 2
       }
     },
     "block_values": {

--- a/data/tha/monsters.json
+++ b/data/tha/monsters.json
@@ -24,7 +24,8 @@
         "intent": "Attack",
         "damage": {
           "normal": 11,
-          "ascension": 12
+          "ascension": 12,
+          "hit_count": 2
         }
       },
       {
@@ -40,7 +41,8 @@
       },
       "EyeLasers": {
         "normal": 11,
-        "ascension": 12
+        "ascension": 12,
+        "hit_count": 2
       }
     },
     "block_values": {

--- a/data/tur/monsters.json
+++ b/data/tur/monsters.json
@@ -24,7 +24,8 @@
         "intent": "Attack",
         "damage": {
           "normal": 11,
-          "ascension": 12
+          "ascension": 12,
+          "hit_count": 2
         }
       },
       {
@@ -40,7 +41,8 @@
       },
       "EyeLasers": {
         "normal": 11,
-        "ascension": 12
+        "ascension": 12,
+        "hit_count": 2
       }
     },
     "block_values": {

--- a/data/zhs/monsters.json
+++ b/data/zhs/monsters.json
@@ -24,7 +24,8 @@
         "intent": "Attack",
         "damage": {
           "normal": 11,
-          "ascension": 12
+          "ascension": 12,
+          "hit_count": 2
         }
       },
       {
@@ -40,7 +41,8 @@
       },
       "EyeLasers": {
         "normal": 11,
-        "ascension": 12
+        "ascension": 12,
+        "hit_count": 2
       }
     },
     "block_values": {


### PR DESCRIPTION
The data half of the multi-hit fix. #601 merged at its parser-only commit, and this backfill got pushed to that branch afterward, so it never reached main — Aeonglass's Eye Lasers still reads as a single 12 on prod. Re-basing it here off current `main`.

Fills the one `hit_count` the parser fix recovers directly into the committed `data/<lang>/monsters.json` across all 14 languages: Aeonglass's Eye Lasers → 2 (12×2) on both the move and `damage_values`. Only fills absent values (never overwrites), cross-checked against the decompiled C# (agrees with all 44 existing hit counts, zero disagreements).

Note: game data is baked into the backend image, so this needs the backend image rebuilt + redeployed to show up.