### PR TITLE
Scope CF purge to news URLs on data-only deploys and re-warm after full purges

### DIFF
--- a/infrastructure/ansible/files/autodeploy.sh
+++ b/infrastructure/ansible/files/autodeploy.sh
@@ -2,7 +2,9 @@
 # Hourly auto-deploy for spire-codex prod. Polls origin/main; if HEAD
 # advanced, pulls Docker images and recreates the backend+frontend
 # containers. After a clean restart, purges Cloudflare cache so /news,
-# /api/news, sitemap.xml, etc. immediately reflect the new build.
+# /api/news, sitemap.xml, etc. immediately reflect the new build. Code
+# deploys purge the whole zone and then re-warm the hot pages;
+# news-data-only commits purge just the news URLs (see the purge block).
 #
 # Installed by playbooks/install-autodeploy.yml. Triggered by
 # /etc/cron.d/spire-codex-autodeploy. Manual run: just exec this script.
@@ -131,8 +133,35 @@ fi
 
 # Purge Cloudflare cache. Without this, /news + /api/news + sitemap.xml
 # keep serving the pre-deploy HTML (CF s-maxage is up to 1 year for some
-# routes). We purge everything because the cost of overpurging is just a
-# brief cold cache, while the cost of underpurging is invisible stale data.
+# routes). Scope depends on what changed:
+#
+#   RECREATE=1 : real code deploy — page HTML can change on every route,
+#                so purge everything (a prefix purge needs a paid CF
+#                plan). Overpurging here costs a brief cold cache;
+#                underpurging is invisible stale data.
+#   RECREATE=0 : news/beta-data-only commit (the hourly news workflow,
+#                several per day). Only the news surfaces changed, so a
+#                targeted `files` purge keeps /static/* (1y immutable),
+#                the R2 images, and every other cached API response warm
+#                instead of going cold zone-wide every hour.
+if [ "$RECREATE" = "1" ]; then
+  PURGE_BODY='{"purge_everything":true}'
+  PURGE_WHAT="everything"
+else
+  # The URLs whose content moves when a news commit lands:
+  #   /            homepage embeds the latest 3 announcements (HomeNewsSection)
+  #   /news        list page, plus its tab views (?tab=press, ?tab=all)
+  #   /api/news    the list endpoint clients hit through CF
+  #   sitemap.xml  in case lastmod moved
+  # Not purged, on purpose: /news/<slug> detail pages — a NEW article is a
+  # never-cached URL, and enumerating existing slugs isn't cheap here.
+  # /api/news query-string variants we can't enumerate expire on their own
+  # within s-maxage=3600. Localized /<lang>/news is force-dynamic (uncached).
+  PURGE_BODY='{"files":["https://spire-codex.com/","https://spire-codex.com/news","https://spire-codex.com/news?tab=press","https://spire-codex.com/news?tab=all","https://spire-codex.com/api/news","https://spire-codex.com/sitemap.xml"]}'
+  PURGE_WHAT="news URLs only"
+fi
+
+PURGED=0
 if [ -f "$CF_ENV" ]; then
   # shellcheck source=/dev/null
   source "$CF_ENV"
@@ -141,9 +170,10 @@ if [ -f "$CF_ENV" ]; then
       -X POST "https://api.cloudflare.com/client/v4/zones/${CF_ZONE}/purge_cache" \
       -H "Authorization: Bearer ${CF_TOKEN}" \
       -H "Content-Type: application/json" \
-      -d '{"purge_everything":true}')
+      -d "$PURGE_BODY")
     if [ "$HTTP" = "200" ]; then
-      log "✓ CF cache purged"
+      log "✓ CF cache purged ($PURGE_WHAT)"
+      PURGED=1
     else
       log "✗ CF purge returned $HTTP: $(cat /tmp/cf-purge.out)"
     fi
@@ -152,6 +182,21 @@ if [ -f "$CF_ENV" ]; then
   fi
 else
   log "⚠ $CF_ENV not found — skipping cache purge"
+fi
+
+# A full purge leaves the whole edge cold, so the next visitor to every
+# page pays origin latency (and the origin pays the fan-in). Re-warm the
+# hot landing pages right away; entity detail pages re-warm via the
+# startup.sh --full crawl or organically. Best-effort: warming is an
+# optimization and must never fail the deploy. Skipped when the purge was
+# skipped or failed — nothing went cold.
+if [ "$RECREATE" = "1" ] && [ "$PURGED" = "1" ]; then
+  log "  re-warming hot pages after full purge"
+  if timeout 10m python3 "$REPO/tools/warm_cache.py" --hot >> "$LOG" 2>&1; then
+    log "✓ warm crawl done (hot pages)"
+  else
+    log "⚠ warm crawl failed or timed out; continuing (pages warm on first visit)"
+  fi
 fi
 
 log "==== deploy done ===="

