### PR TITLE
Log committed searches only, not every keystroke

### DIFF
--- a/backend/app/routers/search.py
+++ b/backend/app/routers/search.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 from typing import Any, Callable, Iterable
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Query, Request
+from fastapi import APIRouter, Depends, Query, Request
+from pydantic import BaseModel, Field
 
 from ..dependencies import client_ip, get_lang
 from ..services import data_service, mechanics_pages, search_analytics
@@ -110,7 +111,6 @@ _REFERENCE_SOURCES: list[tuple[str, str, str]] = [
 @router.get("", tags=["Search"])
 def global_search(
     request: Request,
-    background_tasks: BackgroundTasks,
     q: str = Query(..., min_length=1, max_length=80),
     lang: str = Depends(get_lang),
 ) -> dict[str, Any]:
@@ -212,10 +212,27 @@ def global_search(
         ],
     )
 
-    # Log what was searched (fire-and-forget, after the response is sent) so the
-    # admin search-analytics page can see it, including zero-result queries.
-    total = sum(len(c.get("items") or []) for c in categories)
-    background_tasks.add_task(
-        search_analytics.log_search, q, lang, total, client_ip(request)
-    )
     return {"query": q, "categories": categories}
+
+
+class SearchLog(BaseModel):
+    """Beacon the frontend sends once a search is 'committed' — the user picked
+    a result or settled on a final query — so the log holds real intent, not
+    every debounced keystroke."""
+
+    q: str = Field(..., min_length=1, max_length=80)
+    lang: str = "eng"
+    results: int = 0
+    clicked: bool = False
+
+
+@router.post("/log", include_in_schema=False)
+def log_committed_search(payload: SearchLog, request: Request) -> dict[str, bool]:
+    search_analytics.log_search(
+        payload.q,
+        payload.lang,
+        payload.results,
+        client_ip(request),
+        payload.clicked,
+    )
+    return {"ok": True}

--- a/backend/app/services/search_analytics.py
+++ b/backend/app/services/search_analytics.py
@@ -1,18 +1,14 @@
 """Search-query logging + analytics over the global search bar.
 
-Every real /api/search hit (the navbar search) is logged to a Mongo
-`search_log` collection so we can see what people actually look for — including
-the queries that return nothing, which is the useful "what can't they find"
-signal Prometheus's per-entity counters miss. Writes are fire-and-forget (a
-FastAPI BackgroundTask) and never touch the search response; a TTL index trims
-the log after the retention window. The raw IP is never stored, only a
-day-scoped hash so a client de-dupes within a day but isn't trackable across
-days.
-
-Note: the search bar is debounced but still fires while typing, so short
-prefixes ("fir" on the way to "fireleaf") land in the log too. Top-searches is
-directional rather than exact; the zero-result and volume views are the clean
-signals.
+The frontend beacons a *committed* search — the query the user picked a result
+on, or settled on before leaving — to /api/search/log, which lands here. Logging
+the settled query rather than every debounced keystroke keeps prefixes ("fir" on
+the way to "fireleaf") out of the data, so the counts reflect real intent. Each
+row records the query, lang, result count, a zero flag, whether it led to a
+click, and a day-scoped IP hash (the raw IP is never stored). A TTL index trims
+the log after the retention window. Zero-result queries — the "what can't they
+find" signal Prometheus's per-entity counters miss — come through the same
+beacon when a search returns nothing and the user gives up.
 """
 
 import hashlib
@@ -62,9 +58,11 @@ def _cutoff(days: int) -> datetime:
     return datetime.now(timezone.utc) - timedelta(days=max(1, days))
 
 
-def log_search(q: str, lang: str, results: int, ip: str = "") -> None:
-    """Record one search. Guarded and swallowed so a logging hiccup can never
-    fail the search request that scheduled it."""
+def log_search(
+    q: str, lang: str, results: int, ip: str = "", clicked: bool = False
+) -> None:
+    """Record one committed search. Guarded and swallowed so a logging hiccup
+    can never fail the request that sent it."""
     if not os.environ.get("MONGO_URL", "").strip():
         return
     try:
@@ -78,6 +76,7 @@ def log_search(q: str, lang: str, results: int, ip: str = "") -> None:
                 "lang": lang or "eng",
                 "results": int(results),
                 "zero": int(results) == 0,
+                "clicked": bool(clicked),
                 "ip_hash": _ip_hash(ip) if ip else None,
                 "at": datetime.now(timezone.utc),
             }
@@ -95,6 +94,7 @@ def _top(match: dict, limit: int) -> list[dict]:
                 "count": {"$sum": 1},
                 "clients": {"$addToSet": "$ip_hash"},
                 "zero": {"$sum": {"$cond": ["$zero", 1, 0]}},
+                "clicks": {"$sum": {"$cond": ["$clicked", 1, 0]}},
                 "sample": {"$last": "$q"},
                 "last_at": {"$max": "$at"},
             }
@@ -111,6 +111,7 @@ def _top(match: dict, limit: int) -> list[dict]:
                 "query": r.get("sample") or r["_id"],
                 "count": count,
                 "clients": len(clients),
+                "clicks": r.get("clicks") or 0,
                 "zero_rate": round((r.get("zero") or 0) / count, 3) if count else 0,
                 "last_at": _iso(r.get("last_at")),
             }
@@ -170,6 +171,7 @@ def summary(days: int = 7) -> dict:
                 "_id": None,
                 "total": {"$sum": 1},
                 "zero": {"$sum": {"$cond": ["$zero", 1, 0]}},
