### PR TITLE
Clarify pairings-panel copy + add hover previews

### DIFF
--- a/backend/app/services/item_pairings.py
+++ b/backend/app/services/item_pairings.py
@@ -310,15 +310,21 @@ def build_and_store() -> int:
 
 
 @lru_cache(maxsize=32)
-def _name_maps(lang: str) -> dict[str, dict[str, str]]:
-    """Per-language {kind: {ID: display name}} for enriching partner ids at read
-    time. The cached pairings are language-agnostic (built once), so names are
-    resolved here per request. Cached per lang; catalogs are static per deploy."""
+def _name_maps(lang: str) -> dict[str, dict[str, dict[str, str]]]:
+    """Per-language {kind: {ID: {"name":..., "desc":...}}} for enriching partner
+    ids at read time — name for the label, description for the hover tooltip. The
+    cached pairings are language-agnostic (built once), so this is resolved here
+    per request. Cached per lang; catalogs are static per deploy."""
     from .data_service import load_cards, load_potions, load_relics
 
     def m(rows):
         return {
-            (r["id"]).upper(): (r.get("name") or r["id"]) for r in rows if r.get("id")
+            (r["id"]).upper(): {
+                "name": r.get("name") or r["id"],
+                "desc": r.get("description") or "",
+            }
+            for r in rows
+            if r.get("id")
         }
 
     try:
