### PR TITLE
Add a shop: search filter to Browse Runs and fix the asc: parse trap

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -201,22 +201,27 @@ def _warm_run_entity_stats() -> None:
             start_stats_refresher()
         except Exception:
             pass
-        # One-time username_lower backfill for pre-normalization runs, off the
-        # request path (the runs collection is large). Idempotent via the
-        # $exists guard, so running it on every worker is safe — all but the
-        # first are a bounded no-op.
+        # One-time field backfills for runs that predate a field
+        # (username_lower normalization, the `bought` shop-purchase list),
+        # off the request path (the runs collection is large). Idempotent
+        # via their $exists guards, so running them on every worker is
+        # safe — all but the first are a bounded no-op.
         import threading
 
-        def _backfill_username_lower():
+        def _backfill_run_fields():
             try:
-                from .services.runs_db_mongo import backfill_username_lower
+                from .services.runs_db_mongo import (
+                    backfill_bought,
+                    backfill_username_lower,
+                )
 
                 backfill_username_lower()
+                backfill_bought()
             except Exception:
                 pass
 
         threading.Thread(
-            target=_backfill_username_lower, daemon=True, name="username-lc-backfill"
+            target=_backfill_run_fields, daemon=True, name="run-field-backfill"
         ).start()
         return
     import threading

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -293,6 +293,7 @@ def list_runs(
     build_ids: str | None = None,
     card: str | None = None,
     relic: str | None = None,
+    shop: str | None = None,
     today: bool = False,
     page: int = 1,
     limit: int = 50,
@@ -302,6 +303,10 @@ def list_runs(
     `winrate_min` / `winrate_max` filter runs by their submitter's overall
     win rate percentage; only users with at least 5 submitted runs qualify,
     and anonymous runs never match.
+
+    `shop` matches runs that bought the item (card, relic, or potion) at a
+    shop; comma-separated ids AND together like `card`/`relic`. Mongo only —
+    the dev SQLite fallback ignores it, like the card/relic filters.
     """
     # Normalize once so the cache key and the DB filter key off the same
     # case-insensitive value (the runs are matched on username_lower).
@@ -332,6 +337,7 @@ def list_runs(
             ascension_max,
             card,
             relic,
+            shop,
             int(today),
             page,
             limit,
@@ -360,6 +366,7 @@ def list_runs(
             ascension_max=ascension_max,
             card=card,
             relic=relic,
+            shop=shop,
             today=today,
             page=page,
             limit=limit,

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -16,6 +16,7 @@ Document shape (one doc per player-run):
         "relics": [{ "id": ..., "floor_added": ... }],
         "potions": [{ "id": ..., "was_picked": ..., "was_used": ... }],
         "card_choices": [{ "card_id": ..., "was_picked": ..., "floor": ... }],
+        "bought": [<clean ids of everything bought at a shop, run-level>],
         "raw": <the full submitted JSON, for share pages>,
     }
 
@@ -174,6 +175,9 @@ def _ensure_indexes(coll) -> None:
     coll.create_index([("build_id", ASCENDING)])
     coll.create_index([("deck.id", ASCENDING)])
     coll.create_index([("relics.id", ASCENDING)])
+    # Multikey over the small per-run shop-purchase list; backs the run
+    # browser's shop: filter.
+    coll.create_index([("bought", ASCENDING)])
     coll.create_index([("killed_by", ASCENDING)])
     # /api/runs/list hot shapes: filter+sort compounds so Mongo never
     # in-memory-sorts a 40k-doc subset, plus seed for anchored prefix search.
@@ -495,6 +499,42 @@ def submit_run(
     return results[0]
 
 
+def _shop_purchases(data: dict) -> list[str]:
+    """Clean ids of everything bought at a shop in this run, all players.
+
+    A shop floor's player_stats record every shelf item with was_picked
+    (card_choices / potion_choices / relic_choices) plus the colorless
+    shelf as a plain id list (bought_colorless). Collected run-level, not
+    per player: the run browser filters runs, and per-player attribution
+    isn't recoverable for the backfill's pre-existing docs anyway."""
+    bought: set[str] = set()
+    for act_floors in data.get("map_point_history", []) or []:
+        for floor in act_floors or []:
+            rooms = floor.get("rooms") or []
+            if not any((r or {}).get("room_type") == "shop" for r in rooms):
+                continue
+            for ps in floor.get("player_stats", []) or []:
+                for choice in ps.get("card_choices", []) or []:
+                    if choice.get("was_picked"):
+                        cid = clean_id((choice.get("card") or {}).get("id") or "")
+                        if cid:
+                            bought.add(cid)
+                for pc in ps.get("potion_choices", []) or []:
+                    if pc.get("was_picked"):
+                        pid = clean_id(pc.get("choice") or "")
+                        if pid:
+                            bought.add(pid)
+                for rc in ps.get("relic_choices", []) or []:
+                    if rc.get("was_picked"):
+                        rid = clean_id(rc.get("choice") or "")
+                        if rid:
+                            bought.add(rid)
+                for cc in ps.get("bought_colorless", []) or []:
+                    if isinstance(cc, str) and cc:
+                        bought.add(clean_id(cc))
+    return sorted(bought)
+
+
 def _submit_player_run(
     data: dict,
     player: dict,
@@ -614,6 +654,9 @@ def _submit_player_run(
         "relics": relics,
         "potions": potions,
         "card_choices": card_choices,
+        # Small indexed list backing the run browser's shop: filter (see
+        # _shop_purchases for why it's run-level).
+        "bought": _shop_purchases(data),
         # Per-room history needed for the encounter-stats aggregation
         # (`/api/runs/encounter-stats`). Stored as the original 2D
         # array (acts → rooms) so the agg can `$unwind` it without a
@@ -720,6 +763,129 @@ def backfill_username_lower() -> int:
         result = coll.update_many(
             {"username": {"$nin": [None, ""]}, "username_lower": {"$exists": False}},
             [{"$set": {"username_lower": {"$toLower": "$username"}}}],
+        )
+        return result.modified_count
+    except Exception:
+        return 0
+
+
+def backfill_bought() -> int:
+    """One-time backfill: materialize `bought` (clean ids of shop purchases,
+    run-level — see _shop_purchases) on docs that predate the field, so the
+    run browser's shop: filter matches old runs too. Runs server-side as one
+    aggregation-pipeline update walking each doc's map_point_history — no
+    round-trips. Idempotent via the $exists guard; best effort like
+    backfill_username_lower."""
+
+    # Picked shelf ids from one player_stats entry ($$this in the reduce
+    # below): the choice rows with was_picked, mapped to their id field.
+    def _picked(choices_path: str, id_expr: str) -> dict:
+        return {
+            "$map": {
+                "input": {
+                    "$filter": {
+                        "input": {"$ifNull": [choices_path, []]},
+                        "as": "ch",
+                        "cond": {"$eq": ["$$ch.was_picked", True]},
+                    }
+                },
+                "as": "ch",
+                "in": id_expr,
+            }
+        }
+
+    # One floor's purchases: nothing unless the floor has a shop room, else
+    # every picked shelf id (card/potion/relic) plus the colorless buys,
+    # across all players. Bound to $$floor via $let since $reduce can't name
+    # its variable.
+    per_floor = {
+        "$cond": [
+            {
+                "$gt": [
+                    {
+                        "$size": {
+                            "$filter": {
+                                "input": {"$ifNull": ["$$floor.rooms", []]},
+                                "as": "r",
+                                "cond": {"$eq": ["$$r.room_type", "shop"]},
+                            }
+                        }
+                    },
+                    0,
+                ]
+            },
+            {
+                "$reduce": {
+                    "input": {"$ifNull": ["$$floor.player_stats", []]},
+                    "initialValue": [],
+                    "in": {
+                        "$concatArrays": [
+                            "$$value",
+                            _picked("$$this.card_choices", "$$ch.card.id"),
+                            _picked("$$this.potion_choices", "$$ch.choice"),
+                            _picked("$$this.relic_choices", "$$ch.choice"),
+                            {"$ifNull": ["$$this.bought_colorless", []]},
+                        ]
+                    },
+                }
+            },
+            [],
+        ]
+    }
+
+    # acts -> floors -> per-floor purchases, concatenated.
+    raw_ids = {
+        "$reduce": {
+            "input": {"$ifNull": ["$map_point_history", []]},
+            "initialValue": [],
+            "in": {
+                "$concatArrays": [
+                    "$$value",
+                    {
+                        "$reduce": {
+                            "input": {"$ifNull": ["$$this", []]},
+                            "initialValue": [],
+                            "in": {
+                                "$concatArrays": [
+                                    "$$value",
+                                    {
+                                        "$let": {
+                                            "vars": {"floor": "$$this"},
+                                            "in": per_floor,
+                                        }
+                                    },
+                                ]
+                            },
+                        }
+                    },
+                ]
+            },
+        }
+    }
+
+    # Strip the CARD./POTION./RELIC. namespace (mirrors clean_id) and drop
+    # anything that wasn't a string (a malformed entry must not abort the
+    # whole update); $setUnion dedupes.
+    cleaned = {
+        "$map": {
+            "input": raw_ids,
+            "as": "id",
+            "in": {
+                "$cond": [
+                    {"$eq": [{"$type": "$$id"}, "string"]},
+                    {"$arrayElemAt": [{"$split": ["$$id", "."]}, -1]},
+                    None,
+                ]
+            },
+        }
+    }
+    bought_expr = {"$setDifference": [{"$setUnion": [cleaned]}, [None]]}
+
+    try:
+        coll = _get_collection()
+        result = coll.update_many(
+            {"bought": {"$exists": False}},
+            [{"$set": {"bought": bought_expr}}],
         )
         return result.modified_count
     except Exception:
@@ -1617,6 +1783,7 @@ def list_runs(
     ascension_max: int | None = None,
     card: str | None = None,
     relic: str | None = None,
+    shop: str | None = None,
     today: bool = False,
     page: int = 1,
     limit: int = 50,
@@ -1712,6 +1879,17 @@ def list_runs(
             q["relics.id"] = relics_f[0]
         elif relics_f:
             q["relics.id"] = {"$all": relics_f}
+    if shop:
+        # Items bought at a shop (any type — the `bought` list holds clean
+        # card/potion/relic ids together). Comma-separated values AND like
+        # the card/relic filters.
+        bought_f = [
+            s.strip().upper().replace(" ", "_") for s in shop.split(",") if s.strip()
+        ]
+        if len(bought_f) == 1:
+            q["bought"] = bought_f[0]
+        elif bought_f:
+            q["bought"] = {"$all": bought_f}
     if today:
         q["seed"] = _today_daily_seed_match()
 

--- a/frontend/app/runs/BrowseRunsClient.tsx
+++ b/frontend/app/runs/BrowseRunsClient.tsx
@@ -49,8 +49,9 @@ function formatTimeShort(s: number): string {
 }
 
 // Parse an ascension value: "20" → exact, "3-4" → range, "3+" → min.
+// Tolerates the in-game "A10" spelling ("a10", "a3-a7").
 function parseAscension(value: string): { exact?: number; min?: number; max?: number } {
-  const v = value.trim();
+  const v = value.trim().replace(/a(?=\d)/gi, "");
   if (!v) return {};
   const range = /^(\d+)\s*-\s*(\d+)$/.exec(v);
   if (range) {
@@ -73,7 +74,7 @@ type Sort = "date" | "time_asc" | "time_desc" | "ascension_desc";
 // Parse `key:value` expressions out of a free-text query.
 // Returns extracted filters and the remaining free-text (after stripping
 // recognized key:value pairs).
-type QueryKey = "user" | "seed" | "char" | "asc" | "version" | "mode" | "result" | "players" | "card" | "relic" | "winrate";
+type QueryKey = "user" | "seed" | "char" | "asc" | "version" | "mode" | "result" | "players" | "card" | "relic" | "shop" | "winrate";
 
 function parseQuery(q: string): {
   filters: Partial<Record<QueryKey, string>>;
@@ -85,7 +86,15 @@ function parseQuery(q: string): {
   // card/relic accumulate across repeated tokens AND comma-separated values
   const appendMulti = (existing: string | undefined, value: string) =>
     existing ? `${existing},${value}` : value;
-  for (const tok of tokens) {
+  for (let i = 0; i < tokens.length; i++) {
+    let tok = tokens[i];
+    // Tolerate a space after the colon ("asc: 10"): a bare "key:" token
+    // absorbs the next token as its value. Without this the pair fell
+    // through to the username search and silently matched nothing.
+    if (/^[a-z]+:$/i.test(tok) && tokens[i + 1] && !tokens[i + 1].includes(":")) {
+      tok = tok + tokens[i + 1];
+      i++;
+    }
     const m = /^([a-z]+):"?([^"]+)"?$/i.exec(tok);
     if (!m) {
       restTokens.push(tok);
@@ -103,6 +112,7 @@ function parseQuery(q: string): {
     else if (["players", "p"].includes(key)) filters.players = value;
     else if (["card", "cards"].includes(key)) filters.card = appendMulti(filters.card, value);
     else if (["relic", "relics"].includes(key)) filters.relic = appendMulti(filters.relic, value);
+    else if (["shop", "bought", "buy"].includes(key)) filters.shop = appendMulti(filters.shop, value);
     else if (["winrate", "wr"].includes(key)) filters.winrate = value;
     else restTokens.push(tok);
   }
@@ -240,6 +250,7 @@ export default function BrowseRunsClient() {
       : "");
   const effectiveCard = queryFilters.card || "";
   const effectiveRelic = queryFilters.relic || "";
+  const effectiveShop = queryFilters.shop || "";
   const effectiveWinrate = queryFilters.winrate || "";
 
   // Reset page when any filter changes
@@ -289,6 +300,7 @@ export default function BrowseRunsClient() {
     }
     if (effectiveCard) params.set("card", effectiveCard);
     if (effectiveRelic) params.set("relic", effectiveRelic);
+    if (effectiveShop) params.set("shop", effectiveShop);
     if (effectiveWinrate) {
       const wr = parseWinrate(effectiveWinrate);
       if (wr.min !== undefined) params.set("winrate_min", String(wr.min));
@@ -313,7 +325,7 @@ export default function BrowseRunsClient() {
       })
       .catch(() => {})
       .finally(() => setLoading(false));
-  }, [effectiveChar, effectiveWin, effectiveUser, effectiveSeed, effectiveBuildId, effectivePlayers, effectiveGameMode, effectiveAscension, effectiveCard, effectiveRelic, effectiveWinrate, versions, sort, page]);
+  }, [effectiveChar, effectiveWin, effectiveUser, effectiveSeed, effectiveBuildId, effectivePlayers, effectiveGameMode, effectiveAscension, effectiveCard, effectiveRelic, effectiveShop, effectiveWinrate, versions, sort, page]);
 
   function clearAll() {
     setQuery("");
@@ -361,7 +373,7 @@ export default function BrowseRunsClient() {
           className="w-full text-sm px-4 py-2.5 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]"
         />
         <p className="mt-1.5 text-[10px] text-[var(--text-tertiary)]">
-          Expressions: <code>user:name</code>, <code>char:ironclad</code>, <code>asc:10</code> or <code>asc:3-7</code>, <code>card:bash,anger</code>, <code>relic:burning_blood</code> (combine for AND), <code>winrate:50-70</code>, <code>winrate:&gt;50</code>, or <code>winrate:100</code> (submitter win rate, min 5 runs), <code>version:v0.106.0</code> or <code>version:v0.104.0-v0.106.0</code>, <code>seed:abc</code>, <code>mode:daily</code>, <code>result:win</code>, <code>players:single</code>
+          Expressions: <code>user:name</code>, <code>char:ironclad</code>, <code>asc:10</code> or <code>asc:3-7</code>, <code>card:bash,anger</code>, <code>relic:burning_blood</code> (combine for AND), <code>shop:orange_dough</code> (bought at a shop — cards, relics, or potions), <code>winrate:50-70</code>, <code>winrate:&gt;50</code>, or <code>winrate:100</code> (submitter win rate, min 5 runs), <code>version:v0.106.0</code> or <code>version:v0.104.0-v0.106.0</code>, <code>seed:abc</code>, <code>mode:daily</code>, <code>result:win</code>, <code>players:single</code>
         </p>
       </div>
 


### PR DESCRIPTION
Two Browse Runs changes.

**shop: filter.** `shop:orange_dough` finds every run that bought the item at a shop — cards, relics, and potions all match through one key, and comma values AND together like `card:`/`relic:` (`shop:finesse,ghost_seed`). `bought:` and `buy:` are aliases. The help line documents it.

How it works: run submissions now materialize a small `bought` array on each run doc (clean ids picked off the shop shelves — the card/potion/relic choice rows with `was_picked` plus the colorless-shelf buys), with a multikey index, so the filter is an index hit instead of a walk of `map_point_history`. A one-time backfill fills the field for existing runs as a single server-side aggregation-pipeline update, guarded by `$exists` and run off the request path in the same startup thread as the username_lower backfill. I verified the pipeline against a real Mongo 7.0 (prod's version) using a production run blob: it produces exactly what the Python submit path produces, leaves docs that already have the field alone, and writes `[]` for docs with no map history. First deploy after merge spends a few minutes of background writes on the backfill; requests are unaffected.

**asc: parse trap.** I couldn't reproduce `asc:10` failing — `asc`, `ascension`, and `a` have always mapped to the same filter, and the deployed bundle matches. What DOES fail is a space after the colon: `asc: 10` tokenized as a bare `asc:` plus free text, fell through to the username search, and silently matched nothing — which looks exactly like "asc:10 shows no ascension 10 runs". The parser now lets a bare `key:` token absorb the next token as its value, so `asc: 10` works. Ascension values also accept the in-game spelling (`asc:a10`, `asc:a3-a7`).

The dev SQLite fallback ignores `shop:` like it already ignores `card:`/`relic:`.