### PR TITLE
Fix illegible white-on-gold buttons in the run upload drop zone

### DIFF
--- a/frontend/app/components/RunDropZone.tsx
+++ b/frontend/app/components/RunDropZone.tsx
@@ -95,7 +95,7 @@ export default function RunDropZone({ onFiles, uploading, uploadProgress }: RunD
             href="https://www.overwolf.com/app/ptrlrd-spire_codex"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center justify-center w-full sm:w-auto px-5 py-2.5 sm:py-2 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-white hover:opacity-90 transition-opacity"
+            className="inline-flex items-center justify-center w-full sm:w-auto px-5 py-2.5 sm:py-2 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-[var(--bg-primary)] hover:opacity-90 transition-opacity"
           >
             Download Overwolf Companion App
           </a>
@@ -103,7 +103,7 @@ export default function RunDropZone({ onFiles, uploading, uploadProgress }: RunD
             href="https://steamcommunity.com/sharedfiles/filedetails/?id=3747536911"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center justify-center w-full sm:w-auto px-5 py-2.5 sm:py-2 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-white hover:opacity-90 transition-opacity"
+            className="inline-flex items-center justify-center w-full sm:w-auto px-5 py-2.5 sm:py-2 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-[var(--bg-primary)] hover:opacity-90 transition-opacity"
           >
             Get the Mod
           </a>


### PR DESCRIPTION
The two call-to-action buttons in the run upload drop zone ("Download Overwolf Companion App" and "Get the Mod") used `bg-[var(--accent-gold)] text-white`. Accent gold is `#e8b830`, a bright yellow, so white text on it comes out around **1.85:1** contrast, which is basically unreadable.

I switched both to `text-[var(--bg-primary)]` (dark text on gold, ~10:1) so they match every other gold button on the site (the submit form, the runs upload label, the comment submit button all already do this). Two-attribute change, no layout impact.