### PR TITLE
Add per-version stats: version brackets in the snapshot and a dropdown on metrics

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1078,6 +1078,11 @@ def community_stats(request: Request, response: Response, bracket: str | None = 
         _p, _, _s = bracket.partition(":")
         _ok = _p in _players and _s in _skills
     if not _ok:
+        # Version slices (build_id keys) are valid brackets too.
+        from ..services.run_entity_stats import get_recent_stat_versions
+
+        _ok = bracket in get_recent_stat_versions()
+    if not _ok:
         raise HTTPException(status_code=400, detail="bad bracket")
     # An empty shell during a post-deploy rebuild must not stick in the
     # edge cache for 5 minutes on top of the rebuild itself.

--- a/backend/app/services/community_stats.py
+++ b/backend/app/services/community_stats.py
@@ -115,10 +115,12 @@ def _new_acc_one() -> dict[str, Any]:
     }
 
 
-def new_accumulator() -> dict[str, Any]:
+def new_accumulator(recent_versions: tuple | list = ()) -> dict[str, Any]:
     """Per-bracket accumulators; accumulate() folds each run into every content
-    bracket it belongs to."""
-    return {b: _new_acc_one() for b in _BLOB_BRACKETS}
+    bracket it belongs to. `recent_versions` adds one accumulator per recent
+    game version (build_id keys) so the blob can serve per-version slices."""
+    keys = list(_BLOB_BRACKETS) + [v for v in recent_versions if v]
+    return {b: _new_acc_one() for b in keys}
 
 
 # Field groups for merging two accumulators (from parallel run-chunk walks).

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -914,7 +914,7 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=()):
     # Community / fun stats, folded in from the same blob read (no 2nd walk).
     from . import charts_stats, community_stats, encounter_stats
 
-    community_acc = community_stats.new_accumulator()
+    community_acc = community_stats.new_accumulator(recent_versions)
     charts_acc = charts_stats.new_accumulator()
     # Seed one encounter bucket per recent version so per-version runs have a
     # bucket to fold into (accumulate() only fills buckets that already exist).
@@ -1006,9 +1006,14 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=()):
         # Community blob ALSO slices by the player x skill composites (solo:wr50,
         # ...) so its page can combine both axes like the tier list. These only
         # apply to A10 runs from qualifying players, so most runs add nothing.
-        community_blob_brackets = mp_blob_brackets + [
-            c for c in extra_brackets if c in _COMPOSITE_BRACKETS_SET
-        ]
+        community_blob_brackets = (
+            mp_blob_brackets
+            + [c for c in extra_brackets if c in _COMPOSITE_BRACKETS_SET]
+            # Version slice: the community blob keeps one accumulator per
+            # recent game version too, so /community-stats and the stats
+            # page overview can filter by version.
+            + ([_bid] if _bid in _recent_versions_set else [])
+        )
 
         # Community / fun stats, accumulated from the same blob. Guarded so
         # one malformed blob can't abort the whole snapshot rebuild.

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -239,7 +239,7 @@ _HISTORY_RETENTION_DAYS = 90
 # the skill tiers), so ?character= combines with any bracket on the metrics
 # endpoint — e.g. bracket=solo:a10&character=IRONCLAD (additive; the bump
 # forces the rebuild).
-SNAPSHOT_VERSION = 17
+SNAPSHOT_VERSION = 18
 # The oldest snapshot version readers can still serve. Bump SNAPSHOT_VERSION
 # on every shape change; bump this floor ONLY when a change actually breaks
 # readers (a removed/retyped field). Everything in between is additive, and
@@ -953,6 +953,14 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=()):
         uname = (row.get("username") or "").lower()
         if uname:
             extra_brackets = extra_brackets + _winrate_brackets(_asc, wr_map.get(uname))
+        # Version brackets: a run's build_id (when it's one of the recent
+        # versions the snapshot keeps slices for) becomes one more bracket
+        # key, so metrics/scores/stats can filter to a single game version
+        # through the same ?bracket= machinery. Versions never pair into
+        # composites; the pairing below only looks at player/skill keys.
+        _bid = (row.get("build_id") or "").strip()
+        if _bid in _recent_versions_set:
+            extra_brackets = extra_brackets + [_bid]
         # Player-count x skill composites (solo:wr50, ...) so the metrics page can
         # slice by both at once. Cheap: the run already matched both sides. Only
         # the entity cache reads these; the blob-bracket lists below filter to
@@ -2273,7 +2281,7 @@ def get_all_entity_scores(
     # counts, mirroring get_entity_metrics_table. character scoping isn't tracked
     # per bracket, so it's ignored here; act + bracket don't combine (act returns
     # above). Unknown bracket falls through to the all-runs path below.
-    if bracket and bracket in _BRACKET_KEYS:
+    if bracket and (bracket in _BRACKET_KEYS or bracket in _recent_stat_versions):
         c_baseline = _bracket_baselines.get(bracket, {}).get(
             entity_type, _baseline_win_rate()
         )
@@ -2401,7 +2409,7 @@ def get_entity_metrics_table(
     """
     _maybe_rebuild()
     character = (character or "").strip().upper() or None
