### PR TITLE
Exclude quest and curse cards from pick signals

### DIFF
--- a/backend/app/services/item_pairings.py
+++ b/backend/app/services/item_pairings.py
@@ -79,6 +79,8 @@ def _official_sets() -> dict[str, frozenset[str]]:
                     for c in load_cards()
                     if c.get("id")
                     and c.get("rarity") != "Basic"
+                    and c.get("rarity") != "Quest"
+                    and c.get("type") not in ("Quest", "Curse")
                     and up(c["id"]) != "ASCENDERS_BANE"
                 ),
                 "relics": frozenset(

--- a/backend/app/services/run_vectors.py
+++ b/backend/app/services/run_vectors.py
@@ -762,7 +762,15 @@ def _nondraftable() -> frozenset[str]:
 
             terms: set[str] = {"ASCENDERS_BANE"}
             for c in data_service.load_cards("eng"):
-                if c.get("rarity_key") == "Basic" or c.get("rarity") == "Basic":
+                # Basic = starters; Quest/Curse = granted by events and
+                # ancients, never drafted (Spoils Map was naming archetypes).
+                if (
+                    c.get("rarity_key") == "Basic"
+                    or c.get("rarity") == "Basic"
+                    or c.get("rarity_key") == "Quest"
+                    or c.get("type_key") == "Quest"
+                    or c.get("type_key") == "Curse"
+                ):
                     terms.add(str(c.get("id", "")).upper())
             for r in data_service.load_relics("eng"):
                 if "Starter" in str(r.get("rarity") or ""):


### PR DESCRIPTION
Quest cards (Spoils Map was naming an archetype) and curses are granted by events and ancients rather than drafted, so they now join the non-draftable set that archetype names, the deck advisor, winners-also-took, and NPMI pairings already filter through.