### PR TITLE
Load every CDN image in CORS mode to stop cache-poisoned broken images

### DIFF
--- a/frontend/app/[lang]/badges/[id]/page.tsx
+++ b/frontend/app/[lang]/badges/[id]/page.tsx
@@ -152,7 +152,7 @@ export default async function LangBadgePage({ params }: Props) {
       <div className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-6">
         {badge.image_url && (
           <div className="flex justify-center mb-6">
-            <img
+            <img crossOrigin="anonymous"
               src={imageUrl(badge.image_url)}
               alt={`${badge.name} badge`}
               className="w-24 h-24 object-contain"

--- a/frontend/app/[lang]/badges/page.tsx
+++ b/frontend/app/[lang]/badges/page.tsx
@@ -190,7 +190,7 @@ function BadgeCard({ badge, lang }: { badge: Badge; lang: string }) {
       className={`bg-[var(--bg-card)] rounded-lg border ${borderClass} p-4 hover:bg-[var(--bg-card-hover)] hover:border-[var(--border-accent)] transition-all flex gap-4 group`}
     >
       {badge.image_url && (
-        <img
+        <img crossOrigin="anonymous"
           src={imageUrl(badge.image_url)}
           alt={`${badge.name} badge`}
           className="w-14 h-14 object-contain shrink-0"

--- a/frontend/app/badges/[id]/page.tsx
+++ b/frontend/app/badges/[id]/page.tsx
@@ -208,7 +208,7 @@ export default async function BadgePage({ params }: Props) {
         {hasImage && (
           <aside className="aside">
             <div className="box">
-              <img
+              <img crossOrigin="anonymous"
                 src={imageUrl(badge.image_url!)}
                 alt={`Slay the Spire 2 ${badge.name} badge`}
                 className="meta-icon"

--- a/frontend/app/badges/page.tsx
+++ b/frontend/app/badges/page.tsx
@@ -128,7 +128,7 @@ function BadgeCard({ badge }: { badge: Badge }) {
       className={`bg-[var(--bg-card)] rounded-lg border ${borderClass} p-4 hover:bg-[var(--bg-card-hover)] hover:border-[var(--border-accent)] transition-all flex gap-4 group`}
     >
       {badge.image_url && (
-        <img
+        <img crossOrigin="anonymous"
           src={imageUrl(badge.image_url)}
           alt={`Slay the Spire 2 ${badge.name} badge`}
           className="w-14 h-14 object-contain shrink-0"

--- a/frontend/app/components/HomeLeaderboardSection.tsx
+++ b/frontend/app/components/HomeLeaderboardSection.tsx
@@ -228,7 +228,7 @@ export default async function HomeLeaderboardSection({
                         <td className="rk">{i + 1}</td>
                         <td>
                           <Link className="ent" href={`${runsBase}/${r.run_hash}`}>
-                            <img className="lb-ico" src={characterIcon(r.character)} alt={characterLabel(r.character, characterNames)} loading="lazy" />
+                            <img crossOrigin="anonymous" className="lb-ico" src={characterIcon(r.character)} alt={characterLabel(r.character, characterNames)} loading="lazy" />
                             <span className="lb-who">
                               <span className="lb-name" style={{ color: characterHex(r.character) || undefined }}>
                                 {characterLabel(r.character, characterNames)}
@@ -273,7 +273,7 @@ export default async function HomeLeaderboardSection({
                         <td className="rk">{i + 1}</td>
                         <td>
                           <Link className="ent" href={`${runsBase}/${r.run_hash}`}>
-                            <img className="lb-ico" src={characterIcon(r.character)} alt={characterLabel(r.character, characterNames)} loading="lazy" />
+                            <img crossOrigin="anonymous" className="lb-ico" src={characterIcon(r.character)} alt={characterLabel(r.character, characterNames)} loading="lazy" />
                             <span className="lb-who">
                               <span className="lb-name" style={{ color: characterHex(r.character) || undefined }}>
                                 {characterLabel(r.character, characterNames)}
@@ -328,7 +328,7 @@ export default async function HomeLeaderboardSection({
                         <tr key={r.run_hash}>
                           <td>
                             <Link className="ent" href={`${runsBase}/${r.run_hash}`}>
-                              <img className="lb-ico" src={characterIcon(r.character)} alt={characterLabel(r.character, characterNames)} loading="lazy" />
+                              <img crossOrigin="anonymous" className="lb-ico" src={characterIcon(r.character)} alt={characterLabel(r.character, characterNames)} loading="lazy" />
                               <span className="lb-who">
                                 <span className="lb-name" style={{ color: characterHex(r.character) || undefined }}>
                                   {characterLabel(r.character, characterNames)}


### PR DESCRIPTION
Fixes the intermittently broken CDN images (seen on mobile Firefox).

## Cause

Mixed loading modes for the same image URLs. Most `<img>`s send `crossOrigin="anonymous"` (CORS mode → `Origin` header → R2 attaches `Access-Control-Allow-Origin: *`), but seven — the home leaderboard character icons and the badge pages — loaded plainly (no-cors → no `Origin` → R2 attaches nothing, per its CORS spec behavior). The browser caches whichever response arrives first per URL; a cached headerless response served to a later CORS-mode `<img>` fails the CORS check and renders broken. Firefox reuses the mismatched cache entry more aggressively than Chromium, hence "sometimes, on Firefox." The `?bg` suffix on CSS background urls already dodges this exact trap for backgrounds — these were the remaining holes.

## Fix

`crossOrigin="anonymous"` on all seven, making CORS mode universal for CDN-bound `<img>`s. Verified by a repo-wide scan: zero remaining CDN `<img>`s without it (the only other hits are inside a docs code sample on /developers).

## Also unblocks edge caching

cdn.spire-codex.com currently serves `cf-cache-status: BYPASS` (a cache-rule Edge TTL setting). Re-enabling edge caching before this change would have been risky: Cloudflare stores one variant per URL and ignores `Vary: Origin`, so a headerless no-Origin fill would break CORS image loads for every visitor until purged. With every site `<img>` sending `Origin` (and backgrounds segregated by `?bg`), the edge cache fills with header-carrying variants. A belt-and-braces option remains adding `Access-Control-Allow-Origin: *` unconditionally via a Snippet/Worker on the cdn host (Transform Rules refuse to set that header).

tsc clean, eslint clean.
