### PR TITLE
Restore retired official encounters (the Doormaker) to the stats

### DIFF
--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -998,16 +998,21 @@ def hp_loss_by_floor(stats: dict[str, Any], players: int | None) -> list[dict]:
 
 
 def _encounter_names() -> dict[str, str]:
+    # Historical entries ride along: retired-but-official content (the
+    # Doormaker era) still fills months of run rows, and this map doubles as
+    # the modded-id guard, so without them those rows silently vanish.
+    from .encounter_stats import HISTORICAL_ENCOUNTERS
     from . import data_service
 
     try:
-        return {
+        names = {
             e["id"]: e.get("name") or e["id"]
             for e in data_service.load_encounters()
             if e.get("id")
         }
+        return {**HISTORICAL_ENCOUNTERS, **names}
     except Exception:
-        return {}
+        return dict(HISTORICAL_ENCOUNTERS)
 
 
 def encounter_ranking(
@@ -1016,8 +1021,20 @@ def encounter_ranking(
     """Encounters ranked by avg % max HP lost per fight, or by avg turns."""
     merged = _merge_cells(stats.get("enc") or [], players)
     names = _encounter_names()
-    rows = []
+    # Fold renamed ids into their current id first (Toadpoles -> Seapunk),
+    # so a renamed fight ranks as one entry instead of two half-sized ones.
+    from .encounter_stats import ENCOUNTER_ID_RENAMES
+
+    folded: dict[str, list[float]] = {}
     for enc, (s, n, st, nt) in (merged.get("ALL") or {}).items():
+        key = ENCOUNTER_ID_RENAMES.get(enc, enc)
+        f = folded.setdefault(key, [0.0, 0, 0.0, 0])
+        f[0] += s
+        f[1] += n
+        f[2] += st
+        f[3] += nt
+    rows = []
+    for enc, (s, n, st, nt) in folded.items():
         if names and enc not in names:
             continue  # modded encounters
         if metric == "turns":

--- a/backend/app/services/encounter_stats.py
+++ b/backend/app/services/encounter_stats.py
@@ -208,6 +208,29 @@ def empty_one() -> dict[str, Any]:
     return _finalize_one(_new_acc_one())
 
 
+# Retired-but-official encounters: content that shipped in an official build
+# and was later replaced outright, so the current catalog no longer lists it,
+# but months of submitted runs still reference it. Without these the modded-id
+# scrub silently erases that history: the Doormaker was the Act 3 boss from
+# the 2025-10-16 patch until the v0.100.0 (2026-05-07) Aeonglass rework, and
+# every one of those fights vanished from the encounter stats. Maps id ->
+# display name (the catalog can't name what it no longer contains).
+HISTORICAL_ENCOUNTERS: dict[str, str] = {
+    "DOORMAKER_BOSS": "The Doormaker",
+    # The Dreamer was the Act 3 boss the Doormaker replaced (2025-10-16).
+    # Both id spellings are allowed since the exact retired id predates the
+    # current decompile; an entry that never matches simply never surfaces.
+    "DREAMER_BOSS": "The Dreamer",
+    "THE_DREAMER_BOSS": "The Dreamer",
+}
+
+# Same fight, renamed id. The game migrates local saves (V100Renames in the
+# decompiled SharedMigrationHelper), but runs submitted before the rename
+# reached us with the old id, so fold those rows into the current id.
+ENCOUNTER_ID_RENAMES: dict[str, str] = {
+    "TOADPOLES_NORMAL": "SEAPUNK_NORMAL",
+}
+
 _official_enc_ids: frozenset[str] | None = None
 
 
@@ -240,7 +263,7 @@ def _official_encounter_ids() -> frozenset[str]:
     except Exception:
         logger.warning("encounter official-id load failed", exc_info=True)
         return frozenset()
-    _official_enc_ids = frozenset(ids)
+    _official_enc_ids = frozenset(ids | set(HISTORICAL_ENCOUNTERS))
     return _official_enc_ids
 
 
@@ -279,6 +302,9 @@ def rollup(
     grouped: dict[tuple[str, int, str], dict[str, Any]] = {}
     for cell in cells:
         enc_id, act, room_type, character, mp, total, fatal, dmg, turns = cell
+        # Renamed content: old-id rows fold into the current id so the same
+        # fight isn't split into two half-sized entries.
+        enc_id = ENCOUNTER_ID_RENAMES.get(enc_id, enc_id)
         if official and enc_id not in official:
             continue
         if mp not in mp_keep:

--- a/frontend/app/leaderboards/encounters/EncounterStatsClient.tsx
+++ b/frontend/app/leaderboards/encounters/EncounterStatsClient.tsx
@@ -51,7 +51,17 @@ function toggle<T>(set: Set<T>, value: T): Set<T> {
   return next;
 }
 
+// Retired-but-official encounters: the game data no longer names them (the
+// Doormaker was the Act 3 boss until the v0.100.0 Aeonglass rework), but the
+// stats still carry their rows. Mirrors HISTORICAL_ENCOUNTERS on the backend.
+const LEGACY_NAMES: Record<string, string> = {
+  DOORMAKER_BOSS: "The Doormaker",
+  DREAMER_BOSS: "The Dreamer",
+  THE_DREAMER_BOSS: "The Dreamer",
+};
+
 function displayName(id: string): string {
+  if (LEGACY_NAMES[id]) return LEGACY_NAMES[id];
   // Fallback when we don't have an encounters lookup hit, humanize the
   // upper-snake-case id. Matches the convention other stats tables use.
   return id


### PR DESCRIPTION
The Doormaker went missing from the encounter stats because the modded-id scrub only trusts the current game catalog. The patch notes tell the story: the Doormaker replaced The Dreamer as the Act 3 boss on 2025-10-16, then the v0.100.0 patch (2026-05-07) replaced it with Aeonglass — "Doormaker has been replaced with a brand new boss, Aeonglass!". Seven months of submitted Doormaker fights were in the snapshot the whole time; the guard just filtered them out as if they were modded.

- `HISTORICAL_ENCOUNTERS` (id + display name) joins the official-id guard in both `encounter_stats.rollup` and the charts encounter ranking, so retired-but-official content stays visible. Doormaker and both Dreamer id spellings are included (an entry that never matches never surfaces).
- `ENCOUNTER_ID_RENAMES` folds renamed ids into the current fight — Toadpoles into Seapunk, matching the game's own V100Renames save migration — so a renamed fight ranks as one entry instead of two half-sized ones.
- The encounters page names the retired ids with a matching legacy map ("The Doormaker" instead of a humanized id).

Both fixes apply at rollup (query) time, so the rows reappear on deploy with the existing snapshot — no rebuild needed. Verified with a synthetic cells blob: Doormaker survives the guard, a fake modded id doesn't, and Toadpoles+Seapunk fold into one row with summed totals. ruff and tsc pass.

Aeonglass keeps its own separate entry: it's a different fight, so merging the eras would poison both stats.