### PR TITLE
Advertise the API to agents: api-catalog well-known URI and Link headers

### DIFF
--- a/frontend/app/.well-known/api-catalog/route.ts
+++ b/frontend/app/.well-known/api-catalog/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { SITE_URL } from "@/lib/seo";
+
+// RFC 9727 api-catalog: a linkset (RFC 9264) describing the site's public
+// API so agents and API clients can discover it from the well-known URI
+// (advertised via the homepage's Link header in next.config.ts).
+export const dynamic = "force-static";
+
+export function GET() {
+  const linkset = {
+    linkset: [
+      {
+        anchor: `${SITE_URL}/api`,
+        "service-desc": [
+          {
+            href: `${SITE_URL}/openapi.json`,
+            type: "application/json",
+            title: "Spire Codex API (OpenAPI 3)",
+          },
+        ],
+        "service-doc": [
+          {
+            href: `${SITE_URL}/developers`,
+            type: "text/html",
+            title: "Spire Codex developer documentation",
+          },
+        ],
+        "service-meta": [
+          {
+            href: `${SITE_URL}/llms.txt`,
+            type: "text/plain",
+            title: "Site overview for AI agents (llms.txt)",
+          },
+        ],
+        describes: [
+          {
+            href: `${SITE_URL}/`,
+            type: "text/html",
+          },
+        ],
+      },
+    ],
+  };
+  return NextResponse.json(linkset, {
+    headers: {
+      "Content-Type": "application/linkset+json",
+      "Cache-Control": "public, max-age=86400",
+    },
+  });
+}

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -26,6 +26,19 @@ const nextConfig: NextConfig = {
           { key: "Access-Control-Allow-Origin", value: "*" },
         ],
       },
+      // RFC 8288 Link headers on the homepage so agents and API clients can
+      // discover the machine-readable surfaces without parsing HTML:
+      // the RFC 9727 api-catalog, the human API docs, and llms.txt.
+      {
+        source: "/",
+        headers: [
+          {
+            key: "Link",
+            value:
+              '</.well-known/api-catalog>; rel="api-catalog", </developers>; rel="service-doc", </llms.txt>; rel="describedby"; type="text/plain"',
+          },
+        ],
+      },
     ];
   },
 };


### PR DESCRIPTION
Two small agent-discovery surfaces, both plain IETF standards.

- **/.well-known/api-catalog** (RFC 9727): a linkset describing the public API — the OpenAPI schema at /openapi.json, the human docs at /developers, and llms.txt. Served as application/linkset+json, force-static.
- **RFC 8288 Link headers on the homepage**: `Link: </.well-known/api-catalog>; rel="api-catalog", </developers>; rel="service-doc", </llms.txt>; rel="describedby"` so agents and crawlers can discover those resources from a bare HEAD request.

Verified /openapi.json and /docs are publicly served at the root, so the catalog URLs are real.