### PR TITLE
Make monster/card secondary prose readable (lift out of the muted text tier)

### DIFF
--- a/frontend/app/card-revamp.css
+++ b/frontend/app/card-revamp.css
@@ -76,7 +76,7 @@
 /* ── sections ── */
 .card-rvmp section { padding-top: 40px; scroll-margin-top: 128px; }
 .card-rvmp h2 { font-family: var(--serif); font-size: 25px; font-weight: 600; margin: 0 0 4px; color: var(--text); }
-.card-rvmp .h-note { color: var(--text-3); font-size: 13px; margin: 0 0 18px; }
+.card-rvmp .h-note { color: var(--text-2); font-size: 13px; margin: 0 0 18px; }
 .card-rvmp .subh { font-family: var(--serif); font-weight: 600; font-size: 17px; margin: 30px 0 4px; color: var(--text); }
 
 /* inline entity cross-links */
@@ -106,7 +106,7 @@
 .card-rvmp .insight { margin-top: 16px; font-size: 14px; color: var(--text-2); background: var(--spine-soft);
   border-radius: var(--radius); padding: 12px 15px; border: 1px solid color-mix(in srgb, var(--spine) 30%, transparent); }
 .card-rvmp .insight b { color: var(--text); }
-.card-rvmp .stat-note { margin-top: 14px; font-size: 12px; color: var(--text-3); }
+.card-rvmp .stat-note { margin-top: 14px; font-size: 13px; color: var(--text-2); }
 
 /* ── trend charts (weekly win rate / pick rate over time) ── */
 .card-rvmp .et-trends { margin-top: 8px; }


### PR DESCRIPTION
The secondary prose on the monster and card pages was hard to read in the dark theme because it used the dimmest text tier.

The move-effect summary line, the encounter community sentence ("In N community runs, the X fight was fatal to Y%..."), and the section subtitles all read as body copy, but `.h-note` and `.stat-note` used `--text-3` (the muted tier). In the dark theme that's `#506570`, roughly 2.5:1 contrast on the card surface, which fails WCAG AA and is genuinely hard to read.

I moved `.h-note` and `.stat-note` up to `--text-2` (the readable secondary tier, ~4.8:1, the same one `.move-effect` already uses) and bumped `.stat-note` from 12px to 13px so the sentence isn't cramped. These are shared `.card-rvmp` rules, so card/relic/potion/encounter pages get the same readability bump.

CSS-only, no behavior change.