### PR TITLE
Fix the Semrush crawl findings: modifiers 404s, hreflang, sitemap, llms.txt

### DIFF
--- a/frontend/app/[lang]/modifiers/page.tsx
+++ b/frontend/app/[lang]/modifiers/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+import JsonLd from "@/app/components/JsonLd";
+import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
+import ModifiersClient from "@/app/modifiers/ModifiersClient";
+import {
+  isValidLang,
+  LANG_GAME_NAME,
+  LANG_NAMES,
+  LANG_HREFLANG,
+  SUPPORTED_LANGS,
+  type LangCode,
+} from "@/lib/languages";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { t } from "@/lib/ui-translations";
+
+// The localized reference hub and footer link /<lang>/modifiers on every
+// localized page; without this list page they all 404'd (only the
+// [lang]/modifiers/[id] detail route existed).
+
+const CATEGORY = "modifiers";
+const CATEGORY_LABEL = "Modifiers";
+
+export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
+  const { lang } = await params;
+  if (!isValidLang(lang)) return {};
+
+  const langCode = lang as LangCode;
+  const gameName = LANG_GAME_NAME[langCode];
+  const nativeName = LANG_NAMES[langCode];
+
+  const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
+  const description = `${gameName} ${t(CATEGORY_LABEL, lang)} (${nativeName}). All 16 custom-mode modifiers, Draft, Sealed Deck, Insanity, and more. Effects, deck rules, and Neow interactions for each.`;
+
+  const languages: Record<string, string> = {
+    "en": `${SITE_URL}/${CATEGORY}`,
+    "x-default": `${SITE_URL}/${CATEGORY}`,
+  };
+  for (const code of SUPPORTED_LANGS) {
+    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
+  }
+
+  return {
+    title,
+    description,
+    openGraph: {
+      type: "website",
+      siteName: SITE_NAME,
+      url: `${SITE_URL}/${lang}/${CATEGORY}`,
+      title,
+      description,
+      locale: LANG_HREFLANG[langCode],
+      images: [{ url: DEFAULT_OG_IMAGE }],
+    },
+    twitter: { card: "summary_large_image", title, description },
+    alternates: {
+      canonical: `/${lang}/${CATEGORY}`,
+      languages,
+    },
+  };
+}
+
+export default async function LangModifiersPage({ params }: { params: Promise<{ lang: string }> }) {
+  const { lang } = await params;
+  if (!isValidLang(lang)) return null;
+
+  const langCode = lang as LangCode;
+  const gameName = LANG_GAME_NAME[langCode];
+  const nativeName = LANG_NAMES[langCode];
+
+  const jsonLd = [
+    buildBreadcrumbJsonLd([
+      { name: "Home", href: "/" },
+      { name: nativeName, href: `/${lang}` },
+      { name: CATEGORY_LABEL, href: `/${lang}/${CATEGORY}` },
+    ]),
+    buildCollectionPageJsonLd({
+      name: `${gameName} ${t(CATEGORY_LABEL, lang)}`,
+      description: `All 16 custom-mode modifiers in ${gameName}.`,
+      path: `/${lang}/${CATEGORY}`,
+      inLanguage: LANG_HREFLANG[langCode],
+    }),
+  ];
+
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+      <ModifiersClient />
+    </>
+  );
+}

--- a/frontend/app/[lang]/thank-you/page.tsx
+++ b/frontend/app/[lang]/thank-you/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const gameName = LANG_GAME_NAME[langCode];
   const nativeName = LANG_NAMES[langCode];
 
-  const title = `${t("Thank", lang)} ${t("You", lang)} - ${gameName} | Spire Codex (${nativeName})`;
+  const title = `${t("Thank You", lang)} - ${gameName} | Spire Codex (${nativeName})`;
   const description = `Thank you to the ${gameName} community, Ko-fi supporters, and contributors who help grow Spire Codex. ${nativeName}.`;
 
   return {

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -369,16 +369,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }))
   );
 
-  // Localized news article pages
-  const langNewsEntries: MetadataRoute.Sitemap = SUPPORTED_LANGS.flatMap((lang) =>
-    newsItems.map((n) => ({
-      url: `${SITE_URL}/${lang}/news/${n.gid}`,
-      lastModified: n.date ? new Date(n.date * 1000) : lastMod.community,
-      changeFrequency: "monthly" as const,
-      priority: 0.3,
-    }))
-  );
-
   // Localized entity detail pages, only for routes that have a real
   // [id]/page.tsx under `app/[lang]/`. Previously this expanded ALL
   // DYNAMIC_ROUTES including timeline/acts/etc, producing 13 × 57 = 741
@@ -405,7 +395,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...browseEntries,
     ...langListEntries,
     ...langMechanicsEntries,
