### PR TITLE
Entity version picker fixes

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -3483,7 +3483,26 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
     # Skill tiers first (they carry per-character splits), then the player
     # counts and player x skill composites (picks/wins only) so the detail
     # page can filter by co-op size like the metrics table does.
-    for ck in ("a10", "wr30", "wr50", "wr75", *_PLAYER_BRACKETS, *_COMPOSITE_BRACKETS):
+    # Version slices (bare "v0.108.0" and composed "a10:v0.108.0") ride the
+    # same agg dict; without them the entity-page version picker changed the
+    # bracket to a key the payload never carried and silently fell back to
+    # all-runs.
+    import re
+
+    version_keys = sorted(
+        k
+        for k in agg_brackets
+        if re.match(r"^v\d", k.rpartition(":")[2]) and agg_brackets[k].get("picks")
+    )
+    for ck in (
+        "a10",
+        "wr30",
+        "wr50",
+        "wr75",
+        *_PLAYER_BRACKETS,
+        *_COMPOSITE_BRACKETS,
+        *version_keys,
+    ):
         cd = agg_brackets.get(ck)
         if not cd:
             continue

--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -180,7 +180,6 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
   // Bracket shared with EntityRunStats so the infobox mini-stats track the
   // pill the user picked in the Community section.
   const [statsBracket, setStatsBracket] = useState("all");
-  const [dataVersion, setDataVersion] = useState("");
   const [powerData, setPowerData] = useState<Record<string, { id: string; name: string; description: string; type: string; image_url: string | null }>>({});
   const [keywordData, setKeywordData] = useState<Record<string, { id: string; name: string; description: string }>>({});
   const [glossaryData, setGlossaryData] = useState<Record<string, { id: string; name: string; description: string }>>({});
@@ -747,30 +746,15 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
                 </select>
               )}
 
-              <div className="variant-cap">
-                {enchActive ? (
-                  <>
-                    {enchMeta[selectedEnch]?.name ?? selectedEnch}
-                    {isUpgraded ? " + Upgraded" : ""}
-                  </>
-                ) : (
-                  <EntityVersionSelect
-                    entityType="cards"
-                    entityId={id}
-                    bracket={statsBracket}
-                    onBracketChange={setStatsBracket}
-                    onEntityData={(d, v) => {
-                      if (d) setCard(d as Card);
-                      setDataVersion(v);
-                    }}
-                  />
-                )}
-              </div>
-              {dataVersion && (
-                <div className="variant-cap">
-                  {dataVersion} {t("data", lang)} · {t("current render shown", lang)}
-                </div>
-              )}
+              <EntityVersionSelect
+                entityType="cards"
+                entityId={id}
+                bracket={statsBracket}
+                onBracketChange={setStatsBracket}
+                onEntityData={(d) => {
+                  if (d) setCard(d as Card);
+                }}
+              />
             </div>
 
             {/* Facts table */}

--- a/frontend/app/components/EntityVersionSelect.tsx
+++ b/frontend/app/components/EntityVersionSelect.tsx
@@ -58,7 +58,7 @@ export default function EntityVersionSelect({
 
   return (
     <select
-      className="rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)] focus:outline-none"
+      className="ench-select"
       aria-label="Game version"
       value={selected}
       onChange={(e) => pick(e.target.value)}


### PR DESCRIPTION
The per-entity stats payload never carried version bracket slices (a hardcoded key tuple predating version brackets), so picking a version silently fell back to all-runs stats; the loop now includes an entity's version and version-composite slices, the picker adopts the enchantment dropdown's styling, and the render-type caption text under the variant buttons is gone.