### PR TITLE
Show beta cards on /live and a MODDED CARD tile for unknown ids

### DIFF
--- a/frontend/app/live/LiveClient.tsx
+++ b/frontend/app/live/LiveClient.tsx
@@ -14,7 +14,7 @@ import Link from "next/link";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { cachedFetch } from "@/lib/fetch-cache";
-import { imageUrl, fullCardUrl } from "@/lib/image-url";
+import { imageUrl } from "@/lib/image-url";
 import {
   CardPill,
   RelicPill,
@@ -27,6 +27,7 @@ import {
   API,
   CharacterIcon,
   FightingChip,
+  LiveCardImg,
   LiveDot,
   PartnerBadge,
   WatchOnTwitch,
@@ -52,14 +53,12 @@ function PlayerCard({
   relicData,
   monsters,
   lp,
-  lang,
 }: {
   p: LivePlayer;
   cardData: Record<string, CardInfo>;
   relicData: Record<string, RelicInfo>;
   monsters: MonsterMap;
   lp: string;
-  lang: string;
 }) {
   const hpPct =
     p.hp != null && p.max_hp ? Math.max(0, Math.min(100, (p.hp / p.max_hp) * 100)) : null;
@@ -149,9 +148,6 @@ function PlayerCard({
           <div className="flex gap-1.5">
             {withOrdinalKeys(recent).map(({ item: raw, key }) => {
               const { id, upgraded } = parseDeckId(raw);
-              const fallback = cardData[id]?.image_url
-                ? imageUrl(cardData[id].image_url as string)
-                : "";
               return (
                 <CardPill
                   key={key}
@@ -161,17 +157,12 @@ function PlayerCard({
                   lp={lp}
                   className="block w-12 shrink-0"
                 >
-                  <img
-                    src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                  <LiveCardImg
+                    id={id}
+                    upgraded={upgraded}
                     alt={cardData[id]?.name || displayName(`CARD.${id}`)}
                     className="w-12 h-auto rounded-sm"
-                    crossOrigin="anonymous"
-                    loading="lazy"
-                    onError={(e) => {
-                      const el = e.target as HTMLImageElement;
-                      if (fallback && el.src !== fallback) el.src = fallback;
-                      else el.style.visibility = "hidden";
-                    }}
+                    portrait={cardData[id]?.image_url}
                   />
                 </CardPill>
               );
@@ -315,7 +306,6 @@ export default function LiveClient() {
               relicData={relicData}
               monsters={monsters}
               lp={lp}
-              lang={lang}
             />
           ))}
         </div>

--- a/frontend/app/live/LiveEventShop.tsx
+++ b/frontend/app/live/LiveEventShop.tsx
@@ -7,7 +7,7 @@
 // the full card / relic tooltip). Contract: markdown-docs/live-presence.md (v4).
 
 import Link from "next/link";
-import { imageUrl, fullCardUrl } from "@/lib/image-url";
+import { imageUrl } from "@/lib/image-url";
 import { RichDescriptionSimple } from "@/app/components/RichDescription";
 import {
   CardPill,
@@ -20,6 +20,7 @@ import {
   type RelicInfo,
 } from "../runs/[hash]/RunPills";
 import {
+  LiveCardImg,
   parseDeckId,
   safeId,
   withOrdinalKeys,
@@ -103,15 +104,11 @@ export function LiveEventPanel({
                             lp={lp}
                             className="block w-16 shrink-0"
                           >
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img
-                              src={fullCardUrl(o.card)}
+                            <LiveCardImg
+                              id={cleanId(o.card)}
                               alt=""
                               className="w-16 rounded shadow"
-                              crossOrigin="anonymous"
-                              onError={(e) => {
-                                (e.target as HTMLImageElement).style.display = "none";
-                              }}
+                              portrait={cards?.[cleanId(o.card)]?.image_url}
                             />
                           </CardPill>
                         )}
@@ -161,7 +158,6 @@ function ShopSection({
   relics,
   potions,
   lp,
-  lang,
 }: {
   title: string;
   items: ShopItem[];
@@ -170,7 +166,6 @@ function ShopSection({
   relics: Record<string, RelicInfo>;
   potions: Record<string, PotionInfo>;
   lp: string;
-  lang: string;
 }) {
   const real = items.filter((it) => it.id);
   if (real.length === 0) return null;
@@ -189,17 +184,12 @@ function ShopSection({
           const portrait = info?.image_url ? imageUrl(info.image_url) : "";
           const thumb =
             kind === "card" ? (
-              <img
-                src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+              <LiveCardImg
+                id={id}
+                upgraded={upgraded}
                 alt={name}
                 className="w-7 h-auto rounded-sm"
-                crossOrigin="anonymous"
-                loading="lazy"
-                onError={(e) => {
-                  const el = e.target as HTMLImageElement;
-                  if (portrait && el.src !== portrait) el.src = portrait;
-                  else el.style.visibility = "hidden";
-                }}
+                portrait={info?.image_url}
               />
             ) : (
               <img
@@ -261,14 +251,12 @@ export function LiveShopPanel({
   relics,
   potions,
   lp,
-  lang,
 }: {
   shop: LiveShop;
   cards: Record<string, CardInfo>;
   relics: Record<string, RelicInfo>;
   potions: Record<string, PotionInfo>;
   lp: string;
-  lang: string;
 }) {
   const removal = shop.removal;
   return (
@@ -276,9 +264,9 @@ export function LiveShopPanel({
       <div className="text-[10px] font-bold uppercase tracking-wider text-[var(--accent-gold)]">
         Shop
       </div>
-      <ShopSection title="Cards" items={shop.cards ?? []} kind="card" cards={cards} relics={relics} potions={potions} lp={lp} lang={lang} />
-      <ShopSection title="Relics" items={shop.relics ?? []} kind="relic" cards={cards} relics={relics} potions={potions} lp={lp} lang={lang} />
-      <ShopSection title="Potions" items={shop.potions ?? []} kind="potion" cards={cards} relics={relics} potions={potions} lp={lp} lang={lang} />
+      <ShopSection title="Cards" items={shop.cards ?? []} kind="card" cards={cards} relics={relics} potions={potions} lp={lp} />
+      <ShopSection title="Relics" items={shop.relics ?? []} kind="relic" cards={cards} relics={relics} potions={potions} lp={lp} />
+      <ShopSection title="Potions" items={shop.potions ?? []} kind="potion" cards={cards} relics={relics} potions={potions} lp={lp} />
       {removal && removal.cost != null && (
         <div className="flex items-center gap-2 pt-1 border-t border-[var(--border-subtle)]">
           <span className={`text-sm flex-1 ${removal.stocked === false ? "text-[var(--text-muted)] line-through" : "text-[var(--text-secondary)]"}`}>
@@ -304,14 +292,12 @@ export function LiveLootPanel({
   relics,
   potions,
   lp,
-  lang,
 }: {
   loot: LiveLoot;
   cards: Record<string, CardInfo>;
   relics: Record<string, RelicInfo>;
   potions: Record<string, PotionInfo>;
   lp: string;
-  lang: string;
 }) {
   const cardIds = loot.cards ?? [];
   const relicIds = loot.relics ?? [];
@@ -394,12 +380,12 @@ export function LiveLootPanel({
                       lp={lp}
                       className="relative block w-16 shrink-0"
                     >
-                      <img
-                        src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                      <LiveCardImg
+                        id={id}
+                        upgraded={upgraded}
                         alt={cards[id]?.name || displayName(`CARD.${id}`)}
                         className="h-auto w-16 rounded-sm"
-                        crossOrigin="anonymous"
-                        loading="lazy"
+                        portrait={cards[id]?.image_url}
                       />
                     </CardPill>
                   );
@@ -423,12 +409,12 @@ export function LiveLootPanel({
                 lp={lp}
                 className="relative block w-16 shrink-0"
               >
-                <img
-                  src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                <LiveCardImg
+                  id={id}
+                  upgraded={upgraded}
                   alt={cards[id]?.name || displayName(`CARD.${id}`)}
                   className="h-auto w-16 rounded-sm"
-                  crossOrigin="anonymous"
-                  loading="lazy"
+                  portrait={cards[id]?.image_url}
                 />
               </CardPill>
             );

--- a/frontend/app/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/live/[steamId]/LivePlayerClient.tsx
@@ -13,7 +13,7 @@ import { useParams } from "next/navigation";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { cachedFetch } from "@/lib/fetch-cache";
-import { imageUrl, fullCardUrl } from "@/lib/image-url";
+import { imageUrl } from "@/lib/image-url";
 import LiveMap from "../LiveMap";
 import LiveScene from "./LiveScene";
 import { LiveEventPanel, LiveLootPanel, LiveShopPanel } from "../LiveEventShop";
@@ -31,6 +31,7 @@ import {
   API,
   CharacterIcon,
   EnemyCircle,
+  LiveCardImg,
   LiveDot,
   LiveEnemiesPanel,
   PartnerBadge,
@@ -428,12 +429,10 @@ function LiveCombatPanel({
   p,
   cat,
   lp,
-  lang,
 }: {
   p: LivePlayer;
   cat: Catalogs;
   lp: string;
-  lang: string;
 }) {
   const [openPile, setOpenPile] = useState<string | null>(null);
   const dmg: [string, number | null | undefined][] = [
@@ -511,12 +510,12 @@ function LiveCombatPanel({
                   lp={lp}
                   className="relative block w-16 shrink-0"
                 >
-                  <img
-                    src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                  <LiveCardImg
+                    id={id}
+                    upgraded={upgraded}
                     alt={cat.cards[id]?.name || displayName(`CARD.${id}`)}
                     className="h-auto w-16 rounded-sm"
-                    crossOrigin="anonymous"
-                    loading="lazy"
+                    portrait={cat.cards[id]?.image_url}
                   />
                 </CardPill>
               );
@@ -603,12 +602,12 @@ function LiveCombatPanel({
                     lp={lp}
                     className="relative block w-32 shrink-0"
                   >
-                    <img
-                      src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                    <LiveCardImg
+                      id={id}
+                      upgraded={upgraded}
                       alt={cat.cards[id]?.name || displayName(`CARD.${id}`)}
                       className="h-auto w-32 rounded-sm"
-                      crossOrigin="anonymous"
-                      loading="lazy"
+                      portrait={cat.cards[id]?.image_url}
                     />
                     {count > 1 && (
                       <span className="absolute -top-1 -right-1 rounded bg-[var(--accent-gold)] px-1 text-[10px] font-bold text-[var(--bg-primary)]">
@@ -986,7 +985,7 @@ export default function LivePlayerClient() {
     <div className="space-y-4">
       {hasEnemies && <LiveEnemiesPanel p={p} monsters={monsters} />}
       {p.screen === "combat" && !p.loot && (
-        <LiveCombatPanel p={p} cat={cat} lp={lp} lang={lang} />
+        <LiveCombatPanel p={p} cat={cat} lp={lp} />
       )}
       {p.event && (
         <LiveEventPanel
@@ -1003,7 +1002,6 @@ export default function LivePlayerClient() {
           relics={cat.relics}
           potions={cat.potions}
           lp={lp}
-          lang={lang}
         />
       )}
       {p.loot && (
@@ -1013,7 +1011,6 @@ export default function LivePlayerClient() {
           relics={cat.relics}
           potions={cat.potions}
           lp={lp}
-          lang={lang}
         />
       )}
     </div>
@@ -1057,9 +1054,6 @@ export default function LivePlayerClient() {
           <div className="flex flex-wrap gap-1.5">
             {deckGroups.map(({ raw, count }) => {
               const { id, upgraded } = parseDeckId(raw);
-              const fallback = cat.cards[id]?.image_url
-                ? imageUrl(cat.cards[id].image_url as string)
-                : "";
               return (
                 <CardPill
                   key={raw}
@@ -1069,17 +1063,12 @@ export default function LivePlayerClient() {
                   lp={lp}
                   className="relative block w-28 shrink-0"
                 >
-                  <img
-                    src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                  <LiveCardImg
+                    id={id}
+                    upgraded={upgraded}
                     alt={cat.cards[id]?.name || displayName(`CARD.${id}`)}
                     className="w-28 h-auto rounded-sm"
-                    crossOrigin="anonymous"
-                    loading="lazy"
-                    onError={(e) => {
-                      const el = e.target as HTMLImageElement;
-                      if (fallback && el.src !== fallback) el.src = fallback;
-                      else el.style.visibility = "hidden";
-                    }}
+                    portrait={cat.cards[id]?.image_url}
                   />
                   {count > 1 && (
                     <span className="absolute -top-1 -right-1 px-1 rounded bg-[var(--accent-gold)] text-[var(--bg-primary)] text-[10px] font-bold">
@@ -1220,7 +1209,6 @@ export default function LivePlayerClient() {
               monsters={monsters}
               encounters={encounters}
               lp={lp}
-              lang={lang}
             />
           </div>
         </div>

--- a/frontend/app/live/[steamId]/LiveScene.tsx
+++ b/frontend/app/live/[steamId]/LiveScene.tsx
@@ -8,7 +8,7 @@
 // the normal layout. All driven by the same presence fields the panels use.
 
 import { useState } from "react";
-import { imageUrl, fullCardUrl } from "@/lib/image-url";
+import { imageUrl } from "@/lib/image-url";
 import { RichDescriptionSimple } from "@/app/components/RichDescription";
 import LiveMap from "../LiveMap";
 import {
@@ -24,6 +24,7 @@ import {
 import {
   CharacterIcon,
   EnemyCircle,
+  LiveCardImg,
   monsterName,
   parseDeckId,
   withOrdinalKeys,
@@ -285,14 +286,12 @@ export default function LiveScene({
   monsters,
   encounters,
   lp,
-  lang,
 }: {
   p: LivePlayer;
   cat: Catalogs;
   monsters: MonsterMap;
   encounters: EncounterMap;
   lp: string;
-  lang: string;
 }) {
   const char = (p.character ?? "colorless").toLowerCase();
   const enemies: Enemy[] = (p.enemies ?? []).filter((e) => (e.hp ?? 1) > 0);
@@ -556,7 +555,6 @@ export default function LiveScene({
                 relics={cat.relics}
                 potions={cat.potions}
                 lp={lp}
-                lang={lang}
               />
             </div>
           ) : p.screen === "combat" && enemies.length > 0 ? (
@@ -637,7 +635,6 @@ export default function LiveScene({
                   relics={cat.relics}
                   potions={cat.potions}
                   lp={lp}
-                  lang={lang}
                 />
               </div>
               <span className="inline-flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden rounded-full border-2 border-[var(--accent-gold)]/60 bg-[var(--bg-primary)]">
@@ -737,12 +734,12 @@ export default function LiveScene({
                   lp={lp}
                   className="relative block w-20 shrink-0 transition hover:-translate-y-2"
                 >
-                  <img
-                    src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                  <LiveCardImg
+                    id={id}
+                    upgraded={upgraded}
                     alt={cat.cards[id]?.name || displayName(`CARD.${id}`)}
                     className="h-auto w-20 rounded-sm"
-                    crossOrigin="anonymous"
-                    loading="lazy"
+                    portrait={cat.cards[id]?.image_url}
                   />
                 </CardPill>
               );
@@ -809,12 +806,12 @@ export default function LiveScene({
                       lp={lp}
                       className="relative block w-24 shrink-0"
                     >
-                      <img
-                        src={fullCardUrl(id.toLowerCase(), upgraded, "stable", lang)}
+                      <LiveCardImg
+                        id={id}
+                        upgraded={upgraded}
                         alt={cat.cards[id]?.name || displayName(`CARD.${id}`)}
                         className="h-auto w-24 rounded-sm"
-                        crossOrigin="anonymous"
-                        loading="lazy"
+                        portrait={cat.cards[id]?.image_url}
                       />
                       {count > 1 && (
                         <span className="absolute -top-1 -right-1 rounded bg-[var(--accent-gold)] px-1 text-[10px] font-bold text-[var(--bg-primary)]">

--- a/frontend/app/live/live-shared.tsx
+++ b/frontend/app/live/live-shared.tsx
@@ -9,7 +9,7 @@
 import { useEffect, useState } from "react";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { cachedFetch } from "@/lib/fetch-cache";
-import { imageUrl } from "@/lib/image-url";
+import { imageUrl, fullCardUrl } from "@/lib/image-url";
 import { cleanId, displayName } from "../runs/[hash]/RunPills";
 import TwitchIcon from "@/app/components/TwitchIcon";
 
@@ -354,6 +354,67 @@ export function withOrdinalKeys(items: string[]): { item: string; key: string }[
     seen[item] = n + 1;
     return { item, key: `${item}#${n}` };
   });
+}
+
+/** A card render for the live views with a three-step source chain: the main
+ * (live) render first, then the current beta render (beta players carry cards
+ * that don't exist on main yet), then the catalog portrait art (official cards
+ * with no full render, e.g. mad_science). An id that resolves through none of
+ * those is modded content with no render anywhere, so a MODDED CARD tile
+ * stands in instead of a broken image. */
+export function LiveCardImg({
+  id,
+  upgraded = false,
+  alt,
+  className = "",
+  portrait,
+}: {
+  id: string;
+  upgraded?: boolean;
+  alt: string;
+  className?: string;
+  portrait?: string | null;
+}) {
+  const { lang } = useLanguage();
+  // The exhausted-chain marker is keyed by card+lang+chain shape so the tile
+  // resets if this slot rerenders as a different card (ordinal keys reuse list
+  // positions across polls) or the catalog portrait arrives late.
+  const cardKey = `${id}|${upgraded}|${lang}|${portrait ? 1 : 0}`;
+  const [failedKey, setFailedKey] = useState("");
+  if (!safeId(id) || failedKey === cardKey) {
+    return (
+      <span
+        className={`flex aspect-[10/13] items-center justify-center overflow-hidden rounded-sm border border-dashed border-[var(--border-subtle)] bg-[var(--bg-primary)] p-1 text-center ${className}`}
+        title={alt}
+      >
+        <span className="text-[8px] font-bold uppercase leading-tight tracking-wider text-[var(--text-muted)]">
+          Modded card
+        </span>
+      </span>
+    );
+  }
+  const lower = id.toLowerCase();
+  const chain = [
+    fullCardUrl(lower, upgraded, "stable", lang),
+    fullCardUrl(lower, upgraded, "beta", lang),
+    ...(portrait ? [imageUrl(portrait)] : []),
+  ];
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={chain[0]}
+      alt={alt}
+      className={className}
+      crossOrigin="anonymous"
+      loading="lazy"
+      onError={(e) => {
+        const el = e.target as HTMLImageElement;
+        const next = chain[chain.indexOf(el.src) + 1];
+        if (next) el.src = next;
+        else setFailedKey(cardKey);
+      }}
+    />
+  );
 }
 
 export function LiveDot() {

--- a/frontend/app/runs/[hash]/RunPills.tsx
+++ b/frontend/app/runs/[hash]/RunPills.tsx
@@ -92,7 +92,8 @@ export function CardPill({
       {show && (
         // Pop the full rendered card (enchanted and/or upgraded variant when
         // the run says so) instead of the text tooltip. Falls back from the
-        // enchanted render to the plain one, then to the portrait art.
+        // enchanted render to the plain one, then to the beta render (cards
+        // that only exist on the beta channel yet), then to the portrait art.
         <span
           className={`pointer-events-none absolute z-50 left-1/2 w-40 -translate-x-1/2 ${
             above ? "bottom-full mb-2" : "top-full mt-2"
@@ -109,12 +110,16 @@ export function CardPill({
             crossOrigin="anonymous"
             onError={(e) => {
               const el = e.target as HTMLImageElement;
-              const plain = fullCardUrl(cardId.toLowerCase(), upgraded, "stable", lang);
-              if (enchantment && el.src !== plain) {
-                el.src = plain;
-              } else if (info?.image_url) {
-                el.src = imageUrl(info.image_url);
-              }
+              const chain = [
+                fullCardUrl(cardId.toLowerCase(), upgraded, "stable", lang),
+                fullCardUrl(cardId.toLowerCase(), upgraded, "beta", lang),
+                ...(info?.image_url ? [imageUrl(info.image_url)] : []),
+              ];
+              // The enchanted src isn't in the chain, so its failure lands on
+              // the plain render (indexOf -1 + 1 = 0).
+              const next = chain[chain.indexOf(el.src) + 1];
+              if (next) el.src = next;
+              else el.style.visibility = "hidden";
             }}
           />
         </span>


### PR DESCRIPTION
Beta players' new cards rendered as broken images on the live views because every card img pointed straight at the stable render path.

Card images on /live now resolve through a three-step chain, in order:

1. The main (live) render, same as before.
2. The current beta render, so cards that only exist on the beta channel show their real art. The beta render version already refreshes from /api/beta/version, so new beta drops keep resolving without code changes.
3. The catalog portrait, for official cards with no full render (mad_science).

An id that resolves through none of those is modded content with no render anywhere, so a dashed MODDED CARD tile stands in instead of a broken image.

The chain lives in one shared LiveCardImg component used by the roster's latest-cards row, the deck and pile viewers, the hand in the battle scene, the loot and pack panels, the shop list, and event option previews. The CardPill hover preview gets the same beta step in its fallback chain, which also helps beta runs on the run pages. The lang prop threading that only fed the old hardcoded URLs is gone.