### PR TITLE
Raise dark-theme secondary/muted text into a high-contrast range

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -34,8 +34,13 @@
   --color-colorless: #6b7280;
   --color-curse: #8b1a1a;
   --text-primary: #e0ddd8;
-  --text-secondary: #8a9298;
-  --text-muted: #506570;
+  /* secondary/muted were too dim on the dark ground: muted #506570 was ~2.7:1
+     on the card surface, well below WCAG AA (4.5:1) and hard to read wherever
+     quiet sub-text appears. Lifted both into a high-contrast 8-10:1 band
+     (secondary ~9.5:1, muted ~8.2:1 on the card surface) so sub-text reads
+     clearly everywhere, keeping a step down from primary. Light theme unchanged. */
+  --text-secondary: #bfc4ca;
+  --text-muted: #b1b7be;
   --border-subtle: #1e3040;
   --border-accent: #2a4555;
 }


### PR DESCRIPTION
Follow-up to the monster/card readability fix, but at the root instead of per-class. The dark theme's quiet text tiers are too dim against the dark ground, so sub-text is hard to read in a lot of places, not just the monster page.

Measured against the two dark grounds (page `#0a1118`, card `#132028`):

| Tier | Now | Contrast (card) | Proposed | Contrast (card / page) |
|---|---|---|---|---|
| primary `#e0ddd8` | — | ~12:1 | unchanged | ~12:1 |
| secondary `#8a9298` | passes, low | 5.2:1 | `#bfc4ca` | **9.5:1 / 10.9:1** |
| muted `#506570` | **fails AA** | **2.7:1** | `#b1b7be` | **8.2:1 / 9.5:1** |

Both quiet tiers now land in a high-contrast 8-10:1 band (WCAG AA is 4.5:1; the muted tier was below it). I raised `--text-secondary` and `--text-muted` in the dark `:root` only, keeping a step down from primary. Primary text and the light theme are untouched.

`--text-muted` feeds ~172 files (every timestamp, caption, and note), so this lifts sub-text readability everywhere at once rather than page by page. The ~18 hardcoded `text-gray-400` spots are a separate minor sweep if wanted.

Two lines of actual change (plus a comment).