### PR TITLE
Publish auth.md and an agent-skills discovery index

### DIFF
--- a/frontend/public/.well-known/agent-skills/index.json
+++ b/frontend/public/.well-known/agent-skills/index.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://agentskills.io/schemas/index/v0.2.0.json",
+  "version": "0.2.0",
+  "site": "https://spire-codex.com",
+  "skills": [
+    {
+      "name": "spire-codex-api",
+      "type": "skill",
+      "description": "Look up Slay the Spire 2 game data and community stats through the Spire Codex REST API.",
+      "url": "https://spire-codex.com/.well-known/agent-skills/spire-codex-api/SKILL.md",
+      "sha256": "3ab2f66099199e451c38488e6eee478fa456a88cdaafd90d6d18c1d03467db4f"
+    }
+  ]
+}

--- a/frontend/public/.well-known/agent-skills/spire-codex-api/SKILL.md
+++ b/frontend/public/.well-known/agent-skills/spire-codex-api/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: spire-codex-api
+description: Look up Slay the Spire 2 game data and community stats through the Spire Codex REST API.
+---
+
+# Spire Codex API
+
+Spire Codex serves Slay the Spire 2 game data (cards, relics, potions, monsters, events, powers) and community run statistics over a public REST API.
+
+## Usage
+
+- Base URL: https://spire-codex.com/api
+- OpenAPI schema: https://spire-codex.com/openapi.json
+- Docs: https://spire-codex.com/developers
+- No key needed to browse. Send an `X-API-Key` header for higher rate limits (see /auth.md).
+
+## Common calls
+
+- `GET /api/cards?lang=eng` — every card; also /api/relics, /api/potions, /api/monsters, /api/events, /api/powers
+- `GET /api/cards/{id}` — one entity by id
+- `GET /api/runs/scores/{cards|relics|potions}` — Codex Scores and Elo per entity
+- `GET /api/runs/metrics/{cards|relics|potions}?bracket=a10` — win/pick rates by bracket
+- `GET /api/runs/community-stats` — event decisions, deadliest encounters, records
+- 14 languages via `?lang=` (eng, deu, jpn, zhs, ...)

--- a/frontend/public/auth.md
+++ b/frontend/public/auth.md
@@ -1,0 +1,29 @@
+# Auth.md
+
+How agents and API clients authenticate with the Spire Codex API.
+
+## Anonymous access
+
+All read endpoints under https://spire-codex.com/api are public. Unauthenticated traffic gets the browse rate tier, applied per IP and per endpoint. Current tier caps: https://spire-codex.com/api/rate-limits
+
+## Registering for an API key
+
+1. Sign in at https://spire-codex.com with Steam or Discord.
+2. Open Settings, then the API Key tab.
+3. Create a key. It is shown once and starts with `sk-codex-`. One key per account.
+
+## Using the key
+
+Send it as a header on every request:
+
+    X-API-Key: sk-codex-...
+
+Keyed requests get the registered tier (higher caps; paid supporters get the paid tier). Responses carry X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset so clients can pace themselves.
+
+## Revocation
+
+Delete the key from the same Settings tab. Revocation takes effect within seconds.
+
+## Notes
+
+There is no OAuth flow; authentication is API-key only. Terms: https://spire-codex.com/terms


### PR DESCRIPTION
Follow-up to #651 (these two files were pushed to that branch after it merged, so they never landed). /auth.md documents the API-key flow: anonymous tier, registration in Settings, the X-API-Key header, rate-limit response headers, and revocation. There is no OAuth flow, and auth.md says so. /.well-known/agent-skills/index.json is the v0.2.0 discovery index listing one real skill, a SKILL.md covering the public API endpoints, with its sha256 digest.