-    use_bracket = bracket in _BRACKET_KEYS
+    use_bracket = bracket in _BRACKET_KEYS or bracket in _recent_stat_versions
     if use_bracket:
         baseline = _bracket_baselines.get(bracket, {}).get(
             entity_type, _baseline_win_rate()

--- a/frontend/app/components/EntityRunStats.tsx
+++ b/frontend/app/components/EntityRunStats.tsx
@@ -155,6 +155,13 @@ export default function EntityRunStats({ entityType, entityId, entityName, varia
   // A10 selected reads the "solo:a10" composite block. Only offered when the
   // API response carries player-count brackets (post-update snapshots).
   const availablePlayers = PLAYER_BRACKETS.filter((b) => brackets[b.key]);
+  // Version slices ride the same brackets dict (build_id keys, v18+
+  // snapshots). A version is exclusive: it replaces the player/skill pair.
+  const availableVersions = Object.keys(brackets)
+    .filter((k) => /^v\d/.test(k))
+    .sort()
+    .reverse();
+  const selVersion = availableVersions.includes(selectedBracket) ? selectedBracket : "";
   const { player: selPlayer, skill: selSkill } = splitBracket(selectedBracket);
   const pickPlayer = (p: string) => setSelectedBracket(combineBracket(p, selSkill));
   const pickSkill = (sk: string) =>
@@ -230,6 +237,19 @@ export default function EntityRunStats({ entityType, entityId, entityName, varia
                   </button>
                 ))}
               </div>
+            )}
+            {availableVersions.length > 0 && (
+              <select
+                value={selVersion}
+                onChange={(e) => setSelectedBracket(e.target.value || "all")}
+                className="ml-1 rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)] focus:outline-none"
+                aria-label="Game version"
+              >
+                <option value="">{t("All versions", lang)}</option>
+                {availableVersions.map((v) => (
+                  <option key={v} value={v}>{v}</option>
+                ))}
+              </select>
             )}
 
             <div className="tiles">

