### PR TITLE
Server-render run share pages and clean the sitemap news entries

### DIFF
--- a/frontend/app/runs/[hash]/SharedRunClient.tsx
+++ b/frontend/app/runs/[hash]/SharedRunClient.tsx
@@ -20,12 +20,16 @@ const CHAR_CSS_VAR: Record<string, string> = {
   REGENT: "var(--color-regent)",
 };
 
-export default function SharedRunClient() {
+// `initialRun` is the server-fetched run from page.tsx. With it, the whole
+// page server-renders with real data — before, the body was an empty shell
+// until the client refetched the same endpoint, so every run page looked
+// identical to crawlers (duplicate content) and carried no unique text.
+export default function SharedRunClient({ initialRun }: { initialRun?: any }) {
   const { hash } = useParams<{ hash: string }>();
   const lp = useLangPrefix();
   const { lang } = useLanguage();
-  const [run, setRun] = useState<any>(null);
-  const [loading, setLoading] = useState(true);
+  const [run, setRun] = useState<any>(initialRun ?? null);
+  const [loading, setLoading] = useState(!initialRun);
   const [notFound, setNotFound] = useState(false);
   const [copied, setCopied] = useState(false);
   const [cardData, setCardData] = useState<Record<string, CardInfo>>({});
@@ -37,11 +41,14 @@ export default function SharedRunClient() {
 
   useEffect(() => {
     if (!hash) return;
-    fetch(`${API}/api/runs/shared/${hash}`)
-      .then((r) => { if (!r.ok) throw new Error(); return r.json(); })
-      .then(setRun)
-      .catch(() => setNotFound(true))
-      .finally(() => setLoading(false));
+    // Server already delivered the run; no need to refetch it client-side.
+    if (!initialRun) {
+      fetch(`${API}/api/runs/shared/${hash}`)
+        .then((r) => { if (!r.ok) throw new Error(); return r.json(); })
+        .then(setRun)
+        .catch(() => setNotFound(true))
+        .finally(() => setLoading(false));
+    }
 
     cachedFetch<CardInfo[]>(`${API}/api/cards?lang=${lang}`).then((cards) => {
       const m: Record<string, CardInfo> = {};
@@ -168,17 +175,18 @@ export default function SharedRunClient() {
         className="rounded-xl border px-4 py-3 mb-4 flex items-center justify-between flex-wrap gap-2"
         style={{ borderColor: `color-mix(in srgb, ${charColor} 40%, transparent)`, background: `color-mix(in srgb, ${charColor} 8%, var(--bg-card))` }}
       >
-        <div className="flex items-center gap-3">
+        {/* h1 on purpose: this line is the page's one heading, and run pages
+            audited as headingless before it. */}
+        <h1 className="flex items-center gap-3 text-xl font-bold">
           <span
-            className="text-xl font-bold"
             style={{ color: run.win ? "var(--color-silent)" : run.was_abandoned ? "var(--text-muted)" : "var(--color-ironclad)" }}
           >
             {run.win ? t("Victory", lang) : run.was_abandoned ? t("Abandoned", lang) : t("Defeat", lang)}
           </span>
-          <Link href={`${lp}/characters/${charId.toLowerCase()}`} className="text-base hover:underline" style={{ color: charColor }}>
+          <Link href={`${lp}/characters/${charId.toLowerCase()}`} className="text-base font-normal hover:underline" style={{ color: charColor }}>
             {localizedCharName(player.character)}
           </Link>
-        </div>
+        </h1>
         <div className="text-sm text-[var(--text-muted)]">
           {t("Ascension", lang)} {run.ascension || 0}
           {!run.win && !run.was_abandoned && run.killed_by_encounter && run.killed_by_encounter !== "NONE.NONE" && (

--- a/frontend/app/runs/[hash]/page.tsx
+++ b/frontend/app/runs/[hash]/page.tsx
@@ -89,7 +89,10 @@ export default async function SharedRunPage({ params }: Props) {
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <SharedRunClient />
+      {/* The run is passed down so the page server-renders with real
+          content; without it every run page was an identical client-side
+          shell (duplicate content, no unique text for crawlers). */}
+      <SharedRunClient initialRun={run} />
     </>
   );
 }

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -291,22 +291,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.6,
   }));
 
-  // News detail pages, pull recent gids from /api/news. Articles
-  // canonical-link back to Steam (see `news/[...slug]/page.tsx`) so
-  // they're additive for "Slay the Spire 2 news"-style queries.
-  type NewsItem = { gid: string; date?: number };
-  type NewsResponse = { items?: NewsItem[] };
-  const newsRes = await fetch(`${API}/api/news?limit=500`, {
-    next: { revalidate: 1800 },
-  }).catch(() => null);
-  const newsItems: NewsItem[] =
-    newsRes && newsRes.ok ? ((await newsRes.json()) as NewsResponse).items ?? [] : [];
-  const newsEntries: MetadataRoute.Sitemap = newsItems.map((n) => ({
-    url: `${SITE_URL}/news/${n.gid}`,
-    lastModified: n.date ? new Date(n.date * 1000) : lastMod.community,
-    changeFrequency: "monthly" as const,
-    priority: 0.5,
-  }));
+  // News detail pages canonical-link back to Steam (see
+  // news/[...slug]/page.tsx), and a sitemap must only list canonical URLs —
+  // crawlers flag non-canonical entries. The /news list page stays; the
+  // articles are reachable from it.
 
   // Tier list filter variants, each is its own indexable URL with
   // its own generateMetadata title + canonical, so they need their
@@ -390,7 +378,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   return [
     ...staticEntries,
     ...mechanicsEntries,
-    ...newsEntries,
     ...tierListVariants,
     ...browseEntries,
     ...langListEntries,


### PR DESCRIPTION
Two fixes from the latest crawl.

**Run share pages rendered as identical empty shells to crawlers.** page.tsx already fetched the run server-side but only used it for JSON-LD; the visible page client-refetched the same endpoint. The run now passes into SharedRunClient as initialRun, so the full page server-renders with real content (and the client skips the duplicate fetch — one request saved per view). The Victory/Defeat banner line is the page's h1. This clears the 6 duplicate-content flags, the duplicate titles/descriptions on run pages, and their missing-h1 rows.

**Sitemap listed non-canonical news URLs.** The /news/<gid> articles canonical-link back to Steam, and a sitemap must only carry canonical URLs. The article entries are removed; the /news list page stays in the sitemap and links every article.