### PR TITLE
Serve real page content to non-JS crawlers

### DIFF
--- a/frontend/app/cards/CardsClient.tsx
+++ b/frontend/app/cards/CardsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { Suspense, useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import type { Card } from "@/lib/api";
 import { cachedFetch } from "@/lib/fetch-cache";
@@ -61,7 +61,7 @@ const keywordOptions = [
   { label: "Eternal", value: "Eternal" },
 ];
 
-export default function CardsClient({ initialCards }: { initialCards: Card[] }) {
+function CardsClientInner({ initialCards }: { initialCards: Card[] }) {
   const lp = useLangPrefix();
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -240,5 +240,17 @@ export default function CardsClient({ initialCards }: { initialCards: Card[] }) 
         <CardGrid cards={sortedCards} />
       )}
     </>
+  );
+}
+
+// useSearchParams needs a Suspense boundary above it now that the root
+// layout no longer provides one (the app-wide boundary made every dynamic
+// page's body invisible to non-JS crawlers). The boundary lives here so
+// every page that renders this client, English and localized, gets it.
+export default function CardsClient(props: Parameters<typeof CardsClientInner>[0]) {
+  return (
+    <Suspense fallback={null}>
+      <CardsClientInner {...props} />
+    </Suspense>
   );
 }

--- a/frontend/app/charts/ChartsClient.tsx
+++ b/frontend/app/charts/ChartsClient.tsx
@@ -3,7 +3,7 @@
 // The /charts explorer. All aggregation happens in the backend
 // (/api/charts/{key}); this component is controls + a Chart.js canvas.
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { CONTENT_BRACKETS, normalizeBracket } from "@/lib/content-brackets";
 import { useLanguage } from "@/app/contexts/LanguageContext";
