### PR TITLE
Infobox version dropdown on entity pages

### DIFF
--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -18,6 +18,7 @@ import EntityPairings from "@/app/components/EntityPairings";
 import EntityDraftRecs from "@/app/components/EntityDraftRecs";
 import { imageUrl, fullCardUrl, enchantedCardUrl } from "@/lib/image-url";
 import EntityRunStats, { type EntityStats } from "@/app/components/EntityRunStats";
+import EntityVersionSelect from "@/app/components/EntityVersionSelect";
 import HoverTooltip from "@/app/components/HoverTooltip";
 import { useChannel, useLangPrefix } from "@/lib/use-lang-prefix";
 import BetaDiffNotice from "@/app/components/BetaDiffNotice";
@@ -179,6 +180,9 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
   // Bracket shared with EntityRunStats so the infobox mini-stats track the
   // pill the user picked in the Community section.
   const [statsBracket, setStatsBracket] = useState("all");
+  const hasStatVersions = Object.keys(miniStats?.brackets ?? {}).some((k) =>
+    /^v\d/.test(k),
+  );
   const [powerData, setPowerData] = useState<Record<string, { id: string; name: string; description: string; type: string; image_url: string | null }>>({});
   const [keywordData, setKeywordData] = useState<Record<string, { id: string; name: string; description: string }>>({});
   const [glossaryData, setGlossaryData] = useState<Record<string, { id: string; name: string; description: string }>>({});
@@ -766,6 +770,12 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
                   <>
                     Beta art{isUpgraded ? " + Upgraded" : ""}
                   </>
+                ) : hasStatVersions ? (
+                  <EntityVersionSelect
+                    brackets={miniStats?.brackets}
+                    bracket={statsBracket}
+                    onBracketChange={setStatsBracket}
+                  />
                 ) : (
                   <>
                     {isUpgraded ? "Upgraded" : "Normal"}

--- a/frontend/app/components/EntityVersionSelect.tsx
+++ b/frontend/app/components/EntityVersionSelect.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useLanguage } from "@/app/contexts/LanguageContext";
+import { t } from "@/lib/ui-translations";
+import { splitBracket, combineBracket } from "@/lib/content-brackets";
+
+export default function EntityVersionSelect({
+  brackets,
+  bracket,
+  onBracketChange,
+}: {
+  brackets: Record<string, unknown> | undefined | null;
+  bracket: string;
+  onBracketChange: (b: string) => void;
+}) {
+  const { lang } = useLanguage();
+  const versions = Object.keys(brackets ?? {})
+    .filter((k) => /^v\d/.test(k))
+    .sort()
+    .reverse();
+  if (versions.length === 0) return null;
+  const { player, skill, version } = splitBracket(bracket);
+  return (
+    <select
+      className="rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)] focus:outline-none"
+      aria-label="Game version"
+      value={version}
+      onChange={(e) => onBracketChange(combineBracket(player, skill, e.target.value))}
+    >
+      <option value="">{t("All versions", lang)}</option>
+      {versions.map((v) => (
+        <option key={v} value={v}>
+          {v}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/frontend/app/potions/[id]/PotionDetail.tsx
+++ b/frontend/app/potions/[id]/PotionDetail.tsx
@@ -14,6 +14,7 @@ import RelatedItems from "@/app/components/RelatedItems";
 import EntityProse from "@/app/components/EntityProse";
 import EntityPairings from "@/app/components/EntityPairings";
 import EntityRunStats, { type EntityStats } from "@/app/components/EntityRunStats";
+import EntityVersionSelect from "@/app/components/EntityVersionSelect";
 import { imageUrl } from "@/lib/image-url";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import "../../card-revamp.css";
@@ -273,6 +274,14 @@ export default function PotionDetail({
                 crossOrigin="anonymous"
               />
             )}
+
+            <div className="mb-2 text-center">
+              <EntityVersionSelect
+                brackets={miniStats?.brackets}
+                bracket={statsBracket}
+                onBracketChange={setStatsBracket}
+              />
+            </div>
 
             {/* Facts table */}
             <div className="facts">

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -15,6 +15,7 @@ import EntityProse from "@/app/components/EntityProse";
 import EntityPairings from "@/app/components/EntityPairings";
 import EntityDraftRecs from "@/app/components/EntityDraftRecs";
 import EntityRunStats, { type EntityStats } from "@/app/components/EntityRunStats";
+import EntityVersionSelect from "@/app/components/EntityVersionSelect";
 import { imageUrl } from "@/lib/image-url";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import BetaDiffNotice from "@/app/components/BetaDiffNotice";
@@ -338,6 +339,14 @@ export default function RelicDetail({
                 </div>
               );
             })()}
+
+            <div className="mb-2 text-center">
+              <EntityVersionSelect
+                brackets={miniStats?.brackets}
+                bracket={statsBracket}
+                onBracketChange={setStatsBracket}
+              />
+            </div>
 
             {/* Facts table */}
             <div className="facts">


### PR DESCRIPTION
Card, relic, and potion infoboxes gain a game-version dropdown above At a glance (replacing the Normal/Upgraded render caption on cards when versions exist) that drives the shared bracket state, so picking a version re-scopes the mini-stats and the whole Community section.