### PR TITLE
Blank out Codex Elo on combined metrics brackets instead of showing 0

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -2342,6 +2342,9 @@ def get_entity_metrics_table(entity_type: str, bracket: str = "all") -> dict[str
     """
     _maybe_rebuild()
     use_bracket = bracket in _BRACKET_KEYS
+    # Composites (solo:a10, ...) skip the reward-pairwise / Elo build (v13), so
+    # their stored Elo is a meaningless 0 — surface it as null (blank cell).
+    is_composite = bracket in _COMPOSITE_BRACKETS_SET
     if use_bracket:
         baseline = _bracket_baselines.get(bracket, {}).get(
             entity_type, _baseline_win_rate()
@@ -2397,7 +2400,7 @@ def get_entity_metrics_table(entity_type: str, bracket: str = "all") -> dict[str
                     eid,
                     data.get("picks", 0),
                     data.get("wins", 0),
-                    elo=data.get("elo"),
+                    elo=None if is_composite else data.get("elo"),
                     offered=data.get("offered", 0),
                     picked=data.get("picked", 0),
                     off_act=data.get("off_act") or z3,

--- a/frontend/app/leaderboards/metrics/MetricsClient.tsx
+++ b/frontend/app/leaderboards/metrics/MetricsClient.tsx
@@ -269,6 +269,14 @@ export default function MetricsClient({
           {totalRuns.toLocaleString()} {t("runs", lang)} · {t("baseline win rate", lang)} {baselineWinRate}% ·{" "}
           {visible.length} {t("cards shown", lang)}
         </p>
+        {sel.player && sel.skill && (
+          <p className="mt-1 text-xs text-[var(--text-muted)]">
+            {t(
+              "Combined brackets carry Codex Score and Win% only. Elo and Pick% aren't computed for them.",
+              lang,
+            )}
+          </p>
+        )}
       </header>
 
       {/* Two combinable axes (player count x skill tier) plus an exclusive game


### PR DESCRIPTION
On the card metrics page, selecting a combined bracket (Solo + A10, or any Players × Skill combo) showed **Codex Elo = 0** for every card, which read as broken.

## Cause

Composite brackets (`solo:a10`, ...) deliberately skip the reward-pairwise / Codex Elo build — per the v13 snapshot note, running the full Elo pass over 26 brackets × ~740k runs was too heavy to finish, so composites keep Codex Score + Win% only. Pick% and per-act splits already came back `null` (offered = 0) and rendered the blank `·`, but Elo was passed straight through as the stored `0`, so it printed a literal "0".

## Fix

- `get_entity_metrics_table`: return `elo=None` for composite brackets, so the cell shows `·` like the other not-computed columns. Read-time only — no snapshot rebuild.
- `MetricsClient`: added a one-line note under a combined bracket ("carries Codex Score and Win% only") so the blank Elo/Pick% reads as intentional rather than missing.

Single brackets (just A10, or just Solo) still show the full Elo/Pick% set — only the combined ones drop the pairwise columns, which was already the case; this just makes it read correctly.

ruff + py_compile clean, tsc clean, eslint clean.
