### PR TITLE
Make the snapshot rebuild interval env-tunable

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -237,13 +237,26 @@ SNAPSHOT_VERSION = 14
 # rebuild takes beats serving nothing: to users an empty stats page is
 # indistinguishable from the site losing its data.
 SNAPSHOT_MIN_COMPAT = 3
+
+
 # Leader rebuilds the heavy walk at most this often. The walk reads every run
-# blob (~750k files, ~80 min on the current box), so a 10-minute interval had the
-# leader walking almost continuously — one worker pegged, a full run + file scan
-# back-to-back — which starved the DB and slowed the whole site. These stats
-# (tier list / community / Codex Score) don't need minute-fresh data, so rebuild
-# a few times a day instead; the walk now runs a fraction of the time.
-_SNAPSHOT_REBUILD_SECONDS = 2 * 60 * 60
+# blob (~750k files). Serial it was ~80 min, so a short interval pinned one core
+# in a back-to-back walk that starved the DB and slowed the whole site — hence
+# the conservative 2h default. With the parallel rebuild
+# (ENTITY_STATS_REBUILD_WORKERS>1) the walk is far shorter, so the interval can be
+# lowered for fresher public numbers. Tunable via
+# ENTITY_STATS_REBUILD_INTERVAL_SECONDS; keep it comfortably above the observed
+# walk duration so the box isn't perpetually mid-rebuild (the walk now pegs all
+# the rebuild workers, not one core). Floored at 300s against a runaway loop.
+def _rebuild_interval_seconds() -> int:
+    try:
+        v = int(os.environ.get("ENTITY_STATS_REBUILD_INTERVAL_SECONDS", "7200"))
+    except ValueError:
+        v = 2 * 60 * 60
+    return max(300, v)
+
+
+_SNAPSHOT_REBUILD_SECONDS = _rebuild_interval_seconds()
 # Workers reload the snapshot from Mongo this often (cheap read).
 _SNAPSHOT_LOAD_SECONDS = 5 * 60
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,6 +40,11 @@ services:
       # (the serial ~80min walk); capped at the box's CPU count. Set the value
       # in the box .env after validating with scripts/validate_parallel_rebuild.py.
       - ENTITY_STATS_REBUILD_WORKERS=${ENTITY_STATS_REBUILD_WORKERS:-1}
+      # How often the leader may rerun the heavy walk (seconds). Default 7200
+      # (2h). With the parallel rebuild on, lower it for fresher public numbers,
+      # but keep it well above the observed walk time so the box isn't always
+      # mid-rebuild. Floored at 300s in code.
+      - ENTITY_STATS_REBUILD_INTERVAL_SECONDS=${ENTITY_STATS_REBUILD_INTERVAL_SECONDS:-7200}
       - FEEDBACK_WEBHOOK_URL=${FEEDBACK_WEBHOOK_URL:-}
       # Cloudflare purge from the admin cache tab. Same token/zone the
       # autodeploy script uses; set them in the box's .env.


### PR DESCRIPTION
The heavy entity-stats walk is hardcoded to run at most every 2h (`_SNAPSHOT_REBUILD_SECONDS`). That default was chosen when the serial walk took ~80 min and a shorter interval pinned one core in a near-continuous walk that starved the DB. Now that the rebuild runs in parallel (`ENTITY_STATS_REBUILD_WORKERS>1`), the walk is far shorter, so the public 'runs tracked' / tier-list / community-stats numbers can refresh more often than every 2h — which is what makes them lag uploads by up to 2h today.

I made `_SNAPSHOT_REBUILD_SECONDS` read `ENTITY_STATS_REBUILD_INTERVAL_SECONDS` from the environment (**default 7200, unchanged**; floored at 300s against a runaway loop) and wired the var through `docker-compose.prod.yml` exactly like the workers knob.

**Default behavior is unchanged** — nothing moves until the `.env` value is set, so this is safe to merge on its own. To tune: measure the parallel walk duration first (`snapshot rebuild: starting` in the logs → the next `built_at`), then set the interval **comfortably above** that so the box isn't perpetually mid-rebuild. Note the walk now pegs all the rebuild workers (all 4 cores on this box), not one — so I'd start conservative, e.g. `ENTITY_STATS_REBUILD_INTERVAL_SECONDS=2700` (45 min) if the walk lands around 20-25 min, and watch serving latency.

`_archive_metric_history` is day-keyed and idempotent, so more frequent rebuilds overwrite the day's trend point rather than piling up — no chart noise from a shorter interval.