### PR TITLE
Map Spanish hreflang to es-ES and generic es

### DIFF
--- a/frontend/lib/languages.ts
+++ b/frontend/lib/languages.ts
@@ -12,7 +12,7 @@ export type LangCode = (typeof SUPPORTED_LANGS)[number];
 /** Maps 3-letter game codes to BCP-47 / hreflang codes */
 export const LANG_HREFLANG: Record<LangCode, string> = {
   deu: "de",
-  esp: "es",
+  esp: "es-ES",
   fra: "fr",
   ita: "it",
   jpn: "ja",
@@ -20,7 +20,11 @@ export const LANG_HREFLANG: Record<LangCode, string> = {
   pol: "pl",
   ptb: "pt-BR",
   rus: "ru",
-  spa: "es-419",
+  // Generic "es" on purpose: the LatAm variant is the catch-all Spanish
+  // (Spain gets the explicit es-ES above). The old es-419 region code is
+  // valid per BCP 47 and Google, but most SEO crawlers only accept ISO
+  // country codes and flagged every page for it.
+  spa: "es",
   tha: "th",
   tur: "tr",
   zhs: "zh-Hans",


### PR DESCRIPTION
Every crawled page was flagged with "Unknown country code" for the es-419 hreflang. The code is valid per BCP 47 and Google's own docs, but most SEO validators only accept ISO country codes. This keeps both Spanish variants correctly targeted while using codes every tool accepts: esp is explicit Castilian (es-ES), and the LatAm variant becomes the generic es catch-all, so Spanish speakers outside Spain still match LatAm Spanish, same as with es-419. This mirrors how the game itself ships a base ES plus a Spain variant.