### PR TITLE
Move the charts frame reload off the request path and warm every variant

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -201,6 +201,16 @@ def _warm_run_entity_stats() -> None:
             start_stats_refresher()
         except Exception:
             pass
+        # Kick the charts metadata-frame load now (it's a 60-100s scan of
+        # every run row) so it happens during the deploy window instead of
+        # inside the first visitor's chart request. get_frame() without
+        # wait just starts the background thread and returns.
+        try:
+            from .services import charts_stats
+
+            charts_stats.get_frame()
+        except Exception:
+            pass
         # One-time field backfills for runs that predate a field
         # (username_lower normalization, the `bought` shop-purchase list),
         # off the request path (the runs collection is large). Idempotent

--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -12,6 +12,7 @@ is set.
 """
 
 import logging
+import os
 import re
 import time
 
@@ -491,37 +492,68 @@ def _compute_chart(
     }
 
 
-def prewarm_charts() -> int:
-    """Precompute chart payloads for the slices people actually open and warm
-    the shared cache, so the /charts page, chart switches, and the common
-    bracket/version filters serve from Redis instead of aggregating live.
+def prewarm_charts(budget_s: float | None = None) -> int:
+    """Precompute chart payloads into the shared cache so filter clicks on
+    /charts serve from Redis instead of aggregating live.
 
-    Warmed per chart (skipping charts that wait on a user-picked entity,
-    encounter, or event): the unfiltered default, each plain bracket
-    (solo/2p/.../wr75), and the newest few game versions. Composite slices
-    (solo:a10:v0.109.0 and friends) stay on-demand — the long tail is huge
-    and _CACHE_TTL keeps repeat views of any slice cheap.
+    Greedy with a time budget: the slice list covers EVERY combination the
+    UI can request — the unfiltered default, each bracket (plain and
+    player:skill composites), each game version, and every bracket x version
+    composite — ordered so the highest-traffic slices warm first and older
+    versions' composites warm last. Warming stops when the budget runs out
+    and logs how many slices didn't make it, so coverage is visible, not
+    assumed. CHART_PREWARM_BUDGET_S tunes the budget (default 900s); the
+    long tail that misses the cut computes on demand and _CACHE_TTL keeps
+    its repeat views cheap.
+
+    Charts that wait on a user-picked entity, encounter, or event are
+    skipped — they have no default worth warming.
 
     Called from the stats refresher cycle right after each snapshot rebuild,
     so every cycle overwrites the warm set with fresh data. Returns how many
     payloads were warmed."""
+    if budget_s is None:
+        try:
+            budget_s = float(os.environ.get("CHART_PREWARM_BUDGET_S", "") or 900)
+        except ValueError:
+            budget_s = 900.0
     plain_brackets = [b for b in _BRACKET_KEYS if ":" not in b]
-    versions = get_recent_stat_versions()[:3]
+    versions = get_recent_stat_versions()  # newest first
     slices: list[tuple[str | None, str | None]] = [(None, None)]
     slices += [(b, None) for b in plain_brackets]
     slices += [(None, v) for v in versions]
+    slices += [(b, None) for b in _BRACKET_KEYS if ":" in b]
+    # Full composite grid, newest versions first so a tight budget drops the
+    # oldest (least-visited) slices.
+    slices += [(b, v) for v in versions for b in _BRACKET_KEYS]
+
+    eligible: list[tuple[str, dict]] = [
+        (chart_key, spec)
+        for chart_key, spec in CHARTS.items()
+        if not any(n in ("entity", "encounter", "event") for n in spec.get("needs", []))
+    ]
     warmed = 0
     started = time.monotonic()
