### PR TITLE
Per-entity version time machine

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -785,13 +785,19 @@ def get_run_versions(request: Request):
     per-version encounter slice for — the options the stats-page version
     dropdown should offer, since only these have version-filtered data.
     """
+    from ..services.data_service import list_data_versions
     from ..services.run_entity_stats import get_recent_stat_versions
 
     stat_versions = get_recent_stat_versions()
+    data_versions = list_data_versions()
     if os.environ.get("MONGO_URL", "").strip():
         from ..services.runs_db_mongo import distinct_build_ids
 
-        return {"versions": distinct_build_ids(), "stat_versions": stat_versions}
+        return {
+            "versions": distinct_build_ids(),
+            "stat_versions": stat_versions,
+            "data_versions": data_versions,
+        }
 
     from ..services.runs_db import get_conn
 

--- a/backend/app/services/data_service.py
+++ b/backend/app/services/data_service.py
@@ -52,15 +52,43 @@ def get_beta_version() -> str | None:
 def _resolve_base(version: str | None = None) -> Path:
     """Resolve the base data directory for a given version.
 
-    - version="v0.103.0" → DATA_DIR/v0.103.0/
+    - version="v0.103.0" → DATA_DIR/v0.103.0/, else the beta history tree
+      (every patch shipped through a beta drop, so data-beta/<ver>/ is the
+      site's per-version archive; the stable tree is flat, current-only)
     - version=None → DATA_DIR/latest/ (if symlink exists) or DATA_DIR/ (flat, stable site)
     """
     if version:
-        return DATA_DIR / version
+        stable = DATA_DIR / version
+        if stable.exists():
+            return stable
+        beta = BETA_DATA_DIR / version
+        if beta.exists():
+            return beta
+        return stable
     latest = DATA_DIR / "latest"
     if latest.exists():
         return latest
     return DATA_DIR
+
+
+def list_data_versions() -> list[str]:
+    """Version dirs a `?version=` request can actually serve, newest first."""
+    out: set[str] = set()
+    for base in (DATA_DIR, BETA_DATA_DIR):
+        try:
+            for p in base.iterdir():
+                if p.is_dir() and p.name.startswith("v") and (p / "eng").exists():
+                    out.add(p.name)
+        except OSError:
+            continue
+
+    def _key(v: str):
+        try:
+            return tuple(int(x) for x in v.lstrip("v").split(".") if x.isdigit())
+        except ValueError:
+            return (0,)
+
+    return sorted(out, key=_key, reverse=True)
 
 
 def _get_version() -> str | None:

--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -180,9 +180,7 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
   // Bracket shared with EntityRunStats so the infobox mini-stats track the
   // pill the user picked in the Community section.
   const [statsBracket, setStatsBracket] = useState("all");
-  const hasStatVersions = Object.keys(miniStats?.brackets ?? {}).some((k) =>
-    /^v\d/.test(k),
-  );
+  const [dataVersion, setDataVersion] = useState("");
   const [powerData, setPowerData] = useState<Record<string, { id: string; name: string; description: string; type: string; image_url: string | null }>>({});
   const [keywordData, setKeywordData] = useState<Record<string, { id: string; name: string; description: string }>>({});
   const [glossaryData, setGlossaryData] = useState<Record<string, { id: string; name: string; description: string }>>({});
@@ -749,40 +747,30 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
                 </select>
               )}
 
-              {hasBetaArt && (
-                <button
-                  type="button"
-                  className={`betabtn${betaArt ? " on" : ""}`}
-                  aria-pressed={betaArt}
-                  onClick={() => setBetaArt(!betaArt)}
-                >
-                  {t("Beta art", lang)}
-                </button>
-              )}
-
               <div className="variant-cap">
                 {enchActive ? (
                   <>
                     {enchMeta[selectedEnch]?.name ?? selectedEnch}
                     {isUpgraded ? " + Upgraded" : ""}
                   </>
-                ) : betaArt ? (
-                  <>
-                    Beta art{isUpgraded ? " + Upgraded" : ""}
-                  </>
-                ) : hasStatVersions ? (
+                ) : (
                   <EntityVersionSelect
-                    brackets={miniStats?.brackets}
+                    entityType="cards"
+                    entityId={id}
                     bracket={statsBracket}
                     onBracketChange={setStatsBracket}
+                    onEntityData={(d, v) => {
+                      if (d) setCard(d as Card);
+                      setDataVersion(v);
+                    }}
                   />
-                ) : (
-                  <>
-                    {isUpgraded ? "Upgraded" : "Normal"}
-                    {activeVariant ? ` · ${activeVariant.type}` : ""} render
-                  </>
                 )}
               </div>
+              {dataVersion && (
+                <div className="variant-cap">
+                  {dataVersion} {t("data", lang)} · {t("current render shown", lang)}
+                </div>
+              )}
             </div>
 
             {/* Facts table */}

--- a/frontend/app/components/EntityVersionSelect.tsx
+++ b/frontend/app/components/EntityVersionSelect.tsx
@@ -1,34 +1,71 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
+import { cachedFetch } from "@/lib/fetch-cache";
 import { splitBracket, combineBracket } from "@/lib/content-brackets";
 
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+interface VersionsResponse {
+  stat_versions?: string[];
+  data_versions?: string[];
+}
+
 export default function EntityVersionSelect({
-  brackets,
+  entityType,
+  entityId,
   bracket,
   onBracketChange,
+  onEntityData,
 }: {
-  brackets: Record<string, unknown> | undefined | null;
+  entityType: "cards" | "relics" | "potions";
+  entityId: string;
   bracket: string;
   onBracketChange: (b: string) => void;
+  onEntityData?: (data: unknown | null, version: string) => void;
 }) {
   const { lang } = useLanguage();
-  const versions = Object.keys(brackets ?? {})
-    .filter((k) => /^v\d/.test(k))
-    .sort()
-    .reverse();
-  if (versions.length === 0) return null;
-  const { player, skill, version } = splitBracket(bracket);
+  const [versions, setVersions] = useState<VersionsResponse | null>(null);
+  const [selected, setSelected] = useState("");
+
+  useEffect(() => {
+    cachedFetch<VersionsResponse>(`${API}/api/runs/versions`)
+      .then(setVersions)
+      .catch(() => {});
+  }, []);
+
+  const dataVersions = versions?.data_versions ?? [];
+  if (dataVersions.length === 0) return null;
+  const statVersions = new Set(versions?.stat_versions ?? []);
+
+  async function pick(v: string) {
+    setSelected(v);
+    const { player, skill } = splitBracket(bracket);
+    onBracketChange(combineBracket(player, skill, statVersions.has(v) ? v : ""));
+    if (!onEntityData) return;
+    const qs = `lang=${lang}${v ? `&version=${v}` : ""}`;
+    try {
+      const d = await cachedFetch<{ id?: string }>(
+        `${API}/api/${entityType}/${entityId.toLowerCase()}?${qs}`,
+      );
+      onEntityData(d?.id ? d : null, v);
+    } catch {
+      onEntityData(null, v);
+    }
+  }
+
   return (
     <select
       className="rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)] focus:outline-none"
       aria-label="Game version"
-      value={version}
-      onChange={(e) => onBracketChange(combineBracket(player, skill, e.target.value))}
+      value={selected}
+      onChange={(e) => pick(e.target.value)}
+      title={t("View this entity's data and stats as of a game version", lang)}
     >
-      <option value="">{t("All versions", lang)}</option>
-      {versions.map((v) => (
+      <option value="">{t("Current version", lang)}</option>
+      {dataVersions.map((v) => (
         <option key={v} value={v}>
           {v}
         </option>

--- a/frontend/app/potions/[id]/PotionDetail.tsx
+++ b/frontend/app/potions/[id]/PotionDetail.tsx
@@ -277,9 +277,13 @@ export default function PotionDetail({
 
             <div className="mb-2 text-center">
               <EntityVersionSelect
-                brackets={miniStats?.brackets}
+                entityType="potions"
+                entityId={id}
                 bracket={statsBracket}
                 onBracketChange={setStatsBracket}
+                onEntityData={(d) => {
+                  if (d) setPotion(d as Potion);
+                }}
               />
             </div>
 

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -342,9 +342,13 @@ export default function RelicDetail({
 
             <div className="mb-2 text-center">
               <EntityVersionSelect
-                brackets={miniStats?.brackets}
+                entityType="relics"
+                entityId={id}
                 bracket={statsBracket}
                 onBracketChange={setStatsBracket}
+                onEntityData={(d) => {
+                  if (d) setRelic(d as Relic);
+                }}
               />
             </div>
 


### PR DESCRIPTION
The card/relic/potion pages' render caption becomes a version picker: selecting a patch refetches the entity's data as of that version (the resolver now falls back to the data-beta history tree, which archives every release since v0.96.1, verified live-style on the Expertise rework) and re-scopes the page metrics to the matching version bracket, with /api/runs/versions now advertising which versions have servable data.