### PR TITLE
NitroPay follow-ups: SPA mode, the anchor unit, footer consent links

### DIFF
--- a/frontend/app/components/Footer.tsx
+++ b/frontend/app/components/Footer.tsx
@@ -8,6 +8,13 @@ import { t } from "@/lib/ui-translations";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
+declare global {
+  interface Window {
+    __tcfapi?: (command: string, version: number, callback: () => void) => void;
+    __uspapi?: (command: string) => void;
+  }
+}
+
 function FeedbackModal({ onClose, page }: { onClose: () => void; page: string }) {
   const { lang } = useLanguage();
   const [type, setType] = useState("Bug");
@@ -200,6 +207,20 @@ export default function Footer() {
         >
           Privacy
         </Link>
+        <span className="text-[var(--border-subtle)]" aria-hidden>·</span>
+        <button
+          onClick={() => window.__tcfapi?.("displayConsentUi", 2, () => {})}
+          className="hover:text-[var(--accent-gold)] transition-colors"
+        >
+          Manage Consent
+        </button>
+        <span className="text-[var(--border-subtle)]" aria-hidden>·</span>
+        <button
+          onClick={() => window.__uspapi?.("displayUspUi")}
+          className="hover:text-[var(--accent-gold)] transition-colors"
+        >
+          Do Not Sell My Personal Information
+        </button>
         <span className="text-[var(--border-subtle)]" aria-hidden>·</span>
         <Link
           href="/terms"

--- a/frontend/app/components/NitroAnchor.tsx
+++ b/frontend/app/components/NitroAnchor.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+
+declare global {
+  interface Window {
+    nitroAds?: {
+      createAd: (id: string, config: Record<string, unknown>) => Promise<unknown>;
+    };
+  }
+}
+
+/** The site's single ad unit: a dismissible bottom anchor. The head stub
+ * queues this call if the loader hasn't arrived yet, and data-spa="auto"
+ * keeps it fresh across client-side navigations. */
+export default function NitroAnchor() {
+  useEffect(() => {
+    window.nitroAds?.createAd("anchor", {
+      format: "anchor",
+      anchor: "bottom",
+      anchorPersistClose: true,
+      mediaQuery: "(min-width: 320px)",
+      report: {
+        enabled: true,
+        icon: true,
+        wording: "Report Ad",
+        position: "top-right",
+      },
+    });
+  }, []);
+  return null;
+}

--- a/frontend/app/components/NitroAnchor.tsx
+++ b/frontend/app/components/NitroAnchor.tsx
@@ -10,16 +10,20 @@ declare global {
   }
 }
 
-/** The site's single ad unit: a dismissible bottom anchor. The head stub
- * queues this call if the loader hasn't arrived yet, and data-spa="auto"
- * keeps it fresh across client-side navigations. */
+/** The site's single ad unit: the dashboard-configured "scnp-anchor"
+ * floating bottom anchor. The head stub queues this call if the loader
+ * hasn't arrived yet, and data-spa="auto" keeps it fresh across
+ * client-side navigations. Config mirrors the placement builder output. */
 export default function NitroAnchor() {
   useEffect(() => {
-    window.nitroAds?.createAd("anchor", {
-      format: "anchor",
+    window.nitroAds?.createAd("scnp-anchor", {
+      format: "anchor-v2",
       anchor: "bottom",
-      anchorPersistClose: true,
-      mediaQuery: "(min-width: 320px)",
+      anchorBgColor: "rgb(0 0 0 / 80%)",
+      anchorClose: true,
+      anchorPersistClose: false,
+      anchorStickyOffset: 0,
+      mediaQuery: "(min-width: 0px)",
       report: {
         enabled: true,
         icon: true,

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -8,6 +8,7 @@ import AlertTicker from "./components/AlertTicker";
 import Footer from "./components/Footer";
 import GlobalSearch from "./components/GlobalSearch";
 import FloatingFeedback from "./components/FloatingFeedback";
+import NitroAnchor from "./components/NitroAnchor";
 import HighlightFeedback from "./components/HighlightFeedback";
 import { LanguageProvider } from "./contexts/LanguageContext";
 import { BetaVersionProvider } from "./contexts/BetaVersionContext";
@@ -167,6 +168,7 @@ export default function RootLayout({
               <Footer />
               <GlobalSearch />
               <FloatingFeedback />
+              {process.env.NODE_ENV === "production" && <NitroAnchor />}
               <HighlightFeedback />
               </ToastProvider>
               </AuthProvider>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -121,6 +121,7 @@ export default function RootLayout({
             src="https://s.nitropay.com/ads-2467.js"
             strategy="beforeInteractive"
             data-cfasync="false"
+            data-spa="auto"
             async
           />
         </>


### PR DESCRIPTION
Recovers the commits that landed after #765 merged and finishes the setup: data-spa=auto on the loader, the dashboard-configured scnp-anchor bottom unit as the site's only ad, and the Manage Consent and Do Not Sell footer links.