-    for chart_key, spec in CHARTS.items():
-        needs = spec.get("needs", [])
-        # These charts have no sensible default until the user picks one.
-        if any(n in ("entity", "encounter", "event") for n in needs):
-            continue
-        stat = "deck_size" if "stat" in needs else None
-        x = "floors_reached" if "x" in needs else None
-        y = "deck_size" if "x" in needs else None
-        split = "character"
-        for bracket, build_id in slices:
+    out_of_budget = False
+    for si, (bracket, build_id) in enumerate(slices):
+        if time.monotonic() - started > budget_s:
+            skipped = (len(slices) - si) * len(eligible)
+            logger.info(
+                "chart prewarm: budget (%.0fs) exhausted at slice %d/%d; "
+                "~%d payloads left on-demand",
+                budget_s,
+                si,
+                len(slices),
+                skipped,
+            )
+            out_of_budget = True
+            break
+        for chart_key, spec in eligible:
+            needs = spec.get("needs", [])
+            stat = "deck_size" if "stat" in needs else None
+            x = "floors_reached" if "x" in needs else None
+            y = "deck_size" if "x" in needs else None
+            split = "character"
             try:
                 payload = _compute_chart(
                     chart_key,
@@ -572,9 +604,11 @@ def prewarm_charts() -> int:
             app_cache.set_json(key, payload, 30 if payload["building"] else _WARM_TTL)
             warmed += 1
     logger.info(
-        "chart prewarm: %d payloads (%d slices) in %.1fs",
+        "chart prewarm: %d payloads (%d/%d slices%s) in %.1fs",
         warmed,
+        min(si + (0 if out_of_budget else 1), len(slices)) if slices else 0,
         len(slices),
+        ", budget hit" if out_of_budget else "",
         time.monotonic() - started,
     )
     return warmed

--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -428,11 +428,16 @@ def _compute_chart(
     building = False
     if spec["kind"] == "frame":
         mode = "daily" if spec.get("daily") else game_mode
+        frame = cs.get_frame()
         rows = cs.filter_rows(
-            cs.get_frame(), players, ascension, mode, username, bracket, build_id
+            frame, players, ascension, mode, username, bracket, build_id
         )
         series = _build_frame_chart(chart_key, rows, stat, x, y, split)
         total = len(rows)
+        # A cold worker's frame is still loading in the background; say so
+        # instead of caching a bogus empty chart for the full TTL.
+        if not frame and cs.frame_loading():
+            building = True
     else:
         # Blob charts: snapshot rollup (sliced to the requested content bracket
         # and/or game version — the v20 blob keeps bracket x version buckets),
@@ -517,6 +522,9 @@ def prewarm_charts(budget_s: float | None = None) -> int:
             budget_s = float(os.environ.get("CHART_PREWARM_BUDGET_S", "") or 900)
         except ValueError:
             budget_s = 900.0
+    # Block until the frame is actually loaded: warming every frame chart
+    # from an empty frame would fill Redis with empty payloads.
+    cs.get_frame(wait=True)
     plain_brackets = [b for b in _BRACKET_KEYS if ":" not in b]
     versions = get_recent_stat_versions()  # newest first
     slices: list[tuple[str | None, str | None]] = [(None, None)]

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -209,23 +209,73 @@ def _load_frame() -> list[tuple]:
     return rows
 
 
-def get_frame() -> list[tuple]:
-    """The metadata frame, reloading from the store at most every TTL.
-    Keeps serving the previous frame if a reload fails."""
-    global _FRAME, _FRAME_TS
-    if _FRAME and time.time() - _FRAME_TS < _FRAME_TTL:
-        return _FRAME
+_FRAME_REFRESHING = False
+
+
+def _kick_frame_refresh() -> None:
+    """Reload the frame on a daemon thread, at most one in flight. The scan
+    walks every eligible run row (60-100s on prod), which used to run
+    synchronously inside whichever chart request crossed the TTL — a
+    once-per-10-minutes-per-worker visitor ate a one-minute hang and
+    usually a 504. Requests now always get the current frame instantly."""
+    global _FRAME_REFRESHING
     with _FRAME_LOCK:
-        if _FRAME and time.time() - _FRAME_TS < _FRAME_TTL:
-            return _FRAME
+        if _FRAME_REFRESHING:
+            return
+        _FRAME_REFRESHING = True
+
+    def _run() -> None:
+        global _FRAME, _FRAME_TS, _FRAME_REFRESHING
         try:
             rows = _load_frame()
-            if rows or not _FRAME:
-                _FRAME = rows
-            _FRAME_TS = time.time()
+            with _FRAME_LOCK:
+                # Keep serving the previous frame if a reload comes back
+                # empty; an empty store only wins when there was nothing.
+                if rows or not _FRAME:
+                    _FRAME = rows
+                _FRAME_TS = time.time()
         except Exception:
             logger.warning("charts frame reload failed", exc_info=True)
-            _FRAME_TS = time.time()  # don't hammer a broken store
+            with _FRAME_LOCK:
+                _FRAME_TS = time.time()  # don't hammer a broken store
+        finally:
+            with _FRAME_LOCK:
+                _FRAME_REFRESHING = False
+
+    threading.Thread(target=_run, name="charts-frame-refresh", daemon=True).start()
+
+
+def frame_loading() -> bool:
+    """True while the frame is empty because its first load hasn't finished,
+    so endpoints can mark payloads "building" instead of caching a bogus
+    empty chart. False once any load has completed, even an empty one (a
+    store with no runs is empty, not warming up)."""
+    return not _FRAME and (_FRAME_REFRESHING or _FRAME_TS == 0)
+
+
+def get_frame(wait: bool = False) -> list[tuple]:
+    """The metadata frame, refreshed from the store at most every TTL.
+
+    Request path (wait=False): never blocks. A fresh frame serves as-is; a
+    stale or missing one kicks a background reload and serves whatever is
+    loaded right now (stale beats a one-minute hang, and `frame_loading`
+    tells callers when empty means "still warming").
+
+    wait=True is for the prewarmer: it must never compute warm payloads
+    from an empty frame, so it waits out the load (bounded) instead.
+
+    Freshness keys off the timestamp, not the frame's truthiness: a store
+    with zero runs is a completed (empty) load, not a reason to rescan on
+    every call."""
+    if _FRAME_TS and time.time() - _FRAME_TS < _FRAME_TTL:
+        return _FRAME
+    _kick_frame_refresh()
+    if wait:
+        deadline = time.time() + 600
+        while time.time() < deadline:
+            if time.time() - _FRAME_TS < _FRAME_TTL:
+                break
+            time.sleep(1)
     return _FRAME
 
 


### PR DESCRIPTION
Fixes the minute-long chart hangs (the frame's 60-100s scan ran synchronously inside whichever request crossed its 10-minute TTL) and makes the prewarmer warm every bracket and version combination under a time budget.