### PR TITLE
Hotfix: never edge-cache /api/keys or /api/admin responses

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -371,6 +371,12 @@ class CORSStaticMiddleware(BaseHTTPMiddleware):
             response.headers["Cache-Control"] = "no-store"
         elif path.startswith("/api/runs/"):
             response.headers["Cache-Control"] = "public, max-age=30, s-maxage=30"
+        elif path.startswith("/api/keys") or path.startswith("/api/admin"):
+            # Per-user (API keys) and operator (admin) responses must never land
+            # in a shared cache: the public catch-all below let Cloudflare cache
+            # an authed /api/keys response at the edge for an hour, serving one
+            # user's (stale) key list to everyone.
+            response.headers["Cache-Control"] = "private, no-store"
         elif path.startswith("/api/"):
             response.headers["Cache-Control"] = "public, max-age=300, s-maxage=3600"
         return response

--- a/frontend/app/components/ApiKeysSection.tsx
+++ b/frontend/app/components/ApiKeysSection.tsx
@@ -44,10 +44,14 @@ export default function ApiKeysSection() {
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(() => {
-    fetch(`${API_BASE}/api/keys`, { credentials: "include" })
+    fetch(`${API_BASE}/api/keys`, { credentials: "include", cache: "no-store" })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
       .then((d: { keys: ApiKey[] }) => setKeys(d.keys ?? []))
-      .catch(() => setKeys([]));
+      .catch(() => {
+        // A failed load is not "you have no keys" - say so instead.
+        setKeys([]);
+        setError("Could not load your keys. Refresh to retry.");
+      });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
**Fixes "I made a key but it says no keys" — and closes a privacy-class caching hole.**

## What happened

The Cache-Control middleware's public catch-all (`public, max-age=300, s-maxage=3600` on `/api/*`) applied to the new authenticated endpoints. Cloudflare edge-cached a `GET /api/keys` response from before the key existed and served that stale empty list to every subsequent request — profile page, admin page, everyone. The key itself was created fine and is sitting in Mongo; it just couldn't be seen past the cache. Confirmed live: unauthenticated `GET /api/keys` returned `200 {"keys":[]}` with `cf-cache-status: HIT`.

Luck check: the cached body was an empty list, and raw keys are never returned by GET (only once, at creation, via POST — which isn't cacheable). So nothing sensitive leaked. But an authed response publicly cached is a privacy bug class, so:

## Fix

- `/api/keys` and `/api/admin` now get `private, no-store`, exactly like the existing `/api/auth/*` exemption (admin was reachable only through Cloudflare Access, but its authorized responses were still edge-cacheable — now excluded outright).
- The profile keys section fetches with `cache: "no-store"` and no longer renders a failed load as "No keys yet."

## Verified full-stack (auth dependency overridden so the real 200 paths run)

- `GET /api/keys` 200 → `private, no-store`
- `GET /api/admin/rate-limits` 200 → `private, no-store`
- `GET /api/versions` keeps `public, max-age=300, s-maxage=3600`

## After merge + deploy

The stale edge entries need a purge (Cloudflare → Caching → Custom Purge, by URL: `https://spire-codex.com/api/keys` and `https://spire-codex.com/api/admin/keys`) or an hour for the s-maxage to lapse. The already-created key is intact in Mongo and shows up as soon as the cache clears; no recreation needed.

