### PR TITLE
Make every endpoint rate limit tunable from the admin dashboard

### DIFF
--- a/backend/app/routers/admin_rate_limits.py
+++ b/backend/app/routers/admin_rate_limits.py
@@ -21,9 +21,13 @@ router = APIRouter(
 
 @router.get("")
 def get_rate_limits(request: Request):
-    """Current browse cap, per-tier caps, and whether limiting is on."""
+    """Current browse cap, per-tier caps, per-endpoint caps (with their
+    hardcoded defaults), and whether limiting is on."""
     _audit(request)
-    return rate_limit_config.get_config()
+    return {
+        **rate_limit_config.get_config(),
+        "endpoint_defaults": rate_limit_config.endpoint_defaults(),
+    }
 
 
 class OverrideItem(BaseModel):
@@ -47,6 +51,15 @@ class RateLimitUpdate(BaseModel):
             "wins and applies to every tier; /api/admin can't be clamped."
         ),
     )
+    endpoint_limits: dict[str, str] | None = Field(
+        default=None,
+        description=(
+            "Per-endpoint caps keyed by knob name (replaces the whole map). "
+            "An empty value reverts that endpoint to its hardcoded default. "
+            "These ignore the enabled kill switch, like the old hardcoded "
+            "limits did."
+        ),
+    )
     enabled: bool | None = Field(
         default=None,
         description="False turns limiting off (per-endpoint limits stay).",
@@ -55,8 +68,9 @@ class RateLimitUpdate(BaseModel):
 
 @router.put("")
 def set_rate_limits(body: RateLimitUpdate, request: Request):
-    """Change the browse cap, tier caps, endpoint clamps, and/or toggle limiting.
-    Takes effect across workers within the config cache window (~15s)."""
+    """Change the browse cap, tier caps, endpoint clamps, per-endpoint caps,
+    and/or toggle limiting. Takes effect across workers within the config
+    cache window (~15s)."""
     _audit(request)
     try:
         return rate_limit_config.set_config(
@@ -66,6 +80,7 @@ def set_rate_limits(body: RateLimitUpdate, request: Request):
             [o.model_dump() for o in body.overrides]
             if body.overrides is not None
             else None,
+            body.endpoint_limits,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -51,7 +51,7 @@ def me(request: Request):
 
 
 @router.post("/steam/disconnect")
-@limiter.limit("10/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth.disconnect_steam", "10/minute"))
 def disconnect_steam(request: Request):
     user = require_user(request)
     from ..services.users_db import unlink_steam
@@ -63,7 +63,7 @@ def disconnect_steam(request: Request):
 
 
 @router.post("/discord/disconnect")
-@limiter.limit("10/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth.disconnect_discord", "10/minute"))
 def disconnect_discord(request: Request):
     user = require_user(request)
     from ..services.users_db import unlink_discord
@@ -75,7 +75,7 @@ def disconnect_discord(request: Request):
 
 
 @router.post("/twitch/disconnect")
-@limiter.limit("10/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth.disconnect_twitch", "10/minute"))
 def disconnect_twitch(request: Request):
     user = require_user(request)
     from ..services.users_db import unlink_twitch
@@ -94,7 +94,7 @@ def logout(request: Request):
 
 
 @router.post("/set-cookie")
