### PR TITLE
Time the full rebuild's finalize/persist and add a version-cap knob

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -362,8 +362,28 @@ _recent_stat_versions: list[str] = []
 # How many game versions get their own per-version bucket. None = every
 # release version that has a submitted run (the dropdowns go back to the
 # first patch, not just the recent window). Per-version buckets are small,
-# so unbounded growth tracks the game's release cadence, not run volume.
-_RECENT_VERSIONS_N: int | None = None
+# so unbounded growth tracks the game's release cadence, not run volume —
+# but every version also multiplies the per-bracket Elo fits and blob
+# shards, so ENTITY_STATS_RECENT_VERSIONS_N caps it when that cost
+# outgrows the box. Capping to N hides versions older than the newest N
+# from every stats-page version dropdown (stat_versions in
+# /api/runs/versions) AND makes /api/runs/list reject a build_id filter
+# naming a dropped version, so the default stays unbounded.
+
+
+def _env_recent_versions_n() -> int | None:
+    raw = (os.environ.get("ENTITY_STATS_RECENT_VERSIONS_N") or "").strip()
+    if not raw:
+        return None
+    try:
+        n = int(raw)
+    except ValueError:
+        logger.warning("ignoring non-integer ENTITY_STATS_RECENT_VERSIONS_N=%r", raw)
+        return None
+    return n if n > 0 else None
+
+
+_RECENT_VERSIONS_N: int | None = _env_recent_versions_n()
 _cache_built_at: float = 0.0
 _building: bool = False
 # The snapshot_version of whatever is currently loaded (None = nothing
@@ -1858,7 +1878,15 @@ def _build_cache_data(stash: bool = False) -> tuple[dict, dict, dict, dict]:
             "blob_final_memo": _incr["blob_final_memo"],
             "elo_memo": _incr["elo_memo"],
         }
+    _t_fin = time.time()
     result = _finalize(**raw, **fin_kwargs)
+    # The finalize used to be an unlogged gap between the walk-done line above
+    # and the "snapshot rebuilt" line; time it like the incremental tick does.
+    logger.info(
+        "snapshot rebuild: finalize done in %.1fs (%d brackets)",
+        time.time() - _t_fin,
+        len(raw["bracket_accs"]),
+    )
     # Advertise which versions actually got their own bucket, so the read path
     # and the version dropdown only offer versions that have data. result[3] is
     # the bracket_meta dict.
@@ -2699,16 +2727,20 @@ def refresh_entity_stats_snapshot(force_full: bool = False) -> int:
     cache, totals, baselines, bracket_meta = _build_cache_data(
         stash=_INCREMENTAL_ENABLED
     )
+    _t_persist = time.time()
     _persist_snapshot(cache, totals, baselines, bracket_meta)
+    _persist_secs = time.time() - _t_persist
     _apply_cache(cache, totals, baselines, bracket_meta)
     _cache_snapshot_version = SNAPSHOT_VERSION
     # Best-effort: the snapshot + cache are already committed above; this only
     # appends the daily Score/Elo history and never raises into the rebuild.
     _archive_metric_history()
     logger.info(
-        "entity-stats snapshot rebuilt: %d entities across %d runs",
+        "entity-stats snapshot rebuilt: %d entities across %d runs "
+        "(persist %.1fs)",
         len(cache),
         totals["total_runs"],
+        _persist_secs,
     )
     if _INCREMENTAL_ENABLED and _USING_MONGO:
         save_stats_checkpoint()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,6 +40,13 @@ services:
       # (the serial ~80min walk); capped at the box's CPU count. Set the value
       # in the box .env after validating with scripts/validate_parallel_rebuild.py.
       - ENTITY_STATS_REBUILD_WORKERS=${ENTITY_STATS_REBUILD_WORKERS:-1}
+      # Optional cap on how many release versions keep their own per-version
+      # stats bucket. Empty = code default (unbounded: every release version
+      # with a run stays in the stats-page version dropdowns). Setting N drops
+      # versions older than the newest N from the dropdowns and the
+      # /api/runs/list version filter, in exchange for fewer per-version Elo
+      # fits and blob shards per rebuild/persist.
+      - ENTITY_STATS_RECENT_VERSIONS_N=${ENTITY_STATS_RECENT_VERSIONS_N:-}
       # How often the leader may rerun the heavy walk (seconds). Default 7200
       # (2h). With the parallel rebuild on, lower it for fresher public numbers,
       # but keep it well above the observed walk time so the box isn't always
@@ -166,6 +173,9 @@ services:
       - BETA_DATA_DIR=/data-beta
       - STATS_REFRESHER=on
       - ENTITY_STATS_REBUILD_WORKERS=${ENTITY_STATS_REBUILD_WORKERS:-1}
+      # See the backend service: optional cap on per-version stats buckets.
+      # Must match the backend's value so both build the same snapshot shape.
+      - ENTITY_STATS_RECENT_VERSIONS_N=${ENTITY_STATS_RECENT_VERSIONS_N:-}
       - ENTITY_STATS_REBUILD_INTERVAL_SECONDS=${ENTITY_STATS_REBUILD_INTERVAL_SECONDS:-7200}
       - MONGO_URL=${MONGO_URL:-}
       - REDIS_URL=${REDIS_URL:-redis://spire-codex-redis:6379/0}


### PR DESCRIPTION
## Problem

Two small gaps left after #712/#713 (which this branch originally overlapped before rebasing onto them):

1. The incremental tick logs its finalize+persist timing, but the **full rebuild's** finalize and persist phases are still unlogged — the rebuild's wall-clock can't be split into blob-walk vs finalize vs persist from prod logs.
2. `_RECENT_VERSIONS_N` is hardcoded `None` (unbounded): every release version ever seen keeps its bracket accumulators, fits, and snapshot size forever, with no operator control.

## Changes (`services/run_entity_stats.py`, `docker-compose.prod.yml`)

- `_build_cache_data` logs `snapshot rebuild: finalize done in %.1fs (%d brackets)`; the `entity-stats snapshot rebuilt` line gains `(persist %.1fs)` — matching the incremental path's log style.
- `_RECENT_VERSIONS_N` is now settable via `ENTITY_STATS_RECENT_VERSIONS_N` (unset/0/negative/garbage -> None, i.e. today's unbounded behavior). Env passthrough added to both `backend` and `rebuilder` services. **Default unchanged** — a cap hides older versions from the frontend version dropdowns and would reject `build_id` filters naming dropped versions, so enabling it is an explicit operator choice.

Originally this branch also warm-started the Elo fits and skipped untouched brackets; both were dropped as superseded by #713 (checkpoint-persisted `elo_memo`, refit gating) and #712 (delta finalize, per-shard persist).

## Verification

- `python -m pytest -x -q` in `backend/`: 17 passed; `py_compile` clean; compose YAML parses.
- Env knob parsing exercised across unset/`3`/`0`/garbage/empty; `_pick_recent_versions(rows, 3)` returns the newest 3 matching the unbounded head; both new log lines exercised against a real `_finalize` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9p1QxFzhXFjJ322kD5ttX