### PR TITLE
Make the blanket rate limit admin-tunable at runtime

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,6 +51,7 @@ from .routers import (
     beta,
     admin,
     admin_searches,
+    admin_rate_limits,
     glossary,
     guides,
     versions,
@@ -77,6 +78,7 @@ from .services.data_service import (
     load_translation_maps,
 )
 from .dependencies import client_ip, get_lang, VALID_LANGUAGES, LANGUAGE_NAMES
+from .services import rate_limit_config
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from .metrics import (
@@ -131,7 +133,12 @@ IS_BETA_BACKEND = os.environ.get("DISABLE_RUN_SUBMISSIONS") == "1"
 # /api/* lookups per page, low enough to choke off scraping. Endpoints
 # that want a tighter cap (guide submission, auth, feedback) declare
 # `@limiter.limit(...)` at the router level and override this default.
-limiter = Limiter(key_func=client_ip, default_limits=["300/minute"])
+# The blanket cap is a callable so an operator can retune it at runtime via
+# /api/admin/rate-limits (default stays 300/minute). slowapi re-evaluates it
+# per request.
+limiter = Limiter(
+    key_func=client_ip, default_limits=[rate_limit_config.default_limit_value]
+)
 
 app = FastAPI(
     title="Spire Codex API",
@@ -595,6 +602,7 @@ app.include_router(beta.router)
 # Hidden from the OpenAPI schema (/docs): internal admin surface.
 app.include_router(admin.router, include_in_schema=False)
 app.include_router(admin_searches.router, include_in_schema=False)
+app.include_router(admin_rate_limits.router, include_in_schema=False)
 app.include_router(glossary.router)
 app.include_router(guides.router)
 app.include_router(versions.router)

--- a/backend/app/routers/admin_rate_limits.py
+++ b/backend/app/routers/admin_rate_limits.py
@@ -1,0 +1,45 @@
+"""Admin control over the API's blanket rate limit.
+
+Gated by the same require_admin as the rest of the operator surface. Lets me
+raise/lower the global per-IP cap or switch it off entirely at runtime, without
+a redeploy. Per-endpoint limits (auth, feedback, ...) are unaffected.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ..services import rate_limit_config
+from ..services.auth_jwt import require_admin
+
+router = APIRouter(
+    prefix="/api/admin/rate-limits",
+    tags=["Admin"],
+    dependencies=[Depends(require_admin)],
+)
+
+
+@router.get("")
+def get_rate_limits():
+    """Current blanket cap + whether limiting is on."""
+    return rate_limit_config.get_config()
+
+
+class RateLimitUpdate(BaseModel):
+    default_limit: str | None = Field(
+        default=None,
+        description="Blanket per-IP cap, e.g. '300/minute' or '5/second'.",
+    )
+    enabled: bool | None = Field(
+        default=None,
+        description="False turns the blanket cap off (per-endpoint limits stay).",
+    )
+
+
+@router.put("")
+def set_rate_limits(body: RateLimitUpdate):
+    """Change the blanket cap and/or toggle it. Takes effect across workers
+    within the config cache window (~15s)."""
+    try:
+        return rate_limit_config.set_config(body.default_limit, body.enabled)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/services/rate_limit_config.py
+++ b/backend/app/services/rate_limit_config.py
@@ -1,0 +1,106 @@
+"""Admin-tunable global rate limit.
+
+The API's blanket per-IP cap (slowapi ``default_limits``) is normally a hardcoded
+``300/minute``. This lets an operator change that number, or switch the blanket
+cap off entirely, at runtime without a redeploy. The value lives in one Mongo
+doc so all workers converge on it (each caches for a few seconds); the per-IP
+counters themselves stay slowapi's per-worker in-memory ones, so this tunes the
+*limit*, not where the counts live.
+
+Endpoints with their own tighter ``@limiter.limit(...)`` (auth, feedback, guide
+submission) keep those — this only moves the blanket default everything else
+falls back to.
+"""
+
+import logging
+import os
+import time
+
+logger = logging.getLogger("spire-codex")
+
+_COLLECTION = "app_config"
+_DOC_ID = "rate_limit"
+_DEFAULT_LIMIT = "300/minute"
+# Effectively unlimited: what the blanket cap becomes when an operator toggles
+# limiting off (per-endpoint limits still apply).
+_DISABLED_LIMIT = "1000000/minute"
+_CACHE_TTL_SECONDS = 15.0
+
+_cache: dict = {"at": 0.0, "cfg": None}
+
+
+def _coll():
+    from .runs_db_mongo import _get_collection
+
+    return _get_collection().database[_COLLECTION]
+
+
+def _fallback() -> dict:
+    return {"default_limit": _DEFAULT_LIMIT, "enabled": True}
+
+
+def get_config() -> dict:
+    """The current {default_limit, enabled}, cached per worker so a read on the
+    hot rate-limit path is cheap. Falls back to the built-in default on any
+    trouble so limiting never breaks."""
+    if not os.environ.get("MONGO_URL", "").strip():
+        return _fallback()
+    now = time.monotonic()
+    cached = _cache["cfg"]
+    if cached is not None and now - _cache["at"] < _CACHE_TTL_SECONDS:
+        return cached
+    cfg = _fallback()
+    try:
+        doc = _coll().find_one({"_id": _DOC_ID})
+        if doc:
+            cfg = {
+                "default_limit": doc.get("default_limit") or _DEFAULT_LIMIT,
+                "enabled": bool(doc.get("enabled", True)),
+            }
+    except Exception:
+        logger.warning("rate-limit config read failed", exc_info=True)
+    _cache["cfg"] = cfg
+    _cache["at"] = now
+    return cfg
+
+
+def default_limit_value(*_args, **_kwargs) -> str:
+    """slowapi ``default_limits`` callable: the current blanket per-IP cap,
+    re-read (cached) on each request so an admin change takes effect within the
+    cache window without a restart. Returns an effectively-unlimited value when
+    limiting is toggled off."""
+    cfg = get_config()
+    if not cfg.get("enabled", True):
+        return _DISABLED_LIMIT
+    return cfg.get("default_limit") or _DEFAULT_LIMIT
+
+
+def set_config(default_limit: str | None = None, enabled: bool | None = None) -> dict:
+    """Update the config. Validates the limit string (e.g. ``300/minute``,
+    ``5/second``) and raises ValueError if it doesn't parse. Busts the local
+    cache so the calling worker reflects it immediately; the others pick it up
+    within the cache window."""
+    if not os.environ.get("MONGO_URL", "").strip():
+        raise ValueError("rate-limit config needs MONGO_URL")
+    current = get_config()
+    new = dict(current)
+    if default_limit is not None:
+        from limits import parse
+
+        candidate = default_limit.strip()
+        try:
+            parse(candidate)
+        except Exception as exc:
+            raise ValueError(
+                f"'{default_limit}' is not a valid limit (try e.g. 300/minute)"
+            ) from exc
+        new["default_limit"] = candidate
+    if enabled is not None:
+        new["enabled"] = bool(enabled)
+    _coll().replace_one(
+        {"_id": _DOC_ID},
+        {"_id": _DOC_ID, **new},
+        upsert=True,
+    )
+    _cache["cfg"] = None
+    return new

--- a/frontend/app/admin/rate-limits/RateLimitsClient.tsx
+++ b/frontend/app/admin/rate-limits/RateLimitsClient.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+// Operator control over the API's blanket per-IP cap. Reads/writes
+// /api/admin/rate-limits; changes propagate to every worker within the config
+// cache window (~15s). Per-endpoint limits (auth, feedback, ...) are untouched.
+
+import { useEffect, useState } from "react";
+import { AdminShell, adminFetch } from "../shared";
+
+interface Config {
+  default_limit: string;
+  enabled: boolean;
+}
+
+const PRESETS = ["60/minute", "120/minute", "300/minute", "600/minute", "5/second"];
+
+export default function RateLimitsClient() {
+  const [cfg, setCfg] = useState<Config | null>(null);
+  const [limit, setLimit] = useState("");
+  const [enabled, setEnabled] = useState(true);
+  const [note, setNote] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    adminFetch<Config>("/api/admin/rate-limits")
+      .then((c) => {
+        setCfg(c);
+        setLimit(c.default_limit);
+        setEnabled(c.enabled);
+      })
+      .catch((e) => setNote(String((e as Error)?.message || e)));
+  }, []);
+
+  const save = (patch: Partial<Config>) => {
+    setSaving(true);
+    setNote(null);
+    adminFetch<Config>("/api/admin/rate-limits", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(patch),
+    })
+      .then((c) => {
+        setCfg(c);
+        setLimit(c.default_limit);
+        setEnabled(c.enabled);
+        setNote("Saved. Live across all workers within ~15s.");
+      })
+      .catch((e) => setNote(String((e as Error)?.message || e)))
+      .finally(() => setSaving(false));
+  };
+
+  return (
+    <AdminShell title="Rate limits" subtitle="blanket per-IP cap">
+      <p className="text-sm text-[var(--text-secondary)] mb-4 max-w-2xl">
+        The blanket per-IP cap every endpoint falls back to. Endpoints with their own
+        tighter limit (auth, feedback, guide submission) keep it. Changes go live across
+        all workers within ~15 seconds, no redeploy.
+      </p>
+
+      {note && <p className="text-sm text-[var(--text-secondary)] mb-4">{note}</p>}
+
+      {cfg === null && !note && (
+        <p className="text-sm text-[var(--text-muted)]">Loading…</p>
+      )}
+
+      {cfg && (
+        <div className="space-y-4 max-w-lg">
+          <div className="flex items-center justify-between rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+            <div>
+              <div className="text-sm font-semibold text-[var(--text-primary)]">
+                Blanket limit {enabled ? "on" : "off"}
+              </div>
+              <div className="text-xs text-[var(--text-muted)] mt-0.5">
+                Off leaves only the per-endpoint limits (auth etc.).
+              </div>
+            </div>
+            <button
+              type="button"
+              disabled={saving}
+              onClick={() => save({ enabled: !enabled })}
+              className={`px-3 py-1.5 rounded-lg text-sm border transition-colors disabled:opacity-50 ${
+                enabled
+                  ? "bg-emerald-500/15 border-emerald-500/40 text-emerald-400"
+                  : "bg-red-500/15 border-red-500/40 text-red-400"
+              }`}
+            >
+              {enabled ? "Enabled" : "Disabled"}
+            </button>
+          </div>
+
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+            <label className="block text-sm font-semibold text-[var(--text-primary)] mb-2">
+              Requests per IP
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={limit}
+                onChange={(e) => setLimit(e.target.value)}
+                placeholder="300/minute"
+                className="flex-1 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-3 py-2 text-sm font-mono text-[var(--text-primary)]"
+              />
+              <button
+                type="button"
+                disabled={saving || !limit.trim()}
+                onClick={() => save({ default_limit: limit.trim() })}
+                className="px-4 py-2 rounded-lg text-sm border border-[var(--accent-gold)]/40 bg-[var(--accent-gold)]/15 text-[var(--accent-gold)] disabled:opacity-50"
+              >
+                Save
+              </button>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {PRESETS.map((p) => (
+                <button
+                  key={p}
+                  type="button"
+                  disabled={saving}
+                  onClick={() => {
+                    setLimit(p);
+                    save({ default_limit: p });
+                  }}
+                  className={`rounded-md border px-2.5 py-1 text-xs transition-colors disabled:opacity-50 ${
+                    cfg.default_limit === p
+                      ? "border-[var(--accent-gold)]/40 bg-[var(--accent-gold)]/10 text-[var(--accent-gold)]"
+                      : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                  }`}
+                >
+                  {p}
+                </button>
+              ))}
+            </div>
+            <p className="mt-2 text-xs text-[var(--text-muted)]">
+              Format <span className="font-mono">count/period</span> — e.g. 300/minute,
+              5/second, 10000/hour.
+            </p>
+          </div>
+        </div>
+      )}
+    </AdminShell>
+  );
+}

--- a/frontend/app/admin/rate-limits/page.tsx
+++ b/frontend/app/admin/rate-limits/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import RateLimitsClient from "./RateLimitsClient";
+
+export const metadata: Metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminRateLimitsPage() {
+  return <RateLimitsClient />;
+}

--- a/frontend/app/admin/shared.tsx
+++ b/frontend/app/admin/shared.tsx
@@ -85,6 +85,7 @@ const SECTIONS = [
   { href: "/admin/analytics", label: "Analytics" },
   { href: "/admin/searches", label: "Searches" },
   { href: "/admin/cache", label: "Cache" },
+  { href: "/admin/rate-limits", label: "Rate limits" },
 ];
 
 export function AdminShell({


### PR DESCRIPTION
## Audit: coverage is already complete

Went through the API — everything is already rate-limited. `main.py` sets `default_limits=["300/minute"]` and `SlowAPIMiddleware` applies it to **every** request/route (the comment there documents closing the old "70/85 routes unthrottled" gap). Abuse-sensitive endpoints layer a tighter `@limiter.limit(...)` on top (auth 10/min, feedback, guide submission, etc.), and slowapi uses the tightest applicable per request. So there was nothing unthrottled to fix.

## New: runtime control over the blanket cap

Since the cap was a hardcoded constant, this makes it operator-tunable without a redeploy:

- **`rate_limit_config.py`** — the blanket cap lives in a Mongo `app_config` doc (`{default_limit, enabled}`), read through a ~15s per-worker cache. Falls back to `300/minute` on any trouble, so limiting can never break.
- **`main.py`** — `default_limits` is now the callable `default_limit_value`; slowapi re-reads the configured cap per request, so a change takes effect within the cache window across all 4 workers, no restart.
- **`admin_rate_limits.py`** — `GET`/`PUT /api/admin/rate-limits` behind the existing `require_admin`. `PUT` validates the limit string (`limits.parse`, so a typo 400s instead of bricking the limiter) and can toggle the blanket cap off entirely (per-endpoint limits stay).
- **`/admin/rate-limits` page** — current cap + on/off toggle, a text field and presets (60/120/300/600 per minute, 5/second), saving through the endpoint. Added to the admin nav.

## Scope / caveats

- This tunes the **blanket default**. The per-endpoint caps (auth etc.) are still their own hardcoded decorators — happy to add named, individually-tunable tiers as a follow-up if you want that level of control.
- The **counters** are still slowapi's per-worker in-memory ones (4 workers → a client effectively gets up to 4× the cap). That's pre-existing and the thing the planned Redis move would fix; this PR only makes the *limit value* controllable, not where the counts live.

ruff + py_compile clean, tsc clean, eslint clean.
