### PR TITLE
Add opt-in Cloudflare-origin verification to nginx

### DIFF
--- a/infrastructure/ansible/group_vars/all.yml
+++ b/infrastructure/ansible/group_vars/all.yml
@@ -28,3 +28,12 @@ compose_file: "{{ prod_compose_file }}"
 # before invoking sync-secrets.yml.
 env_template_path: "{{ playbook_dir }}/../files/.env.tpl"
 remote_env_path: "{{ spire_codex_dir }}/.env"
+
+# Cloudflare-origin verification secret. When set (and a matching Cloudflare
+# Transform Rule adds `X-Origin-Verify: <this value>` to every proxied
+# request), nginx refuses direct-to-origin traffic that bypasses Cloudflare —
+# closing the WAF / rate-limit / Access bypass you'd otherwise have if the
+# origin IP leaks. Empty by default = no enforcement (safe no-op), so this can
+# ship before the Cloudflare side is wired up. To enable, override in
+# sync-config.yml from 1Password (see the commented task there) or set it here.
+origin_verify_secret: ""

--- a/infrastructure/ansible/playbooks/sync-config.yml
+++ b/infrastructure/ansible/playbooks/sync-config.yml
@@ -32,6 +32,17 @@
         admin_ip: "{{ lookup('pipe', 'op read \"op://Spire Codex/Peter''s Machine/ip\"') }}"
       no_log: true
 
+    # Cloudflare-origin verification secret. Uncomment once you've added a
+    # Cloudflare Transform Rule that injects `X-Origin-Verify: <secret>` on
+    # every proxied request AND stored that same secret in 1Password. With it
+    # set, nginx.conf.j2 refuses direct-to-origin traffic that bypasses
+    # Cloudflare (WAF / rate-limit / Access bypass). Leave commented to keep
+    # the check a no-op (default origin_verify_secret is "" in group_vars).
+    # - name: Fetch Cloudflare origin-verify secret from 1Password
+    #   set_fact:
+    #     origin_verify_secret: "{{ lookup('pipe', 'op read \"op://Spire Codex/Server/origin-verify-secret\"') }}"
+    #   no_log: true
+
     - name: Ensure QA host directory exists
       become: true
       file:

--- a/infrastructure/ansible/templates/nginx.conf.j2
+++ b/infrastructure/ansible/templates/nginx.conf.j2
@@ -56,7 +56,15 @@ http {
     set_real_ip_from 2a06:98c0::/29;
     set_real_ip_from 2c0f:f248::/32;
     real_ip_header CF-Connecting-IP;
-    # Allow Cloudflare IPs
+    # NOTE: these `allow` directives do NOT restrict the origin to Cloudflare.
+    # Because `real_ip_header CF-Connecting-IP` rewrites $remote_addr to the
+    # real visitor IP BEFORE the access phase runs (see the umami block below),
+    # allow/deny here compares the visitor IP, not Cloudflare's edge — so an
+    # `allow <CF ranges>; deny all;` would block every legitimate user, not
+    # direct-to-origin traffic. Locking the origin to Cloudflare must happen at
+    # the cloud firewall (restrict inbound tcp/80,443 to Cloudflare's ranges)
+    # and/or via the `origin_verify_secret` check below. These `allow` lines are
+    # effectively a no-op today; kept only to document intent.
     allow 173.245.48.0/20;
     allow 103.21.244.0/22;
     allow 103.22.200.0/22;
@@ -73,10 +81,34 @@ http {
     allow 172.64.0.0/13;
     allow 131.0.72.0/22;
 
+{% if origin_verify_secret | default('') %}
+    # Cloudflare-origin verification. Cloudflare injects a secret header on
+    # every proxied request (configure a Transform Rule / Managed Transform to
+    # add `X-Origin-Verify: <secret>`); a request that arrives WITHOUT the
+    # matching value skipped the edge (direct-to-origin) and is refused below.
+    # This is the belt to the cloud-firewall's suspenders and, unlike an IP
+    # allow-list, is unaffected by the real_ip rewrite. Enforced only when
+    # `origin_verify_secret` is set in the ansible vars; unset = no-op, so
+    # deploying this template without the matching Cloudflare rule changes
+    # nothing.
+    map $http_x_origin_verify $origin_verify_ok {
+        default 0;
+        "{{ origin_verify_secret }}" 1;
+    }
+{% endif %}
 
  server {
       listen 80;
       server_name spire-codex.com www.spire-codex.com;
+
+{% if origin_verify_secret | default('') %}
+      # Refuse requests that didn't come through Cloudflare (missing/incorrect
+      # origin-verify header). Applies to the public apex only — the LB health
+      # origins and the IP-gated umami dashboard have their own blocks.
+      if ($origin_verify_ok = 0) {
+          return 403;
+      }
+{% endif %}
 
       location ~ /\. {
           return 404;


### PR DESCRIPTION
The http-level 'allow <CF ranges>' list has no 'deny all', so it does not restrict the origin to Cloudflare — and it cannot: real_ip_header rewrites $remote_addr to the visitor IP before the access phase, so an allow/deny there would block real users, not direct-to-origin traffic. If the origin IP leaks and the cloud firewall doesn't lock inbound 80/443 to Cloudflare, an attacker bypasses the WAF, edge rate-limiting, and Cloudflare Access on /admin.

Add an opt-in origin-verify check: when origin_verify_secret is set (and a Cloudflare Transform Rule injects a matching X-Origin-Verify header), nginx 403s any request lacking it on the public apex. Default is empty = strict no-op, so this ships safely before the Cloudflare side is wired up. Also document why the existing allow-list is a no-op, add the group_vars default, and a commented 1Password wiring task in sync-config.yml.


Claude-Session: https://claude.ai/code/session_01CUsbnn1iMF4jCRWBCWBVG6