### PR TITLE
Fix invalid YAML that 500s all mechanics pages

### DIFF
--- a/data/mechanics_pages/unknown-rooms.md
+++ b/data/mechanics_pages/unknown-rooms.md
@@ -1,6 +1,6 @@
 ---
 title: Unknown Room Probabilities
-description: What happens when you enter a "?" room: the adaptive odds system for events, fights, shops, and treasure, including the between-acts reset.
+description: What happens when you enter a "?" room, including the adaptive odds for events, fights, shops, and treasure, and the between-acts reset.
 category: mechanics
 order: 7
 ---


### PR DESCRIPTION
Hotfix for a bug I shipped in #680: the new frontmatter description on unknown-rooms.md contained an unquoted colon, which is invalid YAML. `list_sections()` parses every mechanics file, so the one bad file 500s the entire /api/mechanics API and blanks the /mechanics pages on the site.

Reworded the description without the colon. This time I verified through the actual service: `list_sections()` returns all sections and `get_section("unknown-rooms")` renders with all constant tokens resolved.