### PR TITLE
Move sync Mongo work off the event loop in run submit and presence heartbeat

### DIFF
--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -9,8 +9,10 @@ GET  /api/presence/{steam_id} — one player's full live doc (deck/relics/potion
 """
 
 import os
+import time
 
 from fastapi import APIRouter, HTTPException, Request
+from starlette.concurrency import run_in_threadpool
 
 router = APIRouter(prefix="/api/presence", tags=["Presence"])
 
@@ -649,6 +651,53 @@ def _require_mongo():
         raise HTTPException(status_code=503, detail="presence unavailable")
 
 
+# Process-local TTL cache of user records for the heartbeat path only (same
+# idiom as runs.py's _stats_fallback_cache: monotonic timestamps, expired
+# entries swept on miss). The mod beats ~every 30s, so without this every
+# heartbeat pays a cross-host Mongo round trip just to re-read a username
+# that almost never changes. users_db semantics elsewhere are untouched.
+_USER_CACHE_TTL_SECONDS = 300
+_USER_CACHE_MAX_ENTRIES = 4096
+_user_cache: dict[str, tuple[float, dict | None]] = {}
+
+
+def _cached_user(steam_id: str) -> dict | None:
+    """get_user_by_steam_id with a small TTL cache — heartbeat path only."""
+    now = time.monotonic()
+    hit = _user_cache.get(steam_id)
+    if hit and now - hit[0] < _USER_CACHE_TTL_SECONDS:
+        return hit[1]
+    for k in [
+        k for k, (t, _) in _user_cache.items() if now - t >= _USER_CACHE_TTL_SECONDS
+    ]:
+        del _user_cache[k]
+    from ..services.users_db import get_user_by_steam_id
+
+    user = get_user_by_steam_id(steam_id)
+    if len(_user_cache) < _USER_CACHE_MAX_ENTRIES:
+        _user_cache[steam_id] = (now, user)
+    return user
+
+
+def _heartbeat_sync(
+    steam_id: str, fields: dict, events: list[dict], unset: list[str]
+) -> None:
+    """The heartbeat's blocking Mongo work (user lookup + presence upsert +
+    live-time credit), bundled so the async route ships it to the threadpool
+    in one hop. Mongo runs on a separate host, so each call here is a network
+    round trip that must never run on the event loop."""
+    from ..services import presence_db
+
+    # Display name: the verified user record outranks the client-sent username.
+    try:
+        user = _cached_user(steam_id)
+        if user and user.get("username"):
+            fields["username"] = user["username"]
+    except Exception:
+        pass
+    presence_db.heartbeat(steam_id, fields, events, unset)
+
+
 @router.post("")
 async def post_presence(request: Request):
     _require_mongo()
@@ -673,7 +722,8 @@ async def post_presence(request: Request):
     from ..services import presence_db
 
     if data.get("ended"):
-        presence_db.end(steam_id)
+        # Sync pymongo delete = a cross-host round trip; off the event loop.
+        await run_in_threadpool(presence_db.end, steam_id)
         return {"ok": True, "ended": True}
 
     # Whitelist-copy the heartbeat; everything else in the body is dropped.
@@ -774,17 +824,12 @@ async def post_presence(request: Request):
         if k in data and data[k] is None
     ]
 
-    # Display name: the verified user record outranks the client-sent username.
-    try:
-        from ..services.users_db import get_user_by_steam_id
-
-        user = get_user_by_steam_id(steam_id)
-        if user and user.get("username"):
-            fields["username"] = user["username"]
-    except Exception:
-        pass
-
-    presence_db.heartbeat(steam_id, fields, _clean_events(data.get("events")), unset)
+    # All the Mongo work (user lookup, presence upsert, live-time credit, peak
+    # check) in one threadpool hop: run on the event loop, these cross-host
+    # round trips would stall every concurrent request on this worker.
+    await run_in_threadpool(
+        _heartbeat_sync, steam_id, fields, _clean_events(data.get("events")), unset
+    )
     return {"ok": True}
 
 

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 from pathlib import Path
 from fastapi import APIRouter, HTTPException, Query, Request, Response
 from slowapi import Limiter
+from starlette.concurrency import run_in_threadpool
 from ..dependencies import client_ip
 from ..services import rate_limit_config
 from ..services.runs_db import submit_run, get_stats, claim_runs
@@ -159,7 +160,11 @@ async def submit_run_endpoint(
         digits = "".join(ch for ch in discord_id if ch.isdigit())
         clean_discord_id = digits or None
 
-    result = submit_run(
+    # Threadpool: submit_run is sync work (Mongo insert on a separate host +
+    # JSON file write); run on the event loop it would stall every concurrent
+    # request on this worker for the duration of the round trips.
+    result = await run_in_threadpool(
+        submit_run,
         data,
         username=clean_username,
         steam_id=clean_steam_id,
@@ -198,7 +203,8 @@ async def submit_run_endpoint(
         try:
             from ..services.runs_db_mongo import seed_rank_for
 
-            rank = seed_rank_for(clean_steam_id, seed)
+            # Several sync Mongo queries — off the event loop, same as above.
+            rank = await run_in_threadpool(seed_rank_for, clean_steam_id, seed)
             result["seed_rank"] = rank.get("seed_rank")
             result["seed_total"] = rank.get("seed_total")
         except Exception:
@@ -275,7 +281,8 @@ async def claim_runs_endpoint(request: Request):
     if not clean_hashes:
         return {"claimed": 0, "already_claimed": 0, "unknown": 0}
 
-    return claim_runs(sanitized, clean_hashes)
+    # Sync DB write (cross-host round trips) — off the event loop.
+    return await run_in_threadpool(claim_runs, sanitized, clean_hashes)
 
 
 @router.get("/list", tags=["Runs"])

--- a/backend/app/services/presence_db.py
+++ b/backend/app/services/presence_db.py
@@ -115,29 +115,61 @@ def _credit_live_time(steam_id: str, username: str | None, now: datetime) -> Non
     total. Best-effort: accounting never breaks a heartbeat. Gaps longer than
     CREDIT_CAP_SECONDS (a crash/quit and a later return) aren't counted, so the
     total reflects real continuous play. Because credit accrues per beat, it
-    captures sessions that end by crash/TTL, not just clean stops."""
-    try:
-        from pymongo import ReturnDocument
+    captures sessions that end by crash/TTL, not just clean stops.
 
