### PR TITLE
Speed up the profile stats and the admin pages

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -165,19 +165,41 @@ def _dau_info() -> dict:
         return {}
 
 
+# Overview vitals cache: the five info blocks are independent Mongo queries
+# (the DAU aggregations are the slow ones); computed serially they made the
+# admin landing page drag. Fan out + a short TTL so revisits are instant.
+_OVERVIEW_TTL_SECONDS = 20.0
+_overview_cache: dict = {"at": 0.0, "data": None}
+
+
 @router.get("/overview")
 def overview(request: Request):
     """Operational vitals: run volume, users, snapshot freshness, Redis, and
     the mod's daily-active-user counts."""
     _audit(request)
-    return {
-        "runs": _runs_info(),
-        "users": _users_info(),
-        "snapshot": _snapshot_info(),
-        "redis": app_cache.info(),
-        "dau": _dau_info(),
-        "environment": os.environ.get("ENVIRONMENT", "development"),
-    }
+    import time
+    from concurrent.futures import ThreadPoolExecutor
+
+    now = time.monotonic()
+    if (
+        _overview_cache["data"] is not None
+        and now - _overview_cache["at"] < _OVERVIEW_TTL_SECONDS
+    ):
+        return _overview_cache["data"]
+
+    with ThreadPoolExecutor(max_workers=5, thread_name_prefix="admin-ov") as pool:
+        futures = {
+            "runs": pool.submit(_runs_info),
+            "users": pool.submit(_users_info),
+            "snapshot": pool.submit(_snapshot_info),
+            "redis": pool.submit(app_cache.info),
+            "dau": pool.submit(_dau_info),
+        }
+        data = {k: f.result() for k, f in futures.items()}
+    data["environment"] = os.environ.get("ENVIRONMENT", "development")
+    _overview_cache["data"] = data
+    _overview_cache["at"] = now
+    return data
 
 
 @router.get("/live")

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -24,8 +24,11 @@ _MAX_UPLOAD_SIZE = 512 * 1024  # 512 KB per file
 _MAX_UPLOAD_FILES = 100
 
 
+# These handlers are plain `def` on purpose: they call blocking pymongo, and
+# as `async def` they ran ON the event loop, stalling every other request for
+# the duration of their queries. Plain `def` routes run in the threadpool.
 @router.get("/me")
-async def me(request: Request):
+def me(request: Request):
     user = get_current_user(request)
     if not user:
         raise HTTPException(status_code=401, detail="Not authenticated")
@@ -46,7 +49,7 @@ async def me(request: Request):
 
 @router.post("/steam/disconnect")
 @limiter.limit("10/minute")
-async def disconnect_steam(request: Request):
+def disconnect_steam(request: Request):
     user = require_user(request)
     from ..services.users_db import unlink_steam
 
@@ -58,7 +61,7 @@ async def disconnect_steam(request: Request):
 
 @router.post("/discord/disconnect")
 @limiter.limit("10/minute")
-async def disconnect_discord(request: Request):
+def disconnect_discord(request: Request):
     user = require_user(request)
     from ..services.users_db import unlink_discord
 
@@ -70,7 +73,7 @@ async def disconnect_discord(request: Request):
 
 @router.post("/twitch/disconnect")
 @limiter.limit("10/minute")
-async def disconnect_twitch(request: Request):
+def disconnect_twitch(request: Request):
     user = require_user(request)
     from ..services.users_db import unlink_twitch
 
@@ -81,7 +84,7 @@ async def disconnect_twitch(request: Request):
 
 
 @router.post("/logout")
-async def logout(request: Request):
+def logout(request: Request):
     response = JSONResponse({"success": True})
     clear_auth_cookie(response)
     return response
@@ -142,7 +145,7 @@ async def update_username(request: Request):
 
 
 @router.get("/username/check")
-async def check_username(username: str):
+def check_username(username: str):
     if not username or not username.strip():
         return {"available": False}
     from ..services.users_db import check_username_available
