### PR TITLE
Canonicalize co-op sibling run pages and complete the VideoGame schema

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -816,6 +816,13 @@ def get_shared_run(run_hash: str, request: Request):
         from ..services.runs_db_mongo import clean_damage
 
         blob["damage"] = clean_damage(blob.pop("_spirecodex_damage", None))
+        # Co-op sibling hashes all serve this same blob; tell the frontend
+        # which hash is canonical so sibling pages can canonical-link to it.
+        from ..services.runs_db_mongo import primary_share_hash
+
+        primary = primary_share_hash(blob)
+        if primary and primary != run_hash:
+            blob["primary_hash"] = primary
         if using_mongo:
             from ..services.runs_db_mongo import get_username_for_hash
 

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -2276,6 +2276,29 @@ def get_user_picks(steam_id: str) -> dict[str, dict]:
 
 
 @_instrument("get_username_for_hash")
+def primary_share_hash(data: dict) -> str | None:
+    """The player-0 share hash recomputed from a submitted run blob.
+
+    Multiplayer runs get one share hash per player (the hash key ends in
+    player_idx), and every sibling page serves the same file, so crawlers
+    see N identical pages. The player-0 hash is the canonical one; it is
+    derivable from the blob alone with the same key _submit_player_run
+    uses. None for single-player blobs (the requested hash IS primary)
+    or anything malformed."""
+    try:
+        players = data.get("players") or []
+        if len(players) < 2:
+            return None
+        p0 = players[0]
+        key = (
+            f"{data.get('seed', '')}:{p0['character']}:{data.get('start_time', '')}:"
+            f"{data.get('run_time', 0)}:{len(p0.get('deck', []))}:0"
+        )
+        return hashlib.sha256(key.encode()).hexdigest()[:16]
+    except Exception:
+        return None
+
+
 def get_username_for_hash(run_hash: str) -> str | None:
     """Look up the username associated with a single run hash."""
     doc = _get_collection().find_one({"_id": run_hash}, {"username": 1})

--- a/frontend/app/[lang]/page.tsx
+++ b/frontend/app/[lang]/page.tsx
@@ -11,6 +11,7 @@ import HomeFAQ from "@/app/components/HomeFAQ";
 import JsonLd from "@/app/components/JsonLd";
 import SearchTrigger from "@/app/components/SearchTrigger";
 import { buildWebSiteJsonLd, buildVideoGameJsonLd } from "@/lib/jsonld";
+import { fetchSteamMeta } from "@/lib/steam-meta";
 import { t } from "@/lib/ui-translations";
 import { SITE_URL, SITE_NAME, IS_BETA, HOME_OG_IMAGE } from "@/lib/seo";
 import "@/app/home-revamp.css";