-        set_fields: dict[str, Any] = {"last_seen": now}
-        if username:
-            set_fields["username"] = username
-        prev = _live_totals_coll().find_one_and_update(
-            {"_id": steam_id},
-            {
-                "$set": set_fields,
-                "$setOnInsert": {"first_seen": now, "total_seconds": 0},
+    One aggregation-pipeline update: the gap is computed server-side from the
+    stored last_seen, so the old read-back (find_one_and_update) + $inc pair —
+    two cross-host round trips per heartbeat — collapses into one."""
+    try:
+        set_stage: dict[str, Any] = {
+            "last_seen": now,
+            "first_seen": {"$ifNull": ["$first_seen", now]},
+            "total_seconds": {
+                "$let": {
+                    # Seconds since the previous beat; on a fresh upsert
+                    # last_seen is absent, so the gap is zero (no credit),
+                    # matching the old insert path's total_seconds: 0.
+                    "vars": {
+                        "delta": {
+                            "$divide": [
+                                {
+                                    "$subtract": [
+                                        now,
+                                        {"$ifNull": ["$last_seen", now]},
+                                    ]
+                                },
+                                1000,
+                            ]
+                        }
+                    },
+                    "in": {
+                        "$add": [
+                            {"$ifNull": ["$total_seconds", 0]},
+                            {
+                                "$cond": [
+                                    {
+                                        "$and": [
+                                            {"$gt": ["$$delta", 0]},
+                                            {"$lte": ["$$delta", CREDIT_CAP_SECONDS]},
+                                        ]
+                                    },
+                                    # int(delta) equivalent (delta is positive).
+                                    {"$toInt": {"$trunc": "$$delta"}},
+                                    0,
+                                ]
+                            },
+                        ]
+                    },
+                }
             },
-            upsert=True,
-            return_document=ReturnDocument.BEFORE,
+        }
+        if username:
+            # $literal: the username is client-derived text; a leading "$"
+            # must not be read as a field path by the pipeline.
+            set_stage["username"] = {"$literal": username}
+        _live_totals_coll().update_one(
+            {"_id": steam_id}, [{"$set": set_stage}], upsert=True
         )
-        last = (prev or {}).get("last_seen")
-        if isinstance(last, datetime):
-            delta = (now - last.replace(tzinfo=timezone.utc)).total_seconds()
-            if 0 < delta <= CREDIT_CAP_SECONDS:
-                _live_totals_coll().update_one(
-                    {"_id": steam_id}, {"$inc": {"total_seconds": int(delta)}}
-                )
     except Exception:
         pass
 


### PR DESCRIPTION
## Problem

Three `async def` routes call sync pymongo directly on the uvicorn event loop, stalling every concurrent request on that worker for the duration. With Mongo on a separate host, each call is a network RTT: run submission (`submit_run` insert + file write, plus `seed_rank_for`'s ~4 queries), run claiming, and the presence heartbeat (user lookup + presence upsert + two `live_totals` writes + first-beat peak check = 4-6 sequential round trips per beat, every 30s per online player).

## Changes

- **`routers/runs.py`**: `submit_run_endpoint` and `claim_runs_endpoint` now run their sync DB work via `await run_in_threadpool(...)`.
- **`routers/presence.py`**: `post_presence`'s entire sync tail (user lookup, presence upsert, live-time credit, peak check) is bundled into one sync helper and shipped to the threadpool in a single hop; the `ended` branch's delete is wrapped too. New bounded TTL cache (300s, max 4096 entries) for `get_user_by_steam_id` on the heartbeat path only, following the existing process-local TTL cache idiom.
- **`services/presence_db.py`**: the `live_totals` `find_one_and_update` + `update_one` pair is now a single aggregation-pipeline `update_one` (`upsert=True`) that computes the credit delta server-side. Semantics preserved exactly: no credit on fresh upsert, `0 < delta <= 150` cap, truncation, `last_seen` always advances on uncredited gaps, and `username` passed via `$literal` so `$`-prefixed client names can't be parsed as field paths. Requires Mongo 4.2+ (prod runs 7.0).

## Verification

- `python -m pytest -x -q` in `backend/`: 17 passed; `py_compile` clean; app imports.
- `_credit_live_time` exercised against mongomock: fresh upsert, +30s credit, 150s boundary (counted), 151s (uncredited, `last_seen` advances), fractional truncation, `$`-prefixed username stored literally, negative-gap/clock-skew no-credit — all match the previous two-call semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9p1QxFzhXFjJ322kD5ttX