### PR TITLE
Version filters everywhere: all release versions, more pages, metrics fix

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -475,6 +475,7 @@ def get_leaderboard(
     limit: int = 50,
     ascension_min: int | None = None,
     winrate_min: float | None = None,
+    build_id: str | None = None,
 ):
     """Leaderboard for winning runs.
 
@@ -506,6 +507,7 @@ def get_leaderboard(
         limit=limit,
         ascension_min=ascension_min,
         winrate_min=winrate_min,
+        build_id=build_id,
     )
     cached = app_cache.get_json(cache_key)
     if cached is not None:
@@ -523,6 +525,7 @@ def get_leaderboard(
             limit=limit,
             ascension_min=ascension_min,
             winrate_min=winrate_min,
+            build_id=build_id,
         )
         app_cache.set_json(cache_key, result, ttl_seconds=60)
         return result
@@ -548,6 +551,9 @@ def get_leaderboard(
         if ascension_min is not None:
             conditions.append("ascension >= ?")
             params.append(ascension_min)
+        if build_id:
+            conditions.append("build_id = ?")
+            params.append(build_id)
         where = "WHERE " + " AND ".join(conditions)
 
         if category == "highest_ascension":

--- a/backend/app/services/cache.py
+++ b/backend/app/services/cache.py
@@ -79,12 +79,14 @@ def leaderboard_key(
     limit: int = 50,
     ascension_min: int | None = None,
     winrate_min: float | None = None,
+    build_id: str | None = None,
 ) -> str:
     return (
         f"leaderboard:{category}:{(character or '').upper()}:{players or ''}:"
         f"{game_mode or ''}:{int(today)}:{page}:{limit}:"
         f"{ascension_min if ascension_min is not None else ''}:"
-        f"{winrate_min if winrate_min is not None else ''}"
+        f"{winrate_min if winrate_min is not None else ''}:"
+        f"{build_id or ''}"
     )
 
 

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -239,7 +239,7 @@ _HISTORY_RETENTION_DAYS = 90
 # the skill tiers), so ?character= combines with any bracket on the metrics
 # endpoint — e.g. bracket=solo:a10&character=IRONCLAD (additive; the bump
 # forces the rebuild).
-SNAPSHOT_VERSION = 18
+SNAPSHOT_VERSION = 19
 # The oldest snapshot version readers can still serve. Bump SNAPSHOT_VERSION
 # on every shape change; bump this floor ONLY when a change actually breaks
 # readers (a removed/retyped field). Everything in between is additive, and
@@ -301,9 +301,11 @@ _encounter_blob_stats: dict[str, Any] = {}
 # buckets for — the options the stats-page version dropdown offers. Newest
 # first. Empty until the first v15+ snapshot is built/loaded.
 _recent_stat_versions: list[str] = []
-# How many recent game versions get their own encounter bucket. Bounds the
-# snapshot growth: older versions fold into "all" only.
-_RECENT_VERSIONS_N = 6
+# How many game versions get their own per-version bucket. None = every
+# release version that has a submitted run (the dropdowns go back to the
+# first patch, not just the recent window). Per-version buckets are small,
+# so unbounded growth tracks the game's release cadence, not run volume.
+_RECENT_VERSIONS_N: int | None = None
 _cache_built_at: float = 0.0
 _building: bool = False
 # The snapshot_version of whatever is currently loaded (None = nothing
@@ -1516,11 +1518,18 @@ def _version_sort_key(build_id: str) -> tuple:
     return tuple(int(x) for x in re.findall(r"\d+", build_id or ""))
 
 
-def _pick_recent_versions(rows, n: int) -> list[str]:
-    """The n newest distinct build_ids present in the run rows, newest first.
-    These get their own encounter bucket; everything else folds into "all"."""
+def _pick_recent_versions(rows, n: int | None = None) -> list[str]:
+    """Distinct release build_ids present in the run rows, newest first.
+    These get their own per-version bucket; anything else folds into "all".
+    Only release-shaped ids (v0.107.1) qualify — dev/modded builds like
+    NON-RELEASE-VERSION stay out per the modded-content policy. `n` caps
+    the list; None keeps every release version."""
+    import re
+
     seen = {r.get("build_id") for r in rows if r.get("build_id")}
-    return sorted(seen, key=_version_sort_key, reverse=True)[:n]
+    releases = [b for b in seen if re.fullmatch(r"v\d+(\.\d+)*", b or "")]
+    ordered = sorted(releases, key=_version_sort_key, reverse=True)
+    return ordered[:n] if n else ordered
 
 
 def _build_cache_data() -> tuple[dict, dict, dict, dict]:

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1951,6 +1951,7 @@ def leaderboard(
     limit: int = 50,
     ascension_min: int | None = None,
     winrate_min: float | None = None,
+    build_id: str | None = None,
 ) -> dict:
     """Wins-only leaderboard. Mirrors the /api/runs/leaderboard SQLite path.
 
