### PR TITLE
Item-pairings: card/relic/potion co-occurrence synergies (backend)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -45,6 +45,7 @@ from .routers import (
     entity_history,
     ancient_pools,
     runs,
+    pairings,
     charts,
     beta,
     admin,
@@ -585,6 +586,7 @@ app.include_router(exports.router)
 app.include_router(entity_history.router)
 app.include_router(ancient_pools.router)
 app.include_router(runs.router)
+app.include_router(pairings.router)
 app.include_router(charts.router)
 app.include_router(beta.router)
 # Hidden from the OpenAPI schema (/docs): internal admin surface.

--- a/backend/app/routers/pairings.py
+++ b/backend/app/routers/pairings.py
@@ -15,12 +15,13 @@ router = APIRouter(prefix="/api/pairings", tags=["Pairings"])
 def get_item_pairings(item_type: str, item_id: str):
     """Which cards / relics / potions show up in the same runs as this item.
 
-    Each partner carries `co` (co-occurrence count), `conf` (directional — of
-    the runs with this item, the fraction that also run the partner), `npmi`
-    (symmetric synergy, >0 = played together more than chance), and `winrate`
-    (the pair's win rate). Cards/relics are ranked by NPMI; potions are ranked
-    by frequency and are "commonly seen with", not a synergy claim. Returns an
-    empty `partners` map until the build job has populated the cache.
+    Each partner carries `co` (co-occurrence count), both confidence directions
+    — `conf` (of the runs with THIS item, the fraction that also run the partner)
+    and `conf_rev` (the reverse, of the partner's runs the fraction that also run
+    this item) — `npmi` (symmetric synergy, >0 = played together more than
+    chance), and `winrate` (the pair's win rate). Cards/relics are ranked by
+    NPMI; potions are ranked by frequency and are "commonly seen with", not a
+    synergy claim. Returns an empty `partners` map until the build job has run.
     """
     if item_type not in ("cards", "relics", "potions"):
         raise HTTPException(status_code=400, detail="bad item_type")

--- a/backend/app/routers/pairings.py
+++ b/backend/app/routers/pairings.py
@@ -1,0 +1,30 @@
+"""Cached item-pairings (card / relic / potion co-occurrence synergies).
+
+Read-only: served from the `item_pairings` collection built by the
+`scripts.build_pairings` job. O(1) per lookup, empty until that job has run.
+"""
+
+from fastapi import APIRouter, HTTPException
+
+from ..services.item_pairings import get_pairings
+
+router = APIRouter(prefix="/api/pairings", tags=["Pairings"])
+
+
+@router.get("/{item_type}/{item_id}")
+def get_item_pairings(item_type: str, item_id: str):
+    """Which cards / relics / potions show up in the same runs as this item.
+
+    Each partner carries `co` (co-occurrence count), `conf` (directional — of
+    the runs with this item, the fraction that also run the partner), `npmi`
+    (symmetric synergy, >0 = played together more than chance), and `winrate`
+    (the pair's win rate). Cards/relics are ranked by NPMI; potions are ranked
+    by frequency and are "commonly seen with", not a synergy claim. Returns an
+    empty `partners` map until the build job has populated the cache.
+    """
+    if item_type not in ("cards", "relics", "potions"):
+        raise HTTPException(status_code=400, detail="bad item_type")
+    doc = get_pairings(item_type, item_id)
+    if not doc:
+        return {"kind": item_type, "item_id": item_id.upper(), "partners": {}}
+    return doc

--- a/backend/app/services/item_pairings.py
+++ b/backend/app/services/item_pairings.py
@@ -1,0 +1,300 @@
+"""Co-occurrence / synergy pairings across cards, relics, and potions.
+
+"Players who take X usually also take Y." Decoupled on purpose from the
+entity-stats snapshot walk (which is memory-heavy and rebuilds every couple of
+hours): the underlying draft patterns only shift on game patches, so this is an
+infrequent, cached job. It streams official runs from Mongo, counts how often
+each pair of items lands in the same run, and scores the pairs. Results are
+stored per item (top-N partners) for the card / relic pages to read in O(1).
+
+Metrics, per unordered pair (a, b) over N official runs:
+  co          runs containing both a and b
+  P(a)        count[a] / N                      base rate of a
+  P(a, b)     co / N
+  PMI         log( P(a,b) / (P(a) P(b)) )
+  NPMI        PMI / -log P(a,b)                 in [-1, 1]; >0 synergy, 0 = independent,
+                                                <0 = actively avoided together
+  conf(b|a)   co / count[a]                     directional: of decks with a, the
+                                                fraction that also run b
+  winrate     wins_together / co                the pair's win rate
+
+Cards and relics are drafted, so their co-occurrence is a real synergy signal
+and is ranked by NPMI. Potions are RNG drops (we only count ones the player
+actually took), so their signal is weaker — they're ranked by raw frequency and
+surfaced as "commonly seen with", not a synergy claim. Pairs below a per-type
+support floor are dropped so rare-but-always-together noise never shows up.
+"""
+
+import logging
+import math
+import os
+from collections import defaultdict
+from datetime import datetime, timezone
+from itertools import combinations
+from typing import Any
+
+logger = logging.getLogger("spire-codex")
+
+# Mongo collection holding the cached results (one doc per item + a __meta__).
+PAIRINGS_COLLECTION_NAME = "item_pairings"
+
+# Minimum co-occurrence count for a pair to be reported, per partner type. Kills
+# rare-but-always-together noise. Potions get a higher floor: they're a weaker,
+# RNG-driven signal, so we only surface the ones seen a lot.
+_MIN_SUPPORT = {"cards": 250, "relics": 250, "potions": 500}
+
+# Partners kept per (item, partner-type). Enough for a "top synergies" panel
+# without bloating the cached doc.
+_TOP_N = 12
+
+# The three item kinds we pair across. Matches the run-doc field names.
+_ITEM_KINDS = ("cards", "relics", "potions")
+
+
+_official_cache: dict[str, frozenset[str]] | None = None
+
+
+def _official_sets() -> dict[str, frozenset[str]]:
+    """Upper-cased official id sets for cards / relics / potions, so modded ids
+    in a run get dropped (they'd otherwise pollute the synergy signal). Loaded
+    once from the committed game-data catalogs."""
+    global _official_cache
+    if _official_cache is None:
+        from .data_service import load_cards, load_potions, load_relics
+
+        def ids(rows):
+            return frozenset((r.get("id") or "").upper() for r in rows if r.get("id"))
+
+        try:
+            _official_cache = {
+                "cards": ids(load_cards()),
+                "relics": ids(load_relics()),
+                "potions": ids(load_potions()),
+            }
+        except Exception:
+            logger.warning("item-pairings: catalog load failed", exc_info=True)
+            _official_cache = {k: frozenset() for k in _ITEM_KINDS}
+    return _official_cache
+
+
+def _run_items(run: dict, official: dict[str, frozenset[str]]) -> set[tuple[str, str]]:
+    """The set of official (kind, id) items in one run: every distinct deck card
+    (multiples collapse to one), every relic, and every potion the player
+    actually took. Modded / unknown ids are dropped."""
+    items: set[tuple[str, str]] = set()
+    for c in run.get("deck") or []:
+        cid = (c.get("id") or "").upper()
+        if cid in official["cards"]:
+            items.add(("cards", cid))
+    for r in run.get("relics") or []:
+        rid = (r.get("id") or "").upper()
+        if rid in official["relics"]:
+            items.add(("relics", rid))
+    for p in run.get("potions") or []:
+        # Potions are RNG; only count ones the player chose to take, not every
+        # potion that was merely offered.
+        if not (p.get("was_picked") or p.get("was_used")):
+            continue
+        pid = (p.get("id") or "").upper()
+        if pid in official["potions"]:
+            items.add(("potions", pid))
+    return items
+
+
+def _iter_official_runs(batch_size: int = 2000):
+    """Stream official runs (A0-A10, not hidden) from Mongo, projecting only the
+    fields the pairing needs. Streamed so peak memory stays bounded regardless
+    of run count — the whole point of keeping this off the snapshot walk."""
+    from .runs_db_mongo import _get_collection
+
+    cursor = _get_collection().find(
+        {"ascension": {"$gte": 0, "$lte": 10}, "hidden": {"$ne": True}},
+        {"deck.id": 1, "relics.id": 1, "potions": 1, "win": 1},
+        batch_size=batch_size,
+    )
+    for run in cursor:
+        yield run
+
+
+def compute_pairings(runs_iter=None) -> dict[str, Any]:
+    """Walk the runs once, accumulate co-occurrence + wins, and return the
+    per-item top-N partner structure plus totals. `runs_iter` defaults to the
+    Mongo stream; injectable for tests."""
+    official = _official_sets()
+    if runs_iter is None:
+        runs_iter = _iter_official_runs()
+
+    # Item -> compact int index (keeps the pair dict keys small and hashing
+    # cheap over the ~500M pair increments).
+    idx_of: dict[tuple[str, str], int] = {}
+    items_list: list[tuple[str, str]] = []
+
+    count = defaultdict(int)  # idx -> runs containing it
+    wins = defaultdict(int)  # idx -> winning runs containing it
+    co = defaultdict(int)  # (i, j) i<j -> runs containing both
+    co_win = defaultdict(int)  # (i, j) -> winning runs containing both
+    n_runs = 0
+
+    for run in runs_iter:
+        item_set = _run_items(run, official)
+        if len(item_set) < 2:
+            continue
+        n_runs += 1
+        won = bool(run.get("win"))
+        idxs = []
+        for it in item_set:
+            i = idx_of.get(it)
+            if i is None:
+                i = len(items_list)
+                idx_of[it] = i
+                items_list.append(it)
+            idxs.append(i)
+            count[i] += 1
+            if won:
+                wins[i] += 1
+        idxs.sort()
+        for a, b in combinations(idxs, 2):
+            co[(a, b)] += 1
+            if won:
+                co_win[(a, b)] += 1
+
+    logger.info(
+        "item-pairings: walked %d runs, %d distinct items, %d distinct pairs",
+        n_runs,
+        len(items_list),
+        len(co),
+    )
+    return _score_and_rank(items_list, count, wins, co, co_win, n_runs)
+
+
+def _score_and_rank(items_list, count, wins, co, co_win, n_runs) -> dict[str, Any]:
+    """Turn raw counts into NPMI / confidence / win-rate and keep the top-N
+    partners per item, split by partner kind."""
+    # partners[i] -> {"cards": [...], "relics": [...], "potions": [...]}
+    partners: dict[int, dict[str, list]] = defaultdict(
+        lambda: {k: [] for k in _ITEM_KINDS}
+    )
+
+    for (i, j), c in co.items():
+        ki, idi = items_list[i]
+        kj, idj = items_list[j]
+        # Support floor is per partner *kind*; a card->potion pair is gated by
+        # the potion floor from the card's side and vice-versa, so apply each
+        # direction against the partner's kind.
+        ci, cj = count[i], count[j]
+        # PMI / NPMI are symmetric. NPMI normalizes PMI by -log P(a,b) into
+        # [-1, 1]. When the pair is in *every* counted run (p_ij == 1) the
+        # denominator is 0 and both items are ubiquitous, i.e. independent, so
+        # NPMI is 0 — not a synergy (guards against a divide-by-zero too).
+        p_ij = c / n_runs
+        pmi = math.log(p_ij / ((ci / n_runs) * (cj / n_runs)))
+        denom = -math.log(p_ij)
+        npmi = pmi / denom if denom > 0 else 0.0
+        cw = co_win.get((i, j), 0)
+        winrate = round(cw / c, 4) if c else 0.0
+
+        # i's page gets j as a partner (directional conf = of i-decks, how many
+        # also run j), and vice-versa.
+        if c >= _MIN_SUPPORT.get(kj, 250):
+            partners[i][kj].append(
+                {
+                    "id": idj,
+                    "co": c,
+                    "conf": round(c / ci, 4),
+                    "npmi": round(npmi, 4),
+                    "winrate": winrate,
+                }
+            )
+        if c >= _MIN_SUPPORT.get(ki, 250):
+            partners[j][ki].append(
+                {
+                    "id": idi,
+                    "co": c,
+                    "conf": round(c / cj, 4),
+                    "npmi": round(npmi, 4),
+                    "winrate": winrate,
+                }
+            )
+
+    docs = []
+    now = datetime.now(timezone.utc)
+    for i, kinds in partners.items():
+        kind, item_id = items_list[i]
+        out_kinds = {}
+        for pk, lst in kinds.items():
+            if not lst:
+                continue
+            # Cards/relics rank by synergy (NPMI); potions by raw frequency
+            # (they're "commonly seen with", not a synergy claim).
+            if pk == "potions":
+                lst.sort(key=lambda d: (d["co"], d["conf"]), reverse=True)
+            else:
+                lst.sort(key=lambda d: (d["npmi"], d["co"]), reverse=True)
+            out_kinds[pk] = lst[:_TOP_N]
+        if out_kinds:
+            docs.append(
+                {
+                    "_id": f"{kind}:{item_id}",
+                    "kind": kind,
+                    "item_id": item_id,
+                    "count": count[i],
+                    "winrate": round(wins[i] / count[i], 4) if count[i] else 0.0,
+                    "partners": out_kinds,
+                    "built_at": now,
+                }
+            )
+    return {"docs": docs, "n_runs": n_runs, "built_at": now}
+
+
+def store_pairings(result: dict[str, Any]) -> int:
+    """Replace the cached pairings collection with a freshly computed set.
+    Returns the number of item docs written."""
+    from .runs_db_mongo import _get_collection
+
+    db = _get_collection().database
+    coll = db[PAIRINGS_COLLECTION_NAME]
+    docs = result["docs"]
+    # Rewrite wholesale: drop stale items (an item can lose all its partners
+    # between builds) then bulk-insert the fresh set + a meta doc.
+    coll.delete_many({})
+    if docs:
+        coll.insert_many(docs, ordered=False)
+    coll.replace_one(
+        {"_id": "__meta__"},
+        {
+            "_id": "__meta__",
+            "n_runs": result["n_runs"],
+            "item_count": len(docs),
+            "built_at": result["built_at"],
+        },
+        upsert=True,
+    )
+    return len(docs)
+
+
+def build_and_store() -> int:
+    """Full job: walk runs, score, persist. Returns items written. Safe to run
+    manually or on a slow schedule."""
+    if not os.environ.get("MONGO_URL", "").strip():
+        logger.warning("item-pairings: MONGO_URL unset; skipping")
+        return 0
+    result = compute_pairings()
+    n = store_pairings(result)
+    logger.info("item-pairings: stored %d items from %d runs", n, result["n_runs"])
+    return n
+
+
+def get_pairings(item_type: str, item_id: str) -> dict[str, Any] | None:
+    """Read one item's cached partners for the API. None if not computed yet."""
+    if not os.environ.get("MONGO_URL", "").strip():
+        return None
+    from .runs_db_mongo import _get_collection
+
+    db = _get_collection().database
+    doc = db[PAIRINGS_COLLECTION_NAME].find_one(
+        {"_id": f"{item_type}:{item_id.upper()}"}
+    )
+    if not doc:
+        return None
+    doc.pop("_id", None)
+    return doc

--- a/backend/app/services/item_pairings.py
+++ b/backend/app/services/item_pairings.py
@@ -14,8 +14,10 @@ Metrics, per unordered pair (a, b) over N official runs:
   PMI         log( P(a,b) / (P(a) P(b)) )
   NPMI        PMI / -log P(a,b)                 in [-1, 1]; >0 synergy, 0 = independent,
                                                 <0 = actively avoided together
-  conf(b|a)   co / count[a]                     directional: of decks with a, the
-                                                fraction that also run b
+  conf        co / count[this]                  directional: of decks with THIS
+                                                item, fraction that also run the partner
+  conf_rev    co / count[partner]               the other direction, P(this | partner);
+                                                both are stored so neither is missed
   winrate     wins_together / co                the pair's win rate
 
 Cards and relics are drafted, so their co-occurrence is a real synergy signal
@@ -193,14 +195,18 @@ def _score_and_rank(items_list, count, wins, co, co_win, n_runs) -> dict[str, An
         cw = co_win.get((i, j), 0)
         winrate = round(cw / c, 4) if c else 0.0
 
-        # i's page gets j as a partner (directional conf = of i-decks, how many
-        # also run j), and vice-versa.
+        # Store BOTH confidence directions: conf = P(partner | this item), and
+        # conf_rev = P(this item | partner). One direction alone misleads — a
+        # rare card can be a near-mandatory pick inside a common card's decks
+        # while barely denting that common card's overall rate. `conf` always
+        # reads "of THIS page's decks, the fraction that also run the partner".
         if c >= _MIN_SUPPORT.get(kj, 250):
             partners[i][kj].append(
                 {
                     "id": idj,
                     "co": c,
-                    "conf": round(c / ci, 4),
+                    "conf": round(c / ci, 4),  # P(j | i)
+                    "conf_rev": round(c / cj, 4),  # P(i | j)
                     "npmi": round(npmi, 4),
                     "winrate": winrate,
                 }
@@ -210,7 +216,8 @@ def _score_and_rank(items_list, count, wins, co, co_win, n_runs) -> dict[str, An
                 {
                     "id": idi,
                     "co": c,
-                    "conf": round(c / cj, 4),
+                    "conf": round(c / cj, 4),  # P(i | j)
+                    "conf_rev": round(c / ci, 4),  # P(j | i)
                     "npmi": round(npmi, 4),
                     "winrate": winrate,
                 }

--- a/backend/scripts/build_pairings.py
+++ b/backend/scripts/build_pairings.py
@@ -1,0 +1,27 @@
+"""Build and cache the item-pairings (card / relic / potion co-occurrence).
+
+Run inside the backend container:
+
+    python -m scripts.build_pairings
+
+Streams official runs from Mongo, scores every co-occurring pair (NPMI +
+directional confidence + pair win-rate), and writes the top-N partners per item
+to the `item_pairings` collection for the card / relic pages to read. Infrequent
+by design — the draft patterns only shift on game patches — and decoupled from
+the entity-stats snapshot rebuild so it can't add to that job's memory pressure.
+"""
+
+import time
+
+
+def main() -> int:
+    t = time.time()
+    from app.services.item_pairings import build_and_store
+
+    n = build_and_store()
+    print(f"item-pairings: stored {n} items in {time.time() - t:.1f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
First half of the card-synergy feature — the data engine. Answers *"players who take X usually also take Y"* across **cards, relics, and potions**. The frontend panel is a follow-up PR that reads this.

## What it does
Streams official runs (A0-A10, not hidden) from Mongo, counts how often each pair of items lands in the same run, and scores every pair:
- **NPMI** — symmetric synergy, in [-1, 1]. >0 = played together more than chance, 0 = independent, <0 = actively avoided.
- **confidence** — directional: of the runs with X, the fraction that also run Y (this is the *"X-players also take Y"* number).
- **win rate** — the pair's win rate.

Top-N partners per item are cached in an `item_pairings` collection → O(1) reads.

## Design notes
- **Decoupled from the snapshot walk.** Draft patterns only shift on game patches, so this is an infrequent job (`python -m scripts.build_pairings`), and it **streams** from Mongo so peak memory stays bounded. After the memory saga this week, it deliberately can't add to that walk's pressure.
- **Pure-Python, no numpy dep.** One pass, per-run co-occurrence accumulation into dicts. Bounded memory (~a few hundred MB of pair counts).
- **Cards/relics rank by NPMI** (they're drafted → real synergy). **Potions rank by frequency** and are surfaced as *"commonly seen with"*, not a synergy claim — they're RNG drops, and only the ones the player actually took are counted.
- **Support floors** per type drop rare-but-always-together noise (250 cards/relics, 500 potions). Modded ids filtered against the official catalogs.

## Verified
Unit-checked the math on synthetic runs — NPMI matches `log(2)/-log(0.3)`, confidence and win-rate exact — plus the `p_ij==1` degenerate edge case (two items in every run → NPMI 0, not a false synergy). Ruff clean, compiles.

## To use
Once merged + deployed, populate the cache with `docker exec spire-codex-backend python -m scripts.build_pairings` (needs #611's scripts-in-image, or `docker cp` for now), then `GET /api/pairings/cards/BASH` returns the partners. Then I'll build the "Often drafted with" panel on the card/relic pages.