### PR TITLE
Prerender the language home pages with ISR

### DIFF
--- a/frontend/app/[lang]/page.tsx
+++ b/frontend/app/[lang]/page.tsx
@@ -25,7 +25,17 @@ import {
   type LangCode,
 } from "@/lib/languages";
 
-export const dynamic = "force-dynamic";
+// ISR, not force-dynamic: rendering this tree per request cost ~1.2s of
+// server time on every localized home hit (the English home, prerendered,
+// serves in ~50ms). The data fetches were already cached at 300s; now the
+// page itself prerenders for all 13 languages and revalidates on the same
+// clock, so freshness is unchanged and the render cost is paid once per
+// window instead of per visitor.
+export const revalidate = 300;
+
+export function generateStaticParams() {
+  return SUPPORTED_LANGS.map((lang) => ({ lang }));
+}
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 


### PR DESCRIPTION
The audit's last error row is /fra flagged for slow load, and it's structural: the [lang] home was force-dynamic, so every visitor to every localized home paid a ~1.2s server render of the full home tree, while the English home serves prerendered HTML in ~50ms. The first crawl measured all 13 language homes between 1.1s and 1.5s.

The data fetches were already cached at 300s, so nothing about freshness changes: the page itself now prerenders for all 13 languages (generateStaticParams) and revalidates on the same clock. Verified against the production build: the route table shows /[lang] as static, and repeat requests serve in 10-50ms locally. This also takes real load off the box, since the language homes are among the most-visited pages.