-    ...langNewsEntries,
     ...langDetailEntries,
     ...englishDetailEntries,
   ];

--- a/frontend/lib/seo.ts
+++ b/frontend/lib/seo.ts
@@ -37,8 +37,12 @@ export function buildLanguageAlternates(path: string): Record<string, string> {
     en: `${SITE_URL}${trimmed}`,
     "x-default": `${SITE_URL}${trimmed}`,
   };
+  // For the home page the localized URL is /<code>, not /<code>/ — the
+  // trailing-slash form 308s, and hreflang alternates must not redirect
+  // (every crawl flagged them as incorrect hreflang links).
+  const suffix = trimmed === "/" ? "" : trimmed;
   for (const code of SUPPORTED_LANGS) {
-    map[LANG_HREFLANG[code]] = `${SITE_URL}/${code}${trimmed}`;
+    map[LANG_HREFLANG[code]] = `${SITE_URL}/${code}${suffix}`;
   }
   return map;
 }

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -1,0 +1,38 @@
+# Spire Codex
+
+> Fan-built database, wiki, and community stats site for Slay the Spire 2 (STS2), the deck-building roguelike by Mega Crit. Game data is extracted from the game files each patch and served in 14 languages, alongside community-submitted run statistics, tier lists, and leaderboards.
+
+Spire Codex is not affiliated with Mega Crit. Game content belongs to Mega Crit; the site's own data is available through a public REST API.
+
+## Game data
+
+- [Cards](https://spire-codex.com/cards): every card with cost, type, rarity, character, and full text
+- [Relics](https://spire-codex.com/relics): every relic with effects and rarity
+- [Potions](https://spire-codex.com/potions): every potion with effects and prices
+- [Characters](https://spire-codex.com/characters): the five playable characters with starting decks
+- [Monsters](https://spire-codex.com/monsters): every monster with HP ranges and attack patterns
+- [Encounters](https://spire-codex.com/encounters): combat encounters with monster compositions
+- [Events](https://spire-codex.com/events): every event with choices and outcomes
+- [Powers](https://spire-codex.com/powers): every buff and debuff
+- [Keywords](https://spire-codex.com/keywords): game terms with the cards that use them
+- [Merchant guide](https://spire-codex.com/merchant): shop prices and mechanics
+- [Reference](https://spire-codex.com/reference): keywords, orbs, afflictions, intents, modifiers, achievements, acts, and ascensions
+
+## Community stats
+
+- [Tier list](https://spire-codex.com/tier-list): cards, relics, and potions ranked by Codex Score from community runs
+- [Card metrics](https://spire-codex.com/leaderboards/metrics): win rate, pick rate, and Codex Elo per card
+- [Community stats](https://spire-codex.com/community-stats): event decisions, deadliest encounters, win rates
+- [Leaderboards](https://spire-codex.com/leaderboards): fastest wins and daily climbs
+- [Run charts](https://spire-codex.com/charts): interactive charts over community-submitted runs
+
+## Developers
+
+- [API documentation](https://spire-codex.com/developers): public REST API with 22+ endpoints and an embeddable tooltip widget
+- [Changelog](https://spire-codex.com/changelog): what changes between game patches and site releases
+
+## Optional
+
+- [About](https://spire-codex.com/about): how the site works and its data pipeline
+- [Guides](https://spire-codex.com/guides): community strategy guides
+- [News](https://spire-codex.com/news): Slay the Spire 2 patch notes and announcements


### PR DESCRIPTION
Code fixes for the Semrush site audit (health check against the live crawl from today).

- **/<lang>/modifiers 404 (43 broken internal links).** Every localized page's reference hub linked `/<lang>/modifiers`, but only the `[id]` detail route existed under `[lang]/modifiers` — the list page.tsx was missing, so all 13 language variants 404'd. Added it, same metadata/hreflang/JSON-LD pattern as the other localized list pages.
- **39 incorrect hreflang links.** The home page's hreflang alternates pointed at `/<lang>/` with a trailing slash, which 308-redirects. `buildLanguageAlternates` now emits `/<lang>` for the root path. This also removes most of the flagged links-to-permanent-redirects.
- **Non-canonical pages in sitemap.xml.** The sitemap listed localized news articles (`/deu/news/<gid>`, 13 langs x every article) that canonical to their English page. Dropped; the English entries stay.
- **llms.txt was a soft 404.** `/llms.txt` fell through to the `[lang]` route and served the 404 page with a 200 status, which Semrush read as an llms.txt with formatting issues. A real llms.txt (site overview + key sections + API pointer) now ships from `public/`.
- **"Danke Du".** The localized thank-you page title translated "Thank" and "You" as separate words. It uses the single "Thank You" translation key now ("Danke", "Gracias", ...).

Remaining audit findings are Cloudflare dashboard settings or bigger follow-ups, listed in the PR discussion.