### PR TITLE
Add a Spire Codex news tab with an unread megaphone in the nav

### DIFF
--- a/frontend/app/components/AnnouncementBadge.tsx
+++ b/frontend/app/components/AnnouncementBadge.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+// Megaphone next to the Live button: lights up when there's a Spire Codex
+// announcement the visitor hasn't seen yet, links to the news tab, and
+// clears itself once clicked (or once the tab is visited, via the
+// sc-news-seen event MarkAnnouncementsSeen dispatches).
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ANNOUNCEMENT_SEEN_KEY, LATEST_ANNOUNCEMENT_ID } from "@/lib/announcements";
+
+function MegaphoneIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M3 11v3a1 1 0 0 0 1 1h2l3.5 4.5a1 1 0 0 0 1.8-.6V5.1a1 1 0 0 0-1.8-.6L6 9H4a1 1 0 0 0-1 1z" />
+      <path d="M15 9c1.2 1.6 1.2 4.4 0 6" />
+      <path d="M18 6c2.7 3.2 2.7 8.8 0 12" />
+    </svg>
+  );
+}
+
+export default function AnnouncementBadge({
+  variant = "desktop",
+}: {
+  variant?: "desktop" | "mobile";
+}) {
+  const [unread, setUnread] = useState(false);
+
+  useEffect(() => {
+    const check = () => {
+      try {
+        setUnread(
+          !!LATEST_ANNOUNCEMENT_ID &&
+            localStorage.getItem(ANNOUNCEMENT_SEEN_KEY) !== LATEST_ANNOUNCEMENT_ID,
+        );
+      } catch {
+        setUnread(false);
+      }
+    };
+    check();
+    window.addEventListener("sc-news-seen", check);
+    return () => window.removeEventListener("sc-news-seen", check);
+  }, []);
+
+  if (!unread) return null;
+
+  const markSeen = () => {
+    try {
+      localStorage.setItem(ANNOUNCEMENT_SEEN_KEY, LATEST_ANNOUNCEMENT_ID);
+    } catch {}
+    setUnread(false);
+  };
+
+  if (variant === "mobile") {
+    return (
+      <Link
+        href="/news?tab=codex"
+        onClick={markSeen}
+        className="flex items-center gap-2 text-lg font-semibold text-[var(--accent-gold)]"
+      >
+        <MegaphoneIcon />
+        <span>What&apos;s new</span>
+      </Link>
+    );
+  }
+
+  return (
+    <Link
+      href="/news?tab=codex"
+      onClick={markSeen}
+      title="New on Spire Codex"
+      aria-label="New Spire Codex announcement"
+      className="relative inline-flex items-center px-2 py-2 rounded-md text-[var(--accent-gold)] hover:bg-[var(--bg-card)] transition-colors shrink-0"
+    >
+      <MegaphoneIcon />
+      <span className="absolute top-1.5 right-1 flex h-2 w-2">
+        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-[var(--accent-gold)] opacity-75" />
+        <span className="relative inline-flex h-2 w-2 rounded-full bg-[var(--accent-gold)]" />
+      </span>
+    </Link>
+  );
+}

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -7,6 +7,7 @@ import LanguageSelector from "./LanguageSelector";
 import SearchTrigger from "./SearchTrigger";
 import SiteSwitcher from "./SiteSwitcher";
 import LiveNavButton from "./LiveNavButton";
+import AnnouncementBadge from "./AnnouncementBadge";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { useAuth } from "@/app/contexts/AuthContext";
 import DiscordIcon from "./DiscordIcon";
@@ -395,6 +396,7 @@ export default function Navbar() {
             <div className="hidden lg:flex items-center gap-1">
               {NAV_GROUPS.map((group, i) => renderMega(group, i === NAV_GROUPS.length - 1))}
               <LiveNavButton />
+              <AnnouncementBadge />
             </div>
           </div>
 
@@ -648,6 +650,7 @@ export default function Navbar() {
 
                   <div className="border-b border-[var(--border-subtle)] px-5 py-3">
                     <LiveNavButton variant="mobile" />
+                    <AnnouncementBadge variant="mobile" />
                   </div>
 
                   <ThemeToggle variant="segmented" />

--- a/frontend/app/news/MarkAnnouncementsSeen.tsx
+++ b/frontend/app/news/MarkAnnouncementsSeen.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import { ANNOUNCEMENT_SEEN_KEY, LATEST_ANNOUNCEMENT_ID } from "@/lib/announcements";
+
+/** Rendered on the Spire Codex news tab: viewing it clears the navbar
+ * megaphone by recording the newest announcement id as seen. */
+export default function MarkAnnouncementsSeen() {
+  useEffect(() => {
+    try {
+      localStorage.setItem(ANNOUNCEMENT_SEEN_KEY, LATEST_ANNOUNCEMENT_ID);
+      window.dispatchEvent(new Event("sc-news-seen"));
+    } catch {}
+  }, []);
+  return null;
+}

--- a/frontend/app/news/page.tsx
+++ b/frontend/app/news/page.tsx
@@ -5,6 +5,8 @@ import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE, buildLanguageAlternates } from "@/lib/seo";
 import type { NewsArticle, NewsListResponse } from "@/lib/api";
 import { newsExcerpt, formatNewsDate, newsSlugForArticle } from "@/lib/steam-news";
+import { ANNOUNCEMENTS } from "@/lib/announcements";
+import MarkAnnouncementsSeen from "./MarkAnnouncementsSeen";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -41,17 +43,18 @@ export const metadata: Metadata = {
   },
 };
 
