### PR TITLE
Load the stats snapshot in the background with batched reads

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -211,6 +211,15 @@ def _warm_run_entity_stats() -> None:
             charts_stats.get_frame()
         except Exception:
             pass
+        # Same idea for the shared entity-stats snapshot: start loading it
+        # from Mongo now so the post-deploy "stats are rebuilding" window
+        # is the load's actual duration, not "until someone asks + load".
+        try:
+            from .services.run_entity_stats import kick_snapshot_load
+
+            kick_snapshot_load()
+        except Exception:
+            pass
         # One-time field backfills for runs that predate a field
         # (username_lower normalization, the `bought` shop-purchase list),
         # off the request path (the runs collection is large). Idempotent

--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -523,8 +523,12 @@ def prewarm_charts(budget_s: float | None = None) -> int:
         except ValueError:
             budget_s = 900.0
     # Block until the frame is actually loaded: warming every frame chart
-    # from an empty frame would fill Redis with empty payloads.
+    # from an empty frame would fill Redis with empty payloads for hours.
+    # If it still isn't ready at the deadline, warm blob charts only.
     cs.get_frame(wait=True)
+    frame_missing = cs.frame_loading()
+    if frame_missing:
+        logger.warning("chart prewarm: charts frame unavailable; skipping frame charts")
     plain_brackets = [b for b in _BRACKET_KEYS if ":" not in b]
     versions = get_recent_stat_versions()  # newest first
     slices: list[tuple[str | None, str | None]] = [(None, None)]
@@ -557,6 +561,8 @@ def prewarm_charts(budget_s: float | None = None) -> int:
             out_of_budget = True
             break
         for chart_key, spec in eligible:
+            if frame_missing and spec["kind"] == "frame":
+                continue
             needs = spec.get("needs", [])
             stat = "deck_size" if "stat" in needs else None
             x = "floors_reached" if "x" in needs else None

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -210,14 +210,16 @@ def _load_frame() -> list[tuple]:
 
 
 _FRAME_REFRESHING = False
+_FRAME_OK = False
+_FRAME_RETRY_TS = 0.0
+_FRAME_RETRY_SECONDS = 30
 
 
 def _kick_frame_refresh() -> None:
-    """Reload the frame on a daemon thread, at most one in flight. The scan
-    walks every eligible run row (60-100s on prod), which used to run
-    synchronously inside whichever chart request crossed the TTL — a
-    once-per-10-minutes-per-worker visitor ate a one-minute hang and
-    usually a 504. Requests now always get the current frame instantly."""
+    """Reload the frame on a daemon thread, at most one in flight. A failed
+    load must NOT count as fresh: it only sets the retry stamp, so the
+    worker retries within seconds instead of serving an empty frame for a
+    full TTL (that was hours of blank charts when a scan died under load)."""
     global _FRAME_REFRESHING
     with _FRAME_LOCK:
         if _FRAME_REFRESHING:
@@ -225,19 +227,24 @@ def _kick_frame_refresh() -> None:
         _FRAME_REFRESHING = True
 
     def _run() -> None:
-        global _FRAME, _FRAME_TS, _FRAME_REFRESHING
+        global _FRAME, _FRAME_TS, _FRAME_REFRESHING, _FRAME_OK, _FRAME_RETRY_TS
+        started = time.monotonic()
         try:
             rows = _load_frame()
             with _FRAME_LOCK:
-                # Keep serving the previous frame if a reload comes back
-                # empty; an empty store only wins when there was nothing.
                 if rows or not _FRAME:
                     _FRAME = rows
                 _FRAME_TS = time.time()
+                _FRAME_OK = True
+            logger.info(
+                "charts frame loaded: %d rows in %.1fs",
+                len(rows),
+                time.monotonic() - started,
+            )
         except Exception:
             logger.warning("charts frame reload failed", exc_info=True)
             with _FRAME_LOCK:
-                _FRAME_TS = time.time()  # don't hammer a broken store
+                _FRAME_RETRY_TS = time.time()
         finally:
             with _FRAME_LOCK:
                 _FRAME_REFRESHING = False
