### PR TITLE
Drop hreflang alternates on metrics filter variants

### DIFF
--- a/frontend/app/[lang]/leaderboards/metrics/page.tsx
+++ b/frontend/app/[lang]/leaderboards/metrics/page.tsx
@@ -20,11 +20,17 @@ export const dynamic = "force-dynamic";
 
 export async function generateMetadata({
   params,
+  searchParams,
 }: {
   params: Promise<{ lang: string }>;
+  searchParams: Promise<{ bracket?: string; character?: string }>;
 }): Promise<Metadata> {
   const { lang } = await params;
+  const sp = await searchParams;
   if (!isValidLang(lang)) return {};
+  // Filter variants canonical to the clean URL; a non-canonical page must
+  // not carry hreflang alternates (crawlers flag the conflict).
+  const isVariant = Boolean(sp.bracket || sp.character);
   const langCode = lang as LangCode;
   const gameName = LANG_GAME_NAME[langCode];
   const nativeName = LANG_NAMES[langCode];
@@ -52,7 +58,10 @@ export async function generateMetadata({
       images: [{ url: DEFAULT_OG_IMAGE }],
     },
     twitter: { card: "summary_large_image", title, description },
-    alternates: { canonical: `/${lang}/leaderboards/metrics`, languages },
+    alternates: {
+      canonical: `/${lang}/leaderboards/metrics`,
+      ...(isVariant ? {} : { languages }),
+    },
   };
 }
 

--- a/frontend/app/leaderboards/metrics/page.tsx
+++ b/frontend/app/leaderboards/metrics/page.tsx
@@ -16,23 +16,34 @@ const title = `Card Metrics - Codex Elo, Win Rate & Pick Rate - Slay the Spire 2
 const description =
   "Every Slay the Spire 2 (sts2) card ranked by Codex Elo, Codex Score, win rate and pick rate. Revealed-preference ratings from community card-reward picks, plus per-act splits and raw counts.";
 
-export const metadata: Metadata = {
-  title,
-  description,
-  alternates: {
-    canonical: "/leaderboards/metrics",
-    languages: buildLanguageAlternates("/leaderboards/metrics"),
-  },
-  openGraph: {
-    type: "website",
-    siteName: SITE_NAME,
-    url: `${SITE_URL}/leaderboards/metrics`,
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<{ bracket?: string; character?: string }>;
+}): Promise<Metadata> {
+  const sp = await searchParams;
+  // Filter variants (?bracket=, ?character=) canonical to the clean URL, and
+  // a page whose canonical points elsewhere must not carry hreflang
+  // alternates — crawlers flag that as an hreflang conflict.
+  const isVariant = Boolean(sp.bracket || sp.character);
+  return {
     title,
     description,
-    images: [{ url: DEFAULT_OG_IMAGE }],
-  },
-  twitter: { card: "summary_large_image", title, description },
-};
+    alternates: {
+      canonical: "/leaderboards/metrics",
+      ...(isVariant ? {} : { languages: buildLanguageAlternates("/leaderboards/metrics") }),
+    },
+    openGraph: {
+      type: "website",
+      siteName: SITE_NAME,
+      url: `${SITE_URL}/leaderboards/metrics`,
+      title,
+      description,
+      images: [{ url: DEFAULT_OG_IMAGE }],
+    },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
 
 export default async function MetricsPage({
   searchParams,


### PR DESCRIPTION
The ?bracket= / ?character= metrics URLs canonical to the clean page but still carried the full hreflang set, which crawlers flag as an hreflang conflict (a non-canonical page advertising alternates). Both the English and localized metrics pages now omit the languages alternates when a filter param is present; the canonical stays on the clean URL either way.