+                "clicks": {"$sum": {"$cond": ["$clicked", 1, 0]}},
                 "queries": {"$addToSet": "$q_norm"},
                 "clients": {"$addToSet": "$ip_hash"},
             }
@@ -182,6 +184,7 @@ def summary(days: int = 7) -> dict:
             "distinct": 0,
             "zero": 0,
             "zero_rate": 0,
+            "ctr": 0,
             "clients": 0,
             "days": days,
         }
@@ -192,6 +195,7 @@ def summary(days: int = 7) -> dict:
         "distinct": len([q for q in (d.get("queries") or []) if q]),
         "zero": d.get("zero") or 0,
         "zero_rate": round((d.get("zero") or 0) / total, 3) if total else 0,
+        "ctr": round((d.get("clicks") or 0) / total, 3) if total else 0,
         "clients": len([c for c in (d.get("clients") or []) if c]),
         "days": days,
     }

--- a/frontend/app/admin/searches/SearchesClient.tsx
+++ b/frontend/app/admin/searches/SearchesClient.tsx
@@ -12,6 +12,7 @@ interface Summary {
   distinct: number;
   zero: number;
   zero_rate: number;
+  ctr: number;
   clients: number;
   days: number;
 }
@@ -200,9 +201,10 @@ export default function SearchesClient() {
       {note && <p className="text-sm text-red-400 mb-4">{note}</p>}
 
       {s && (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+        <div className="grid grid-cols-2 lg:grid-cols-5 gap-3 mb-6">
           <Card label="Searches" value={s.total.toLocaleString()} sub={`last ${s.days}d`} />
           <Card label="Distinct queries" value={s.distinct.toLocaleString()} />
+          <Card label="Click-through" value={pct(s.ctr)} sub="picked a result" />
           <Card
             label="Zero-result rate"
             value={pct(s.zero_rate)}
@@ -218,7 +220,7 @@ export default function SearchesClient() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
           <QueryTable
             title="Top searches"
-            note="Most-typed queries. Debounced typing means prefixes show up too."
+            note="What people settle on — the query when they pick a result or leave."
             rows={data.top}
             showZeroRate
           />

--- a/frontend/app/components/GlobalSearch.tsx
+++ b/frontend/app/components/GlobalSearch.tsx
@@ -125,6 +125,47 @@ export default function GlobalSearch() {
     ...sections.flatMap((s) => s.items),
   ];
 
+  // Keep the latest query + result count in refs so the "committed search"
+  // beacon reads current values without stale-closure bugs.
+  const queryRef = useRef("");
+  const resultsRef = useRef(0);
+  queryRef.current = query;
+  resultsRef.current = flatResults.length;
+  const committedRef = useRef<string | null>(null);
+
+  // Log a committed search: the user picked a result (clicked) or settled on a
+  // final query and closed the box. One beacon per settled query, so debounced
+  // keystrokes ("fir" -> "fireleaf") never pollute the analytics.
+  const logCommitted = useCallback(
+    (clicked: boolean) => {
+      const q = queryRef.current.trim();
+      if (q.length < 2 || committedRef.current === q) return;
+      committedRef.current = q;
+      try {
+        fetch(buildApiUrl(`${API}/api/search/log`), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ q, lang, results: resultsRef.current, clicked }),
+          keepalive: true,
+        }).catch(() => {});
+      } catch {
+        /* best effort */
+      }
+    },
+    [lang],
+  );
+
+  // Reset the dedupe when the box opens; when it closes, log whatever the user
+  // settled on (this is what captures abandoned + zero-result searches, which
+  // have no result to click).
+  useEffect(() => {
+    if (open) {
+      committedRef.current = null;
+    } else {
+      logCommitted(false);
+    }
+  }, [open, logCommitted]);
+
   // Open on "." key when not in an input
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -210,6 +251,7 @@ export default function GlobalSearch() {
   // Navigate to result
   const navigate = useCallback(
     (item: SearchItem) => {
+      logCommitted(true);
       setOpen(false);
       if (item.external) {
         window.open(item.path, "_blank", "noopener,noreferrer");
@@ -217,7 +259,7 @@ export default function GlobalSearch() {
         router.push(item.path);
       }
     },
-    [router]
+    [router, logCommitted]
   );
 
   // Keyboard navigation inside modal


### PR DESCRIPTION
Re-lands the committed-search change that got stranded. It was pushed to the #626 branch after #626 had already merged the earlier commit, so it never reached main — the merged search-analytics page still logs every debounced `/api/search` request (prefixes and all). This is that commit, cherry-picked onto current main.

## What it does

The search bar is debounced, so logging every request fills the data with prefixes ("fir" → "fireleaf"). Instead the frontend beacons a search only once it's **committed** — the user clicked a result, or settled on a final query and closed the box — so the log holds real intent. Zero-result and abandoned searches (nothing to click) are captured on close.

- **`GlobalSearch.tsx`** — beacons `POST /api/search/log` via keepalive fetch: `clicked=true` on result-click, `clicked=false` on close, de-duped to one per settled query.
- **`search.py`** — drops the GET BackgroundTask auto-capture; adds `POST /api/search/log` (query, lang, result count, clicked).
- **`search_analytics.py`** — stores the `clicked` flag; top + summary now expose click-through.
- **`/admin/searches`** — adds a click-through card, reworks the top-searches note (the prefix-noise caveat is gone).

tsc clean, eslint clean (the GlobalSearch warnings are all pre-existing), ruff + py_compile clean.
