### PR TITLE
Make game versions a composable third bracket axis, everywhere

### DIFF
--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -12,6 +12,7 @@ is set.
 """
 
 import logging
+import re
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from slowapi import Limiter
@@ -376,6 +377,7 @@ def _chart_cache_key(
     etype,
     entity,
     bracket=None,
+    build_id=None,
 ) -> str:
     """Redis key for one chart + filter combo. Shared by the live endpoint and
     the prewarmer so a warmed entry is a byte-for-byte hit on a real request."""
@@ -383,7 +385,7 @@ def _chart_cache_key(
         f"charts:{chart_key}:{players or ''}:{ascension if ascension is not None else ''}:"
         f"{game_mode or ''}:{(username or '').lower()}:{split}:{stat or ''}:{x or ''}:{y or ''}:"
         f"{(encounter or '').lower()}:{(event or '').lower()}:{etype or ''}:{(entity or '').lower()}:"
-        f"{bracket or ''}"
+        f"{bracket or ''}:{build_id or ''}"
     )
 
 
@@ -403,6 +405,7 @@ def _compute_chart(
     etype,
     entity,
     bracket=None,
+    build_id=None,
 ) -> dict:
     """Build one chart payload (no caching). Raises HTTPException for invalid
     blob filters, same as the endpoint."""
@@ -410,12 +413,13 @@ def _compute_chart(
     if spec["kind"] == "frame":
         mode = "daily" if spec.get("daily") else game_mode
         rows = cs.filter_rows(
-            cs.get_frame(), players, ascension, mode, username, bracket
+            cs.get_frame(), players, ascension, mode, username, bracket, build_id
         )
         series = _build_frame_chart(chart_key, rows, stat, x, y, split)
         total = len(rows)
     else:
-        # Blob charts: snapshot rollup (sliced to the requested content bracket),
+        # Blob charts: snapshot rollup (sliced to the requested content bracket
+        # and/or game version — the v20 blob keeps bracket x version buckets),
         # or a per-user walk when username set (username is the filter; the
         # bracket doesn't apply there).
         if ascension is not None or game_mode:
@@ -427,7 +431,16 @@ def _compute_chart(
             stats = cs.build_user_blob_stats(username)
         else:
             blob = get_charts_blob_stats()
-            stats = blob.get(bracket or "all") or blob.get("all") or cs.empty_one()
+            if bracket and build_id:
+                bkey = f"{bracket}:{build_id}"
+            else:
+                bkey = build_id or bracket or "all"
+            if bkey == "all":
+                stats = blob.get("all") or cs.empty_one()
+            else:
+                # A requested slice the snapshot hasn't materialized yet
+                # serves the empty shape, never a silent all-runs fallback.
+                stats = blob.get(bkey) or cs.empty_one()
         series = _build_blob_chart(
             chart_key, stats, spec, players, encounter, event, etype, entity
         )
@@ -548,7 +561,12 @@ def get_chart(
     entity: str | None = Query(None, max_length=80, description="Entity id"),
     bracket: str | None = Query(
         None,
-        description="Content bracket: a10 | wr30 | wr50 | wr75 (frame charts only)",
+        description="Content bracket: a10 | wr30 | wr50 | wr75",
+    ),
+    build_id: str | None = Query(
+        None,
+        max_length=32,
+        description="Game version (e.g. v0.107.1); combines with every other filter",
     ),
 ):
     """One pre-aggregated chart. See /api/charts/meta for the available
