### PR TITLE
Admin key management: list all keys, grant tiers, revoke

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -86,6 +86,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from .metrics import (
     api_errors,
     requests_in_flight,
+    requests_by_tier,
     response_size,
     entity_views,
     entity_list_views,
@@ -478,8 +479,23 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             # check is deterministic regardless of proxy layer.
             version_usage.labels(version="latest").inc()
 
-        # Track entity views and searches from API paths
+        # Track usage by rate-limit tier. The limiter's key_func already
+        # classified this request (memoized on request.state as "tier|domain");
+        # read it back so per-tier volume and 429 pressure are graphable, and
+        # keyed traffic bumps its per-key daily counter.
         path = request.url.path
+        if path.startswith("/api/"):
+            bucket = getattr(request.state, "_rl_bucket", None) or "browse|"
+            tier, _, domain = bucket.partition("|")
+            requests_by_tier.labels(
+                tier=tier, status=f"{response.status_code // 100}xx"
+            ).inc()
+            if domain.startswith("k:"):
+                from .services import api_key_usage
+
+                api_key_usage.record(domain[2:])
+
+        # Track entity views and searches from API paths
         if path.startswith("/api/") and request.method == "GET":
             parts = path.strip("/").split("/")
             if len(parts) >= 2 and parts[1] in _ENTITY_TYPES:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,6 +52,7 @@ from .routers import (
     admin,
     admin_searches,
     admin_rate_limits,
+    admin_api_keys,
     api_keys,
     glossary,
     guides,
@@ -610,6 +611,7 @@ app.include_router(beta.router)
 app.include_router(admin.router, include_in_schema=False)
 app.include_router(admin_searches.router, include_in_schema=False)
 app.include_router(admin_rate_limits.router, include_in_schema=False)
+app.include_router(admin_api_keys.router, include_in_schema=False)
 app.include_router(api_keys.router)
 app.include_router(glossary.router)
 app.include_router(guides.router)

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -29,6 +29,17 @@ api_errors = Counter(
     ["status_code", "method", "path"],
 )
 
+# ── API-key tier usage ───────────────────────────────────────
+requests_by_tier = Counter(
+    "spire_codex_requests_by_tier_total",
+    "API requests by rate-limit tier (browse = no key) and status class, "
+    "so per-tier volume and 429 pressure are graphable",
+    [
+        "tier",
+        "status",
+    ],  # tier: browse/general/registered/academia/paid; status: 2xx..5xx
+)
+
 # ── Entity views ─────────────────────────────────────────────
 entity_views = Counter(
     "spire_codex_entity_views_total",

--- a/backend/app/routers/admin_api_keys.py
+++ b/backend/app/routers/admin_api_keys.py
@@ -1,0 +1,48 @@
+"""Admin management of API keys: list everyone's keys, change a key's tier
+(grant academia / paid), revoke any key. Same require_admin gate as the rest
+of the operator surface.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ..services import api_key_service
+from ..services.auth_jwt import require_admin
+
+router = APIRouter(
+    prefix="/api/admin/keys",
+    tags=["Admin"],
+    dependencies=[Depends(require_admin)],
+)
+
+
+@router.get("")
+def list_keys(q: str | None = None, limit: int = 200):
+    """All keys, newest first, owner usernames joined. `q` filters by
+    username, label, or user/key id."""
+    return {
+        "keys": api_key_service.admin_list_keys(q, limit),
+        "tiers": list(api_key_service.TIERS),
+    }
+
+
+class TierUpdate(BaseModel):
+    tier: str = Field(description="general | registered | academia | paid")
+
+
+@router.put("/{key_id}")
+def change_tier(key_id: str, body: TierUpdate):
+    """Move a key to another tier (e.g. grant academia). Live within seconds."""
+    if body.tier not in api_key_service.TIERS:
+        raise HTTPException(status_code=400, detail=f"unknown tier '{body.tier}'")
+    if not api_key_service.set_tier(key_id, body.tier):
+        raise HTTPException(status_code=404, detail="key not found")
+    return {"ok": True, "tier": body.tier}
+
+
+@router.delete("/{key_id}")
+def revoke_key(key_id: str):
+    """Revoke any user's key. Stops working within seconds."""
+    if not api_key_service.admin_revoke(key_id):
+        raise HTTPException(status_code=404, detail="key not found")
+    return {"ok": True}

--- a/backend/app/services/api_key_service.py
+++ b/backend/app/services/api_key_service.py
@@ -169,11 +169,19 @@ def admin_list_keys(q: str | None = None, limit: int = 200) -> list[dict]:
         except Exception:
             logger.warning("api-key admin list: username join failed", exc_info=True)
 
+    # Usage join: requests today / last 7 days per key, one aggregation.
+    from . import api_key_usage
+
+    usage = api_key_usage.usage_for_keys([d["_id"] for d in docs])
+
     out = []
     for d in docs:
         row = _public(d)
         row["user_id"] = d.get("user_id")
         row["username"] = names.get(d.get("user_id") or "", "")
+        u = usage.get(d["_id"]) or {}
+        row["requests_today"] = u.get("today", 0)
+        row["requests_week"] = u.get("week", 0)
         out.append(row)
 
     if q and q.strip():

--- a/backend/app/services/api_key_service.py
+++ b/backend/app/services/api_key_service.py
@@ -130,6 +130,65 @@ def set_tier(key_id: str, tier: str) -> bool:
     return True
 
 
+def admin_revoke(key_id: str) -> bool:
+    """Revoke any key (no owner scoping — operator action). Cache-busted."""
+    if not os.environ.get("MONGO_URL", "").strip():
+        return False
+    doc = _coll().find_one({"_id": key_id})
+    if not doc:
+        return False
+    _coll().update_one({"_id": key_id}, {"$set": {"revoked": True}})
+    _resolve_cache.pop(doc.get("key_hash", ""), None)
+    return True
+
+
+def admin_list_keys(q: str | None = None, limit: int = 200) -> list[dict]:
+    """Every key, newest first, with the owner's username joined in. `q`
+    filters by username, label, or user/key id (substring, case-insensitive)."""
+    if not os.environ.get("MONGO_URL", "").strip():
+        return []
+    limit = max(1, min(limit, 500))
+    docs = list(_coll().find({}).sort("created_at", -1).limit(limit))
+
+    # Bulk-join usernames: keys store the user's ObjectId as a string.
+    from bson import ObjectId
+
+    from .users_db import _get_collection as _users
+
+    oids = []
+    for d in docs:
+        try:
+            oids.append(ObjectId(d.get("user_id")))
+        except Exception:
+            pass
+    names: dict[str, str] = {}
+    if oids:
+        try:
+            for u in _users().find({"_id": {"$in": oids}}, {"username": 1}):
+                names[str(u["_id"])] = u.get("username") or ""
+        except Exception:
+            logger.warning("api-key admin list: username join failed", exc_info=True)
+
+    out = []
+    for d in docs:
+        row = _public(d)
+        row["user_id"] = d.get("user_id")
+        row["username"] = names.get(d.get("user_id") or "", "")
+        out.append(row)
+
+    if q and q.strip():
+        term = q.strip().lower()
+        out = [
+            r
+            for r in out
+            if term in (r["username"] or "").lower()
+            or term in (r["label"] or "").lower()
+            or term in (r["user_id"] or "").lower()
+            or term in r["id"].lower()
+        ]
+    return out
+
+
 def resolve(raw_key: str) -> dict | None:
     """Resolve an ``X-API-Key`` to {tier, key_id, user_id}, cached. None when the
     key is missing, malformed, unknown, or revoked."""

--- a/backend/app/services/api_key_usage.py
+++ b/backend/app/services/api_key_usage.py
@@ -1,0 +1,135 @@
+"""Per-key daily usage counters.
+
+Every request carrying a valid X-API-Key bumps a per-key per-day counter so the
+admin keys page can show who's actually consuming the API. Increments buffer
+in-process and flush as batched $inc upserts (time- or size-triggered), so the
+request path never waits on Mongo: worst case a worker restart loses a few
+seconds of counts, which is fine for usage accounting. Browse (un-keyed)
+traffic is deliberately NOT tracked per-identity — that would mean per-IP
+counters — only in the aggregate Prometheus tier metric.
+
+Documents: {_id: "<key_id>:<YYYY-MM-DD>", key_id, day, count, ts} with a TTL on
+ts so the collection trims itself after the retention window.
+"""
+
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+
+logger = logging.getLogger("spire-codex")
+
+USAGE_COLLECTION = "api_key_usage"
+_RETENTION_DAYS = 90
+_FLUSH_SECONDS = 10.0
+_FLUSH_MAX_BUFFER = 500
+
+_lock = threading.Lock()
+_buffer: dict[tuple[str, str], int] = {}  # (key_id, day) -> pending count
+_last_flush = 0.0
+_indexed = False
+
+
+def _coll():
+    from .runs_db_mongo import _get_collection
+
+    col = _get_collection().database[USAGE_COLLECTION]
+    global _indexed
+    if not _indexed:
+        try:
+            col.create_index(
+                "ts", expireAfterSeconds=_RETENTION_DAYS * 86400, name="ttl_ts"
+            )
+            col.create_index([("key_id", 1), ("day", -1)])
+            _indexed = True
+        except Exception:
+            logger.warning("api-key usage index setup failed", exc_info=True)
+    return col
+
+
+def record(key_id: str) -> None:
+    """Count one request for a key. Buffers in-process; flushes when the buffer
+    is old or large. Never raises — usage accounting must not break requests."""
+    if not key_id or not os.environ.get("MONGO_URL", "").strip():
+        return
+    try:
+        day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        now = time.monotonic()
+        to_flush: dict[tuple[str, str], int] | None = None
+        global _last_flush
+        with _lock:
+            _buffer[(key_id, day)] = _buffer.get((key_id, day), 0) + 1
+            if (
+                now - _last_flush >= _FLUSH_SECONDS
+                or sum(_buffer.values()) >= _FLUSH_MAX_BUFFER
+            ):
+                to_flush = dict(_buffer)
+                _buffer.clear()
+                _last_flush = now
+        if to_flush:
+            # Off the request path: the unlucky request that trips the flush
+            # shouldn't pay for the bulk write either.
+            threading.Thread(
+                target=_flush_safe, args=(to_flush,), daemon=True, name="key-usage"
+            ).start()
+    except Exception:
+        logger.warning("api-key usage record failed", exc_info=True)
+
+
+def _flush_safe(items: dict[tuple[str, str], int]) -> None:
+    try:
+        _flush(items)
+    except Exception:
+        logger.warning("api-key usage flush failed", exc_info=True)
+
+
+def _flush(items: dict[tuple[str, str], int]) -> None:
+    from pymongo import UpdateOne
+
+    ts = datetime.now(timezone.utc)
+    ops = [
+        UpdateOne(
+            {"_id": f"{kid}:{day}"},
+            {
+                "$inc": {"count": n},
+                "$set": {"ts": ts},
+                "$setOnInsert": {"key_id": kid, "day": day},
+            },
+            upsert=True,
+        )
+        for (kid, day), n in items.items()
+    ]
+    if ops:
+        _coll().bulk_write(ops, ordered=False)
+
+
+def usage_for_keys(key_ids: list[str], days: int = 7) -> dict[str, dict]:
+    """{key_id: {today, week}} for the admin keys list. One aggregation."""
+    if not key_ids or not os.environ.get("MONGO_URL", "").strip():
+        return {}
+    try:
+        from datetime import timedelta
+
+        now = datetime.now(timezone.utc)
+        today = now.strftime("%Y-%m-%d")
+        cutoff = (now - timedelta(days=days)).strftime("%Y-%m-%d")
+        out: dict[str, dict] = {}
+        pipeline = [
+            {"$match": {"key_id": {"$in": key_ids}, "day": {"$gte": cutoff}}},
+            {
+                "$group": {
+                    "_id": "$key_id",
+                    "week": {"$sum": "$count"},
+                    "today": {
+                        "$sum": {"$cond": [{"$eq": ["$day", today]}, "$count", 0]}
+                    },
+                }
+            },
+        ]
+        for r in _coll().aggregate(pipeline):
+            out[r["_id"]] = {"today": r.get("today", 0), "week": r.get("week", 0)}
+        return out
+    except Exception:
+        logger.warning("api-key usage read failed", exc_info=True)
+        return {}

--- a/frontend/app/admin/keys/KeysClient.tsx
+++ b/frontend/app/admin/keys/KeysClient.tsx
@@ -15,6 +15,8 @@ interface AdminKey {
   label: string;
   created_at: string | null;
   last_used_at: string | null;
+  requests_today: number;
+  requests_week: number;
   revoked: boolean;
 }
 
@@ -141,6 +143,15 @@ export default function KeysClient() {
                 </div>
                 <div className="text-xs text-[var(--text-muted)] font-mono">
                   {k.id} · created {fmt(k.created_at)} · last used {fmt(k.last_used_at)}
+                </div>
+              </div>
+              <div className="shrink-0 text-right tabular-nums">
+                <div className="text-sm text-[var(--text-primary)]">
+                  {(k.requests_today ?? 0).toLocaleString()}
+                  <span className="text-xs text-[var(--text-muted)]"> today</span>
+                </div>
+                <div className="text-xs text-[var(--text-muted)]">
+                  {(k.requests_week ?? 0).toLocaleString()} / 7d
                 </div>
               </div>
               {k.revoked ? (

--- a/frontend/app/admin/keys/KeysClient.tsx
+++ b/frontend/app/admin/keys/KeysClient.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+// Operator view of every API key: who owns it, its tier, when it was last
+// used. Change a key's tier from the dropdown (this is how academia / paid get
+// granted until Patreon automates paid), or revoke it outright.
+
+import { useCallback, useEffect, useState } from "react";
+import { AdminShell, adminFetch } from "../shared";
+
+interface AdminKey {
+  id: string;
+  user_id: string;
+  username: string;
+  tier: string;
+  label: string;
+  created_at: string | null;
+  last_used_at: string | null;
+  revoked: boolean;
+}
+
+interface KeysResponse {
+  keys: AdminKey[];
+  tiers: string[];
+}
+
+function fmt(iso: string | null): string {
+  if (!iso) return "never";
+  return new Date(iso).toLocaleDateString();
+}
+
+const TIER_BADGE: Record<string, string> = {
+  general: "text-[var(--text-secondary)] border-[var(--border-subtle)]",
+  registered: "text-[var(--text-primary)] border-[var(--border-subtle)]",
+  academia: "text-blue-400 border-blue-500/40",
+  paid: "text-[var(--accent-gold)] border-[var(--accent-gold)]/40",
+};
+
+export default function KeysClient() {
+  const [data, setData] = useState<KeysResponse | null>(null);
+  const [q, setQ] = useState("");
+  const [busy, setBusy] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+  const [showRevoked, setShowRevoked] = useState(false);
+
+  const load = useCallback((query: string) => {
+    adminFetch<KeysResponse>(
+      `/api/admin/keys?limit=300${query ? `&q=${encodeURIComponent(query)}` : ""}`,
+    )
+      .then((d) => {
+        setData(d);
+        setNote(null);
+      })
+      .catch((e) => setNote(String((e as Error)?.message || e)));
+  }, []);
+
+  // Debounced server-side search.
+  useEffect(() => {
+    const t = setTimeout(() => load(q.trim()), 250);
+    return () => clearTimeout(t);
+  }, [q, load]);
+
+  const setTier = (key: AdminKey, tier: string) => {
+    if (tier === key.tier) return;
+    setBusy(key.id);
+    adminFetch(`/api/admin/keys/${key.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tier }),
+    })
+      .then(() => load(q.trim()))
+      .catch((e) => setNote(String((e as Error)?.message || e)))
+      .finally(() => setBusy(null));
+  };
+
+  const revoke = (key: AdminKey) => {
+    setBusy(key.id);
+    adminFetch(`/api/admin/keys/${key.id}`, { method: "DELETE" })
+      .then(() => load(q.trim()))
+      .catch((e) => setNote(String((e as Error)?.message || e)))
+      .finally(() => setBusy(null));
+  };
+
+  const keys = (data?.keys ?? []).filter((k) => showRevoked || !k.revoked);
+  const tiers = data?.tiers ?? ["general", "registered", "academia", "paid"];
+
+  return (
+    <AdminShell title="API keys" subtitle="tiers + revocation">
+      <p className="text-sm text-[var(--text-secondary)] mb-4 max-w-2xl">
+        Every issued key. Move a key to another tier from the dropdown (academia is
+        granted here; paid will come from Patreon), or revoke it. Changes are live
+        within seconds.
+      </p>
+
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <input
+          type="text"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search username, label, or id…"
+          className="w-72 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] px-3 py-2 text-sm text-[var(--text-primary)]"
+        />
+        <label className="flex items-center gap-2 text-xs text-[var(--text-secondary)]">
+          <input
+            type="checkbox"
+            checked={showRevoked}
+            onChange={(e) => setShowRevoked(e.target.checked)}
+          />
+          Show revoked
+        </label>
+        {data && (
+          <span className="text-xs text-[var(--text-muted)]">
+            {keys.length} key{keys.length === 1 ? "" : "s"}
+          </span>
+        )}
+      </div>
+
+      {note && <p className="text-sm text-red-400 mb-4">{note}</p>}
+      {data === null && !note && (
+        <p className="text-sm text-[var(--text-muted)]">Loading…</p>
+      )}
+
+      {data && keys.length === 0 && (
+        <p className="text-sm text-[var(--text-muted)]">No keys match.</p>
+      )}
+
+      {keys.length > 0 && (
+        <div className="rounded-lg border border-[var(--border-subtle)] overflow-hidden">
+          {keys.map((k) => (
+            <div
+              key={k.id}
+              className={`flex flex-wrap items-center gap-3 px-4 py-2.5 border-b border-[var(--border-subtle)] last:border-0 bg-[var(--bg-card)] ${
+                k.revoked ? "opacity-50" : ""
+              }`}
+            >
+              <div className="flex-1 min-w-[10rem]">
+                <div className="text-sm text-[var(--text-primary)] truncate">
+                  {k.username || <span className="text-[var(--text-muted)]">unknown user</span>}
+                  {k.label && (
+                    <span className="text-[var(--text-muted)]"> · {k.label}</span>
+                  )}
+                </div>
+                <div className="text-xs text-[var(--text-muted)] font-mono">
+                  {k.id} · created {fmt(k.created_at)} · last used {fmt(k.last_used_at)}
+                </div>
+              </div>
+              {k.revoked ? (
+                <span className="shrink-0 text-xs px-2 py-0.5 rounded-full border border-red-500/40 text-red-400">
+                  revoked
+                </span>
+              ) : (
+                <>
+                  <select
+                    value={k.tier}
+                    disabled={busy === k.id}
+                    onChange={(e) => setTier(k, e.target.value)}
+                    className={`shrink-0 text-xs px-2 py-1 rounded-lg border bg-[var(--bg-primary)] disabled:opacity-50 ${TIER_BADGE[k.tier] ?? TIER_BADGE.general}`}
+                  >
+                    {tiers.map((t) => (
+                      <option key={t} value={t}>
+                        {t}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    disabled={busy === k.id}
+                    onClick={() => revoke(k)}
+                    className="shrink-0 text-xs px-2.5 py-1 rounded-lg border border-red-500/40 bg-red-500/10 text-red-400 disabled:opacity-50"
+                  >
+                    Revoke
+                  </button>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </AdminShell>
+  );
+}

--- a/frontend/app/admin/keys/page.tsx
+++ b/frontend/app/admin/keys/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import KeysClient from "./KeysClient";
+
+export const metadata: Metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminKeysPage() {
+  return <KeysClient />;
+}

--- a/frontend/app/admin/shared.tsx
+++ b/frontend/app/admin/shared.tsx
@@ -119,6 +119,7 @@ const SECTIONS = [
   { href: "/admin/searches", label: "Searches" },
   { href: "/admin/cache", label: "Cache" },
   { href: "/admin/rate-limits", label: "Rate limits" },
+  { href: "/admin/keys", label: "API keys" },
 ];
 
 export function AdminShell({


### PR DESCRIPTION
The management side of the API-key tiers (#632): until now academia had no way to be granted and I couldn't see or kill anyone's key without Mongo access.

## /admin/keys

- Every issued key, newest first, with the **owner's username** joined in (bulk lookup, one query), plus label, key id, created, and last-used.
- **Debounced search** over username / label / user id / key id.
- **Tier dropdown per key** — this is how academia gets granted (and paid, until Patreon automates it). Changes bust the resolve cache, so they're live within seconds.
- **Revoke** any key; revoked keys hide behind a "show revoked" toggle.

## Backend

- `admin_list_keys(q, limit)` — all keys + username join; substring filter.
- `admin_revoke(key_id)` — operator revoke, no owner scoping, cache-busted.
- `admin_api_keys` router: `GET /api/admin/keys`, `PUT /api/admin/keys/{id}` (tier), `DELETE /api/admin/keys/{id}` — behind the existing `require_admin`, hidden from the OpenAPI schema like the rest of the admin surface.

Verified: ruff + py_compile clean, router imports, service no-Mongo fallbacks tested, tsc clean, eslint clean.


## Usage tracking

Answering "how much does each tier actually get used": the tier classification the limiter already computes is now recorded instead of thrown away.

- **`requests_by_tier` Prometheus counter** (tier × status class) — per-tier volume and 429 pressure graphable in Grafana next to the existing metrics. Browse (un-keyed) traffic only appears in this aggregate, never per-identity, consistent with not storing IPs.
- **Per-key daily counters** (`api_key_usage` collection): keyed traffic bumps a per-key per-day count. Writes buffer in-process and flush as batched upserts on a background thread, so the request path never waits on Mongo; 90-day TTL.
- **/admin/keys** now shows requests **today / last 7 days** per key (single aggregation join).
