### PR TITLE
Add the pick-coach endpoint and a hidden Deck Lab page

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1849,3 +1849,102 @@ def get_deck_advisor(
     app_cache.set_json(cache_key, payload, ttl_seconds=600)
     response.headers["Cache-Control"] = "public, max-age=300"
     return payload
+
+
+@router.get("/pick-coach", tags=["Runs"])
+@limiter.limit("120/minute")
+def get_pick_coach(
+    request: Request,
+    response: Response,
+    character: str,
+    cards: str = "",
+    relics: str = "",
+    offer: str = "",
+    target: str | None = None,
+    lang: str = "eng",
+):
+    """Build coach: nearest archetypes for a partial deck, and when cards are
+    offered, a per-card score from commitment delta toward the target
+    archetype, support among nearby winning decks, and offer-conditioned lift."""
+    import hashlib
+
+    char = character.strip().upper()
+    card_ids = sorted(c.strip().upper() for c in cards.split(",") if c.strip())
+    relic_ids = sorted(r.strip().upper() for r in relics.split(",") if r.strip())
+    offer_ids = [o.strip().upper() for o in offer.split(",") if o.strip()][:5]
+    key_src = f"{char}|{','.join(card_ids)}|{','.join(relic_ids)}|{','.join(offer_ids)}|{target or ''}|{lang}"
+    cache_key = "pickcoach:" + hashlib.sha1(key_src.encode()).hexdigest()
+    cached = app_cache.get_json(cache_key)
+    if cached is not None:
+        response.headers["Cache-Control"] = "public, max-age=300"
+        return cached
+    from ..services.run_vectors import pick_coach
+
+    try:
+        coach = pick_coach(
+            char,
+            [{"id": c} for c in card_ids],
+            [{"id": r} for r in relic_ids],
+            offer_ids,
+            target=(target or "").strip().upper() or None,
+        )
+    except Exception:
+        logger.warning("pick coach failed", exc_info=True)
+        coach = None
+    if coach is None:
+        response.headers["Cache-Control"] = "no-store"
+        return {"available": False}
+
+    if offer_ids:
+        try:
+            from ..services.draft_recs import score_offer
+
+            held = [f"cards:{c}" for c in card_ids] + [f"relics:{r}" for r in relic_ids]
+            lift = {
+                r["id"]: r
+                for r in (score_offer(held, offer_ids, lang) or {}).get("ranked", [])
+            }
+            for o in coach["offers"]:
+                lr = lift.get(o["id"])
+                o["take_score"] = lr.get("score") if lr else None
+                o["take_base"] = lr.get("base") if lr else None
+        except Exception:
+            logger.warning("pick coach lift blend failed", exc_info=True)
+
+    from ..services import data_service
+
+    try:
+        card_names = {
+            str(c.get("id", "")).upper(): c.get("name")
+            for c in data_service.load_cards(lang)
+        }
+        relic_names = {
+            str(r.get("id", "")).upper(): r.get("name")
+            for r in data_service.load_relics(lang)
+        }
+    except Exception:
+        card_names, relic_names = {}, {}
+
+    def _cname(i: str) -> str:
+        return card_names.get(i) or i.replace("_", " ").title()
+
+    try:
+        from ..services.run_vectors import archetype_alias
+    except ImportError:
+        archetype_alias = None
+
+    for o in coach["offers"]:
+        o["name"] = _cname(o["id"])
+    for grp in [coach["target"], *coach["candidates"]]:
+        raw = grp["defining_cards"]
+        alias = archetype_alias(raw) if archetype_alias else None
+        grp["name"] = alias or " + ".join(_cname(i) for i in raw[:2]) or char.title()
+        grp["defining_cards"] = [{"id": i, "name": _cname(i)} for i in raw]
+        grp["defining_relics"] = [
+            {"id": i, "name": relic_names.get(i) or i.replace("_", " ").title()}
+            for i in grp["defining_relics"]
+        ]
+    payload = {"available": True, "character": char, **coach}
+    app_cache.set_json(cache_key, payload, ttl_seconds=600)
+    response.headers["Cache-Control"] = "public, max-age=300"
+    return payload

--- a/backend/app/services/run_vectors.py
+++ b/backend/app/services/run_vectors.py
@@ -562,6 +562,119 @@ def deck_advisor(
     ]
 
 
+def pick_coach(
+    character: str,
+    deck: list,
+    relics: list,
+    offer: list[str],
+    target: str | None = None,
+) -> dict | None:
+    """Score offered cards by commitment delta toward a target archetype's
+    centroid plus how many nearby winning decks carry them."""
+    import numpy as np
+
+    arch = load_archetypes()
+    clusters = ((arch or {}).get("characters") or {}).get(character)
+    if not clusters:
+        return None
+    try:
+        centers = np.load(_VEC_DIR / f"{character}_centroids.npy")
+    except OSError:
+        return None
+    if centers.shape[0] != len(clusters):
+        return None
+    built = _query_vector(character, deck, relics)
+    if built is None:
+        return None
+    q, mat, meta, _own = built
+    vocab = _load_vocab() or {}
+    total = sum(c["size"] for c in clusters) or 1
+
+    def _key(c: dict) -> str:
+        return "+".join(sorted(c["defining_cards"][:2]))
+
+    sims = centers.dot(q)
+    candidates = sorted(
+        (
+            {
+                "key": _key(c),
+                "defining_cards": c["defining_cards"],
+                "defining_relics": c["defining_relics"],
+                "win_rate": c["win_rate"],
+                "share": round(c["size"] / total * 100, 1),
+                "similarity": round(float(sims[i]) * 100, 1),
+            }
+            for i, c in enumerate(clusters)
+            if c["defining_cards"] or c["defining_relics"]
+        ),
+        key=lambda c: -c["similarity"],
+    )[:5]
+
+    t_idx = None
+    if target:
+        for i, c in enumerate(clusters):
+            if _key(c) == target:
+                t_idx = i
+                break
+    if t_idx is None:
+        for i in np.argsort(sims)[::-1]:
+            c = clusters[int(i)]
+            if c["defining_cards"] or c["defining_relics"]:
+                t_idx = int(i)
+                break
+    if t_idx is None:
+        return None
+    center = centers[t_idx]
+    base_sim = float(center.dot(q))
+
+    neigh = np.asarray(mat.dot(q))
+    wins = meta["win"].astype(bool)
+    win_idx = np.flatnonzero(wins & (neigh > 0))
+    top = win_idx[np.argsort(neigh[win_idx])[::-1][:150]]
+    n_top = int(top.size)
+    offer_cols = {o: vocab.get(o) for o in offer}
+    support = dict.fromkeys(offer, 0)
+    for row in top:
+        start, end = mat.indptr[int(row)], mat.indptr[int(row) + 1]
+        row_cols = set(int(x) for x in mat.indices[start:end])
+        for oid, ci in offer_cols.items():
+            if ci is not None and ci in row_cols:
+                support[oid] += 1
+
+    offers = []
+    for oid in offer:
+        built2 = _query_vector(character, deck + [{"id": oid}], relics)
+        delta = None
+        if built2 is not None:
+            delta = round((float(center.dot(built2[0])) - base_sim) * 100, 2)
+        sup = round(support[oid] / n_top * 100, 1) if n_top else None
+        score = max(0.0, delta or 0.0) * 10 + (sup or 0.0) * 0.5
+        offers.append(
+            {
+                "id": oid,
+                "commitment_delta": delta,
+                "winner_support": sup,
+                "coach_score": round(score, 1),
+            }
+        )
+    offers.sort(key=lambda o: -o["coach_score"])
+
+    tc = clusters[t_idx]
+    return {
+        "target": {
+            "key": _key(tc),
+            "locked": bool(target) and _key(tc) == target,
+            "defining_cards": tc["defining_cards"],
+            "defining_relics": tc["defining_relics"],
+            "win_rate": tc["win_rate"],
+            "share": round(tc["size"] / total * 100, 1),
+            "similarity": round(float(sims[t_idx]) * 100, 1),
+        },
+        "candidates": candidates,
+        "offers": offers,
+    }
+
+
 _nondraftable_cache: frozenset[str] | None = None
 
 

--- a/frontend/app/deck-lab/DeckLabClient.tsx
+++ b/frontend/app/deck-lab/DeckLabClient.tsx
@@ -1,0 +1,472 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { characterHex } from "@/lib/character-colors";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+const CHARACTERS = ["IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"];
+
+interface CatalogItem {
+  id: string;
+  name: string;
+}
+
+interface NamedEntity {
+  id: string;
+  name: string;
+}
+
+interface ArchetypeMatch {
+  key: string;
+  name: string;
+  locked?: boolean;
+  defining_cards: NamedEntity[];
+  defining_relics: NamedEntity[];
+  win_rate: number;
+  share: number;
+  similarity: number;
+}
+
+interface CoachOffer {
+  id: string;
+  name: string;
+  commitment_delta: number | null;
+  winner_support: number | null;
+  coach_score: number;
+  take_score?: number | null;
+  take_base?: number | null;
+}
+
+interface CoachResponse {
+  available: boolean;
+  target?: ArchetypeMatch;
+  candidates?: ArchetypeMatch[];
+  offers?: CoachOffer[];
+}
+
+interface AdvisorItem {
+  id: string;
+  etype: "cards" | "relics";
+  name: string;
+  support: number;
+}
+
+function characterLabel(c: string): string {
+  return c.charAt(0) + c.slice(1).toLowerCase();
+}
+
+function ItemPicker({
+  placeholder,
+  items,
+  onPick,
+}: {
+  placeholder: string;
+  items: CatalogItem[];
+  onPick: (item: CatalogItem) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      if (boxRef.current && !boxRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, []);
+
+  const matches = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [];
+    return items.filter((i) => i.name.toLowerCase().includes(q)).slice(0, 8);
+  }, [query, items]);
+
+  return (
+    <div ref={boxRef} className="relative">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        placeholder={placeholder}
+        className="w-full px-3 py-2 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm focus:outline-none focus:border-[var(--accent-gold)]"
+      />
+      {open && matches.length > 0 && (
+        <div className="absolute z-20 mt-1 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] shadow-lg overflow-hidden">
+          {matches.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              onClick={() => {
+                onPick(m);
+                setQuery("");
+                setOpen(false);
+              }}
+              className="block w-full text-left px-3 py-1.5 text-sm text-[var(--text-secondary)] hover:bg-[var(--bg-card-hover)] hover:text-[var(--text-primary)]"
+            >
+              {m.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function DeckLabClient() {
+  const [character, setCharacter] = useState("SILENT");
+  const [deck, setDeck] = useState<string[]>([]);
+  const [relics, setRelics] = useState<string[]>([]);
+  const [offer, setOffer] = useState<string[]>([]);
+  const [target, setTarget] = useState<string | null>(null);
+  const [cardCatalog, setCardCatalog] = useState<CatalogItem[]>([]);
+  const [relicCatalog, setRelicCatalog] = useState<CatalogItem[]>([]);
+  const [names, setNames] = useState<Record<string, string>>({});
+  const [coach, setCoach] = useState<CoachResponse | null>(null);
+  const [advisor, setAdvisor] = useState<AdvisorItem[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let dead = false;
+    async function loadCatalogs() {
+      try {
+        const [own, colorless, rel] = await Promise.all([
+          fetch(`${API}/api/cards?color=${character.toLowerCase()}`).then((r) => r.json()),
+          fetch(`${API}/api/cards?color=colorless`).then((r) => r.json()),
+          fetch(`${API}/api/relics`).then((r) => r.json()),
+        ]);
+        if (dead) return;
+        const cards = [...own, ...colorless]
+          .filter((c: any) => c.rarity_key !== "Basic" && c.type_key !== "Status" && c.type_key !== "Curse")
+          .map((c: any) => ({ id: String(c.id).toUpperCase(), name: c.name }));
+        const rl = rel.map((r: any) => ({ id: String(r.id).toUpperCase(), name: r.name }));
+        setCardCatalog(cards);
+        setRelicCatalog(rl);
+        setNames((prev) => {
+          const next = { ...prev };
+          for (const i of [...cards, ...rl]) next[i.id] = i.name;
+          return next;
+        });
+      } catch {}
+    }
+    loadCatalogs();
+    return () => {
+      dead = true;
+    };
+  }, [character]);
+
+  const fetchIntel = useCallback(async () => {
+    if (deck.length === 0 && relics.length === 0) {
+      setCoach(null);
+      setAdvisor(null);
+      return;
+    }
+    setLoading(true);
+    const cardsParam = deck.join(",");
+    const relicsParam = relics.join(",");
+    try {
+      const coachUrl = new URL(`${API}/api/runs/pick-coach`);
+      coachUrl.searchParams.set("character", character);
+      coachUrl.searchParams.set("cards", cardsParam);
+      coachUrl.searchParams.set("relics", relicsParam);
+      if (offer.length) coachUrl.searchParams.set("offer", offer.join(","));
+      if (target) coachUrl.searchParams.set("target", target);
+      const advisorUrl = `${API}/api/runs/deck-advisor?character=${character}&cards=${encodeURIComponent(cardsParam)}&relics=${encodeURIComponent(relicsParam)}`;
+      const [c, a] = await Promise.all([
+        fetch(coachUrl.toString()).then((r) => r.json()),
+        fetch(advisorUrl).then((r) => r.json()),
+      ]);
+      setCoach(c?.available ? c : null);
+      setAdvisor(a?.available ? a.items : null);
+    } catch {
+      setCoach(null);
+      setAdvisor(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [character, deck, relics, offer, target]);
+
+  useEffect(() => {
+    const id = setTimeout(fetchIntel, 400);
+    return () => clearTimeout(id);
+  }, [fetchIntel]);
+
+  function pickCharacter(c: string) {
+    setCharacter(c);
+    setDeck([]);
+    setRelics([]);
+    setOffer([]);
+    setTarget(null);
+    setCoach(null);
+    setAdvisor(null);
+  }
+
+  function removeOne(list: string[], setList: (v: string[]) => void, id: string) {
+    const idx = list.indexOf(id);
+    if (idx >= 0) setList([...list.slice(0, idx), ...list.slice(idx + 1)]);
+  }
+
+  const deckCounts = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const id of deck) m.set(id, (m.get(id) || 0) + 1);
+    return m;
+  }, [deck]);
+
+  const maxScore = Math.max(1, ...(coach?.offers ?? []).map((o) => o.coach_score));
+  const color = characterHex(character) || "var(--accent-gold)";
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="flex items-center gap-3 mb-2">
+        <h1 className="text-3xl font-bold">
+          <span className="text-[var(--accent-gold)]">Deck Lab</span>
+        </h1>
+        <span className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border border-[var(--accent-gold)]/40 text-[var(--accent-gold)]">
+          Preview
+        </span>
+      </div>
+      <p className="text-sm text-[var(--text-muted)] mb-8 max-w-3xl">
+        Sketch a draft and see what the community data says: the archetype it
+        is becoming, what winners with similar decks took next, and how each
+        card in an offer commits you. Powered by {""}
+        <Link href="/archetypes" className="text-[var(--accent-gold)] hover:underline">
+          community archetypes
+        </Link>
+        .
+      </p>
+
+      <div className="flex flex-wrap items-center gap-1.5 mb-6">
+        {CHARACTERS.map((c) => (
+          <button
+            key={c}
+            type="button"
+            onClick={() => pickCharacter(c)}
+            className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
+              character === c
+                ? "bg-[var(--bg-card-hover)] border-[var(--border-accent)] text-[var(--text-primary)]"
+                : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
+            }`}
+            style={character === c ? { borderColor: characterHex(c) || undefined } : undefined}
+          >
+            {characterLabel(c)}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="space-y-5">
+          <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+            <h2 className="text-sm font-semibold text-[var(--text-primary)] mb-3">Your draft</h2>
+            <div className="grid gap-2 sm:grid-cols-2 mb-3">
+              <ItemPicker
+                placeholder="Add a card…"
+                items={cardCatalog}
+                onPick={(i) => setDeck((d) => [...d, i.id])}
+              />
+              <ItemPicker
+                placeholder="Add a relic…"
+                items={relicCatalog}
+                onPick={(i) => setRelics((r) => (r.includes(i.id) ? r : [...r, i.id]))}
+              />
+            </div>
+            {deck.length === 0 && relics.length === 0 ? (
+              <p className="text-xs text-[var(--text-muted)]">
+                Add the cards and relics you have picked so far. Starters are
+                assumed and don&apos;t need to be entered.
+              </p>
+            ) : (
+              <div className="flex flex-wrap gap-1.5">
+                {[...deckCounts.entries()].map(([id, n]) => (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => removeOne(deck, setDeck, id)}
+                    title="Click to remove one copy"
+                    className="text-xs px-2 py-0.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-primary)] text-[var(--text-secondary)] hover:border-red-500/50"
+                  >
+                    {names[id] || id}
+                    {n > 1 ? ` ×${n}` : ""}
+                  </button>
+                ))}
+                {relics.map((id) => (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => removeOne(relics, setRelics, id)}
+                    title="Click to remove"
+                    className="text-xs px-2 py-0.5 rounded-md border border-sky-900/50 bg-[var(--bg-primary)] text-sky-300 hover:border-red-500/50"
+                  >
+                    {names[id] || id}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+            <h2 className="text-sm font-semibold text-[var(--text-primary)] mb-3">
+              Card offer{" "}
+              <span className="font-normal text-[var(--text-muted)]">
+                — which should you take?
+              </span>
+            </h2>
+            <div className="mb-3">
+              <ItemPicker
+                placeholder="Add an offered card (up to 5)…"
+                items={cardCatalog}
+                onPick={(i) =>
+                  setOffer((o) => (o.includes(i.id) || o.length >= 5 ? o : [...o, i.id]))
+                }
+              />
+            </div>
+            {offer.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mb-3">
+                {offer.map((id) => (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => setOffer((o) => o.filter((x) => x !== id))}
+                    className="text-xs px-2 py-0.5 rounded-md border border-[var(--accent-gold)]/40 bg-[var(--bg-primary)] text-[var(--accent-gold)] hover:border-red-500/50"
+                  >
+                    {names[id] || id}
+                  </button>
+                ))}
+              </div>
+            )}
+            {coach?.offers && coach.offers.length > 0 && (
+              <div className="space-y-2">
+                {coach.offers.map((o, i) => (
+                  <div key={o.id} className="text-xs">
+                    <div className="flex items-center justify-between mb-0.5">
+                      <span className={i === 0 ? "font-semibold text-[var(--text-primary)]" : "text-[var(--text-secondary)]"}>
+                        {i === 0 ? "★ " : ""}
+                        {o.name}
+                      </span>
+                      <span className="text-[var(--text-muted)] tabular-nums">
+                        {o.commitment_delta != null && (
+                          <span
+                            className="mr-2"
+                            style={{ color: o.commitment_delta >= 0 ? "#22c55e" : "#ef4444" }}
+                            title="How much this pick moves you toward the target build"
+                          >
+                            {o.commitment_delta >= 0 ? "+" : ""}
+                            {o.commitment_delta} commit
+                          </span>
+                        )}
+                        {o.winner_support != null && (
+                          <span title="Share of nearby winning decks carrying this card">
+                            {o.winner_support}% of winners
+                          </span>
+                        )}
+                      </span>
+                    </div>
+                    <div className="h-1.5 rounded bg-[var(--bg-primary)] overflow-hidden">
+                      <div
+                        className="h-full rounded"
+                        style={{
+                          width: `${Math.round((o.coach_score / maxScore) * 100)}%`,
+                          backgroundColor: color,
+                        }}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-5">
+          <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+            <h2 className="text-sm font-semibold text-[var(--text-primary)] mb-3">
+              Build trajectory
+              {loading && <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">updating…</span>}
+            </h2>
+            {!coach?.target ? (
+              <p className="text-xs text-[var(--text-muted)]">
+                Add a few picks and the nearest community archetypes appear here.
+              </p>
+            ) : (
+              <>
+                <div className="mb-3">
+                  <div className="text-lg font-semibold" style={{ color }}>
+                    {coach.target.name}
+                    {coach.target.locked && (
+                      <span className="ml-2 text-[10px] uppercase tracking-wider text-[var(--accent-gold)]">
+                        target locked
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-xs text-[var(--text-muted)]">
+                    {coach.target.similarity}% match · {coach.target.win_rate}% community win
+                    rate · {coach.target.share}% of {characterLabel(character)} runs
+                  </div>
+                </div>
+                {(coach.candidates ?? []).length > 1 && (
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wider text-[var(--text-tertiary)] mb-1.5">
+                      Or steer toward
+                    </div>
+                    <div className="space-y-1">
+                      {(coach.candidates ?? []).map((c) => (
+                        <button
+                          key={c.key}
+                          type="button"
+                          onClick={() => setTarget(target === c.key ? null : c.key)}
+                          className={`flex w-full items-center justify-between text-xs px-2.5 py-1.5 rounded-md border transition-colors ${
+                            target === c.key
+                              ? "border-[var(--accent-gold)]/60 bg-[var(--accent-gold)]/10 text-[var(--accent-gold)]"
+                              : "border-[var(--border-subtle)] bg-[var(--bg-primary)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
+                          }`}
+                        >
+                          <span>{c.name}</span>
+                          <span className="tabular-nums text-[var(--text-muted)]">
+                            {c.similarity}% · {c.win_rate}% WR
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
+            <h2 className="text-sm font-semibold text-[var(--text-primary)] mb-3">
+              Winners with this deck also took
+            </h2>
+            {!advisor || advisor.length === 0 ? (
+              <p className="text-xs text-[var(--text-muted)]">
+                Suggestions from winning decks near yours show up once you add picks.
+              </p>
+            ) : (
+              <div className="flex flex-wrap gap-1.5">
+                {advisor.map((it) => (
+                  <Link
+                    key={`${it.etype}-${it.id}`}
+                    href={`/${it.etype}/${it.id.toLowerCase()}`}
+                    className={`text-xs px-2 py-0.5 rounded-md border bg-[var(--bg-primary)] transition-colors ${
+                      it.etype === "relics"
+                        ? "border-sky-900/50 text-sky-300 hover:border-sky-500/60"
+                        : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50 hover:text-[var(--accent-gold)]"
+                    }`}
+                  >
+                    {it.name}
+                    <span className="ml-1 text-[var(--text-muted)]">{it.support}%</span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/deck-lab/page.tsx
+++ b/frontend/app/deck-lab/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import DeckLabClient from "./DeckLabClient";
+
+export const metadata: Metadata = {
+  title: "Deck Lab",
+  robots: { index: false, follow: false },
+};
+
+export default function DeckLabPage() {
+  return <DeckLabClient />;
+}


### PR DESCRIPTION
New /api/runs/pick-coach scores an offered card by commitment delta toward a target archetype, support among nearby winning decks, and the draft-recs take score, and the unlinked noindexed /deck-lab page previews it alongside the deck advisor.