### PR TITLE
Move run blobs into Mongo (stage one of killing the file walk)

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -69,10 +69,16 @@ def _load_run_blob(run_hash: str) -> str | None:
     json.dumps loop. `None` means file missing.
     """
     run_file = _data_dir / "runs" / f"{run_hash}.json"
-    if not run_file.exists():
-        return None
-    with open(run_file, "r", encoding="utf-8") as f:
-        return f.read()
+    if run_file.exists():
+        with open(run_file, "r", encoding="utf-8") as f:
+            return f.read()
+    if os.environ.get("MONGO_URL", "").strip():
+        from ..services.runs_db_mongo import get_run_blob
+
+        blob = get_run_blob(run_hash)
+        if blob is not None:
+            return json.dumps(blob, ensure_ascii=False)
+    return None
 
 
 @router.post("", tags=["Runs"])

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -1455,13 +1455,23 @@ def build_user_blob_stats(username: str) -> dict[str, Any]:
     # Single-bracket walk: the username is the filter, so content brackets don't
     # apply here. Use the per-bracket-free helpers directly.
     acc = _new_acc_one()
+    blob_map: dict[str, dict] = {}
+    if os.environ.get("MONGO_URL", "").strip():
+        from .runs_db_mongo import get_run_blobs
+
+        blob_map = get_run_blobs([row["run_hash"] for row in rows])
     for row in rows:
-        path = _RUNS_DIR / f"{row['run_hash']}.json"
-        if not path.exists():
-            continue
+        blob = blob_map.get(row["run_hash"])
+        if blob is None:
+            path = _RUNS_DIR / f"{row['run_hash']}.json"
+            if not path.exists():
+                continue
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    blob = json.load(f)
+            except Exception:
+                continue
         try:
-            with open(path, "r", encoding="utf-8") as f:
-                blob = json.load(f)
             _accumulate_one(
                 acc,
                 blob,

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -196,10 +196,7 @@ def _read_blob_file(run_hash: str) -> dict | None:
 
 
 class _BlobProvider:
-    """Feeds run blobs to the walk in row order. On the Mongo path it
-    prefetches batches from the run_blobs collection (one query per 300
-    runs instead of one file open per run) and falls back to the on-disk
-    file for anything not yet backfilled. Holds at most one batch."""
+    """Batched, in-row-order run blob reads: Mongo first, file fallback."""
 
     _BATCH = 300
 

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -182,6 +182,52 @@ _RUNS_DIR = (
     / "runs"
 )
 
+
+def _read_blob_file(run_hash: str) -> dict | None:
+    path = _RUNS_DIR / f"{run_hash}.json"
+    if not path.exists():
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("skipping unreadable run %s: %s", run_hash, e)
+        return None
+
+
+class _BlobProvider:
+    """Feeds run blobs to the walk in row order. On the Mongo path it
+    prefetches batches from the run_blobs collection (one query per 300
+    runs instead of one file open per run) and falls back to the on-disk
+    file for anything not yet backfilled. Holds at most one batch."""
+
+    _BATCH = 300
+
+    def __init__(self, hashes: list[str]):
+        self._hashes = hashes
+        self._pos = 0
+        self._buf: dict[str, dict | None] = {}
+
+    def get(self, run_hash: str) -> dict | None:
+        if run_hash in self._buf:
+            return self._buf.pop(run_hash)
+        while self._pos < len(self._hashes):
+            batch = self._hashes[self._pos : self._pos + self._BATCH]
+            self._pos += self._BATCH
+            fetched: dict[str, dict] = {}
+            if _USING_MONGO:
+                from .runs_db_mongo import get_run_blobs
+
+                fetched = get_run_blobs(batch)
+            self._buf = {
+                h: (fetched.get(h) if h in fetched else _read_blob_file(h))
+                for h in batch
+            }
+            if run_hash in self._buf:
+                return self._buf.pop(run_hash)
+        return _read_blob_file(run_hash)
+
+
 # Materialized-snapshot config. The expensive 100k-file walk runs in a
 # SINGLE leader process (via the existing stats-refresher lease) and is
 # persisted to Mongo. Every worker reads that shared snapshot instead of
@@ -943,6 +989,8 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=()):
         for _b in _BRACKET_KEYS:
             bracket_accs[f"{_b}:{_v}"] = _new_bracket_acc()
 
+    blobs = _BlobProvider([r["run_hash"] for r in rows])
+
     for row in rows:
         # Official runs only: the game's ascensions are A0-A10. A11+ are modded
         # and a negative/placeholder like A-1 is bad data; both must be skipped
@@ -1002,14 +1050,8 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=()):
         if submitted is not None and hasattr(submitted, "isoformat"):
             submitted = submitted.isoformat()
 
-        path = _RUNS_DIR / f"{run_hash}.json"
-        if not path.exists():
-            continue
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                blob = json.load(f)
-        except (OSError, json.JSONDecodeError) as e:
-            logger.warning("skipping unreadable run %s: %s", run_hash, e)
+        blob = blobs.get(run_hash)
+        if blob is None:
             continue
 
         # The content brackets this run feeds, shared by the community, charts,

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -495,8 +495,52 @@ def submit_run(
                             json.dump(data, f, ensure_ascii=False)
                     except Exception as e:
                         print(f"Warning: failed to save run {run_hash}: {e}")
+                    save_run_blob(run_hash, data)
 
     return results[0]
+
+
+def _blob_collection():
+    return _get_collection().database["run_blobs"]
+
+
+def save_run_blob(run_hash: str, data: dict) -> None:
+    """Best-effort: the on-disk file stays the fallback until the
+    migration off run files completes."""
+    try:
+        _blob_collection().replace_one(
+            {"_id": run_hash},
+            {
+                "_id": run_hash,
+                "blob": data,
+                "updated_at": datetime.now(timezone.utc),
+            },
+            upsert=True,
+        )
+    except Exception as e:
+        logger.warning("failed to save run blob %s: %s", run_hash, e)
+
+
+def get_run_blob(run_hash: str) -> dict | None:
+    try:
+        doc = _blob_collection().find_one({"_id": run_hash})
+    except Exception:
+        return None
+    return (doc or {}).get("blob")
+
+
+def get_run_blobs(hashes: list[str]) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    for i in range(0, len(hashes), 300):
+        batch = hashes[i : i + 300]
+        try:
+            for doc in _blob_collection().find({"_id": {"$in": batch}}):
+                if doc.get("blob") is not None:
+                    out[doc["_id"]] = doc["blob"]
+        except Exception as e:
+            logger.warning("run blob batch fetch failed: %s", e)
+            break
+    return out
 
 
 def _shop_purchases(data: dict) -> list[str]:

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -505,8 +505,6 @@ def _blob_collection():
 
 
 def save_run_blob(run_hash: str, data: dict) -> None:
-    """Best-effort: the on-disk file stays the fallback until the
-    migration off run files completes."""
     try:
         _blob_collection().replace_one(
             {"_id": run_hash},

--- a/backend/scripts/backfill_run_blobs.py
+++ b/backend/scripts/backfill_run_blobs.py
@@ -1,0 +1,79 @@
+"""Backfill data/runs/*.json into the run_blobs Mongo collection.
+
+Run inside the backend or rebuilder container:
+
+    python -m scripts.backfill_run_blobs
+
+Idempotent and resumable: hashes already in the collection are skipped, so
+it can be interrupted and re-run. The files are left untouched; readers
+prefer Mongo and fall back to the files, so nothing breaks mid-backfill.
+"""
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--batch", type=int, default=500)
+    args = ap.parse_args()
+    if not os.environ.get("MONGO_URL", "").strip():
+        print("MONGO_URL unset; nothing to do")
+        return 1
+    from app.services.runs_db_mongo import _blob_collection
+
+    runs_dir = Path(os.environ.get("DATA_DIR", "data")) / "runs"
+    files = sorted(runs_dir.glob("*.json"))
+    print(f"{len(files)} run files under {runs_dir}", flush=True)
+    coll = _blob_collection()
+    inserted = skipped = failed = 0
+    started = time.time()
+    for i in range(0, len(files), args.batch):
+        batch = files[i : i + args.batch]
+        ids = [f.stem for f in batch]
+        existing = {d["_id"] for d in coll.find({"_id": {"$in": ids}}, {"_id": 1})}
+        docs = []
+        for f in batch:
+            if f.stem in existing:
+                skipped += 1
+                continue
+            try:
+                docs.append(
+                    {"_id": f.stem, "blob": json.loads(f.read_text(encoding="utf-8"))}
+                )
+            except Exception as e:
+                print(f"unreadable {f.name}: {e}", flush=True)
+                failed += 1
+        if docs:
+            try:
+                coll.insert_many(docs, ordered=False)
+                inserted += len(docs)
+            except Exception:
+                for d in docs:
+                    try:
+                        coll.replace_one({"_id": d["_id"]}, d, upsert=True)
+                        inserted += 1
+                    except Exception as e:
+                        print(f"failed {d['_id']}: {e}", flush=True)
+                        failed += 1
+        if (i // args.batch) % 40 == 0:
+            done = i + len(batch)
+            rate = done / max(time.time() - started, 1)
+            print(
+                f"{done}/{len(files)} files | {inserted} inserted, "
+                f"{skipped} skipped, {failed} failed | {rate:.0f} files/s",
+                flush=True,
+            )
+    print(
+        f"done: {inserted} inserted, {skipped} skipped, {failed} failed "
+        f"in {time.time() - started:.0f}s",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/backfill_run_blobs.py
+++ b/backend/scripts/backfill_run_blobs.py
@@ -1,12 +1,7 @@
-"""Backfill data/runs/*.json into the run_blobs Mongo collection.
-
-Run inside the backend or rebuilder container:
+"""Backfill data/runs/*.json into the run_blobs collection. Idempotent,
+resumable, leaves the files untouched.
 
     python -m scripts.backfill_run_blobs
-
-Idempotent and resumable: hashes already in the collection are skipped, so
-it can be interrupted and re-run. The files are left untouched; readers
-prefer Mongo and fall back to the files, so nothing breaks mid-backfill.
 """
 
 import argparse


### PR DESCRIPTION
Dual-writes submitted runs into a run_blobs collection, batch-reads them in the snapshot and per-user walks with file fallback, and adds an idempotent backfill script for the existing 850k files.