### PR TITLE
Live homepage boxes

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1324,6 +1324,7 @@ def start_stats_refresher() -> None:
 
     def _run_refresh_cycle() -> None:
         from ..services.runs_db_mongo import (
+            refresh_home_stats,
             refresh_leaderboard_summary,
             refresh_stats_summary,
         )
@@ -1333,6 +1334,8 @@ def start_stats_refresher() -> None:
         # whose "done" log never arrives, so we can see which step starves it.
         _cyc0 = time.time()
         logger.info("refresh cycle: starting (leader)")
+
+        _kick_side_job("home_stats", refresh_home_stats)
 
         # Summaries are heavy Mongo aggregations (the stats summary alone can
         # run ~1h under load), so they run on their own thread and cadence;

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1622,6 +1622,21 @@ def refresh_stats_summary() -> int:
     return written
 
 
+@_instrument("refresh_home_stats", collection="stats_summary")
+def refresh_home_stats() -> int:
+    """Refresh only the no-filter stats combo the homepage polls."""
+    result = get_stats()
+    key = _filter_key()
+    doc = {**result, "_id": key, "updated_at": datetime.now(timezone.utc)}
+    _summary_coll().replace_one({"_id": key}, doc, upsert=True)
+    app_cache.set_json(
+        app_cache.stats_key(),
+        result,
+        ttl_seconds=app_cache.WARM_TTL_SECONDS,
+    )
+    return 1
+
+
 @_instrument("refresh_leaderboard_summary", collection="leaderboard_summary")
 def refresh_leaderboard_summary() -> int:
     """Compute the hot (category, character) leaderboard combos and write

--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -54,60 +54,6 @@ interface HomeClientProps {
   initialTranslations: Translations;
 }
 
-function LivePulse({ lang }: { lang: string }) {
-  const [total, setTotal] = useState<number | null>(null);
-  const [shown, setShown] = useState<number | null>(null);
-  const shownRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    let active = true;
-    const load = () => {
-      if (document.hidden) return;
-      fetch(`${API}/api/runs/pulse`)
-        .then((r) => (r.ok ? r.json() : null))
-        .then((d) => {
-          if (active && d && typeof d.total_runs === "number" && d.total_runs > 0) {
-            setTotal(d.total_runs);
-          }
-        })
-        .catch(() => {});
-    };
-    load();
-    const timer = setInterval(load, 10_000);
-    return () => {
-      active = false;
-      clearInterval(timer);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (total == null) return;
-    const from = shownRef.current ?? total;
-    shownRef.current = total;
-    if (from === total) {
-      setShown(total);
-      return;
-    }
-    const t0 = performance.now();
-    let raf = 0;
-    const step = (now: number) => {
-      const p = Math.min(1, (now - t0) / 900);
-      setShown(Math.round(from + (total - from) * (1 - Math.pow(1 - p, 3))));
-      if (p < 1) raf = requestAnimationFrame(step);
-    };
-    raf = requestAnimationFrame(step);
-    return () => cancelAnimationFrame(raf);
-  }, [total]);
-
-  if (shown == null) return null;
-  return (
-    <span className="livepulse" title={t("Updates as runs are uploaded", lang)}>
-      <span className="lp-dot" aria-hidden="true" />
-      <span className="lp-n">{shown.toLocaleString()}</span>&nbsp;{t("runs tracked", lang)}
-    </span>
-  );
-}
-
 export default function HomeClient({ initialStats, initialTranslations }: HomeClientProps) {
   const [stats, setStats] = useState<Stats | null>(initialStats);
   const [translations, setTranslations] = useState<Translations>(initialTranslations);
@@ -302,7 +248,6 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
       <section className="hsec">
         <div className="s-head">
           <h2>{t("Characters", lang)}</h2>
-          <LivePulse lang={lang} />
           <Link className="viewmore" href={`${langPrefix}/characters`}>{t("All characters", lang)} {ARROW}</Link>
         </div>
         <div className="charbar">

--- a/frontend/app/components/HomeLeaderboardLive.tsx
+++ b/frontend/app/components/HomeLeaderboardLive.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { t } from "@/lib/ui-translations";
+import { imageUrl } from "@/lib/image-url";
+import { characterHex } from "@/lib/character-colors";
+import type { FastestBlock, RunRow } from "./HomeLeaderboardSection";
+
+const TARGET_ASCENSION = 10;
+const POLL_MS = 20_000;
+
+const ARROW = (
+  <svg className="arw" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
+);
+
+function characterIcon(character: string): string {
+  return imageUrl(`/static/images/characters/character_icon_${character.toLowerCase()}.webp`);
+}
+
+const ENGLISH_CHARACTER_LABELS: Record<string, string> = {
+  IRONCLAD: "Ironclad",
+  SILENT: "Silent",
+  DEFECT: "Defect",
+  NECROBINDER: "Necrobinder",
+  REGENT: "Regent",
+};
+
+
+/** Resolve a character key (uppercase from the runs API: `IRONCLAD`,
+ * `SILENT`, etc.) to its localized display name. The translations API
+ * keys characters in lowercase, so we lowercase before looking up.
+ * Falls back to the English label, then a title-cased raw key. */
+function characterLabel(c: string, names?: Record<string, string>): string {
+  return names?.[c.toLowerCase()] ?? ENGLISH_CHARACTER_LABELS[c] ?? c.charAt(0) + c.slice(1).toLowerCase();
+}
+
+function formatRunTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return m > 0 ? `${m}m ${s.toString().padStart(2, "0")}s` : `${s}s`;
+}
+
+function formatRelativeDate(submittedAt: string): string {
+  // submitted_at is `YYYY-MM-DD HH:MM:SS` UTC. Treat as UTC then diff.
+  const d = new Date(submittedAt.replace(" ", "T") + "Z");
+  const diffMs = Date.now() - d.getTime();
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  const mo = Math.floor(day / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.floor(mo / 12)}y ago`;
+}
+
+function killedByLabel(killedBy: string | null): string | null {
+  if (!killedBy) return null;
+  // KNOWLEDGE_DEMON_BOSS → Knowledge Demon
+  return killedBy
+    .replace(/_BOSS$/i, "")
+    .toLowerCase()
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export default function HomeLeaderboardLive({
+  initialFastest,
+  initialDaily,
+  initialRecent,
+  langPrefix = "",
+  lang = "eng",
+  characterNames,
+  runsHost,
+  pollBase,
+}: {
+  initialFastest: FastestBlock;
+  initialDaily: RunRow[];
+  initialRecent: RunRow[];
+  langPrefix?: string;
+  lang?: string;
+  characterNames?: Record<string, string>;
+  runsHost: string;
+  pollBase: string;
+}) {
+  const [fastest, setFastest] = useState<FastestBlock>(initialFastest);
+  const [daily, setDaily] = useState<RunRow[]>(initialDaily);
+  const [recent, setRecent] = useState<RunRow[]>(initialRecent);
+
+  useEffect(() => {
+    let active = true;
+    const grab = (url: string) =>
+      fetch(url).then((r) => (r.ok ? r.json() : null)).catch(() => null);
+    const load = () => {
+      if (document.hidden) return;
+      grab(`${pollBase}/api/runs/leaderboard?category=fastest&ascension_min=${TARGET_ASCENSION}&limit=5`).then((d) => {
+        if (active && d?.runs) {
+          const runs = (d.runs as RunRow[]).filter((r) => r.win === 1).slice(0, 5);
+          if (runs.length) setFastest({ runs, ascension: TARGET_ASCENSION });
+        }
+      });
+      grab(`${pollBase}/api/runs/leaderboard?category=highest_ascension&game_mode=daily&today=true&limit=5`).then((d) => {
+        if (active && d?.runs) setDaily((d.runs as RunRow[]).slice(0, 5));
+      });
+      grab(`${pollBase}/api/runs/list?limit=5&sort=newest`).then((d) => {
+        if (active && d?.runs) setRecent(d.runs as RunRow[]);
+      });
+    };
+    const timer = setInterval(load, POLL_MS);
+    return () => {
+      active = false;
+      clearInterval(timer);
+    };
+  }, [pollBase]);
+
+  // On beta, point all in-page links at stable's absolute URL, the data
+  // shown in this section came from stable, so the run-detail / browse /
+  // submit pages need to live there too. On stable, stay relative so
+  // the langPrefix stays meaningful.
+  const lbBase = `${runsHost}${langPrefix}/leaderboards`;
+  const runsBase = `${runsHost}${langPrefix}/runs`;
+  const ascLabel =
+    fastest.ascension === TARGET_ASCENSION
+      ? `A${TARGET_ASCENSION}`
+      : fastest.ascension !== null
+        ? `A${fastest.ascension}`
+        : null;
+
+  return (
+    <div className="rvmp">
+      {/* Section heading mirrors the News / Guides / Showcase pattern.
+          The CTA points at /leaderboards/submit (not the browse page) since
+          that's where new contributors actually need to go to make this
+          section grow. */}
+      <section className="hb">
+        <div className="hsec">
+          <div className="s-head">
+            <h2>{t("Leaderboards", lang)}</h2>
+            <Link className="viewmore" href={`${lbBase}/submit`}>
+              {t("Upload your runs", lang)} {ARROW}
+            </Link>
+          </div>
+
+          <div className="lbgrid">
+            {/* Fastest wins (filtered to the highest available ascension, A10 ideal) */}
+            <section className="panel">
+              <div className="s-head">
+                {ascLabel && <span className="s-kick">{ascLabel}</span>}
+                <h2>{t("Fastest Wins", lang)}</h2>
+                <Link className="viewmore" href={runsBase}>
+                  {t("View more", lang)} {ARROW}
+                </Link>
+              </div>
+              {fastest.runs.length === 0 ? (
+                <p className="lb-empty">{t("No A10 wins submitted yet, be the first.", lang)}</p>
+              ) : (
+                <div className="overflow-x-auto"><table className="dtable">
+                  <thead>
+                    <tr>
+                      <th className="rk">#</th>
+                      <th>Character</th>
+                      <th className="num">Asc</th>
+                      <th className="num">Time</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {fastest.runs.map((r, i) => (
+                      <tr key={r.run_hash}>
+                        <td className="rk">{i + 1}</td>
+                        <td>
+                          <Link className="ent" href={`${runsBase}/${r.run_hash}`}>
+                            <img crossOrigin="anonymous" className="lb-ico" src={characterIcon(r.character)} alt={characterLabel(r.character, characterNames)} loading="lazy" />
+                            <span className="lb-who">
+                              <span className="lb-name" style={{ color: characterHex(r.character) || undefined }}>
+                                {characterLabel(r.character, characterNames)}
+                              </span>
+                              <span className="lb-sub">{r.username ?? "anon"} · fl{r.floors_reached}</span>
+                            </span>
+                          </Link>
+                        </td>
+                        <td className="num">A{r.ascension}</td>
+                        <td className="num mono">{formatRunTime(r.run_time)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table></div>
+              )}
+            </section>
+
+            {/* Daily Climb: top wins on today's shared daily seed, resets 00:00 UTC */}
+            <section className="panel">
+              <div className="s-head">
+                <span className="s-kick">{t("resets 00:00 UTC", lang)}</span>
+                <h2>{t("Daily Climb", lang)}</h2>
+                <Link className="viewmore" href={`${runsBase}?win=true&game_mode=daily_today&sort=ascension_desc`}>
+                  {t("View more", lang)} {ARROW}
+                </Link>
+              </div>
+              {daily.length === 0 ? (
+                <p className="lb-empty">{t("No daily runs yet today.", lang)}</p>
+              ) : (
+                <div className="overflow-x-auto"><table className="dtable">
+                  <thead>
+                    <tr>
+                      <th className="rk">#</th>
+                      <th>Character</th>
+                      <th className="num">Asc</th>
+                      <th className="num">Time</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {daily.map((r, i) => (
+                      <tr key={r.run_hash}>
+                        <td className="rk">{i + 1}</td>
+                        <td>
+                          <Link className="ent" href={`${runsBase}/${r.run_hash}`}>
+                            <img crossOrigin="anonymous" className="lb-ico" src={characterIcon(r.character)} alt={characterLabel(r.character, characterNames)} loading="lazy" />
+                            <span className="lb-who">
+                              <span className="lb-name" style={{ color: characterHex(r.character) || undefined }}>
+                                {characterLabel(r.character, characterNames)}
+                              </span>
+                              <span className="lb-sub">{r.username ?? "anon"} · fl{r.floors_reached}</span>
+                            </span>
+                          </Link>
+                        </td>
+                        <td className="num">A{r.ascension}</td>
+                        <td className="num mono">{formatRunTime(r.run_time)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table></div>
+              )}
+            </section>
+
+            {/* Recent runs */}
+            <section className="panel">
+              <div className="s-head">
+                <h2>{t("Recent Runs", lang)}</h2>
+                <Link className="viewmore" href={runsBase}>
+                  {t("View more", lang)} {ARROW}
+                </Link>
+              </div>
+              {recent.length === 0 ? (
+                <p className="lb-empty">{t("No runs submitted yet.", lang)}</p>
+              ) : (
+                <table className="dtable dtable-fixed">
+                  <thead>
+                    <tr>
+                      <th>Character</th>
+                      <th className="num" style={{ width: "2.75rem" }}>Result</th>
+                      <th className="num" style={{ width: "5rem" }}>When</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {recent.map((r) => {
+                      const result = r.win
+                        ? "win"
+                        : r.was_abandoned
+                          ? "abandoned"
+                          : "loss";
+                      const killer = killedByLabel(r.killed_by);
+                      // Keep the boss name short so the row never widens the
+                      // panel into a horizontal scroll.
+                      const killerShort =
+                        killer && killer.length > 10
+                          ? killer.slice(0, 10).trimEnd() + "…"
+                          : killer;
+                      return (
+                        <tr key={r.run_hash}>
+                          <td>
+                            <Link className="ent" href={`${runsBase}/${r.run_hash}`}>
+                              <img crossOrigin="anonymous" className="lb-ico" src={characterIcon(r.character)} alt={characterLabel(r.character, characterNames)} loading="lazy" />
+                              <span className="lb-who">
+                                <span className="lb-name" style={{ color: characterHex(r.character) || undefined }}>
+                                  {characterLabel(r.character, characterNames)}
+                                  <span className="dim"> A{r.ascension}</span>
+                                </span>
+                                <span className="lb-sub">
+                                  fl{r.floors_reached} · {formatRunTime(r.run_time)}
+                                  {killerShort && result === "loss" ? ` · died to ${killerShort}` : ""}
+                                </span>
+                              </span>
+                            </Link>
+                          </td>
+                          <td className="num">
+                            {result === "win" && <span className="wr-sg" title="Win">W</span>}
+                            {result === "loss" && <span className="wr-loss" title="Loss">R</span>}
+                            {result === "abandoned" && <span className="dim" title="Abandoned">A</span>}
+                          </td>
+                          <td className="num dim">{formatRelativeDate(r.submitted_at)}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              )}
+            </section>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/components/HomeLeaderboardSection.tsx
+++ b/frontend/app/components/HomeLeaderboardSection.tsx
@@ -1,40 +1,21 @@
-import Link from "next/link";
-import { t } from "@/lib/ui-translations";
 import { IS_BETA } from "@/lib/seo";
+import HomeLeaderboardLive from "./HomeLeaderboardLive";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-// Beta has run submissions disabled, so its local runs.db is essentially
+// Beta has run submissions disabled, so its local runs data is essentially
 // empty. Fetch leaderboard + recent-runs data from stable instead so the
-// section actually has content to show. Server-side fetch, no CORS hop.
-// All in-page links (row → /runs/{hash}, View more → /leaderboards) on
-// beta point at stable's absolute URL since the data only lives there.
+// section actually has content to show; in-page links point at stable too.
 const RUNS_HOST = IS_BETA ? "https://spire-codex.com" : "";
 const RUNS_API = IS_BETA ? "https://spire-codex.com" : API;
-// The browser fetches images from the public API URL, `API_INTERNAL_URL`
-// only resolves inside the Docker network during server render. The
-// production build sets `NEXT_PUBLIC_API_URL=""` (empty) on purpose so
-// images render as same-origin `/static/...` paths that nginx routes
-// to the backend, so use `??` (nullish) instead of `||` (falsy) here,
-// otherwise an intentional empty string falls through to localhost and
-// leaks into the SSR'd HTML.
+// Browser-side polling must use the PUBLIC API base; API_INTERNAL_URL only
+// resolves inside the Docker network during server render.
 const PUBLIC_API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
-
-import { imageUrl } from "@/lib/image-url";
-import { characterHex } from "@/lib/character-colors";
-
-const ARROW = (
-  <svg className="arw" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
-);
-
-function characterIcon(character: string): string {
-  return imageUrl(`/static/images/characters/character_icon_${character.toLowerCase()}.webp`);
-}
+const POLL_BASE = IS_BETA ? "https://spire-codex.com" : PUBLIC_API;
 
 const REVALIDATE = 300;
-
 const TARGET_ASCENSION = 10;
 
-interface RunRow {
+export interface RunRow {
   run_hash: string;
   character: string;
   win: number;
@@ -47,67 +28,17 @@ interface RunRow {
   submitted_at: string;
 }
 
+export interface FastestBlock {
+  runs: RunRow[];
+  ascension: number | null;
+}
+
 interface RunListResponse {
   runs: RunRow[];
   total: number;
 }
 
-const ENGLISH_CHARACTER_LABELS: Record<string, string> = {
-  IRONCLAD: "Ironclad",
-  SILENT: "Silent",
-  DEFECT: "Defect",
-  NECROBINDER: "Necrobinder",
-  REGENT: "Regent",
-};
-
-
-/** Resolve a character key (uppercase from the runs API: `IRONCLAD`,
- * `SILENT`, etc.) to its localized display name. The translations API
- * keys characters in lowercase, so we lowercase before looking up.
- * Falls back to the English label, then a title-cased raw key. */
-function characterLabel(c: string, names?: Record<string, string>): string {
-  return names?.[c.toLowerCase()] ?? ENGLISH_CHARACTER_LABELS[c] ?? c.charAt(0) + c.slice(1).toLowerCase();
-}
-
-function formatRunTime(seconds: number): string {
-  const m = Math.floor(seconds / 60);
-  const s = seconds % 60;
-  return m > 0 ? `${m}m ${s.toString().padStart(2, "0")}s` : `${s}s`;
-}
-
-function formatRelativeDate(submittedAt: string): string {
-  // submitted_at is `YYYY-MM-DD HH:MM:SS` UTC. Treat as UTC then diff.
-  const d = new Date(submittedAt.replace(" ", "T") + "Z");
-  const diffMs = Date.now() - d.getTime();
-  const sec = Math.floor(diffMs / 1000);
-  if (sec < 60) return "just now";
-  const min = Math.floor(sec / 60);
-  if (min < 60) return `${min}m ago`;
-  const hr = Math.floor(min / 60);
-  if (hr < 24) return `${hr}h ago`;
-  const day = Math.floor(hr / 24);
-  if (day < 30) return `${day}d ago`;
-  const mo = Math.floor(day / 30);
-  if (mo < 12) return `${mo}mo ago`;
-  return `${Math.floor(mo / 12)}y ago`;
-}
-
-function killedByLabel(killedBy: string | null): string | null {
-  if (!killedBy) return null;
-  // KNOWLEDGE_DEMON_BOSS → Knowledge Demon
-  return killedBy
-    .replace(/_BOSS$/i, "")
-    .toLowerCase()
-    .split("_")
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(" ");
-}
-
-async function loadFastestWins(): Promise<{ runs: RunRow[]; ascension: number | null }> {
-  // Ask the server for the fastest A10+ wins directly. Filtering client-side
-  // off a global fastest page didn't work: low-ascension speedruns dominate the
-  // global fastest list, so only a few A10 wins survived the filter (the card
-  // showed 3, not 5). ascension_min keeps it to the A10 board the badge claims.
+async function loadFastestWins(): Promise<FastestBlock> {
   try {
     const res = await fetch(
       `${RUNS_API}/api/runs/leaderboard?category=fastest&ascension_min=${TARGET_ASCENSION}&limit=5`,
@@ -136,9 +67,6 @@ async function loadRecentRuns(): Promise<RunRow[]> {
 }
 
 async function loadDailyClimb(): Promise<RunRow[]> {
-  // Top wins on today's Daily Climb (the daily seed everyone shares),
-  // ranked by ascension. `today=true` scopes to runs since 00:00 UTC,
-  // which is when the daily resets.
   try {
     const res = await fetch(
       `${RUNS_API}/api/runs/leaderboard?category=highest_ascension&game_mode=daily&today=true&limit=5`,
@@ -159,9 +87,6 @@ export default async function HomeLeaderboardSection({
 }: {
   langPrefix?: string;
   lang?: string;
-  /** `character_names` from `/api/translations?lang=...`, keyed by
-   * lowercase character id. Pre-fetched by the parent home page so we
-   * don't make an extra API hop here. */
   characterNames?: Record<string, string>;
 }) {
   const [fastest, daily, recent] = await Promise.all([
@@ -172,191 +97,16 @@ export default async function HomeLeaderboardSection({
   if (fastest.runs.length === 0 && daily.length === 0 && recent.length === 0)
     return null;
 
-  // On beta, point all in-page links at stable's absolute URL, the data
-  // shown in this section came from stable, so the run-detail / browse /
-  // submit pages need to live there too. On stable, stay relative so
-  // the langPrefix stays meaningful.
-  const lbBase = `${RUNS_HOST}${langPrefix}/leaderboards`;
-  const runsBase = `${RUNS_HOST}${langPrefix}/runs`;
-  const ascLabel =
-    fastest.ascension === TARGET_ASCENSION
-      ? `A${TARGET_ASCENSION}`
-      : fastest.ascension !== null
-        ? `A${fastest.ascension}`
-        : null;
-
   return (
-    <div className="rvmp">
-      {/* Section heading mirrors the News / Guides / Showcase pattern.
-          The CTA points at /leaderboards/submit (not the browse page) since
-          that's where new contributors actually need to go to make this
-          section grow. */}
-      <section className="hb">
-        <div className="hsec">
-          <div className="s-head">
-            <h2>{t("Leaderboards", lang)}</h2>
-            <Link className="viewmore" href={`${lbBase}/submit`}>
-              {t("Upload your runs", lang)} {ARROW}
-            </Link>
-          </div>
-
-          <div className="lbgrid">
-            {/* Fastest wins (filtered to the highest available ascension, A10 ideal) */}
-            <section className="panel">
-              <div className="s-head">
-                {ascLabel && <span className="s-kick">{ascLabel}</span>}
-                <h2>{t("Fastest Wins", lang)}</h2>
-                <Link className="viewmore" href={runsBase}>
-                  {t("View more", lang)} {ARROW}
-                </Link>
-              </div>
-              {fastest.runs.length === 0 ? (
-                <p className="lb-empty">{t("No A10 wins submitted yet, be the first.", lang)}</p>
-              ) : (
-                <div className="overflow-x-auto"><table className="dtable">
-                  <thead>
-                    <tr>
-                      <th className="rk">#</th>
-                      <th>Character</th>
-                      <th className="num">Asc</th>
-                      <th className="num">Time</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {fastest.runs.map((r, i) => (
-                      <tr key={r.run_hash}>
-                        <td className="rk">{i + 1}</td>
-                        <td>
-                          <Link className="ent" href={`${runsBase}/${r.run_hash}`}>
-                            <img crossOrigin="anonymous" className="lb-ico" src={characterIcon(r.character)} alt={characterLabel(r.character, characterNames)} loading="lazy" />
-                            <span className="lb-who">
-                              <span className="lb-name" style={{ color: characterHex(r.character) || undefined }}>
-                                {characterLabel(r.character, characterNames)}
-                              </span>
-                              <span className="lb-sub">{r.username ?? "anon"} · fl{r.floors_reached}</span>
-                            </span>
-                          </Link>
-                        </td>
-                        <td className="num">A{r.ascension}</td>
-                        <td className="num mono">{formatRunTime(r.run_time)}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table></div>
-              )}
-            </section>
-
-            {/* Daily Climb: top wins on today's shared daily seed, resets 00:00 UTC */}
-            <section className="panel">
-              <div className="s-head">
-                <span className="s-kick">{t("resets 00:00 UTC", lang)}</span>
-                <h2>{t("Daily Climb", lang)}</h2>
-                <Link className="viewmore" href={`${runsBase}?win=true&game_mode=daily_today&sort=ascension_desc`}>
-                  {t("View more", lang)} {ARROW}
-                </Link>
-              </div>
-              {daily.length === 0 ? (
-                <p className="lb-empty">{t("No daily runs yet today.", lang)}</p>
-              ) : (
-                <div className="overflow-x-auto"><table className="dtable">
-                  <thead>
-                    <tr>
-                      <th className="rk">#</th>
-                      <th>Character</th>
-                      <th className="num">Asc</th>
-                      <th className="num">Time</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {daily.map((r, i) => (
-                      <tr key={r.run_hash}>
-                        <td className="rk">{i + 1}</td>
-                        <td>
-                          <Link className="ent" href={`${runsBase}/${r.run_hash}`}>
-                            <img crossOrigin="anonymous" className="lb-ico" src={characterIcon(r.character)} alt={characterLabel(r.character, characterNames)} loading="lazy" />
-                            <span className="lb-who">
-                              <span className="lb-name" style={{ color: characterHex(r.character) || undefined }}>
-                                {characterLabel(r.character, characterNames)}
-                              </span>
-                              <span className="lb-sub">{r.username ?? "anon"} · fl{r.floors_reached}</span>
-                            </span>
-                          </Link>
-                        </td>
-                        <td className="num">A{r.ascension}</td>
-                        <td className="num mono">{formatRunTime(r.run_time)}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table></div>
-              )}
-            </section>
-
-            {/* Recent runs */}
-            <section className="panel">
-              <div className="s-head">
-                <h2>{t("Recent Runs", lang)}</h2>
-                <Link className="viewmore" href={runsBase}>
-                  {t("View more", lang)} {ARROW}
-                </Link>
-              </div>
-              {recent.length === 0 ? (
-                <p className="lb-empty">{t("No runs submitted yet.", lang)}</p>
-              ) : (
-                <table className="dtable dtable-fixed">
-                  <thead>
-                    <tr>
-                      <th>Character</th>
-                      <th className="num" style={{ width: "2.75rem" }}>Result</th>
-                      <th className="num" style={{ width: "5rem" }}>When</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {recent.map((r) => {
-                      const result = r.win
-                        ? "win"
-                        : r.was_abandoned
-                          ? "abandoned"
-                          : "loss";
-                      const killer = killedByLabel(r.killed_by);
-                      // Keep the boss name short so the row never widens the
-                      // panel into a horizontal scroll.
-                      const killerShort =
-                        killer && killer.length > 10
-                          ? killer.slice(0, 10).trimEnd() + "…"
-                          : killer;
-                      return (
-                        <tr key={r.run_hash}>
-                          <td>
-                            <Link className="ent" href={`${runsBase}/${r.run_hash}`}>
-                              <img crossOrigin="anonymous" className="lb-ico" src={characterIcon(r.character)} alt={characterLabel(r.character, characterNames)} loading="lazy" />
-                              <span className="lb-who">
-                                <span className="lb-name" style={{ color: characterHex(r.character) || undefined }}>
-                                  {characterLabel(r.character, characterNames)}
-                                  <span className="dim"> A{r.ascension}</span>
-                                </span>
-                                <span className="lb-sub">
-                                  fl{r.floors_reached} · {formatRunTime(r.run_time)}
-                                  {killerShort && result === "loss" ? ` · died to ${killerShort}` : ""}
-                                </span>
-                              </span>
-                            </Link>
-                          </td>
-                          <td className="num">
-                            {result === "win" && <span className="wr-sg" title="Win">W</span>}
-                            {result === "loss" && <span className="wr-loss" title="Loss">R</span>}
-                            {result === "abandoned" && <span className="dim" title="Abandoned">A</span>}
-                          </td>
-                          <td className="num dim">{formatRelativeDate(r.submitted_at)}</td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              )}
-            </section>
-          </div>
-        </div>
-      </section>
-    </div>
+    <HomeLeaderboardLive
+      initialFastest={fastest}
+      initialDaily={daily}
+      initialRecent={recent}
+      langPrefix={langPrefix}
+      lang={lang}
+      characterNames={characterNames}
+      runsHost={RUNS_HOST}
+      pollBase={POLL_BASE}
+    />
   );
 }

--- a/frontend/app/components/HomeStatsLive.tsx
+++ b/frontend/app/components/HomeStatsLive.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { t } from "@/lib/ui-translations";
+import { characterHex } from "@/lib/character-colors";
+import type { CommunityStats } from "./HomeStatsSection";
+
+const POLL_MS = 20_000;
+
+const ARROW = (
+  <svg className="arw" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
+);
+
+const ENGLISH_CHARACTER_LABELS: Record<string, string> = {
+  IRONCLAD: "Ironclad",
+  SILENT: "Silent",
+  DEFECT: "Defect",
+  NECROBINDER: "Necrobinder",
+  REGENT: "Regent",
+};
+
+function characterLabel(c: string, names?: Record<string, string>): string {
+  return names?.[c.toLowerCase()] ?? ENGLISH_CHARACTER_LABELS[c] ?? c.charAt(0) + c.slice(1).toLowerCase();
+}
+
+function winRateColor(pct: number): string {
+  if (pct >= 30) return "#22c55e";
+  if (pct >= 15) return "#84cc16";
+  if (pct >= 5) return "#eab308";
+  return "#ef4444";
+}
+
+export default function HomeStatsLive({
+  initialStats,
+  langPrefix = "",
+  lang = "eng",
+  characterNames,
+  runsHost,
+  pollBase,
+}: {
+  initialStats: CommunityStats;
+  langPrefix?: string;
+  lang?: string;
+  characterNames?: Record<string, string>;
+  runsHost: string;
+  pollBase: string;
+}) {
+  const [stats, setStats] = useState<CommunityStats>(initialStats);
+
+  useEffect(() => {
+    let active = true;
+    const load = () => {
+      if (document.hidden) return;
+      fetch(`${pollBase}/api/runs/stats`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((d) => {
+          if (active && d?.total_runs) setStats(d as CommunityStats);
+        })
+        .catch(() => null);
+    };
+    const timer = setInterval(load, POLL_MS);
+    return () => {
+      active = false;
+      clearInterval(timer);
+    };
+  }, [pollBase]);
+
+  const losses = (stats.total_runs || 0) - (stats.total_wins || 0) - (stats.total_abandoned || 0);
+  const maxWinRate = Math.max(1, ...stats.characters.map((c) => c.win_rate));
+  const mostPlayed = stats.characters.length
+    ? stats.characters.reduce((a, b) => (b.total > a.total ? b : a))
+    : null;
+
+  return (
+    <div className="rvmp">
+      <section className="hb">
+        <section className="panel">
+          <div className="s-head">
+            <span className="s-kick">{t("Overview", lang)}</span>
+            <h2>{t("Stats", lang)}</h2>
+            <Link className="viewmore" href={`${runsHost}${langPrefix}/leaderboards/stats`}>
+              {t("View all stats", lang)} {ARROW}
+            </Link>
+          </div>
+
+          <div className="statgrid five">
+            <div className="stat">
+              <span className="stat-v">{stats.total_runs}</span>
+              <span className="stat-k">{t("Runs", lang)}</span>
+            </div>
+            <div className="stat">
+              <span className="stat-v" style={{ color: "var(--good)" }}>{stats.total_wins}</span>
+              <span className="stat-k">{t("Wins", lang)}</span>
+            </div>
+            <div className="stat">
+              <span className="stat-v" style={{ color: "var(--warn)" }}>{losses}</span>
+              <span className="stat-k">{t("Losses", lang)}</span>
+            </div>
+            <div className="stat">
+              <span className="stat-v">{stats.win_rate}%</span>
+              <span className="stat-k">{t("Win %", lang)}</span>
+            </div>
+            <div className="stat">
+              <span
+                className="stat-v"
+                style={{ color: mostPlayed ? characterHex(mostPlayed.character) || "var(--gold)" : "var(--text-3)" }}
+                title={mostPlayed ? characterLabel(mostPlayed.character, characterNames) : ""}
+              >
+                {mostPlayed ? characterLabel(mostPlayed.character, characterNames) : "—"}
+              </span>
+              <span className="stat-k">{t("Most Played", lang)}</span>
+            </div>
+          </div>
+
+          {stats.characters.length > 0 && (
+            <div>
+              <div className="wr-title">{t("Character Win Rates", lang)}</div>
+              {stats.characters.map((c) => {
+                const charColor = characterHex(c.character) || "var(--text-3)";
+                const relPct = (c.win_rate / maxWinRate) * 100;
+                return (
+                  <div key={c.character} className="wr-row wr-stat">
+                    <span className="wr-name" style={{ color: charColor }}>
+                      {characterLabel(c.character, characterNames)}
+                    </span>
+                    <span className="wr-track">
+                      <span className="wr-fill" style={{ width: `${relPct}%`, background: charColor }} />
+                    </span>
+                    <span className="wr-wl">
+                      {c.wins}W / {c.total - c.wins}L
+                    </span>
+                    <span className="wr-num" style={{ color: winRateColor(c.win_rate) }}>
+                      {c.win_rate}%
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/components/HomeStatsSection.tsx
+++ b/frontend/app/components/HomeStatsSection.tsx
@@ -1,11 +1,5 @@
-import Link from "next/link";
-import { t } from "@/lib/ui-translations";
 import { IS_BETA } from "@/lib/seo";
-import { characterHex } from "@/lib/character-colors";
-
-const ARROW = (
-  <svg className="arw" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
-);
+import HomeStatsLive from "./HomeStatsLive";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 // Beta has run submissions disabled, so its stats endpoint reports near
@@ -13,41 +7,17 @@ const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "
 // leaderboards above. Server-side fetch, no CORS hop.
 const RUNS_HOST = IS_BETA ? "https://spire-codex.com" : "";
 const RUNS_API = IS_BETA ? "https://spire-codex.com" : API;
+const PUBLIC_API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+const POLL_BASE = IS_BETA ? "https://spire-codex.com" : PUBLIC_API;
 
 const REVALIDATE = 300;
 
-interface CommunityStats {
+export interface CommunityStats {
   total_runs: number;
   total_wins: number;
   total_abandoned: number;
   win_rate: number;
   characters: { character: string; total: number; wins: number; win_rate: number }[];
-}
-
-const ENGLISH_CHARACTER_LABELS: Record<string, string> = {
-  IRONCLAD: "Ironclad",
-  SILENT: "Silent",
-  DEFECT: "Defect",
-  NECROBINDER: "Necrobinder",
-  REGENT: "Regent",
-};
-
-/** Resolve a character key (uppercase from the runs API) to its localized
- * display name. The translations API keys characters in lowercase, so we
- * lowercase before looking up. Falls back to the English label. */
-function characterLabel(c: string, names?: Record<string, string>): string {
-  return names?.[c.toLowerCase()] ?? ENGLISH_CHARACTER_LABELS[c] ?? c.charAt(0) + c.slice(1).toLowerCase();
-}
-
-/** Mirror of the win-rate colour ramp on /leaderboards/stats so a player
- * scanning the home page sees the same visual encoding for the same
- * percentages. Kept in lockstep manually, the source helper there is a
- * client component and not exported. */
-function winRateColor(pct: number): string {
-  if (pct >= 30) return "#22c55e";
-  if (pct >= 15) return "#84cc16";
-  if (pct >= 5) return "#eab308";
-  return "#ef4444";
 }
 
 async function loadStats(): Promise<CommunityStats | null> {
@@ -67,94 +37,19 @@ export default async function HomeStatsSection({
 }: {
   langPrefix?: string;
   lang?: string;
-  /** `character_names` from `/api/translations?lang=...`, keyed by
-   * lowercase character id. Pre-fetched by the parent home page so we
-   * don't make an extra API hop here. */
   characterNames?: Record<string, string>;
 }) {
   const stats = await loadStats();
   if (!stats || stats.total_runs === 0) return null;
-  const losses = (stats.total_runs || 0) - (stats.total_wins || 0) - (stats.total_abandoned || 0);
-  // Win-rate bars are scaled relative to the strongest character (like the
-  // mockup): the top character fills the track, the rest scale down from it.
-  const maxWinRate = Math.max(1, ...stats.characters.map((c) => c.win_rate));
-  // The character with the highest run count drives the "Most Played" tile.
-  // `stats.characters` isn't guaranteed-sorted, so derive it explicitly.
-  const mostPlayed = stats.characters.length
-    ? stats.characters.reduce((a, b) => (b.total > a.total ? b : a))
-    : null;
 
   return (
-    <div className="rvmp">
-      {/* Single full-width panel, same vertical layout as the Overview tab
-          on /leaderboards/stats: stat strip on top, character win-rate
-          bars below, both inside one bordered surface. */}
-      <section className="hb">
-        <section className="panel">
-          <div className="s-head">
-            <span className="s-kick">{t("Overview", lang)}</span>
-            <h2>{t("Stats", lang)}</h2>
-            <Link className="viewmore" href={`${RUNS_HOST}${langPrefix}/leaderboards/stats`}>
-              {t("View all stats", lang)} {ARROW}
-            </Link>
-          </div>
-
-          <div className="statgrid five">
-            <div className="stat">
-              <span className="stat-v">{stats.total_runs}</span>
-              <span className="stat-k">{t("Runs", lang)}</span>
-            </div>
-            <div className="stat">
-              <span className="stat-v" style={{ color: "var(--good)" }}>{stats.total_wins}</span>
-              <span className="stat-k">{t("Wins", lang)}</span>
-            </div>
-            <div className="stat">
-              <span className="stat-v" style={{ color: "var(--warn)" }}>{losses}</span>
-              <span className="stat-k">{t("Losses", lang)}</span>
-            </div>
-            <div className="stat">
-              <span className="stat-v">{stats.win_rate}%</span>
-              <span className="stat-k">{t("Win %", lang)}</span>
-            </div>
-            <div className="stat">
-              <span
-                className="stat-v"
-                style={{ color: mostPlayed ? characterHex(mostPlayed.character) || "var(--gold)" : "var(--text-3)" }}
-                title={mostPlayed ? characterLabel(mostPlayed.character, characterNames) : ""}
-              >
-                {mostPlayed ? characterLabel(mostPlayed.character, characterNames) : "—"}
-              </span>
-              <span className="stat-k">{t("Most Played", lang)}</span>
-            </div>
-          </div>
-
-          {stats.characters.length > 0 && (
-            <div>
-              <div className="wr-title">{t("Character Win Rates", lang)}</div>
-              {stats.characters.map((c) => {
-                const charColor = characterHex(c.character) || "var(--text-3)";
-                const relPct = (c.win_rate / maxWinRate) * 100;
-                return (
-                  <div key={c.character} className="wr-row wr-stat">
-                    <span className="wr-name" style={{ color: charColor }}>
-                      {characterLabel(c.character, characterNames)}
-                    </span>
-                    <span className="wr-track">
-                      <span className="wr-fill" style={{ width: `${relPct}%`, background: charColor }} />
-                    </span>
-                    <span className="wr-wl">
-                      {c.wins}W / {c.total - c.wins}L
-                    </span>
-                    <span className="wr-num" style={{ color: winRateColor(c.win_rate) }}>
-                      {c.win_rate}%
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </section>
-      </section>
-    </div>
+    <HomeStatsLive
+      initialStats={stats}
+      langPrefix={langPrefix}
+      lang={lang}
+      characterNames={characterNames}
+      runsHost={RUNS_HOST}
+      pollBase={POLL_BASE}
+    />
   );
 }

--- a/frontend/app/home-revamp.css
+++ b/frontend/app/home-revamp.css
@@ -190,9 +190,3 @@
 .rvmp .act-steam:hover { background: #2a475e; }
 .rvmp .act-discord { background: #5865f2; }
 .rvmp .act-discord:hover { background: #4752c4; }
-
-.rvmp .livepulse { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono); font-size: 11.5px; color: var(--text-3); }
-.rvmp .livepulse .lp-n { color: var(--text); font-weight: 600; }
-.rvmp .lp-dot { width: 7px; height: 7px; border-radius: 50%; background: #2fbf71; animation: lp-pulse 2s ease-out infinite; }
-@keyframes lp-pulse { 0% { box-shadow: 0 0 0 0 rgba(47,191,113,.45); } 70% { box-shadow: 0 0 0 7px rgba(47,191,113,0); } 100% { box-shadow: 0 0 0 0 rgba(47,191,113,0); } }
-@media (prefers-reduced-motion: reduce) { .rvmp .lp-dot { animation: none; } }


### PR DESCRIPTION
The Fastest Wins, Daily Climb, Recent Runs, and Stats boxes now poll for fresh data every 20s (with a per-minute backend refresh of the homepage stats combo), replacing the run counter from #716.