### PR TITLE
Add Patreon to the nav Support group, above Ko-fi

### DIFF
--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -114,6 +114,7 @@ const NAV_GROUPS: NavGroup[] = [
       { href: "/changelog", label: "Changelog" },
       { href: "/news", label: "News" },
       { href: "/thank-you", label: "Thank You" },
+      { href: "https://www.patreon.com/cw/SpireCodex", label: "Patreon" },
       { href: "https://ko-fi.com/yitsy", label: "Ko-fi" },
       { href: "/privacy", label: "Privacy" },
       { href: "/terms", label: "Terms" },
@@ -172,7 +173,7 @@ const NAV_COLUMNS: Record<string, { title: string; labels: string[] }[]> = {
   ],
   About: [
     { title: "Project", labels: ["Spire Codex", "Changelog", "News", "Thank You"] },
-    { title: "Support", labels: ["Ko-fi", "Feedback", "Email"] },
+    { title: "Support", labels: ["Patreon", "Ko-fi", "Feedback", "Email"] },
     { title: "Elsewhere", labels: ["Discord", "GitHub", "Privacy", "Terms"] },
   ],
 };


### PR DESCRIPTION
Adds a Patreon entry to the About menu's Support group, ordered above Ko-fi, using the same page URL the home showcase and alert ticker already link (`patreon.com/cw/SpireCodex`). The desktop mega menu and mobile menu render from the shared link arrays, so both pick it up. tsc clean, eslint clean.