### PR TITLE
Bind OAuth state to the browser to stop CSRF forced-linking

### DIFF
--- a/backend/app/routers/auth_discord.py
+++ b/backend/app/routers/auth_discord.py
@@ -18,7 +18,13 @@ from slowapi import Limiter
 
 from ..dependencies import client_ip
 from ..services import rate_limit_config
-from ..services.auth_jwt import create_oauth_state, verify_oauth_state
+from ..services.auth_jwt import (
+    clear_oauth_state_cookie,
+    create_oauth_state,
+    oauth_state_cookie,
+    set_oauth_state_cookie,
+    verify_oauth_state_bound,
+)
 
 logger = logging.getLogger("spire-codex.auth")
 
@@ -65,7 +71,11 @@ async def start(request: Request):
         "prompt": "consent",
     }
     url = f"{_DISCORD_AUTHORIZE}?{urllib.parse.urlencode(params)}"
-    return RedirectResponse(url)
+    response = RedirectResponse(url)
+    # Bind the state to this browser so the callback can reject a state that
+    # wasn't minted for it (CSRF / forced-link protection).
+    set_oauth_state_cookie(response, state)
+    return response
 
 
 @router.get("/callback")
@@ -83,8 +93,10 @@ async def callback(request: Request):
     if not code or not state:
         return RedirectResponse(f"{base}/profile?error=invalid_response")
 
-    if not verify_oauth_state(state):
-        return RedirectResponse(f"{base}/profile?error=invalid_session")
+    if not verify_oauth_state_bound(state, oauth_state_cookie(request)):
+        resp = RedirectResponse(f"{base}/profile?error=invalid_session")
+        clear_oauth_state_cookie(resp)
+        return resp
 
     client_id, client_secret = _get_discord_config()
     redirect_uri = f"{base}/api/auth/discord/callback"
@@ -193,6 +205,7 @@ async def callback(request: Request):
         redirect_path = "/settings" if needs_email else "/settings?linked=discord"
         response = RedirectResponse(f"{base}{redirect_path}")
         set_auth_cookie(response, token)
+        clear_oauth_state_cookie(response)
 
         logger.info(
             "discord-auth ok discord_id=%s user=%s username=%s linked=%s",

--- a/backend/app/routers/auth_patreon.py
+++ b/backend/app/routers/auth_patreon.py
@@ -33,7 +33,14 @@ from slowapi import Limiter
 
 from ..dependencies import client_ip
 from ..services import rate_limit_config
-from ..services.auth_jwt import create_oauth_state, get_current_user, verify_oauth_state
+from ..services.auth_jwt import (
+    clear_oauth_state_cookie,
+    create_oauth_state,
+    get_current_user,
+    oauth_state_cookie,
+    set_oauth_state_cookie,
+    verify_oauth_state_bound,
+)
 
 logger = logging.getLogger("spire-codex.auth")
 
@@ -92,7 +99,13 @@ async def start(request: Request):
         "scope": "identity identity.memberships",
         "state": state,
     }
-    return RedirectResponse(f"{_PATREON_AUTHORIZE}?{urllib.parse.urlencode(params)}")
+    response = RedirectResponse(
+        f"{_PATREON_AUTHORIZE}?{urllib.parse.urlencode(params)}"
+    )
+    # Bind the state to this browser so the callback can reject a state that
+    # wasn't minted for it (CSRF / forced-link protection).
+    set_oauth_state_cookie(response, state)
+    return response
 
 
 @router.get("/callback")
@@ -105,8 +118,10 @@ async def callback(request: Request):
     state = request.query_params.get("state")
     if not code or not state:
         return RedirectResponse(f"{base}/settings?error=invalid_response")
-    if not verify_oauth_state(state):
-        return RedirectResponse(f"{base}/settings?error=invalid_session")
+    if not verify_oauth_state_bound(state, oauth_state_cookie(request)):
+        resp = RedirectResponse(f"{base}/settings?error=invalid_session")
+        clear_oauth_state_cookie(resp)
+        return resp
 
     user = get_current_user(request)
     if not user:
@@ -169,7 +184,9 @@ async def callback(request: Request):
             f"{base}/settings?error={urllib.parse.quote(result['error'])}"
         )
     _apply_paid(user["_id"], paid)
-    return RedirectResponse(f"{base}/settings?linked=patreon")
+    response = RedirectResponse(f"{base}/settings?linked=patreon")
+    clear_oauth_state_cookie(response)
+    return response
 
 
 @router.post("/disconnect")

--- a/backend/app/routers/auth_twitch.py
+++ b/backend/app/routers/auth_twitch.py
@@ -24,7 +24,13 @@ from slowapi import Limiter
 
 from ..dependencies import client_ip
 from ..services import rate_limit_config
-from ..services.auth_jwt import create_oauth_state, verify_oauth_state
+from ..services.auth_jwt import (
+    clear_oauth_state_cookie,
+    create_oauth_state,
+    oauth_state_cookie,
+    set_oauth_state_cookie,
+    verify_oauth_state_bound,
+)
 
 logger = logging.getLogger("spire-codex.auth")
 