--- a/tools/startup.sh
+++ b/tools/startup.sh
@@ -2,11 +2,14 @@
 # Manual deploy entrypoint.
 #
 #   ./tools/startup.sh             defer to the installed autodeploy script
-#                                  (no-op when there's no new commit on main)
+#                                  (deploy no-ops when there's no new commit
+#                                  on main), then start the full warm crawl
+#                                  in the background
 #   ./tools/startup.sh release     force a full deploy NOW via autodeploy:
 #                                  pull images, snapshot prewarm, recreate
 #                                  backend+frontend, nginx reload, Cloudflare
 #                                  purge - even when the commit didn't change
+#                                  - then the background warm crawl
 #   ./tools/startup.sh --bypass    release entirely by hand: skip the
 #                                  autodeploy script, leave git alone, and
 #                                  just pull images + recreate backend and
@@ -32,10 +35,22 @@ done
 if [ "$BYPASS" != "1" ] && [ -x /usr/local/bin/spire-codex-autodeploy ]; then
     if [ "$MODE" = "release" ]; then
         echo "forcing a full deploy via spire-codex-autodeploy --force"
-        exec sudo /usr/local/bin/spire-codex-autodeploy --force
+        sudo /usr/local/bin/spire-codex-autodeploy --force
+    else
+        echo "delegating to spire-codex-autodeploy"
+        sudo /usr/local/bin/spire-codex-autodeploy
     fi
-    echo "delegating to spire-codex-autodeploy"
-    exec sudo /usr/local/bin/spire-codex-autodeploy
+    # set -e: reaching this line means autodeploy exited 0 (a same-commit
+    # tick no-ops and still exits 0); on failure we exit with its status
+    # and skip the crawl. Historically these were `exec` calls, which
+    # replaced the shell and made the warm crawl below unreachable in the
+    # automated path. Autodeploy re-warms the hot landing pages itself
+    # after a full purge; this --full crawl adds the entity detail pages
+    # (the on-demand ISR pages a container recreate resets).
+    nohup python3 "$(dirname "$0")/warm_cache.py" --full \
+        >/tmp/spire-warm-cache.log 2>&1 &
+    echo "cache warm crawl started in the background (log: /tmp/spire-warm-cache.log)"
+    exit 0
 fi
 
 # Bypass mode, or the autodeploy script isn't installed: the raw deploy.


### PR DESCRIPTION
## Problem

`autodeploy.sh` sends `{"purge_everything":true}` to Cloudflare on **every commit that lands**, outside the `RECREATE` conditional. The hourly `news-refresh` workflow commits several times a day, so the entire CF zone — the 1-year-immutable `/static/*`, all `s-maxage=3600` API responses, page HTML, and CDN images — goes cold at every PoP multiple times daily. Since nginx does no proxy caching, CF is the only shared cache, and the single 4-vCPU origin absorbs the full refill each time. Additionally, the warm crawler in `tools/startup.sh` was dead code: the `exec` on the autodeploy call replaced the shell before the crawl line was ever reached.

## Changes

- **`infrastructure/ansible/files/autodeploy.sh`**: purge body now depends on the existing `RECREATE` flag.
  - `RECREATE=1` (real code deploy): keeps `purge_everything`, then runs `tools/warm_cache.py --hot` (10-min timeout, best-effort, only after a successful purge) to re-warm sitemap landing pages.
  - `RECREATE=0` (news/beta-data-only commit): targeted `{"files":[...]}` purge of `/`, `/news`, `/news?tab=press`, `/news?tab=all`, `/api/news`, `/sitemap.xml` only. URL list derived from the actual routes (homepage embeds latest announcements; news details aren't in the sitemap). Deliberate omissions documented in comments.
- **`tools/startup.sh`**: removed the `exec` calls so the documented background `--full` warm crawl actually runs after automated deploys; `--bypass` and no-autodeploy paths unchanged.

## Verification

- `bash -n` passes on both scripts; both purge bodies validated as parseable JSON.
- `warm_cache.py` CLI (`--hot`, default base URL, always-zero exit) verified against the script source.
- `RECREATE` is set on every path reaching the purge block (`set -u` safe); targeted purge cannot fire on a no-op tick; warm crawl cannot run on a skipped/failed purge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9p1QxFzhXFjJ322kD5ttX