### PR TITLE
Run the stats rebuild in a dedicated container that survives deploys

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1205,7 +1205,20 @@ def start_stats_refresher() -> None:
     actually runs the heavy aggregation cycle. Others spin idle
     every refresh interval and the lease auto-rotates if the holder
     dies.
+
+    STATS_REFRESHER=off opts an instance out of the lease entirely:
+    the web containers set it so the heavy walk runs only in the
+    dedicated rebuilder service, whose container survives web deploys
+    (which used to kill every in-flight rebuild).
     """
+    if os.environ.get("STATS_REFRESHER", "on").strip().lower() in (
+        "off",
+        "0",
+        "false",
+        "no",
+    ):
+        logger.info("stats refresher disabled on this instance (STATS_REFRESHER=off)")
+        return
     import threading
 
     def _loop() -> None:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -127,6 +127,12 @@ services:
       # to node_exporter (`node_cpu_*`, `node_memory_*`) or cAdvisor
       # (`container_cpu_*`, `container_memory_*`).
       - PROMETHEUS_MULTIPROC_DIR=/tmp/prom_multiproc
+      # The heavy stats walk runs only in the rebuilder service below, so a
+      # web deploy recreating this container no longer kills an in-flight
+      # rebuild (which is how the snapshot sat stale for days). Set
+      # BACKEND_STATS_REFRESHER=on in the box .env to revert to the old
+      # single-container behavior.
+      - STATS_REFRESHER=${BACKEND_STATS_REFRESHER:-off}
     # Ordering only (no health condition): the backend must boot fine with
     # Redis down, since the cache layer is fail-safe by design.
     depends_on:
@@ -138,6 +144,43 @@ services:
       options:
         max-size: "10m"
         max-file: "5"
+
+  # Dedicated stats-rebuild worker. Same image as the backend, no published
+  # port, single process: it alone holds the refresh lease, so the
+  # 80-minute-plus snapshot walk survives web deploys (compose only
+  # recreates this container when the backend image itself changes).
+  # KEEP THIS SERVICE IN THE DEPLOY SCRIPT'S `up` LIST - a rebuilder left
+  # on an old image would keep writing old-version snapshots and the
+  # current version would never build.
+  rebuilder:
+    image: ptrlrd/spire-codex-backend:latest
+    container_name: spire-codex-rebuilder
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001"]
+    volumes:
+      - ./data:/data
+      - ./data-beta:/data-beta:ro
+      - ./backend/static:/app/static:ro
+      - ./.secrets:/secrets:ro
+    environment:
+      - DATA_DIR=/data
+      - BETA_DATA_DIR=/data-beta
+      - STATS_REFRESHER=on
+      - ENTITY_STATS_REBUILD_WORKERS=${ENTITY_STATS_REBUILD_WORKERS:-1}
+      - ENTITY_STATS_REBUILD_INTERVAL_SECONDS=${ENTITY_STATS_REBUILD_INTERVAL_SECONDS:-7200}
+      - MONGO_URL=${MONGO_URL:-}
+      - REDIS_URL=${REDIS_URL:-redis://spire-codex-redis:6379/0}
+      - SENTRY_DSN=${SENTRY_DSN:-}
+      - ENVIRONMENT=${ENVIRONMENT:-production}
+    depends_on:
+      - redis
+    networks:
+      - nginx_web-network
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
 
   redis:
     image: redis:7-alpine


### PR DESCRIPTION
I moved the snapshot walk into a dedicated rebuilder service so web deploys stop killing in-flight rebuilds.