### PR TITLE
Ship backend/scripts in the image so ops commands run in-container

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,7 +1,6 @@
 __pycache__
 *.pyc
 .env
-scripts
 # static/ never ships in the image: it's bind-mounted in prod and dev
 # (same pattern as data/), and image bytes are served from the CDN.
 # Keeping it out of the build context saves tarring 2.6 GB per build.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,6 +13,12 @@ RUN pip install --no-cache-dir -r requirements.txt
 # and ZIP building. main.py skips the /static mount if the dir is absent.
 COPY app/ app/
 
+# Maintenance/ops scripts (run in-container with `python -m scripts.<name>`,
+# e.g. scripts.validate_parallel_rebuild before enabling parallel snapshot
+# rebuilds). Small and dependency-free; ships so the documented commands work
+# without copying files into a running container.
+COPY scripts/ scripts/
+
 EXPOSE 8000
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
`validate_parallel_rebuild.py` documents running `python -m scripts.validate_parallel_rebuild` inside the backend container before enabling parallel snapshot rebuilds, but the image never carried `scripts/`: `backend/.dockerignore` excluded it and the Dockerfile only copied `app/`. So the command failed with `ModuleNotFoundError: No module named 'scripts'` and the script had to be `docker cp`'d into the running container by hand.

I dropped the `scripts` exclusion from `.dockerignore` and added `COPY scripts/ scripts/` after the app copy. It's ~11 kB and dependency-free, so the documented ops commands now run straight in the container.