-@limiter.limit("20/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth.set_cookie", "20/minute"))
 async def set_cookie(request: Request):
     """Accept a JWT token and set it as an httpOnly cookie.
 
@@ -122,7 +122,7 @@ async def set_cookie(request: Request):
 
 
 @router.patch("/username")
-@limiter.limit("10/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth.update_username", "10/minute"))
 async def update_username(request: Request):
     user = require_user(request)
     try:
@@ -160,7 +160,7 @@ def check_username(username: str):
 
 
 @router.patch("/email")
-@limiter.limit("10/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth.update_email", "10/minute"))
 async def update_email(request: Request):
     user = require_user(request)
     try:
@@ -182,7 +182,7 @@ async def update_email(request: Request):
 
 
 @router.get("/runs")
-@limiter.limit("60/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth.get_my_runs", "60/minute"))
 def get_my_runs(
     request: Request,
     page: int = 1,
@@ -203,7 +203,7 @@ def get_my_runs(
 
 
 @router.delete("/runs/{run_hash}")
-@limiter.limit("30/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth.delete_run", "30/minute"))
 def delete_run(run_hash: str, request: Request):
     user = require_user(request)
 
@@ -225,7 +225,7 @@ def delete_run(run_hash: str, request: Request):
 
 
 @router.get("/stats")
-@limiter.limit("10/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth.user_stats", "10/minute"))
 def user_stats(request: Request):
     user = require_user(request)
     username = user.get("username")
@@ -320,7 +320,7 @@ def _compute_personal_bests(username: str) -> dict:
 
 
 @router.get("/personal-bests")
-@limiter.limit("10/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth.personal_bests", "10/minute"))
 def personal_bests(request: Request):
     user = require_user(request)
     username = user.get("username")
@@ -330,7 +330,7 @@ def personal_bests(request: Request):
 
 
 @router.get("/competitive")
-@limiter.limit("10/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth.competitive_stats", "10/minute"))
 def competitive_stats(request: Request):
     user = require_user(request)
     username = user.get("username")
@@ -391,7 +391,7 @@ def competitive_stats(request: Request):
 
 
 @router.post("/runs/upload")
-@limiter.limit("10/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth.upload_runs", "10/minute"))
 async def upload_runs(request: Request, files: list[UploadFile] = File(...)):
     user = require_user(request)
 
@@ -514,7 +514,7 @@ async def upload_runs(request: Request, files: list[UploadFile] = File(...)):
 
 
 @router.get("/runs/stats")
-@limiter.limit("60/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth.get_my_stats", "60/minute"))
 def get_my_stats(request: Request):
     user = require_user(request)
     username = user.get("username")

--- a/backend/app/routers/auth_discord.py
+++ b/backend/app/routers/auth_discord.py
@@ -53,7 +53,7 @@ def _frontend_url(request: Request) -> str:
 
 
 @router.get("/start")
-@limiter.limit("20/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth_discord.start", "20/minute"))
 async def start(request: Request):
     client_id, _ = _get_discord_config()
 

--- a/backend/app/routers/auth_patreon.py
+++ b/backend/app/routers/auth_patreon.py
@@ -81,7 +81,7 @@ def _apply_paid(user_id: str, paid: bool) -> None:
 
 
 @router.get("/start")
-@limiter.limit("20/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth_patreon.start", "20/minute"))
 async def start(request: Request):
     base = _frontend_url(request)
     if not get_current_user(request):
@@ -190,7 +190,7 @@ async def callback(request: Request):
 
 
 @router.post("/disconnect")
-@limiter.limit("10/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth_patreon.disconnect", "10/minute"))
 async def disconnect(request: Request):
     from ..services.auth_jwt import require_user
     from ..services.users_db import unlink_patreon

--- a/backend/app/routers/auth_steam.py
+++ b/backend/app/routers/auth_steam.py
@@ -66,7 +66,7 @@ def _public_base(request: Request) -> str:
 
 
 @router.post("/start")
-@limiter.limit("20/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth_steam.start", "20/minute"))
 async def start(request: Request) -> dict:
     """Begin a Steam OpenID sign-in flow.
 
@@ -99,7 +99,9 @@ async def start(request: Request) -> dict:
 
 
 @router.get("/redirect")
-@limiter.limit("20/minute")
+@limiter.limit(
+    rate_limit_config.endpoint_limit("auth_steam.redirect_to_steam", "20/minute")
+)
 async def redirect_to_steam(request: Request):
     """Direct browser redirect to Steam login. For mobile and popup-blocked flows."""
     sid = auth_session_store.create_session()
@@ -527,7 +529,7 @@ class TicketBody(BaseModel):
 
 
 @router.post("/ticket")
-@limiter.limit("30/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth_steam.ticket_auth", "30/minute"))
 async def ticket_auth(request: Request, body: TicketBody) -> JSONResponse:
     """Silent sign-in for the in-game mod: exchanges a Steamworks Web API auth
     ticket (`SteamUser.GetAuthTicketForWebApi("spire-codex")`) for the same JWT

--- a/backend/app/routers/auth_twitch.py
+++ b/backend/app/routers/auth_twitch.py
@@ -59,7 +59,7 @@ def _frontend_url(request: Request) -> str:
 
 
 @router.get("/start")
-@limiter.limit("20/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("auth_twitch.start", "20/minute"))
 async def start(request: Request):
     base = _frontend_url(request)
     try:

--- a/backend/app/routers/beta.py
+++ b/backend/app/routers/beta.py
@@ -21,7 +21,7 @@ limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
 
 
 @router.get("/diff")
-@limiter.limit("120/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("beta.beta_diff", "120/minute"))
 def beta_diff(request: Request):
     """What the current beta adds, changes, and removes, per entity type.
 
