### PR TITLE
Tunable web worker count

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
       - >-
         mkdir -p "$$PROMETHEUS_MULTIPROC_DIR" &&
         rm -rf "$$PROMETHEUS_MULTIPROC_DIR"/* &&
-        exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 4
+        exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers ${BACKEND_WEB_WORKERS:-4}
     volumes:
       - ./data:/data
       - ./data-beta:/data-beta:ro


### PR DESCRIPTION
The uvicorn worker count moves from a hardcoded 4 to BACKEND_WEB_WORKERS in the box .env, since each worker duplicates the ~2GB stats snapshot and dropping to 2 frees ~4GB for Mongo's cache without touching the compose file again.