### PR TITLE
Stop disallowing /_next/ in robots.txt

### DIFF
--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -24,10 +24,12 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: "/",
+        // /_next/ is deliberately NOT disallowed: Googlebot has to fetch the
+        // JS/CSS chunks to render pages, and a disallow there blocked every
+        // asset on every page (crawlers flagged all of them).
         disallow: [
           "/api/",       // backend JSON + download endpoints
           "/static/",    // static asset trees (CDN-served)
-          "/_next/",     // Next.js build output (already not indexable but explicit)
           "/uninstall",  // Overwolf post-uninstall survey, entered only by the OW client
         ],
       },


### PR DESCRIPTION
The robots disallow on /_next/ blocked crawlers from fetching every page's JS and CSS chunks — 1,268 blocked internal resources in the latest audit, and worse, it degrades how Googlebot renders the pages themselves (disallow blocks fetching, not indexing; the assets were never indexable anyway). /api/, /static/, and /uninstall stay disallowed.