### PR TITLE
Refresh live home boxes on tab focus

### DIFF
--- a/frontend/app/components/HomeLeaderboardLive.tsx
+++ b/frontend/app/components/HomeLeaderboardLive.tsx
@@ -112,9 +112,14 @@ export default function HomeLeaderboardLive({
       });
     };
     const timer = setInterval(load, POLL_MS);
+    const onVisible = () => {
+      if (!document.hidden) load();
+    };
+    document.addEventListener("visibilitychange", onVisible);
     return () => {
       active = false;
       clearInterval(timer);
+      document.removeEventListener("visibilitychange", onVisible);
     };
   }, [pollBase]);
 

--- a/frontend/app/components/HomeStatsLive.tsx
+++ b/frontend/app/components/HomeStatsLive.tsx
@@ -60,9 +60,14 @@ export default function HomeStatsLive({
         .catch(() => null);
     };
     const timer = setInterval(load, POLL_MS);
+    const onVisible = () => {
+      if (!document.hidden) load();
+    };
+    document.addEventListener("visibilitychange", onVisible);
     return () => {
       active = false;
       clearInterval(timer);
+      document.removeEventListener("visibilitychange", onVisible);
     };
   }, [pollBase]);
 


### PR DESCRIPTION
A tab left in the background stops polling by design, but coming back to it showed stale rows until the next 20s tick, so the leaderboard and stats boxes now fire an immediate refresh on visibilitychange.