### PR TITLE
Bound the summary-refresh aggregations

### DIFF
--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1607,7 +1607,7 @@ def refresh_stats_summary() -> int:
     written = 0
     for filters in HOT_FILTER_COMBOS:
         try:
-            result = get_stats(**filters)
+            result = get_stats(**filters, max_time_ms=120_000)
             key = _filter_key(**filters)
             doc = {**result, "_id": key, "updated_at": datetime.now(timezone.utc)}
             summary.replace_one({"_id": key}, doc, upsert=True)


### PR DESCRIPTION
The six-combo stats summary job runs 54 unbounded full-collection aggregations and has been wedging on every boot just like home_stats did, keeping Mongo busy enough to starve the bounded home refresh, so its get_stats calls now carry a 120s per-aggregation cap (a timed-out combo skips and retries on the next cadence).