### PR TITLE
Drop the sitelinks SearchAction from the WebSite JSON-LD

### DIFF
--- a/frontend/lib/jsonld.ts
+++ b/frontend/lib/jsonld.ts
@@ -156,14 +156,6 @@ export function buildWebSiteJsonLd() {
     description:
       "The complete Slay the Spire 2 database. Browse all cards, relics, characters, monsters, potions, events, powers, and more.",
     publisher: PUBLISHER_ORG,
-    potentialAction: {
-      "@type": "SearchAction",
-      target: {
-        "@type": "EntryPoint",
-        urlTemplate: `${SITE_URL}/?q={search_term_string}`,
-      },
-      "query-input": "required name=search_term_string",
-    },
   };
 }
 


### PR DESCRIPTION
The WebSite structured data advertised a sitelinks search box with /?q={search_term_string} as the endpoint, but the site has no server-side search results page at that URL (search is the client-side palette), and validators flag SearchActions whose target doesn't work. Removing the potentialAction clears the flagged construct on the home pages; the WebSite, VideoGame, FAQ, and NewsArticle blocks all validate otherwise.