### PR TITLE
Move rate-limit counters to Redis so caps are exact across workers

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -145,11 +145,15 @@ IS_BETA_BACKEND = os.environ.get("DISABLE_RUN_SUBMISSIONS") == "1"
 # /api/cards/{id} across hundreds of ids got the full cap on each one.
 # headers_enabled: responses carry X-RateLimit-Limit/Remaining/Reset (and 429s
 # a Retry-After) so API consumers can see their quota and back off politely.
+# storage_kwargs points the counters at Redis when REDIS_URL is set, so all
+# workers share them and a cap means exactly what it says (previously each of
+# the 4 workers kept its own in-memory count, ~4x the configured cap).
 limiter = Limiter(
     key_func=rate_limit_config.rate_limit_key,
     default_limits=[rate_limit_config.tier_limit_value],
     key_style="endpoint",
     headers_enabled=True,
+    **rate_limit_config.storage_kwargs(),
 )
 
 app = FastAPI(

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 from slowapi import Limiter
 
 from ..dependencies import client_ip
+from ..services import rate_limit_config
 from ..services.auth_jwt import (
     get_current_user,
     is_admin,
@@ -18,7 +19,7 @@ from ..services.auth_jwt import (
 )
 
 router = APIRouter(prefix="/api/auth", tags=["Auth"])
-limiter = Limiter(key_func=client_ip)
+limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
 
 _MAX_UPLOAD_SIZE = 512 * 1024  # 512 KB per file
 _MAX_UPLOAD_FILES = 100

--- a/backend/app/routers/auth_discord.py
+++ b/backend/app/routers/auth_discord.py
@@ -17,12 +17,13 @@ from fastapi.responses import RedirectResponse
 from slowapi import Limiter
 
 from ..dependencies import client_ip
+from ..services import rate_limit_config
 from ..services.auth_jwt import create_oauth_state, verify_oauth_state
 
 logger = logging.getLogger("spire-codex.auth")
 
 router = APIRouter(prefix="/api/auth/discord", tags=["Auth"])
-limiter = Limiter(key_func=client_ip)
+limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
 
 _DISCORD_API = "https://discord.com/api/v10"
 _DISCORD_AUTHORIZE = "https://discord.com/api/oauth2/authorize"

--- a/backend/app/routers/auth_steam.py
+++ b/backend/app/routers/auth_steam.py
@@ -38,13 +38,14 @@ from pydantic import BaseModel
 from slowapi import Limiter
 
 from ..dependencies import client_ip
+from ..services import rate_limit_config
 from ..services import auth_session_store
 from ..services.auth_session_store import SESSION_TTL_SECONDS
 
 logger = logging.getLogger("spire-codex.auth")
 
 router = APIRouter(prefix="/api/auth/steam", tags=["Auth"])
-limiter = Limiter(key_func=client_ip)
+limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
 
 _REALM_ENV_KEY = "SPIRE_CODEX_PUBLIC_BASE"
 

--- a/backend/app/routers/auth_twitch.py
+++ b/backend/app/routers/auth_twitch.py
@@ -23,12 +23,13 @@ from fastapi.responses import RedirectResponse
 from slowapi import Limiter
 
 from ..dependencies import client_ip
+from ..services import rate_limit_config
 from ..services.auth_jwt import create_oauth_state, verify_oauth_state
 
 logger = logging.getLogger("spire-codex.auth")
 
 router = APIRouter(prefix="/api/auth/twitch", tags=["Auth"])
-limiter = Limiter(key_func=client_ip)
+limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
 
 _TWITCH_AUTHORIZE = "https://id.twitch.tv/oauth2/authorize"
 _TWITCH_TOKEN = "https://id.twitch.tv/oauth2/token"

--- a/backend/app/routers/beta.py
+++ b/backend/app/routers/beta.py
@@ -8,6 +8,7 @@ VersionMiddleware). What lives here is the metadata about the beta branch.
 from fastapi import APIRouter, Request
 from slowapi import Limiter
 from ..dependencies import client_ip
+from ..services import rate_limit_config
 
 from ..services.beta_diff import get_beta_diff
 from ..services.data_service import get_beta_version
@@ -16,7 +17,7 @@ router = APIRouter(prefix="/api/beta", tags=["Beta"])
 # client_ip, not slowapi's get_remote_address: behind Cloudflare -> nginx
 # the latter reads the proxy address, so every visitor would share ONE
 # bucket and these limits would trip fleet-wide (see dependencies.client_ip).
-limiter = Limiter(key_func=client_ip)
+limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
 
 
 @router.get("/diff")

--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -16,6 +16,7 @@ import logging
 from fastapi import APIRouter, HTTPException, Query, Request
 from slowapi import Limiter
 from ..dependencies import client_ip
+from ..services import rate_limit_config
 
 from ..services import cache as app_cache
 from ..services import charts_stats as cs
@@ -25,7 +26,7 @@ router = APIRouter(prefix="/api/charts", tags=["Charts"])
 # client_ip, not slowapi's get_remote_address: behind Cloudflare -> nginx
 # the latter reads the proxy address, so every visitor would share ONE
 # bucket and these limits would trip fleet-wide (see dependencies.client_ip).
-limiter = Limiter(key_func=client_ip)
+limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
 logger = logging.getLogger(__name__)
 
 _CACHE_TTL = 300

--- a/backend/app/routers/exports.py
+++ b/backend/app/routers/exports.py
@@ -13,12 +13,13 @@ from pymongo import ASCENDING
 from slowapi import Limiter
 
 from ..dependencies import VALID_LANGUAGES, client_ip
+from ..services import rate_limit_config
 from ..metrics import data_exports, run_export_pages, run_exports
 from ..services.data_service import DATA_DIR
 
 router = APIRouter(prefix="/api/exports", tags=["Exports"])
 
-limiter = Limiter(key_func=client_ip)
+limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
 
 ENTITY_FILES = [
     "cards",

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from slowapi import Limiter
 
 from ..dependencies import client_ip
+from ..services import rate_limit_config
 from ..metrics import feedback_submissions
 from ..services import github_issues
 
@@ -18,7 +19,7 @@ router = APIRouter(prefix="/api/feedback", tags=["Feedback"])
 
 WEBHOOK_URL = os.environ.get("FEEDBACK_WEBHOOK_URL", "")
 
-limiter = Limiter(key_func=client_ip)
+limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
 
 
 class FeedbackRequest(BaseModel):

--- a/backend/app/routers/guides.py
+++ b/backend/app/routers/guides.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from slowapi import Limiter
 
 from ..dependencies import client_ip
+from ..services import rate_limit_config
 from ..models.schemas import GuideSummary, Guide
 from ..services.data_service import load_guides
 from ..metrics import guide_submissions
@@ -19,7 +20,7 @@ router = APIRouter(prefix="/api/guides", tags=["Guides"])
 
 WEBHOOK_URL = os.environ.get("GUIDE_WEBHOOK_URL", "")
 
-limiter = Limiter(key_func=client_ip)
+limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
 
 
 @router.get("", response_model=list[GuideSummary])

--- a/backend/app/routers/qa_feedback.py
+++ b/backend/app/routers/qa_feedback.py
@@ -23,11 +23,12 @@ from pydantic import BaseModel, Field
 from slowapi import Limiter
 
 from ..dependencies import client_ip
+from ..services import rate_limit_config
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/qa-feedback", tags=["Feedback"])
-limiter = Limiter(key_func=client_ip)
+limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
 
 
 class QAFeedback(BaseModel):

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException, Query, Request, Response
 from slowapi import Limiter
 from ..dependencies import client_ip
+from ..services import rate_limit_config
 from ..services.runs_db import submit_run, get_stats, claim_runs
 from ..services import cache as app_cache
 from ..services.run_entity_stats import (
@@ -41,7 +42,7 @@ router = APIRouter(prefix="/api/runs", tags=["Runs"])
 # client_ip, not slowapi's get_remote_address: behind Cloudflare -> nginx
 # the latter reads the proxy address, so every visitor would share ONE
 # bucket and these limits would trip fleet-wide (see dependencies.client_ip).
-limiter = Limiter(key_func=client_ip)
+limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
 
 MAX_BODY_SIZE = 512 * 1024  # 512 KB
 

--- a/backend/app/routers/uninstall.py
+++ b/backend/app/routers/uninstall.py
@@ -24,11 +24,12 @@ from pydantic import BaseModel, Field
 from slowapi import Limiter
 
 from ..dependencies import client_ip
+from ..services import rate_limit_config
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/uninstall-feedback", tags=["Feedback"])
-limiter = Limiter(key_func=client_ip)
+limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
 
 RESEND_ENDPOINT = "https://api.resend.com/emails"
 

--- a/backend/app/services/rate_limit_config.py
+++ b/backend/app/services/rate_limit_config.py
@@ -22,6 +22,11 @@ an operator can clamp a specific path prefix live when it's being abused (e.g.
 ``/api/runs`` -> ``30/minute``). Longest matching prefix wins, the override
 applies to every tier (a clamp during an attack should clamp everyone), and
 ``/api/admin`` is never overridable so the controls can't lock themselves out.
+
+With REDIS_URL set (prod always sets it, the cache lives there) the counters
+live in Redis via ``storage_kwargs`` and are shared across all workers, so a
+cap means exactly what it says. Unset, or with Redis down, slowapi falls back
+to per-worker in-memory counters (~workers x the cap) — the pre-Redis behavior.
 """
 
 import logging
@@ -57,6 +62,22 @@ _cache: dict = {"at": 0.0, "cfg": None}
 # before the limit callable, in the same context) so tier_limit_value can apply
 # endpoint overrides without access to the request object.
 _current_path: ContextVar[str] = ContextVar("rl_current_path", default="")
+
+
+def storage_kwargs() -> dict:
+    """kwargs for every slowapi ``Limiter(...)``: Redis-backed counters when
+    RATE_LIMIT_REDIS_URL or REDIS_URL is set (shared across workers, so caps are
+    exact), else slowapi's in-memory default. in_memory_fallback_enabled means a
+    Redis outage degrades to per-worker limiting instead of 500s. The shared
+    cache Redis runs allkeys-lru; counter keys are tiny and short-lived, so
+    eviction pressure at worst forgets a window early (fail-generous)."""
+    url = (
+        os.environ.get("RATE_LIMIT_REDIS_URL", "").strip()
+        or os.environ.get("REDIS_URL", "").strip()
+    )
+    if not url:
+        return {}
+    return {"storage_uri": url, "in_memory_fallback_enabled": True}
 
 
 def _coll():


### PR DESCRIPTION
Closes the standing caveat on the key program: rate-limit counters were per-worker in-memory, so every cap was effectively ~4x what it said (4 uvicorn workers). Fine-ish for the blanket browse cap, but it breaks the promise of the key tiers — a "60/minute" registered key really got ~240, and paid would have too.

## What it does

- **`storage_kwargs()`** in `rate_limit_config`: when `RATE_LIMIT_REDIS_URL` or `REDIS_URL` is set, every limiter stores counters in Redis (`in_memory_fallback_enabled`, so a Redis outage degrades to per-worker limiting — exactly the old behavior — instead of 500s). Unset = in-memory, bare-metal dev unchanged.
- **All 13 `Limiter(...)` constructions** (the app limiter + the 12 router-local ones for auth/runs/charts/etc.) take the kwargs, so the tighter decorated limits share counters too.
- **Zero infra work**: the `redis` service and `REDIS_URL` env have been in both compose files since the cache landed — slowapi just never used them. Counter keys are tiny and short-lived; the shared cache's `allkeys-lru` at worst evicts a window early (fail-generous), noted in the helper docstring.

## Scope

Per the workspace plan ("confirm exact scope"): this is **rate-limit counters only**. Sessions, snapshots, and the JSON cache keep their current homes. A side benefit: with counters shared, the ~15s config-propagation window for admin cap changes stops mattering for fairness.

## Verification

Kwargs shape, `Limiter` + `RedisStorage` construction, no-env fallback, and all 12 routers importing are tested. **Live shared counting needs a deploy smoke test** (this box has no local Redis): after deploy, hit any endpoint ~5x fast and check `X-RateLimit-Remaining` decrements monotonically instead of jumping between per-worker values.