@@ -246,35 +253,38 @@ def _kick_frame_refresh() -> None:
 
 
 def frame_loading() -> bool:
-    """True while the frame is empty because its first load hasn't finished,
-    so endpoints can mark payloads "building" instead of caching a bogus
-    empty chart. False once any load has completed, even an empty one (a
-    store with no runs is empty, not warming up)."""
-    return not _FRAME and (_FRAME_REFRESHING or _FRAME_TS == 0)
+    """True while the frame is empty and no load has ever SUCCEEDED, so
+    endpoints mark payloads "building" (short cache) instead of caching a
+    bogus empty chart. A successful empty load clears it: a store with no
+    runs is empty, not warming up."""
+    return not _FRAME and not _FRAME_OK
+
+
+def _frame_fresh() -> bool:
+    return _FRAME_OK and time.time() - _FRAME_TS < _FRAME_TTL
 
 
 def get_frame(wait: bool = False) -> list[tuple]:
     """The metadata frame, refreshed from the store at most every TTL.
 
     Request path (wait=False): never blocks. A fresh frame serves as-is; a
-    stale or missing one kicks a background reload and serves whatever is
-    loaded right now (stale beats a one-minute hang, and `frame_loading`
-    tells callers when empty means "still warming").
+    stale or missing one kicks a background reload (throttled after
+    failures) and serves whatever is loaded right now.
 
     wait=True is for the prewarmer: it must never compute warm payloads
-    from an empty frame, so it waits out the load (bounded) instead.
-
-    Freshness keys off the timestamp, not the frame's truthiness: a store
-    with zero runs is a completed (empty) load, not a reason to rescan on
-    every call."""
-    if _FRAME_TS and time.time() - _FRAME_TS < _FRAME_TTL:
+    from an empty frame, so it waits out the load (bounded), re-kicking
+    after failures until the deadline."""
+    if _frame_fresh():
         return _FRAME
-    _kick_frame_refresh()
+    if time.time() - _FRAME_RETRY_TS >= _FRAME_RETRY_SECONDS:
+        _kick_frame_refresh()
     if wait:
         deadline = time.time() + 600
         while time.time() < deadline:
-            if time.time() - _FRAME_TS < _FRAME_TTL:
+            if _frame_fresh():
                 break
+            if time.time() - _FRAME_RETRY_TS >= _FRAME_RETRY_SECONDS:
+                _kick_frame_refresh()
             time.sleep(1)
     return _FRAME
 

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -2035,6 +2035,7 @@ def _load_snapshot() -> bool:
     False if no snapshot exists yet (caller falls back to local build)."""
     global _cache_snapshot_version
     coll = _snapshot_coll()
+    started = time.monotonic()
     meta = coll.find_one({"_id": "__meta__"})
     if not meta:
         return False
@@ -2070,8 +2071,10 @@ def _load_snapshot() -> bool:
         # older ones keep it inline. Read whichever shape this doc has.
         entities = doc.get("entities", [])
         if not entities and doc.get("chunk_count"):
-            for ci in range(int(doc["chunk_count"])):
-                cdoc = coll.find_one({"_id": f"{etype}:chunk:{ci}"}) or {}
+            # One batched query instead of a round trip per chunk; chunk
+            # order doesn't matter, the cache is keyed by (etype, id).
+            ids = [f"{etype}:chunk:{ci}" for ci in range(int(doc["chunk_count"]))]
+            for cdoc in coll.find({"_id": {"$in": ids}}):
                 entities.extend(cdoc.get("entities", []))
         for e in entities:
             by_char = {
@@ -2117,13 +2120,19 @@ def _load_snapshot() -> bool:
         keys = doc.get("keys")
         if not keys:
             return doc.get("blob") or meta.get(blob_id) or {}
+        # One batched query for all shards of this blob: with version
+        # composites that's hundreds of keys, and a round trip per key was
+        # most of the post-deploy snapshot-load window.
         out: dict[str, Any] = {}
-        for k in keys:
-            kdoc = coll.find_one({"_id": f"{blob_id}:{k}"}) or {}
+        prefix = f"{blob_id}:"
+        for kdoc in coll.find({"_id": {"$in": [prefix + k for k in keys]}}):
             if kdoc.get("blob") is not None:
-                out[k] = kdoc["blob"]
+                out[kdoc["_id"][len(prefix) :]] = kdoc["blob"]
         return out
 
+    community = _blob_doc("community")
+    charts = _blob_doc("charts")
+    encounters = _blob_doc("encounters")
     _apply_cache(
         new_cache,
         meta.get("global_totals", {"total_runs": 0, "total_wins": 0}),
@@ -2134,13 +2143,21 @@ def _load_snapshot() -> bool:
             or meta.get("cohort_baselines")
             or {},
             "totals": meta.get("bracket_totals") or meta.get("cohort_totals") or {},
-            "community": _blob_doc("community"),
-            "charts": _blob_doc("charts"),
-            "encounters": _blob_doc("encounters"),
+            "community": community,
+            "charts": charts,
+            "encounters": encounters,
             "recent_versions": meta.get("recent_versions") or [],
         },
     )
     _cache_snapshot_version = meta_version
