### PR TITLE
Card trivia (curated + derived) + fix the schema dropping sources/trivia

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -56,6 +56,14 @@ class CardTypeVariant(BaseModel):
     riders: list[CardRiderEffect] | None = None
 
 
+class CardSource(BaseModel):
+    """Where a card comes from in combat, e.g. a monster that generates it."""
+
+    type: str
+    id: str
+    name: str
+
+
 class Card(BaseModel):
     id: str
     name: str
@@ -94,6 +102,12 @@ class Card(BaseModel):
     # surface the field when it's explicitly `false` to keep the payload tight.
     can_be_generated_in_combat: bool | None = None
     compendium_order: int = 0
+    # Which monsters generate this card in combat (parsed from the game code —
+    # see card_parser.build_card_sources). Absent on cards with no source.
+    sources: list[CardSource] | None = None
+    # A short "did you know" note — a curated line (data/card_trivia.json) or a
+    # derived one, merged in by the card endpoint. English-only, like the prose.
+    trivia: str | None = None
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/backend/app/routers/cards.py
+++ b/backend/app/routers/cards.py
@@ -1,11 +1,44 @@
 """Card API endpoints."""
 
+import json
+from functools import lru_cache
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from ..models.schemas import Card
-from ..services.data_service import load_cards, load_translation_maps
+from ..services.data_service import DATA_DIR, load_cards, load_translation_maps
 from ..dependencies import get_lang, matches_search
 
 router = APIRouter(prefix="/api/cards", tags=["Cards"])
+
+# Card types with few enough members that "one of N" reads as a fun fact.
+_TRIVIA_TYPES = {"Status", "Curse", "Power"}
+
+
+@lru_cache(maxsize=1)
+def _curated_trivia() -> dict[str, str]:
+    """Hand-written 'did you know' lines keyed by card id, from a flat file the
+    card parser can't overwrite on regen. English-only; empty if the file's
+    absent."""
+    try:
+        with open(DATA_DIR / "card_trivia.json", "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _resolve_trivia(card: dict, cards: list[dict]) -> str | None:
+    """A curated line if we have one, else a derived 'one of N <type>' fact for
+    the special card types (Status/Curse/Power)."""
+    curated = _curated_trivia().get(card["id"])
+    if curated:
+        return curated
+    ctype = card.get("type")
+    if ctype in _TRIVIA_TYPES:
+        n = sum(1 for c in cards if c.get("type") == ctype)
+        if n > 1:
+            return f"{card['name']} is one of {n} {ctype} cards in Slay the Spire 2."
+    return None
 
 
 @router.get("", response_model=list[Card])
@@ -82,5 +115,7 @@ def get_card(request: Request, card_id: str, lang: str = Depends(get_lang)):
     cards = load_cards(lang)
     for card in cards:
         if card["id"] == card_id.upper():
-            return card
+            trivia = _resolve_trivia(card, cards)
+            # Copy so the trivia we add doesn't stick to the lru-cached list.
+            return {**card, "trivia": trivia} if trivia else card
     raise HTTPException(status_code=404, detail=f"Card '{card_id}' not found")

--- a/data/card_trivia.json
+++ b/data/card_trivia.json
@@ -1,0 +1,3 @@
+{
+  "WITHER": "Wither can't be played; it just sits in your hand, dealing damage at the end of every turn. Aeonglass keeps handing you more of them (already upgraded) the longer the fight drags on."
+}

--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -415,6 +415,14 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
             {/* Overview prose as the hero lead (replaces the old token-stripped
                 description lede, which rendered blanks like "Gain ."). */}
             <EntityProse kind="card" card={card} lead />
+            {card.trivia && (
+              <p className="mt-3 rounded-md border-l-2 border-[var(--accent-gold)]/50 bg-[var(--accent-gold)]/5 px-3 py-2 text-sm leading-relaxed text-[var(--text-secondary)]">
+                <span className="font-semibold text-[var(--accent-gold)]">
+                  {t("Did you know?", lang)}{" "}
+                </span>
+                {card.trivia}
+              </p>
+            )}
           </div>
 
           {/* Sticky ToC */}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -84,6 +84,8 @@ export interface Card {
    * the C# default of `true`, so a missing value means "yes, can spawn". */
   can_be_generated_in_combat: boolean | null;
   compendium_order: number;
+  /** A short "did you know" note (curated or derived), merged by the API. */
+  trivia?: string | null;
 }
 
 export interface CharacterDialogueLine {


### PR DESCRIPTION
Adds a short **"Did you know?"** note to the card hero:
- **Curated** — hand-written lines in `data/card_trivia.json` (a flat file the parser won't wipe on regen). Seeded with Wither, written from our own data.
- **Derived** fallback — "one of N Status/Curse/Power cards" for the special types, computed from the catalog.

**Also fixes a real gap:** the card `response_model=Card` was silently dropping any field not declared on the model. So the `sources` field from #605 (which never added it to the schema) would never reach the client. This adds both `sources` and `trivia` to the `Card` schema.

⚠️ Dependency: for the **Sources** section (#605) to actually show, both this PR (schema) and #605 (data + parser + frontend) need to land — I split it this way to avoid pushing onto #605's open branch. `ruff` + `tsc` + `eslint` clean.