@@ -1966,10 +1967,12 @@ def leaderboard(
     # Fast path: serve from the materialized summary when the combo is one
     # we materialize (find_one misses otherwise and we fall to live). Docs
     # store 50 rows, so any page-1 request up to that size can be sliced.
-    # An ascension_min / winrate_min filter isn't materialized, so skip to live.
+    # An ascension_min / winrate_min / build_id filter isn't materialized, so
+    # skip to live.
     if (
         ascension_min is None
         and winrate_min is None
+        and build_id is None
         and not today
         and page == 1
         and limit <= 50
@@ -2003,6 +2006,7 @@ def leaderboard(
         limit=limit,
         ascension_min=ascension_min,
         winrate_min=winrate_min,
+        build_id=build_id,
     )
 
 
@@ -2016,6 +2020,7 @@ def _leaderboard_live(
     limit: int = 50,
     ascension_min: int | None = None,
     winrate_min: float | None = None,
+    build_id: str | None = None,
 ) -> dict:
     """Live leaderboard query -- the original implementation, used directly
     by refresh_leaderboard_summary and as the fallback when the summary
@@ -2048,6 +2053,8 @@ def _leaderboard_live(
         q["player_count"] = {"$gt": 1}
     if game_mode:
         q["game_mode"] = game_mode
+    if build_id:
+        q["build_id"] = build_id
     # Clamp to the official ascension range (A10 is the game's cap); A11+ runs are
     # modded and must never top the ladder. Merge an explicit ascension_min in.
     if ascension_min is not None:

--- a/frontend/app/components/BracketFilter.tsx
+++ b/frontend/app/components/BracketFilter.tsx
@@ -7,6 +7,7 @@ import {
   combineBracket,
   type ContentBracket,
 } from "@/lib/content-brackets";
+import VersionSelectNav from "@/app/components/VersionSelectNav";
 
 /**
  * Bracket pill rows (All / Asc 10 / win-rate tiers, plus player count) for
@@ -60,13 +61,17 @@ export default function BracketFilter({
       </Link>
     );
     return (
-      <div className="flex flex-wrap items-center gap-1.5 mb-5">
-        <span className="text-xs text-[var(--text-muted)] mr-1">Bracket</span>
-        {CONTENT_BRACKETS.map(renderPill)}
-        {/* Player count shares the ?bracket= slot, so picking one clears the
-            content bracket and vice versa. */}
-        <span className="text-xs text-[var(--text-muted)] mx-1">Players</span>
-        {PLAYER_BRACKETS.map(renderPill)}
+      <div className="mb-5 space-y-1.5">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-xs text-[var(--text-muted)] mr-1">Bracket</span>
+          {CONTENT_BRACKETS.map(renderPill)}
+          {/* Player count shares the ?bracket= slot, so picking one clears the
+              content bracket and vice versa. */}
+          <span className="text-xs text-[var(--text-muted)] mx-1">Players</span>
+          {PLAYER_BRACKETS.map(renderPill)}
+        </div>
+        {/* Game version shares the same slot too (exclusive slice). */}
+        <VersionSelectNav basePath={basePath} current={active} extraParams={extraParams} />
       </div>
     );
   }
@@ -103,6 +108,9 @@ export default function BracketFilter({
           </Link>
         ))}
       </div>
+      {/* Game version is an exclusive slice of the same ?bracket= slot:
+          picking one replaces the player/skill selection and vice versa. */}
+      <VersionSelectNav basePath={basePath} current={active} extraParams={extraParams} />
     </div>
   );
 }

--- a/frontend/app/components/VersionSelectNav.tsx
+++ b/frontend/app/components/VersionSelectNav.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { isVersionBracket } from "@/lib/content-brackets";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+/**
+ * The Version row of BracketFilter. Client half of a server component: it
+ * self-populates from /api/runs/versions (stat_versions = the versions the
+ * snapshot keeps per-version slices for) and navigates the same way the
+ * bracket pills do (?bracket=v0.107.1; "All versions" drops the param).
+ * A version is an exclusive bracket, so picking one replaces any player/
+ * skill selection, and picking a pill afterwards replaces the version.
+ * Renders nothing while the version list is loading or empty.
+ */
+export default function VersionSelectNav({
+  basePath,
+  current,
+  extraParams,
+}: {
+  basePath: string;
+  current: string;
+  extraParams?: Record<string, string | undefined>;
+}) {
+  const router = useRouter();
+  const [versions, setVersions] = useState<string[]>([]);
+
+  useEffect(() => {
+    fetch(`${API}/api/runs/versions`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => setVersions(d?.stat_versions || []))
+      .catch(() => {});
+  }, []);
+
+  if (versions.length === 0) return null;
+
+  // Keep a URL-supplied version selectable even if it fell out of the
+  // snapshot's list (stale link), so the select reflects the page state.
+  const value = isVersionBracket(current) ? current : "";
+  const options = value && !versions.includes(value) ? [value, ...versions] : versions;
+
+  const onChange = (v: string) => {
+    const params = new URLSearchParams();
+    for (const [k, val] of Object.entries(extraParams ?? {})) {
+      if (val) params.set(k, val);
+    }
+    if (v) params.set("bracket", v);
+    const qs = params.toString();
+    router.push(qs ? `${basePath}?${qs}` : basePath);
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="w-14 text-xs text-[var(--text-muted)]">Version</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label="Game version"
+        className="text-xs px-2 py-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-card)] text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent-gold)]"
+      >
+        <option value="">All versions</option>
+        {options.map((v) => (
+          <option key={v} value={v}>
+            {v}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
+++ b/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
@@ -198,7 +198,7 @@ export default function LeaderboardBrowseClient() {
   }, [tab, mode, gameMode, lbChar, browseChar, browseWin, browseUser, browseBuildId, browseBracket]);
 
   // Reset leaderboard page when filters change
-  useEffect(() => { setLbPage(1); }, [tab, lbChar, mode, gameMode, browseBracket]);
+  useEffect(() => { setLbPage(1); }, [tab, lbChar, mode, gameMode, browseBracket, browseBuildId]);
 
   // Fetch leaderboard (only when on a leaderboard tab)
   useEffect(() => {
@@ -218,6 +218,7 @@ export default function LeaderboardBrowseClient() {
     const bp = bracketListParams(browseBracket);
     if (bp.ascension_min) params.set("ascension_min", String(bp.ascension_min));
     if (bp.winrate_min) params.set("winrate_min", String(bp.winrate_min));
+    if (browseBuildId) params.set("build_id", browseBuildId);
     params.set("page", String(lbPage));
     params.set("limit", "20");
     fetch(`${API}/api/runs/leaderboard?${params}`)
@@ -238,7 +239,7 @@ export default function LeaderboardBrowseClient() {
         setLbTotalPages(0);
       })
       .finally(() => setLbLoading(false));
-  }, [tab, lbChar, lbPage, mode, gameMode, browseBracket]);
+  }, [tab, lbChar, lbPage, mode, gameMode, browseBracket, browseBuildId]);
 
   // Reset browse page when filters change
   useEffect(() => { setBrowsePage(1); }, [browseChar, browseWin, browseUser, browseSeed, browseBuildId, browseSort, browseBracket, mode, gameMode]);
@@ -437,6 +438,21 @@ export default function LeaderboardBrowseClient() {
                 <span className="hidden sm:inline text-sm">{stripThe(charName(ch))}</span>
               </button>
             ))}
+            {/* Game version narrows the ladder to runs on that patch. Shared
+                with the browse tab's version filter (same state). */}
+            {versions.length > 0 && (
+              <select
+                value={browseBuildId}
+                onChange={(e) => setBrowseBuildId(e.target.value)}
+                aria-label="Game version"
+                className="text-sm px-3 py-1.5 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]"
+              >
+                <option value="">{t("All Versions", lang)}</option>
+                {versions.map((v) => (
+                  <option key={v} value={v}>{v}</option>
+                ))}
+              </select>
+            )}
           </div>
 
           {/* Leaderboard table */}

--- a/frontend/app/leaderboards/encounters/EncounterStatsClient.tsx
+++ b/frontend/app/leaderboards/encounters/EncounterStatsClient.tsx
@@ -266,20 +266,24 @@ export default function EncounterStatsClient() {
             );
           })}
         </div>
-      </div>
+
         {statVersions.length > 0 && (
-          <select
-            value={version}
-            onChange={(e) => { setVersion(e.target.value); }}
-            className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-card)] px-2 py-1 text-sm text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent-gold)]"
-            aria-label="Game version"
-          >
-            <option value="">All versions</option>
-            {statVersions.map((v) => (
-              <option key={v} value={v}>{v}</option>
-            ))}
-          </select>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm text-[var(--text-muted)] w-20">Version:</span>
+            <select
+              value={version}
+              onChange={(e) => { setVersion(e.target.value); }}
+              className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-card)] px-2 py-1 text-sm text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent-gold)]"
+              aria-label="Game version"
+            >
+              <option value="">All versions</option>
+              {statVersions.map((v) => (
+                <option key={v} value={v}>{v}</option>
+              ))}
+            </select>
+          </div>
         )}
+      </div>
 
       {loading ? (
         <div className="text-center py-12 text-[var(--text-muted)]">Loading…</div>

--- a/frontend/app/leaderboards/metrics/MetricsClient.tsx
+++ b/frontend/app/leaderboards/metrics/MetricsClient.tsx
@@ -355,11 +355,6 @@ export default function MetricsClient({
               <option key={v} value={v}>{v}</option>
             ))}
           </select>
-          {selVersion && (
-            <span className="text-xs text-[var(--text-muted)]">
-              {t("Version view: player, skill, and mode filters don't combine with it.", lang)}
-            </span>
-          )}
         </div>
       )}
       {/* Server-side re-scope to one character's runs (any bracket combines).

--- a/frontend/app/leaderboards/metrics/metrics-data.ts
+++ b/frontend/app/leaderboards/metrics/metrics-data.ts
@@ -71,6 +71,10 @@ const _PLAYER_KEYS = ["solo", "2p", "3p", "4p"];
 const _SKILL_KEYS = ["a10", "wr30", "wr50", "wr75"];
 function isValidBracket(b: string): boolean {
   if (BRACKETS.some((c) => c.key === b)) return true;
+  // Game-version slices (v0.107.1) are exclusive snapshot brackets too.
+  // Without this the server silently normalized ?bracket=v0.106.0 to "all",
+  // so the version dropdown wrote the URL but nothing changed.
+  if (/^v\d+(\.\d+)*$/.test(b)) return true;
   const [p, s] = b.split(":");
   return _PLAYER_KEYS.includes(p) && _SKILL_KEYS.includes(s);
 }

--- a/frontend/lib/content-brackets.ts
+++ b/frontend/lib/content-brackets.ts
@@ -39,6 +39,15 @@ const _SKILL_KEYS = new Set(
 );
 
 /**
+ * A game-version bracket ("v0.107.1"): the snapshot keeps an exclusive
+ * per-version slice for every release version, so a version is a valid
+ * ?bracket= value on its own (it never composes with player/skill).
+ */
+export function isVersionBracket(raw: string | undefined | null): boolean {
+  return !!raw && /^v\d+(\.\d+)*$/.test(raw);
+}
+
+/**
  * A "player:skill" composite (e.g. "solo:wr50") combines a player-count bracket
  * with a content/skill bracket. Only the entity cache (tier list + metrics)
  * materializes these, so BracketFilter offers them only in composite mode.
@@ -77,6 +86,7 @@ export function normalizeBracket(raw: string | undefined | null): string {
   if (!raw) return "all";
   if (_BY_KEY.has(raw)) return raw;
   if (isCompositeBracket(raw)) return raw;
+  if (isVersionBracket(raw)) return raw;
   return "all";
 }
 
@@ -85,7 +95,7 @@ export function normalizeBracket(raw: string | undefined | null): string {
 export function bracketParam(key: string | undefined | null): string | null {
   const n = normalizeBracket(key);
   if (n === "all") return null;
-  if (isCompositeBracket(n)) return n;
+  if (isCompositeBracket(n) || isVersionBracket(n)) return n;
   return _BY_KEY.get(n)?.param ?? null;
 }
 


### PR DESCRIPTION
Round 2 of version filtering based on the live feedback:

**Fixes**
- /leaderboards/metrics?bracket=v0.106.0 did nothing: the server-side `isValidBracket` rejected version keys and silently normalized to "all", so the URL changed but the select and data didn't. It accepts version brackets now.
- The encounters version select rendered orphaned below the filter card; it's now a labeled Version row directly under Players.

**New coverage**
- BracketFilter grows a Version row (under Players, matching encounters), which adds the dropdown to /tier-list/cards, /tier-list/relics, /tier-list/potions, and /community-stats in one place — the scores and community endpoints already accept version brackets.
- The leaderboard tabs on /leaderboards get the same version select the browse tab had, backed by a new `build_id` param on /api/runs/leaderboard (threaded through the Redis cache key, the Mongo query, and the SQLite fallback; the materialized fast path is skipped when it's set).

**Depth**
- Per-version buckets now cover every release version with a submitted run instead of the 6 newest, so the dropdowns go back to the first patch. Dev/modded build ids (NON-RELEASE-VERSION) stay excluded per the modded-content policy. SNAPSHOT_VERSION bumps 18 to 19 — the deeper version lists appear after the post-deploy rebuild.

Verified: tsc, production build, ruff check + format, and a unit exercise of the version picker (release filtering + ordering) and the new cache key.

Heads up: the v19 rebuild also carries the v18 changes (per-entity version buckets, community blob version keys), so entity pages and community-stats version slices all light up together once it lands.