### PR TITLE
Stop rebuild windows from poisoning the archetypes page caches

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1727,6 +1727,13 @@ def get_archetypes(request: Request, response: Response, lang: str = "eng"):
 
     data = load_archetypes()
     if not data:
+        # Mid-rebuild the file can be briefly unreadable; a transient
+        # "available: false" here gets baked into ISR and edge caches for
+        # hours, so serve the last good payload instead when we have one.
+        last_good = app_cache.get_json(f"archetypes:lastgood:{lang}")
+        if last_good is not None:
+            response.headers["Cache-Control"] = "public, max-age=120"
+            return last_good
         response.headers["Cache-Control"] = "no-store"
         return {"available": False, "characters": {}}
     from ..services import data_service
@@ -1824,6 +1831,7 @@ def get_archetypes(request: Request, response: Response, lang: str = "eng"):
         "characters": out_chars,
     }
     app_cache.set_json(cache_key, payload, ttl_seconds=1800)
+    app_cache.set_json(f"archetypes:lastgood:{lang}", payload, ttl_seconds=7 * 86400)
     response.headers["Cache-Control"] = "public, max-age=600"
     return payload
 

--- a/backend/app/services/run_vectors.py
+++ b/backend/app/services/run_vectors.py
@@ -174,7 +174,11 @@ def build_run_vectors() -> dict:
             except Exception:
                 logger.warning("archetype clustering failed for %s", ch, exc_info=True)
     if archetypes:
-        (_VEC_DIR / "archetypes.json").write_text(
+        # tmp + replace like vocab.json below: a reader catching a direct
+        # write_text mid-flight got truncated JSON, which cascaded into
+        # "available: false" getting baked into page caches for hours.
+        arch_tmp = _VEC_DIR / "archetypes.json.tmp"
+        arch_tmp.write_text(
             json.dumps(
                 {
                     "characters": archetypes,
@@ -183,6 +187,7 @@ def build_run_vectors() -> dict:
             ),
             encoding="utf-8",
         )
+        arch_tmp.replace(_VEC_DIR / "archetypes.json")
     tmp = _VEC_DIR / "vocab.json.tmp"
     tmp.write_text(
         json.dumps(
@@ -453,7 +458,7 @@ def _cluster_shard(character: str, mat, meta: list, vocab_list: list[str], k: in
 def load_archetypes() -> dict | None:
     try:
         return json.loads((_VEC_DIR / "archetypes.json").read_text(encoding="utf-8"))
-    except OSError:
+    except (OSError, ValueError):
         return None
 
 


### PR DESCRIPTION
archetypes.json now writes atomically via tmp+rename, a truncated read returns None instead of raising, and the endpoint falls back to a week-long last-good Redis copy instead of answering available:false, so an ISR revalidation landing mid-rebuild can no longer bake a 'still building' page into the edge and browser caches for hours.