@@ -560,6 +578,8 @@ def get_chart(
     # per bracket in the snapshot).
     if bracket is not None and bracket not in ("a10", "wr30", "wr50", "wr75"):
         raise HTTPException(status_code=400, detail="bad bracket")
+    if build_id is not None and not re.fullmatch(r"v[\d.]+", build_id):
+        raise HTTPException(status_code=400, detail="bad build_id")
     if game_mode and game_mode not in ("standard", "daily", "custom"):
         raise HTTPException(status_code=400, detail="bad game_mode")
     for name, value in (("stat", stat), ("x", x), ("y", y)):
@@ -588,6 +608,7 @@ def get_chart(
         etype,
         entity,
         bracket,
+        build_id,
     )
     cached = app_cache.get_json(cache_key)
     if cached is not None:
@@ -609,6 +630,7 @@ def get_chart(
         etype,
         entity,
         bracket,
+        build_id,
     )
     # A still-building snapshot resolves within minutes; don't pin the empty
     # answer for the full TTL.

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1075,21 +1075,15 @@ def community_stats(request: Request, response: Response, bracket: str | None = 
 
     `bracket` slices to a content bracket (`a10`, `wr30`, `wr50`, `wr75`);
     omit for all runs."""
-    # Accept the player-count buckets, the skill tiers, and their player:skill
-    # composites (solo:wr50, ...) — the last let the page combine both axes.
-    _players = ("solo", "2p", "3p", "4p")
-    _skills = ("a10", "wr30", "wr50", "wr75")
-    _ok = bracket is None or bracket in _players or bracket in _skills
-    if not _ok and ":" in (bracket or ""):
-        _p, _, _s = bracket.partition(":")
-        _ok = _p in _players and _s in _skills
-    if not _ok:
-        # Version slices (build_id keys) are valid brackets too.
-        from ..services.run_entity_stats import get_recent_stat_versions
+    # One grammar for every bracket surface: plain keys, player:skill
+    # composites, game versions, and any of those composed with a version
+    # (solo:wr50:v0.107.1). Shared with the entity endpoints so this route
+    # can't drift from what the snapshot actually materializes.
+    if bracket is not None:
+        from ..services.run_entity_stats import is_valid_stat_bracket
 
-        _ok = bracket in get_recent_stat_versions()
-    if not _ok:
-        raise HTTPException(status_code=400, detail="bad bracket")
+        if not is_valid_stat_bracket(bracket):
+            raise HTTPException(status_code=400, detail="bad bracket")
     # An empty shell during a post-deploy rebuild must not stick in the
     # edge cache for 5 minutes on top of the rebuild itself.
     response.headers["Cache-Control"] = (

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -57,7 +57,8 @@ _RUNS_DIR = _DATA_DIR / "runs"
     ABANDONED,
     ACTS,
     DAILY,
-) = range(14)
+    BUILD,
+) = range(15)
 
 _FRAME: list[tuple] = []
 _FRAME_TS: float = 0.0
@@ -150,6 +151,7 @@ def _load_frame() -> list[tuple]:
                 "was_abandoned": 1,
                 "acts_completed": 1,
                 "seed": 1,
+                "build_id": 1,
             },
         )
         for d in cursor:
@@ -170,6 +172,7 @@ def _load_frame() -> list[tuple]:
                     1 if d.get("was_abandoned") else 0,
                     int(d.get("acts_completed") or 0),
                     _daily_date(d.get("seed"), mode),
+                    (d.get("build_id") or "").strip(),
                 )
             )
     else:
@@ -179,7 +182,8 @@ def _load_frame() -> list[tuple]:
             for d in conn.execute(
                 "SELECT character, win, ascension, game_mode, player_count,"
                 " run_time, floors_reached, deck_size, relic_count,"
-                " submitted_at, username, was_abandoned, acts_completed, seed"
+                " submitted_at, username, was_abandoned, acts_completed, seed,"
+                " build_id"
                 " FROM runs WHERE ascension BETWEEN 0 AND 10"
             ):
                 mode = (d["game_mode"] or "standard").lower()
@@ -199,6 +203,7 @@ def _load_frame() -> list[tuple]:
                         1 if d["was_abandoned"] else 0,
                         int(d["acts_completed"] or 0),
                         _daily_date(d["seed"], mode),
+                        (d["build_id"] or "").strip(),
                     )
                 )
     return rows
@@ -288,12 +293,17 @@ def filter_rows(
     game_mode: str | None,
     username: str | None,
     bracket: str | None = None,
+    build_id: str | None = None,
 ) -> list[tuple]:
     u = (username or "").lower().strip()
     asc_floor, wr_floor = _BRACKET_FILTERS.get(bracket or "", (None, None))
     wr_map = _frame_winrate_map() if wr_floor is not None else None
     out = []
     for r in rows:
+        # Game version: query-time on the frame, so it combines with every
+        # other filter here (unlike the snapshot brackets, no materialization).
+        if build_id and r[BUILD] != build_id:
+            continue
         if players is not None and r[PLAYERS] != players:
             continue
         if ascension is not None and r[ASC] != ascension:
@@ -635,10 +645,20 @@ def _new_acc_one() -> dict[str, Any]:
     }
 
 
-def new_accumulator() -> dict[str, Any]:
+def new_accumulator(versions=None) -> dict[str, Any]:
     """Per-bracket blob accumulators; accumulate() folds each run into the
-    sub-accumulator for every content bracket it belongs to."""
-    return {b: _new_acc_one() for b in _BLOB_BRACKETS}
+    sub-accumulator for every content bracket it belongs to. `versions`
+    (release build_ids) pre-seeds one bucket per version plus one per
+    bracket x version composite (``a10:v0.107.1``), so the blob charts
+    honor the same version filter the frame charts apply query-time.
+    accumulate() only folds into buckets that already exist."""
+    acc = {b: _new_acc_one() for b in _BLOB_BRACKETS}
+    for v in versions or []:
+        acc[v] = _new_acc_one()
+        for b in _BLOB_BRACKETS:
+            if b != "all":
+                acc[f"{b}:{v}"] = _new_acc_one()
+    return acc
 
 
 # Merging two accumulators (from parallel run-chunk walks) adds per key. Most

--- a/backend/app/services/community_stats.py
+++ b/backend/app/services/community_stats.py
@@ -117,9 +117,17 @@ def _new_acc_one() -> dict[str, Any]:
 
 def new_accumulator(recent_versions: tuple | list = ()) -> dict[str, Any]:
     """Per-bracket accumulators; accumulate() folds each run into every content
-    bracket it belongs to. `recent_versions` adds one accumulator per recent
-    game version (build_id keys) so the blob can serve per-version slices."""
-    keys = list(_BLOB_BRACKETS) + [v for v in recent_versions if v]
+    bracket it belongs to. `recent_versions` adds one accumulator per game
+    version (build_id keys) plus one per bracket x version composite
+    ("solo:wr50:v0.107.1"), so the blob serves every combination the
+    community page can express ("all:version" collapses to the bare
+    version key)."""
+    versions = [v for v in recent_versions if v]
+    keys = (
+        list(_BLOB_BRACKETS)
+        + versions
+        + [f"{b}:{v}" for b in _BLOB_BRACKETS if b != "all" for v in versions]
+    )
     return {b: _new_acc_one() for b in keys}
 
 

--- a/backend/app/services/encounter_stats.py
+++ b/backend/app/services/encounter_stats.py
@@ -55,15 +55,18 @@ def new_accumulator(versions=None) -> dict[str, Any]:
     """Per-bracket accumulators; accumulate() folds each run into every content
     bracket it belongs to.
 
-    `versions` (recent build_ids) pre-seeds one extra bucket per version, keyed
-    ``ver:<build_id>``. These are siblings of the content brackets, not a
-    sub-axis: a run feeds its own version's bucket (over all its content), so
-    the stats page can slice by game version without cross-multiplying the
-    bracket cells. accumulate() only folds into buckets that already exist, so
-    they must be seeded here."""
+    `versions` (release build_ids) pre-seeds one bucket per version (keyed
+    ``ver:<build_id>``, the legacy bare-version key) PLUS one per
+    bracket x version composite (``solo:v0.107.1``), so the encounters page
+    combines bracket and version instead of one overriding the other.
+    accumulate() only folds into buckets that already exist, so they must
+    be seeded here."""
     acc = {b: _new_acc_one() for b in _BLOB_BRACKETS}
     for v in versions or []:
         acc[f"ver:{v}"] = _new_acc_one()
+        for b in _BLOB_BRACKETS:
+            if b != "all":
+                acc[f"{b}:{v}"] = _new_acc_one()
     return acc
 
 

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -239,7 +239,11 @@ _HISTORY_RETENTION_DAYS = 90
 # the skill tiers), so ?character= combines with any bracket on the metrics
 # endpoint — e.g. bracket=solo:a10&character=IRONCLAD (additive; the bump
 # forces the rebuild).
-SNAPSHOT_VERSION = 19
+SNAPSHOT_VERSION = 20
+# Entities per persisted chunk doc. With version-composable brackets a
+# popular entity carries hundreds of per-bracket blocks, so entity arrays
+# are split across docs to stay well under Mongo's 16MB document cap.
+_ENTITY_CHUNK = 150
 # The oldest snapshot version readers can still serve. Bump SNAPSHOT_VERSION
 # on every shape change; bump this floor ONLY when a change actually breaks
 # readers (a removed/retyped field). Everything in between is additive, and
@@ -917,7 +921,7 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=()):
     from . import charts_stats, community_stats, encounter_stats
 
     community_acc = community_stats.new_accumulator(recent_versions)
-    charts_acc = charts_stats.new_accumulator()
+    charts_acc = charts_stats.new_accumulator(recent_versions)
     # Seed one encounter bucket per recent version so per-version runs have a
     # bucket to fold into (accumulate() only fills buckets that already exist).
     encounter_acc = encounter_stats.new_accumulator(recent_versions)
@@ -955,14 +959,6 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=()):
         uname = (row.get("username") or "").lower()
         if uname:
             extra_brackets = extra_brackets + _winrate_brackets(_asc, wr_map.get(uname))
-        # Version brackets: a run's build_id (when it's one of the recent
-        # versions the snapshot keeps slices for) becomes one more bracket
-        # key, so metrics/scores/stats can filter to a single game version
-        # through the same ?bracket= machinery. Versions never pair into
-        # composites; the pairing below only looks at player/skill keys.
-        _bid = (row.get("build_id") or "").strip()
-        if _bid in _recent_versions_set:
-            extra_brackets = extra_brackets + [_bid]
         # Player-count x skill composites (solo:wr50, ...) so the metrics page can
         # slice by both at once. Cheap: the run already matched both sides. Only
         # the entity cache reads these; the blob-bracket lists below filter to