--- a/frontend/app/leaderboards/encounters/EncounterStatsClient.tsx
+++ b/frontend/app/leaderboards/encounters/EncounterStatsClient.tsx
@@ -68,6 +68,17 @@ export default function EncounterStatsClient() {
   const [roomTypes, setRoomTypes] = useState<Set<string>>(new Set());
   const [multiplayer, setMultiplayer] = useState<"any" | "only" | "exclude">("any");
   const [bracket, setBracket] = useState("all");
+  // Game versions the snapshot keeps encounter slices for; filters via the
+  // endpoint's build_id param (exclusive axis, does not combine with bracket
+  // on the backend's per-version slices).
+  const [version, setVersion] = useState("");
+  const [statVersions, setStatVersions] = useState<string[]>([]);
+  useEffect(() => {
+    fetch(`${API}/api/runs/versions`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => setStatVersions(d?.stat_versions || []))
+      .catch(() => {});
+  }, []);
   const [page, setPage] = useState(1);
 
   const [data, setData] = useState<EncounterResponse | null>(null);
@@ -97,6 +108,7 @@ export default function EncounterStatsClient() {
     if (roomTypes.size) params.set("room_type", Array.from(roomTypes).join(","));
     if (multiplayer !== "any") params.set("multiplayer", multiplayer);
     if (bracket !== "all") params.set("bracket", bracket);
+    if (version) params.set("build_id", version);
     params.set("page", String(page));
     params.set("limit", "50");
     fetch(`${API}/api/runs/encounter-stats?${params}`)
@@ -104,7 +116,7 @@ export default function EncounterStatsClient() {
       .then((d: EncounterResponse) => setData(d))
       .catch(() => setData({ encounters: [], page, limit: 50, total: 0, has_next: false }))
       .finally(() => setLoading(false));
-  }, [acts, roomTypes, multiplayer, bracket, page]);
+  }, [acts, roomTypes, multiplayer, bracket, version, page]);
 
   // Reset to page 1 whenever the filter set changes, paging through a
   // previous query's results after a filter change would be confusing.
@@ -255,6 +267,19 @@ export default function EncounterStatsClient() {
           })}
         </div>
       </div>
+        {statVersions.length > 0 && (
+          <select
+            value={version}
+            onChange={(e) => { setVersion(e.target.value); }}
+            className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-card)] px-2 py-1 text-sm text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent-gold)]"
+            aria-label="Game version"
+          >
+            <option value="">All versions</option>
+            {statVersions.map((v) => (
+              <option key={v} value={v}>{v}</option>
+            ))}
+          </select>
+        )}
 
       {loading ? (
         <div className="text-center py-12 text-[var(--text-muted)]">Loading…</div>

--- a/frontend/app/leaderboards/metrics/MetricsClient.tsx
+++ b/frontend/app/leaderboards/metrics/MetricsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { fullCardUrl, imageUrl } from "@/lib/image-url";
@@ -8,6 +8,8 @@ import { colorTextClass } from "@/lib/character-colors";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 import StatsRebuildingNotice from "@/app/components/StatsRebuildingNotice";
 
 export interface MetricRow {
@@ -187,6 +189,17 @@ export default function MetricsClient({
   } | null>(null);
 
   const sel = parseBracket(bracket);
+  // Game versions the snapshot keeps per-version slices for. A version is
+  // its own exclusive bracket (it doesn't compose with player/skill), so
+  // selecting one clears the other axes, same as the mode pills.
+  const [statVersions, setStatVersions] = useState<string[]>([]);
+  useEffect(() => {
+    fetch(`${API}/api/runs/versions`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => setStatVersions(d?.stat_versions || []))
+      .catch(() => {});
+  }, []);
+  const selVersion = statVersions.includes(bracket) ? bracket : "";
   const nav = (key: string, char: string = character) => {
     const base = `${lp}/leaderboards/metrics`;
     const params = new URLSearchParams();
@@ -329,6 +342,26 @@ export default function MetricsClient({
           </button>
         ))}
       </div>
+      {statVersions.length > 0 && (
+        <div className="mb-2 flex flex-wrap items-center gap-1.5">
+          <span className="mr-1 w-12 text-xs text-[var(--text-muted)]">{t("Version", lang)}</span>
+          <select
+            value={selVersion}
+            onChange={(e) => nav(e.target.value || "all")}
+            className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-card)] px-2 py-1 text-xs text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent-gold)]"
+          >
+            <option value="">{t("All versions", lang)}</option>
+            {statVersions.map((v) => (
+              <option key={v} value={v}>{v}</option>
+            ))}
+          </select>
+          {selVersion && (
+            <span className="text-xs text-[var(--text-muted)]">
+              {t("Version view: player, skill, and mode filters don't combine with it.", lang)}
+            </span>
+          )}
+        </div>
+      )}
       {/* Server-side re-scope to one character's runs (any bracket combines).
           Not the card-color filter: this changes whose runs are counted. */}
       <div className="mb-3 flex flex-wrap items-center gap-1.5">

