### PR TITLE
Add a hidden seed finder over community-run evidence

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1828,6 +1828,79 @@ def get_archetypes(request: Request, response: Response, lang: str = "eng"):
     return payload
 
 
+@router.get("/seed-finder", tags=["Runs"], include_in_schema=False)
+@limiter.limit(rate_limit_config.endpoint_limit("runs.get_seed_finder", "20/minute"))
+def get_seed_finder(
+    request: Request,
+    response: Response,
+    character: str | None = None,
+    deck: str = "",
+    offered: str = "",
+    relics: str = "",
+    events: str = "",
+    ancient: str | None = None,
+    ancient_act: int | None = Query(None, ge=1, le=4),
+    limit: int = Query(20, ge=1, le=50),
+):
+    """Find community runs whose seed demonstrated a combination of content:
+    cards kept or offered (ID or ID:count), relics obtained, events seen, and
+    ancient relic offers. Ranked by how many predicates matched."""
+    import hashlib
+
+    def _counted(raw: str) -> list[tuple[str, int]]:
+        out = []
+        for part in raw.split(","):
+            part = part.strip().upper()
+            if not part:
+                continue
+            pid, _, n = part.partition(":")
+            try:
+                out.append((pid, max(1, int(n)) if n else 1))
+            except ValueError:
+                out.append((pid, 1))
+        return out
+
+    char = (character or "").strip().upper() or None
+    deck_cards = _counted(deck)
+    offered_cards = _counted(offered)
+    relic_ids = sorted(r.strip().upper() for r in relics.split(",") if r.strip())
+    event_ids = sorted(e.strip().upper() for e in events.split(",") if e.strip())
+    ancient_id = (ancient or "").strip().upper() or None
+    if not (deck_cards or offered_cards or relic_ids or event_ids or ancient_id):
+        response.headers["Cache-Control"] = "no-store"
+        return {"available": False, "detail": "give me at least one predicate"}
+
+    key_src = f"{char}|{deck_cards}|{offered_cards}|{relic_ids}|{event_ids}|{ancient_id}|{ancient_act}|{limit}"
+    cache_key = "seedfind:" + hashlib.sha1(key_src.encode()).hexdigest()
+    cached = app_cache.get_json(cache_key)
+    if cached is not None:
+        response.headers["Cache-Control"] = "public, max-age=300"
+        return cached
+    from ..services.seed_finder import find_seeds
+
+    try:
+        found = find_seeds(
+            char,
+            deck_cards,
+            offered_cards,
+            relic_ids,
+            event_ids,
+            ancient_id,
+            ancient_act,
+            limit=limit,
+        )
+    except Exception:
+        logger.warning("seed finder failed", exc_info=True)
+        found = None
+    if found is None:
+        response.headers["Cache-Control"] = "no-store"
+        return {"available": False}
+    payload = {"available": True, **found}
+    app_cache.set_json(cache_key, payload, ttl_seconds=600)
+    response.headers["Cache-Control"] = "public, max-age=300"
+    return payload
+
+
 @router.get("/encounter-builds", tags=["Runs"])
 @limiter.limit(
     rate_limit_config.endpoint_limit("runs.get_encounter_builds", "60/minute")

--- a/backend/app/services/seed_finder.py
+++ b/backend/app/services/seed_finder.py
@@ -1,0 +1,247 @@
+"""Seed finder: mine submitted runs for seeds whose observed content matches
+a combination of predicates (cards offered or kept, relics obtained, events
+seen, ancient relic offers).
+
+Funnel: vector shards answer "which runs have these cards/relics at all"
+in memory (anchor stage), the flattened card_choices on the run docs verify
+offer counts, and only events/ancient predicates fall through to blobs.
+Results rank full matches first, then by how many predicates hit."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_NAMESPACES = {"CARD", "RELIC", "ENCOUNTER", "EVENT", "POTION", "ENCHANTMENT"}
+
+MAX_CANDIDATES = 8000
+MAX_BLOB_FETCH = 2000
+
+
+def _bare(raw: str | None) -> str:
+    if not raw:
+        return ""
+    parts = raw.split(".")
+    if len(parts) > 1 and parts[0] in _NAMESPACES:
+        return ".".join(parts[1:])
+    return raw
+
+
+def _anchor_hashes(characters: list[str], terms: list[str]) -> list[str] | None:
+    """Run hashes whose composition vector contains every anchor term,
+    newest first. None when the vector build isn't available."""
+    import numpy as np
+
+    from .run_vectors import _load_shard, _load_vocab
+
+    vocab = _load_vocab()
+    if vocab is None:
+        return None
+    cols = []
+    for t in terms:
+        idx = vocab.get(t)
+        if idx is None:
+            return []
+        cols.append(idx)
+    dated: list[tuple[bytes, bytes]] = []
+    for ch in characters:
+        loaded = _load_shard(ch)
+        if loaded is None:
+            continue
+        mat, meta = loaded
+        mask = None
+        for col in cols:
+            e = np.zeros(mat.shape[1], dtype=np.float32)
+            e[col] = 1.0
+            pres = np.asarray(mat.dot(e)) > 0
+            mask = pres if mask is None else (mask & pres)
+        if mask is None or not mask.any():
+            continue
+        rows = np.flatnonzero(mask)
+        dates = meta["date"][rows]
+        hashes = meta["hash"][rows]
+        dated.extend(zip(dates, hashes))
+    dated.sort(reverse=True)
+    return [h.decode() for _, h in dated[:MAX_CANDIDATES]]
+
+
+def _blob_matches(
+    blob: dict,
+    events: list[str],
+    ancient_relic: str | None,
+    ancient_act: int | None,
+) -> tuple[set[str], set[str]]:
+    """(matched, missing) labels for the blob-only predicates of one run."""
+    want_events = set(events)
+    seen_events: set[str] = set()
+    ancient_hit = False
+    for act_idx, act_floors in enumerate(blob.get("map_point_history") or []):
+        for floor in act_floors or []:
+            for ps in floor.get("player_stats") or []:
+                for ec in ps.get("event_choices") or []:
+                    title = ec.get("title") or {}
+                    if title.get("table") != "events":
+                        continue
+                    eid = (title.get("key") or "").split(".", 1)[0].upper()
+                    if eid in want_events:
+                        seen_events.add(eid)
+                if ancient_relic and not ancient_hit:
+                    if ancient_act is not None and act_idx != ancient_act - 1:
+                        continue
+                    for offer in ps.get("ancient_choice") or []:
+                        rid = offer.get("TextKey") or _bare(
+                            (offer.get("title") or {}).get("key")
+                        )
+                        if (rid or "").upper() == ancient_relic:
+                            ancient_hit = True
+                            break
+    matched: set[str] = set()
+    missing: set[str] = set()
+    for eid in want_events:
+        (matched if eid in seen_events else missing).add(f"event:{eid}")
+    if ancient_relic:
+        label = f"ancient:{ancient_relic}" + (
+            f":act{ancient_act}" if ancient_act else ""
+        )
+        (matched if ancient_hit else missing).add(label)
+    return matched, missing
+
+
+def find_seeds(
+    character: str | None,
+    deck_cards: list[tuple[str, int]],
+    offered_cards: list[tuple[str, int]],
+    relics: list[str],
+    events: list[str],
+    ancient_relic: str | None,
+    ancient_act: int | None,
+    limit: int = 20,
+) -> dict | None:
+    """Rank submitted runs by how many predicates their seed demonstrated."""
+    from .run_vectors import _OFFICIAL_CHARACTERS
+    from .runs_db_mongo import _get_collection, get_run_blobs
+
+    characters = (
+        [character] if character in _OFFICIAL_CHARACTERS else list(_OFFICIAL_CHARACTERS)
+    )
+    anchor_terms = [cid for cid, _ in deck_cards] + [f"R:{rid}" for rid in relics]
+
+    coll = _get_collection()
+    sampled = False
+    if anchor_terms:
+        hashes = _anchor_hashes(characters, anchor_terms)
+        if hashes is None:
+            return None
+        if not hashes:
+            return {"sampled": False, "scanned": 0, "results": []}
+        query = {"_id": {"$in": hashes}}
+    else:
+        # No composition anchor to narrow on: sample the newest runs.
+        sampled = True
+        query = {
+            "hidden": {"$ne": True},
+            "player_count": 1,
+            "character": {"$in": characters},
+            "seed": {"$nin": ["", None]},
+        }
+
+    projection = {
+        "seed": 1,
+        "character": 1,
+        "ascension": 1,
+        "win": 1,
+        "submitted_at": 1,
+        "player_count": 1,
+        "hidden": 1,
+        "deck.id": 1,
+        "relics.id": 1,
+        "card_choices.card_id": 1,
+    }
+    cursor = coll.find(query, projection)
+    if sampled:
+        cursor = cursor.sort("submitted_at", -1).limit(MAX_CANDIDATES)
+
+    need_blob = bool(events or ancient_relic)
+    doc_total = len(deck_cards) + len(offered_cards) + len(relics)
+    blob_total = len(events) + (1 if ancient_relic else 0)
+
+    scanned = 0
+    rows = []
+    for doc in cursor:
+        scanned += 1
+        seed = (doc.get("seed") or "").strip()
+        if not seed or doc.get("hidden") or (doc.get("player_count") or 1) != 1:
+            continue
+        matched: set[str] = set()
+        missing: set[str] = set()
+        deck_counts: dict[str, int] = {}
+        for c in doc.get("deck") or []:
+            cid = str(c.get("id") or "").upper()
+            deck_counts[cid] = deck_counts.get(cid, 0) + 1
+        for cid, n in deck_cards:
+            label = f"deck:{cid}" + (f"x{n}" if n > 1 else "")
+            (matched if deck_counts.get(cid, 0) >= n else missing).add(label)
+        relic_ids = {str(r.get("id") or "").upper() for r in doc.get("relics") or []}
+        for rid in relics:
+            (matched if rid in relic_ids else missing).add(f"relic:{rid}")
+        offer_counts: dict[str, int] = {}
+        for ch in doc.get("card_choices") or []:
+            cid = str(ch.get("card_id") or "").upper()
+            offer_counts[cid] = offer_counts.get(cid, 0) + 1
+        for cid, n in offered_cards:
+            label = f"offered:{cid}" + (f"x{n}" if n > 1 else "")
+            (matched if offer_counts.get(cid, 0) >= n else missing).add(label)
+        rows.append(
+            {
+                "run_hash": doc["_id"],
+                "seed": seed,
+                "character": doc.get("character"),
+                "ascension": doc.get("ascension"),
+                "win": bool(doc.get("win")),
+                "date": str(doc.get("submitted_at") or "")[:10],
+                "matched": matched,
+                "missing": missing,
+            }
+        )
+
+    if need_blob and rows:
+        # Blob predicates are unknowable from the doc, so fetch blobs for the
+        # rows that matched everything checkable so far, best first.
+        rows.sort(key=lambda r: (len(r["missing"]), -len(r["matched"])))
+        to_fetch = [r for r in rows[:MAX_BLOB_FETCH]]
+        if len(rows) > MAX_BLOB_FETCH:
+            sampled = True
+        blobs = get_run_blobs([r["run_hash"] for r in to_fetch])
+        for r in rows:
+            blob = blobs.get(r["run_hash"])
+            if blob is None:
+                r["missing"] |= {f"event:{e}" for e in events}
+                if ancient_relic:
+                    r["missing"].add(f"ancient:{ancient_relic}")
+                continue
+            m, mi = _blob_matches(blob, events, ancient_relic, ancient_act)
+            r["matched"] |= m
+            r["missing"] |= mi
+
+    total = doc_total + blob_total
+    rows.sort(
+        key=lambda r: (len(r["missing"]), -len(r["matched"]), not r["win"]),
+    )
+    out = []
+    for r in rows[:limit]:
+        out.append(
+            {
+                **r,
+                "matched": sorted(r["matched"]),
+                "missing": sorted(r["missing"]),
+                "full_match": not r["missing"],
+                "url": f"/runs/{r['run_hash']}",
+            }
+        )
+    return {
+        "sampled": sampled,
+        "scanned": scanned,
+        "predicates": total,
+        "results": out,
+    }

--- a/frontend/app/seed-lab/SeedLabClient.tsx
+++ b/frontend/app/seed-lab/SeedLabClient.tsx
@@ -1,0 +1,482 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { characterHex } from "@/lib/character-colors";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+const CHARACTERS = ["ANY", "IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"];
+
+interface CatalogItem {
+  id: string;
+  name: string;
+}
+
+interface SeedResult {
+  run_hash: string;
+  seed: string;
+  character: string;
+  ascension: number;
+  win: boolean;
+  date: string;
+  matched: string[];
+  missing: string[];
+  full_match: boolean;
+  url: string;
+}
+
+interface FinderResponse {
+  available: boolean;
+  sampled?: boolean;
+  scanned?: number;
+  predicates?: number;
+  results?: SeedResult[];
+  detail?: string;
+}
+
+interface CountedPick {
+  id: string;
+  name: string;
+  count: number;
+}
+
+function characterLabel(c: string): string {
+  return c.charAt(0) + c.slice(1).toLowerCase();
+}
+
+function Picker({
+  placeholder,
+  items,
+  onPick,
+}: {
+  placeholder: string;
+  items: CatalogItem[];
+  onPick: (item: CatalogItem) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      if (boxRef.current && !boxRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, []);
+
+  const matches = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [];
+    return items.filter((i) => i.name.toLowerCase().includes(q)).slice(0, 8);
+  }, [query, items]);
+
+  return (
+    <div ref={boxRef} className="relative">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        placeholder={placeholder}
+        className="w-full px-3 py-2 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm focus:outline-none focus:border-[var(--accent-gold)]"
+      />
+      {open && matches.length > 0 && (
+        <div className="absolute z-20 mt-1 w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] shadow-lg overflow-hidden">
+          {matches.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              onClick={() => {
+                onPick(m);
+                setQuery("");
+                setOpen(false);
+              }}
+              className="block w-full text-left px-3 py-1.5 text-sm text-[var(--text-secondary)] hover:bg-[var(--bg-card-hover)] hover:text-[var(--text-primary)]"
+            >
+              {m.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CountedChips({
+  picks,
+  onBump,
+  onRemove,
+  accent,
+}: {
+  picks: CountedPick[];
+  onBump: (id: string) => void;
+  onRemove: (id: string) => void;
+  accent?: string;
+}) {
+  if (picks.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1.5 mt-2">
+      {picks.map((p) => (
+        <span
+          key={p.id}
+          className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-md border bg-[var(--bg-primary)] ${
+            accent || "border-[var(--border-subtle)] text-[var(--text-secondary)]"
+          }`}
+        >
+          <button type="button" onClick={() => onBump(p.id)} title="Click to require one more">
+            {p.name}
+            {p.count > 1 ? ` ×${p.count}` : ""}
+          </button>
+          <button
+            type="button"
+            onClick={() => onRemove(p.id)}
+            className="text-[var(--text-muted)] hover:text-red-400"
+            aria-label="Remove"
+          >
+            ✕
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default function SeedLabClient() {
+  const [character, setCharacter] = useState("ANY");
+  const [deckPicks, setDeckPicks] = useState<CountedPick[]>([]);
+  const [offerPicks, setOfferPicks] = useState<CountedPick[]>([]);
+  const [relicPicks, setRelicPicks] = useState<CatalogItem[]>([]);
+  const [eventPicks, setEventPicks] = useState<CatalogItem[]>([]);
+  const [ancientPick, setAncientPick] = useState<CatalogItem | null>(null);
+  const [ancientAct, setAncientAct] = useState<number | null>(null);
+  const [cards, setCards] = useState<CatalogItem[]>([]);
+  const [relicCatalog, setRelicCatalog] = useState<CatalogItem[]>([]);
+  const [eventCatalog, setEventCatalog] = useState<CatalogItem[]>([]);
+  const [result, setResult] = useState<FinderResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let dead = false;
+    async function load() {
+      try {
+        const [cardRes, relicRes, eventRes] = await Promise.all([
+          fetch(`${API}/api/cards`).then((r) => r.json()),
+          fetch(`${API}/api/relics`).then((r) => r.json()),
+          fetch(`${API}/api/events`).then((r) => r.json()),
+        ]);
+        if (dead) return;
+        setCards(
+          cardRes.map((c: any) => ({ id: String(c.id).toUpperCase(), name: c.name })),
+        );
+        setRelicCatalog(
+          relicRes.map((r: any) => ({ id: String(r.id).toUpperCase(), name: r.name })),
+        );
+        setEventCatalog(
+          eventRes.map((e: any) => ({ id: String(e.id).toUpperCase(), name: e.name })),
+        );
+      } catch {}
+    }
+    load();
+    return () => {
+      dead = true;
+    };
+  }, []);
+
+  const hasPredicates =
+    deckPicks.length > 0 ||
+    offerPicks.length > 0 ||
+    relicPicks.length > 0 ||
+    eventPicks.length > 0 ||
+    ancientPick !== null;
+
+  async function search() {
+    if (!hasPredicates || loading) return;
+    setLoading(true);
+    try {
+      const url = new URL(`${API}/api/runs/seed-finder`);
+      if (character !== "ANY") url.searchParams.set("character", character);
+      if (deckPicks.length)
+        url.searchParams.set(
+          "deck",
+          deckPicks.map((p) => (p.count > 1 ? `${p.id}:${p.count}` : p.id)).join(","),
+        );
+      if (offerPicks.length)
+        url.searchParams.set(
+          "offered",
+          offerPicks.map((p) => (p.count > 1 ? `${p.id}:${p.count}` : p.id)).join(","),
+        );
+      if (relicPicks.length)
+        url.searchParams.set("relics", relicPicks.map((p) => p.id).join(","));
+      if (eventPicks.length)
+        url.searchParams.set("events", eventPicks.map((p) => p.id).join(","));
+      if (ancientPick) {
+        url.searchParams.set("ancient", ancientPick.id);
+        if (ancientAct) url.searchParams.set("ancient_act", String(ancientAct));
+      }
+      const res = await fetch(url.toString());
+      setResult(await res.json());
+    } catch {
+      setResult(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const names = useMemo(() => {
+    const m: Record<string, string> = {};
+    for (const i of [...cards, ...relicCatalog, ...eventCatalog]) m[i.id] = i.name;
+    return m;
+  }, [cards, relicCatalog, eventCatalog]);
+
+  function labelFor(tag: string): string {
+    const [kind, rest] = [tag.slice(0, tag.indexOf(":")), tag.slice(tag.indexOf(":") + 1)];
+    const m = rest.match(/^(.*?)(?:x(\d+))?(?::act(\d))?$/);
+    const id = m?.[1] ?? rest;
+    const count = m?.[2] ? ` ×${m[2]}` : "";
+    const act = m?.[3] ? ` (act ${m[3]})` : "";
+    const name = names[id] || id.replace(/_/g, " ").toLowerCase();
+    const verb =
+      kind === "deck" ? "kept" : kind === "offered" ? "offered" : kind === "relic" ? "got" : kind === "event" ? "saw" : "ancient offered";
+    return `${verb} ${name}${count}${act}`;
+  }
+
+  const bump = (setter: React.Dispatch<React.SetStateAction<CountedPick[]>>) => (id: string) =>
+    setter((ps) => ps.map((p) => (p.id === id ? { ...p, count: Math.min(4, p.count + 1) } : p)));
+  const drop = (setter: React.Dispatch<React.SetStateAction<CountedPick[]>>) => (id: string) =>
+    setter((ps) => ps.filter((p) => p.id !== id));
+  const addCounted =
+    (setter: React.Dispatch<React.SetStateAction<CountedPick[]>>) => (i: CatalogItem) =>
+      setter((ps) => (ps.some((p) => p.id === i.id) ? ps : [...ps, { ...i, count: 1 }]));
+
+  const card = "rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4";
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="flex items-center gap-3 mb-2">
+        <h1 className="text-3xl font-bold">
+          <span className="text-[var(--accent-gold)]">Seed Lab</span>
+        </h1>
+        <span className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border border-[var(--accent-gold)]/40 text-[var(--accent-gold)]">
+          Preview
+        </span>
+      </div>
+      <p className="text-sm text-[var(--text-muted)] mb-6 max-w-3xl">
+        Search community runs for seeds that demonstrably produced a combination
+        of content: cards offered or kept, relics obtained, events encountered,
+        ancient offers. A hit is a real run — open it to see the route that got there.
+      </p>
+
+      <div className="flex flex-wrap items-center gap-1.5 mb-5">
+        {CHARACTERS.map((c) => (
+          <button
+            key={c}
+            type="button"
+            onClick={() => setCharacter(c)}
+            className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
+              character === c
+                ? "bg-[var(--bg-card-hover)] border-[var(--border-accent)] text-[var(--text-primary)]"
+                : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
+            }`}
+            style={
+              character === c && c !== "ANY"
+                ? { borderColor: characterHex(c) || undefined }
+                : undefined
+            }
+          >
+            {c === "ANY" ? "Any character" : characterLabel(c)}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 mb-5">
+        <div className={card}>
+          <h2 className="text-sm font-semibold text-[var(--text-primary)] mb-1">Cards offered</h2>
+          <p className="text-xs text-[var(--text-muted)] mb-2">
+            Appeared as a card reward. Click a chip to require more copies.
+          </p>
+          <Picker placeholder="Add a card…" items={cards} onPick={addCounted(setOfferPicks)} />
+          <CountedChips
+            picks={offerPicks}
+            onBump={bump(setOfferPicks)}
+            onRemove={drop(setOfferPicks)}
+            accent="border-[var(--accent-gold)]/40 text-[var(--accent-gold)]"
+          />
+        </div>
+
+        <div className={card}>
+          <h2 className="text-sm font-semibold text-[var(--text-primary)] mb-1">Cards kept</h2>
+          <p className="text-xs text-[var(--text-muted)] mb-2">
+            In the final deck. Click a chip to require more copies.
+          </p>
+          <Picker placeholder="Add a card…" items={cards} onPick={addCounted(setDeckPicks)} />
+          <CountedChips picks={deckPicks} onBump={bump(setDeckPicks)} onRemove={drop(setDeckPicks)} />
+        </div>
+
+        <div className={card}>
+          <h2 className="text-sm font-semibold text-[var(--text-primary)] mb-1">Relics obtained</h2>
+          <p className="text-xs text-[var(--text-muted)] mb-2">
+            Picked up during the run (shop stock the player skipped isn&apos;t recorded).
+          </p>
+          <Picker
+            placeholder="Add a relic…"
+            items={relicCatalog}
+            onPick={(i) => setRelicPicks((ps) => (ps.some((p) => p.id === i.id) ? ps : [...ps, i]))}
+          />
+          {relicPicks.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-2">
+              {relicPicks.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => setRelicPicks((ps) => ps.filter((x) => x.id !== p.id))}
+                  className="text-xs px-2 py-0.5 rounded-md border border-sky-900/50 bg-[var(--bg-primary)] text-sky-300 hover:border-red-500/50"
+                >
+                  {p.name} ✕
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className={card}>
+          <h2 className="text-sm font-semibold text-[var(--text-primary)] mb-1">Events seen</h2>
+          <p className="text-xs text-[var(--text-muted)] mb-2">Encountered anywhere in the run.</p>
+          <Picker
+            placeholder="Add an event…"
+            items={eventCatalog}
+            onPick={(i) => setEventPicks((ps) => (ps.some((p) => p.id === i.id) ? ps : [...ps, i]))}
+          />
+          {eventPicks.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-2">
+              {eventPicks.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => setEventPicks((ps) => ps.filter((x) => x.id !== p.id))}
+                  className="text-xs px-2 py-0.5 rounded-md border border-purple-900/50 bg-[var(--bg-primary)] text-purple-300 hover:border-red-500/50"
+                >
+                  {p.name} ✕
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className={`${card} sm:col-span-2`}>
+          <h2 className="text-sm font-semibold text-[var(--text-primary)] mb-1">Ancient offer</h2>
+          <p className="text-xs text-[var(--text-muted)] mb-2">
+            A relic offered by an ancient, optionally locked to an act.
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="flex-1 min-w-[220px]">
+              <Picker
+                placeholder="Relic offered by an ancient…"
+                items={relicCatalog}
+                onPick={setAncientPick}
+              />
+            </div>
+            {[null, 1, 2, 3, 4].map((a) => (
+              <button
+                key={String(a)}
+                type="button"
+                onClick={() => setAncientAct(a)}
+                className={`text-xs px-2.5 py-1.5 rounded-md border ${
+                  ancientAct === a
+                    ? "border-[var(--accent-gold)]/50 text-[var(--accent-gold)] bg-[var(--accent-gold)]/10"
+                    : "border-[var(--border-subtle)] text-[var(--text-secondary)]"
+                }`}
+              >
+                {a === null ? "Any act" : `Act ${a}`}
+              </button>
+            ))}
+            {ancientPick && (
+              <button
+                type="button"
+                onClick={() => setAncientPick(null)}
+                className="text-xs px-2 py-0.5 rounded-md border border-[var(--accent-gold)]/40 bg-[var(--bg-primary)] text-[var(--accent-gold)] hover:border-red-500/50"
+              >
+                {ancientPick.name} ✕
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        disabled={!hasPredicates || loading}
+        onClick={search}
+        className="px-5 py-2.5 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-black hover:opacity-90 transition-opacity disabled:opacity-40 mb-6"
+      >
+        {loading ? "Searching…" : "Find seeds"}
+      </button>
+
+      {result && result.available && (
+        <div className={card}>
+          <div className="text-xs text-[var(--text-muted)] mb-3">
+            Scanned {result.scanned?.toLocaleString()} candidate runs
+            {result.sampled ? " (sampled — add a card kept or relic to search everything)" : ""}.
+          </div>
+          {(result.results ?? []).length === 0 ? (
+            <p className="text-sm text-[var(--text-secondary)]">
+              Nothing matched. Loosen a predicate or drop the character filter.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {(result.results ?? []).map((r) => (
+                <div
+                  key={r.run_hash}
+                  className="flex flex-wrap items-center gap-x-3 gap-y-1 px-3 py-2 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)]"
+                  style={
+                    r.full_match
+                      ? { borderColor: "color-mix(in srgb, var(--accent-gold) 50%, transparent)" }
+                      : undefined
+                  }
+                >
+                  <span
+                    className="w-2 h-2 rounded-full shrink-0"
+                    style={{ backgroundColor: characterHex(r.character) || "#888" }}
+                  />
+                  <code
+                    className="text-sm font-semibold text-[var(--accent-gold)] cursor-pointer"
+                    title="Click to copy seed"
+                    onClick={() => navigator.clipboard?.writeText(r.seed)}
+                  >
+                    {r.seed}
+                  </code>
+                  <span className="text-xs text-[var(--text-muted)]">
+                    {characterLabel(r.character || "")} · A{r.ascension} ·{" "}
+                    {r.win ? "win" : "loss"} · {r.date}
+                  </span>
+                  <span className="flex flex-wrap gap-1 text-[11px]">
+                    {r.matched.map((t) => (
+                      <span key={t} className="px-1.5 py-0.5 rounded bg-green-500/10 text-green-400">
+                        ✓ {labelFor(t)}
+                      </span>
+                    ))}
+                    {r.missing.map((t) => (
+                      <span key={t} className="px-1.5 py-0.5 rounded bg-[var(--bg-card)] text-[var(--text-muted)]">
+                        ✗ {labelFor(t)}
+                      </span>
+                    ))}
+                  </span>
+                  <Link
+                    href={r.url}
+                    className="ml-auto text-xs text-[var(--accent-gold)] hover:underline"
+                  >
+                    view run →
+                  </Link>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/seed-lab/page.tsx
+++ b/frontend/app/seed-lab/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import SeedLabClient from "./SeedLabClient";
+
+export const metadata: Metadata = {
+  title: "Seed Lab",
+  robots: { index: false, follow: false },
+};
+
+export default function SeedLabPage() {
+  return <SeedLabClient />;
+}


### PR DESCRIPTION
New unlisted /api/runs/seed-finder mines submitted runs for seeds that demonstrably produced a combination of cards offered or kept, relics obtained, events seen, and ancient offers (vector shards anchor the candidate set, flattened card_choices verify offers, blobs cover events and ancients), with a hidden noindexed /seed-lab page to play with it.