### PR TITLE
Archetypes and the vector feature family

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -201,6 +201,32 @@ async def submit_run_endpoint(
                 apply_run_async(run_hash, data)
             except Exception:
                 pass
+        try:
+            players = data.get("players") or []
+            if len(players) == 1:
+                from ..services import data_service
+                from ..services.run_vectors import match_archetype
+                from ..services.runs_db_mongo import clean_id
+
+                p = players[0]
+                arch = await run_in_threadpool(
+                    match_archetype,
+                    clean_id(str(p.get("character") or "")).upper(),
+                    [{"id": clean_id(c.get("id", ""))} for c in p.get("deck") or []],
+                    [{"id": clean_id(r.get("id", ""))} for r in p.get("relics") or []],
+                )
+                if arch:
+                    names = {
+                        str(c.get("id", "")).upper(): c.get("name")
+                        for c in data_service.load_cards("eng")
+                    }
+                    arch["name"] = " + ".join(
+                        names.get(i) or i.replace("_", " ").title()
+                        for i in arch["defining_cards"][:2]
+                    )
+                    result["archetype"] = arch
+        except Exception:
+            pass
     seed = (data.get("seed") or "").strip()
     if (
         seed
@@ -1651,6 +1677,12 @@ def get_similar_runs(
     for w in result["winners_also_took"]:
         catalog = cards if w["etype"] == "cards" else relics
         w["name"] = catalog.get(w["id"]) or w["id"].replace("_", " ").title()
+    arch = result.get("archetype")
+    if arch:
+        arch["name"] = " + ".join(
+            cards.get(i) or i.replace("_", " ").title()
+            for i in arch["defining_cards"][:2]
+        )
     payload = {"run_hash": run_hash, "available": True, **result}
     app_cache.set_json(cache_key, payload, ttl_seconds=6 * 3600)
     response.headers["Cache-Control"] = "public, max-age=300"
@@ -1690,15 +1722,42 @@ def get_archetypes(request: Request, response: Response, lang: str = "eng"):
     def _name(catalog: dict, eid: str) -> str:
         return catalog.get(eid) or eid.replace("_", " ").title()
 
+    def _ver_key(v: str):
+        try:
+            return tuple(int(x) for x in v.lstrip("v").split("."))
+        except ValueError:
+            return (0,)
+
     out_chars: dict[str, list] = {}
     for ch, clusters in (data.get("characters") or {}).items():
         char_total = sum(c["size"] for c in clusters) or 1
+        ver_totals: dict[str, int] = {}
+        for c in clusters:
+            for v, sw in (c.get("versions") or {}).items():
+                ver_totals[v] = ver_totals.get(v, 0) + sw[0]
+        recent = sorted((v for v, n in ver_totals.items() if n >= 200), key=_ver_key)[
+            -2:
+        ]
         rows = []
         for c in clusters:
             if c["size"] < 50:
                 continue
+            trend = None
+            if len(recent) == 2:
+                now_v, prev_v = recent[1], recent[0]
+                share_now = (
+                    (c.get("versions", {}).get(now_v, [0])[0]) / ver_totals[now_v]
+                )
+                share_prev = (
+                    (c.get("versions", {}).get(prev_v, [0])[0]) / ver_totals[prev_v]
+                )
+                trend = {
+                    "version": now_v,
+                    "delta": round((share_now - share_prev) * 100, 1),
+                }
             rows.append(
                 {
+                    "trend": trend,
                     "name": " + ".join(_name(cards, i) for i in c["defining_cards"][:2])
                     or ch.title(),
                     "size": c["size"],
@@ -1722,4 +1781,66 @@ def get_archetypes(request: Request, response: Response, lang: str = "eng"):
     }
     app_cache.set_json(cache_key, payload, ttl_seconds=1800)
     response.headers["Cache-Control"] = "public, max-age=600"
+    return payload
+
+
+@router.get("/deck-advisor", tags=["Runs"])
+@limiter.limit("120/minute")
+def get_deck_advisor(
+    request: Request,
+    response: Response,
+    character: str,
+    cards: str = "",
+    relics: str = "",
+    limit: int = Query(8, ge=1, le=20),
+    lang: str = "eng",
+):
+    """Deck advisor: among the winning decks nearest this partial deck, the
+    cards and relics they carry that the draft doesn't yet, with the share of
+    those winners carrying each."""
+    import hashlib
+
+    char = character.strip().upper()
+    card_ids = sorted(c.strip().upper() for c in cards.split(",") if c.strip())
+    relic_ids = sorted(r.strip().upper() for r in relics.split(",") if r.strip())
+    key_src = f"{char}|{','.join(card_ids)}|{','.join(relic_ids)}|{limit}|{lang}"
+    cache_key = "deckadv:" + hashlib.sha1(key_src.encode()).hexdigest()
+    cached = app_cache.get_json(cache_key)
+    if cached is not None:
+        response.headers["Cache-Control"] = "public, max-age=300"
+        return cached
+    from ..services.run_vectors import deck_advisor
+
+    try:
+        recs = deck_advisor(
+            char,
+            [{"id": c} for c in card_ids],
+            [{"id": r} for r in relic_ids],
+            limit=limit,
+        )
+    except Exception:
+        logger.warning("deck advisor failed", exc_info=True)
+        recs = None
+    if recs is None:
+        response.headers["Cache-Control"] = "no-store"
+        return {"available": False, "items": []}
+    from ..services import data_service
+
+    try:
+        card_names = {
+            str(c.get("id", "")).upper(): c.get("name")
+            for c in data_service.load_cards(lang)
+        }
+        relic_names = {
+            str(r.get("id", "")).upper(): r.get("name")
+            for r in data_service.load_relics(lang)
+        }
+    except Exception:
+        card_names, relic_names = {}, {}
+    for r in recs:
+        catalog = card_names if r["etype"] == "cards" else relic_names
+        r["name"] = catalog.get(r["id"]) or r["id"].replace("_", " ").title()
+    payload = {"available": True, "character": char, "items": recs}
+    app_cache.set_json(cache_key, payload, ttl_seconds=600)
+    response.headers["Cache-Control"] = "public, max-age=300"
     return payload

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1655,3 +1655,71 @@ def get_similar_runs(
     app_cache.set_json(cache_key, payload, ttl_seconds=6 * 3600)
     response.headers["Cache-Control"] = "public, max-age=300"
     return payload
+
+
+@router.get("/archetypes", tags=["Runs"])
+@limiter.limit("60/minute")
+def get_archetypes(request: Request, response: Response, lang: str = "eng"):
+    """Community deck archetypes, clustered nightly from run-composition
+    vectors: defining cards/relics, share, and win rate per build."""
+    cache_key = f"archetypes:{lang}"
+    cached = app_cache.get_json(cache_key)
+    if cached is not None:
+        response.headers["Cache-Control"] = "public, max-age=600"
+        return cached
+    from ..services.run_vectors import load_archetypes
+
+    data = load_archetypes()
+    if not data:
+        response.headers["Cache-Control"] = "no-store"
+        return {"available": False, "characters": {}}
+    from ..services import data_service
+
+    try:
+        cards = {
+            str(c.get("id", "")).upper(): c.get("name")
+            for c in data_service.load_cards(lang)
+        }
+        relics = {
+            str(r.get("id", "")).upper(): r.get("name")
+            for r in data_service.load_relics(lang)
+        }
+    except Exception:
+        cards, relics = {}, {}
+
+    def _name(catalog: dict, eid: str) -> str:
+        return catalog.get(eid) or eid.replace("_", " ").title()
+
+    out_chars: dict[str, list] = {}
+    for ch, clusters in (data.get("characters") or {}).items():
+        char_total = sum(c["size"] for c in clusters) or 1
+        rows = []
+        for c in clusters:
+            if c["size"] < 50:
+                continue
+            rows.append(
+                {
+                    "name": " + ".join(_name(cards, i) for i in c["defining_cards"][:2])
+                    or ch.title(),
+                    "size": c["size"],
+                    "share": round(c["size"] / char_total * 100, 1),
+                    "win_rate": c["win_rate"],
+                    "defining_cards": [
+                        {"id": i, "name": _name(cards, i)} for i in c["defining_cards"]
+                    ],
+                    "defining_relics": [
+                        {"id": i, "name": _name(relics, i)}
+                        for i in c["defining_relics"]
+                    ],
+                    "example_runs": c["example_runs"],
+                }
+            )
+        out_chars[ch] = rows
+    payload = {
+        "available": True,
+        "built_at": data.get("built_at"),
+        "characters": out_chars,
+    }
+    app_cache.set_json(cache_key, payload, ttl_seconds=1800)
+    response.headers["Cache-Control"] = "public, max-age=600"
+    return payload

--- a/backend/app/services/run_vectors.py
+++ b/backend/app/services/run_vectors.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import gzip
 import json
 import logging
 import os
@@ -86,8 +85,10 @@ def build_run_vectors() -> dict:
             "relics.id": 1,
         },
     )
-    per_char: dict[str, dict[str, list]] = {
-        ch: {"rows": [], "cols": [], "vals": [], "meta": []}
+    from array import array
+
+    per_char: dict[str, dict] = {
+        ch: {"rows": array("i"), "cols": array("i"), "vals": array("f"), "meta": []}
         for ch in _OFFICIAL_CHARACTERS
     }
     for doc in cursor:
@@ -127,16 +128,34 @@ def build_run_vectors() -> dict:
         if n == 0:
             continue
         mat = sparse.csr_matrix(
-            (acc["vals"], (acc["rows"], acc["cols"])),
+            (
+                np.asarray(acc["vals"], dtype=np.float32),
+                (
+                    np.asarray(acc["rows"], dtype=np.int32),
+                    np.asarray(acc["cols"], dtype=np.int32),
+                ),
+            ),
             shape=(n, len(vocab_list)),
-            dtype=np.float32,
         )
         norms = sparse.linalg.norm(mat, axis=1)
         norms[norms == 0] = 1.0
         mat = sparse.diags(1.0 / norms).dot(mat).tocsr()
-        sparse.save_npz(_VEC_DIR / f"{ch}.npz", mat)
-        with gzip.open(_VEC_DIR / f"{ch}_meta.json.gz", "wt", encoding="utf-8") as f:
-            json.dump(acc["meta"], f, ensure_ascii=False)
+        # Raw .npy components instead of one .npz: workers reload them with
+        # mmap_mode="r", so all four share a single page-cache copy.
+        np.save(_VEC_DIR / f"{ch}_vdata.npy", mat.data.astype(np.float32))
+        np.save(_VEC_DIR / f"{ch}_vindices.npy", mat.indices.astype(np.int32))
+        np.save(_VEC_DIR / f"{ch}_vindptr.npy", mat.indptr.astype(np.int32))
+        m = acc["meta"]
+        np.savez(
+            _VEC_DIR / f"{ch}_meta.npz",
+            hash=np.array([r["hash"] for r in m], dtype="S24"),
+            win=np.array([r["win"] for r in m], dtype=np.uint8),
+            asc=np.array([r["asc"] for r in m], dtype=np.int8),
+            time=np.array([r["time"] for r in m], dtype=np.int32),
+            user=np.array([r["user"] or "" for r in m], dtype="S32"),
+            date=np.array([r["date"] for r in m], dtype="S10"),
+            ver=np.array([r.get("ver") or "" for r in m], dtype="S16"),
+        )
         total += n
         k = max(4, min(14, n // 3000))
         if n >= 200 and k >= 2:
@@ -201,18 +220,27 @@ def _load_vocab() -> dict[str, int] | None:
 
 
 def _load_shard(character: str):
+    import numpy as np
     from scipy import sparse
 
     with _lock:
         hit = _shards.get(character)
         if hit is not None:
             return hit
+    vocab = _load_vocab()
+    if vocab is None:
+        return None
     try:
-        mat = sparse.load_npz(_VEC_DIR / f"{character}.npz")
-        with gzip.open(
-            _VEC_DIR / f"{character}_meta.json.gz", "rt", encoding="utf-8"
-        ) as f:
-            meta = json.load(f)
+        data = np.load(_VEC_DIR / f"{character}_vdata.npy", mmap_mode="r")
+        indices = np.load(_VEC_DIR / f"{character}_vindices.npy", mmap_mode="r")
+        indptr = np.load(_VEC_DIR / f"{character}_vindptr.npy", mmap_mode="r")
+        mat = sparse.csr_matrix(
+            (data, indices, indptr),
+            shape=(len(indptr) - 1, len(vocab)),
+            copy=False,
+        )
+        with np.load(_VEC_DIR / f"{character}_meta.npz") as z:
+            meta = {k: z[k] for k in z.files}
     except OSError:
         return None
     with _lock:
@@ -253,34 +281,33 @@ def similar_runs(run_hash: str, limit: int = 5) -> dict | None:
     sims = mat.dot(q)
     order = np.argsort(sims)[::-1]
     items = []
+    picked_rows: list[int] = []
     seen_hashes = {run_hash}
     for i in order:
         if len(items) >= limit or sims[i] <= 0:
             break
-        m = meta[int(i)]
-        if not m["win"] or m["hash"] in seen_hashes:
+        ri = int(i)
+        h = meta["hash"][ri].decode()
+        if not meta["win"][ri] or h in seen_hashes:
             continue
-        seen_hashes.add(m["hash"])
+        seen_hashes.add(h)
+        picked_rows.append(ri)
         items.append(
             {
-                "run_hash": m["hash"],
-                "ascension": m["asc"],
-                "run_time": m["time"],
-                "username": m["user"],
-                "date": m["date"],
-                "build_id": m.get("ver"),
+                "run_hash": h,
+                "ascension": int(meta["asc"][ri]),
+                "run_time": int(meta["time"][ri]),
+                "username": meta["user"][ri].decode() or None,
+                "date": meta["date"][ri].decode(),
+                "build_id": meta["ver"][ri].decode() or None,
                 "similarity": round(float(sims[i]) * 100, 1),
             }
         )
     own_terms = set(terms)
     counts: dict[str, int] = {}
-    hash_to_row = {m["hash"]: idx for idx, m in enumerate(meta)}
     inv = {i: t for t, i in vocab.items()}
-    for it in items:
-        row = hash_to_row.get(it["run_hash"])
-        if row is None:
-            continue
-        start, end = mat.indptr[row], mat.indptr[row + 1]
+    for row in picked_rows:
+        start, end = int(mat.indptr[row]), int(mat.indptr[row + 1])
         for c in mat.indices[start:end]:
             term = inv[int(c)]
             if term not in own_terms:
@@ -419,16 +446,18 @@ def anomalous_runs(limit: int = 30) -> list[dict]:
     for ch in _OFFICIAL_CHARACTERS:
         try:
             dists = np.load(_VEC_DIR / f"{ch}_dists.npy")
-            with gzip.open(
-                _VEC_DIR / f"{ch}_meta.json.gz", "rt", encoding="utf-8"
-            ) as f:
-                meta = json.load(f)
+            with np.load(_VEC_DIR / f"{ch}_meta.npz") as z:
+                hashes = z["hash"]
         except OSError:
             continue
-        n = min(len(meta), len(dists))
+        n = min(len(hashes), len(dists))
         for i in np.argsort(dists[:n])[::-1][:limit]:
-            m = meta[int(i)]
-            out.append({"run_hash": m["hash"], "distance": round(float(dists[i]), 3)})
+            out.append(
+                {
+                    "run_hash": hashes[int(i)].decode(),
+                    "distance": round(float(dists[int(i)]), 3),
+                }
+            )
     out.sort(key=lambda r: -r["distance"])
     return out[:limit]
 
@@ -497,7 +526,7 @@ def deck_advisor(
         return None
     q, mat, meta, own_terms = built
     sims = np.asarray(mat.dot(q))
-    wins = np.array([m["win"] for m in meta], dtype=bool)
+    wins = meta["win"].astype(bool)
     win_idx = np.flatnonzero(wins & (sims > 0))
     if win_idx.size == 0:
         return []

--- a/backend/app/services/run_vectors.py
+++ b/backend/app/services/run_vectors.py
@@ -141,10 +141,11 @@ def build_run_vectors() -> dict:
         k = max(4, min(14, n // 3000))
         if n >= 200 and k >= 2:
             try:
-                clusters, _labels, dists = _cluster_shard(
+                clusters, _labels, dists, centers = _cluster_shard(
                     ch, mat, acc["meta"], vocab_list, k
                 )
                 np.save(_VEC_DIR / f"{ch}_dists.npy", dists)
+                np.save(_VEC_DIR / f"{ch}_centroids.npy", centers)
                 archetypes[ch] = clusters
             except Exception:
                 logger.warning("archetype clustering failed for %s", ch, exc_info=True)
@@ -302,6 +303,9 @@ def similar_runs(run_hash: str, limit: int = 5) -> dict | None:
         "items": items,
         "winners_also_took": winners_also_took,
         "neighbors": len(items),
+        "archetype": match_archetype(
+            doc["character"], doc.get("deck"), doc.get("relics")
+        ),
     }
 
 
@@ -348,7 +352,9 @@ def _cluster_shard(character: str, mat, meta: list, vocab_list: list[str], k: in
     labels, centers, dists = _spherical_kmeans(mat, k)
     global_mean = np.asarray(mat.mean(axis=0)).ravel()
     wins = np.array([m["win"] for m in meta], dtype=np.int32)
+    vers = [m.get("ver") or "" for m in meta]
     out = []
+    kept_centers = []
     for j in range(k):
         mask = labels == j
         size = int(mask.sum())
@@ -371,6 +377,14 @@ def _cluster_shard(character: str, mat, meta: list, vocab_list: list[str], k: in
         win_members = member_idx[wins[member_idx] == 1]
         pool = win_members if win_members.size else member_idx
         examples = pool[np.argsort(dists[pool])][:3]
+        by_ver: dict[str, list[int]] = {}
+        for i in member_idx:
+            v = vers[int(i)]
+            if not v:
+                continue
+            slot = by_ver.setdefault(v, [0, 0])
+            slot[0] += 1
+            slot[1] += int(wins[int(i)])
         out.append(
             {
                 "character": character,
@@ -380,10 +394,14 @@ def _cluster_shard(character: str, mat, meta: list, vocab_list: list[str], k: in
                 "defining_cards": cards,
                 "defining_relics": relics,
                 "example_runs": [meta[int(i)]["hash"] for i in examples],
+                "versions": by_ver,
             }
         )
-    out.sort(key=lambda c: -c["size"])
-    return out, labels, dists
+        kept_centers.append(centers[j])
+    order = sorted(range(len(out)), key=lambda i: -out[i]["size"])
+    out = [out[i] for i in order]
+    kept = np.array([kept_centers[i] for i in order], dtype=np.float32)
+    return out, labels, dists, kept
 
 
 def load_archetypes() -> dict | None:
@@ -413,3 +431,93 @@ def anomalous_runs(limit: int = 30) -> list[dict]:
             out.append({"run_hash": m["hash"], "distance": round(float(dists[i]), 3)})
     out.sort(key=lambda r: -r["distance"])
     return out[:limit]
+
+
+def _query_vector(character: str, deck: list, relics: list):
+    import numpy as np
+
+    vocab = _load_vocab()
+    if vocab is None:
+        return None
+    loaded = _load_shard(character)
+    if loaded is None:
+        return None
+    mat, meta = loaded
+    terms = _row_terms(deck, relics)
+    q = np.zeros(mat.shape[1], dtype=np.float32)
+    for t, v in terms.items():
+        idx = vocab.get(t)
+        if idx is not None:
+            q[idx] = v
+    norm = float(np.linalg.norm(q))
+    if norm == 0:
+        return None
+    return q / norm, mat, meta, set(terms)
+
+
+def match_archetype(character: str, deck: list, relics: list) -> dict | None:
+    """Nearest archetype for a deck: the cluster dict plus match similarity."""
+    import numpy as np
+
+    arch = load_archetypes()
+    clusters = ((arch or {}).get("characters") or {}).get(character)
+    if not clusters:
+        return None
+    try:
+        centers = np.load(_VEC_DIR / f"{character}_centroids.npy")
+    except OSError:
+        return None
+    if centers.shape[0] != len(clusters):
+        return None
+    built = _query_vector(character, deck, relics)
+    if built is None:
+        return None
+    q = built[0]
+    sims = centers.dot(q)
+    j = int(np.argmax(sims))
+    total = sum(c["size"] for c in clusters) or 1
+    c = clusters[j]
+    return {
+        "defining_cards": c["defining_cards"],
+        "win_rate": c["win_rate"],
+        "share": round(c["size"] / total * 100, 1),
+        "similarity": round(float(sims[j]) * 100, 1),
+    }
+
+
+def deck_advisor(
+    character: str, deck: list, relics: list, limit: int = 8
+) -> list[dict] | None:
+    """Most common cards/relics among the winning decks nearest this draft
+    that the draft doesn't have yet, with the share of neighbors carrying each."""
+    import numpy as np
+
+    built = _query_vector(character, deck, relics)
+    if built is None:
+        return None
+    q, mat, meta, own_terms = built
+    sims = np.asarray(mat.dot(q))
+    wins = np.array([m["win"] for m in meta], dtype=bool)
+    win_idx = np.flatnonzero(wins & (sims > 0))
+    if win_idx.size == 0:
+        return []
+    top = win_idx[np.argsort(sims[win_idx])[::-1][:150]]
+    vocab = _load_vocab() or {}
+    inv = {i: t for t, i in vocab.items()}
+    counts: dict[str, int] = {}
+    for row in top:
+        start, end = mat.indptr[int(row)], mat.indptr[int(row) + 1]
+        for c in mat.indices[start:end]:
+            term = inv[int(c)]
+            if term not in own_terms:
+                counts[term] = counts.get(term, 0) + 1
+    ranked = sorted(counts.items(), key=lambda tn: -tn[1])[:limit]
+    n = int(top.size)
+    return [
+        {
+            "id": t[2:] if t.startswith("R:") else t,
+            "etype": "relics" if t.startswith("R:") else "cards",
+            "support": round(cnt / n * 100, 1),
+        }
+        for t, cnt in ranked
+    ]

--- a/backend/app/services/run_vectors.py
+++ b/backend/app/services/run_vectors.py
@@ -121,6 +121,7 @@ def build_run_vectors() -> dict:
 
     _VEC_DIR.mkdir(parents=True, exist_ok=True)
     total = 0
+    archetypes: dict[str, list] = {}
     for ch, acc in per_char.items():
         n = len(acc["meta"])
         if n == 0:
@@ -137,6 +138,26 @@ def build_run_vectors() -> dict:
         with gzip.open(_VEC_DIR / f"{ch}_meta.json.gz", "wt", encoding="utf-8") as f:
             json.dump(acc["meta"], f, ensure_ascii=False)
         total += n
+        k = max(4, min(14, n // 3000))
+        if n >= 200 and k >= 2:
+            try:
+                clusters, _labels, dists = _cluster_shard(
+                    ch, mat, acc["meta"], vocab_list, k
+                )
+                np.save(_VEC_DIR / f"{ch}_dists.npy", dists)
+                archetypes[ch] = clusters
+            except Exception:
+                logger.warning("archetype clustering failed for %s", ch, exc_info=True)
+    if archetypes:
+        (_VEC_DIR / "archetypes.json").write_text(
+            json.dumps(
+                {
+                    "characters": archetypes,
+                    "built_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                }
+            ),
+            encoding="utf-8",
+        )
     tmp = _VEC_DIR / "vocab.json.tmp"
     tmp.write_text(
         json.dumps(
@@ -282,3 +303,113 @@ def similar_runs(run_hash: str, limit: int = 5) -> dict | None:
         "winners_also_took": winners_also_took,
         "neighbors": len(items),
     }
+
+
+def _spherical_kmeans(mat, k: int, iters: int = 25, seed: int = 0):
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    n = mat.shape[0]
+    first = int(rng.integers(n))
+    centroid_rows = [first]
+    sims = mat.dot(mat[first].T.toarray().ravel())
+    for _ in range(k - 1):
+        d = 1.0 - sims
+        d = np.clip(d, 0, None) ** 2
+        total = float(d.sum())
+        if total <= 0:
+            centroid_rows.append(int(rng.integers(n)))
+            continue
+        pick = int(rng.choice(n, p=d / total))
+        centroid_rows.append(pick)
+        sims = np.maximum(sims, mat.dot(mat[pick].T.toarray().ravel()))
+    centers = mat[centroid_rows].toarray()
+    labels = None
+    for _ in range(iters):
+        scores = mat.dot(centers.T)
+        new_labels = np.asarray(scores.argmax(axis=1)).ravel()
+        if labels is not None and (new_labels == labels).all():
+            break
+        labels = new_labels
+        for j in range(k):
+            members = mat[labels == j]
+            if members.shape[0] == 0:
+                continue
+            c = np.asarray(members.mean(axis=0)).ravel()
+            norm = np.linalg.norm(c)
+            centers[j] = c / norm if norm > 0 else c
+    dists = 1.0 - np.asarray(mat.dot(centers.T))[np.arange(n), labels]
+    return labels, centers, dists
+
+
+def _cluster_shard(character: str, mat, meta: list, vocab_list: list[str], k: int):
+    import numpy as np
+
+    labels, centers, dists = _spherical_kmeans(mat, k)
+    global_mean = np.asarray(mat.mean(axis=0)).ravel()
+    wins = np.array([m["win"] for m in meta], dtype=np.int32)
+    out = []
+    for j in range(k):
+        mask = labels == j
+        size = int(mask.sum())
+        if size == 0:
+            continue
+        lift = centers[j] / (global_mean + 1e-6)
+        lift[centers[j] < 0.02] = 0
+        top = np.argsort(lift)[::-1]
+        cards, relics = [], []
+        for idx in top:
+            if lift[idx] <= 1.0 or (len(cards) >= 3 and len(relics) >= 2):
+                break
+            term = vocab_list[idx]
+            if term.startswith("R:"):
+                if len(relics) < 2:
+                    relics.append(term[2:])
+            elif len(cards) < 3:
+                cards.append(term)
+        member_idx = np.flatnonzero(mask)
+        win_members = member_idx[wins[member_idx] == 1]
+        pool = win_members if win_members.size else member_idx
+        examples = pool[np.argsort(dists[pool])][:3]
+        out.append(
+            {
+                "character": character,
+                "size": size,
+                "wins": int(wins[mask].sum()),
+                "win_rate": round(float(wins[mask].mean()) * 100, 1) if size else 0.0,
+                "defining_cards": cards,
+                "defining_relics": relics,
+                "example_runs": [meta[int(i)]["hash"] for i in examples],
+            }
+        )
+    out.sort(key=lambda c: -c["size"])
+    return out, labels, dists
+
+
+def load_archetypes() -> dict | None:
+    try:
+        return json.loads((_VEC_DIR / "archetypes.json").read_text(encoding="utf-8"))
+    except OSError:
+        return None
+
+
+def anomalous_runs(limit: int = 30) -> list[dict]:
+    """Runs farthest from every archetype centroid: nothing else looks like them."""
+    import numpy as np
+
+    out: list[dict] = []
+    for ch in _OFFICIAL_CHARACTERS:
+        try:
+            dists = np.load(_VEC_DIR / f"{ch}_dists.npy")
+            with gzip.open(
+                _VEC_DIR / f"{ch}_meta.json.gz", "rt", encoding="utf-8"
+            ) as f:
+                meta = json.load(f)
+        except OSError:
+            continue
+        n = min(len(meta), len(dists))
+        for i in np.argsort(dists[:n])[::-1][:limit]:
+            m = meta[int(i)]
+            out.append({"run_hash": m["hash"], "distance": round(float(dists[i]), 3)})
+    out.sort(key=lambda r: -r["distance"])
+    return out[:limit]

--- a/frontend/app/archetypes/page.tsx
+++ b/frontend/app/archetypes/page.tsx
@@ -1,0 +1,175 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE, buildLanguageAlternates } from "@/lib/seo";
+import JsonLd from "@/app/components/JsonLd";
+import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import { characterHex } from "@/lib/character-colors";
+
+const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export const revalidate = 600;
+
+const TITLE = `Slay the Spire 2 Deck Archetypes - Community Builds Ranked (sts2) | ${SITE_NAME}`;
+const DESCRIPTION =
+  "Every Slay the Spire 2 (sts2) deck archetype discovered from community runs: defining cards and relics, popularity, and real win rates per build.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: `${SITE_URL}/archetypes`, languages: buildLanguageAlternates("/archetypes") },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: `${SITE_URL}/archetypes`,
+    siteName: SITE_NAME,
+    type: "website",
+    images: [{ url: DEFAULT_OG_IMAGE }],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESCRIPTION },
+};
+
+interface NamedEntity {
+  id: string;
+  name: string;
+}
+
+interface Archetype {
+  name: string;
+  size: number;
+  share: number;
+  win_rate: number;
+  defining_cards: NamedEntity[];
+  defining_relics: NamedEntity[];
+  example_runs: string[];
+}
+
+interface ArchetypesResponse {
+  available: boolean;
+  built_at?: string;
+  characters: Record<string, Archetype[]>;
+}
+
+const CHARACTER_ORDER = ["IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"];
+
+function characterLabel(c: string): string {
+  return c.charAt(0) + c.slice(1).toLowerCase();
+}
+
+function winRateColor(pct: number): string {
+  if (pct >= 30) return "#22c55e";
+  if (pct >= 15) return "#84cc16";
+  if (pct >= 5) return "#eab308";
+  return "#ef4444";
+}
+
+async function loadArchetypes(): Promise<ArchetypesResponse | null> {
+  try {
+    const res = await fetch(`${API_INTERNAL}/api/runs/archetypes`, {
+      next: { revalidate: 600 },
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as ArchetypesResponse;
+  } catch {
+    return null;
+  }
+}
+
+export default async function ArchetypesPage() {
+  const data = await loadArchetypes();
+  const jsonLd = [
+    buildBreadcrumbJsonLd([
+      { name: "Home", href: "/" },
+      { name: "Archetypes", href: "/archetypes" },
+    ]),
+  ];
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <JsonLd data={jsonLd} />
+      <h1 className="text-3xl font-bold mb-2">
+        <span className="text-[var(--accent-gold)]">Deck Archetypes</span>
+      </h1>
+      <p className="text-sm text-[var(--text-muted)] mb-8 max-w-3xl">
+        Builds discovered automatically from community-submitted runs: decks are
+        clustered by their cards and relics, so every archetype below is something
+        players actually pilot, with its real popularity and win rate. Rebuilt daily.
+      </p>
+
+      {!data?.available ? (
+        <p className="text-sm text-[var(--text-muted)]">
+          Archetype data is still building. Check back shortly.
+        </p>
+      ) : (
+        CHARACTER_ORDER.filter((ch) => (data.characters[ch] ?? []).length > 0).map((ch) => {
+          const color = characterHex(ch) || "var(--accent-gold)";
+          return (
+            <section key={ch} className="mb-10">
+              <h2 className="text-xl font-bold mb-4" style={{ color }}>
+                {characterLabel(ch)}
+              </h2>
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {data.characters[ch].map((a, i) => (
+                  <div
+                    key={`${ch}-${i}`}
+                    className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4"
+                  >
+                    <div className="flex items-baseline justify-between gap-2 mb-1">
+                      <h3 className="font-semibold text-[var(--text-primary)] leading-tight">
+                        {a.name}
+                      </h3>
+                      <span
+                        className="text-sm font-bold tabular-nums flex-shrink-0"
+                        style={{ color: winRateColor(a.win_rate) }}
+                      >
+                        {a.win_rate}%
+                      </span>
+                    </div>
+                    <div className="text-xs text-[var(--text-muted)] mb-3">
+                      {a.share}% of {characterLabel(ch)} runs · {a.size.toLocaleString()} decks
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {a.defining_cards.map((e) => (
+                        <Link
+                          key={e.id}
+                          href={`/cards/${e.id.toLowerCase()}`}
+                          className="text-xs px-2 py-0.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-primary)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50 hover:text-[var(--accent-gold)] transition-colors"
+                        >
+                          {e.name}
+                        </Link>
+                      ))}
+                      {a.defining_relics.map((e) => (
+                        <Link
+                          key={e.id}
+                          href={`/relics/${e.id.toLowerCase()}`}
+                          className="text-xs px-2 py-0.5 rounded-md border border-sky-900/50 bg-[var(--bg-primary)] text-sky-300 hover:border-sky-500/60 transition-colors"
+                        >
+                          {e.name}
+                        </Link>
+                      ))}
+                    </div>
+                    {a.example_runs.length > 0 && (
+                      <div className="mt-3 text-xs text-[var(--text-muted)]">
+                        Examples:{" "}
+                        {a.example_runs.map((h, j) => (
+                          <span key={h}>
+                            {j > 0 && ", "}
+                            <Link
+                              href={`/runs/${h}`}
+                              className="text-[var(--accent-gold)] hover:underline font-mono"
+                            >
+                              {h.slice(0, 8)}
+                            </Link>
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/frontend/app/archetypes/page.tsx
+++ b/frontend/app/archetypes/page.tsx
@@ -41,6 +41,7 @@ interface Archetype {
   defining_cards: NamedEntity[];
   defining_relics: NamedEntity[];
   example_runs: string[];
+  trend?: { version: string; delta: number } | null;
 }
 
 interface ArchetypesResponse {
@@ -126,6 +127,15 @@ export default async function ArchetypesPage() {
                     </div>
                     <div className="text-xs text-[var(--text-muted)] mb-3">
                       {a.share}% of {characterLabel(ch)} runs · {a.size.toLocaleString()} decks
+                      {a.trend && Math.abs(a.trend.delta) >= 0.5 && (
+                        <span
+                          className="ml-2 font-semibold"
+                          style={{ color: a.trend.delta > 0 ? "#22c55e" : "#ef4444" }}
+                          title={`Share change in ${a.trend.version} vs the previous version`}
+                        >
+                          {a.trend.delta > 0 ? "▲" : "▼"} {Math.abs(a.trend.delta)}%
+                        </span>
+                      )}
                     </div>
                     <div className="flex flex-wrap gap-1.5">
                       {a.defining_cards.map((e) => (

--- a/frontend/app/runs/[hash]/SimilarRuns.tsx
+++ b/frontend/app/runs/[hash]/SimilarRuns.tsx
@@ -28,6 +28,12 @@ interface SimilarResponse {
   available: boolean;
   items: SimilarItem[];
   winners_also_took: AlsoTook[];
+  archetype?: {
+    name: string;
+    win_rate: number;
+    share: number;
+    similarity: number;
+  } | null;
 }
 
 function formatRunTime(seconds: number): string {
@@ -64,6 +70,21 @@ export default function SimilarRuns({ hash }: { hash: string }) {
       <p className="text-xs text-[var(--text-muted)] mb-3">
         {t("The closest winning decks to this one, by cards and relics.", lang)}
       </p>
+      {data.archetype && (
+        <p className="text-xs mb-3">
+          <span className="text-[var(--text-muted)]">{t("Build", lang)}: </span>
+          <Link
+            href={`${lp}/archetypes`}
+            className="text-[var(--accent-gold)] hover:underline font-semibold"
+          >
+            {data.archetype.name}
+          </Link>
+          <span className="text-[var(--text-muted)]">
+            {" "}· {data.archetype.win_rate}% {t("win rate", lang)} ·{" "}
+            {data.archetype.share}% {t("of runs", lang)}
+          </span>
+        </p>
+      )}
       <div className="space-y-1.5">
         {data.items.map((it) => (
           <Link


### PR DESCRIPTION
Spherical k-means over the nightly run vectors gives every character named deck archetypes with win rates, shares, and per-version trends on a new /archetypes page, plus the whole consumer family: a /api/runs/deck-advisor endpoint for build-context draft suggestions, an archetype line with post-run insight in the submit response and on run pages, vector anomaly scoring for the admin queue, and columnar/mmap-shared shard storage so worker count no longer multiplies vector RAM.