@@ -177,7 +180,7 @@ async def update_email(request: Request):
 
 @router.get("/runs")
 @limiter.limit("60/minute")
-async def get_my_runs(
+def get_my_runs(
     request: Request,
     page: int = 1,
     limit: int = 50,
@@ -198,7 +201,7 @@ async def get_my_runs(
 
 @router.delete("/runs/{run_hash}")
 @limiter.limit("30/minute")
-async def delete_run(run_hash: str, request: Request):
+def delete_run(run_hash: str, request: Request):
     user = require_user(request)
 
     if not os.environ.get("MONGO_URL", "").strip():
@@ -220,7 +223,7 @@ async def delete_run(run_hash: str, request: Request):
 
 @router.get("/stats")
 @limiter.limit("10/minute")
-async def user_stats(request: Request):
+def user_stats(request: Request):
     user = require_user(request)
     username = user.get("username")
     if not username:
@@ -232,6 +235,29 @@ async def user_stats(request: Request):
     from ..services.runs_db_mongo import get_stats
 
     return get_stats(username=username)
+
+
+# Per-user cache for personal bests: both /personal-bests and /competitive need
+# them, so without this a single profile load computed the same five sorted
+# queries twice. 60s is plenty; a just-submitted run shows up on the next load.
+_BESTS_TTL_SECONDS = 60.0
+_bests_cache: dict[str, tuple[float, dict]] = {}
+
+
+def _personal_bests_cached(username: str) -> dict:
+    import time
+
+    now = time.monotonic()
+    hit = _bests_cache.get(username.lower())
+    if hit and hit[0] > now:
+        return hit[1]
+    bests = _compute_personal_bests(username)
+    # Bounded: drop expired entries past a size cap so it can't grow forever.
+    if len(_bests_cache) > 2000:
+        for k in [k for k, (exp, _) in _bests_cache.items() if exp <= now]:
+            _bests_cache.pop(k, None)
+    _bests_cache[username.lower()] = (now + _BESTS_TTL_SECONDS, bests)
+    return bests
 
 
 def _compute_personal_bests(username: str) -> dict:
@@ -292,17 +318,17 @@ def _compute_personal_bests(username: str) -> dict:
 
 @router.get("/personal-bests")
 @limiter.limit("10/minute")
-async def personal_bests(request: Request):
+def personal_bests(request: Request):
     user = require_user(request)
     username = user.get("username")
     if not username or not os.environ.get("MONGO_URL", "").strip():
         return {}
-    return _compute_personal_bests(username)
+    return _personal_bests_cached(username)
 
 
 @router.get("/competitive")
 @limiter.limit("10/minute")
-async def competitive_stats(request: Request):
+def competitive_stats(request: Request):
     user = require_user(request)
     username = user.get("username")
     if not username or not os.environ.get("MONGO_URL", "").strip():
@@ -318,7 +344,7 @@ async def competitive_stats(request: Request):
         get_win_rate_comparison,
     )
 
-    bests = _compute_personal_bests(username)
+    bests = _personal_bests_cached(username)
 
     rank_configs = {
         "fastest_solo": {
@@ -340,17 +366,25 @@ async def competitive_stats(request: Request):
         "fastest_daily": {"category": "fastest", "game_mode": "daily"},
     }
 
-    personal_ranks = {}
-    for key, cfg in rank_configs.items():
-        best = bests.get(key)
-        if best:
-            personal_ranks[key] = get_run_rank_scoped(best["run_hash"], **cfg)
+    # Up to 5 rank counts + the leaderboard + the comparison are independent
+    # Mongo queries; serially they were the profile page's long pole. Fan them
+    # out on a small pool so the endpoint costs one slow query, not the sum.
+    from concurrent.futures import ThreadPoolExecutor
 
-    return {
-        "daily_leaderboard": get_daily_leaderboard(username),
-        "personal_ranks": personal_ranks,
-        "win_rate_comparison": get_win_rate_comparison(username),
-    }
+    with ThreadPoolExecutor(max_workers=4, thread_name_prefix="competitive") as pool:
+        rank_futures = {
+            key: pool.submit(get_run_rank_scoped, bests[key]["run_hash"], **cfg)
+            for key, cfg in rank_configs.items()
+            if bests.get(key)
+        }
+        daily_future = pool.submit(get_daily_leaderboard, username)
+        wr_future = pool.submit(get_win_rate_comparison, username)
+        personal_ranks = {key: f.result() for key, f in rank_futures.items()}
+        return {
+            "daily_leaderboard": daily_future.result(),
+            "personal_ranks": personal_ranks,
+            "win_rate_comparison": wr_future.result(),
+        }
 
 
 @router.post("/runs/upload")
@@ -478,7 +512,7 @@ async def upload_runs(request: Request, files: list[UploadFile] = File(...)):
 
 @router.get("/runs/stats")
 @limiter.limit("60/minute")
-async def get_my_stats(request: Request):
+def get_my_stats(request: Request):
     user = require_user(request)
     username = user.get("username")
     if not username:

--- a/frontend/app/admin/shared.tsx
+++ b/frontend/app/admin/shared.tsx
@@ -47,16 +47,49 @@ interface Me {
   is_admin?: boolean;
 }
 
+// The gate verdict, cached for the tab's lifetime: without this every /admin/*
+// navigation re-fetched /api/auth/me and blanked the page on "Loading..."
+// before the page's own data fetch could even start. The gate is cosmetic
+// (every /api/admin/* endpoint enforces require_admin server-side), so trusting
+// a same-session verdict is safe; sign-out clears sessionStorage cookies-side
+// and the API would 401 anyway.
+let _gateMe: Me | null = null;
+
+function cachedGate(): Me | null {
+  if (_gateMe) return _gateMe;
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = sessionStorage.getItem("admin_gate_me");
+    if (raw) {
+      _gateMe = JSON.parse(raw) as Me;
+      return _gateMe;
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
 export function useAdminGate(): { state: "loading" | "denied" | "ok"; me: Me | null } {
-  const [state, setState] = useState<"loading" | "denied" | "ok">("loading");
-  const [me, setMe] = useState<Me | null>(null);
+  const cached = cachedGate();
+  const [state, setState] = useState<"loading" | "denied" | "ok">(
+    cached ? "ok" : "loading",
+  );
+  const [me, setMe] = useState<Me | null>(cached);
   useEffect(() => {
+    if (cachedGate()) return;
     fetch(`${API}/api/auth/me`, { credentials: "include", headers: authHeaders() })
       .then((r) => (r.ok ? r.json() : null))
       .then((m: Me | null) => {
         if (!m?.is_admin) {
           setState("denied");
           return;
+        }
+        _gateMe = m;
+        try {
+          sessionStorage.setItem("admin_gate_me", JSON.stringify(m));
+        } catch {
+          /* ignore */
         }
         setMe(m);
         setState("ok");

--- a/frontend/app/components/ProfileStats.tsx
+++ b/frontend/app/components/ProfileStats.tsx
@@ -161,33 +161,60 @@ export default function ProfileStats({
   const [tab, setTab] = useState<Tab>("overview");
 
   useEffect(() => {
-    async function load() {
-      try {
-        const [statsRes, bestsRes, competitiveRes, cards, relics, potions] = await Promise.all([
-          fetch(`${API}/api/auth/stats`, { credentials: "include" }).then((r) => r.ok ? r.json() : null),
-          fetch(`${API}/api/auth/personal-bests`, { credentials: "include" }).then((r) => r.ok ? r.json() : null),
-          fetch(`${API}/api/auth/competitive`, { credentials: "include" }).then((r) => r.ok ? r.json() : null),
-          cachedFetch<EntityInfo[]>(`${API}/api/cards`),
-          cachedFetch<EntityInfo[]>(`${API}/api/relics`),
-          cachedFetch<EntityInfo[]>(`${API}/api/potions`),
-        ]);
-        if (statsRes) setStats(statsRes);
-        if (bestsRes) setBests(bestsRes);
-        if (competitiveRes) setCompetitive(competitiveRes);
+    // Progressive load: each piece renders as it arrives instead of the whole
+    // panel blanking on a skeleton until the slowest endpoint (/competitive,
+    // a dozen Mongo queries) returns. The headline stats paint first.
+    let alive = true;
+
+    fetch(`${API}/api/auth/stats`, { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!alive) return;
+        if (d) setStats(d);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+
+    fetch(`${API}/api/auth/personal-bests`, { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => alive && d && setBests(d))
+      .catch(() => {});
+
+    fetch(`${API}/api/auth/competitive`, { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => alive && d && setCompetitive(d))
+      .catch(() => {});
+
+    cachedFetch<EntityInfo[]>(`${API}/api/cards`)
+      .then((cards) => {
+        if (!alive) return;
         const cm: Record<string, EntityInfo> = {};
         for (const c of cards) cm[c.id] = c;
         setCardData(cm);
+      })
+      .catch(() => {});
+    cachedFetch<EntityInfo[]>(`${API}/api/relics`)
+      .then((relics) => {
+        if (!alive) return;
         const rm: Record<string, EntityInfo> = {};
         for (const r of relics) rm[r.id] = r;
         setRelicData(rm);
+      })
+      .catch(() => {});
+    cachedFetch<EntityInfo[]>(`${API}/api/potions`)
+      .then((potions) => {
+        if (!alive) return;
         const pm: Record<string, EntityInfo> = {};
         for (const p of potions) pm[p.id] = p;
         setPotionData(pm);
-      } catch {} finally {
-        setLoading(false);
-      }
-    }
-    load();
+      })
+      .catch(() => {});
+
+    return () => {
+      alive = false;
+    };
   }, []);
 
   if (loading) {


### PR DESCRIPTION
Profile stats were slow to load and the admin pages felt sluggish. Four compounding causes, all fixed:

## The big one: blocking the event loop

`auth.py` declared 12 read endpoints `async def` while calling blocking pymongo — so `/api/auth/me` (hit by the navbar on every page and by the admin gate), the profile stats trio, and the runs list all ran **on the event loop**, stalling every other request in the worker for the duration of their Mongo queries. They're plain `def` now, so FastAPI runs them in its threadpool. The four endpoints that genuinely `await` (uploads, username/email updates, set-cookie) stay async. This helps the whole site, not just these two pages.

## /api/auth/competitive was the profile's long pole

It ran ~12 Mongo queries serially (5 personal bests + up to 5 rank counts + the daily leaderboard + the win-rate comparison) and recomputed the same bests `/personal-bests` had just computed in the same page load. Now:
- Personal bests are cached 60s per user (bounded map), shared by both endpoints.
- The independent query groups fan out on a small thread pool, so the endpoint costs roughly one slow query instead of the sum.

## Profile stats render progressively

`ProfileStats` awaited a `Promise.all` of six fetches and blanked on a skeleton until the slowest returned. Each piece now sets state as it arrives: the headline stats paint as soon as `/stats` returns, bests/competitive/catalogs fill in behind.

## Admin: no more per-page gate waterfall

Every `/admin/*` navigation re-fetched `/api/auth/me` and sat on "Loading..." before the page's own data fetch even started. The gate verdict is now cached for the tab session (module + sessionStorage), so switching between admin pages renders instantly — the real enforcement was always server-side `require_admin` on every `/api/admin/*` endpoint, the gate is cosmetic. `/api/admin/overview` also fans its five info blocks (runs/users/snapshot/redis/DAU) out concurrently behind a 20s TTL cache instead of running them serially.

Verified: ruff + py_compile clean, routers import, the async/sync split asserted in a test (the four awaiting endpoints still coroutines, the reads not), tsc clean, eslint clean.
