### PR TITLE
Add the 'Often drafted with' pairings panel to card/relic/potion pages

### DIFF
--- a/backend/app/routers/pairings.py
+++ b/backend/app/routers/pairings.py
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/api/pairings", tags=["Pairings"])
 
 
 @router.get("/{item_type}/{item_id}")
-def get_item_pairings(item_type: str, item_id: str):
+def get_item_pairings(item_type: str, item_id: str, lang: str = "eng"):
     """Which cards / relics / potions show up in the same runs as this item.
 
     Each partner carries `co` (co-occurrence count), both confidence directions
@@ -25,7 +25,7 @@ def get_item_pairings(item_type: str, item_id: str):
     """
     if item_type not in ("cards", "relics", "potions"):
         raise HTTPException(status_code=400, detail="bad item_type")
-    doc = get_pairings(item_type, item_id)
+    doc = get_pairings(item_type, item_id, lang)
     if not doc:
         return {"kind": item_type, "item_id": item_id.upper(), "partners": {}}
     return doc

--- a/backend/app/services/item_pairings.py
+++ b/backend/app/services/item_pairings.py
@@ -32,6 +32,7 @@ import math
 import os
 from collections import defaultdict
 from datetime import datetime, timezone
+from functools import lru_cache
 from itertools import combinations
 from typing import Any
 
@@ -291,8 +292,36 @@ def build_and_store() -> int:
     return n
 
 
-def get_pairings(item_type: str, item_id: str) -> dict[str, Any] | None:
-    """Read one item's cached partners for the API. None if not computed yet."""
+@lru_cache(maxsize=32)
+def _name_maps(lang: str) -> dict[str, dict[str, str]]:
+    """Per-language {kind: {ID: display name}} for enriching partner ids at read
+    time. The cached pairings are language-agnostic (built once), so names are
+    resolved here per request. Cached per lang; catalogs are static per deploy."""
+    from .data_service import load_cards, load_potions, load_relics
+
+    def m(rows):
+        return {
+            (r["id"]).upper(): (r.get("name") or r["id"]) for r in rows if r.get("id")
+        }
+
+    try:
+        return {
+            "cards": m(load_cards(lang)),
+            "relics": m(load_relics(lang)),
+            "potions": m(load_potions(lang)),
+        }
+    except Exception:
+        logger.warning(
+            "item-pairings: name map load failed for %s", lang, exc_info=True
+        )
+        return {k: {} for k in _ITEM_KINDS}
+
+
+def get_pairings(
+    item_type: str, item_id: str, lang: str = "eng"
+) -> dict[str, Any] | None:
+    """Read one item's cached partners for the API, with each partner's
+    localized display name attached. None if not computed yet."""
     if not os.environ.get("MONGO_URL", "").strip():
         return None
     from .runs_db_mongo import _get_collection
@@ -304,4 +333,9 @@ def get_pairings(item_type: str, item_id: str) -> dict[str, Any] | None:
     if not doc:
         return None
     doc.pop("_id", None)
+    names = _name_maps(lang)
+    for kind, lst in (doc.get("partners") or {}).items():
+        nm = names.get(kind, {})
+        for p in lst:
+            p["name"] = nm.get(p["id"], p["id"])
     return doc

--- a/frontend/app/card-revamp.css
+++ b/frontend/app/card-revamp.css
@@ -235,3 +235,36 @@ a.kw { text-decoration: none; }
   .card-rvmp .hero-art { display: none; }
   .card-rvmp .toc { top: 64px; }
 }
+
+/* ── "Often drafted with" pairings panel ── */
+.card-rvmp .pair-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 22px;
+  margin-top: 6px;
+}
+.card-rvmp .pair-list {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+}
+.card-rvmp .pair-row { display: flex; flex-direction: column; gap: 2px; }
+.card-rvmp .pair-name {
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--accent-gold);
+  text-decoration: none;
+}
+.card-rvmp .pair-name:hover { text-decoration: underline; }
+.card-rvmp .pair-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 12px;
+  font-size: 12px;
+  color: var(--text-2);
+  font-variant-numeric: tabular-nums;
+}
+.card-rvmp .pair-wr { color: var(--text); }

--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -14,6 +14,7 @@ import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import RelatedCards from "@/app/components/RelatedCards";
 import EntityProse from "@/app/components/EntityProse";
+import EntityPairings from "@/app/components/EntityPairings";
 import { imageUrl, fullCardUrl, enchantedCardUrl } from "@/lib/image-url";
 import EntityRunStats, { type EntityStats } from "@/app/components/EntityRunStats";
 import HoverTooltip from "@/app/components/HoverTooltip";
@@ -673,6 +674,8 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
               />
             </div>
           </section>
+
+          <EntityPairings kind="cards" id={id} name={card.name} lang={lang} lp={lp} />
 
           {/* Version history + localized names */}
           <section id="history">