@@ -971,6 +967,18 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=()):
         _sk = [b for b in extra_brackets if b in _SKILL_BRACKETS]
         if _pc and _sk:
             extra_brackets = extra_brackets + [f"{p}:{c}" for p in _pc for c in _sk]
+        # Version brackets: a run's build_id becomes one more bracket key AND
+        # composes with every bracket key the run already matched (player,
+        # skill, mode, player:skill), so any filter combo the UI can express
+        # has a materialized slice (solo:a10:v0.107.1). This doubles the
+        # per-run key count, which is what the sharded persistence and the
+        # ~2x walk cost in the PR notes account for.
+        _bid = (row.get("build_id") or "").strip()
+        _has_ver = _bid in _recent_versions_set
+        if _has_ver:
+            extra_brackets = (
+                extra_brackets + [f"{b}:{_bid}" for b in extra_brackets] + [_bid]
+            )
         for ck in extra_brackets:
             ct = bracket_accs[ck]["totals"]
             ct["total_runs"] += 1
@@ -1008,14 +1016,19 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=()):
         # Community blob ALSO slices by the player x skill composites (solo:wr50,
         # ...) so its page can combine both axes like the tier list. These only
         # apply to A10 runs from qualifying players, so most runs add nothing.
-        community_blob_brackets = (
-            mp_blob_brackets
-            + [c for c in extra_brackets if c in _COMPOSITE_BRACKETS_SET]
-            # Version slice: the community blob keeps one accumulator per
-            # recent game version too, so /community-stats and the stats
-            # page overview can filter by version.
-            + ([_bid] if _bid in _recent_versions_set else [])
-        )
+        community_blob_brackets = mp_blob_brackets + [
+            c for c in extra_brackets if c in _COMPOSITE_BRACKETS_SET
+        ]
+        # Version slices: one accumulator per game version, plus the version
+        # composed onto every other blob bracket ("all:version" collapses to
+        # the bare version key), so /community-stats combines version with
+        # players and skill like the entity cache does.
+        if _has_ver:
+            community_blob_brackets = (
+                community_blob_brackets
+                + [f"{b}:{_bid}" for b in community_blob_brackets if b != "all"]
+                + [_bid]
+            )
 
         # Community / fun stats, accumulated from the same blob. Guarded so
         # one malformed blob can't abort the whole snapshot rebuild.
@@ -1034,12 +1047,21 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=()):
                 "community-stats accumulate failed for %s", run_hash, exc_info=True
             )
 
-        # Chart cells for /api/charts, same guard.
+        # Chart cells for /api/charts, same guard. The blob charts combine
+        # their skill brackets with versions the same way the entity cache
+        # does, so the charts version filter isn't frame-charts-only.
+        charts_blob_brackets = blob_brackets
+        if _has_ver:
+            charts_blob_brackets = (
+                blob_brackets
+                + [f"{b}:{_bid}" for b in blob_brackets if b != "all"]
+                + [_bid]
+            )
         try:
             charts_stats.accumulate(
                 charts_acc,
                 blob,
-                brackets=blob_brackets,
+                brackets=charts_blob_brackets,
                 is_win=is_win,
                 character=character,
                 player_count=row.get("player_count") or 1,
@@ -1053,14 +1075,18 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=()):
         # Per-encounter combat stats for /api/runs/encounter-stats, folded
         # into the same blob read so the endpoint serves a precomputed
         # snapshot instead of a per-request triple-$unwind over every run.
-        # Also fold this run into its game-version bucket ("ver:<build_id>"),
-        # when that version is one of the recent ones we keep a slice for. It's
-        # a sibling of the content brackets, so this is just one more bucket in
-        # the same list — no cross-multiplication.
-        bid = row.get("build_id")
+        # Also fold this run into its game-version bucket ("ver:<build_id>",
+        # the legacy bare-version key the endpoint still reads) AND into the
+        # version composed with every content/player bracket, so the
+        # encounters page can combine bracket + version instead of the
+        # version overriding the bracket.
         enc_brackets = mp_blob_brackets
