### PR TITLE
Credit the VideoGame author correctly and de-duplicate anonymous run titles

### DIFF
--- a/frontend/app/runs/[hash]/page.tsx
+++ b/frontend/app/runs/[hash]/page.tsx
@@ -11,6 +11,7 @@ const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API
 type Props = { params: Promise<{ hash: string }> };
 
 interface SharedRun {
+  run_time?: number;
   primary_hash?: string;
   win?: boolean;
   was_abandoned?: boolean;
@@ -45,7 +46,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { char, result, username, ascension } = describeRun(run);
   // Title format requested by user:
   //   "{username} - {character} - Ascension N win/loss - Slay the Spire 2 (sts2) | Spire Codex"
-  const title = `${username} - ${char} - Ascension ${ascension} ${result} - Slay the Spire 2 (sts2) | Spire Codex`;
+  // Anonymous runs need a discriminator: two anonymous wins with the same
+  // character and ascension otherwise share one title, and crawlers flag
+  // the collision. Run duration is unique enough and meaningful.
+  const mins = Math.round((run.run_time ?? 0) / 60);
+  const anonTag = username === "Anonymous" && mins > 0 ? ` in ${mins}m` : "";
+  const title = `${username} - ${char} - Ascension ${ascension} ${result}${anonTag} - Slay the Spire 2 (sts2) | Spire Codex`;
   const description = `${username}'s ${result === "win" ? "victorious" : result} ${char} run at Ascension ${ascension}. ${run.players?.[0]?.deck?.length || 0} cards, ${run.players?.[0]?.relics?.length || 0} relics.`;
   return {
     title,

--- a/frontend/lib/jsonld.ts
+++ b/frontend/lib/jsonld.ts
@@ -186,7 +186,10 @@ export function buildVideoGameJsonLd(steam?: {
     applicationCategory: "GameApplication",
     image: DEFAULT_OG_IMAGE,
     publisher: { "@type": "Organization", name: "Mega Crit Games" },
-    developer: { "@type": "Organization", name: "Mega Crit Games" },
+    // author, not developer: schema.org has no `developer` property on
+    // SoftwareApplication/VideoGame (validators flag it NOT_RECOGNIZED);
+    // author is the CreativeWork-sanctioned way to credit the studio.
+    author: { "@type": "Organization", name: "Mega Crit Games" },
     url: STEAM_STORE_URL,
     ...(steam && {
       aggregateRating: {


### PR DESCRIPTION
The last home-page structured-data field, extracted from the crawler's page-level report: `developer` with cause NOT_RECOGNIZED — and the validator is right, schema.org defines no developer property on SoftwareApplication or VideoGame. Mega Crit is credited through `author` now, the CreativeWork-sanctioned property, alongside the existing publisher. That clears all 14 home rows.

The remaining /developers row wants aggregateRating or review on the API's SoftwareApplication block; nothing rates the API, so that row is a permanent, honest ignore.

Also fixes the last duplicate-title pair: two anonymous Ironclad A10 wins shared a title, since anonymous runs have no username to differentiate them. Anonymous run titles now carry the run duration ("Anonymous - Ironclad - Ascension 10 win in 43m").