### PR TITLE
Swap entity info boxes for thin rules under section titles

### DIFF
--- a/frontend/app/card-revamp.css
+++ b/frontend/app/card-revamp.css
@@ -78,9 +78,8 @@
 .card-rvmp h2 { font-family: var(--serif); font-size: 25px; font-weight: 600; margin: 0 0 4px; color: var(--text); }
 .card-rvmp .h-note { color: var(--text-2); font-size: 13px; margin: 0 0 18px; }
 .card-rvmp .subh { font-family: var(--serif); font-weight: 600; font-size: 17px; margin: 30px 0 4px; color: var(--text); }
-/* Boxed info panels: Other languages + Version history, shown in full. */
-.card-rvmp .info-card { margin-top: 10px; background: var(--surface); border: 1px solid var(--border-2);
-  border-radius: 10px; padding: 16px 18px; }
+/* Thin rule under each section title, separating one section from the next. */
+.card-rvmp section h2 { border-bottom: 1px solid var(--border-2); padding-bottom: 10px; margin-bottom: 14px; }
 
 /* inline entity cross-links */
 .card-rvmp .ent { color: var(--gold); border-bottom: 1px dotted color-mix(in srgb, var(--gold) 55%, transparent); cursor: help; }

--- a/frontend/app/components/EntityHistory.tsx
+++ b/frontend/app/components/EntityHistory.tsx
@@ -113,8 +113,7 @@ export default function EntityHistory({ entityType, entityId }: EntityHistoryPro
   return (
     <section id="history">
       <h2>{t("Version history", lang)}</h2>
-      <div className="info-card">
-        {history && history.length > 0 ? (
+      {history && history.length > 0 ? (
           <div className="relative ml-2">
             {/* Timeline line */}
             <div className="absolute left-[5px] top-2 bottom-2 w-px bg-[var(--border-subtle)]" />
@@ -215,7 +214,6 @@ export default function EntityHistory({ entityType, entityId }: EntityHistoryPro
         >
           {t("View the full changelog", lang)} &rarr;
         </Link>
-      </div>
     </section>
   );
 }

--- a/frontend/app/components/LocalizedNames.tsx
+++ b/frontend/app/components/LocalizedNames.tsx
@@ -100,37 +100,35 @@ export default function LocalizedNames({
   return (
     <section id="other-languages">
       <h2>{t("Other languages", lang)}</h2>
-      <div className="info-card">
-        {rows.length > 0 ? (
-          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1.5 text-sm list-none p-0 m-0">
-            {rows.map(({ apiName, name, href, hrefLang }) => (
-              <li key={apiName}>
-                {href ? (
-                  <Link
-                    href={href}
-                    hrefLang={hrefLang}
-                    className="flex justify-between gap-3 rounded px-1.5 -mx-1.5 py-1 hover:bg-[var(--bg-card)] transition-colors"
-                  >
-                    <span className="text-[var(--text-secondary)]">{apiName}</span>
-                    <span className="text-[var(--text-primary)] text-right">
-                      {name}
-                    </span>
-                  </Link>
-                ) : (
-                  <div className="flex justify-between gap-3 px-1.5 py-1">
-                    <span className="text-[var(--text-secondary)]">{apiName}</span>
-                    <span className="text-[var(--text-primary)] text-right">
-                      {name}
-                    </span>
-                  </div>
-                )}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="text-xs text-[var(--text-muted)] m-0">Loading…</p>
-        )}
-      </div>
+      {rows.length > 0 ? (
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1.5 text-sm list-none p-0 m-0">
+          {rows.map(({ apiName, name, href, hrefLang }) => (
+            <li key={apiName}>
+              {href ? (
+                <Link
+                  href={href}
+                  hrefLang={hrefLang}
+                  className="flex justify-between gap-3 rounded px-1.5 -mx-1.5 py-1 hover:bg-[var(--bg-card)] transition-colors"
+                >
+                  <span className="text-[var(--text-secondary)]">{apiName}</span>
+                  <span className="text-[var(--text-primary)] text-right">
+                    {name}
+                  </span>
+                </Link>
+              ) : (
+                <div className="flex justify-between gap-3 px-1.5 py-1">
+                  <span className="text-[var(--text-secondary)]">{apiName}</span>
+                  <span className="text-[var(--text-primary)] text-right">
+                    {name}
+                  </span>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-xs text-[var(--text-muted)] m-0">Loading…</p>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
Follow-up to #622. Instead of boxing "Other languages" and "Version history", drop the boxes and use a thin divider under each section title, so the entity pages read as a clean run of sections rather than cards-within-a-card.

- `LocalizedNames` / `EntityHistory`: removed the `.info-card` wrapper. The content (language grid, version timeline, changelog links) now sits directly under the title like every other section. Everything from #622 stays: both shown in full, no drawers, fetched on mount, version numbers still deep-link to `/changelog#<version>`.
- Added a 1px bottom rule to section headings, scoped to `.card-rvmp section h2`, so it only affects the entity detail pages and not the aside/infobox.

This applies the rule to every section title on the entity pages (not just the two SEO sections), so the whole page gets consistent separators. Easy to scope down to just those two if that's too much.

tsc clean, eslint clean.