-        if bid and bid in _recent_versions_set:
-            enc_brackets = mp_blob_brackets + [f"ver:{bid}"]
+        if _has_ver:
+            enc_brackets = (
+                mp_blob_brackets
+                + [f"{b}:{_bid}" for b in mp_blob_brackets if b != "all"]
+                + [f"ver:{_bid}"]
+            )
         try:
             encounter_stats.accumulate(
                 encounter_acc,
@@ -1896,21 +1922,59 @@ def _persist_snapshot(
         by_type.setdefault(etype, []).append(entry)
     now = datetime.now(timezone.utc)
     for etype, entities in by_type.items():
+        # Chunked storage: with version-composable brackets every popular
+        # entity carries hundreds of per-bracket blocks, so one doc per
+        # entity type can cross Mongo's 16MB document cap. The index doc
+        # keeps the chunk count; stale higher-numbered chunks from a
+        # previous (larger) snapshot are deleted so a shrink can't leave
+        # phantom entities behind.
+        prev = coll.find_one({"_id": etype}, {"chunk_count": 1}) or {}
+        chunks = [
+            entities[i : i + _ENTITY_CHUNK]
+            for i in range(0, len(entities), _ENTITY_CHUNK)
+        ] or [[]]
+        for ci, chunk in enumerate(chunks):
+            coll.replace_one(
+                {"_id": f"{etype}:chunk:{ci}"},
+                {"_id": f"{etype}:chunk:{ci}", "entities": chunk, "updated_at": now},
+                upsert=True,
+            )
         coll.replace_one(
             {"_id": etype},
-            {"_id": etype, "entities": entities, "updated_at": now},
+            {"_id": etype, "chunk_count": len(chunks), "updated_at": now},
             upsert=True,
         )
+        stale = [
+            f"{etype}:chunk:{ci}"
+            for ci in range(len(chunks), prev.get("chunk_count") or 0)
+        ]
+        if stale:
+            coll.delete_many({"_id": {"$in": stale}})
     bracket_meta = bracket_meta or {}
-    # The charts, community, and encounter blobs are all per-bracket now (~5x
-    # bigger), so each lives in its own doc rather than __meta__ to stay well
-    # under Mongo's 16MB per-document cap as more bracketed cells accumulate.
-    for blob_id in ("charts", "community", "encounters"):
+    # The community, charts, and encounter blobs are per-bracket AND
+    # per-version-composite now (hundreds of keys), far past the 16MB
+    # single-doc cap, so each shards one doc per bracket key with the key
+    # list in its index doc. Stale keys from a previous (larger) snapshot
+    # are deleted the same way as entity chunks.
+    for blob_id in ("community", "charts", "encounters"):
+        blob = bracket_meta.get(blob_id, {}) or {}
+        prev_doc = coll.find_one({"_id": blob_id}, {"keys": 1}) or {}
+        for bkey, acc in blob.items():
+            coll.replace_one(
+                {"_id": f"{blob_id}:{bkey}"},
+                {"_id": f"{blob_id}:{bkey}", "blob": acc, "updated_at": now},
+                upsert=True,
+            )
         coll.replace_one(
             {"_id": blob_id},
-            {"_id": blob_id, "blob": bracket_meta.get(blob_id, {}), "updated_at": now},
+            {"_id": blob_id, "keys": sorted(blob.keys()), "updated_at": now},
             upsert=True,
         )
+        stale = [
+            f"{blob_id}:{k}" for k in (prev_doc.get("keys") or []) if k not in blob
+        ]
+        if stale:
+            coll.delete_many({"_id": {"$in": stale}})
     coll.replace_one(
         {"_id": "__meta__"},
         {
@@ -1966,7 +2030,14 @@ def _load_snapshot() -> bool:
         doc = coll.find_one({"_id": etype})
         if not doc:
             continue
-        for e in doc.get("entities", []):
+        # v20+ snapshots chunk the entity array across docs (16MB cap);
+        # older ones keep it inline. Read whichever shape this doc has.
+        entities = doc.get("entities", [])
+        if not entities and doc.get("chunk_count"):
+            for ci in range(int(doc["chunk_count"])):
+                cdoc = coll.find_one({"_id": f"{etype}:chunk:{ci}"}) or {}
+                entities.extend(cdoc.get("entities", []))
+        for e in entities:
             by_char = {
                 c["character"]: {"picks": c["picks"], "wins": c["wins"]}
                 for c in e.get("by_character", [])
@@ -2002,8 +2073,20 @@ def _load_snapshot() -> bool:
     # encounters inline in __meta__, so fall back to that. A genuinely missing
     # blob stays empty until the leader rebuilds the new shape.
     def _blob_doc(blob_id: str):
-        doc = coll.find_one({"_id": blob_id})
-        return (doc or {}).get("blob") or meta.get(blob_id) or {}
+        # v20+ shards each blob one doc per bracket key (the key list lives
+        # in the index doc — hundreds of keys with version composites, far
+        # past the single-doc cap); older snapshots kept the whole map in
+        # one doc's "blob" (or inline in __meta__ before that).
+        doc = coll.find_one({"_id": blob_id}) or {}
+        keys = doc.get("keys")
+        if not keys:
+            return doc.get("blob") or meta.get(blob_id) or {}
+        out: dict[str, Any] = {}
+        for k in keys:
+            kdoc = coll.find_one({"_id": f"{blob_id}:{k}"}) or {}
+            if kdoc.get("blob") is not None:
+                out[k] = kdoc["blob"]
+        return out
 
     _apply_cache(
         new_cache,
@@ -2159,13 +2242,19 @@ def _compute_score(wins: int, picks: int, baseline: float) -> int | None:
 
 
 def _pick_bracket_blob(blob: dict, bracket: str | None, empty_one):
-    """Pick one bracket's finalized sub-blob from a per-bracket blob. Unknown
-    bracket falls back to 'all'; a pre-v9 FLAT blob (no per-bracket keys) is
-    served as-is for any bracket; an empty/missing blob -> a single empty blob."""
+    """Pick one bracket's finalized sub-blob from a per-bracket blob. A
+    requested-but-absent bracket returns the EMPTY shape, not the "all"
+    fallback: silently serving all-runs data for a version slice the
+    snapshot hasn't materialized yet reads as wrong numbers, while an empty
+    state honestly says "no data for this slice" (it self-heals when the
+    current-version snapshot finishes rebuilding). A pre-v9 FLAT blob (no
+    per-bracket keys) is served as-is; an empty/missing blob -> empty."""
     if not blob:
         return empty_one()
     if "all" in blob:  # per-bracket shape {all: ..., a10: ..., ...}
-        return blob.get(bracket or "all") or blob.get("all") or empty_one()
+        if bracket and bracket != "all":
+            return blob.get(bracket) or empty_one()
+        return blob.get("all") or empty_one()
     return blob  # flat pre-v9 blob; the bracket can't apply until it rebuilds
 
 
@@ -2194,6 +2283,22 @@ def get_charts_blob_stats() -> dict[str, Any]:
     return _charts_blob_stats or charts_stats.empty()
 
 
+def is_valid_stat_bracket(bracket: str | None) -> bool:
+    """True when `bracket` names a materialized snapshot slice: a plain
+    bracket key (solo, a10, solo:wr50, ...), a bare game version
+    (v0.107.1), or any plain key composed with a version
+    (solo:a10:v0.107.1). The single source of truth for ?bracket=
+    validation, so the endpoints can't drift from what _accumulate
+    actually materializes."""
+    if not bracket:
+        return False
+    _maybe_rebuild()
+    if bracket in _BRACKET_KEYS or bracket in _recent_stat_versions:
+        return True
+    base, sep, ver = bracket.rpartition(":")
+    return bool(sep) and ver in _recent_stat_versions and base in _BRACKET_KEYS
+
+
 def get_recent_stat_versions() -> list[str]:
     """Game versions (build_ids) the encounter blob carries a per-version slice
     for, newest first — the options the stats-page version dropdown offers.
@@ -2219,12 +2324,19 @@ def get_encounter_stats(
 
     `build_id` selects the per-version slice ("ver:<build_id>") instead of a
     content bracket, for comparing an enemy across balance patches. Only the
-    recent versions in `get_recent_stat_versions()` have a bucket; an unknown
-    one falls back to "all"."""
+    versions in `get_recent_stat_versions()` have a bucket; an unknown one
+    returns the empty shape (never a silent all-runs fallback)."""
     _maybe_rebuild()
     from . import encounter_stats
 
-    key = f"ver:{build_id}" if build_id else bracket
+    # bracket + build_id COMBINE (v20 keeps bracket x version buckets); a
+    # bare version reads the legacy "ver:" bucket.
+    if build_id and bracket and bracket != "all":
+        key = f"{bracket}:{build_id}"
+    elif build_id:
+        key = f"ver:{build_id}"
+    else:
+        key = bracket
     sub = _pick_bracket_blob(
         _encounter_blob_stats or encounter_stats.empty(),
         key,
@@ -2295,7 +2407,7 @@ def get_all_entity_scores(
     # counts, mirroring get_entity_metrics_table. character scoping isn't tracked
     # per bracket, so it's ignored here; act + bracket don't combine (act returns
     # above). Unknown bracket falls through to the all-runs path below.
-    if bracket and (bracket in _BRACKET_KEYS or bracket in _recent_stat_versions):
+    if bracket and is_valid_stat_bracket(bracket):
         c_baseline = _bracket_baselines.get(bracket, {}).get(
             entity_type, _baseline_win_rate()
         )
@@ -2423,7 +2535,7 @@ def get_entity_metrics_table(
     """
     _maybe_rebuild()
     character = (character or "").strip().upper() or None
-    use_bracket = bracket in _BRACKET_KEYS or bracket in _recent_stat_versions
+    use_bracket = is_valid_stat_bracket(bracket)
     if use_bracket:
         baseline = _bracket_baselines.get(bracket, {}).get(
             entity_type, _baseline_win_rate()

--- a/frontend/app/charts/ChartsClient.tsx
+++ b/frontend/app/charts/ChartsClient.tsx
@@ -244,6 +244,16 @@ function ChartsClientInner() {
   const [players, setPlayers] = useState(searchParams.get("players") || "");
   const [ascension, setAscension] = useState(searchParams.get("ascension") || "");
   const [bracket, setBracket] = useState(() => normalizeBracket(searchParams.get("bracket")));
+  // Game version: query-time on frame charts, per-version snapshot buckets
+  // on blob charts — combines with every other filter either way.
+  const [buildId, setBuildId] = useState(searchParams.get("version") || "");
+  const [versions, setVersions] = useState<string[]>([]);
+  useEffect(() => {
+    fetch(`${API}/api/runs/versions`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => setVersions(d?.stat_versions || []))
+      .catch(() => {});
+  }, []);
   const [gameMode, setGameMode] = useState(searchParams.get("mode") || "");
   const [usernameInput, setUsernameInput] = useState(searchParams.get("user") || "");
   const [username, setUsername] = useState(searchParams.get("user") || "");
@@ -331,6 +341,7 @@ function ChartsClientInner() {
     if (players) p.set("players", players);
     if (ascension) p.set("ascension", ascension);
     if (bracket !== "all") p.set("bracket", bracket);
+    if (buildId) p.set("version", buildId);
     if (gameMode) p.set("mode", gameMode);
     if (username) p.set("user", username);
     if (split !== "character" && spec?.splits.includes(split)) p.set("split", split);
@@ -347,7 +358,7 @@ function ChartsClientInner() {
     }
     const qs = p.toString();
     router.replace(`/charts${qs ? `?${qs}` : ""}`, { scroll: false });
-  }, [chart, players, ascension, bracket, gameMode, username, split, stat, xStat, yStat, encounter, event, etype, entity, needsEntity, spec, router]);
+  }, [chart, players, ascension, bracket, buildId, gameMode, username, split, stat, xStat, yStat, encounter, event, etype, entity, needsEntity, spec, router]);
 
   // Fetch the chart itself.
   useEffect(() => {
@@ -359,6 +370,7 @@ function ChartsClientInner() {
     if (players) p.set("players", players);
     if (spec.kind === "frame" && !spec.daily && ascension) p.set("ascension", ascension);
     if (!spec.daily && bracket !== "all") p.set("bracket", bracket);
+    if (buildId) p.set("build_id", buildId);
     if (spec.kind === "frame" && !spec.daily && gameMode) p.set("game_mode", gameMode);
     if (username) p.set("username", username);
     if (spec.splits.includes(split) && split !== "character") p.set("split", split);
@@ -410,7 +422,7 @@ function ChartsClientInner() {
       }
     })();
     return () => ctrl.abort();
-  }, [spec, meta, players, ascension, bracket, gameMode, username, split, stat, xStat, yStat, encounter, event, effEtype, entity, needsEntity]);
+  }, [spec, meta, players, ascension, bracket, buildId, gameMode, username, split, stat, xStat, yStat, encounter, event, effEtype, entity, needsEntity]);
 
   const groups = useMemo(() => {
     const g = new Map<string, ChartSpec[]>();
@@ -559,6 +571,21 @@ function ChartsClientInner() {
             onChange={setBracket}
             disabled={spec?.daily}
           />
+          {/* Game version: combines with every other filter (query-time on
+              frame charts, per-version snapshot buckets on blob charts). */}
+          {versions.length > 0 && (
+            <select
+              value={buildId}
+              onChange={(e) => setBuildId(e.target.value)}
+              aria-label="Game version"
+              className="text-xs px-2 py-1.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-card)] text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent-gold)]"
+            >
+              <option value="">{t("All versions", lang)}</option>
+              {versions.map((v) => (
+                <option key={v} value={v}>{v}</option>
+              ))}
+            </select>
+          )}
           {spec?.kind === "blob" && (
             <span className="text-xs text-[var(--text-muted)]">
               {t("Exact ascension and mode don't apply here; use the Bracket to slice by skill.", lang)}

--- a/frontend/app/components/BracketFilter.tsx
+++ b/frontend/app/components/BracketFilter.tsx
@@ -5,6 +5,7 @@ import {
   normalizeBracket,
   splitBracket,
   combineBracket,
+  stripVersion,
   type ContentBracket,
 } from "@/lib/content-brackets";
 import VersionSelectNav from "@/app/components/VersionSelectNav";
@@ -34,7 +35,7 @@ export default function BracketFilter({
   composite?: boolean;
 }) {
   const active = normalizeBracket(current);
-  const { player, skill } = splitBracket(active);
+  const { player, skill, version } = splitBracket(active);
 
   const hrefFor = (bracketValue: string) => {
     const params = new URLSearchParams();
@@ -54,9 +55,15 @@ export default function BracketFilter({
     }`;
 
   if (!composite) {
-    // Mutually-exclusive: each pill sets ?bracket=<its key>.
+    // Mutually-exclusive pills (each sets the base bracket), but the version
+    // axis still composes: picking a pill keeps the version and vice versa.
+    const base = stripVersion(active);
     const renderPill = (b: ContentBracket) => (
-      <Link key={b.key} href={hrefFor(b.key)} className={pillCls(active === b.key)}>
+      <Link
+        key={b.key}
+        href={hrefFor(b.key === "all" ? version || "all" : version ? `${b.key}:${version}` : b.key)}
+        className={pillCls(base === b.key || (b.key === "all" && !base))}
+      >
         {b.label}
       </Link>
     );
@@ -70,8 +77,12 @@ export default function BracketFilter({
           <span className="text-xs text-[var(--text-muted)] mx-1">Players</span>
           {PLAYER_BRACKETS.map(renderPill)}
         </div>
-        {/* Game version shares the same slot too (exclusive slice). */}
-        <VersionSelectNav basePath={basePath} current={active} extraParams={extraParams} />
+        <VersionSelectNav
+          basePath={basePath}
+          current={active}
+          extraParams={extraParams}
+          base={base}
+        />
       </div>
     );
   }
@@ -88,7 +99,7 @@ export default function BracketFilter({
           return (
             <Link
               key={b.key}
-              href={hrefFor(combineBracket(player, targetSkill))}
+              href={hrefFor(combineBracket(player, targetSkill, version))}
               className={pillCls(skill === targetSkill)}
             >
               {b.label}
@@ -101,16 +112,21 @@ export default function BracketFilter({
         {playerOpts.map((b) => (
           <Link
             key={b.key || "all"}
-            href={hrefFor(combineBracket(b.key, skill))}
+            href={hrefFor(combineBracket(b.key, skill, version))}
             className={pillCls(player === b.key)}
           >
             {b.label}
           </Link>
         ))}
       </div>
-      {/* Game version is an exclusive slice of the same ?bracket= slot:
-          picking one replaces the player/skill selection and vice versa. */}
-      <VersionSelectNav basePath={basePath} current={active} extraParams={extraParams} />
+      {/* Game version is a third axis: it composes with the player and
+          skill selections instead of replacing them. */}
+      <VersionSelectNav
+        basePath={basePath}
+        current={active}
+        extraParams={extraParams}
+        base={combineBracket(player, skill) === "all" ? "" : combineBracket(player, skill)}
+      />
     </div>
   );
 }

--- a/frontend/app/components/EntityRunStats.tsx
+++ b/frontend/app/components/EntityRunStats.tsx
@@ -155,17 +155,24 @@ export default function EntityRunStats({ entityType, entityId, entityName, varia
   // A10 selected reads the "solo:a10" composite block. Only offered when the
   // API response carries player-count brackets (post-update snapshots).
   const availablePlayers = PLAYER_BRACKETS.filter((b) => brackets[b.key]);
-  // Version slices ride the same brackets dict (build_id keys, v18+
-  // snapshots). A version is exclusive: it replaces the player/skill pair.
+  // Version slices ride the same brackets dict (build_id keys). The version
+  // is a third axis (v20 snapshots): it composes with the player/skill pair
+  // (solo:a10:v0.107.1) instead of replacing it.
   const availableVersions = Object.keys(brackets)
     .filter((k) => /^v\d/.test(k))
     .sort()
     .reverse();
-  const selVersion = availableVersions.includes(selectedBracket) ? selectedBracket : "";
-  const { player: selPlayer, skill: selSkill } = splitBracket(selectedBracket);
-  const pickPlayer = (p: string) => setSelectedBracket(combineBracket(p, selSkill));
+  const {
+    player: selPlayer,
+    skill: selSkill,
+    version: selVersion,
+  } = splitBracket(selectedBracket);
+  const pickPlayer = (p: string) =>
+    setSelectedBracket(combineBracket(p, selSkill, selVersion));
   const pickSkill = (sk: string) =>
-    setSelectedBracket(combineBracket(selPlayer, sk === "all" ? "" : sk));
+    setSelectedBracket(combineBracket(selPlayer, sk === "all" ? "" : sk, selVersion));
+  const pickVersion = (v: string) =>
+    setSelectedBracket(combineBracket(selPlayer, selSkill, v));
   const sel = brackets[selectedBracket] ?? brackets["all"];
   // Everything below scopes to the selected bracket, with a fall back to the
   // global figures for a pre-update API response that lacks the per-bracket data.
@@ -179,6 +186,7 @@ export default function EntityRunStats({ entityType, entityId, entityName, varia
     [
       availablePlayers.find((b) => b.key === selPlayer)?.label,
       CONTENT_BRACKETS.find((b) => b.key === (selSkill || "all"))?.label,
+      selVersion || undefined,
     ]
       .filter(Boolean)
       .join(" · ") || "All";
@@ -241,7 +249,7 @@ export default function EntityRunStats({ entityType, entityId, entityName, varia
             {availableVersions.length > 0 && (
               <select
                 value={selVersion}
-                onChange={(e) => setSelectedBracket(e.target.value || "all")}
+                onChange={(e) => pickVersion(e.target.value)}
                 className="ml-1 rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)] focus:outline-none"
                 aria-label="Game version"
               >

--- a/frontend/app/components/VersionSelectNav.tsx
+++ b/frontend/app/components/VersionSelectNav.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { isVersionBracket } from "@/lib/content-brackets";
+import { splitBracket } from "@/lib/content-brackets";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -10,19 +10,22 @@ const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
  * The Version row of BracketFilter. Client half of a server component: it
  * self-populates from /api/runs/versions (stat_versions = the versions the
  * snapshot keeps per-version slices for) and navigates the same way the
- * bracket pills do (?bracket=v0.107.1; "All versions" drops the param).
- * A version is an exclusive bracket, so picking one replaces any player/
- * skill selection, and picking a pill afterwards replaces the version.
- * Renders nothing while the version list is loading or empty.
+ * bracket pills do. The version is a third axis that COMPOSES with the
+ * current bracket selection: picking one keeps `base` (the player/skill
+ * selection, e.g. "solo:wr50") and emits ?bracket=solo:wr50:v0.107.1;
+ * "All versions" drops back to the base alone. Renders nothing while the
+ * version list is loading or empty.
  */
 export default function VersionSelectNav({
   basePath,
   current,
   extraParams,
+  base = "",
 }: {
   basePath: string;
   current: string;
   extraParams?: Record<string, string | undefined>;
+  base?: string;
 }) {
   const router = useRouter();
   const [versions, setVersions] = useState<string[]>([]);
@@ -38,15 +41,16 @@ export default function VersionSelectNav({
 
   // Keep a URL-supplied version selectable even if it fell out of the
   // snapshot's list (stale link), so the select reflects the page state.
-  const value = isVersionBracket(current) ? current : "";
+  const value = splitBracket(current).version;
   const options = value && !versions.includes(value) ? [value, ...versions] : versions;
 
   const onChange = (v: string) => {
+    const bracket = v ? (base ? `${base}:${v}` : v) : base;
     const params = new URLSearchParams();
     for (const [k, val] of Object.entries(extraParams ?? {})) {
       if (val) params.set(k, val);
     }
-    if (v) params.set("bracket", v);
+    if (bracket && bracket !== "all") params.set("bracket", bracket);
     const qs = params.toString();
     router.push(qs ? `${basePath}?${qs}` : basePath);
   };

--- a/frontend/app/leaderboards/encounters/EncounterStatsClient.tsx
+++ b/frontend/app/leaderboards/encounters/EncounterStatsClient.tsx
@@ -79,8 +79,8 @@ export default function EncounterStatsClient() {
   const [multiplayer, setMultiplayer] = useState<"any" | "only" | "exclude">("any");
   const [bracket, setBracket] = useState("all");
   // Game versions the snapshot keeps encounter slices for; filters via the
-  // endpoint's build_id param (exclusive axis, does not combine with bracket
-  // on the backend's per-version slices).
+  // endpoint's build_id param. Combines with the bracket (v20 snapshots
+  // keep bracket x version buckets).
   const [version, setVersion] = useState("");
   const [statVersions, setStatVersions] = useState<string[]>([]);
   useEffect(() => {

--- a/frontend/app/leaderboards/metrics/MetricsClient.tsx
+++ b/frontend/app/leaderboards/metrics/MetricsClient.tsx
@@ -80,28 +80,44 @@ const PLAYER_KEYS = PLAYER_AXIS.map((a) => a.key).filter(Boolean);
 const SKILL_KEYS = SKILL_AXIS.map((a) => a.key).filter(Boolean);
 const MODE_KEYS = MODE_AXIS.map((a) => a.key).filter(Boolean);
 
-// Split a bracket key into its axes. A "player:skill" composite splits on the
-// colon; a single bracket maps to whichever axis owns it.
-function parseBracket(b: string): { player: string; skill: string; mode: string } {
+// Split a bracket key into its axes. The version rides as a trailing
+// ":vX.Y.Z" segment on any base (or stands alone); a "player:skill"
+// composite splits on the colon; a single bracket maps to whichever axis
+// owns it.
+function parseBracket(b: string): {
+  player: string;
+  skill: string;
+  mode: string;
+  version: string;
+} {
+  let version = "";
+  const i = b.lastIndexOf(":");
+  if (i > 0 && /^v\d/.test(b.slice(i + 1))) {
+    version = b.slice(i + 1);
+    b = b.slice(0, i);
+  } else if (/^v\d/.test(b)) {
+    return { player: "", skill: "", mode: "", version: b };
+  }
   if (b.includes(":")) {
     const [p, s] = b.split(":");
-    return { player: p, skill: s, mode: "" };
+    return { player: p, skill: s, mode: "", version };
   }
-  if (PLAYER_KEYS.includes(b)) return { player: b, skill: "", mode: "" };
-  if (SKILL_KEYS.includes(b)) return { player: "", skill: b, mode: "" };
-  if (MODE_KEYS.includes(b)) return { player: "", skill: "", mode: b };
-  return { player: "", skill: "", mode: "" };
+  if (PLAYER_KEYS.includes(b)) return { player: b, skill: "", mode: "", version };
+  if (SKILL_KEYS.includes(b)) return { player: "", skill: b, mode: "", version };
+  if (MODE_KEYS.includes(b)) return { player: "", skill: "", mode: b, version };
+  return { player: "", skill: "", mode: "", version };
 }
 
-// Mode is exclusive with player/skill (there are no daily/custom composites).
-function combineBracket(player: string, skill: string, mode: string): string {
-  if (mode) return mode;
-  if (player && skill) return `${player}:${skill}`;
-  return player || skill || "all";
+// Mode is exclusive with player/skill (there are no daily/custom player
+// composites), but the version composes with any of them.
+function combineBracket(player: string, skill: string, mode: string, version = ""): string {
+  const base = mode || [player, skill].filter(Boolean).join(":");
+  if (base && version) return `${base}:${version}`;
+  return base || version || "all";
 }
 
 function bracketLabel(b: string, lang: string): string {
-  const { player, skill, mode } = parseBracket(b);
+  const { player, skill, mode, version } = parseBracket(b);
   const parts: string[] = [];
   const pl = PLAYER_AXIS.find((a) => a.key === player);
   if (player && pl) parts.push(t(pl.label, lang));
@@ -109,6 +125,7 @@ function bracketLabel(b: string, lang: string): string {
   if (skill && sl) parts.push(t(sl.label, lang));
   const ml = MODE_AXIS.find((a) => a.key === mode);
   if (mode && ml) parts.push(t(ml.label, lang));
+  if (version) parts.push(version);
   return parts.length ? parts.join(" + ") : t("All runs", lang);
 }
 
@@ -189,9 +206,9 @@ export default function MetricsClient({
   } | null>(null);
 
   const sel = parseBracket(bracket);
-  // Game versions the snapshot keeps per-version slices for. A version is
-  // its own exclusive bracket (it doesn't compose with player/skill), so
-  // selecting one clears the other axes, same as the mode pills.
+  // Game versions the snapshot keeps per-version slices for. The version is
+  // a third axis (v20): it composes with the player/skill (or mode) pills
+  // instead of clearing them.
   const [statVersions, setStatVersions] = useState<string[]>([]);
   useEffect(() => {
     fetch(`${API}/api/runs/versions`)
@@ -199,7 +216,7 @@ export default function MetricsClient({
       .then((d) => setStatVersions(d?.stat_versions || []))
       .catch(() => {});
   }, []);
-  const selVersion = statVersions.includes(bracket) ? bracket : "";
+  const selVersion = sel.version;
   const nav = (key: string, char: string = character) => {
     const base = `${lp}/leaderboards/metrics`;
     const params = new URLSearchParams();
@@ -209,9 +226,12 @@ export default function MetricsClient({
     router.push(qs ? `${base}?${qs}` : base);
   };
   // Player and skill combine; picking either clears the exclusive mode axis.
-  const pickPlayer = (p: string) => nav(combineBracket(p, sel.skill, ""));
-  const pickSkill = (s: string) => nav(combineBracket(sel.player, s, ""));
-  const pickMode = (m: string) => nav(m || "all");
+  // Every pill keeps the version selection.
+  const pickPlayer = (p: string) => nav(combineBracket(p, sel.skill, "", sel.version));
+  const pickSkill = (s: string) => nav(combineBracket(sel.player, s, "", sel.version));
+  const pickMode = (m: string) => nav(combineBracket("", "", m, sel.version));
+  const pickVersion = (v: string) =>
+    nav(combineBracket(sel.player, sel.skill, sel.mode, v));
   // "Played by": server-side character re-scope (that character's runs), on top
   // of any bracket. Distinct from the card-color filter below, which only
   // narrows which cards are listed.
@@ -347,7 +367,7 @@ export default function MetricsClient({
           <span className="mr-1 w-12 text-xs text-[var(--text-muted)]">{t("Version", lang)}</span>
           <select
             value={selVersion}
-            onChange={(e) => nav(e.target.value || "all")}
+            onChange={(e) => pickVersion(e.target.value)}
             className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-card)] px-2 py-1 text-xs text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent-gold)]"
           >
             <option value="">{t("All versions", lang)}</option>

--- a/frontend/app/leaderboards/metrics/metrics-data.ts
+++ b/frontend/app/leaderboards/metrics/metrics-data.ts
@@ -70,11 +70,17 @@ export const BRACKETS = [
 const _PLAYER_KEYS = ["solo", "2p", "3p", "4p"];
 const _SKILL_KEYS = ["a10", "wr30", "wr50", "wr75"];
 function isValidBracket(b: string): boolean {
+  // A trailing ":vX.Y.Z" version segment composes with any base (v20
+  // snapshots), and a bare version stands alone. Without this the server
+  // silently normalized version brackets to "all", so the dropdown wrote
+  // the URL but nothing changed.
+  const i = b.lastIndexOf(":");
+  if (i > 0 && /^v\d+(\.\d+)*$/.test(b.slice(i + 1))) {
+    b = b.slice(0, i);
+  } else if (/^v\d+(\.\d+)*$/.test(b)) {
+    return true;
+  }
   if (BRACKETS.some((c) => c.key === b)) return true;
-  // Game-version slices (v0.107.1) are exclusive snapshot brackets too.
-  // Without this the server silently normalized ?bracket=v0.106.0 to "all",
-  // so the version dropdown wrote the URL but nothing changed.
-  if (/^v\d+(\.\d+)*$/.test(b)) return true;
   const [p, s] = b.split(":");
   return _PLAYER_KEYS.includes(p) && _SKILL_KEYS.includes(s);
 }

--- a/frontend/app/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/leaderboards/stats/StatsClient.tsx
@@ -333,13 +333,16 @@ export default function StatsClient() {
       .then((d) => setStatVersions(d?.stat_versions || []))
       .catch(() => {});
   }, []);
-  const bracketActive = bracket !== "all";
-  const isVersion = /^v\d/.test(bracket);
-  // The ?bracket= value combining both axes, e.g. "wr50", "solo:wr50".
-  // A version bracket is exclusive: it never composes with player counts.
-  const apiBracket = isVersion
-    ? bracket
-    : combineBracket(PLAYERS_TO_BRACKET[players] ?? "", bracketActive ? bracket : "");
+  // Game version: a third axis (v20 snapshots) that composes with the
+  // skill bracket and the player count instead of replacing them.
+  const [version, setVersion] = useState("");
+  const bracketActive = bracket !== "all" || version !== "";
+  // The ?bracket= value combining all axes, e.g. "solo:wr50:v0.107.1".
+  const apiBracket = combineBracket(
+    PLAYERS_TO_BRACKET[players] ?? "",
+    bracket !== "all" ? bracket : "",
+    version,
+  );
 
   // Tabs
   const [tab, setTab] = useState<TopTab>("overview");
@@ -939,8 +942,8 @@ export default function StatsClient() {
         })}
         {statVersions.length > 0 && (
           <select
-            value={isVersion ? bracket : ""}
-            onChange={(e) => setBracket(e.target.value || "all")}
+            value={version}
+            onChange={(e) => setVersion(e.target.value)}
             className="text-xs px-2 py-1.5 rounded-md border bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent-gold)]"
             aria-label="Game version"
           >

--- a/frontend/lib/content-brackets.ts
+++ b/frontend/lib/content-brackets.ts
@@ -39,12 +39,31 @@ const _SKILL_KEYS = new Set(
 );
 
 /**
- * A game-version bracket ("v0.107.1"): the snapshot keeps an exclusive
- * per-version slice for every release version, so a version is a valid
- * ?bracket= value on its own (it never composes with player/skill).
+ * A game-version bracket ("v0.107.1"): the snapshot keeps a per-version
+ * slice for every release version, both standalone and composed onto any
+ * other bracket key ("solo:wr50:v0.107.1"), so versions combine with the
+ * player and skill axes everywhere.
  */
 export function isVersionBracket(raw: string | undefined | null): boolean {
   return !!raw && /^v\d+(\.\d+)*$/.test(raw);
+}
+
+/** The bracket value minus any trailing version segment ("" for a bare
+ * version or "all"). */
+export function stripVersion(raw: string | undefined | null): string {
+  if (!raw || raw === "all") return "";
+  const { base } = splitVersion(raw);
+  return base === "all" ? "" : base;
+}
+
+/** Split a trailing ":vX.Y.Z" version segment off a bracket value. */
+function splitVersion(raw: string): { base: string; version: string } {
+  const i = raw.lastIndexOf(":");
+  if (i > 0 && isVersionBracket(raw.slice(i + 1))) {
+    return { base: raw.slice(0, i), version: raw.slice(i + 1) };
+  }
+  if (isVersionBracket(raw)) return { base: "", version: raw };
+  return { base: raw, version: "" };
 }
 
 /**
@@ -58,35 +77,43 @@ export function isCompositeBracket(raw: string | undefined | null): boolean {
   return _PLAYER_KEYS.has(p) && _SKILL_KEYS.has(s);
 }
 
-/** Split a bracket value into its player + skill axes. A single bracket maps to
- * whichever axis owns it; "all"/unknown gives both empty. */
+/** Split a bracket value into its player + skill + version axes. A single
+ * bracket maps to whichever axis owns it; "all"/unknown gives all empty. */
 export function splitBracket(raw: string | undefined | null): {
   player: string;
   skill: string;
+  version: string;
 } {
   const b = normalizeBracket(raw);
-  if (isCompositeBracket(b)) {
-    const [player, skill] = b.split(":");
-    return { player, skill };
+  const { base, version } = splitVersion(b === "all" ? "" : b);
+  if (isCompositeBracket(base)) {
+    const [player, skill] = base.split(":");
+    return { player, skill, version };
   }
-  if (_PLAYER_KEYS.has(b)) return { player: b, skill: "" };
-  if (_SKILL_KEYS.has(b)) return { player: "", skill: b };
-  return { player: "", skill: "" };
+  if (_PLAYER_KEYS.has(base)) return { player: base, skill: "", version };
+  if (_SKILL_KEYS.has(base)) return { player: "", skill: base, version };
+  return { player: "", skill: "", version };
 }
 
-/** Combine a player + skill selection into one ?bracket= value. */
-export function combineBracket(player: string, skill: string): string {
-  if (player && skill) return `${player}:${skill}`;
-  return player || skill || "all";
+/** Combine player + skill + version selections into one ?bracket= value.
+ * Any subset works: the axes compose in canonical player:skill:version
+ * order, and all-empty collapses to "all". */
+export function combineBracket(player: string, skill: string, version = ""): string {
+  const base = [player, skill].filter(Boolean).join(":");
+  if (base && version) return `${base}:${version}`;
+  return base || version || "all";
 }
 
-/** Normalize a raw ?bracket= value to a known bracket key or a player:skill
- * composite ("all" if unknown). */
+/** Normalize a raw ?bracket= value to a known bracket key, a player:skill
+ * composite, a game version, or any of those with a trailing version
+ * ("all" if unknown). */
 export function normalizeBracket(raw: string | undefined | null): string {
   if (!raw) return "all";
   if (_BY_KEY.has(raw)) return raw;
   if (isCompositeBracket(raw)) return raw;
   if (isVersionBracket(raw)) return raw;
+  const { base, version } = splitVersion(raw);
+  if (version && base && (_BY_KEY.has(base) || isCompositeBracket(base))) return raw;
   return "all";
 }
 
@@ -109,7 +136,9 @@ export function bracketListParams(key: string | undefined | null): {
   ascension_min?: number;
   winrate_min?: number;
 } {
-  switch (normalizeBracket(key)) {
+  // Only the skill axis maps to list filters; a composed player/version
+  // segment rides on its own params (players= / build_id=) at the callers.
+  switch (splitBracket(key).skill || normalizeBracket(key)) {
     case "a10":
       return { ascension_min: 10 };
     case "wr30":


### PR DESCRIPTION
This delivers the full flexibility we discussed: the version dropdown no longer clears the player/skill selection anywhere. Every bracket key a run matches also gets a version-composited sibling (`solo:wr50:v0.107.1`), so any filter combination the UI can express has a materialized slice.

**Coverage**
- Entity community boxes (cards/relics/potions): version select composes with the bracket + player pills.
- Metrics: version composes with player, skill, AND mode pills; the label row shows the full combination.
- Stats page: version is a separate axis that combines with the bracket pills and player filter.
- Tier lists + community-stats (via BracketFilter): pills keep the version, the version keeps the pills.
- Encounters: bracket + version now combine (previously build_id overrode the bracket).
- Charts: new version dropdown — query-time on frame charts (new build_id frame column), per-version snapshot buckets on blob charts, threaded through the Redis cache key.

**Snapshot mechanics** (the ~20x growth you approved)
- SNAPSHOT_VERSION 20. Entity docs chunk 150 entities per Mongo doc, and the community/charts/encounter blobs shard one doc per bracket key — a single doc would cross Mongo's 16MB document cap at this size. Loaders read both new and legacy shapes, and stale chunks/keys are cleaned up on persist.
- One shared `is_valid_stat_bracket()` grammar (plain key | version | key:version) validates ?bracket= on the entity endpoints and the community route, so validation can't drift from what the walk materializes.
- Honest empties: a requested slice the snapshot hasn't materialized yet returns the empty shape instead of silently serving all-runs data (the failure mode that made the version dropdowns look broken before).

**Costs to know about**
- The per-run bracket key count roughly doubles, so expect the post-deploy v20 rebuild to take about twice the usual walk time. Composed slices are empty until it lands (the UI shows them as no-data rather than wrong data).
- Snapshot storage grows ~10-20x on the bracket blocks; the sharded persistence keeps every doc well under the Mongo cap.

Verified: bracket-grammar unit tests (valid/invalid composites), accumulator key-set tests for all three blobs, ruff check + format, tsc, and a full production build.