### PR TITLE
Add the keywords and terms guide

### DIFF
--- a/data/guides.json
+++ b/data/guides.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "keywords-guide",
+    "slug": "keywords-guide",
+    "title": "Keywords and Terms, Explained",
+    "author": "Spire Codex",
+    "date": "2026-07-16",
+    "updated": null,
+    "category": "general",
+    "tags": [
+      "keywords",
+      "mechanics",
+      "reference"
+    ],
+    "summary": "Every Slay the Spire 2 keyword, buff, debuff, and orb with current-patch definitions from the game files, organized by what is universal and what belongs to each character.",
+    "difficulty": "beginner",
+    "character": null,
+    "website": null,
+    "bluesky": null,
+    "twitter": null,
+    "twitch": null,
+    "content": "Slay the Spire 2 splits its vocabulary into a few distinct systems, and knowing which is which makes card text much easier to read: card keywords (properties printed on cards), powers (buffs and debuffs applied in combat), orbs (the Defect's system), and a handful of character mechanics. Every definition below comes from the current game files, and every name links to a live page that lists which cards and monsters actually use it.\n\n## Card keywords\n\nThese seven are printed on cards and describe how the card itself behaves:\n\n- [[keyword:Exhaust]]: Removed until the end of combat.\n- [[keyword:Ethereal]]: If this card is in your Hand at the end of the turn, it is Exhausted.\n- [[keyword:Innate]]: Start each combat with this card in your Hand.\n- [[keyword:Retain]]: Not discarded at the end of turn.\n- [[keyword:Eternal]]: Cannot be removed or transformed from your Deck. New to the sequel, and the reason some cards are with you for life.\n- [[keyword:Sly]]: If discarded from your Hand before the end of your turn, it plays for free. The engine behind Silent's discard decks.\n- [[keyword:Unplayable]]: Cannot be played.\n\nTwo related terms appear in card text rather than as printed keywords: Replay plays the card an additional time (the Glam and Spiral enchantments grant it), and Stun prevents an enemy from acting on its next turn.\n\n## Buffs\n\n- [[power:Strength]]: Increases attack damage.\n- [[power:Dexterity]]: Increases Block gained from cards.\n- [[power:Focus]]: Increases the effectiveness of Orbs.\n- [[power:Vigor]]: The next Attack deals additional damage.\n- [[power:Thorns]]: When hit by an attack, deal damage back.\n- [[power:Artifact]]: Negates debuffs, one charge per debuff.\n- [[power:Buffer]]: Prevents the next 2 times you would lose HP. Worth knowing: it is 2 charges per stack this patch, not 1.\n- [[power:Intangible]]: Reduce all damage taken and HP loss to 1 this turn.\n- [[power:Barricade]]: Block is not removed at the start of your turn.\n- [[power:Plating]]: Gain Block at the end of your turn, reduced by 1 each turn.\n- [[power:Regen]]: Heal at the end of your turn, reduced by 1 each turn.\n- [[power:Ritual]]: Gain Strength at the end of your turn.\n\n## Debuffs\n\n- [[power:Weak]]: Deal 25% less damage with Attacks.\n- [[power:Vulnerable]]: Take 50% more damage from Attacks.\n- [[power:Frail]]: Gain 25% less Block from cards. Easy to forget because it only hurts your defense.\n- [[power:Poison]]: Lose HP at the start of the turn, reduced by 1 each turn.\n- [[power:Doom]]: At the end of the enemy turn, a creature with at least as much Doom as HP dies outright. Necrobinder's execute mechanic.\n- [[power:Confused]]: Card costs randomize from 0 to 3 on draw.\n- [[power:Smoggy]]: Only 1 Skill can be played per turn.\n\n## Orbs, Channel, and Evoke\n\nOrbs are the Defect's system. Channeling an orb fills your first empty slot; if the slots are full, the oldest orb Evokes automatically to make room, and you can Evoke on demand to consume the rightmost orb for its stronger effect. [[power:Focus]] scales all of it, with one exception below.\n\n- [[orb:Lightning]]: Passively deals 3 damage to a random enemy each turn; Evoke deals 8.\n- [[orb:Frost]]: Passively gains 2 Block each turn; Evoke gains 5.\n- [[orb:Dark]]: Grows by 6 damage every turn, and Evoke unloads it on the lowest-HP enemy. The patient option.\n- [[orb:Glass]]: New to the sequel: passively deals 4 damage to ALL enemies but decays by 1 each turn, Evoke for 8 to everyone. Strong now, weaker later, the anti-Dark.\n- [[orb:Plasma]]: Grants energy passively and on Evoke, and is the one orb Focus does not affect.\n\n## Character mechanics\n\n- **Summon** (Necrobinder): Summons Osty, her skeletal companion; repeat Summons raise his Max HP for the combat. Souls are the Ethereal cards her engine feeds on.\n- **Forge** (Regent): The first Forge each combat adds Sovereign Blade to your Hand, and every point of Forge adds damage to it. Fencing Manual's Forge 10 every combat is why it rates so well in the [Regent tier list](https://spire-codex.com/guides/regent-tier-list).\n- **Shivs** (Silent): 0-cost throwaway Attacks; half her pool creates or upgrades them.\n\nThe [reference page](https://spire-codex.com/reference) keeps all of this in one place, [keywords](https://spire-codex.com/keywords) lists every card using each keyword, and each power page shows every card and monster that applies it. Definitions regenerate from the game files each patch, so when a number changes, the pages change with it."
+  },
+  {
     "id": "enchantments-guide",
     "slug": "enchantments-guide",
     "title": "How Enchantments Work",

--- a/data/guides/keywords-guide.md
+++ b/data/guides/keywords-guide.md
@@ -1,0 +1,69 @@
+---
+title: "Keywords and Terms, Explained"
+slug: "keywords-guide"
+author: "Spire Codex"
+date: "2026-07-16"
+category: "general"
+tags: ["keywords", "mechanics", "reference"]
+summary: "Every Slay the Spire 2 keyword, buff, debuff, and orb with current-patch definitions from the game files, organized by what is universal and what belongs to each character."
+difficulty: "beginner"
+---
+
+Slay the Spire 2 splits its vocabulary into a few distinct systems, and knowing which is which makes card text much easier to read: card keywords (properties printed on cards), powers (buffs and debuffs applied in combat), orbs (the Defect's system), and a handful of character mechanics. Every definition below comes from the current game files, and every name links to a live page that lists which cards and monsters actually use it.
+
+## Card keywords
+
+These seven are printed on cards and describe how the card itself behaves:
+
+- [[keyword:Exhaust]]: Removed until the end of combat.
+- [[keyword:Ethereal]]: If this card is in your Hand at the end of the turn, it is Exhausted.
+- [[keyword:Innate]]: Start each combat with this card in your Hand.
+- [[keyword:Retain]]: Not discarded at the end of turn.
+- [[keyword:Eternal]]: Cannot be removed or transformed from your Deck. New to the sequel, and the reason some cards are with you for life.
+- [[keyword:Sly]]: If discarded from your Hand before the end of your turn, it plays for free. The engine behind Silent's discard decks.
+- [[keyword:Unplayable]]: Cannot be played.
+
+Two related terms appear in card text rather than as printed keywords: Replay plays the card an additional time (the Glam and Spiral enchantments grant it), and Stun prevents an enemy from acting on its next turn.
+
+## Buffs
+
+- [[power:Strength]]: Increases attack damage.
+- [[power:Dexterity]]: Increases Block gained from cards.
+- [[power:Focus]]: Increases the effectiveness of Orbs.
+- [[power:Vigor]]: The next Attack deals additional damage.
+- [[power:Thorns]]: When hit by an attack, deal damage back.
+- [[power:Artifact]]: Negates debuffs, one charge per debuff.
+- [[power:Buffer]]: Prevents the next 2 times you would lose HP. Worth knowing: it is 2 charges per stack this patch, not 1.
+- [[power:Intangible]]: Reduce all damage taken and HP loss to 1 this turn.
+- [[power:Barricade]]: Block is not removed at the start of your turn.
+- [[power:Plating]]: Gain Block at the end of your turn, reduced by 1 each turn.
+- [[power:Regen]]: Heal at the end of your turn, reduced by 1 each turn.
+- [[power:Ritual]]: Gain Strength at the end of your turn.
+
+## Debuffs
+
+- [[power:Weak]]: Deal 25% less damage with Attacks.
+- [[power:Vulnerable]]: Take 50% more damage from Attacks.
+- [[power:Frail]]: Gain 25% less Block from cards. Easy to forget because it only hurts your defense.
+- [[power:Poison]]: Lose HP at the start of the turn, reduced by 1 each turn.
+- [[power:Doom]]: At the end of the enemy turn, a creature with at least as much Doom as HP dies outright. Necrobinder's execute mechanic.
+- [[power:Confused]]: Card costs randomize from 0 to 3 on draw.
+- [[power:Smoggy]]: Only 1 Skill can be played per turn.
+
+## Orbs, Channel, and Evoke
+
+Orbs are the Defect's system. Channeling an orb fills your first empty slot; if the slots are full, the oldest orb Evokes automatically to make room, and you can Evoke on demand to consume the rightmost orb for its stronger effect. [[power:Focus]] scales all of it, with one exception below.
+
+- [[orb:Lightning]]: Passively deals 3 damage to a random enemy each turn; Evoke deals 8.
+- [[orb:Frost]]: Passively gains 2 Block each turn; Evoke gains 5.
+- [[orb:Dark]]: Grows by 6 damage every turn, and Evoke unloads it on the lowest-HP enemy. The patient option.
+- [[orb:Glass]]: New to the sequel: passively deals 4 damage to ALL enemies but decays by 1 each turn, Evoke for 8 to everyone. Strong now, weaker later, the anti-Dark.
+- [[orb:Plasma]]: Grants energy passively and on Evoke, and is the one orb Focus does not affect.
+
+## Character mechanics
+
+- **Summon** (Necrobinder): Summons Osty, her skeletal companion; repeat Summons raise his Max HP for the combat. Souls are the Ethereal cards her engine feeds on.
+- **Forge** (Regent): The first Forge each combat adds Sovereign Blade to your Hand, and every point of Forge adds damage to it. Fencing Manual's Forge 10 every combat is why it rates so well in the [Regent tier list](https://spire-codex.com/guides/regent-tier-list).
+- **Shivs** (Silent): 0-cost throwaway Attacks; half her pool creates or upgrades them.
+
+The [reference page](https://spire-codex.com/reference) keeps all of this in one place, [keywords](https://spire-codex.com/keywords) lists every card using each keyword, and each power page shows every card and monster that applies it. Definitions regenerate from the game files each patch, so when a number changes, the pages change with it.


### PR DESCRIPTION
The glossary companion to the enchantments guide, at /guides/keywords-guide, grounded in the game files rather than STS1 memory. What it has that the circulating articles don't: the card-keyword versus power distinction (which makes card text legible), the new-to-sequel entries (Eternal, Glass orb, Doom, Sly, Forge), real orb numbers including the Plasma Focus exemption, and current values where shared lists are stale (Buffer prevents the next 2 HP losses this patch, not 1; Frail exists and is usually omitted).

Hovertips throughout via keyword:, power:, and orb: prefixes, links to the reference and keywords pages, and a cross-link into the Regent tier list where Forge pays off. Markdown source and compiled guides.json entry ship together.