### PR TITLE
Wire up NitroPay: head scripts and the ads.txt redirect

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -108,6 +108,23 @@ export default function RootLayout({
           RTTs that's a few hundred ms off every art-heavy page. */}
       <link rel="preconnect" href="https://cdn.spire-codex.com" crossOrigin="anonymous" />
       <link rel="dns-prefetch" href="https://cdn.spire-codex.com" />
+      {/* NitroPay: the queue stub must exist before any createAd call, and
+          the loader wants <head> placement so the auction starts early.
+          beforeInteractive injects both into <head>. Production builds only —
+          Nitro authorizes spire-codex.com, so dev would just log errors. */}
+      {process.env.NODE_ENV === "production" && (
+        <>
+          <Script id="nitro-stub" strategy="beforeInteractive">
+            {`window.nitroAds=window.nitroAds||{createAd:function(){return new Promise(e=>{window.nitroAds.queue.push(["createAd",arguments,e])})},addUserToken:function(){window.nitroAds.queue.push(["addUserToken",arguments])},queue:[]};`}
+          </Script>
+          <Script
+            src="https://s.nitropay.com/ads-2467.js"
+            strategy="beforeInteractive"
+            data-cfasync="false"
+            async
+          />
+        </>
+      )}
       <body
         className={`${kreon.variable} ${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}
       >

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -5,6 +5,17 @@ const LANGS = "deu|esp|fra|ita|jpn|kor|pol|ptb|rus|spa|tha|tur|zhs";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  // NitroPay hosts our ads.txt so exchange entries stay current without
+  // deploys; the 301 is their recommended setup.
+  async redirects() {
+    return [
+      {
+        source: "/ads.txt",
+        destination: "https://api.nitropay.com/v1/ads-2467.txt",
+        permanent: true,
+      },
+    ];
+  },
   // The /beta section itself is wired up in middleware.ts, which rewrites
   // /beta/cards/x to /cards/x?channel=beta. Only the SEO shielding lives
   // here. Decision: /beta carries zero SEO risk, so every beta URL gets a


### PR DESCRIPTION
NitroPay wired up end to end: head stub + loader with SPA mode on production builds, the ads.txt 301 to their hosted copy, and a single dismissible bottom anchor as the site's only ad unit.