### PR TITLE
Stop the home Recent Runs box from scrolling sideways

### DIFF
--- a/frontend/app/components/HomeLeaderboardSection.tsx
+++ b/frontend/app/components/HomeLeaderboardSection.tsx
@@ -302,12 +302,12 @@ export default async function HomeLeaderboardSection({
               {recent.length === 0 ? (
                 <p className="lb-empty">{t("No runs submitted yet.", lang)}</p>
               ) : (
-                <div className="overflow-x-auto"><table className="dtable">
+                <table className="dtable dtable-fixed">
                   <thead>
                     <tr>
                       <th>Character</th>
-                      <th className="num">Result</th>
-                      <th className="num">When</th>
+                      <th className="num" style={{ width: "2.75rem" }}>Result</th>
+                      <th className="num" style={{ width: "5rem" }}>When</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -318,6 +318,12 @@ export default async function HomeLeaderboardSection({
                           ? "abandoned"
                           : "loss";
                       const killer = killedByLabel(r.killed_by);
+                      // Keep the boss name short so the row never widens the
+                      // panel into a horizontal scroll.
+                      const killerShort =
+                        killer && killer.length > 10
+                          ? killer.slice(0, 10).trimEnd() + "…"
+                          : killer;
                       return (
                         <tr key={r.run_hash}>
                           <td>
@@ -330,21 +336,22 @@ export default async function HomeLeaderboardSection({
                                 </span>
                                 <span className="lb-sub">
                                   fl{r.floors_reached} · {formatRunTime(r.run_time)}
-                                  {killer && result === "loss" ? ` · died to ${killer}` : ""}
+                                  {killerShort && result === "loss" ? ` · died to ${killerShort}` : ""}
                                 </span>
                               </span>
                             </Link>
                           </td>
                           <td className="num">
-                            {result === "win" && <span className="wr-sg">Win</span>}
-                            {result === "abandoned" && <span className="dim">Abandoned</span>}
+                            {result === "win" && <span className="wr-sg" title="Win">W</span>}
+                            {result === "loss" && <span className="wr-loss" title="Loss">R</span>}
+                            {result === "abandoned" && <span className="dim" title="Abandoned">A</span>}
                           </td>
                           <td className="num dim">{formatRelativeDate(r.submitted_at)}</td>
                         </tr>
                       );
                     })}
                   </tbody>
-                </table></div>
+                </table>
               )}
             </section>
           </div>

--- a/frontend/app/home-revamp.css
+++ b/frontend/app/home-revamp.css
@@ -105,7 +105,11 @@
 .rvmp .dtable .dim { color: var(--text-3); font-weight: 500; }
 .rvmp .dot2 { width: 9px; height: 9px; border-radius: 3px; flex: none; }
 .rvmp .wr-sg { color: #35c07a; }
+.rvmp .wr-loss { color: #e5484d; }
 .rvmp .wr-g { color: #6fae4f; }
+/* Recent runs: fixed layout so the long "died to …" subline truncates in its
+   cell instead of widening the table and forcing a horizontal scroll. */
+.rvmp .dtable-fixed { table-layout: fixed; }
 .rvmp .wr-n { color: var(--text); }
 .rvmp .wr-r { color: var(--warn); }
 .rvmp .lb-cta { display: inline-flex; align-items: center; gap: 6px; margin: 12px 4px 2px; font-family: var(--sans); font-size: 13px; font-weight: 600; color: var(--gold); }


### PR DESCRIPTION
The Recent Runs panel on the home page scrolled left/right. It grew past the panel width because of the "died to {boss}" subline and the full-word result ("Win" / "Abandoned").

Fixes:
- **Result is a single colored letter**: `W` green (win), `R` red (loss), `A` grey (abandoned). Each has a `title` with the full word for hover/accessibility.
- **Boss name capped at 10 characters** + an ellipsis in the "died to …" subline.
- **Fixed table layout** on the Recent Runs table (`dtable-fixed`) so the subline truncates inside its cell (its ellipsis styling was already there but the auto-layout table was growing to fit it), and dropped the `overflow-x-auto` wrapper so the panel can't scroll sideways. The Fastest Wins / Daily Climb tables are untouched.

tsc clean, eslint clean.