@@ -34,7 +34,7 @@ def beta_diff(request: Request):
 
 
 @router.get("/version")
-@limiter.limit("120/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("beta.beta_version", "120/minute"))
 def beta_version(request: Request):
     """The current beta version (from the data-beta latest pointer)."""
     return {"beta_version": get_beta_version()}

--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -271,7 +271,7 @@ CHARTS: dict[str, dict] = {
 
 
 @router.get("/meta")
-@limiter.limit("120/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("charts.charts_meta", "120/minute"))
 def charts_meta(request: Request):
     """Everything the explorer UI needs to draw its controls, including the
     event list (events actually present in the data) for the outcome chart."""
@@ -629,7 +629,7 @@ def prewarm_charts(budget_s: float | None = None) -> int:
 
 
 @router.get("/{chart_key}")
-@limiter.limit("120/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("charts.get_chart", "120/minute"))
 def get_chart(
     request: Request,
     response: Response,

--- a/backend/app/routers/exports.py
+++ b/backend/app/routers/exports.py
@@ -230,7 +230,10 @@ def _stream_runs_jsonl(hashes):
 # Declared BEFORE the /{lang} route so FastAPI matches the literal
 # path "runs" instead of treating it as a language code.
 @router.get("/runs")
-@limiter.limit("120/hour", cost=_export_cost)
+@limiter.limit(
+    rate_limit_config.endpoint_limit("exports.export_runs", "120/hour"),
+    cost=_export_cost,
+)
 def export_runs(
     request: Request,
     limit: int | None = Query(
@@ -292,7 +295,7 @@ def export_runs(
 
 
 @router.get("/{lang}")
-@limiter.limit("10/hour")
+@limiter.limit(rate_limit_config.endpoint_limit("exports.export_language", "10/hour"))
 def export_language(lang: str, request: Request):
     if lang not in VALID_LANGUAGES:
         lang = "eng"

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -29,7 +29,7 @@ class FeedbackRequest(BaseModel):
 
 
 @router.post("")
-@limiter.limit("5/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("feedback.submit_feedback", "5/minute"))
 async def submit_feedback(request: Request, body: FeedbackRequest):
     if not WEBHOOK_URL:
         raise HTTPException(status_code=503, detail="Feedback not configured")

--- a/backend/app/routers/guides.py
+++ b/backend/app/routers/guides.py
@@ -117,7 +117,7 @@ def _validate_url(url: str | None) -> str | None:
 
 
 @router.post("")
-@limiter.limit("3/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("guides.submit_guide", "3/minute"))
 async def submit_guide(request: Request, body: GuideSubmission):
     if not WEBHOOK_URL:
         raise HTTPException(status_code=503, detail="Guide submissions not configured")

--- a/backend/app/routers/qa_feedback.py
+++ b/backend/app/routers/qa_feedback.py
@@ -45,7 +45,9 @@ class QAFeedback(BaseModel):
 # second without tripping the limiter, and gives headroom for several
 # reviewers behind one NAT/office IP. Discord's own per-webhook cap
 # (~5 / 2s) is the real ceiling above this.
-@limiter.limit("60/minute")
+@limiter.limit(
+    rate_limit_config.endpoint_limit("qa_feedback.submit_qa_feedback", "60/minute")
+)
 async def submit_qa_feedback(request: Request, body: QAFeedback):
     webhook = os.environ.get("FEEDBACK_WEBHOOK_URL", "")
     if not webhook:

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -83,7 +83,9 @@ def _load_run_blob(run_hash: str) -> str | None:
 
 
 @router.post("", tags=["Runs"])
-@limiter.limit("3000/hour")
+@limiter.limit(
+    rate_limit_config.endpoint_limit("runs.submit_run_endpoint", "3000/hour")
+)
 async def submit_run_endpoint(
     request: Request,
     username: str | None = None,
@@ -274,7 +276,9 @@ MAX_CLAIM_HASHES = 5000
 
 
 @router.post("/claim", tags=["Runs"])
-@limiter.limit("10/minute")
+@limiter.limit(
+    rate_limit_config.endpoint_limit("runs.claim_runs_endpoint", "10/minute")
+)
 async def claim_runs_endpoint(request: Request):
     """Attach a username to previously-submitted runs by hash.
 
@@ -323,7 +327,7 @@ async def claim_runs_endpoint(request: Request):
 
 
 @router.get("/list", tags=["Runs"])
-@limiter.limit("120/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("runs.list_runs", "120/minute"))
 def list_runs(
     request: Request,
     response: Response,
@@ -512,7 +516,7 @@ def list_runs(
 
 
 @router.get("/leaderboard", tags=["Runs"])
-@limiter.limit("120/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("runs.get_leaderboard", "120/minute"))
 def get_leaderboard(
     request: Request,
     response: Response,
@@ -642,7 +646,7 @@ def get_leaderboard(
 
 
 @router.get("/leaderboard/seed-rank", tags=["Runs"])
-@limiter.limit("120/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("runs.get_seed_rank", "120/minute"))
 def get_seed_rank(request: Request, seed: str, steam_id: str | None = None):
     """Seed + global standing for the in-game mod (F9 panel, post-run card).
 
@@ -676,7 +680,7 @@ def get_seed_rank(request: Request, seed: str, steam_id: str | None = None):
 
 
 @router.get("/leaderboard/rank/{run_hash}", tags=["Runs"])
-@limiter.limit("120/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("runs.get_run_rank", "120/minute"))
 def get_run_rank(request: Request, run_hash: str, category: str = "fastest"):
     """Rank of a single winning run within its character's leaderboard.
 
@@ -730,7 +734,9 @@ def get_run_rank(request: Request, run_hash: str, category: str = "fastest"):
 
 
 @router.get("/encounter-stats", tags=["Runs"])
-@limiter.limit("60/minute")
+@limiter.limit(
+    rate_limit_config.endpoint_limit("runs.get_encounter_stats_endpoint", "60/minute")
+)
 def get_encounter_stats_endpoint(
     request: Request,
     act: str | None = None,
@@ -845,7 +851,7 @@ def get_run_versions(request: Request):
 # Per-IP cap. Legitimate share-link traffic is one request per run; this
 # only bites scrapers enumerating hashes — which was sustaining ~8 req/s
 # against this single endpoint and pegging the worker at 100% CPU.
-@limiter.limit("60/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("runs.get_shared_run", "60/minute"))
 def get_shared_run(run_hash: str, request: Request):
     """Retrieve a shared run by its hash, merged with DB-side username.
 
@@ -964,7 +970,9 @@ _ENTITY_STATS_TYPES = {"relics", "cards", "potions"}
 
 
 @router.get("/stats/{entity_type}/{entity_id}", tags=["Runs"])
-@limiter.limit("120/minute")
+@limiter.limit(
+    rate_limit_config.endpoint_limit("runs.get_entity_run_stats", "120/minute")
+)
 def get_entity_run_stats(request: Request, entity_type: str, entity_id: str):
     if entity_type not in _ENTITY_STATS_TYPES:
         raise HTTPException(
@@ -996,7 +1004,11 @@ def get_entity_run_stats(request: Request, entity_type: str, entity_id: str):
 
 
 @router.get("/stats/{entity_type}/{entity_id}/history", tags=["Runs"])
-@limiter.limit("120/minute")
+@limiter.limit(
+    rate_limit_config.endpoint_limit(
+        "runs.get_entity_metric_history_endpoint", "120/minute"
+    )
+)
 def get_entity_metric_history_endpoint(
     request: Request,
     entity_type: str,
@@ -1021,7 +1033,7 @@ def get_entity_metric_history_endpoint(
 
 
 @router.get("/scores/{entity_type}", tags=["Runs"])
-@limiter.limit("60/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("runs.get_entity_scores", "60/minute"))
 def get_entity_scores(
     request: Request,
     entity_type: str,
@@ -1112,7 +1124,9 @@ def get_entity_scores(
 
 
 @router.get("/snapshot-status", tags=["Runs"])
-@limiter.limit("120/minute")
+@limiter.limit(
+    rate_limit_config.endpoint_limit("runs.runs_snapshot_status", "120/minute")
+)
 def runs_snapshot_status(request: Request, response: Response):
     """Whether the stats snapshot is loaded, rebuilding after a deploy, or
     serving a previous version while the current one builds. Lets the UI
@@ -1123,7 +1137,7 @@ def runs_snapshot_status(request: Request, response: Response):
 
 
 @router.get("/pulse", tags=["Runs"])
-@limiter.limit("240/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("runs.runs_pulse", "240/minute"))
 def runs_pulse(request: Request, response: Response):
     """Live community totals: the snapshot baseline plus the hot overlay's
     counters, which update within milliseconds of each accepted upload.
@@ -1144,7 +1158,7 @@ def runs_pulse(request: Request, response: Response):
 
 
 @router.get("/community-stats", tags=["Runs"])
-@limiter.limit("60/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("runs.community_stats", "60/minute"))
 def community_stats(request: Request, response: Response, bracket: str | None = None):
     """Community / fun stats for the /community-stats page: per-event player
     decision breakdowns, deadliest encounters/events, headline totals by
@@ -1172,7 +1186,7 @@ def community_stats(request: Request, response: Response, bracket: str | None = 
 
 
 @router.get("/me/picks", tags=["Runs"])
-@limiter.limit("60/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("runs.my_picks", "60/minute"))
 def my_picks(request: Request, response: Response):
     """The signed-in player's own pick rates across decision surfaces (card
     rewards + ancient 3-relic offers for now). Scoped to the JWT's verified
@@ -1193,7 +1207,7 @@ def my_picks(request: Request, response: Response):
 
 
 @router.get("/metrics/{entity_type}", tags=["Runs"])
-@limiter.limit("60/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("runs.get_entity_metrics", "60/minute"))
 def get_entity_metrics(
     request: Request,
     response: Response,
@@ -1241,7 +1255,9 @@ def get_entity_metrics(
 
 
 @router.get("/top/{entity_type}/{character}", tags=["Runs"])
-@limiter.limit("120/minute")
+@limiter.limit(
+    rate_limit_config.endpoint_limit("runs.get_top_for_character", "120/minute")
+)
 def get_top_for_character(
     request: Request, entity_type: str, character: str, limit: int = 5
 ):
@@ -1507,7 +1523,9 @@ def start_stats_refresher() -> None:
 
 
 @router.get("/stats", tags=["Runs"])
-@limiter.limit("120/minute")
+@limiter.limit(
+    rate_limit_config.endpoint_limit("runs.get_community_stats", "120/minute")
+)
 def get_community_stats(
     request: Request,
     character: str | None = None,
@@ -1634,7 +1652,7 @@ def get_community_stats(
 
 
 @router.get("/{run_hash}/similar", tags=["Runs"])
-@limiter.limit("60/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("runs.get_similar_runs", "60/minute"))
 def get_similar_runs(
     request: Request, response: Response, run_hash: str, lang: str = "eng"
 ):
@@ -1696,7 +1714,7 @@ def get_similar_runs(
 
 
 @router.get("/archetypes", tags=["Runs"])
-@limiter.limit("60/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("runs.get_archetypes", "60/minute"))
 def get_archetypes(request: Request, response: Response, lang: str = "eng"):
     """Community deck archetypes, clustered nightly from run-composition
     vectors: defining cards/relics, share, and win rate per build."""
@@ -1874,7 +1892,7 @@ def get_encounter_builds(
 
 
 @router.get("/deck-advisor", tags=["Runs"])
-@limiter.limit("120/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("runs.get_deck_advisor", "120/minute"))
 def get_deck_advisor(
     request: Request,
     response: Response,

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1829,7 +1829,9 @@ def get_archetypes(request: Request, response: Response, lang: str = "eng"):
 
 
 @router.get("/encounter-builds", tags=["Runs"])
-@limiter.limit("60/minute")
+@limiter.limit(
+    rate_limit_config.endpoint_limit("runs.get_encounter_builds", "60/minute")
+)
 def get_encounter_builds(
     request: Request, response: Response, encounter: str, lang: str = "eng"
 ):
@@ -1954,7 +1956,7 @@ def get_deck_advisor(
 
 
 @router.get("/pick-coach", tags=["Runs"])
-@limiter.limit("120/minute")
+@limiter.limit(rate_limit_config.endpoint_limit("runs.get_pick_coach", "120/minute"))
 def get_pick_coach(
     request: Request,
     response: Response,

--- a/backend/app/routers/uninstall.py
+++ b/backend/app/routers/uninstall.py
@@ -138,7 +138,9 @@ async def _send_via_resend(
 
 
 @router.post("")
-@limiter.limit("5/minute")
+@limiter.limit(
+    rate_limit_config.endpoint_limit("uninstall.submit_uninstall_feedback", "5/minute")
+)
 async def submit_uninstall_feedback(request: Request, body: UninstallFeedback):
     # Drop completely-empty submissions — Overwolf can flash the window
     # past a user and we don't want auto-blank rows piling up.

--- a/backend/app/services/rate_limit_config.py
+++ b/backend/app/services/rate_limit_config.py
@@ -93,6 +93,7 @@ def _fallback() -> dict:
         "default_limit": _DEFAULT_LIMIT,
         "tiers": dict(_DEFAULT_TIERS),
         "overrides": [],
+        "endpoint_limits": {},
         "enabled": True,
     }
 
@@ -124,6 +125,11 @@ def get_config() -> dict:
                 "default_limit": doc.get("default_limit") or _DEFAULT_LIMIT,
                 "tiers": tiers,
                 "overrides": overrides,
+                "endpoint_limits": {
+                    k: v
+                    for k, v in (doc.get("endpoint_limits") or {}).items()
+                    if isinstance(k, str) and isinstance(v, str) and v
+                },
                 "enabled": bool(doc.get("enabled", True)),
             }
     except Exception:
@@ -229,6 +235,38 @@ def tier_limit_value() -> str:
     return _limit_for_tier(_current_tier.get() or "browse", cfg)
 
 
+# Every endpoint-limit knob registered via endpoint_limit(), name -> hardcoded
+# default. Populated at import time as routers load, so by the time the admin
+# surface reads it every knob is present.
+_ENDPOINT_DEFAULTS: dict[str, str] = {}
+
+
+def endpoint_limit(name: str, default: str):
+    """Admin-tunable replacement for a hardcoded ``@limiter.limit("...")``.
+
+    Returns a no-arg limit callable (same slowapi constraint as
+    tier_limit_value) that reads ``endpoint_limits[name]`` from the config doc
+    and falls back to ``default``. These caps deliberately ignore the global
+    ``enabled`` kill switch, matching the old behavior where per-endpoint
+    limits survived turning blanket limiting off; to effectively disable one,
+    set it to something huge in the dashboard."""
+    if name in _ENDPOINT_DEFAULTS:
+        raise ValueError(f"duplicate endpoint limit name '{name}'")
+    _ENDPOINT_DEFAULTS[name] = _validate_limit(default, name)
+
+    def _value() -> str:
+        cfg = get_config()
+        return (cfg.get("endpoint_limits") or {}).get(name) or default
+
+    _value.__name__ = f"limit_{name.replace('.', '_')}"
+    return _value
+
+
+def endpoint_defaults() -> dict[str, str]:
+    """Registered endpoint-limit knobs and their hardcoded defaults."""
+    return dict(_ENDPOINT_DEFAULTS)
+
+
 # Back-compat: the browse cap on its own (a handy helper; the limiter uses
 # tier_limit_value now).
 def default_limit_value(*_args, **_kwargs) -> str:
@@ -256,6 +294,7 @@ def set_config(
     enabled: bool | None = None,
     tiers: dict | None = None,
     overrides: list[dict] | None = None,
+    endpoint_limits: dict | None = None,
 ) -> dict:
     """Update the config. Validates every limit string and raises ValueError on a
     bad one. ``overrides`` replaces the whole list (the admin page edits it as a
@@ -268,6 +307,7 @@ def set_config(
         "default_limit": current["default_limit"],
         "tiers": dict(current["tiers"]),
         "overrides": list(current.get("overrides") or []),
+        "endpoint_limits": dict(current.get("endpoint_limits") or {}),
         "enabled": current["enabled"],
     }
     if default_limit is not None:
@@ -294,6 +334,16 @@ def set_config(
                 }
             )
         new["overrides"] = cleaned
+    if endpoint_limits is not None:
+        cleaned_ep: dict[str, str] = {}
+        for name, value in endpoint_limits.items():
+            if name not in _ENDPOINT_DEFAULTS:
+                raise ValueError(f"unknown endpoint limit '{name}'")
+            value = (value or "").strip()
+            # Empty value = back to the hardcoded default (drop the entry).
+            if value:
+                cleaned_ep[name] = _validate_limit(value, name)
+        new["endpoint_limits"] = cleaned_ep
     if enabled is not None:
         new["enabled"] = bool(enabled)
     _coll().replace_one({"_id": _DOC_ID}, {"_id": _DOC_ID, **new}, upsert=True)

--- a/frontend/app/admin/rate-limits/RateLimitsClient.tsx
+++ b/frontend/app/admin/rate-limits/RateLimitsClient.tsx
@@ -17,6 +17,8 @@ interface Config {
   default_limit: string;
   tiers: Record<string, string>;
   overrides: Override[];
+  endpoint_limits: Record<string, string>;
+  endpoint_defaults: Record<string, string>;
   enabled: boolean;
 }
 
@@ -35,6 +37,9 @@ export default function RateLimitsClient() {
   const [enabled, setEnabled] = useState(true);
   const [tiers, setTiers] = useState<Record<string, string>>({});
   const [overrides, setOverrides] = useState<Override[]>([]);
+  const [epLimits, setEpLimits] = useState<Record<string, string>>({});
+  const [epDefaults, setEpDefaults] = useState<Record<string, string>>({});
+  const [epFilter, setEpFilter] = useState("");
   const [note, setNote] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -44,6 +49,8 @@ export default function RateLimitsClient() {
     setEnabled(c.enabled);
     setTiers(c.tiers || {});
     setOverrides(c.overrides || []);
+    setEpLimits(c.endpoint_limits || {});
+    if (c.endpoint_defaults) setEpDefaults(c.endpoint_defaults);
   };
 
   useEffect(() => {
@@ -266,6 +273,74 @@ export default function RateLimitsClient() {
                 Save clamps
               </button>
             </div>
+          </div>
+
+          <div className={card}>
+            <label className="block text-sm font-semibold text-[var(--text-primary)]">
+              Endpoint caps
+            </label>
+            <div className="text-xs text-[var(--text-muted)] mb-3">
+              Every endpoint&apos;s own cap (formerly hardcoded). Empty means the
+              built-in default shown in grey. These always apply, even with
+              limiting off.
+            </div>
+            <input
+              type="text"
+              value={epFilter}
+              onChange={(e) => setEpFilter(e.target.value)}
+              placeholder="Filter (e.g. runs, auth, export)…"
+              className={`w-full mb-3 ${input}`}
+            />
+            <div className="space-y-1.5 max-h-96 overflow-y-auto pr-1">
+              {Object.keys(epDefaults)
+                .sort()
+                .filter((k) => k.toLowerCase().includes(epFilter.trim().toLowerCase()))
+                .map((k) => (
+                  <div key={k} className="flex items-center gap-2">
+                    <div className="flex-1 min-w-0">
+                      <div className="text-xs font-mono text-[var(--text-primary)] truncate">{k}</div>
+                      <div className="text-[10px] text-[var(--text-muted)]">
+                        default {epDefaults[k]}
+                      </div>
+                    </div>
+                    <input
+                      type="text"
+                      value={epLimits[k] ?? ""}
+                      onChange={(e) =>
+                        setEpLimits({ ...epLimits, [k]: e.target.value })
+                      }
+                      placeholder={epDefaults[k]}
+                      className={`w-36 ${input} ${
+                        (epLimits[k] ?? "").trim()
+                          ? "border-[var(--accent-gold)]/50"
+                          : ""
+                      }`}
+                    />
+                  </div>
+                ))}
+              {Object.keys(epDefaults).length === 0 && (
+                <p className="text-xs text-[var(--text-muted)]">
+                  No endpoint caps registered (backend predates this panel).
+                </p>
+              )}
+            </div>
+            <button
+              type="button"
+              disabled={saving}
+              onClick={() => {
+                const cleaned: Record<string, string> = {};
+                for (const [k, v] of Object.entries(epLimits)) {
+                  if (v.trim()) cleaned[k] = v.trim();
+                }
+                save({ endpoint_limits: cleaned });
+              }}
+              className={`mt-3 ${goldBtn}`}
+            >
+              Save endpoint caps
+            </button>
+            <p className="mt-2 text-xs text-[var(--text-muted)]">
+              Clear a field and save to fall back to the hardcoded default.
+            </p>
           </div>
         </div>
       )}


### PR DESCRIPTION
All 51 hardcoded endpoint rate limits now register through an endpoint_limit() factory that reads an admin-editable per-endpoint cap from the rate-limit config doc (hardcoded value stays as the fallback default), and the admin rate-limits page grew a searchable Endpoint caps card to set or revert any of them live.