--- a/frontend/app/components/EntityPairings.tsx
+++ b/frontend/app/components/EntityPairings.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+// "Often drafted with" — the cards / relics / potions that show up in the same
+// community runs as this entity, from the cached item-pairings job. Reads
+// /api/pairings/{kind}/{id}; renders nothing until data arrives or if the item
+// has no partners yet. Cards/relics are ranked by synergy (NPMI); potions are
+// "commonly seen with" (RNG, ranked by frequency). Each row shows both
+// confidence directions plus the pair's win rate.
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { cachedFetch } from "@/lib/fetch-cache";
+import { t } from "@/lib/ui-translations";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+const TOP = 5;
+const pct = (x: number) => `${Math.round((x ?? 0) * 100)}%`;
+
+type Partner = {
+  id: string;
+  name: string;
+  co: number;
+  conf: number;
+  conf_rev: number;
+  npmi: number;
+  winrate: number;
+};
+
+type Pairings = {
+  partners?: { cards?: Partner[]; relics?: Partner[]; potions?: Partner[] };
+};
+
+type Kind = "cards" | "relics" | "potions";
+
+export default function EntityPairings({
+  kind,
+  id,
+  name,
+  lang,
+  lp,
+}: {
+  kind: Kind;
+  id: string;
+  name: string;
+  lang: string;
+  lp: string;
+}) {
+  const [data, setData] = useState<Pairings | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    cachedFetch<Pairings>(`${API}/api/pairings/${kind}/${id}?lang=${lang}`)
+      .then((d) => {
+        if (alive) {
+          setData(d);
+          setLoaded(true);
+        }
+      })
+      .catch(() => {
+        if (alive) setLoaded(true);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [kind, id, lang]);
+
+  const p = data?.partners || {};
+  // Potions aren't drafted, so they're framed as "commonly seen with" rather
+  // than a synergy claim.
+  const allGroups: { key: Kind; heading: string; items: Partner[] }[] = [
+    { key: "cards", heading: t("Cards", lang), items: (p.cards || []).slice(0, TOP) },
+    { key: "relics", heading: t("Relics", lang), items: (p.relics || []).slice(0, TOP) },
+    {
+      key: "potions",
+      heading: t("Commonly seen with", lang),
+      items: (p.potions || []).slice(0, TOP),
+    },
+  ];
+  const groups = allGroups.filter((g) => g.items.length > 0);
+
+  if (!loaded || groups.length === 0) return null;
+
+  return (
+    <section id="pairings">
+      <h2>{t("Often drafted with", lang)}</h2>
+      <p className="h-note">
+        {t("Cards, relics and potions that show up in the same community runs as", lang)}{" "}
+        {name}.
+      </p>
+      <div className="pair-groups">
+        {groups.map((g) => (
+          <div key={g.key} className="pair-group">
+            <h3 className="subh">{g.heading}</h3>
+            <ul className="pair-list">
+              {g.items.map((it) => (
+                <li key={it.id} className="pair-row">
+                  <Link
+                    href={`${lp}/${g.key}/${it.id.toLowerCase()}`}
+                    className="pair-name"
+                  >
+                    {it.name}
+                  </Link>
+                  <span className="pair-stats">
+                    <span title={t("Of this item's runs, the share that also run it", lang)}>
+                      {pct(it.conf)} {t("of decks", lang)}
+                    </span>
+                    <span title={t("Of that item's runs, the share that also run this one", lang)}>
+                      {pct(it.conf_rev)} {t("of theirs", lang)}
+                    </span>
+                    <span className="pair-wr">
+                      {pct(it.winrate)} {t("win", lang)}
+                    </span>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/potions/[id]/PotionDetail.tsx
+++ b/frontend/app/potions/[id]/PotionDetail.tsx
@@ -12,6 +12,7 @@ import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import RelatedItems from "@/app/components/RelatedItems";
 import EntityProse from "@/app/components/EntityProse";
+import EntityPairings from "@/app/components/EntityPairings";
 import EntityRunStats, { type EntityStats } from "@/app/components/EntityRunStats";
 import { imageUrl } from "@/lib/image-url";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
@@ -247,6 +248,8 @@ export default function PotionDetail({
               ]}
             />
           </section>
+
+          <EntityPairings kind="potions" id={id} name={potion.name} lang={lang} lp={lp} />
 
           {/* Version history + localized names */}
           <section id="history">

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -12,6 +12,7 @@ import LocalizedNames from "@/app/components/LocalizedNames";
 import EntityHistory from "@/app/components/EntityHistory";
 import RelatedItems from "@/app/components/RelatedItems";
 import EntityProse from "@/app/components/EntityProse";
+import EntityPairings from "@/app/components/EntityPairings";
 import EntityRunStats, { type EntityStats } from "@/app/components/EntityRunStats";
 import { imageUrl } from "@/lib/image-url";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
@@ -281,6 +282,8 @@ export default function RelicDetail({
               ]}
             />
           </section>
+
+          <EntityPairings kind="relics" id={id} name={relic.name} lang={lang} lp={lp} />
 
           {/* Version history + localized names */}
           <section id="history">


### PR DESCRIPTION
The frontend for the card-synergy feature (backend engine landed in #616, starter cleanup in #617). Adds an **"Often drafted with"** section to card, relic, and potion detail pages.

## What it shows
Top 5 partners in each of three groups:
- **Cards** and **Relics** — ranked by synergy (NPMI).
- **Commonly seen with** (potions) — RNG, so framed as frequency, not a synergy claim.

Each row links to the partner and shows **both confidence directions** — "X% of this item's decks also run it" *and* "Y% of the partner's decks run this" — plus the **pair win-rate**. That's the asymmetry guard: a one-way dependency (a niche card that's near-mandatory in a common card's decks) reads correctly from either page instead of looking weak from one side.

## How it's wired
- `EntityPairings.tsx`: client component, fetches `/api/pairings/{kind}/{id}?lang=`, renders **nothing** until data arrives or if the item has no partners yet — so it's safe to ship before the cache is populated.
- Dropped into `CardDetail` / `RelicDetail` / `PotionDetail`; it's a `.card-rvmp section[id]` so it auto-joins the existing scroll-spy section nav.
- Backend: the pairings endpoint now attaches each partner's **localized name** (cached per lang; the stored pairings doc stays language-agnostic, so no per-language rebuild).
- Scoped CSS in `card-revamp.css`, using the contrast-fixed text tiers so it's theme-aware.

## Verified
`tsc --noEmit` and `eslint` both clean on the changed files. Strings go through `t()` (English fallback, translation-ready).

Lights up once the `item_pairings` cache is built (and looks best after #617 + a rebuild clears the starter noise).