### PR TITLE
Type the news articles' about reference as Thing, not VideoGame

### DIFF
--- a/frontend/lib/jsonld.ts
+++ b/frontend/lib/jsonld.ts
@@ -317,6 +317,10 @@ export function buildNewsArticleJsonLd({
     ...(externalUrl ? { isBasedOn: externalUrl } : {}),
     url: `${SITE_URL}${path}`,
     inLanguage: inLanguage ?? "en",
-    about: { "@type": "VideoGame", name: "Slay the Spire 2" },
+    // "Thing", not "VideoGame": a nested VideoGame stub with only a name
+    // gets validated against full SoftwareApplication rules by crawlers and
+    // flagged for every field it lacks. Thing carries the same topical
+    // signal without the app schema obligations.
+    about: { "@type": "Thing", name: "Slay the Spire 2" },
   };
 }


### PR DESCRIPTION
The remaining structured-data flags on news pages come from the NewsArticle's about field: it nested a VideoGame with only a name, and validators hold any VideoGame node to full SoftwareApplication rules, so every news page flagged for the stub's missing fields. It's a Thing now, same as the entity detail pages use, which keeps the topical signal with no app-schema obligations. The home pages keep their complete VideoGame block with the Steam rating and price.