### PR TITLE
Server-render localized pages in their own language

### DIFF
--- a/frontend/app/[lang]/layout.tsx
+++ b/frontend/app/[lang]/layout.tsx
@@ -10,6 +10,8 @@ import {
   type LangCode,
 } from "@/lib/languages";
 import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE } from "@/lib/seo";
+import { LanguageProvider } from "@/app/contexts/LanguageContext";
+import HtmlLang from "@/app/components/HtmlLang";
 
 interface Props {
   params: Promise<{ lang: string }>;
@@ -67,5 +69,15 @@ export default async function LangLayout({ params, children }: Props) {
     notFound();
   }
 
-  return <>{children}</>;
+  // A nested provider seeded with the URL segment: client components under
+  // /<lang>/ now server-render their UI strings in the page's language
+  // instead of the English default (crawlers were detecting every localized
+  // page as English content). HtmlLang fixes the <html lang> attribute
+  // after hydration, since the root layout can't see this segment.
+  return (
+    <LanguageProvider initialLang={lang}>
+      <HtmlLang lang={lang} />
+      {children}
+    </LanguageProvider>
+  );
 }

--- a/frontend/app/components/HtmlLang.tsx
+++ b/frontend/app/components/HtmlLang.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { LANG_HREFLANG, isValidLang, type LangCode } from "@/lib/languages";
+
+// The root layout hardcodes <html lang="en"> and can't see the [lang]
+// segment (reading it there would force every page dynamic). This sets the
+// real BCP 47 code after hydration so browsers, translators, and screen
+// readers treat localized pages as their actual language, and restores
+// "en" when navigating back to English pages.
+export default function HtmlLang({ lang }: { lang: string }) {
+  useEffect(() => {
+    const code = isValidLang(lang) ? LANG_HREFLANG[lang as LangCode] : "en";
+    document.documentElement.lang = code;
+    return () => {
+      document.documentElement.lang = "en";
+    };
+  }, [lang]);
+  return null;
+}

--- a/frontend/app/contexts/LanguageContext.tsx
+++ b/frontend/app/contexts/LanguageContext.tsx
@@ -59,8 +59,20 @@ function getInitialLang(): string {
   return "eng";
 }
 
-export function LanguageProvider({ children }: { children: ReactNode }) {
-  const [lang, setLangState] = useState(getInitialLang);
+// `initialLang` seeds the language during server rendering. Without it,
+// getInitialLang can only see the URL in the browser, so every client
+// component under /<lang>/ prerendered its UI strings in English — and
+// crawlers detected localized pages as English-language content. The
+// [lang] layout nests a provider seeded with its URL segment, so the
+// server render matches what the viewer hydrates into.
+export function LanguageProvider({
+  children,
+  initialLang,
+}: {
+  children: ReactNode;
+  initialLang?: string;
+}) {
+  const [lang, setLangState] = useState(() => initialLang ?? getInitialLang());
   const pathname = usePathname();
 
   // Sync language from URL on every navigation


### PR DESCRIPTION
Root cause of the 62 hreflang language-mismatch notices (the crawler's page report shows detectedLang: en against hreflang: zh/de/...): the language context only initialized in the browser, so client components under /<lang>/ always prerendered their UI strings in English. Harmless while page bodies were invisible to crawlers; after the SSR fix made bodies visible, the English text became exactly what got crawled.

The [lang] layout now nests a LanguageProvider seeded with its URL segment, so localized pages server-render in their language — verified against the production build: /zhs/relics raw HTML contains the Chinese filter strings. A small HtmlLang component also sets the real BCP 47 code on the html element after hydration (the root layout hardcodes lang="en" and cannot see the segment without going fully dynamic).

This should clear the language-mismatch notices and improve the localized pages' text-ratio and word-count standing, since their crawlable text now matches their declared language.