### PR TITLE
Add the boss deadliness guide

### DIFF
--- a/data/guides.json
+++ b/data/guides.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "boss-guide",
+    "slug": "boss-guide",
+    "title": "Boss Guide: Every Boss Ranked by Deadliness",
+    "author": "Spire Codex",
+    "date": "2026-07-16",
+    "updated": null,
+    "category": "general",
+    "tags": [
+      "bosses",
+      "elites",
+      "encounters",
+      "strategy"
+    ],
+    "summary": "Every Slay the Spire 2 boss and elite ranked by how many runs it actually ends, from 800,000+ community runs, with the fights each character should fear most.",
+    "difficulty": "intermediate",
+    "character": null,
+    "website": null,
+    "bluesky": null,
+    "twitter": null,
+    "twitch": null,
+    "content": "Most boss guides tell you what the author died to. This one is built from what everyone died to: every ranking below comes from community-submitted runs on Spire Codex, counting how many parties walked into each fight and how many did not walk out. The [live encounter stats](https://spire-codex.com/leaderboards/encounters) update continuously; these numbers are a mid-July 2026 snapshot of the main branch.\n\n## The deadliest boss in the game\n\n[[encounter:Aeonglass]] ends 25.4% of the runs that reach it, the highest death rate of any fight in the game. It also deals the most damage per fight (74 on average) in only 7 turns, the highest damage density of any boss. Mega Crit added it in Major Update #2 as the replacement for the Doormaker fight, and the community data says the replacement did not make act 3 kinder. Every character suffers here, but Necrobinder dies most at 29%.\n\n## Act by act\n\n**Act 1** has six possible bosses, and they are not created equal. [[encounter:Vantom]] (16.5% deaths) and [[encounter:Lagavulin Matriarch]] (16.1%) top the list, while [[encounter:Soul Fysh]] (12.6%) is the one you hope the map gives you. The Matriarch hides a character-specific trap: she kills 23% of Silents against 12 to 17% of everyone else, the most lopsided character split of any boss. If you are on Silent and see her on the map, route for extra damage before the boss floor.\n\n**Act 2** is where runs go to die in volume. [[encounter:Knowledge Demon]] ends 22.1% of attempts (Defect suffers most at 26%), and [[encounter:Kaiser Crab]] takes 19.9% with Ironclad as its favorite meal. [[encounter:The Insatiable]] is the merciful draw at 16%. Both of the big two average around 60 damage across 8 turns, so walking in below roughly two thirds HP is how healthy runs become dead ones.\n\n**Act 3** stacks [[encounter:Aeonglass]] next to [[encounter:Test Subject]] (22%) and [[encounter:Queen]] (18%). Test Subject is the longest boss fight in the game at 9.3 average turns, which makes it a pure scaling check: a deck that plateaus by turn 5 loses slowly and certainly. Queen punishes the front-loaded decks instead, with Ironclad and Defect dying most.\n\n## The elite gatekeepers\n\nElites kill fewer parties per fight but you face far more of them. [[encounter:The Decimillipede]] is the deadliest at 11.5%, and its 4.4-turn average makes it the opposite of Test Subject: a burst check that is over before scaling matters. [[encounter:Phantasmal Gardeners]] (11%) and [[encounter:Phrog Parasite]] (9.4%) rule act 1, and both punish decks that drafted setup cards over damage in the first few floors. By act 3 the elites ([[encounter:Knight Gang]], [[encounter:Mecha Knight]], [[encounter:Soul Nexus]]) all sit under 4.2%, not because they are weak but because the decks that reach them are strong. The act 1 elite gauntlet is the real filter.\n\n## What the numbers say about preparation\n\nThree patterns fall straight out of the data. First, fight length is the hidden stat: short fights (Decimillipede) check burst, long fights (Test Subject, Vantom at 9 turns) check scaling, and a deck needs an answer to both by act 2. Second, know your character's nemesis: Silent fears the Matriarch, Defect fears the Knowledge Demon, Ironclad fears the Crab and the Queen, and everyone fears Aeonglass. Third, average damage taken tells you the entry fee: act 2 bosses cost about 60 HP, Aeonglass costs 74, and the [merchant's](https://spire-codex.com/merchant) removal service before a boss floor is usually worth more than another card.\n\nPer-boss pages carry full per-character splits, HP ranges, and attack patterns, linked from the [encounters index](https://spire-codex.com/encounters). For what to draft so these fights stop ending your runs, the [character tier lists](https://spire-codex.com/guides) rank every card and relic from the same run data, and [Understanding Encounters](https://spire-codex.com/guides/understanding-encounters) covers reading intents. If a boss ended your run anyway, [upload it](https://spire-codex.com/leaderboards/submit) and make the numbers smarter."
+  },
+  {
     "id": "regent-tier-list",
     "slug": "regent-tier-list",
     "title": "Regent Card Tier List",

--- a/data/guides/boss-guide.md
+++ b/data/guides/boss-guide.md
@@ -1,0 +1,34 @@
+---
+title: "Boss Guide: Every Boss Ranked by Deadliness"
+slug: "boss-guide"
+author: "Spire Codex"
+date: "2026-07-16"
+category: "general"
+tags: ["bosses", "elites", "encounters", "strategy"]
+summary: "Every Slay the Spire 2 boss and elite ranked by how many runs it actually ends, from 800,000+ community runs, with the fights each character should fear most."
+difficulty: "intermediate"
+---
+
+Most boss guides tell you what the author died to. This one is built from what everyone died to: every ranking below comes from community-submitted runs on Spire Codex, counting how many parties walked into each fight and how many did not walk out. The [live encounter stats](https://spire-codex.com/leaderboards/encounters) update continuously; these numbers are a mid-July 2026 snapshot of the main branch.
+
+## The deadliest boss in the game
+
+[[encounter:Aeonglass]] ends 25.4% of the runs that reach it, the highest death rate of any fight in the game. It also deals the most damage per fight (74 on average) in only 7 turns, the highest damage density of any boss. Mega Crit added it in Major Update #2 as the replacement for the Doormaker fight, and the community data says the replacement did not make act 3 kinder. Every character suffers here, but Necrobinder dies most at 29%.
+
+## Act by act
+
+**Act 1** has six possible bosses, and they are not created equal. [[encounter:Vantom]] (16.5% deaths) and [[encounter:Lagavulin Matriarch]] (16.1%) top the list, while [[encounter:Soul Fysh]] (12.6%) is the one you hope the map gives you. The Matriarch hides a character-specific trap: she kills 23% of Silents against 12 to 17% of everyone else, the most lopsided character split of any boss. If you are on Silent and see her on the map, route for extra damage before the boss floor.
+
+**Act 2** is where runs go to die in volume. [[encounter:Knowledge Demon]] ends 22.1% of attempts (Defect suffers most at 26%), and [[encounter:Kaiser Crab]] takes 19.9% with Ironclad as its favorite meal. [[encounter:The Insatiable]] is the merciful draw at 16%. Both of the big two average around 60 damage across 8 turns, so walking in below roughly two thirds HP is how healthy runs become dead ones.
+
+**Act 3** stacks [[encounter:Aeonglass]] next to [[encounter:Test Subject]] (22%) and [[encounter:Queen]] (18%). Test Subject is the longest boss fight in the game at 9.3 average turns, which makes it a pure scaling check: a deck that plateaus by turn 5 loses slowly and certainly. Queen punishes the front-loaded decks instead, with Ironclad and Defect dying most.
+
+## The elite gatekeepers
+
+Elites kill fewer parties per fight but you face far more of them. [[encounter:The Decimillipede]] is the deadliest at 11.5%, and its 4.4-turn average makes it the opposite of Test Subject: a burst check that is over before scaling matters. [[encounter:Phantasmal Gardeners]] (11%) and [[encounter:Phrog Parasite]] (9.4%) rule act 1, and both punish decks that drafted setup cards over damage in the first few floors. By act 3 the elites ([[encounter:Knight Gang]], [[encounter:Mecha Knight]], [[encounter:Soul Nexus]]) all sit under 4.2%, not because they are weak but because the decks that reach them are strong. The act 1 elite gauntlet is the real filter.
+
+## What the numbers say about preparation
+
+Three patterns fall straight out of the data. First, fight length is the hidden stat: short fights (Decimillipede) check burst, long fights (Test Subject, Vantom at 9 turns) check scaling, and a deck needs an answer to both by act 2. Second, know your character's nemesis: Silent fears the Matriarch, Defect fears the Knowledge Demon, Ironclad fears the Crab and the Queen, and everyone fears Aeonglass. Third, average damage taken tells you the entry fee: act 2 bosses cost about 60 HP, Aeonglass costs 74, and the [merchant's](https://spire-codex.com/merchant) removal service before a boss floor is usually worth more than another card.
+
+Per-boss pages carry full per-character splits, HP ranges, and attack patterns, linked from the [encounters index](https://spire-codex.com/encounters). For what to draft so these fights stop ending your runs, the [character tier lists](https://spire-codex.com/guides) rank every card and relic from the same run data, and [Understanding Encounters](https://spire-codex.com/guides/understanding-encounters) covers reading intents. If a boss ended your run anyway, [upload it](https://spire-codex.com/leaderboards/submit) and make the numbers smarter.


### PR DESCRIPTION
A data-grounded replacement for the generic boss-guide article: every boss and elite ranked by how many runs it actually ends, from the community encounter stats. Headlines the data handed us: Aeonglass is the deadliest fight in the game at 25.4% with the highest damage density (74 damage in 7.2 turns), Lagavulin Matriarch kills 23% of Silents against 12-17% of everyone else, Test Subject is the longest fight and therefore a pure scaling check, and Decimillipede at 4.4 turns is the opposite. Each character's statistical nemesis is named from the per-character splits.

Targets the "slay the spire 2 bosses" query family and links the encounters index, per-boss pages, merchant guide, tier-list guides, and the intents guide. Lives at /guides/boss-guide with encounter hover markup throughout; markdown source and compiled guides.json entry ship together.