### PR TITLE
Incremental stats: fold new runs in instead of rebuilding everything

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1201,6 +1201,34 @@ _STATS_FALLBACK_TTL_SECONDS = 300
 _stats_fallback_cache: dict[tuple, tuple[float, dict]] = {}
 
 _REFRESHER_INTERVAL_SECONDS = 60
+_SUMMARY_INTERVAL_SECONDS = max(
+    300, int(os.environ.get("STATS_SUMMARY_INTERVAL_SECONDS", "") or 7200)
+)
+_PREWARM_INTERVAL_SECONDS = max(
+    300, int(os.environ.get("CHART_PREWARM_INTERVAL_SECONDS", "") or 7200)
+)
+_cadence = {"summary": 0.0, "prewarm": 0.0}
+_side_jobs: dict[str, bool] = {}
+
+
+def _kick_side_job(name: str, fn) -> None:
+    """Run fn on a daemon thread, one in flight per name, so the hour-long
+    summary/prewarm jobs never block the every-minute stats tick."""
+    import threading
+
+    if _side_jobs.get(name):
+        return
+    _side_jobs[name] = True
+
+    def _run() -> None:
+        try:
+            fn()
+        except Exception:
+            logger.warning("%s job failed", name, exc_info=True)
+        finally:
+            _side_jobs[name] = False
+
+    threading.Thread(target=_run, daemon=True, name=f"stats-{name}").start()
 
 
 def start_stats_refresher() -> None:
@@ -1278,47 +1306,40 @@ def start_stats_refresher() -> None:
         _cyc0 = time.time()
         logger.info("refresh cycle: starting (leader)")
 
-        # The entity-stats snapshot rebuild below is the critical product data
-        # (tier list / Codex Score / metrics), so it runs FIRST and nothing may
-        # starve it. Charts prewarm — which loads the full ~740k-run frame from
-        # Mongo and can run long under DB load — is deferred to the END of the
-        # cycle. This reverses PR #567's ordering: putting prewarm first let it
-        # block the snapshot rebuild indefinitely, so the snapshot never advanced.
+        # Summaries are heavy Mongo aggregations (the stats summary alone can
+        # run ~1h under load), so they run on their own thread and cadence;
+        # the snapshot tick below must stay every-minute.
+        if time.time() - _cadence["summary"] >= _SUMMARY_INTERVAL_SECONDS:
+            _cadence["summary"] = time.time()
+
+            def _summaries() -> None:
+                refresh_stats_summary()
+                logger.info(
+                    "refresh cycle: stats summary done at %.1fs",
+                    time.time() - _cyc0,
+                )
+                refresh_leaderboard_summary()
+                logger.info(
+                    "refresh cycle: leaderboard summary done at %.1fs",
+                    time.time() - _cyc0,
+                )
+
+            _kick_side_job("summaries", _summaries)
+
+        # Entity-stats snapshot: full walk at boot / repair / new game
+        # version, otherwise an incremental fold of just the new runs.
+        persisted = 0
         try:
-            refresh_stats_summary()
-        except Exception:
-            logger.warning("stats summary refresh failed", exc_info=True)
-        logger.info("refresh cycle: stats summary done at %.1fs", time.time() - _cyc0)
-        # Pre-compute the default (category, character) ladder
-        # views into leaderboard_summary. Reads for the common
-        # combos become O(1) find_one instead of a 500ms
-        # count+sort. Cheap (~600ms total) and idempotent.
-        try:
-            refresh_leaderboard_summary()
-        except Exception:
-            logger.warning("leaderboard summary refresh failed", exc_info=True)
-        logger.info(
-            "refresh cycle: leaderboard summary done at %.1fs, entering snapshot "
-            "rebuild",
-            time.time() - _cyc0,
-        )
-        # Rebuild the shared entity-stats snapshot (tier-list
-        # / Codex Score source) on the same leader-only loop.
-        # Internally throttled, so this is a no-op find_one
-        # most cycles and only walks the run files every
-        # ~10 min on one worker.
-        try:
-            refresh_entity_stats_snapshot()
+            persisted = refresh_entity_stats_snapshot()
         except Exception:
             logger.warning("entity-stats snapshot refresh failed", exc_info=True)