-type Tab = "community" | "press" | "all";
+type Tab = "community" | "codex" | "press" | "all";
 
 const TABS: { key: Tab; label: string; sublabel: string; feedType: number | null }[] = [
   { key: "community", label: "Mega Crit", sublabel: "Steam announcements", feedType: 1 },
+  { key: "codex", label: "Spire Codex", sublabel: "Site updates & new features", feedType: null },
   { key: "press", label: "Press", sublabel: "PCGamesN, RPS, GamingOnLinux…", feedType: 0 },
   { key: "all", label: "All", sublabel: "Everything", feedType: null },
 ];
 
 function tabFromParam(value: string | string[] | undefined): Tab {
   const v = Array.isArray(value) ? value[0] : value;
-  if (v === "press" || v === "all") return v;
+  if (v === "codex" || v === "press" || v === "all") return v;
   return "community";
 }
 
@@ -75,7 +78,10 @@ export default async function NewsPage({
   const sp = await searchParams;
   const activeTab = tabFromParam(sp.tab);
   const tabConfig = TABS.find((t) => t.key === activeTab) ?? TABS[0];
-  const data = await loadNews(tabConfig.feedType);
+  const isCodex = activeTab === "codex";
+  const data = isCodex
+    ? { total: 0, limit: 0, offset: 0, items: [] }
+    : await loadNews(tabConfig.feedType);
   const items = data.items;
   const latest = items[0];
 
@@ -128,7 +134,31 @@ export default async function NewsPage({
         })}
       </div>
 
-      {items.length === 0 ? (
+      {isCodex ? (
+        <>
+          <MarkAnnouncementsSeen />
+          <ul className="space-y-3">
+            {ANNOUNCEMENTS.map((a) => (
+              <li key={a.id}>
+                <Link
+                  href={a.href}
+                  className="block bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] p-5 hover:border-[var(--border-accent)] transition-colors"
+                >
+                  <div className="flex items-baseline justify-between gap-3 mb-1">
+                    <h2 className="text-lg font-semibold text-[var(--text-primary)]">{a.title}</h2>
+                    <time className="text-xs text-[var(--text-muted)] shrink-0">{a.date}</time>
+                  </div>
+                  <p className="text-xs text-[var(--text-muted)] mb-2">Spire Codex</p>
+                  <p className="text-sm text-[var(--text-secondary)] leading-relaxed">{a.body}</p>
+                  <span className="inline-block mt-3 text-sm text-[var(--accent-gold)]">
+                    Check it out →
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : items.length === 0 ? (
         <p className="text-[var(--text-muted)]">No news available right now. Check back soon.</p>
       ) : (
         <ul className="space-y-3">

--- a/frontend/lib/announcements.ts
+++ b/frontend/lib/announcements.ts
@@ -1,0 +1,54 @@
+// Spire Codex site announcements, newest first. These feed the "Spire Codex"
+// tab on /news and the unread megaphone in the navbar. Adding a new entry at
+// the top is what makes the megaphone light up for returning visitors, so
+// keep ids unique and stable.
+
+export interface Announcement {
+  id: string;
+  /** ISO date, e.g. "2026-07-20" */
+  date: string;
+  title: string;
+  body: string;
+  /** Where "check it out" points. */
+  href: string;
+}
+
+export const ANNOUNCEMENTS: Announcement[] = [
+  {
+    id: "encounter-builds",
+    date: "2026-07-20",
+    title: "What beats each boss",
+    body:
+      "Encounter pages now show which community builds die to a fight the most and which walk past it, joined from half a million analyzed runs. Check any boss page for the new Builds section.",
+    href: "/encounters/aeonglass_boss",
+  },
+  {
+    id: "deck-archetypes",
+    date: "2026-07-19",
+    title: "Community deck archetypes",
+    body:
+      "Every build the community actually pilots, discovered automatically from submitted runs: defining cards and relics, real win rates, popularity trends per patch, and the biggest meta movers.",
+    href: "/archetypes",
+  },
+  {
+    id: "score-by-patch",
+    date: "2026-07-19",
+    title: "Codex Score by patch",
+    body:
+      "Card, relic, and potion pages now chart their Codex Score across every game version, so you can see exactly when a balance change landed and what it did.",
+    href: "/cards/hidden_gem",
+  },
+  {
+    id: "post-run-insights",
+    date: "2026-07-19",
+    title: "Instant insights when you upload a run",
+    body:
+      "Submitting a run now shows which community archetype your deck matches, its win rate, and how your seed stacks up, right on the upload page.",
+    href: "/leaderboards/submit",
+  },
+];
+
+export const LATEST_ANNOUNCEMENT_ID = ANNOUNCEMENTS[0]?.id ?? "";
+
+/** localStorage key holding the id of the newest announcement the user has seen. */
+export const ANNOUNCEMENT_SEEN_KEY = "sc-news-seen";


### PR DESCRIPTION
The news page gains a Spire Codex tab (ordered Mega Crit, Spire Codex, Press, All) fed from a simple announcements module, and a gold megaphone with a pulse dot appears next to the Live button whenever the newest announcement hasn't been seen yet, clearing on click or on visiting the tab.