### PR TITLE
Fix the parallel-merge TypeError on ancient take-rates

### DIFF
--- a/backend/app/services/community_stats.py
+++ b/backend/app/services/community_stats.py
@@ -104,7 +104,7 @@ def _new_acc_one() -> dict[str, Any]:
         # below 50% max HP walking INTO the campfire (previous floor's HP, so a
         # Heal doesn't reclassify itself as a high-HP choice).
         "rest": {},
-        "ancient": {},  # relic_id -> count (chosen from the 3-relic offer)
+        "ancient": {},  # relic_id -> [chosen, offered] (the 3-relic offer take-rate)
         "removed": {},  # card_id -> count (purged at a shop/event)
         "stolen": {},  # card_id -> count (taken by the Thieving Hopper)
         "reward_screens": 0,
@@ -136,11 +136,19 @@ def new_accumulator(recent_versions: tuple | list = ()) -> dict[str, Any]:
 # nested event -> {option -> count}; the counter dicts add per key; the three
 # records keep the best (min run_time / max run_time / max deck_size).
 _COMMUNITY_INT_FIELDS = ("total_runs", "total_wins", "reward_screens", "reward_skips")
-_COMMUNITY_LIST_DICT_FIELDS = ("by_ascension", "by_character", "map_danger", "rest")
+# "ancient" belongs here, NOT in the counters: its values became
+# [chosen, offered] lists when the take-rate tip shipped, and merging it as
+# an int counter is the TypeError that broke every parallel rebuild.
+_COMMUNITY_LIST_DICT_FIELDS = (
+    "by_ascension",
+    "by_character",
+    "map_danger",
+    "rest",
+    "ancient",
+)
 _COMMUNITY_COUNTER_FIELDS = (
     "deaths_encounter",
     "deaths_event",
-    "ancient",
     "removed",
     "stolen",
 )

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -240,10 +240,13 @@ _HISTORY_RETENTION_DAYS = 90
 # endpoint — e.g. bracket=solo:a10&character=IRONCLAD (additive; the bump
 # forces the rebuild).
 SNAPSHOT_VERSION = 20
-# Entities per persisted chunk doc. With version-composable brackets a
-# popular entity carries hundreds of per-bracket blocks, so entity arrays
-# are split across docs to stay well under Mongo's 16MB document cap.
-_ENTITY_CHUNK = 150
+# Serialized-byte budget per persisted chunk doc. With version-composable
+# brackets a popular entity carries hundreds of per-bracket blocks and
+# entity sizes vary wildly (a card dwarfs an affliction), so chunks are
+# packed by measured BSON size, not entity count — a fixed count crossed
+# Mongo's 16MB document cap once version brackets multiplied per-entity
+# payloads. Half the cap leaves headroom for command overhead and growth.
+_CHUNK_MAX_BYTES = 8 * 1024 * 1024
 # The oldest snapshot version readers can still serve. Bump SNAPSHOT_VERSION
 # on every shape change; bump this floor ONLY when a change actually breaks
 # readers (a removed/retyped field). Everything in between is additive, and
@@ -1757,6 +1760,26 @@ def _snapshot_coll():
     return _get_collection().database[SNAPSHOT_COLLECTION_NAME]
 
 
+def _size_chunks(entities: list[dict]) -> list[list[dict]]:
+    """Split an entity array into chunks whose serialized size stays under
+    _CHUNK_MAX_BYTES each. Always returns at least one (possibly empty)
+    chunk so an empty entity type still gets its chunk:0 doc."""
+    from bson import encode as bson_encode
+
+    chunks: list[list[dict]] = []
+    cur: list[dict] = []
+    cur_bytes = 0
+    for entry in entities:
+        size = len(bson_encode({"e": entry}))
+        if cur and cur_bytes + size > _CHUNK_MAX_BYTES:
+            chunks.append(cur)
+            cur, cur_bytes = [], 0
+        cur.append(entry)
+        cur_bytes += size
+    chunks.append(cur)
+    return chunks
+
+
 _history_indexes_ready = False
 
 
@@ -1945,10 +1968,7 @@ def _persist_snapshot(
         # previous (larger) snapshot are deleted so a shrink can't leave
         # phantom entities behind.
         prev = coll.find_one({"_id": etype}, {"chunk_count": 1}) or {}
-        chunks = [
-            entities[i : i + _ENTITY_CHUNK]
-            for i in range(0, len(entities), _ENTITY_CHUNK)
-        ] or [[]]
+        chunks = _size_chunks(entities)
         for ci, chunk in enumerate(chunks):
             coll.replace_one(
                 {"_id": f"{etype}:chunk:{ci}"},


### PR DESCRIPTION
Fixes the two crashes that kept the v20 snapshot from ever landing: the int + list TypeError in the parallel community merge, and the DocumentTooLarge persist failure from count-based entity chunking.