@@ -234,7 +234,7 @@ function Pills({
 const selectCls =
   "bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded-md px-3 py-1.5 text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]/50 max-w-72";
 
-export default function ChartsClient() {
+function ChartsClientInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { lang } = useLanguage();
@@ -853,5 +853,17 @@ function ScatterChart({ data, lang }: { data: ChartResponse; lang: string }) {
         {t("Sampled from", lang)} {sampled.toLocaleString()} {t("matching runs.", lang)}
       </p>
     </>
+  );
+}
+
+// useSearchParams needs a Suspense boundary above it now that the root
+// layout no longer provides one (the app-wide boundary made every dynamic
+// page's body invisible to non-JS crawlers). The boundary lives here so
+// every page that renders this client, English and localized, gets it.
+export default function ChartsClient() {
+  return (
+    <Suspense fallback={null}>
+      <ChartsClientInner  />
+    </Suspense>
   );
 }

--- a/frontend/app/contexts/BetaVersionContext.tsx
+++ b/frontend/app/contexts/BetaVersionContext.tsx
@@ -7,7 +7,7 @@ import {
   useEffect,
   type ReactNode,
 } from "react";
-import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { IS_BETA } from "@/lib/seo";
 import { setBetaVersion, clearCache } from "@/lib/fetch-cache";
 
@@ -34,9 +34,16 @@ const BetaVersionContext = createContext<BetaVersionContextType>({
 export function BetaVersionProvider({ children }: { children: ReactNode }) {
   const [version, setVersionState] = useState<string | null>(null);
   const [versions, setVersions] = useState<VersionInfo[]>([]);
-  const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+  // window.location.search instead of useSearchParams() on purpose: the
+  // params are only read inside effects and handlers (never for render),
+  // and useSearchParams in a provider that wraps every page forces a
+  // Suspense boundary around the whole app — which made dynamic pages
+  // stream their entire body after the shell, invisible to non-JS
+  // crawlers (no h1, no text in the raw HTML).
+  const currentParams = () =>
+    new URLSearchParams(typeof window === "undefined" ? "" : window.location.search);
 
   // Fetch available versions on mount (only on beta)
   useEffect(() => {
@@ -52,7 +59,8 @@ export function BetaVersionProvider({ children }: { children: ReactNode }) {
   // On mount + URL change: URL param takes priority, then localStorage
   useEffect(() => {
     if (!IS_BETA) return;
-    const urlVersion = searchParams.get("version");
+    const params = currentParams();
+    const urlVersion = params.get("version");
     if (urlVersion && urlVersion !== "latest") {
       setVersionState(urlVersion);
       setBetaVersion(urlVersion);
@@ -63,12 +71,12 @@ export function BetaVersionProvider({ children }: { children: ReactNode }) {
         setVersionState(stored);
         setBetaVersion(stored);
         // Re-add version to URL so links are always shareable
-        const params = new URLSearchParams(searchParams.toString());
         params.set("version", stored);
         router.replace(`${pathname}?${params.toString()}`, { scroll: false });
       }
     }
-  }, [searchParams, pathname]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
 
   const setVersion = (v: string | null) => {
     setVersionState(v);
@@ -80,7 +88,7 @@ export function BetaVersionProvider({ children }: { children: ReactNode }) {
       localStorage.removeItem(STORAGE_KEY);
     }
     // Update URL with version param
-    const params = new URLSearchParams(searchParams.toString());
+    const params = currentParams();
     if (v) {
       params.set("version", v);
     } else {

--- a/frontend/app/enchantments/EnchantmentsClient.tsx
+++ b/frontend/app/enchantments/EnchantmentsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { Suspense, useState, useEffect, useRef, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import type { Enchantment } from "@/lib/api";
@@ -25,7 +25,7 @@ const cardTypeOptions = [
   { label: "Power", value: "Power" },
 ];
 
-export default function EnchantmentsClient({ initialEnchantments }: { initialEnchantments: Enchantment[] }) {
+function EnchantmentsClientInner({ initialEnchantments }: { initialEnchantments: Enchantment[] }) {
   const lp = useLangPrefix();
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -140,5 +140,17 @@ export default function EnchantmentsClient({ initialEnchantments }: { initialEnc
         ))}
       </div>
     </>
+  );
+}
+
+// useSearchParams needs a Suspense boundary above it now that the root
+// layout no longer provides one (the app-wide boundary made every dynamic
+// page's body invisible to non-JS crawlers). The boundary lives here so
+// every page that renders this client, English and localized, gets it.
+export default function EnchantmentsClient(props: Parameters<typeof EnchantmentsClientInner>[0]) {
+  return (
+    <Suspense fallback={null}>
+      <EnchantmentsClientInner {...props} />
+    </Suspense>
   );
 }

--- a/frontend/app/encounters/EncountersClient.tsx
+++ b/frontend/app/encounters/EncountersClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { Suspense, useState, useEffect, useRef, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import type { Encounter } from "@/lib/api";
@@ -40,7 +40,7 @@ const actOptions = [
   { label: "Act 3 - Glory", value: "glory" },
 ];
 
-export default function EncountersClient({ initialEncounters }: { initialEncounters: Encounter[] }) {
+function EncountersClientInner({ initialEncounters }: { initialEncounters: Encounter[] }) {
   const lp = useLangPrefix();
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -197,5 +197,17 @@ export default function EncountersClient({ initialEncounters }: { initialEncount
         ))}
       </div>
     </>
+  );
+}
+
+// useSearchParams needs a Suspense boundary above it now that the root
+// layout no longer provides one (the app-wide boundary made every dynamic
+// page's body invisible to non-JS crawlers). The boundary lives here so
+// every page that renders this client, English and localized, gets it.
+export default function EncountersClient(props: Parameters<typeof EncountersClientInner>[0]) {
+  return (
+    <Suspense fallback={null}>
+      <EncountersClientInner {...props} />
+    </Suspense>
   );
 }

--- a/frontend/app/events/EventsClient.tsx
+++ b/frontend/app/events/EventsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { Suspense, useState, useEffect, useRef, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import type { GameEvent, EventPage, DialogueLine } from "@/lib/api";
@@ -100,7 +100,7 @@ function PageBlock({
   );
 }
 
-export default function EventsClient({ initialEvents }: { initialEvents: GameEvent[] }) {
+function EventsClientInner({ initialEvents }: { initialEvents: GameEvent[] }) {
   const lp = useLangPrefix();
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -424,5 +424,17 @@ export default function EventsClient({ initialEvents }: { initialEvents: GameEve
         })}
       </div>
     </>
+  );
+}
+
+// useSearchParams needs a Suspense boundary above it now that the root
+// layout no longer provides one (the app-wide boundary made every dynamic
+// page's body invisible to non-JS crawlers). The boundary lives here so
+// every page that renders this client, English and localized, gets it.
+export default function EventsClient(props: Parameters<typeof EventsClientInner>[0]) {
+  return (
+    <Suspense fallback={null}>
+      <EventsClientInner {...props} />
+    </Suspense>
   );
 }

--- a/frontend/app/guides/GuidesClient.tsx
+++ b/frontend/app/guides/GuidesClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { Suspense, useState, useEffect, useMemo, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import type { GuideSummary } from "@/lib/api";
 import { cachedFetch } from "@/lib/fetch-cache";
@@ -41,7 +41,7 @@ const sortOptions = [
   { label: "Z → A", value: "za" },
 ];
 
-export default function GuidesClient({ initialGuides }: { initialGuides: GuideSummary[] }) {
+function GuidesClientInner({ initialGuides }: { initialGuides: GuideSummary[] }) {
   const lp = useLangPrefix();
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -160,5 +160,17 @@ export default function GuidesClient({ initialGuides }: { initialGuides: GuideSu
         </div>
       )}
     </>
+  );
+}
+
+// useSearchParams needs a Suspense boundary above it now that the root
+// layout no longer provides one (the app-wide boundary made every dynamic
+// page's body invisible to non-JS crawlers). The boundary lives here so
+// every page that renders this client, English and localized, gets it.
+export default function GuidesClient(props: Parameters<typeof GuidesClientInner>[0]) {
+  return (
+    <Suspense fallback={null}>
+      <GuidesClientInner {...props} />
+    </Suspense>
   );
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -9,7 +9,6 @@ import Footer from "./components/Footer";
 import GlobalSearch from "./components/GlobalSearch";
 import FloatingFeedback from "./components/FloatingFeedback";
 import HighlightFeedback from "./components/HighlightFeedback";
-import { Suspense } from "react";
 import { LanguageProvider } from "./contexts/LanguageContext";
 import { BetaVersionProvider } from "./contexts/BetaVersionContext";
 import { AuthProvider } from "./contexts/AuthContext";
@@ -121,8 +120,12 @@ export default function RootLayout({
             __html: `(function(){try{var t=localStorage.getItem('theme');if(t==='light'){document.documentElement.setAttribute('data-theme','light');document.documentElement.classList.remove('dark');}else{document.documentElement.setAttribute('data-theme','dark');}}catch(e){}})();`,
           }}
         />
+        {/* No Suspense between here and the page: a boundary above {children}
+            made every dynamic page stream its whole body after the shell,
+            so non-JS crawlers saw pages with no h1 and no text. The only
+            component that needed it (BetaVersionProvider's useSearchParams)
+            reads window.location instead now. */}
         <LanguageProvider>
-          <Suspense>
             <BetaVersionProvider>
               <AuthProvider>
               <ToastProvider>
@@ -145,7 +148,6 @@ export default function RootLayout({
               </ToastProvider>
               </AuthProvider>
             </BetaVersionProvider>
-          </Suspense>
         </LanguageProvider>
         {UMAMI_SRC && UMAMI_WEBSITE_ID && (
           <Script

--- a/frontend/app/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/leaderboards/stats/StatsClient.tsx
@@ -843,9 +843,17 @@ export default function StatsClient() {
   }, [potionRows, potionRarity, potionSort, potionDir]);
 
   if (loading && !stats) {
+    // Keep the page header in the pre-data render: this branch is what
+    // server-side rendering emits, so without the h1 here the crawled HTML
+    // had no heading at all.
     return (
-      <div className="max-w-5xl mx-auto px-4 py-12 text-center text-[var(--text-muted)]">
-        {t("Loading...", lang)}
+      <div className="mx-auto max-w-[1400px] px-3 sm:px-5 py-6">
+        <h1 className="text-3xl font-bold mb-2">
+          <span className="text-[var(--accent-gold)]">{t("Stats", lang)}</span>
+        </h1>
+        <div className="max-w-5xl py-12 text-center text-[var(--text-muted)]">
+          {t("Loading...", lang)}
+        </div>
       </div>
     );
   }

--- a/frontend/app/monsters/MonstersClient.tsx
+++ b/frontend/app/monsters/MonstersClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { Suspense, useState, useEffect, useRef, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import type { Monster } from "@/lib/api";
@@ -40,7 +40,7 @@ const actOptions = [
   { label: "Weak Encounters", value: "weak" },
 ];
 
-export default function MonstersClient({ initialMonsters }: { initialMonsters: Monster[] }) {
+function MonstersClientInner({ initialMonsters }: { initialMonsters: Monster[] }) {
   const { lang } = useLanguage();
   const lp = useLangPrefix();
   const channel = useChannel();
@@ -243,5 +243,17 @@ export default function MonstersClient({ initialMonsters }: { initialMonsters: M
         ))}
       </div>
     </>
+  );
+}
+
+// useSearchParams needs a Suspense boundary above it now that the root
+// layout no longer provides one (the app-wide boundary made every dynamic
+// page's body invisible to non-JS crawlers). The boundary lives here so
+// every page that renders this client, English and localized, gets it.
+export default function MonstersClient(props: Parameters<typeof MonstersClientInner>[0]) {
+  return (
+    <Suspense fallback={null}>
+      <MonstersClientInner {...props} />
+    </Suspense>
   );
 }

--- a/frontend/app/potions/PotionsClient.tsx
+++ b/frontend/app/potions/PotionsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { Suspense, useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import type { Potion } from "@/lib/api";
 import { cachedFetch } from "@/lib/fetch-cache";
@@ -43,7 +43,7 @@ const sortOptions = [
   { label: "Compendium", value: "compendium" },
 ];
 
-export default function PotionsClient({ initialPotions }: { initialPotions: Potion[] }) {
+function PotionsClientInner({ initialPotions }: { initialPotions: Potion[] }) {
   const { lang } = useLanguage();
   const lp = useLangPrefix();
   const channel = useChannel();
@@ -183,5 +183,17 @@ export default function PotionsClient({ initialPotions }: { initialPotions: Poti
         </div>
       )}
     </>
+  );
+}
+
+// useSearchParams needs a Suspense boundary above it now that the root
+// layout no longer provides one (the app-wide boundary made every dynamic
+// page's body invisible to non-JS crawlers). The boundary lives here so
+// every page that renders this client, English and localized, gets it.
+export default function PotionsClient(props: Parameters<typeof PotionsClientInner>[0]) {
+  return (
+    <Suspense fallback={null}>
+      <PotionsClientInner {...props} />
+    </Suspense>
   );
 }

--- a/frontend/app/relics/RelicsClient.tsx
+++ b/frontend/app/relics/RelicsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { Suspense, useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import type { Relic } from "@/lib/api";
 import { cachedFetch } from "@/lib/fetch-cache";
@@ -63,7 +63,7 @@ const sortOptions = [
   { label: "Compendium", value: "compendium" },
 ];
 
-export default function RelicsClient({ initialRelics }: { initialRelics: Relic[] }) {
+function RelicsClientInner({ initialRelics }: { initialRelics: Relic[] }) {
   const lp = useLangPrefix();
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -234,5 +234,17 @@ export default function RelicsClient({ initialRelics }: { initialRelics: Relic[]
         })}
       </div>
     </>
+  );
+}
+
+// useSearchParams needs a Suspense boundary above it now that the root
+// layout no longer provides one (the app-wide boundary made every dynamic
+// page's body invisible to non-JS crawlers). The boundary lives here so
+// every page that renders this client, English and localized, gets it.
+export default function RelicsClient(props: Parameters<typeof RelicsClientInner>[0]) {
+  return (
+    <Suspense fallback={null}>
+      <RelicsClientInner {...props} />
+    </Suspense>
   );
 }

--- a/frontend/app/runs/BrowseRunsClient.tsx
+++ b/frontend/app/runs/BrowseRunsClient.tsx
@@ -561,13 +561,16 @@ function BrowseRunsClientInner() {
 export default function BrowseRunsClient() {
   // The fallback carries the page header: it's what static prerendering
   // emits, so crawlers see the h1 even though the browse UI itself needs
-  // searchParams. /<lang>/runs permanently redirects here, so English-only
-  // text in the fallback is fine.
+  // searchParams. The URL is always /runs (the /<lang>/ variants redirect
+  // here), but the page still renders in the viewer's language via the
+  // language context, so the fallback h1 is translated too (prerender
+  // emits the English default; hydrated viewers see their language).
+  const { lang } = useLanguage();
   return (
     <Suspense
       fallback={
         <div className="mx-auto max-w-[1400px] px-3 sm:px-5 py-6">
-          <h1 className="text-3xl font-bold text-[var(--accent-gold)]">Browse Runs</h1>
+          <h1 className="text-3xl font-bold text-[var(--accent-gold)]">{t("Browse Runs", lang)}</h1>
         </div>
       }
     >

--- a/frontend/app/runs/BrowseRunsClient.tsx
+++ b/frontend/app/runs/BrowseRunsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { Suspense, useState, useEffect } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
@@ -165,7 +165,7 @@ function expandVersionRange(expr: string, versions: string[]): string[] {
   return versions.slice(lo, hi + 1);
 }
 
-export default function BrowseRunsClient() {
+function BrowseRunsClientInner() {
   const lp = useLangPrefix();
   const { lang } = useLanguage();
   const searchParams = useSearchParams();
@@ -551,5 +551,27 @@ export default function BrowseRunsClient() {
         </>
       )}
     </div>
+  );
+}
+
+// useSearchParams needs a Suspense boundary above it now that the root
+// layout no longer provides one (the app-wide boundary made every dynamic
+// page's body invisible to non-JS crawlers). The boundary lives here so
+// every page that renders this client, English and localized, gets it.
+export default function BrowseRunsClient() {
+  // The fallback carries the page header: it's what static prerendering
+  // emits, so crawlers see the h1 even though the browse UI itself needs
+  // searchParams. /<lang>/runs permanently redirects here, so English-only
+  // text in the fallback is fine.
+  return (
+    <Suspense
+      fallback={
+        <div className="mx-auto max-w-[1400px] px-3 sm:px-5 py-6">
+          <h1 className="text-3xl font-bold text-[var(--accent-gold)]">Browse Runs</h1>
+        </div>
+      }
+    >
+      <BrowseRunsClientInner />
+    </Suspense>
   );
 }


### PR DESCRIPTION
Root cause of the missing-h1 / thin-content audit warnings: the root layout wrapped the entire app in one Suspense boundary (needed because BetaVersionProvider called useSearchParams), which made every dynamic page stream its whole body after the shell — raw HTML had no h1 and no text on /terms, /privacy, /developers, /overlay, the home page, and others.

- BetaVersionProvider reads window.location.search inside its effects instead of useSearchParams (the params never affected render output), so the app-wide boundary is gone.
- The ten list/browse clients that genuinely use useSearchParams (cards, relics, potions, monsters, events, encounters, enchantments, guides, charts, runs) now carry their own Suspense inside the component file — below each page's server-rendered h1, so page chrome stays crawlable and only the interactive UI defers.
- Browse Runs renders its h1 in the Suspense fallback since its header lives inside the client; the stats page renders its h1 in the loading state instead of only after the first fetch.

Verified against the production build served locally: /terms, /, /leaderboards/stats, /cards, /privacy, /developers, /tier-list-maker, and /runs all have their h1 and body text in the raw HTML. This should clear the missing-h1 warnings and most of the low text-to-HTML and low word count batch on the next crawl.