### PR TITLE
Stop edge-caching building chart payloads and slow the frame churn

### DIFF
--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -16,7 +16,7 @@ import os
 import re
 import time
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, HTTPException, Query, Request, Response
 from slowapi import Limiter
 from ..dependencies import client_ip
 from ..services import rate_limit_config
@@ -632,6 +632,7 @@ def prewarm_charts(budget_s: float | None = None) -> int:
 @limiter.limit("120/minute")
 def get_chart(
     request: Request,
+    response: Response,
     chart_key: str,
     players: int | None = Query(None, ge=1, le=4, description="Player count filter"),
     ascension: int | None = Query(
@@ -727,6 +728,10 @@ def get_chart(
         build_id,
     )
     # A still-building snapshot resolves within minutes; don't pin the empty
-    # answer for the full TTL.
+    # answer for the full TTL, and keep it out of the edge cache entirely
+    # (the generic /api/* header let Cloudflare serve a building payload
+    # for an hour after the origin had recovered).
+    if payload["building"]:
+        response.headers["Cache-Control"] = "no-store"
     app_cache.set_json(cache_key, payload, 30 if payload["building"] else _CACHE_TTL)
     return payload

--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -727,10 +727,6 @@ def get_chart(
         bracket,
         build_id,
     )
-    # A still-building snapshot resolves within minutes; don't pin the empty
-    # answer for the full TTL, and keep it out of the edge cache entirely
-    # (the generic /api/* header let Cloudflare serve a building payload
-    # for an hour after the origin had recovered).
     if payload["building"]:
         response.headers["Cache-Control"] = "no-store"
     app_cache.set_json(cache_key, payload, 30 if payload["building"] else _CACHE_TTL)

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -62,7 +62,10 @@ _RUNS_DIR = _DATA_DIR / "runs"
 
 _FRAME: list[tuple] = []
 _FRAME_TS: float = 0.0
-_FRAME_TTL = 600  # seconds between store reloads
+# Seconds between store reloads. The scan takes ~400s on prod under load,
+# so a short TTL kept every worker rescanning most of the time; an hour of
+# staleness is invisible on 850k-run aggregates.
+_FRAME_TTL = 3600
 _FRAME_LOCK = threading.Lock()
 
 # Smallest sample a single point may summarise; thinner buckets are dropped so

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -62,9 +62,7 @@ _RUNS_DIR = _DATA_DIR / "runs"
 
 _FRAME: list[tuple] = []
 _FRAME_TS: float = 0.0
-# Seconds between store reloads. The scan takes ~400s on prod under load,
-# so a short TTL kept every worker rescanning most of the time; an hour of
-# staleness is invisible on 850k-run aggregates.
+# The scan costs ~400s under load; rescanning every 10min starved workers.
 _FRAME_TTL = 3600
 _FRAME_LOCK = threading.Lock()
 


### PR DESCRIPTION
Sends building chart payloads with no-store so Cloudflare can't pin them for an hour, and raises the frame reload TTL to an hour so workers stop spending most of their time rescanning 850k rows.