### PR TITLE
Stop the guide response model from stripping the channel field

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -492,6 +492,10 @@ class GuideSummary(BaseModel):
     bluesky: str | None = None
     twitter: str | None = None
     twitch: str | None = None
+    # "beta" points the page's hovertip widget (and entity links) at the beta
+    # channel; absent/None serves stable. Without this field the response
+    # model silently strips what guides.json carries.
+    channel: str | None = None
 
 
 class Guide(GuideSummary):


### PR DESCRIPTION
guides.json marks the v0.109 patch recap as channel beta and the page and tooltip widget already honor it, but the Guide response models lacked the field so FastAPI stripped it and hovertips on beta guides queried stable data.