### PR TITLE
Describe the API as a WebAPI, not a SoftwareApplication

### DIFF
--- a/frontend/lib/jsonld.ts
+++ b/frontend/lib/jsonld.ts
@@ -213,28 +213,22 @@ export function buildVideoGameJsonLd(steam?: {
 }
 
 export function buildSoftwareApplicationJsonLd() {
-  // Google's SoftwareApplication rich-results gate on `aggregateRating`
-  // or `offers`. We don't accept reviews, keep `offers` (free) so the
-  // schema passes validation. `image` added so the result is eligible
-  // for SoftwareApp panel display.
+  // WebAPI, not SoftwareApplication: the thing described is a REST API,
+  // and SoftwareApplication carries rich-result requirements (a rating or
+  // review) that nothing can honestly satisfy for an API. WebAPI is the
+  // schema.org type for exactly this and, as a Service subtype, supports
+  // provider/offers/termsOfService with no rating obligation.
   return {
     "@context": "https://schema.org",
-    "@type": "SoftwareApplication",
+    "@type": "WebAPI",
     name: "Spire Codex API",
-    applicationCategory: "DeveloperApplication",
-    operatingSystem: "Any",
     url: `${SITE_URL}/developers`,
     image: DEFAULT_OG_IMAGE,
     description:
       "Public REST API and embeddable tooltip widget for Slay the Spire 2 game data. 22+ endpoints, 14-language support, no authentication required.",
     offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
-    publisher: PUBLISHER_ORG,
-    featureList: [
-      "REST API with 22+ endpoints",
-      "Embeddable tooltip widget for all 13 entity types",
-      "14-language support",
-      "Downloadable JSON data exports",
-    ],
+    provider: PUBLISHER_ORG,
+    termsOfService: `${SITE_URL}/terms`,
   };
 }
 


### PR DESCRIPTION
The last two structured-data errors are the developers pages: their SoftwareApplication block is held to app rich-result rules (aggregateRating or review required), and nothing rates the API, so the flag could never clear honestly. The block is typed as WebAPI now — the schema.org type for a REST API — which as a Service subtype supports name, provider, offers, and termsOfService with no rating requirement. The app-only fields (applicationCategory, operatingSystem, featureList) drop because Service doesn't define them, avoiding the NOT_RECOGNIZED class of flag the developer property just taught us about. This should take the structured-data error count to zero on both /developers pages.