### PR TITLE
Fix entity trend charts never rendering

### DIFF
--- a/frontend/app/components/EntityTrends.tsx
+++ b/frontend/app/components/EntityTrends.tsx
@@ -105,8 +105,13 @@ export default function EntityTrends({
       `${API}/api/charts/entity-over-time?etype=${entityType}&entity=${entityId.toUpperCase()}${bq}`,
     )
       .then((r) => (r.ok ? r.json() : null))
-      .then((d: Series[] | null) => {
-        if (alive) setSeries(Array.isArray(d) ? d : []);
+      .then((d: { series?: Series[] } | Series[] | null) => {
+        // The charts endpoint wraps the series in its standard payload
+        // ({chart, label, series: [...]}), not a bare array. Expecting an
+        // array here meant every response parsed to [] and the trend charts
+        // never rendered anywhere.
+        const arr = Array.isArray(d) ? d : d?.series;
+        if (alive) setSeries(Array.isArray(arr) ? arr : []);
       })
       .catch(() => {
         if (alive) setSeries([]);


### PR DESCRIPTION
The per-entity trend charts (weekly win rate vs baseline + pick rate under the community stats box on card/relic/potion pages) have never rendered, and the reason turned out to be a one-line payload mismatch: `EntityTrends` expected `/api/charts/entity-over-time` to return a bare array of series, but the charts endpoint wraps everything in its standard payload (`{chart, label, series: [...], total_runs}`). The `Array.isArray` guard failed on every response, so the component always parsed an empty list and hid itself.

The API side has been fine all along — it's serving 16 weeks of WITH/BASE/PICK series for popular entities right now. This unwraps `series` from the payload (still accepting a bare array defensively), so the charts appear immediately on deploy with no rebuild or data backfill needed.

Verified against the live payload shape and tsc passes.