### PR TITLE
Wire ENTITY_STATS_REBUILD_WORKERS into docker-compose.prod

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,10 @@ services:
     environment:
       - DATA_DIR=/data
       - BETA_DATA_DIR=/data-beta
+      # Parallelize the entity-stats snapshot rebuild across N cores. 1 = off
+      # (the serial ~80min walk); capped at the box's CPU count. Set the value
+      # in the box .env after validating with scripts/validate_parallel_rebuild.py.
+      - ENTITY_STATS_REBUILD_WORKERS=${ENTITY_STATS_REBUILD_WORKERS:-1}
       - FEEDBACK_WEBHOOK_URL=${FEEDBACK_WEBHOOK_URL:-}
       # Cloudflare purge from the admin cache tab. Same token/zone the
       # autodeploy script uses; set them in the box's .env.


### PR DESCRIPTION
Wires the parallel-snapshot-rebuild flag (#586) into the backend service so it can actually be set at deploy time.

`- ENTITY_STATS_REBUILD_WORKERS=${ENTITY_STATS_REBUILD_WORKERS:-1}` — defaults to `1` (the current serial ~80min walk, so this changes nothing on its own), and reads the real value from the box `.env` like `MONGO_URL` and the others.

To turn it on: after `docker exec spire-codex-backend python -m scripts.validate_parallel_rebuild 4`, set `ENTITY_STATS_REBUILD_WORKERS=4` (or 3 to leave a core, on the 4-vCPU box) in the box `.env` and recreate the backend. `_rebuild_workers()` caps it at the CPU count.