@@ -101,7 +102,7 @@ export default async function Home({ params }: { params: Promise<{ lang: string 
 
   return (
     <div className="min-h-screen">
-      <JsonLd data={[buildWebSiteJsonLd(), buildVideoGameJsonLd()]} />
+      <JsonLd data={[buildWebSiteJsonLd(), buildVideoGameJsonLd(await fetchSteamMeta())]} />
       {/* Mirror `/page.tsx` exactly so switching languages keeps the revamp
           home layout instead of falling back to an unstyled hero. */}
       <div className="rvmp">

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -11,6 +11,7 @@ import HomeFAQ from "./components/HomeFAQ";
 import JsonLd from "./components/JsonLd";
 import SearchTrigger from "./components/SearchTrigger";
 import { buildWebSiteJsonLd, buildVideoGameJsonLd } from "@/lib/jsonld";
+import { fetchSteamMeta } from "@/lib/steam-meta";
 import { SITE_NAME, IS_BETA, buildLanguageAlternates, HOME_OG_IMAGE } from "@/lib/seo";
 import "./home-revamp.css";
 
@@ -84,7 +85,7 @@ export default async function Home() {
 
   return (
     <div className="min-h-screen">
-      <JsonLd data={[buildWebSiteJsonLd(), buildVideoGameJsonLd()]} />
+      <JsonLd data={[buildWebSiteJsonLd(), buildVideoGameJsonLd(await fetchSteamMeta())]} />
       <div className="rvmp">
         <main className="home">
           <section className="hero">

--- a/frontend/app/runs/[hash]/page.tsx
+++ b/frontend/app/runs/[hash]/page.tsx
@@ -11,6 +11,7 @@ const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API
 type Props = { params: Promise<{ hash: string }> };
 
 interface SharedRun {
+  primary_hash?: string;
   win?: boolean;
   was_abandoned?: boolean;
   username?: string | null;
@@ -63,8 +64,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     // locale chrome), so localized variants /<lang>/runs/<hash> read to
     // Google as near-duplicates of the canonical /runs/<hash>. That was
     // generating ~5,000 "Duplicate without user-selected canonical"
-    // pages in GSC. Self-canonical only.
-    alternates: { canonical: `/runs/${hash}` },
+    // pages in GSC.
+    // Co-op sibling pages (one share hash per player, identical content)
+    // canonical to the player-0 hash the API reports, so crawlers stop
+    // counting each seat as a duplicate page.
+    alternates: { canonical: `/runs/${run.primary_hash || hash}` },
   };
 }
 

--- a/frontend/lib/jsonld.ts
+++ b/frontend/lib/jsonld.ts
@@ -159,12 +159,21 @@ export function buildWebSiteJsonLd() {
   };
 }
 
-export function buildVideoGameJsonLd() {
-  // VideoGame is a SoftwareApplication subtype. We previously set
-  // `applicationCategory: "Game"` here but that field is for the
-  // SoftwareApplication category taxonomy (e.g. "GameApplication")
-  // and validators flag it as confusing when paired with VideoGame.
-  // Dropped, `@type: VideoGame` already conveys "this is a game".
+const STEAM_STORE_URL = "https://store.steampowered.com/app/2868840/Slay_the_Spire_2/";
+
+export function buildVideoGameJsonLd(steam?: {
+  ratingValue: number;
+  ratingCount: number;
+  price?: string;
+  priceCurrency?: string;
+} | null) {
+  // VideoGame is a SoftwareApplication subtype, so validators hold it to
+  // app rules: applicationCategory, offers, and aggregateRating. The
+  // rating and price come from Steam's public APIs (see lib/steam-meta),
+  // real numbers, refreshed daily — when the fetch fails the optional
+  // fields drop out rather than shipping stale hardcoded values.
+  // "GameApplication" is the correct category taxonomy value (an earlier
+  // attempt used "Game", which validators flagged).
   return {
     "@context": "https://schema.org",
     "@type": "VideoGame",
@@ -174,10 +183,29 @@ export function buildVideoGameJsonLd() {
     genre: ["Roguelike", "Deck-building", "Strategy"],
     gamePlatform: ["PC"],
     operatingSystem: "Windows",
+    applicationCategory: "GameApplication",
     image: DEFAULT_OG_IMAGE,
     publisher: { "@type": "Organization", name: "Mega Crit Games" },
     developer: { "@type": "Organization", name: "Mega Crit Games" },
-    url: "https://store.steampowered.com/app/2868840/Slay_the_Spire_2/",
+    url: STEAM_STORE_URL,
+    ...(steam && {
+      aggregateRating: {
+        "@type": "AggregateRating",
+        ratingValue: steam.ratingValue,
+        bestRating: 100,
+        worstRating: 0,
+        ratingCount: steam.ratingCount,
+      },
+    }),
+    ...(steam?.price && {
+      offers: {
+        "@type": "Offer",
+        price: steam.price,
+        priceCurrency: steam.priceCurrency,
+        url: STEAM_STORE_URL,
+        availability: "https://schema.org/InStock",
+      },
+    }),
   };
 }
 

--- a/frontend/lib/steam-meta.ts
+++ b/frontend/lib/steam-meta.ts
@@ -1,0 +1,47 @@
+// Server-only: live Steam review summary and price for the VideoGame
+// structured data on the home pages. Validators hold VideoGame (a
+// SoftwareApplication subtype) to app rules — offers and aggregateRating —
+// and this is the honest source for both. Cached a day; any failure
+// returns null and callers simply omit the optional fields.
+
+const STEAM_APP_ID = 2868840;
+
+export interface SteamMeta {
+  ratingValue: number; // percent positive, 0-100
+  ratingCount: number;
+  price?: string;
+  priceCurrency?: string;
+}
+
+export async function fetchSteamMeta(): Promise<SteamMeta | null> {
+  try {
+    const [revRes, priceRes] = await Promise.all([
+      fetch(
+        `https://store.steampowered.com/appreviews/${STEAM_APP_ID}?json=1&num_per_page=0&language=all&purchase_type=all`,
+        { next: { revalidate: 86400 } },
+      ),
+      fetch(
+        `https://store.steampowered.com/api/appdetails?appids=${STEAM_APP_ID}&filters=price_overview`,
+        { next: { revalidate: 86400 } },
+      ),
+    ]);
+    if (!revRes.ok) return null;
+    const rev = (await revRes.json())?.query_summary;
+    const total = rev?.total_reviews ?? 0;
+    if (!total) return null;
+    const meta: SteamMeta = {
+      ratingValue: Math.round(((rev.total_positive ?? 0) / total) * 100),
+      ratingCount: total,
+    };
+    if (priceRes.ok) {
+      const price = (await priceRes.json())?.[String(STEAM_APP_ID)]?.data?.price_overview;
+      if (price?.final && price?.currency) {
+        meta.price = (price.final / 100).toFixed(2);
+        meta.priceCurrency = price.currency;
+      }
+    }
+    return meta;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes out the last two error categories in the audit.

**Duplicate run pages (5 duplicate-content + 7 duplicate-title flags).** Multiplayer runs store one share hash per player and every sibling serves the same blob, so each seat crawled as a duplicate page. /api/runs/shared now returns primary_hash, the player-0 hash recomputed from the blob with the same key the submit path uses, and sibling pages set their canonical to it. Verified against the exact pair Semrush flagged: the blob for 99958dae2b4d973c recomputes players 0 and 1 to 93acff87d6ce8a86 and 99958dae2b4d973c.

**Invalid structured data (Software App, 3 fields).** The home pages' VideoGame block is a SoftwareApplication subtype, and validators require applicationCategory, offers, and aggregateRating on it. All three ship with real data now: applicationCategory GameApplication (the correct taxonomy value; an earlier attempt with "Game" was rightly reverted), and the rating (percent positive, review count) and price pulled server-side from Steam's public appreviews/appdetails APIs, cached for a day. When Steam doesn't answer, the optional fields drop out instead of shipping stale hardcoded numbers.

The /developers SoftwareApplication still lacks a rating because nothing rates the API; that single row is a known ignore.