### PR TITLE
Similar runs from composition vectors

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1244,7 +1244,10 @@ _SUMMARY_INTERVAL_SECONDS = max(
 _PREWARM_INTERVAL_SECONDS = max(
     300, int(os.environ.get("CHART_PREWARM_INTERVAL_SECONDS", "") or 7200)
 )
-_cadence = {"summary": 0.0, "prewarm": 0.0}
+_VECTORS_INTERVAL_SECONDS = max(
+    3600, int(os.environ.get("RUN_VECTORS_INTERVAL_SECONDS", "") or 86400)
+)
+_cadence = {"summary": 0.0, "prewarm": 0.0, "vectors": 0.0}
 _side_jobs: dict[str, float] = {}
 _blob_backfill_kicked = False
 
@@ -1392,6 +1395,20 @@ def start_stats_refresher() -> None:
         _kick_side_job("home_stats", refresh_home_stats)
         # One-shot files -> run_blobs backfill, first leader cycle only.
         _maybe_kick_blob_backfill()
+
+        if (
+            os.environ.get("RUN_VECTORS", "on").strip().lower()
+            not in ("off", "0", "false")
+            and time.time() - _cadence["vectors"] >= _VECTORS_INTERVAL_SECONDS
+        ):
+            _cadence["vectors"] = time.time()
+
+            def _vectors() -> None:
+                from ..services.run_vectors import build_run_vectors
+
+                build_run_vectors()
+
+            _kick_side_job("run_vectors", _vectors)
 
         if time.time() - _cadence["summary"] >= _SUMMARY_INTERVAL_SECONDS:
             _cadence["summary"] = time.time()
@@ -1578,3 +1595,57 @@ def get_community_stats(
             app_cache.delete(lock_key)
 
     return result
+
+
+@router.get("/{run_hash}/similar", tags=["Runs"])
+@limiter.limit("60/minute")
+def get_similar_runs(
+    request: Request, response: Response, run_hash: str, lang: str = "eng"
+):
+    """Nearest winning solo decks to this run, from the nightly composition
+    vectors, plus the cards/relics those winners took that this run didn't."""
+    run_hash = run_hash.strip()
+    cache_key = f"simruns:{run_hash}:{lang}"
+    cached = app_cache.get_json(cache_key)
+    if cached is not None:
+        response.headers["Cache-Control"] = "public, max-age=300"
+        return cached
+    empty = {
+        "run_hash": run_hash,
+        "items": [],
+        "winners_also_took": [],
+        "available": False,
+    }
+    from ..services.run_vectors import available, similar_runs
+
+    if not (os.environ.get("MONGO_URL", "").strip() and available()):
+        response.headers["Cache-Control"] = "no-store"
+        return empty
+    try:
+        result = similar_runs(run_hash)
+    except Exception:
+        logger.warning("similar-runs lookup failed for %s", run_hash, exc_info=True)
+        result = None
+    if result is None:
+        response.headers["Cache-Control"] = "no-store"
+        return empty
+    from ..services import data_service
+
+    try:
+        cards = {
+            str(c.get("id", "")).upper(): c.get("name")
+            for c in data_service.load_cards(lang)
+        }
+        relics = {
+            str(r.get("id", "")).upper(): r.get("name")
+            for r in data_service.load_relics(lang)
+        }
+    except Exception:
+        cards, relics = {}, {}
+    for w in result["winners_also_took"]:
+        catalog = cards if w["etype"] == "cards" else relics
+        w["name"] = catalog.get(w["id"]) or w["id"].replace("_", " ").title()
+    payload = {"run_hash": run_hash, "available": True, **result}
+    app_cache.set_json(cache_key, payload, ttl_seconds=6 * 3600)
+    response.headers["Cache-Control"] = "public, max-age=300"
+    return payload

--- a/backend/app/services/run_vectors.py
+++ b/backend/app/services/run_vectors.py
@@ -1,0 +1,284 @@
+"""Run-composition vectors: nightly per-character shards for similar-run lookups."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_VEC_DIR = (
+    Path(os.environ.get("DATA_DIR", Path(__file__).resolve().parents[3] / "data"))
+    / "vectors"
+)
+
+_OFFICIAL_CHARACTERS = ("IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT")
+
+_lock = threading.Lock()
+_vocab: dict[str, int] | None = None
+_vocab_mtime: float = 0.0
+_shards: dict[str, tuple[Any, dict]] = {}
+
+
+def available() -> bool:
+    return (_VEC_DIR / "vocab.json").exists()
+
+
+def _build_vocab() -> list[str]:
+    from . import data_service
+
+    cards = {str(c.get("id", "")).upper() for c in data_service.load_cards("eng")}
+    relics = {
+        f"R:{str(r.get('id', '')).upper()}" for r in data_service.load_relics("eng")
+    }
+    return sorted(cards - {""}) + sorted(relics - {"R:"})
+
+
+def _row_terms(deck: list, relics: list) -> dict[str, float]:
+    import math
+
+    counts: dict[str, int] = {}
+    for c in deck or []:
+        cid = str((c or {}).get("id", "")).upper()
+        if cid:
+            counts[cid] = counts.get(cid, 0) + 1
+    terms = {cid: math.log1p(n) for cid, n in counts.items()}
+    for r in relics or []:
+        rid = str((r or {}).get("id", "")).upper()
+        if rid:
+            terms[f"R:{rid}"] = 1.0
+    return terms
+
+
+def build_run_vectors() -> dict:
+    import numpy as np
+    from scipy import sparse
+
+    from .runs_db_mongo import _get_collection
+
+    t0 = time.time()
+    vocab_list = _build_vocab()
+    index = {term: i for i, term in enumerate(vocab_list)}
+    coll = _get_collection()
+    cursor = coll.find(
+        {
+            "hidden": {"$ne": True},
+            "ascension": {"$gte": 0, "$lte": 10},
+            "player_count": 1,
+            "character": {"$in": list(_OFFICIAL_CHARACTERS)},
+        },
+        {
+            "_id": 1,
+            "character": 1,
+            "win": 1,
+            "ascension": 1,
+            "run_time": 1,
+            "username": 1,
+            "submitted_at": 1,
+            "build_id": 1,
+            "deck.id": 1,
+            "relics.id": 1,
+        },
+    )
+    per_char: dict[str, dict[str, list]] = {
+        ch: {"rows": [], "cols": [], "vals": [], "meta": []}
+        for ch in _OFFICIAL_CHARACTERS
+    }
+    for doc in cursor:
+        ch = doc.get("character")
+        acc = per_char.get(ch)
+        if acc is None:
+            continue
+        terms = _row_terms(doc.get("deck"), doc.get("relics"))
+        pairs = [(index[t], v) for t, v in terms.items() if t in index]
+        if not pairs:
+            continue
+        row = len(acc["meta"])
+        for col, val in pairs:
+            acc["rows"].append(row)
+            acc["cols"].append(col)
+            acc["vals"].append(val)
+        sub = doc.get("submitted_at")
+        acc["meta"].append(
+            {
+                "hash": doc["_id"],
+                "win": 1 if doc.get("win") else 0,
+                "asc": int(doc.get("ascension") or 0),
+                "time": int(doc.get("run_time") or 0),
+                "user": doc.get("username"),
+                "date": sub.strftime("%Y-%m-%d")
+                if hasattr(sub, "strftime")
+                else str(sub or "")[:10],
+                "ver": doc.get("build_id"),
+            }
+        )
+
+    _VEC_DIR.mkdir(parents=True, exist_ok=True)
+    total = 0
+    for ch, acc in per_char.items():
+        n = len(acc["meta"])
+        if n == 0:
+            continue
+        mat = sparse.csr_matrix(
+            (acc["vals"], (acc["rows"], acc["cols"])),
+            shape=(n, len(vocab_list)),
+            dtype=np.float32,
+        )
+        norms = sparse.linalg.norm(mat, axis=1)
+        norms[norms == 0] = 1.0
+        mat = sparse.diags(1.0 / norms).dot(mat).tocsr()
+        sparse.save_npz(_VEC_DIR / f"{ch}.npz", mat)
+        with gzip.open(_VEC_DIR / f"{ch}_meta.json.gz", "wt", encoding="utf-8") as f:
+            json.dump(acc["meta"], f, ensure_ascii=False)
+        total += n
+    tmp = _VEC_DIR / "vocab.json.tmp"
+    tmp.write_text(
+        json.dumps(
+            {
+                "terms": vocab_list,
+                "built_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            }
+        ),
+        encoding="utf-8",
+    )
+    tmp.replace(_VEC_DIR / "vocab.json")
+    with _lock:
+        _shards.clear()
+        global _vocab
+        _vocab = None
+    logger.info(
+        "run vectors built: %d solo runs across %d characters in %.0fs",
+        total,
+        sum(1 for a in per_char.values() if a["meta"]),
+        time.time() - t0,
+    )
+    return {"runs": total, "seconds": round(time.time() - t0)}
+
+
+def _load_vocab() -> dict[str, int] | None:
+    global _vocab, _vocab_mtime
+    path = _VEC_DIR / "vocab.json"
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return None
+    with _lock:
+        if _vocab is not None and mtime == _vocab_mtime:
+            return _vocab
+        data = json.loads(path.read_text(encoding="utf-8"))
+        _vocab = {t: i for i, t in enumerate(data.get("terms", []))}
+        _vocab_mtime = mtime
+        _shards.clear()
+        return _vocab
+
+
+def _load_shard(character: str):
+    from scipy import sparse
+
+    with _lock:
+        hit = _shards.get(character)
+        if hit is not None:
+            return hit
+    try:
+        mat = sparse.load_npz(_VEC_DIR / f"{character}.npz")
+        with gzip.open(
+            _VEC_DIR / f"{character}_meta.json.gz", "rt", encoding="utf-8"
+        ) as f:
+            meta = json.load(f)
+    except OSError:
+        return None
+    with _lock:
+        _shards[character] = (mat, meta)
+    return mat, meta
+
+
+def similar_runs(run_hash: str, limit: int = 5) -> dict | None:
+    """Nearest winning solo decks to this run, plus the composition diff."""
+    import numpy as np
+
+    vocab = _load_vocab()
+    if vocab is None:
+        return None
+    from .runs_db_mongo import _get_collection
+
+    doc = _get_collection().find_one(
+        {"$or": [{"_id": run_hash}, {"run_hash": run_hash}]},
+        {"character": 1, "deck.id": 1, "relics.id": 1},
+    )
+    if not doc or doc.get("character") not in _OFFICIAL_CHARACTERS:
+        return None
+    loaded = _load_shard(doc["character"])
+    if loaded is None:
+        return None
+    mat, meta = loaded
+    terms = _row_terms(doc.get("deck"), doc.get("relics"))
+    cols = [(vocab[t], v) for t, v in terms.items() if t in vocab]
+    if not cols:
+        return None
+    q = np.zeros(mat.shape[1], dtype=np.float32)
+    for c, v in cols:
+        q[c] = v
+    norm = float(np.linalg.norm(q))
+    if norm == 0:
+        return None
+    q /= norm
+    sims = mat.dot(q)
+    order = np.argsort(sims)[::-1]
+    items = []
+    seen_hashes = {run_hash}
+    for i in order:
+        if len(items) >= limit or sims[i] <= 0:
+            break
+        m = meta[int(i)]
+        if not m["win"] or m["hash"] in seen_hashes:
+            continue
+        seen_hashes.add(m["hash"])
+        items.append(
+            {
+                "run_hash": m["hash"],
+                "ascension": m["asc"],
+                "run_time": m["time"],
+                "username": m["user"],
+                "date": m["date"],
+                "build_id": m.get("ver"),
+                "similarity": round(float(sims[i]) * 100, 1),
+            }
+        )
+    own_terms = set(terms)
+    counts: dict[str, int] = {}
+    hash_to_row = {m["hash"]: idx for idx, m in enumerate(meta)}
+    inv = {i: t for t, i in vocab.items()}
+    for it in items:
+        row = hash_to_row.get(it["run_hash"])
+        if row is None:
+            continue
+        start, end = mat.indptr[row], mat.indptr[row + 1]
+        for c in mat.indices[start:end]:
+            term = inv[int(c)]
+            if term not in own_terms:
+                counts[term] = counts.get(term, 0) + 1
+    threshold = max(2, (len(items) + 1) // 2)
+    also = sorted(
+        ((t, n) for t, n in counts.items() if n >= threshold),
+        key=lambda tn: -tn[1],
+    )[:6]
+    winners_also_took = [
+        {
+            "id": t[2:] if t.startswith("R:") else t,
+            "etype": "relics" if t.startswith("R:") else "cards",
+            "count": n,
+        }
+        for t, n in also
+    ]
+    return {
+        "character": doc["character"],
+        "items": items,
+        "winners_also_took": winners_also_took,
+        "neighbors": len(items),
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ python-multipart==0.0.20
 boto3>=1.34,<2
 redis==5.2.1
 numpy==2.2.6
+scipy==1.14.1

--- a/backend/scripts/build_run_vectors.py
+++ b/backend/scripts/build_run_vectors.py
@@ -1,0 +1,22 @@
+"""Build the run-composition vector shards (also runs daily in the rebuilder).
+
+python -m scripts.build_run_vectors
+"""
+
+import logging
+import os
+
+
+def main() -> int:
+    if not os.environ.get("MONGO_URL", "").strip():
+        print("MONGO_URL unset; nothing to do")
+        return 1
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    from app.services.run_vectors import build_run_vectors
+
+    print(build_run_vectors(), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/frontend/app/runs/[hash]/SharedRunClient.tsx
+++ b/frontend/app/runs/[hash]/SharedRunClient.tsx
@@ -8,6 +8,7 @@ import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import { cachedFetch } from "@/lib/fetch-cache";
 import RunSummary, { type PotionInfo } from "./RunSummary";
+import SimilarRuns from "./SimilarRuns";
 import { CardPill, RelicPill, cleanId, displayName, type CardInfo, type RelicInfo } from "./RunPills";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -303,6 +304,8 @@ export default function SharedRunClient({ initialRun }: { initialRun?: any }) {
           ))}
         </div>
       </div>
+
+      <SimilarRuns hash={hash} />
       </>}
     </div>
   );

--- a/frontend/app/runs/[hash]/SimilarRuns.tsx
+++ b/frontend/app/runs/[hash]/SimilarRuns.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { t } from "@/lib/ui-translations";
+import { useLanguage } from "@/app/contexts/LanguageContext";
+import { useLangPrefix } from "@/lib/use-lang-prefix";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+interface SimilarItem {
+  run_hash: string;
+  ascension: number;
+  run_time: number;
+  username: string | null;
+  date: string;
+  similarity: number;
+}
+
+interface AlsoTook {
+  id: string;
+  etype: "cards" | "relics";
+  name: string;
+  count: number;
+}
+
+interface SimilarResponse {
+  available: boolean;
+  items: SimilarItem[];
+  winners_also_took: AlsoTook[];
+}
+
+function formatRunTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return m > 0 ? `${m}m ${s.toString().padStart(2, "0")}s` : `${s}s`;
+}
+
+export default function SimilarRuns({ hash }: { hash: string }) {
+  const { lang } = useLanguage();
+  const lp = useLangPrefix();
+  const [data, setData] = useState<SimilarResponse | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetch(`${API}/api/runs/${hash}/similar?lang=${lang}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: SimilarResponse | null) => {
+        if (active && d?.available && d.items?.length) setData(d);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [hash, lang]);
+
+  if (!data) return null;
+
+  return (
+    <div className="bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] p-5">
+      <h2 className="text-lg font-semibold text-[var(--text-primary)] mb-1">
+        {t("Similar winning runs", lang)}
+      </h2>
+      <p className="text-xs text-[var(--text-muted)] mb-3">
+        {t("The closest winning decks to this one, by cards and relics.", lang)}
+      </p>
+      <div className="space-y-1.5">
+        {data.items.map((it) => (
+          <Link
+            key={it.run_hash}
+            href={`${lp}/runs/${it.run_hash}`}
+            className="flex items-center gap-3 py-1.5 px-2 rounded-md border border-[var(--border-subtle)] hover:border-[var(--border-accent)] transition-colors text-xs"
+          >
+            <span className="font-mono text-[var(--accent-gold)] w-12 flex-shrink-0">
+              {it.similarity}%
+            </span>
+            <span className="text-[var(--text-secondary)]">
+              A{it.ascension} · {formatRunTime(it.run_time)}
+            </span>
+            <span className="text-[var(--text-muted)] truncate">
+              {it.username ?? "anon"}
+            </span>
+            <span className="text-[var(--text-muted)] ml-auto flex-shrink-0">{it.date}</span>
+          </Link>
+        ))}
+      </div>
+      {data.winners_also_took.length > 0 && (
+        <div className="mt-4">
+          <div className="text-xs font-semibold text-[var(--text-secondary)] mb-2">
+            {t("Winners with decks like this also took", lang)}:
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {data.winners_also_took.map((w) => (
+              <Link
+                key={`${w.etype}-${w.id}`}
+                href={`${lp}/${w.etype}/${w.id.toLowerCase()}`}
+                className="text-xs px-2.5 py-1 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-primary)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50 hover:text-[var(--accent-gold)] transition-colors"
+              >
+                {w.name}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Phase one of the run-vector family: a daily rebuilder job builds per-character sparse composition vectors (cards log-weighted plus relics, solo official runs, scipy on the volume), a new /api/runs/{hash}/similar endpoint returns the nearest winning decks with a winners-also-took diff, and the run page grows a Similar winning runs section; first shards need one manual docker exec spire-codex-rebuilder python -m scripts.build_run_vectors or arrive on the first leader cycle after deploy.