+    logger.info(
+        "entity-stats snapshot loaded: %d entities, %d/%d/%d blob keys in %.1fs",
+        len(new_cache),
+        len(community),
+        len(charts),
+        len(encounters),
+        time.monotonic() - started,
+    )
     return True
 
 
@@ -2210,6 +2227,12 @@ def snapshot_status() -> dict[str, Any]:
 
 
 def _maybe_rebuild() -> None:
+    """Kick a background (re)load of the cache when it's stale. Never blocks:
+    the caller reads whatever is in memory right now. The load used to run
+    synchronously on the triggering request thread, which meant the first
+    stats request after a worker boot — and one unlucky request every
+    _SNAPSHOT_LOAD_SECONDS per worker, forever — hung for the full multi-
+    thousand-doc snapshot read."""
     global _building
     age = time.time() - _cache_built_at
     if age < _SNAPSHOT_LOAD_SECONDS:
@@ -2220,24 +2243,38 @@ def _maybe_rebuild() -> None:
         if time.time() - _cache_built_at < _SNAPSHOT_LOAD_SECONDS:
             return
         _building = True
-    try:
-        # On the Mongo path, request threads NEVER walk the run files.
-        # They only load the shared snapshot the leader refresher builds.
-        # If the snapshot doesn't exist yet (cold start before the first
-        # leader cycle), we leave the cache as-is and let the next read
-        # pick it up once the refresher has written it — a few seconds of
-        # an empty tier list beats every worker pegging a CPU.
-        if _USING_MONGO:
-            try:
-                _load_snapshot()
-            except Exception as e:
-                logger.warning("entity-stats snapshot load failed: %s", e)
-            return
-        # SQLite path: no shared snapshot, build locally.
-        _build_cache()
-    finally:
-        with _lock:
-            _building = False
+
+    def _run() -> None:
+        global _building
+        try:
+            # On the Mongo path, request threads NEVER walk the run files.
+            # They only load the shared snapshot the leader refresher builds.
+            # If the snapshot doesn't exist yet (cold start before the first
+            # leader cycle), we leave the cache as-is and let the next read
+            # pick it up once the refresher has written it — a few seconds of
+            # an empty tier list beats every worker pegging a CPU.
+            if _USING_MONGO:
+                try:
+                    _load_snapshot()
+                except Exception as e:
+                    logger.warning("entity-stats snapshot load failed: %s", e)
+                return
+            # SQLite path: no shared snapshot, build locally.
+            _build_cache()
+        finally:
+            with _lock:
+                _building = False
+
+    threading.Thread(
+        target=_run, name="entity-stats-snapshot-load", daemon=True
+    ).start()
+
+
+def kick_snapshot_load() -> None:
+    """Start the first snapshot load in the background. Called at worker
+    startup so the load runs during the deploy window instead of starting
+    on (and delaying) the first visitor's stats request."""
+    _maybe_rebuild()
 
 
 def _baseline_win_rate() -> float:


### PR DESCRIPTION
Fixes the blank charts and stats hangs: snapshot loads run in the background with batched reads and kick at startup, and failed charts-frame scans retry in seconds instead of serving empty for hours.