@@ -81,7 +87,11 @@ async def start(request: Request):
         "force_verify": "true",
     }
     url = f"{_TWITCH_AUTHORIZE}?{urllib.parse.urlencode(params)}"
-    return RedirectResponse(url)
+    response = RedirectResponse(url)
+    # Bind the state to this browser so the callback can reject a state that
+    # wasn't minted for it (CSRF / forced-link protection).
+    set_oauth_state_cookie(response, state)
+    return response
 
 
 @router.get("/callback")
@@ -99,8 +109,10 @@ async def callback(request: Request):
     if not code or not state:
         return RedirectResponse(f"{base}/settings?error=invalid_response")
 
-    if not verify_oauth_state(state):
-        return RedirectResponse(f"{base}/settings?error=invalid_session")
+    if not verify_oauth_state_bound(state, oauth_state_cookie(request)):
+        resp = RedirectResponse(f"{base}/settings?error=invalid_session")
+        clear_oauth_state_cookie(resp)
+        return resp
 
     client_id, client_secret = _get_twitch_config()
     redirect_uri = f"{base}/api/auth/twitch/callback"
@@ -216,6 +228,7 @@ async def callback(request: Request):
 
         response = RedirectResponse(f"{base}/settings?linked=twitch")
         set_auth_cookie(response, token)
+        clear_oauth_state_cookie(response)
 
         logger.info(
             "twitch-auth ok twitch_id=%s login=%s user=%s linked=%s",

--- a/backend/app/services/auth_jwt.py
+++ b/backend/app/services/auth_jwt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 import os
 import secrets
 from datetime import datetime, timedelta, timezone
@@ -16,6 +17,12 @@ _JWT_EXPIRY_DAYS = 7
 _COOKIE_NAME = "spire_session"
 _STATE_PURPOSE = "oauth_state"
 _STATE_TTL_SECONDS = 600
+# Cookie that binds an OAuth `state` value to the browser that started the
+# flow. verify_oauth_state alone only proves WE minted the state, not that it
+# was minted for THIS browser — so without this a signed state could be
+# replayed in a CSRF/forced-link attack. The /start handlers set it; the
+# /callback handlers require the returned state to equal it.
+_OAUTH_STATE_COOKIE = "spire_oauth_state"
 
 
 def _get_secret() -> str:
@@ -74,6 +81,51 @@ def verify_oauth_state(token: str) -> bool:
     except (jwt.ExpiredSignatureError, jwt.InvalidTokenError):
         return False
     return payload.get("purpose") == _STATE_PURPOSE
+
+
+def set_oauth_state_cookie(response, state: str) -> None:
+    """Pin the freshly minted OAuth `state` to the browser starting the flow.
+
+    SameSite=Lax so the cookie survives the top-level redirect back from the
+    OAuth provider (the callback is a GET navigation), while still not riding
+    along on cross-site subrequests."""
+    is_prod = os.environ.get("ENVIRONMENT", "").lower() in ("production", "prod")
+    response.set_cookie(
+        key=_OAUTH_STATE_COOKIE,
+        value=state,
+        httponly=True,
+        secure=is_prod,
+        samesite="lax",
+        path="/",
+        max_age=_STATE_TTL_SECONDS,
+    )
+
+
+def clear_oauth_state_cookie(response) -> None:
+    is_prod = os.environ.get("ENVIRONMENT", "").lower() in ("production", "prod")
+    response.delete_cookie(
+        key=_OAUTH_STATE_COOKIE,
+        path="/",
+        secure=is_prod,
+        samesite="lax",
+    )
+
+
+def oauth_state_cookie(request: Request) -> str:
+    return request.cookies.get(_OAUTH_STATE_COOKIE, "")
+
+
+def verify_oauth_state_bound(state: str, cookie_state: str) -> bool:
+    """CSRF-safe state check: the returned `state` must be a valid, unexpired,
+    server-signed token AND must match the value stashed in the browser's
+    cookie at /start. The cookie match is what stops an attacker from replaying
+    a state they minted themselves into a victim's session (forced account
+    linking / login CSRF). Constant-time compare avoids leaking the cookie."""
+    if not state or not cookie_state:
+        return False
+    if not hmac.compare_digest(state, cookie_state):
+        return False
+    return verify_oauth_state(state)
 
 
 def set_auth_cookie(response: JSONResponse, token: str) -> None:


### PR DESCRIPTION
The Discord/Twitch/Patreon OAuth flows generated a signed `state` but the callbacks only checked verify_oauth_state(), which proves the token was minted by us — not that it was minted for the browser completing the flow. A signed state is valid for 10 minutes and reusable, so an attacker could mint one, capture a fresh authorization `code` for their own identity, and deliver the callback URL to a logged-in victim; the victim's cookie would then link the attacker's identity to the victim's account (forced account linking, escalating to takeover on 'sign in with Discord').

Add a browser-bound state cookie set at /start and required to match the returned state at /callback (constant-time compare + signature/expiry check), then cleared. Steam OpenID is unaffected — it already does a real check_authentication signature replay.


Claude-Session: https://claude.ai/code/session_01CUsbnn1iMF4jCRWBCWBVG6