### PR TITLE
Unwedge the home-stats refresh

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1236,7 +1236,7 @@ _PREWARM_INTERVAL_SECONDS = max(
     300, int(os.environ.get("CHART_PREWARM_INTERVAL_SECONDS", "") or 7200)
 )
 _cadence = {"summary": 0.0, "prewarm": 0.0}
-_side_jobs: dict[str, bool] = {}
+_side_jobs: dict[str, float] = {}
 
 
 def _kick_side_job(name: str, fn) -> None:
@@ -1244,9 +1244,16 @@ def _kick_side_job(name: str, fn) -> None:
     summary/prewarm jobs never block the every-minute stats tick."""
     import threading
 
-    if _side_jobs.get(name):
+    started = _side_jobs.get(name)
+    if started:
+        if time.time() - started > 600:
+            logger.warning(
+                "%s job still in flight after %.0fs; skipping kick",
+                name,
+                time.time() - started,
+            )
         return
-    _side_jobs[name] = True
+    _side_jobs[name] = time.time()
 
     def _run() -> None:
         try:
@@ -1254,7 +1261,7 @@ def _kick_side_job(name: str, fn) -> None:
         except Exception:
             logger.warning("%s job failed", name, exc_info=True)
         finally:
-            _side_jobs[name] = False
+            _side_jobs.pop(name, None)
 
     threading.Thread(target=_run, daemon=True, name=f"stats-{name}").start()
 

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1105,6 +1105,7 @@ def get_stats(
     game_mode: str | None = None,
     players: str | None = None,
     username: str | None = None,
+    max_time_ms: int | None = None,
 ) -> dict:
     """Aggregated community stats. Mirrors the SQLite implementation's
     response shape — frontend doesn't care which backend produced it.
@@ -1139,7 +1140,10 @@ def get_stats(
     # (allowDiskUse doesn't help $facet). Each independent aggregate
     # gets its own 100MB budget + can spill to disk via allowDiskUse.
     def agg(pipeline: list[dict]) -> list[dict]:
-        return list(coll.aggregate(pipeline, allowDiskUse=True))
+        kwargs: dict = {"allowDiskUse": True}
+        if max_time_ms:
+            kwargs["maxTimeMS"] = max_time_ms
+        return list(coll.aggregate(pipeline, **kwargs))
 
     totals_rows = agg(
         [
@@ -1625,7 +1629,8 @@ def refresh_stats_summary() -> int:
 @_instrument("refresh_home_stats", collection="stats_summary")
 def refresh_home_stats() -> int:
     """Refresh only the no-filter stats combo the homepage polls."""
-    result = get_stats()
+    t0 = time.time()
+    result = get_stats(max_time_ms=30_000)
     key = _filter_key()
     doc = {**result, "_id": key, "updated_at": datetime.now(timezone.utc)}
     _summary_coll().replace_one({"_id": key}, doc, upsert=True)
@@ -1633,6 +1638,11 @@ def refresh_home_stats() -> int:
         app_cache.stats_key(),
         result,
         ttl_seconds=app_cache.WARM_TTL_SECONDS,
+    )
+    logger.info(
+        "home stats refreshed: %d runs in %.1fs",
+        result.get("total_runs", 0),
+        time.time() - t0,
     )
     return 1
 


### PR DESCRIPTION
The first refresh_home_stats kick landed during the post-deploy finalize and its aggregation wedged silently, pinning the single-flight slot forever, so I bounded its aggregations with maxTimeMS, logged completion, and made the side-job guard warn when a job is stuck.