-        # Proactive warm of the entity-scores cache (in-memory
-        # reads, cheap every cycle) so tier pages serve straight
-        # from Redis cluster-wide instead of recomputing per
-        # worker. Includes the per-act relic views.
+        # Proactive warm of the entity-scores cache so tier pages serve
+        # straight from Redis cluster-wide. Only after something was
+        # actually persisted; a no-op tick has nothing new to warm.
         try:
             # Never warm Redis from an unloaded cache: that would push
             # empty score maps cluster-wide with the warm TTL.
-            if app_cache.enabled() and snapshot_loaded():
+            if persisted and app_cache.enabled() and snapshot_loaded():
                 for etype in ("cards", "relics", "potions"):
                     app_cache.set_json(
                         app_cache.entity_scores_key(etype),
@@ -1334,18 +1355,24 @@ def start_stats_refresher() -> None:
         except Exception:
             logger.warning("entity-scores cache warm failed", exc_info=True)
 
-        # Charts prewarm LAST — it loads the full run frame from Mongo and can run
-        # for a while under load, so it must never delay the snapshot rebuild
-        # above. Trade-off: /charts warms a bit later after a deploy; the snapshot
-        # actually completing is the priority.
-        try:
-            if app_cache.enabled():
+        # Charts prewarm on its own thread and cadence: it can run up to its
+        # 15-minute budget and must never block the stats tick.
+        if (
+            app_cache.enabled()
+            and time.time() - _cadence["prewarm"] >= _PREWARM_INTERVAL_SECONDS
+        ):
+            _cadence["prewarm"] = time.time()
+
+            def _prewarm() -> None:
                 from .charts import prewarm_charts
 
                 prewarm_charts()
-        except Exception:
-            logger.warning("charts prewarm failed", exc_info=True)
-        logger.info("refresh cycle: charts prewarm done at %.1fs", time.time() - _cyc0)
+                logger.info(
+                    "refresh cycle: charts prewarm done at %.1fs",
+                    time.time() - _cyc0,
+                )
+
+            _kick_side_job("prewarm", _prewarm)
 
     threading.Thread(target=_loop, daemon=True, name="stats-refresher").start()
 

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -1616,7 +1616,7 @@ def _pick_recent_versions(rows, n: int | None = None) -> list[str]:
     return ordered[:n] if n else ordered
 
 
-def _build_cache_data() -> tuple[dict, dict, dict, dict]:
+def _build_cache_data(stash: bool = False) -> tuple[dict, dict, dict, dict]:
     """Walk every run JSON + DB row and return (cache, totals,
     type_baselines, bracket_meta) WITHOUT mutating module globals. The heavy
     100k-file walk lives here so the leader refresher can compute + persist a
@@ -1745,6 +1745,28 @@ def _build_cache_data() -> tuple[dict, dict, dict, dict]:
         time.time() - _t0,
         len(raw["new_cache"]),
     )
+
+    if stash and _USING_MONGO:
+        last_key = None
+        for r in rows:
+            ts = r.get("submitted_at")
+            if ts is None or not hasattr(ts, "timestamp"):
+                continue
+            k = (ts, str(r["run_hash"]))
+            if last_key is None or k > last_key:
+                last_key = k
+        global _incr
+        _incr = {
+            "raw": raw,
+            "wr_counts": _wr_counts,
+            "wr_min": WINRATE_MIN_RUNS,
+            "official_chars": official_chars,
+            "recent_versions": recent_versions,
+            "last_key": last_key,
+            "pending": 0,
+            "last_persist_ts": time.time(),
+            "last_full_ts": time.time(),
+        }
 
     result = _finalize(**raw)
     # Advertise which versions actually got their own bucket, so the read path
@@ -2200,31 +2222,180 @@ def _load_snapshot() -> bool:
     return True
 
 
-def refresh_entity_stats_snapshot() -> int:
-    """Leader-only: rebuild the cache from run files and persist it to
-    Mongo for every worker to read. Skips the heavy walk if the existing
-    snapshot is younger than _SNAPSHOT_REBUILD_SECONDS. Returns the
-    entity count written (0 if skipped)."""
-    coll = _snapshot_coll()
-    meta = coll.find_one({"_id": "__meta__"}, {"built_at": 1, "snapshot_version": 1})
-    # Only honor the freshness skip for a snapshot this code version wrote.
-    # A stale writer keeps built_at young forever, which would otherwise pin
-    # the leader on an old-shape snapshot it can never replace.
+_incr: dict[str, Any] | None = None
+_INCREMENTAL_ENABLED = os.environ.get("STATS_INCREMENTAL", "on").lower() not in (
+    "off",
+    "0",
+    "false",
+    "no",
+)
+_STATS_PERSIST_SECONDS = max(
+    60, int(os.environ.get("STATS_PERSIST_SECONDS", "") or 600)
+)
+_STATS_REPAIR_SECONDS = max(
+    3600, int(os.environ.get("STATS_REPAIR_INTERVAL_SECONDS", "") or 86400)
+)
+_RELEASE_VERSION_RE = None
+
+
+def _is_release_version(build_id: str) -> bool:
+    global _RELEASE_VERSION_RE
+    if _RELEASE_VERSION_RE is None:
+        import re
+
+        _RELEASE_VERSION_RE = re.compile(r"v\d+(\.\d+)*$")
+    return bool(_RELEASE_VERSION_RE.fullmatch(build_id or ""))
+
+
+def _load_rows_after(last_key: tuple) -> list[dict]:
+    """New run rows past the (submitted_at, run_hash) keyset cursor, in
+    submission order — the same ordering contract the run export uses."""
+    from .runs_db_mongo import _get_collection
+
+    ts, h = last_key
+    docs = list(
+        _get_collection()
+        .find(
+            {
+                "$or": [
+                    {"submitted_at": {"$gt": ts}},
+                    {"submitted_at": ts, "_id": {"$gt": h}},
+                ]
+            },
+            {
+                "_id": 1,
+                "character": 1,
+                "win": 1,
+                "submitted_at": 1,
+                "player_count": 1,
+                "ascension": 1,
+                "game_mode": 1,
+                "killed_by": 1,
+                "username": 1,
+                "build_id": 1,
+            },
+        )
+        .sort([("submitted_at", 1), ("_id", 1)])
+    )
+    return [
+        {
+            "run_hash": d["_id"],
+            "character": d.get("character") or "",
+            "win": bool(d.get("win")),
+            "submitted_at": d.get("submitted_at"),
+            "player_count": d.get("player_count") or 1,
+            "ascension": d.get("ascension") or 0,
+            "game_mode": d.get("game_mode") or "standard",
+            "killed_by": d.get("killed_by"),
+            "username": d.get("username") or "",
+            "build_id": d.get("build_id") or "",
+        }
+        for d in docs
+    ]
+
+
+def _incremental_tick() -> int:
+    """Fold newly submitted runs into the retained raw accumulators and
+    re-finalize + persist on the _STATS_PERSIST_SECONDS cadence. The raw
+    state is merge-and-refinalize safe: every finalize output field is
+    recomputed from the accumulators, never consumed from them."""
+    global _cache_snapshot_version
+    assert _incr is not None
+    rows = _load_rows_after(_incr["last_key"])
+    if rows:
+        rec = set(_incr["recent_versions"])
+        for r in rows:
+            b = (r.get("build_id") or "").strip()
+            if b and b not in rec and _is_release_version(b):
+                logger.info(
+                    "incremental stats: new game version %s; running a full "
+                    "rebuild to seed its buckets",
+                    b,
+                )
+                return refresh_entity_stats_snapshot(force_full=True)
+        for r in rows:
+            u = (r.get("username") or "").lower()
+            if u:
+                c = _incr["wr_counts"].setdefault(u, [0, 0])
+                c[0] += 1
+                if r.get("win"):
+                    c[1] += 1
+        wr_map = {
+            u: (w / t)
+            for u, (t, w) in _incr["wr_counts"].items()
+            if t >= _incr["wr_min"] and t > 0
+        }
+        partial = _accumulate(
+            rows, _incr["official_chars"], wr_map, _incr["recent_versions"]
+        )
+        _merge_raw(_incr["raw"], partial)
+        tail = rows[-1]
+        _incr["last_key"] = (tail["submitted_at"], str(tail["run_hash"]))
+        _incr["pending"] += len(rows)
+
     if (
-        meta
-        and meta.get("built_at")
-        and meta.get("snapshot_version") == SNAPSHOT_VERSION
+        _incr["pending"]
+        and time.time() - _incr["last_persist_ts"] >= _STATS_PERSIST_SECONDS
     ):
-        built = meta["built_at"]
-        if built.tzinfo is None:
-            built = built.replace(tzinfo=timezone.utc)
-        if (datetime.now(timezone.utc) - built).total_seconds() < (
-            _SNAPSHOT_REBUILD_SECONDS
+        _t0 = time.time()
+        cache, totals, baselines, bracket_meta = _finalize(**_incr["raw"])
+        bracket_meta["recent_versions"] = _incr["recent_versions"]
+        _persist_snapshot(cache, totals, baselines, bracket_meta)
+        _apply_cache(cache, totals, baselines, bracket_meta)
+        _cache_snapshot_version = SNAPSHOT_VERSION
+        logger.info(
+            "incremental stats: folded %d new runs, finalize+persist took "
+            "%.1fs (%d runs total)",
+            _incr["pending"],
+            time.time() - _t0,
+            totals["total_runs"],
+        )
+        _incr["pending"] = 0
+        _incr["last_persist_ts"] = time.time()
+        return len(cache)
+    return 0
+
+
+def refresh_entity_stats_snapshot(force_full: bool = False) -> int:
+    """Leader-only. With a retained incremental base, folds new runs in and
+    persists every _STATS_PERSIST_SECONDS; otherwise (boot, repair due, new
+    game version, incremental disabled) runs the full walk and retains its
+    raw state as the new base. Returns entities persisted, 0 if nothing."""
+    coll = _snapshot_coll()
+    if (
+        not force_full
+        and _INCREMENTAL_ENABLED
+        and _USING_MONGO
+        and _incr is not None
+        and _incr.get("last_key") is not None
+        and time.time() - _incr["last_full_ts"] < _STATS_REPAIR_SECONDS
+    ):
+        return _incremental_tick()
+
+    if not _INCREMENTAL_ENABLED:
+        meta = coll.find_one(
+            {"_id": "__meta__"}, {"built_at": 1, "snapshot_version": 1}
+        )
+        # Only honor the freshness skip for a snapshot this code version
+        # wrote. A stale writer keeps built_at young forever, which would
+        # otherwise pin the leader on an old-shape snapshot.
+        if (
+            meta
+            and meta.get("built_at")
+            and meta.get("snapshot_version") == SNAPSHOT_VERSION
         ):
-            return 0  # snapshot still fresh
+            built = meta["built_at"]
+            if built.tzinfo is None:
+                built = built.replace(tzinfo=timezone.utc)
+            if (datetime.now(timezone.utc) - built).total_seconds() < (
+                _SNAPSHOT_REBUILD_SECONDS
+            ):
+                return 0  # snapshot still fresh
 
     global _cache_snapshot_version
-    cache, totals, baselines, bracket_meta = _build_cache_data()
+    cache, totals, baselines, bracket_meta = _build_cache_data(
+        stash=_INCREMENTAL_ENABLED
+    )
     _persist_snapshot(cache, totals, baselines, bracket_meta)
     _apply_cache(cache, totals, baselines, bracket_meta)
     _cache_snapshot_version = SNAPSHOT_VERSION


### PR DESCRIPTION
Keeps the raw accumulators in the rebuilder, tails new runs, and re-finalizes every 10 minutes, so stats go from hours stale to minutes fresh and the full walk becomes a boot/patch-day/daily-repair tool.