### PR TITLE
Seed finder feedback: unknown ids, loading state, error states

### DIFF
--- a/backend/app/services/seed_finder.py
+++ b/backend/app/services/seed_finder.py
@@ -119,8 +119,39 @@ def find_seeds(
     limit: int = 20,
 ) -> dict | None:
     """Rank submitted runs by how many predicates their seed demonstrated."""
+    from . import data_service
     from .run_vectors import _OFFICIAL_CHARACTERS
     from .runs_db_mongo import _get_collection, get_run_blobs
+
+    # A typo'd id can never match anything, which reads as "no seeds found";
+    # call it out instead so API callers learn the real id (THE_COURIER, not
+    # COURIER). Beta-only ids flag too: runs are stable-channel only.
+    unknown: list[str] = []
+    try:
+        known_cards = {
+            str(c.get("id", "")).upper() for c in data_service.load_cards("eng")
+        }
+        known_relics = {
+            str(r.get("id", "")).upper() for r in data_service.load_relics("eng")
+        }
+        known_events = {
+            str(e.get("id", "")).upper() for e in data_service.load_events("eng")
+        }
+        for cid, _ in deck_cards + offered_cards:
+            if cid not in known_cards:
+                unknown.append(f"card:{cid}")
+        for rid in relics:
+            if rid not in known_relics:
+                unknown.append(f"relic:{rid}")
+        for eid in events:
+            if eid not in known_events:
+                unknown.append(f"event:{eid}")
+        if ancient_relic and ancient_relic not in known_relics:
+            unknown.append(f"relic:{ancient_relic}")
+    except Exception:
+        logger.warning("seed finder id validation failed", exc_info=True)
+    if unknown:
+        return {"sampled": False, "scanned": 0, "results": [], "unknown": unknown}
 
     characters = (
         [character] if character in _OFFICIAL_CHARACTERS else list(_OFFICIAL_CHARACTERS)

--- a/frontend/app/seed-lab/SeedLabClient.tsx
+++ b/frontend/app/seed-lab/SeedLabClient.tsx
@@ -32,6 +32,7 @@ interface FinderResponse {
   scanned?: number;
   predicates?: number;
   results?: SeedResult[];
+  unknown?: string[];
   detail?: string;
 }
 
@@ -422,7 +423,12 @@ export default function SeedLabClient() {
             Scanned {result.scanned?.toLocaleString()} candidate runs
             {result.sampled ? " (sampled — add a card kept or relic to search everything)" : ""}.
           </div>
-          {(result.results ?? []).length === 0 ? (
+          {(result.unknown ?? []).length > 0 ? (
+            <p className="text-sm text-red-400">
+              Unknown ids: {result.unknown!.join(", ")} — these don&apos;t exist
+              in the game data, check the spelling.
+            </p>
+          ) : (result.results ?? []).length === 0 ? (
             <p className="text-sm text-[var(--text-secondary)]">
               Nothing matched. Loosen a predicate or drop the character filter.
             </p>

--- a/frontend/app/seed-lab/SeedLabClient.tsx
+++ b/frontend/app/seed-lab/SeedLabClient.tsx
@@ -160,6 +160,7 @@ export default function SeedLabClient() {
   const [eventCatalog, setEventCatalog] = useState<CatalogItem[]>([]);
   const [result, setResult] = useState<FinderResponse | null>(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let dead = false;
@@ -198,6 +199,8 @@ export default function SeedLabClient() {
   async function search() {
     if (!hasPredicates || loading) return;
     setLoading(true);
+    setResult(null);
+    setError(null);
     try {
       const url = new URL(`${API}/api/runs/seed-finder`);
       if (character !== "ANY") url.searchParams.set("character", character);
@@ -220,9 +223,27 @@ export default function SeedLabClient() {
         if (ancientAct) url.searchParams.set("ancient_act", String(ancientAct));
       }
       const res = await fetch(url.toString());
-      setResult(await res.json());
+      if (res.status === 429) {
+        setError("Rate limited — give it a minute and try again.");
+        return;
+      }
+      if (!res.ok) {
+        setError(`Search failed (${res.status}). Try again in a moment.`);
+        return;
+      }
+      const data = (await res.json()) as FinderResponse;
+      if (!data.available) {
+        setError(
+          data.detail ||
+            "The finder isn't available right now (vector data may still be building).",
+        );
+        return;
+      }
+      setResult(data);
     } catch {
-      setResult(null);
+      setError(
+        "The search didn't come back — it may have timed out. A cold query can take a while; try again, the result gets cached.",
+      );
     } finally {
       setLoading(false);
     }
@@ -414,8 +435,34 @@ export default function SeedLabClient() {
         onClick={search}
         className="px-5 py-2.5 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-black hover:opacity-90 transition-opacity disabled:opacity-40 mb-6"
       >
-        {loading ? "Searching…" : "Find seeds"}
+        {loading ? (
+          <span className="inline-flex items-center gap-2">
+            <span className="w-3.5 h-3.5 rounded-full border-2 border-black/30 border-t-black animate-spin" />
+            Searching…
+          </span>
+        ) : (
+          "Find seeds"
+        )}
       </button>
+
+      {loading && (
+        <div className={`${card} animate-pulse`}>
+          <p className="text-sm text-[var(--text-secondary)]">
+            Digging through the community runs — combing candidate decks, then
+            verifying offers, events, and ancient rolls.
+          </p>
+          <p className="text-xs text-[var(--text-muted)] mt-1">
+            A cold query can take up to a minute; repeats are cached and come
+            back instantly.
+          </p>
+        </div>
+      )}
+
+      {error && !loading && (
+        <div className={`${card} border-red-500/40`}>
+          <p className="text-sm text-red-400">{error}</p>
+        </div>
+      )}
 
       {result && result.available && (
         <div className={card}>


### PR DESCRIPTION
A typo'd entity id now comes back in an unknown list instead of reading as zero results, and the seed-lab page gained a visible searching panel, a spinner on the button, and real error messages for rate limits, timeouts, and unavailable vector data.