### PR TITLE
Document the between-acts reset in unknown room odds

### DIFF
--- a/data/mechanics_pages/unknown-rooms.md
+++ b/data/mechanics_pages/unknown-rooms.md
@@ -1,16 +1,31 @@
 ---
 title: Unknown Room Probabilities
-description: What happens when you enter a "?" room — adaptive probability system for events, fights, shops, and treasure.
+description: What happens when you enter a "?" room: the adaptive odds system for events, fights, shops, and treasure, including the between-acts reset.
 category: mechanics
 order: 7
 ---
 
 | Outcome | Base Chance | Adaptive |
 |---------|------------:|----------|
-| Event | ~85% | Whatever chance is left after fight/shop/treasure, so it shrinks as those build up from repeated misses (and jumps back up right after one of them hits and resets) |
+| Event | Whatever is left | 100% minus the current fight/shop/treasure odds; shrinks as those build from misses, jumps back when one of them hits and resets |
 | Monster fight | {{constants.unknown_map_point_odds.baseMonsterOdds | pct}} | +{{constants.unknown_map_point_odds.baseMonsterOdds | pct}} each miss |
 | Shop | {{constants.unknown_map_point_odds.baseShopOdds | pct}} | +{{constants.unknown_map_point_odds.baseShopOdds | pct}} each miss |
 | Treasure | {{constants.unknown_map_point_odds.baseTreasureOdds | pct}} | +{{constants.unknown_map_point_odds.baseTreasureOdds | pct}} each miss |
-| Elite | Never (disabled by default) | Only rollable via modifiers like Deadly Events |
+| Elite | Never (odds are negative by default) | Only rollable via modifiers like Deadly Events; negative odds never increase from misses |
 
-> Each outcome has adaptive odds: when it doesn't occur, its chance increases by its base amount. When it does occur, it resets. On your very first run, the first 2 unknown rooms are always events, and the 3rd is always a fight.
+## How the roll actually works
+
+The game makes **one** random roll from 0 to 1 and walks the non-event outcomes in a fixed order (monster, elite, treasure, shop), adding each one's current odds to a running threshold. The first outcome whose cumulative threshold covers the roll wins; if the roll clears them all, the room is an event. After the roll, the outcome that hit resets to its base odds, and every other eligible outcome increases by its own base amount.
+
+## The odds reset between acts
+
+This is the detail most community explanations miss: **all adaptive odds reset to their base values at every act transition** (`ResetToBase()` in the game's `UnknownMapPointOdds`, "Called between acts"). Pity never carries across an act boundary.
+
+That resolves the streaks that look impossible under a run-long model. A run can see seven straight events, or ten "?" rooms without a single fight, because the fight odds never accumulate past an act's worth of misses. With roughly 4-6 unknown rooms per act, monster odds top out around 50-60% before the reset wipes them, and nothing is ever guaranteed.
+
+## Other details from the source
+
+- Blacklisted outcomes (from run context or modifiers) can neither be rolled nor gain odds from misses that turn.
+- An outcome with negative odds (elites by default) is skipped entirely and never accumulates.
+- On your account's **very first run only**, the first two unknown rooms are forced events and the third is a forced fight.
+- Since the event chance is computed as max(0, 100% minus the others), the non-event odds can never push the total "over 100%"; the event share just floors at zero. In practice the act reset keeps it well above that.


### PR DESCRIPTION
A speedrunner (frodododo) reported two runs that are impossible under the mechanics page's description: seven consecutive events (which the old model prices at negative probability) and ten unknown rooms without a fight (which should hit a guaranteed fight by the ninth). The decompiled source explains both, and the page was incomplete rather than the runner wrong:

- `UnknownMapPointOdds.ResetToBase()` is called **between acts** — pity never carries across an act boundary, which the page didn't mention. With 4-6 unknown rooms per act, monster odds top out around 50-60% before wiping, so nothing is ever guaranteed and long event streaks across acts are unremarkable.
- The roll is a single uniform value walked across cumulative thresholds in fixed order (monster, elite, treasure, shop), with the event as the remainder floored at zero — so "over 100%" states can't occur.
- Blacklisted and negative-odds outcomes (elites by default) neither roll nor accumulate.

The base odds (10%/3%/2%) and the first-ever-run forced sequence were already correct. The page now documents the full mechanism.