### PR TITLE
Guard the stats-counters seeding

### DIFF
--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1661,6 +1661,7 @@ def seed_stats_counters(doc: dict) -> None:
     """(Re)initialize the counters from a full global stats doc."""
     counters = {
         "_id": "global",
+        "seeded": True,
         "total": int(doc.get("total_runs") or 0),
         "wins": int(doc.get("total_wins") or 0),
         "abandoned": int(doc.get("total_abandoned") or 0),
@@ -1686,7 +1687,7 @@ def refresh_home_stats() -> int:
     if not doc:
         return 0
     counters = _stats_counters_coll().find_one({"_id": "global"})
-    if not counters:
+    if not counters or not counters.get("seeded"):
         seed_stats_counters(doc)
         counters = _stats_counters_coll().find_one({"_id": "global"})
         if not counters:


### PR DESCRIPTION
Submit-time increments create the counters doc before the rebuilder's first fold, so an unseeded doc holding only post-deploy runs could overwrite the homepage totals with a tiny number; seeding now stamps a seeded flag and the fold re-seeds whenever it's absent.