@@ -338,7 +344,8 @@ def get_pairings(
     item_type: str, item_id: str, lang: str = "eng"
 ) -> dict[str, Any] | None:
     """Read one item's cached partners for the API, with each partner's
-    localized display name attached. None if not computed yet."""
+    localized display name + description attached (name for the label, desc for
+    the hover tooltip). None if not computed yet."""
     if not os.environ.get("MONGO_URL", "").strip():
         return None
     from .runs_db_mongo import _get_collection
@@ -354,5 +361,7 @@ def get_pairings(
     for kind, lst in (doc.get("partners") or {}).items():
         nm = names.get(kind, {})
         for p in lst:
-            p["name"] = nm.get(p["id"], p["id"])
+            meta = nm.get(p["id"]) or {}
+            p["name"] = meta.get("name", p["id"])
+            p["desc"] = meta.get("desc", "")
     return doc

--- a/frontend/app/card-revamp.css
+++ b/frontend/app/card-revamp.css
@@ -251,7 +251,13 @@ a.kw { text-decoration: none; }
   flex-direction: column;
   gap: 11px;
 }
-.card-rvmp .pair-row { display: flex; flex-direction: column; gap: 2px; }
+.card-rvmp .pair-row { display: flex; flex-direction: column; gap: 3px; }
+.card-rvmp .pair-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
 .card-rvmp .pair-name {
   font-weight: 600;
   font-size: 15px;
@@ -259,12 +265,17 @@ a.kw { text-decoration: none; }
   text-decoration: none;
 }
 .card-rvmp .pair-name:hover { text-decoration: underline; }
+.card-rvmp .pair-wr {
+  font-size: 12px;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
 .card-rvmp .pair-stats {
   display: flex;
-  flex-wrap: wrap;
-  gap: 2px 12px;
+  flex-direction: column;
+  gap: 1px;
   font-size: 12px;
   color: var(--text-2);
   font-variant-numeric: tabular-nums;
 }
-.card-rvmp .pair-wr { color: var(--text); }

--- a/frontend/app/components/EntityPairings.tsx
+++ b/frontend/app/components/EntityPairings.tsx
@@ -4,12 +4,14 @@
 // community runs as this entity, from the cached item-pairings job. Reads
 // /api/pairings/{kind}/{id}; renders nothing until data arrives or if the item
 // has no partners yet. Cards/relics are ranked by synergy (NPMI); potions are
-// "commonly seen with" (RNG, ranked by frequency). Each row shows both
-// confidence directions plus the pair's win rate.
+// "commonly seen with" (RNG, ranked by frequency). Each row names both sides so
+// the two confidence directions read plainly, and shows the pair win rate.
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import CardHover from "@/app/components/CardHover";
+import HoverTooltip from "@/app/components/HoverTooltip";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { t } from "@/lib/ui-translations";
 
@@ -21,6 +23,7 @@ const pct = (x: number) => `${Math.round((x ?? 0) * 100)}%`;
 type Partner = {
   id: string;
   name: string;
+  desc: string;
   co: number;
   conf: number;
   conf_rev: number;
@@ -83,12 +86,32 @@ export default function EntityPairings({
 
   if (!loaded || groups.length === 0) return null;
 
+  // Card partners get the full-render hover pop; relics/potions get a text
+  // tooltip from their description.
+  const withHover = (g: Kind, it: Partner) => {
+    const link = (
+      <Link href={`${lp}/${g}/${it.id.toLowerCase()}`} className="pair-name">
+        {it.name}
+      </Link>
+    );
+    if (g === "cards") return <CardHover cardId={it.id}>{link}</CardHover>;
+    return (
+      <HoverTooltip title={it.name} content={it.desc}>
+        {link}
+      </HoverTooltip>
+    );
+  };
+
   return (
     <section id="pairings">
       <h2>{t("Often drafted with", lang)}</h2>
       <p className="h-note">
-        {t("Cards, relics and potions that show up in the same community runs as", lang)}{" "}
-        {name}.
+        {t("How often each is picked up in the same community runs as", lang)} {name}
+        {". "}
+        {t(
+          "The first figure is the share of this item's runs; the second is the share of the partner's runs.",
+          lang,
+        )}
       </p>
       <div className="pair-groups">
         {groups.map((g) => (
@@ -97,21 +120,18 @@ export default function EntityPairings({
             <ul className="pair-list">
               {g.items.map((it) => (
                 <li key={it.id} className="pair-row">
-                  <Link
-                    href={`${lp}/${g.key}/${it.id.toLowerCase()}`}
-                    className="pair-name"
-                  >
-                    {it.name}
-                  </Link>
-                  <span className="pair-stats">
-                    <span title={t("Of this item's runs, the share that also run it", lang)}>
-                      {pct(it.conf)} {t("of decks", lang)}
-                    </span>
-                    <span title={t("Of that item's runs, the share that also run this one", lang)}>
-                      {pct(it.conf_rev)} {t("of theirs", lang)}
-                    </span>
+                  <div className="pair-head">
+                    {withHover(g.key, it)}
                     <span className="pair-wr">
-                      {pct(it.winrate)} {t("win", lang)}
+                      {pct(it.winrate)} {t("win rate", lang)}
+                    </span>
+                  </div>
+                  <span className="pair-stats">
+                    <span>
+                      {pct(it.conf)} {t("of", lang)} {name} {t("runs", lang)}
+                    </span>
+                    <span>
+                      {pct(it.conf_rev)} {t("of", lang)} {it.name} {t("runs", lang)}
                     </span>
                   </span>
                 </li>

--- a/frontend/app/components/EntityPairings.tsx
+++ b/frontend/app/components/EntityPairings.tsx
@@ -106,39 +106,40 @@ export default function EntityPairings({
     <section id="pairings">
       <h2>{t("Often drafted with", lang)}</h2>
       <p className="h-note">
-        {t("How often each is picked up in the same community runs as", lang)} {name}
-        {". "}
-        {t(
-          "The first figure is the share of this item's runs; the second is the share of the partner's runs.",
-          lang,
-        )}
+        {t("How often each shows up in the same community runs as", lang)} {name}.
       </p>
       <div className="pair-groups">
-        {groups.map((g) => (
-          <div key={g.key} className="pair-group">
-            <h3 className="subh">{g.heading}</h3>
-            <ul className="pair-list">
-              {g.items.map((it) => (
-                <li key={it.id} className="pair-row">
-                  <div className="pair-head">
-                    {withHover(g.key, it)}
-                    <span className="pair-wr">
-                      {pct(it.winrate)} {t("win rate", lang)}
+        {groups.map((g) => {
+          // Cards/relics are drafted into a deck ("also run"); potions aren't
+          // deckbuilt, they just turn up in a run ("also had").
+          const unit = g.key === "potions" ? t("runs", lang) : t("decks", lang);
+          const verb = g.key === "potions" ? t("also had", lang) : t("also run", lang);
+          return (
+            <div key={g.key} className="pair-group">
+              <h3 className="subh">{g.heading}</h3>
+              <ul className="pair-list">
+                {g.items.map((it) => (
+                  <li key={it.id} className="pair-row">
+                    <div className="pair-head">
+                      {withHover(g.key, it)}
+                      <span className="pair-wr">
+                        {pct(it.winrate)} {t("win rate together", lang)}
+                      </span>
+                    </div>
+                    <span className="pair-stats">
+                      <span>
+                        {pct(it.conf)} {t("of", lang)} {name} {unit} {verb} {it.name}
+                      </span>
+                      <span>
+                        {pct(it.conf_rev)} {t("of", lang)} {it.name} {unit} {verb} {name}
+                      </span>
                     </span>
-                  </div>
-                  <span className="pair-stats">
-                    <span>
-                      {pct(it.conf)} {t("of", lang)} {name} {t("runs", lang)}
-                    </span>
-                    <span>
-                      {pct(it.conf_rev)} {t("of", lang)} {it.name} {t("runs", lang)}
-                    </span>
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
       </div>
     </section>
   );


### PR DESCRIPTION
Two fixes to the 'Often drafted with' panel from feedback:

**Clearer copy.** `33% of decks · 4% of theirs · 61% win` was ambiguous under a partner row (whose decks?). Now each row names both sides:
- `33% of {this entity} runs` — how often the partner appears in *this* item's runs
- `4% of {partner} runs` — the reverse direction
- `61% win rate` — the pair's win rate (moved up next to the name)

Plus a one-line explainer under the section header.

**Hover previews.** Hovering a partner now shows it: **cards** pop the full game render (reusing `CardHover`), **relics/potions** show a description tooltip (`HoverTooltip`). The pairings endpoint now attaches each partner's localized **description** alongside its name (cached per lang; stored doc stays language-agnostic).

tsc / eslint / ruff clean.