### PR TITLE
Add the Neow relic offer guide

### DIFF
--- a/data/guides/neow-relic-offer.md
+++ b/data/guides/neow-relic-offer.md
@@ -1,11 +1,8 @@
 ---
 title: "Neow in Slay the Spire 2: How Her Relic Offer Works"
 slug: "neow-relic-offer"
-author: "Yitsy"
+author: "Spire Codex"
 date: "2026-07-15"
-twitter: "ptrlrd"
-bluesky: "ptrlrd"
-twitch: "yitsy"
 category: "general"
 tags: ["neow", "ancients", "relics", "early game"]
 summary: "How Neow works in Slay the Spire 2: her full relic pool, the curse exclusion rules, and what community runs say about which offer to take."

--- a/data/guides/neow-relic-offer.md
+++ b/data/guides/neow-relic-offer.md
@@ -1,0 +1,66 @@
+---
+title: "Neow in Slay the Spire 2: How Her Relic Offer Works"
+slug: "neow-relic-offer"
+author: "Yitsy"
+date: "2026-07-15"
+twitter: "ptrlrd"
+bluesky: "ptrlrd"
+twitch: "yitsy"
+category: "general"
+tags: ["neow", "ancients", "relics", "early game"]
+summary: "How Neow works in Slay the Spire 2: her full relic pool, the curse exclusion rules, and what community runs say about which offer to take."
+difficulty: "beginner"
+---
+
+Neow is back in Slay the Spire 2, but she doesn't work the way she did in the first game. There are no blessing menus with four options anymore. In STS2 she is one of the eight Ancients, and like every Ancient she puts three relics in front of you: two from her positive pool and one from her curse pool. You take one. That's the whole interaction, and it's still one of the biggest swings in the run.
+
+This guide covers her exact pools, the exclusion rules the game uses to build the offer, and what the community stats say about which relics are actually worth taking. All of it comes from the game files and from the runs players have submitted to Spire Codex.
+
+## How the offer is built
+
+The game picks the curse option first, then removes anything from the positive pool that would overlap with it. That matters more than it sounds, because several of her relics come in mirrored pairs:
+
+- If [[Cursed Pearl]] (gain Greed, get 333 gold) is the curse, [[Golden Pearl]] (150 gold, no strings) is pulled from the positive pool.
+- If [[Hefty Tablet]] (pick 1 of 3 rares, gain an Injury) is the curse, [[Arcane Scroll]] (random rare, free) is out.
+- If [[Leafy Poultice]] (transform a Strike and a Defend, lose 12 max HP) is the curse, [[New Leaf]] (transform 1 card, free) is out.
+- If [[Precarious Shears]] (remove 2 cards, lose 16 HP) is the curse, [[Precise Scissors]] (remove 1 card, free) is out.
+- If [[Large Capsule]] (2 random relics plus an extra Strike and Defend) is the curse, both [[Small Capsule]] and [[Lava Rock]] are out.
+
+So you never get to choose between the free version and the taxed version of the same effect. Neow makes you pay for the bigger number or settle for the smaller one.
+
+A few positive-pool slots are also coin flips between two relics: [[Lava Rock]] or [[Small Capsule]], [[Neow's Talisman]] or [[Pomander]], [[Nutritious Oyster]] or [[Stone Humidifier]]. And two are situational: [[Massive Scroll]] only shows up in multiplayer, [[Scroll Boxes]] only if your deck can form bundles.
+
+## What players actually take
+
+From over 800,000 submitted runs:
+
+- [[Hefty Tablet]] has a 58% take rate. A rare card of your choice on floor 1 shapes the whole run, and one Injury is a cheap price.
+- [[Arcane Scroll]] sits right beside it at 58%. Same idea, no Injury, no choice of which rare.
+- [[Leafy Poultice]] gets taken 44% of the time. Two targeted transforms out of your starter cards is real deck quality, but 12 max HP is a lot in the early acts.
+- [[Large Capsule]] and [[Precarious Shears]] both sit around 36%. The Capsule's extra Strike and Defend undo part of what the relics give you, and the Shears' 16 HP hurts when act 1 elites are already dangerous.
+
+The pattern is simple: players pay HP and deck pollution for early rares, and they're right to. Early scaling wins runs in STS2 the same way it did in the first game.
+
+## Reading the offer by deck plan
+
+The right pick depends on what your character wants, and STS2's five characters want different things.
+
+If you plan to fight act 1 elites, [[Booming Conch]] (draw 2 extra cards at the start of elite combats) turns those fights from a gamble into a farm. [[Lava Rock]] (the act 1 boss drops 2 relics) is the other elite-adjacent pick, a guaranteed payoff for surviving.
+
+If your deck plan needs thinning, take the removal even when it's taxed. Necrobinder and Silent both come online faster with starters gone, and [[Precarious Shears]]' 16 HP is worth two removals on floor 1 if you route toward an early rest site.
+
+If you're on Defect or Regent and need to hit power spikes, the card relics ([[Hefty Tablet]], [[Arcane Scroll]], [[Kaleidoscope]] for off-character cards) beat the economy relics. Ironclad can afford greedier picks like [[Cursed Pearl]] since gold converts to shop removals anyway.
+
+And don't sleep on [[Phial Holster]]. A potion slot plus two random potions is quiet, but potions carry more fights in STS2 than most players give them credit for.
+
+## The Neow-flavored wildcards
+
+Two of her relics reference her directly and both are gambles. [[Neow's Torment]] adds [[Neow's Fury]] to your deck, a card you either build around or resent every shuffle. [[Neow's Bones]], from the curse pool, hands you 2 random Neow relics plus a random curse, which is the closest thing STS2 has to the old boss relic swap: sometimes you walk away with [[Fishing Rod]] and [[Winged Boots]], sometimes you get punished.
+
+## The short version
+
+Take the rare card options unless your HP is already committed elsewhere. Pay for removal if your deck plan needs to be thin. Check whether the curse option locks out the free version of something you wanted, because if the free version is still on the table, the taxed one has to beat it by a lot.
+
+Every relic in this guide links to live win-rate and pick-rate data on its page, and the full offer tables for all eight Ancients are on the Ancients page. If you want to see how your own Neow picks stack up, upload your runs and check the community stats.
+
+View all of the [cards](https://spire-codex.com/cards) and [relics](https://spire-codex.com/relics) so that way you can stay aware of what others are picking and how everyone is climbing the tower. The [tier list](https://spire-codex.com/tier-list) helps decide what the best players are doing and can help you make more informed decisions.


### PR DESCRIPTION
New guide at /guides/neow-relic-offer covering how Neow works in STS2: the two-positive-plus-one-curse Ancient offer, the curse exclusion pairs from ancient_pools, community take rates, and per-character advice. Every card and relic name is wrapped in the hover markup so readers get the tooltip pills, and the outro links the cards, relics, and tier-list pages.