--- a/frontend/app/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/leaderboards/stats/StatsClient.tsx
@@ -326,12 +326,20 @@ export default function StatsClient() {
   >(null);
   const [bracketOverview, setBracketOverview] = useState<BracketOverview | null>(null);
   const [bracketLoading, setBracketLoading] = useState(false);
+  const [statVersions, setStatVersions] = useState<string[]>([]);
+  useEffect(() => {
+    fetch(`${API}/api/runs/versions`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => setStatVersions(d?.stat_versions || []))
+      .catch(() => {});
+  }, []);
   const bracketActive = bracket !== "all";
+  const isVersion = /^v\d/.test(bracket);
   // The ?bracket= value combining both axes, e.g. "wr50", "solo:wr50".
-  const apiBracket = combineBracket(
-    PLAYERS_TO_BRACKET[players] ?? "",
-    bracketActive ? bracket : "",
-  );
+  // A version bracket is exclusive: it never composes with player counts.
+  const apiBracket = isVersion
+    ? bracket
+    : combineBracket(PLAYERS_TO_BRACKET[players] ?? "", bracketActive ? bracket : "");
 
   // Tabs
   const [tab, setTab] = useState<TopTab>("overview");
@@ -929,6 +937,19 @@ export default function StatsClient() {
             </button>
           );
         })}
+        {statVersions.length > 0 && (
+          <select
+            value={isVersion ? bracket : ""}
+            onChange={(e) => setBracket(e.target.value || "all")}
+            className="text-xs px-2 py-1.5 rounded-md border bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent-gold)]"
+            aria-label="Game version"
+          >
+            <option value="">{t("All versions", lang)}</option>
+            {statVersions.map((v) => (
+              <option key={v} value={v}>{v}</option>
+            ))}
+          </select>
+        )}
         {bracketActive && (
           <span className="text-xs text-[var(--text-muted)] ml-1">
             {t("Result and ascension filters don't apply within a bracket.", lang)}

--- a/frontend/lib/site-pages.json
+++ b/frontend/lib/site-pages.json
@@ -7,6 +7,31 @@
     ]
   },
   {
+    "path": "/admin/keys",
+    "name": "Admin · Keys",
+    "keywords": [
+      "admin",
+      "keys"
+    ]
+  },
+  {
+    "path": "/admin/rate-limits",
+    "name": "Admin · Rate Limits",
+    "keywords": [
+      "admin",
+      "rate",
+      "limits"
+    ]
+  },
+  {
+    "path": "/admin/searches",
+    "name": "Admin · Searches",
+    "keywords": [
+      "admin",
+      "searches"
+    ]
+  },
+  {
     "path": "/admin/users",
     "name": "Admin · Users",
     "keywords": [


### PR DESCRIPTION
First slice of the version-filtering feedback: stats scoped to a single game version.

**Backend.** The snapshot walk now appends a run's build_id to its bracket keys, limited to the recent versions the snapshot already tracks for the encounter slices (get_recent_stat_versions). That means version filtering rides the entire existing bracket machinery — /api/runs/metrics/{type}?bracket=v0.107.1 and /api/runs/scores/{type}?bracket=v0.107.1 work with no new endpoints — and versions deliberately don't pair into player/skill composites, so there's no key explosion. Snapshot version bumps to 18; the slices appear after the first post-deploy rebuild (~15-25 min), and until then version requests fall back to all-runs data exactly like any unknown bracket.

**Frontend.** The metrics page gets a Version dropdown (options from /api/runs/versions stat_versions), exclusive with the other axes like the mode pills, with a note explaining that when active. Elo shows blank on version views since per-version Elo fits aren't built — win rate, pick rate, and score all carry.

Next slices on the same rails once this proves out: the stats page, tier lists, and community stats dropdowns — the backend side of all of them ships here.