### PR TITLE
Fix encounter deadliness picking a tiny noise row (Bygone Effigy showed 2 runs)

### DIFF
--- a/frontend/lib/encounter-stats.ts
+++ b/frontend/lib/encounter-stats.ts
@@ -30,8 +30,14 @@ export async function fetchEncounterStats(
     });
     if (!res.ok) return [];
     const data = (await res.json()) as { encounters?: EncounterStat[] };
+    // The endpoint can return several rows for one encounter_id (tiny beta /
+    // edge slices alongside the real aggregate). Keep the highest-volume row so
+    // a stray "2 runs, 0 damage" slice never masks the true numbers.
     const byId = new Map<string, EncounterStat>();
-    for (const r of data.encounters ?? []) byId.set(r.encounter_id, r);
+    for (const r of data.encounters ?? []) {
+      const prev = byId.get(r.encounter_id);
+      if (!prev || r.total > prev.total) byId.set(r.encounter_id, r);
+    }
     return encounterIds
       .map((id) => byId.get(id))
       .filter((x): x is EncounterStat => !!x && x.total > 0);


### PR DESCRIPTION
`/api/runs/encounter-stats` returns several rows for one `encounter_id` (the real aggregate plus tiny beta/edge slices, e.g. Bygone Effigy Elite has rows of 197,191 / 7 / 2 / 2). The lookup in `lib/encounter-stats.ts` used **last-write-wins**, so it landed on the `total=2, 0 damage, 1 turn` slice — which is why the monster page said "In 2 community runs … 0% … 0 damage over 1 turns."

Now it keeps the **highest-volume row** per encounter, so Bygone Effigy reads its real ~197k / 14.9k. Fixes both the deployed monster-page deadliness and the encounter-page community line (#606). tsc + eslint clean.