### PR TITLE
Drop the dead STS2Replays showcase entry and shorten the guide titles

### DIFF
--- a/data/guides.json
+++ b/data/guides.json
@@ -2,7 +2,7 @@
   {
     "id": "neow-relic-offer",
     "slug": "neow-relic-offer",
-    "title": "Neow in Slay the Spire 2: How Her Relic Offer Works",
+    "title": "How Neow's Relic Offer Works",
     "author": "Spire Codex",
     "date": "2026-07-15",
     "updated": null,
@@ -144,7 +144,7 @@
   {
     "id": "best-mods",
     "slug": "best-mods",
-    "title": "The Best Slay the Spire 2 Mods on the Steam Workshop",
+    "title": "The Best Mods on the Steam Workshop",
     "author": "Spire Codex",
     "date": "2026-07-15",
     "updated": null,

--- a/data/guides/best-mods.md
+++ b/data/guides/best-mods.md
@@ -1,5 +1,5 @@
 ---
-title: "The Best Slay the Spire 2 Mods on the Steam Workshop"
+title: "The Best Mods on the Steam Workshop"
 slug: "best-mods"
 author: "Spire Codex"
 date: "2026-07-15"

--- a/data/guides/neow-relic-offer.md
+++ b/data/guides/neow-relic-offer.md
@@ -1,5 +1,5 @@
 ---
-title: "Neow in Slay the Spire 2: How Her Relic Offer Works"
+title: "How Neow's Relic Offer Works"
 slug: "neow-relic-offer"
 author: "Spire Codex"
 date: "2026-07-15"

--- a/data/showcase.json
+++ b/data/showcase.json
@@ -1,10 +1,58 @@
 [
-  { "id": "bober-in-spire", "name": "BoberInSpire", "description": "A hybrid C# + Python overlay assistant that provides real-time combat analysis and card recommendations for Slay the Spire 2.", "url": "https://github.com/S0ul3r/BoberInSpire", "category": "tool", "author": "S0ul3r" },
-  { "id": "scry", "name": "Scry", "description": "A free companion app for Slay the Spire 2 that automatically tracks runs and provides detailed analysis with global statistics.", "url": "https://scry-sps2.vercel.app/", "category": "app", "author": "Pierre Tusseau" },
-  { "id": "sts-lore-timeline", "name": "The Ultimate Slay the Spire 1 and 2 Lore Timeline", "description": "A comprehensive video covering the full lore timeline across both Slay the Spire games.", "url": "https://www.youtube.com/watch?v=PvlPLCvS8K4", "category": "content", "author": "Placeholder" },
-  { "id": "spiredle", "name": "Spiredle", "description": "Daily Slay the Spire 2 guessing game — Wordle-style modes for cards (by deduction or artwork), relics, powers, potions, and monsters. Pulls entity data straight from Spire Codex.", "url": "https://www.spiredle.net", "category": "app", "author": "Spiredle Team" },
-  { "id": "sts2replays", "name": "STS2Replays.com", "description": "Remember Starcraft 2 replays? Same vibe but for Slay the Spire 2 — replay browser with loads of stats and community-requested features.", "url": "https://sts2replays.com", "category": "app", "author": "STS2Replays Team" },
-  { "id": "knowledge-demon", "name": "Knowledge Demon", "description": "Discord bot for Slay the Spire 2 communities. Slash commands for cards, relics, monsters, potions, characters, events, plus a full moderation toolkit. Powered by the Spire Codex API.", "url": "https://bot.spire-codex.com", "category": "bot", "author": "Spire Codex" },
-  { "id": "claude-plays-the-spire", "name": "ClaudePlaysTheSpire", "description": "Open-source IPC mod that lets AI agents drive Slay the Spire 2 via JSON state/command files. Built for the ClaudePlaysTheSpire Twitch stream — Claude Opus rotating through all 5 characters chasing win-streaks. Bundles Spire Codex data so agents have authoritative card/relic/potion info for every decision instead of scraping mid-run.", "url": "https://github.com/hiKareeem/ClaudePlaysTheSpire", "category": "tool", "author": "hiKareeem" },
-  { "id": "spire-wrapped", "name": "Spire Wrapped", "description": "Spotify Wrapped for Slay the Spire 2! Upload your run history and get a shareable link with your personal analytics.", "url": "https://spire-wrapped.vercel.app", "category": "app", "author": "Anonymous" }
+  {
+    "id": "bober-in-spire",
+    "name": "BoberInSpire",
+    "description": "A hybrid C# + Python overlay assistant that provides real-time combat analysis and card recommendations for Slay the Spire 2.",
+    "url": "https://github.com/S0ul3r/BoberInSpire",
+    "category": "tool",
+    "author": "S0ul3r"
+  },
+  {
+    "id": "scry",
+    "name": "Scry",
+    "description": "A free companion app for Slay the Spire 2 that automatically tracks runs and provides detailed analysis with global statistics.",
+    "url": "https://scry-sps2.vercel.app/",
+    "category": "app",
+    "author": "Pierre Tusseau"
+  },
+  {
+    "id": "sts-lore-timeline",
+    "name": "The Ultimate Slay the Spire 1 and 2 Lore Timeline",
+    "description": "A comprehensive video covering the full lore timeline across both Slay the Spire games.",
+    "url": "https://www.youtube.com/watch?v=PvlPLCvS8K4",
+    "category": "content",
+    "author": "Placeholder"
+  },
+  {
+    "id": "spiredle",
+    "name": "Spiredle",
+    "description": "Daily Slay the Spire 2 guessing game — Wordle-style modes for cards (by deduction or artwork), relics, powers, potions, and monsters. Pulls entity data straight from Spire Codex.",
+    "url": "https://www.spiredle.net",
+    "category": "app",
+    "author": "Spiredle Team"
+  },
+  {
+    "id": "knowledge-demon",
+    "name": "Knowledge Demon",
+    "description": "Discord bot for Slay the Spire 2 communities. Slash commands for cards, relics, monsters, potions, characters, events, plus a full moderation toolkit. Powered by the Spire Codex API.",
+    "url": "https://bot.spire-codex.com",
+    "category": "bot",
+    "author": "Spire Codex"
+  },
+  {
+    "id": "claude-plays-the-spire",
+    "name": "ClaudePlaysTheSpire",
+    "description": "Open-source IPC mod that lets AI agents drive Slay the Spire 2 via JSON state/command files. Built for the ClaudePlaysTheSpire Twitch stream — Claude Opus rotating through all 5 characters chasing win-streaks. Bundles Spire Codex data so agents have authoritative card/relic/potion info for every decision instead of scraping mid-run.",
+    "url": "https://github.com/hiKareeem/ClaudePlaysTheSpire",
+    "category": "tool",
+    "author": "hiKareeem"
+  },
+  {
+    "id": "spire-wrapped",
+    "name": "Spire Wrapped",
+    "description": "Spotify Wrapped for Slay the Spire 2! Upload your run history and get a shareable link with your personal analytics.",
+    "url": "https://spire-wrapped.vercel.app",
+    "category": "app",
+    "author": "Anonymous"
+  }
 ]


### PR DESCRIPTION
sts2replays.com returns a 404, and the showcase rail put that link on every home page — all 7 broken-external-link flags in the audit point at it. The entry is removed; easy to restore if the site comes back.

The two site-authored guides also had the game name in their titles while the guides template appends "Slay the Spire 2 Guides | Spire Codex" — so every rendered title tag said Slay the Spire 2 twice and ran overlong. They are now "How Neow's Relic Offer Works" and "The Best Mods on the Steam Workshop" in both the markdown sources and guides.json.