### PR TITLE
Archetype community-name aliases

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -216,11 +216,15 @@ async def submit_run_endpoint(
                     [{"id": clean_id(r.get("id", ""))} for r in p.get("relics") or []],
                 )
                 if arch:
+                    from ..services.run_vectors import archetype_alias
+
                     names = {
                         str(c.get("id", "")).upper(): c.get("name")
                         for c in data_service.load_cards("eng")
                     }
-                    arch["name"] = " + ".join(
+                    arch["name"] = archetype_alias(
+                        arch["defining_cards"]
+                    ) or " + ".join(
                         names.get(i) or i.replace("_", " ").title()
                         for i in arch["defining_cards"][:2]
                     )
@@ -1679,7 +1683,9 @@ def get_similar_runs(
         w["name"] = catalog.get(w["id"]) or w["id"].replace("_", " ").title()
     arch = result.get("archetype")
     if arch:
-        arch["name"] = " + ".join(
+        from ..services.run_vectors import archetype_alias
+
+        arch["name"] = archetype_alias(arch["defining_cards"]) or " + ".join(
             cards.get(i) or i.replace("_", " ").title()
             for i in arch["defining_cards"][:2]
         )
@@ -1760,10 +1766,13 @@ def get_archetypes(request: Request, response: Response, lang: str = "eng"):
                     "version": now_v,
                     "delta": round((share_now - share_prev) * 100, 1),
                 }
+            from ..services.run_vectors import archetype_alias
+
             rows.append(
                 {
                     "trend": trend,
-                    "name": " + ".join(_name(cards, i) for i in c["defining_cards"][:2])
+                    "name": archetype_alias(c["defining_cards"])
+                    or " + ".join(_name(cards, i) for i in c["defining_cards"][:2])
                     or ch.title(),
                     "size": c["size"],
                     "share": round(c["size"] / char_total * 100, 1),

--- a/backend/app/services/run_vectors.py
+++ b/backend/app/services/run_vectors.py
@@ -585,3 +585,27 @@ def _nondraftable() -> frozenset[str]:
             logger.warning("nondraftable set load failed", exc_info=True)
             _nondraftable_cache = frozenset()
     return _nondraftable_cache
+
+
+_alias_cache: tuple[float, dict] | None = None
+
+
+def archetype_alias(defining_cards: list[str]) -> str | None:
+    """Community name for a cluster signature from data/archetype_names.json."""
+    global _alias_cache
+    path = _VEC_DIR.parent / "archetype_names.json"
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return None
+    if _alias_cache is None or _alias_cache[0] != mtime:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            _alias_cache = (
+                mtime,
+                {k: v for k, v in data.items() if not k.startswith("_")},
+            )
+        except Exception:
+            _alias_cache = (mtime, {})
+    key = "+".join(sorted(defining_cards[:2]))
+    return _alias_cache[1].get(key)

--- a/data/archetype_names.json
+++ b/data/archetype_names.json
@@ -1,0 +1,4 @@
+{
+  "_readme": "Community names for discovered archetypes. Key = the archetype's top-2 defining card ids, sorted alphabetically, joined with '+'. Unmapped clusters fall back to their card-pair name automatically, so entries here are pure polish and can never go stale-wrong: if a patch shifts a cluster's signature, the alias just stops matching.",
+  "CATALYST+NOXIOUS_FUMES": "Poison Silent"
+}


### PR DESCRIPTION
data/archetype_names.json maps sorted top-2 defining-card signatures to community names (Poison Silent seeded as the example), applied across the archetypes page, similar-runs, and submit responses with the card-pair name as the automatic fallback, so curated names can never go stale-wrong when a patch shifts a cluster.