### PR TITLE
Quota headers, admin audit logging, per-endpoint cap docs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -143,10 +143,13 @@ IS_BETA_BACKEND = os.environ.get("DISABLE_RUN_SUBMISSIONS") == "1"
 # key_style="endpoint" scopes each counter by ROUTE, not URL — slowapi's default
 # "url" gave every distinct path its own counter, so a scraper enumerating
 # /api/cards/{id} across hundreds of ids got the full cap on each one.
+# headers_enabled: responses carry X-RateLimit-Limit/Remaining/Reset (and 429s
+# a Retry-After) so API consumers can see their quota and back off politely.
 limiter = Limiter(
     key_func=rate_limit_config.rate_limit_key,
     default_limits=[rate_limit_config.tier_limit_value],
     key_style="endpoint",
+    headers_enabled=True,
 )
 
 app = FastAPI(
@@ -563,7 +566,14 @@ _cors_origins = os.environ.get("CORS_ORIGINS", "").strip()
 # Response headers a browser client is allowed to read; wildcard allow_headers
 # only covers the *request* side. X-Next-Cursor carries the run-export keyset
 # token (GET /api/exports/runs).
-_cors_expose_headers = ["X-Next-Cursor"]
+_cors_expose_headers = [
+    "X-Next-Cursor",
+    # Quota headers, so browser-side API clients can read their remaining budget.
+    "X-RateLimit-Limit",
+    "X-RateLimit-Remaining",
+    "X-RateLimit-Reset",
+    "Retry-After",
+]
 if _cors_origins:
     app.add_middleware(
         CORSMiddleware,

--- a/backend/app/routers/admin_api_keys.py
+++ b/backend/app/routers/admin_api_keys.py
@@ -3,11 +3,12 @@
 of the operator surface.
 """
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from ..services import api_key_service
 from ..services.auth_jwt import require_admin
+from .admin import _audit
 
 router = APIRouter(
     prefix="/api/admin/keys",
@@ -17,9 +18,10 @@ router = APIRouter(
 
 
 @router.get("")
-def list_keys(q: str | None = None, limit: int = 200):
+def list_keys(request: Request, q: str | None = None, limit: int = 200):
     """All keys, newest first, owner usernames joined. `q` filters by
     username, label, or user/key id."""
+    _audit(request)
     return {
         "keys": api_key_service.admin_list_keys(q, limit),
         "tiers": list(api_key_service.TIERS),
@@ -31,8 +33,9 @@ class TierUpdate(BaseModel):
 
 
 @router.put("/{key_id}")
-def change_tier(key_id: str, body: TierUpdate):
+def change_tier(key_id: str, body: TierUpdate, request: Request):
     """Move a key to another tier (e.g. grant academia). Live within seconds."""
+    _audit(request)
     if body.tier not in api_key_service.TIERS:
         raise HTTPException(status_code=400, detail=f"unknown tier '{body.tier}'")
     if not api_key_service.set_tier(key_id, body.tier):
@@ -41,8 +44,9 @@ def change_tier(key_id: str, body: TierUpdate):
 
 
 @router.delete("/{key_id}")
-def revoke_key(key_id: str):
+def revoke_key(key_id: str, request: Request):
     """Revoke any user's key. Stops working within seconds."""
+    _audit(request)
     if not api_key_service.admin_revoke(key_id):
         raise HTTPException(status_code=404, detail="key not found")
     return {"ok": True}

--- a/backend/app/routers/admin_rate_limits.py
+++ b/backend/app/routers/admin_rate_limits.py
@@ -5,11 +5,12 @@ raise/lower the global per-IP cap or switch it off entirely at runtime, without
 a redeploy. Per-endpoint limits (auth, feedback, ...) are unaffected.
 """
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from ..services import rate_limit_config
 from ..services.auth_jwt import require_admin
+from .admin import _audit
 
 router = APIRouter(
     prefix="/api/admin/rate-limits",
@@ -19,8 +20,9 @@ router = APIRouter(
 
 
 @router.get("")
-def get_rate_limits():
+def get_rate_limits(request: Request):
     """Current browse cap, per-tier caps, and whether limiting is on."""
+    _audit(request)
     return rate_limit_config.get_config()
 
 
@@ -52,9 +54,10 @@ class RateLimitUpdate(BaseModel):
 
 
 @router.put("")
-def set_rate_limits(body: RateLimitUpdate):
+def set_rate_limits(body: RateLimitUpdate, request: Request):
     """Change the browse cap, tier caps, endpoint clamps, and/or toggle limiting.
     Takes effect across workers within the config cache window (~15s)."""
+    _audit(request)
     try:
         return rate_limit_config.set_config(
             body.default_limit,

--- a/backend/app/routers/admin_searches.py
+++ b/backend/app/routers/admin_searches.py
@@ -6,10 +6,11 @@ the existing operator login instead of a separate token. Reads the `search_log`
 collection populated by the /api/search hook.
 """
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
 from ..services import search_analytics
 from ..services.auth_jwt import require_admin
+from .admin import _audit
 
 router = APIRouter(
     prefix="/api/admin/searches",
@@ -19,7 +20,8 @@ router = APIRouter(
 
 
 @router.get("")
-def searches_overview(days: int = 7, limit: int = 50):
+def searches_overview(request: Request, days: int = 7, limit: int = 50):
     """Everything the /admin/searches page needs in one call: headline summary,
     top queries, top zero-result queries, per-day volume, and a recent feed."""
+    _audit(request)
     return search_analytics.overview(days, limit)

--- a/backend/app/services/rate_limit_config.py
+++ b/backend/app/services/rate_limit_config.py
@@ -12,6 +12,11 @@ counts live.
 Endpoints with their own tighter ``@limiter.limit(...)`` (auth, feedback, guide
 submission) keep those — those stay per-IP so a key can't buy past them.
 
+Caps count PER ENDPOINT (the limiter scopes counters by route), so a key's
+60/minute means 60/minute on each route, not across the whole API. Deliberate:
+it protects every endpoint from hammering while staying generous to clients
+that fan out across several.
+
 Endpoint overrides: the config also carries a list of {path, limit} entries so
 an operator can clamp a specific path prefix live when it's being abused (e.g.
 ``/api/runs`` -> ``30/minute``). Longest matching prefix wins, the override

--- a/frontend/app/admin/rate-limits/RateLimitsClient.tsx
+++ b/frontend/app/admin/rate-limits/RateLimitsClient.tsx
@@ -118,7 +118,7 @@ export default function RateLimitsClient() {
               Browse cap
             </label>
             <div className="text-xs text-[var(--text-muted)] mb-2">
-              Un-keyed traffic, per IP.
+              Un-keyed traffic, per IP, counted per endpoint.
             </div>
             <div className="flex gap-2">
               <input
@@ -164,7 +164,7 @@ export default function RateLimitsClient() {
               API-key tiers
             </label>
             <div className="text-xs text-[var(--text-muted)] mb-3">
-              Cap per <span className="font-mono">X-API-Key</span>, by the key&apos;s tier.
+              Cap per <span className="font-mono">X-API-Key</span>, by the key&apos;s tier, counted per endpoint.
             </div>
             <div className="space-y-2">
               {TIER_META.map((t) => (

--- a/frontend/app/developers/page.tsx
+++ b/frontend/app/developers/page.tsx
@@ -147,7 +147,7 @@ export default function DevelopersPage() {
           casual use (rate limited per IP). For scripts and tools, create an API key on your{" "}
           <Link href="/profile" className="text-[var(--accent-gold)] hover:underline">profile page</Link>{" "}
           and send it as the <code className="text-xs bg-[var(--bg-card)] px-1.5 py-0.5 rounded">X-API-Key</code>{" "}
-          header to get your own dedicated rate limit instead of sharing the per-IP cap.
+          header to get your own dedicated rate limit (counted per endpoint) instead of sharing the per-IP cap. Responses carry X-RateLimit-Remaining / X-RateLimit-Reset so you can pace requests.
         </p>
 
         <div className="bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] p-5 mb-4">


### PR DESCRIPTION
Gap-audit fixes for the key program (re-landed: the original commit went to #634's branch right as it merged).

- **Quota headers**: `headers_enabled` on the limiter — responses now carry `X-RateLimit-Limit` / `X-RateLimit-Remaining` / `X-RateLimit-Reset` (and 429s a `Retry-After`), CORS-exposed so browser clients can read them. API consumers can finally see their budget and back off politely.
- **Audit logging**: the admin routers added recently (rate-limits, api-keys, searches) now audit-log every hit like the rest of the admin surface. Tier grants, key revocations, and endpoint clamps are exactly the operator actions that should leave a trail.
- **Per-endpoint caps documented**: a key's 60/minute counts per route, not across the whole API (deliberate — protects each endpoint while staying generous to clients that fan out). Now stated in the config docstring, the developers page, and the admin rate-limits page, and the developers page mentions the new quota headers.

ruff + py_compile clean, routers import, tsc + eslint clean (verified before the cherry-pick; the pick applied without conflicts).
