### PR TITLE
Fix the language switcher appending /zht onto zht pages

### DIFF
--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -9,10 +9,11 @@ import { useLanguage } from "./contexts/LanguageContext";
 import { useAuth } from "./contexts/AuthContext";
 import { t } from "@/lib/ui-translations";
 
-const LANG_CODES = new Set(["deu", "esp", "fra", "ita", "jpn", "kor", "pol", "ptb", "rus", "spa", "tha", "tur", "zhs"]);
+const LANG_CODES = LANG_PREFIXES;
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 import { imageUrl } from "@/lib/image-url";
+import { LANG_PREFIXES } from "@/lib/languages";
 
 interface Translations {
   sections?: Record<string, string>;

--- a/frontend/app/components/LanguageSelector.tsx
+++ b/frontend/app/components/LanguageSelector.tsx
@@ -3,8 +3,9 @@
 import { useState, useRef, useEffect } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { useLanguage, LANGUAGES } from "../contexts/LanguageContext";
+import { LANG_PREFIXES } from "../../lib/languages";
 
-const LANG_CODES = new Set(["deu", "esp", "fra", "ita", "jpn", "kor", "pol", "ptb", "rus", "spa", "tha", "tur", "zhs"]);
+const LANG_CODES = LANG_PREFIXES;
 
 const CODE_TO_SHORT: Record<string, string> = {
   deu: "DE",
@@ -21,6 +22,7 @@ const CODE_TO_SHORT: Record<string, string> = {
   tha: "TH",
   tur: "TR",
   zhs: "CN",
+  zht: "TW",
 };
 
 /**

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -15,8 +15,9 @@ import { recordRecent, getRecent, isRecentType, ENTITY_SINGULAR, prettyRecentNam
 import { t } from "@/lib/ui-translations";
 import { cachedFetch } from "@/lib/fetch-cache";
 import { IS_BETA, SITE_URL } from "@/lib/seo";
+import { LANG_PREFIXES } from "@/lib/languages";
 
-const LANG_CODES = new Set(["deu", "esp", "fra", "ita", "jpn", "kor", "pol", "ptb", "rus", "spa", "tha", "tur", "zhs"]);
+const LANG_CODES = LANG_PREFIXES;
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 

--- a/frontend/lib/fetch-cache.ts
+++ b/frontend/lib/fetch-cache.ts
@@ -4,6 +4,8 @@
  * Cache lives for the browser session (cleared on page reload).
  */
 
+import { LANG_PREFIXES } from "./languages";
+
 const cache = new Map<string, { data: unknown; timestamp: number }>();
 const inflight = new Map<string, Promise<unknown>>();
 const MAX_AGE = 5 * 60 * 1000; // 5 minutes
@@ -19,7 +21,7 @@ export function getBetaVersion(): string | null {
   return _betaVersion;
 }
 
-const LANG_CODES = new Set(["deu", "esp", "fra", "ita", "jpn", "kor", "pol", "ptb", "rus", "spa", "tha", "tur", "zhs"]);
+const LANG_CODES = LANG_PREFIXES;
 
 /** "beta" when the browser is on a /beta path (optionally language-prefixed,
  *  e.g. /jpn/beta/cards). Server-side rendering returns null; server pages

--- a/frontend/lib/languages.ts
+++ b/frontend/lib/languages.ts
@@ -10,6 +10,15 @@ export const SUPPORTED_LANGS = [
 
 export type LangCode = (typeof SUPPORTED_LANGS)[number];
 
+/**
+ * URL-prefix membership test, shared by every consumer that parses a
+ * /<lang>/... path (middleware, nav, selector, fetch cache, lang prefix
+ * hook). One source of truth: five separate hardcoded copies of this set
+ * each silently missed zht when it shipped, which made the language
+ * switcher append /zht onto already-prefixed paths.
+ */
+export const LANG_PREFIXES: ReadonlySet<string> = new Set(SUPPORTED_LANGS);
+
 /** Maps 3-letter game codes to BCP-47 / hreflang codes */
 export const LANG_HREFLANG: Record<LangCode, string> = {
   deu: "de",

--- a/frontend/lib/use-lang-prefix.ts
+++ b/frontend/lib/use-lang-prefix.ts
@@ -2,8 +2,9 @@
 
 import { usePathname } from "next/navigation";
 import { useLanguage } from "@/app/contexts/LanguageContext";
+import { LANG_PREFIXES } from "./languages";
 
-const LANG_CODES = new Set(["deu", "esp", "fra", "ita", "jpn", "kor", "pol", "ptb", "rus", "spa", "tha", "tur", "zhs"]);
+const LANG_CODES = LANG_PREFIXES;
 
 /** "beta" when the current path sits in the beta section
  *  (/beta/... or /<lang>/beta/...), else "stable". */

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { LANG_PREFIXES } from "@/lib/languages";
 
 /** Canonicalise news article URLs.
  *
@@ -43,9 +44,7 @@ function gidFromEncoded(seg: string): string | null {
   return null;
 }
 
-const LANG_CODES = new Set([
-  "deu", "esp", "fra", "ita", "jpn", "kor", "pol", "ptb", "rus", "spa", "tha", "tur", "zhs",
-]);
+const LANG_CODES = LANG_PREFIXES;
 
 // Entity types with a real /beta/<type>/[id] detail route (force-dynamic
 // pages under app/beta/), exempt from the rewrite below.


### PR DESCRIPTION
Selecting 繁體中文 while already on a /zht page produced /zht/zht/... because the switcher's prefix-stripping set didn't know zht existed. The real problem was wider: six files (middleware, Navbar, LanguageSelector, HomeClient, fetch-cache's beta detection, and the lang-prefix hook) each had their OWN hardcoded copy of the language-prefix set, and every one silently missed the new language.

All six now import a single `LANG_PREFIXES` set exported from lib/languages.ts and derived from `SUPPORTED_LANGS`, so language #16 can't repeat this. Also adds zht's **TW** short code to the selector dropdown so it aligns with the other entries (and the button shows TW instead of falling back to EN when zht is active).

tsc and the production build pass.