### PR TITLE
Fix cross-user run-ownership takeover in run-claim path

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -554,8 +554,18 @@ def _propagate_username(user_id: str, new_username: str) -> None:
 
 
 def _try_claim_run(run_hash: str, user: dict) -> None:
-    """Claim a run for the user. Also clears deleted_at so re-uploading
-    a previously deleted run restores it to My Runs."""
+    """Claim a run for the user, but ONLY when it isn't already owned.
+
+    The `user_id: None` guard is load-bearing security, not an optimization:
+    run hashes are content-derived (sha256 of public run fields) and every
+    run's full JSON is served by the unauthenticated GET /api/runs/shared/
+    {hash}, so any signed-in user could otherwise fetch another user's run,
+    re-POST it to /api/auth/runs/upload, and have this claim silently
+    reassign ownership to themselves (the duplicate-insert path in
+    submit_run already refuses to reassign for exactly this reason). Scoping
+    the update to unowned runs preserves the legitimate "attach my name to a
+    run I uploaded anonymously" flow while making cross-user theft impossible.
+    """
     if not os.environ.get("MONGO_URL", "").strip() or not run_hash:
         return
     try:
@@ -564,7 +574,7 @@ def _try_claim_run(run_hash: str, user: dict) -> None:
 
         coll = _get_collection()
         coll.update_one(
-            {"_id": run_hash},
+            {"_id": run_hash, "user_id": None},
             {
                 "$set": {
                     "user_id": ObjectId(user["_id"]),


### PR DESCRIPTION
_try_claim_run in the /api/auth/runs/upload handler updated a run doc's owner with only {"_id": run_hash} as the filter — no guard that the run was actually unowned. Because run hashes are content-derived and every run's full JSON is public via GET /api/runs/shared/{hash}, any signed-in user could fetch another user's run, re-upload it, and have this write reassign ownership to themselves (submit_run's own duplicate path already guards against this with a user_id: None filter).

Scope the claim to {"_id": run_hash, "user_id": None} so it only ever claims unowned runs, mirroring submit_run. The legitimate 'attach my name to a run I uploaded anonymously' flow is unchanged.


Claude-Session: https://claude.ai/code/session_01CUsbnn1iMF4jCRWBCWBVG6