### PR TITLE
Fix seed-lab and deck-lab searches under a relative API base

### DIFF
--- a/frontend/app/deck-lab/DeckLabClient.tsx
+++ b/frontend/app/deck-lab/DeckLabClient.tsx
@@ -171,15 +171,18 @@ export default function DeckLabClient() {
     const cardsParam = deck.join(",");
     const relicsParam = relics.join(",");
     try {
-      const coachUrl = new URL(`${API}/api/runs/pick-coach`);
-      coachUrl.searchParams.set("character", character);
-      coachUrl.searchParams.set("cards", cardsParam);
-      coachUrl.searchParams.set("relics", relicsParam);
-      if (offer.length) coachUrl.searchParams.set("offer", offer.join(","));
-      if (target) coachUrl.searchParams.set("target", target);
+      // `new URL` throws when NEXT_PUBLIC_API_URL is empty (prod uses
+      // same-origin relative fetches) — build the query string standalone.
+      const coachParams = new URLSearchParams({
+        character,
+        cards: cardsParam,
+        relics: relicsParam,
+      });
+      if (offer.length) coachParams.set("offer", offer.join(","));
+      if (target) coachParams.set("target", target);
       const advisorUrl = `${API}/api/runs/deck-advisor?character=${character}&cards=${encodeURIComponent(cardsParam)}&relics=${encodeURIComponent(relicsParam)}`;
       const [c, a] = await Promise.all([
-        fetch(coachUrl.toString()).then((r) => r.json()),
+        fetch(`${API}/api/runs/pick-coach?${coachParams.toString()}`).then((r) => r.json()),
         fetch(advisorUrl).then((r) => r.json()),
       ]);
       setCoach(c?.available ? c : null);

--- a/frontend/app/seed-lab/SeedLabClient.tsx
+++ b/frontend/app/seed-lab/SeedLabClient.tsx
@@ -202,27 +202,30 @@ export default function SeedLabClient() {
     setResult(null);
     setError(null);
     try {
-      const url = new URL(`${API}/api/runs/seed-finder`);
-      if (character !== "ANY") url.searchParams.set("character", character);
+      // NEXT_PUBLIC_API_URL is empty in prod (same-origin relative fetches),
+      // and `new URL` throws on a base-less relative path — build the query
+      // string standalone instead.
+      const params = new URLSearchParams();
+      if (character !== "ANY") params.set("character", character);
       if (deckPicks.length)
-        url.searchParams.set(
+        params.set(
           "deck",
           deckPicks.map((p) => (p.count > 1 ? `${p.id}:${p.count}` : p.id)).join(","),
         );
       if (offerPicks.length)
-        url.searchParams.set(
+        params.set(
           "offered",
           offerPicks.map((p) => (p.count > 1 ? `${p.id}:${p.count}` : p.id)).join(","),
         );
       if (relicPicks.length)
-        url.searchParams.set("relics", relicPicks.map((p) => p.id).join(","));
+        params.set("relics", relicPicks.map((p) => p.id).join(","));
       if (eventPicks.length)
-        url.searchParams.set("events", eventPicks.map((p) => p.id).join(","));
+        params.set("events", eventPicks.map((p) => p.id).join(","));
       if (ancientPick) {
-        url.searchParams.set("ancient", ancientPick.id);
-        if (ancientAct) url.searchParams.set("ancient_act", String(ancientAct));
+        params.set("ancient", ancientPick.id);
+        if (ancientAct) params.set("ancient_act", String(ancientAct));
       }
-      const res = await fetch(url.toString());
+      const res = await fetch(`${API}/api/runs/seed-finder?${params.toString()}`);
       if (res.status === 429) {
         setError("Rate limited — give it a minute and try again.");
         return;


### PR DESCRIPTION
new URL() throws on a base-less path when NEXT_PUBLIC_API_URL is empty in prod, which made every seed-lab search and deck-lab coach call fail instantly with the timeout message, so both now build their query strings with URLSearchParams.