### PR TITLE
Guard the live stats aggregation: single-flight, empty-user short-circuit, player_count index

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1450,28 +1450,24 @@ def get_community_stats(
     ]:
         del _stats_fallback_cache[k]
 
-    # 3. Slow path: live aggregation
-    result = get_stats(
-        character=character,
-        win=win,
-        ascension=ascension,
-        game_mode=game_mode,
-        players=players,
-        username=username,
-    )
-    _stats_fallback_cache[cache_key] = (now, result)
-    app_cache.set_json(redis_key, result, ttl_seconds=60)
+    # 3. Slow path: live aggregation. Single-flight per filter combo: the
+    # first miss takes a short Redis lock and computes; concurrent misses
+    # poll briefly for the winner's Redis write instead of stacking
+    # identical multi-second aggregations on Mongo. If the winner's result
+    # never lands (Redis down, holder died), fall through and compute
+    # anyway — degraded behavior is today's behavior, never worse.
+    lock_key = f"lock:{redis_key}"
+    lock_acquired = app_cache.acquire_lock(lock_key, ttl_seconds=30)
+    if not lock_acquired:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            time.sleep(0.25)
+            winner = app_cache.get_json(redis_key)
+            if winner is not None:
+                return winner
 
-    # Lazy write-through to stats_summary so subsequent requests for this
-    # combo -- on any worker -- serve from the materialized view instead
-    # of paying the 5-10s aggregation again. Hot combos still get
-    # overwritten by the periodic refresher; non-hot combos persist until
-    # something else replaces them.
     try:
-        from ..services.runs_db_mongo import write_stats_summary
-
-        write_stats_summary(
-            result,
+        result = get_stats(
             character=character,
             win=win,
             ascension=ascension,
@@ -1479,7 +1475,30 @@ def get_community_stats(
             players=players,
             username=username,
         )
-    except Exception:
-        pass
+        _stats_fallback_cache[cache_key] = (time.monotonic(), result)
+        app_cache.set_json(redis_key, result, ttl_seconds=60)
+
+        # Lazy write-through to stats_summary so subsequent requests for this
+        # combo -- on any worker -- serve from the materialized view instead
+        # of paying the 5-10s aggregation again. Hot combos still get
+        # overwritten by the periodic refresher; non-hot combos persist until
+        # something else replaces them.
+        try:
+            from ..services.runs_db_mongo import write_stats_summary
+
+            write_stats_summary(
+                result,
+                character=character,
+                win=win,
+                ascension=ascension,
+                game_mode=game_mode,
+                players=players,
+                username=username,
+            )
+        except Exception:
+            pass
+    finally:
+        if lock_acquired:
+            app_cache.delete(lock_key)
 
     return result

--- a/backend/app/services/cache.py
+++ b/backend/app/services/cache.py
@@ -167,6 +167,21 @@ def set_json(key: str, value: Any, ttl_seconds: int) -> None:
         cache_errors.labels(namespace=_namespace(key), operation="set").inc()
 
 
+def acquire_lock(key: str, ttl_seconds: int = 30) -> bool:
+    """Best-effort single-flight lock: SET NX with a TTL so a dead holder
+    never wedges the key. Fail-open like the rest of this module — Redis
+    disabled or erroring reports the lock as acquired, so callers proceed
+    exactly as if there were no lock. Release with delete()."""
+    client = _get_client()
+    if client is None:
+        return True
+    try:
+        return bool(client.set(key, "1", nx=True, ex=ttl_seconds))
+    except Exception:
+        cache_errors.labels(namespace=_namespace(key), operation="lock").inc()
+        return True
+
+
 def delete(key: str) -> None:
     """Drop one key. No-ops on any failure."""
     client = _get_client()

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -272,6 +272,11 @@ def _ensure_indexes(coll) -> None:
         [("game_mode", ASCENDING), ("win", ASCENDING), ("run_time", ASCENDING)],
         name="mode_win_runtime",
     )
+    # Stats ?players= filters match on player_count (equality or range)
+    # without character/win, and nothing above leads with it — those
+    # combos were collection scans. Ascension rides along for the
+    # always-present official A0-A10 range in _build_match.
+    coll.create_index([("player_count", ASCENDING), ("ascension", ASCENDING)])
 
 
 def _ensure_run_validator(coll) -> None:
@@ -1120,7 +1125,15 @@ def get_stats(
         character, win, ascension, game_mode, players, username, include_character=False
     )
 
-    total = coll.count_documents(match)
+    # `username` is arbitrary user input; probe the username_lower index
+    # before counting against the composite match so a nonexistent user
+    # costs one index seek instead of a planner-dependent count.
+    if username and (
+        coll.find_one({"username_lower": username.lower()}, {"_id": 1}) is None
+    ):
+        total = 0
+    else:
+        total = coll.count_documents(match)
     if total == 0:
         return {
             "total_runs": 0,


### PR DESCRIPTION
## Problem

Any `/api/runs/stats` filter combo outside `HOT_FILTER_COMBOS` falls through to live `get_stats()`: ~10 sequential aggregations over the full runs collection (~853k docs), including a double-`$unwind` of `map_point_history`. There is no stampede protection — N concurrent cold requests for the same combo run N full aggregations. `username` is arbitrary user input (120 req/min/IP), so nonexistent usernames each cost a full aggregation pass, and `?players=` filters have no selective index (`player_count` led no index).

## Changes

- **Single-flight** (`routers/runs.py` + new `acquire_lock` in `services/cache.py`): on a full cache miss, requests race for a Redis `SET NX EX 30` lock; the winner computes and populates caches as before, losers poll the Redis key for up to 5s and fall through to computing only if the winner never delivers. Worst case is identical to today's behavior; with Redis absent the lock fails open and behavior is byte-for-byte unchanged.
- **Empty-user short-circuit** (`services/runs_db_mongo.py`): a `username` filter now does one indexed `find_one` probe first; a nonexistent user returns the existing empty-stats shape after a single index seek instead of ~10 aggregations. No API contract change.
- **New `(player_count, ascension)` index** in `_ensure_indexes`, matching how `_build_match` filters.

Deliberately **not** done: skipping the potion-shop double-`$unwind` for live calls — it would render an empty potions panel and persist that into Redis/`stats_summary` for all users of the combo (a previously-reported bug class per the comment near the pipeline).

## Verification

- `python -m pytest -x -q` in `backend/`: 17 passed.
- `py_compile` clean; behavior with Redis unconfigured verified unchanged (fail-open lock, poll loop never entered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9p1QxFzhXFjJ322kD5ttX