### PR TITLE
Keep run_blobs in sync with run files and backfill gaps on rebuilder startup

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -303,22 +303,26 @@ def runs_search(
 
 @router.delete("/runs/{run_hash}")
 def runs_delete(request: Request, run_hash: str):
-    """Remove a submitted run: every Mongo doc sharing the hash, the blob
-    file, and the in-process blob cache. Aggregates (snapshot, leaderboard
-    summaries) drop it on their next scheduled rebuild."""
+    """Remove a submitted run: every Mongo doc sharing the hash, the
+    run_blobs doc, the blob file, and the caches in front of them.
+    Aggregates (snapshot, leaderboard summaries) drop it on their next
+    scheduled rebuild."""
     _audit(request)
     from ..services import admin_db
     from .runs import _data_dir, _load_run_blob
 
     result = admin_db.delete_run(run_hash.strip(), _data_dir / "runs")
-    # The shared-run endpoint serves blobs from an in-process LRU; evict so
-    # a deleted run stops being served by this worker immediately. Other
-    # workers age it out on their own.
+    # The shared-run endpoint caches blobs in Redis (run:<hash>, 15min TTL)
+    # and an in-process LRU; evict both so the deleted run stops being served
+    # here immediately. The LRU is per worker, so other workers only age it
+    # out via LRU eviction — acceptable for moderation deletes.
+    app_cache.delete(f"run:{run_hash.strip()}")
     _load_run_blob.cache_clear()
     logger.info(
-        "admin deleted run %s: %s docs, file_removed=%s",
+        "admin deleted run %s: %s docs, blob_deleted=%s, file_removed=%s",
         run_hash,
         result["deleted_docs"],
+        result["blob_deleted"],
         result["file_removed"],
     )
     return {"run_hash": run_hash, **result}

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1239,6 +1239,7 @@ _PREWARM_INTERVAL_SECONDS = max(
 )
 _cadence = {"summary": 0.0, "prewarm": 0.0}
 _side_jobs: dict[str, float] = {}
+_blob_backfill_kicked = False
 
 
 def _kick_side_job(name: str, fn) -> None:
@@ -1266,6 +1267,33 @@ def _kick_side_job(name: str, fn) -> None:
             _side_jobs.pop(name, None)
 
     threading.Thread(target=_run, daemon=True, name=f"stats-{name}").start()
+
+
+def _maybe_kick_blob_backfill() -> None:
+    """Heal any gap between data/runs files and the run_blobs collection,
+    once per process lifetime, on this instance's first leader cycle (i.e.
+    in the rebuilder). Kicked after the snapshot tick with the other side
+    jobs — the tick's finalize pins the GIL and pegs Mongo, so anything
+    started before it just races it — and runs on a side-job thread so it
+    never delays the tick or startup. RUN_BLOBS_STARTUP_BACKFILL=off skips
+    it entirely."""
+    global _blob_backfill_kicked
+    if _blob_backfill_kicked:
+        return
+    if os.environ.get("RUN_BLOBS_STARTUP_BACKFILL", "on").strip().lower() in (
+        "off",
+        "0",
+        "false",
+    ):
+        return
+    _blob_backfill_kicked = True
+
+    def _backfill() -> None:
+        from ..services.runs_db_mongo import backfill_run_blobs
+
+        backfill_run_blobs()
+
+    _kick_side_job("blob-backfill", _backfill)
 
 
 def start_stats_refresher() -> None:
@@ -1355,6 +1383,8 @@ def start_stats_refresher() -> None:
         # Stats aggregations run after the tick: its finalize pins the GIL and
         # pegs Mongo for minutes, so anything kicked before it just races it.
         _kick_side_job("home_stats", refresh_home_stats)
+        # One-shot files -> run_blobs backfill, first leader cycle only.
+        _maybe_kick_blob_backfill()
 
         if time.time() - _cadence["summary"] >= _SUMMARY_INTERVAL_SECONDS:
             _cadence["summary"] = time.time()

--- a/backend/app/services/admin_db.py
+++ b/backend/app/services/admin_db.py
@@ -138,10 +138,11 @@ def dismiss_guide_submission(sub_id: str) -> bool:
 
 def delete_run(run_hash: str, runs_dir: Path) -> dict[str, Any]:
     """Remove a submitted run everywhere it lives synchronously: every Mongo
-    doc with the hash (multiplayer runs store one doc per player) and the
-    blob file. The stats snapshot and leaderboard summaries pick up the
-    removal on their next scheduled rebuild."""
+    doc with the hash (multiplayer runs store one doc per player), the
+    run_blobs doc, and the blob file. The stats snapshot and leaderboard
+    summaries pick up the removal on their next scheduled rebuild."""
     deleted_docs = 0
+    blob_deleted = 0
     if _enabled():
         # Single-player runs key on _id (= run hash) with no run_hash field;
         # multiplayer runs share a run_hash field. Match either so the doc is
@@ -151,6 +152,9 @@ def delete_run(run_hash: str, runs_dir: Path) -> dict[str, Any]:
             .delete_many({"$or": [{"_id": run_hash}, {"run_hash": run_hash}]})
             .deleted_count
         )
+        # Blob docs key on _id == run_hash. Without this the shared-run
+        # endpoint's Mongo fallback resurrects moderation-deleted runs.
+        blob_deleted = _db()["run_blobs"].delete_one({"_id": run_hash}).deleted_count
     file_removed = False
     blob = runs_dir / f"{run_hash}.json"
     try:
@@ -159,7 +163,11 @@ def delete_run(run_hash: str, runs_dir: Path) -> dict[str, Any]:
             file_removed = True
     except OSError:
         logger.warning("run blob delete failed for %s", run_hash, exc_info=True)
-    return {"deleted_docs": deleted_docs, "file_removed": file_removed}
+    return {
+        "deleted_docs": deleted_docs,
+        "blob_deleted": blob_deleted,
+        "file_removed": file_removed,
+    }
 
 
 # ── Announcements (the site banner) ──────────────────────────

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -495,7 +495,11 @@ def submit_run(
                             json.dump(data, f, ensure_ascii=False)
                     except Exception as e:
                         print(f"Warning: failed to save run {run_hash}: {e}")
-                    save_run_blob(run_hash, data)
+                # Outside the exists-gate on purpose: blob write failures are
+                # swallowed, so gating on the file would make one transient
+                # Mongo hiccup permanent (resubmission would skip the repair).
+                # The upsert inside makes the duplicate-submission case cheap.
+                save_run_blob(run_hash, data)
 
     return results[0]
 
@@ -536,9 +540,99 @@ def get_run_blobs(hashes: list[str]) -> dict[str, dict]:
                 if doc.get("blob") is not None:
                     out[doc["_id"]] = doc["blob"]
         except Exception as e:
-            logger.warning("run blob batch fetch failed: %s", e)
+            # Callers fall back to per-file reads for whatever we don't
+            # return, so this degrades quietly — log how much was left.
+            logger.warning(
+                "run blob batch fetch failed, %d of %d ids left to file "
+                "fallback: %s",
+                len(hashes) - i,
+                len(hashes),
+                e,
+            )
             break
     return out
+
+
+def backfill_run_blobs(batch: int = 500) -> dict:
+    """Copy data/runs/*.json into run_blobs for every hash missing a blob.
+
+    Idempotent and resumable: each batch is existence-checked with one $in
+    query, and present blobs are skipped without reading their files. Also
+    invoked automatically by the stats refresher (rebuilder) on its first
+    leader cycle, so gaps — pre-collection history, blob writes that failed
+    at submit time — heal without a manual run.
+    """
+    runs_dir = _data_dir / "runs"
+    # Stems as plain strings, not Path objects: at ~850k files the Path list
+    # alone costs 100MB+.
+    try:
+        stems = sorted(n[:-5] for n in os.listdir(runs_dir) if n.endswith(".json"))
+    except OSError:
+        stems = []
+    coll = _blob_collection()
+    # Cheap gap check before walking 850k stems: orphaned blobs from deleted
+    # runs can push the blob count above the file count; that's fine, it
+    # still means no gap.
+    blob_count = coll.estimated_document_count()
+    if blob_count >= len(stems):
+        logger.info(
+            "run blob backfill: skipped, %d blobs >= %d files",
+            blob_count,
+            len(stems),
+        )
+        return {"files": len(stems), "inserted": 0, "skipped": len(stems), "failed": 0}
+    logger.info(
+        "run blob backfill: starting, %d files vs %d blobs", len(stems), blob_count
+    )
+    inserted = skipped = failed = 0
+    started = time.time()
+    for i in range(0, len(stems), batch):
+        ids = stems[i : i + batch]
+        existing = {d["_id"] for d in coll.find({"_id": {"$in": ids}}, {"_id": 1})}
+        docs = []
+        for stem in ids:
+            if stem in existing:
+                skipped += 1
+                continue
+            try:
+                docs.append(
+                    {
+                        "_id": stem,
+                        "blob": json.loads(
+                            (runs_dir / f"{stem}.json").read_text(encoding="utf-8")
+                        ),
+                    }
+                )
+            except Exception as e:
+                logger.warning("run blob backfill: unreadable %s.json: %s", stem, e)
+                failed += 1
+        if docs:
+            try:
+                coll.insert_many(docs, ordered=False)
+                inserted += len(docs)
+            except Exception:
+                for d in docs:
+                    try:
+                        coll.replace_one({"_id": d["_id"]}, d, upsert=True)
+                        inserted += 1
+                    except Exception as e:
+                        logger.warning(
+                            "run blob backfill: failed %s: %s", d["_id"], e
+                        )
+                        failed += 1
+    logger.info(
+        "run blob backfill: done, %d inserted, %d skipped, %d failed in %.0fs",
+        inserted,
+        skipped,
+        failed,
+        time.time() - started,
+    )
+    return {
+        "files": len(stems),
+        "inserted": inserted,
+        "skipped": skipped,
+        "failed": failed,
+    }
 
 
 def _shop_purchases(data: dict) -> list[str]:

--- a/backend/scripts/backfill_run_blobs.py
+++ b/backend/scripts/backfill_run_blobs.py
@@ -1,14 +1,13 @@
 """Backfill data/runs/*.json into the run_blobs collection. Idempotent,
-resumable, leaves the files untouched.
+resumable, leaves the files untouched. Also runs automatically in the
+rebuilder on its first refresh-lease cycle; this wrapper is for manual runs.
 
     python -m scripts.backfill_run_blobs
 """
 
 import argparse
-import json
+import logging
 import os
-import time
-from pathlib import Path
 
 
 def main() -> int:
@@ -18,55 +17,11 @@ def main() -> int:
     if not os.environ.get("MONGO_URL", "").strip():
         print("MONGO_URL unset; nothing to do")
         return 1
-    from app.services.runs_db_mongo import _blob_collection
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    from app.services.runs_db_mongo import backfill_run_blobs
 
-    runs_dir = Path(os.environ.get("DATA_DIR", "data")) / "runs"
-    files = sorted(runs_dir.glob("*.json"))
-    print(f"{len(files)} run files under {runs_dir}", flush=True)
-    coll = _blob_collection()
-    inserted = skipped = failed = 0
-    started = time.time()
-    for i in range(0, len(files), args.batch):
-        batch = files[i : i + args.batch]
-        ids = [f.stem for f in batch]
-        existing = {d["_id"] for d in coll.find({"_id": {"$in": ids}}, {"_id": 1})}
-        docs = []
-        for f in batch:
-            if f.stem in existing:
-                skipped += 1
-                continue
-            try:
-                docs.append(
-                    {"_id": f.stem, "blob": json.loads(f.read_text(encoding="utf-8"))}
-                )
-            except Exception as e:
-                print(f"unreadable {f.name}: {e}", flush=True)
-                failed += 1
-        if docs:
-            try:
-                coll.insert_many(docs, ordered=False)
-                inserted += len(docs)
-            except Exception:
-                for d in docs:
-                    try:
-                        coll.replace_one({"_id": d["_id"]}, d, upsert=True)
-                        inserted += 1
-                    except Exception as e:
-                        print(f"failed {d['_id']}: {e}", flush=True)
-                        failed += 1
-        if (i // args.batch) % 40 == 0:
-            done = i + len(batch)
-            rate = done / max(time.time() - started, 1)
-            print(
-                f"{done}/{len(files)} files | {inserted} inserted, "
-                f"{skipped} skipped, {failed} failed | {rate:.0f} files/s",
-                flush=True,
-            )
-    print(
-        f"done: {inserted} inserted, {skipped} skipped, {failed} failed "
-        f"in {time.time() - started:.0f}s",
-        flush=True,
-    )
+    result = backfill_run_blobs(batch=args.batch)
+    print(result, flush=True)
     return 0
 
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -133,6 +133,9 @@ services:
       # BACKEND_STATS_REFRESHER=on in the box .env to revert to the old
       # single-container behavior.
       - STATS_REFRESHER=${BACKEND_STATS_REFRESHER:-off}
+      # Only matters if BACKEND_STATS_REFRESHER=on (lease holders run the
+      # run_blobs startup backfill); see the rebuilder service.
+      - RUN_BLOBS_STARTUP_BACKFILL=${RUN_BLOBS_STARTUP_BACKFILL:-on}
     # Ordering only (no health condition): the backend must boot fine with
     # Redis down, since the cache layer is fail-safe by design.
     depends_on:
@@ -165,6 +168,9 @@ services:
       - DATA_DIR=/data
       - BETA_DATA_DIR=/data-beta
       - STATS_REFRESHER=on
+      # One-shot files -> run_blobs backfill on the first lease cycle after
+      # boot. Set to off to skip (e.g. while diagnosing Mongo load).
+      - RUN_BLOBS_STARTUP_BACKFILL=${RUN_BLOBS_STARTUP_BACKFILL:-on}
       - ENTITY_STATS_REBUILD_WORKERS=${ENTITY_STATS_REBUILD_WORKERS:-1}
       - ENTITY_STATS_REBUILD_INTERVAL_SECONDS=${ENTITY_STATS_REBUILD_INTERVAL_SECONDS:-7200}
       - MONGO_URL=${MONGO_URL:-}


### PR DESCRIPTION
## Problem

Run blobs are stored twice (Mongo `run_blobs` + `data/runs/*.json`), and three mechanisms let them diverge permanently:

1. `save_run_blob` was nested inside the file-exists gate in `submit_run` — a transiently failed (and silently swallowed) blob write could never be repaired by resubmission, because the file already existed.
2. Admin `delete_run` removed the runs docs and the file but not the blob, so moderation-deleted runs resurrected on their share page via the Mongo fallback.
3. The `run_blobs` collection is newer than most of the data (#707), so pre-existing runs lack blobs unless the manual backfill script was run — and a single Mongo batch error in `get_run_blobs` silently degraded 300 blobs to per-file fallback reads with no log line.

## Changes

- **`services/runs_db_mongo.py`**: `save_run_blob` moved out of the file-exists gate — every success/duplicate submission upserts the blob (idempotent `replace_one`), so divergence self-heals. `get_run_blobs` batch failures now log a warning with the count of ids left to file fallback. New importable `backfill_run_blobs(batch=500)` (refactored from the script, now a thin CLI wrapper): iterates stems as strings instead of ~850k `Path` objects, and an `estimated_document_count()` pre-check skips the pass entirely when blob count >= file count.
- **`services/admin_db.py` / `routers/admin.py`**: `delete_run` also deletes the `run_blobs` doc (reported as `blob_deleted`); the admin endpoint additionally drops the Redis `run:<hash>` key and clears the local blob LRU (per-worker limitation noted in a comment).
- **`routers/runs.py`**: the refresher kicks the backfill once per process lifetime as a background side-job daemon thread, only while holding the refresh lease — so only the rebuilder runs it and it never blocks startup. Re-seated for #722: the kick now happens inside `_run_refresh_cycle` *after* the snapshot tick, alongside the other side-job kicks, so it can't race the tick's finalize. Kill-switch: `RUN_BLOBS_STARTUP_BACKFILL=off` (passthrough in `docker-compose.prod.yml`).

## Verification

- `python -m pytest -x -q` in `backend/`: 17 passed; `py_compile` clean on all changed files.
- Mongomock exercise, 16/16 checks: backfill inserts missing / skips present without overwriting; pre-check skip when blob count >= file count; unreadable JSON counted as failed; `delete_run` removes single + multiplayer runs docs, the blob doc, and the file; missing-hash delete is a clean no-op.
- Rebased onto current main (678d4a1): #723's counter writes are in a different function, no overlap; nothing upstream supersedes these features.

Notes for deploy: first rebuilder start after merge may run a long (background, resumable) backfill if the historical gap is real — the start/finish log line reports the inserted/skipped split. The rebuilder must be recreated to pick this up (it's not in the deploy scripts' `up` list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9p1QxFzhXFjJ322kD5ttX