### PR TITLE
Move boss builds to monster pages, trim announcements, insight card on re-uploads

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -177,26 +177,30 @@ async def submit_run_endpoint(
         "/"
     )
 
+    is_duplicate = False
     if result.get("error"):
         if result.get("duplicate"):
             run_submissions.labels(status="duplicate").inc()
-            dup_hash = result.get("run_hash")
-            return {
+            # Fall through to the enrichment below: a re-upload should still
+            # get the archetype + seed-rank insight card, just not the live
+            # overlay re-apply.
+            is_duplicate = True
+            result = {
                 "success": True,
                 "duplicate": True,
-                "run_hash": dup_hash,
-                "url": f"{site_base}/runs/{dup_hash}" if dup_hash else None,
+                "run_hash": result.get("run_hash"),
             }
-        run_submissions.labels(status="error").inc()
-        run_errors.labels(reason="missing_fields").inc()
-        raise HTTPException(status_code=400, detail=result["error"])
+        else:
+            run_submissions.labels(status="error").inc()
+            run_errors.labels(reason="missing_fields").inc()
+            raise HTTPException(status_code=400, detail=result["error"])
 
     # Enrich for the in-game post-run card: the shareable page URL, and (when this
     # run is itself a completed upload on a known seed) its seed standing.
     run_hash = result.get("run_hash")
     if run_hash:
         result["url"] = f"{site_base}/runs/{run_hash}"
-        if os.environ.get("MONGO_URL", "").strip():
+        if not is_duplicate and os.environ.get("MONGO_URL", "").strip():
             try:
                 from ..services.live_overlay import apply_run_async
 

--- a/frontend/app/encounters/[id]/EncounterDetail.tsx
+++ b/frontend/app/encounters/[id]/EncounterDetail.tsx
@@ -31,22 +31,6 @@ const roomTypeBadge: Record<string, string> = {
   Boss: "bg-red-950/50 text-red-300 border-red-900/30",
 };
 
-const CHAR_DOT: Record<string, string> = {
-  IRONCLAD: "var(--color-ironclad)",
-  SILENT: "var(--color-silent)",
-  DEFECT: "var(--color-defect)",
-  NECROBINDER: "var(--color-necrobinder)",
-  REGENT: "var(--color-regent)",
-};
-
-interface EncounterBuild {
-  character: string;
-  name: string;
-  size: number;
-  win_rate: number;
-  deaths: number;
-  death_rate: number;
-}
 
 export default function EncounterDetail({ initialEncounter, encounterStat }: { initialEncounter?: Encounter | null; encounterStat?: EncounterStat | null } = {}) {
   const { id } = useParams<{ id: string }>();
@@ -66,15 +50,6 @@ export default function EncounterDetail({ initialEncounter, encounterStat }: { i
       .finally(() => setLoading(false));
   }, [id, lang]);
 
-  const [builds, setBuilds] = useState<EncounterBuild[]>([]);
-  useEffect(() => {
-    if (!id) return;
-    cachedFetch<{ available: boolean; builds: EncounterBuild[] }>(
-      `${API}/api/runs/encounter-builds?encounter=${id}&lang=${lang}`,
-    )
-      .then((data) => setBuilds(data?.available ? data.builds : []))
-      .catch(() => setBuilds([]));
-  }, [id, lang]);
 
   // ToC scroll-spy: highlight the section currently in view.
   useEffect(() => {
@@ -129,17 +104,9 @@ export default function EncounterDetail({ initialEncounter, encounterStat }: { i
 
   const hasCommunity = !!(encounterStat && encounterStat.total > 0);
 
-  const struggles = builds.filter((b) => b.deaths >= 5).slice(0, 5);
-  const struggleKeys = new Set(struggles.map((b) => `${b.character}:${b.name}`));
-  const handles = [...builds]
-    .sort((a, b) => a.death_rate - b.death_rate)
-    .filter((b) => b.size >= 500 && !struggleKeys.has(`${b.character}:${b.name}`))
-    .slice(0, 5);
-  const hasBuilds = struggles.length > 0;
 
   const tocItems: { id: string; label: string }[] = [
     ...(hasCommunity ? [{ id: "community", label: t("Community", lang) }] : []),
-    ...(hasBuilds ? [{ id: "builds", label: t("Builds", lang) }] : []),
     ...(hasMonsters ? [{ id: "composition", label: t("Monsters", lang) }] : []),
     ...(hasLoss ? [{ id: "loss", label: "Loss Text" }] : []),
     { id: "history", label: t("Version history", lang) },
@@ -211,64 +178,6 @@ export default function EncounterDetail({ initialEncounter, encounterStat }: { i
             </section>
           )}
 
-          {/* Which archetypes die here vs walk past — from the nightly
-              run-vector build (labels x killed_by join). */}
-          {hasBuilds && (
-            <section id="builds">
-              <h2>{t("Builds", lang)}</h2>
-              <p className="h-note">
-                Of the community archetypes that face this fight, the share of
-                each build&apos;s runs that end here, next to that build&apos;s
-                overall win rate.
-              </p>
-              <div style={{ display: "grid", gap: "1rem", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))" }}>
-                <div>
-                  <p className="h-note" style={{ color: "var(--warn, #ef4444)" }}>
-                    {t("Dies here most", lang)}
-                  </p>
-                  {struggles.map((b) => (
-                    <div
-                      key={`s-${b.character}-${b.name}`}
-                      style={{ display: "flex", alignItems: "center", gap: "0.5rem", padding: "0.25rem 0", fontSize: "0.85rem" }}
-                    >
-                      <span
-                        style={{ width: 7, height: 7, borderRadius: "50%", background: CHAR_DOT[b.character] || "#888", flexShrink: 0 }}
-                      />
-                      <Link href={`${lp}/archetypes`} className="cn" style={{ flexGrow: 1 }}>
-                        {b.name}
-                      </Link>
-                      <span style={{ color: "var(--text-muted)", fontVariantNumeric: "tabular-nums" }}>
-                        {b.death_rate}% {t("die here", lang)} · {b.win_rate}% WR
-                      </span>
-                    </div>
-                  ))}
-                </div>
-                {handles.length > 0 && (
-                  <div>
-                    <p className="h-note" style={{ color: "var(--good, #22c55e)" }}>
-                      {t("Handles it best", lang)}
-                    </p>
-                    {handles.map((b) => (
-                      <div
-                        key={`h-${b.character}-${b.name}`}
-                        style={{ display: "flex", alignItems: "center", gap: "0.5rem", padding: "0.25rem 0", fontSize: "0.85rem" }}
-                      >
-                        <span
-                          style={{ width: 7, height: 7, borderRadius: "50%", background: CHAR_DOT[b.character] || "#888", flexShrink: 0 }}
-                        />
-                        <Link href={`${lp}/archetypes`} className="cn" style={{ flexGrow: 1 }}>
-                          {b.name}
-                        </Link>
-                        <span style={{ color: "var(--text-muted)", fontVariantNumeric: "tabular-nums" }}>
-                          {b.death_rate}% {t("die here", lang)} · {b.win_rate}% WR
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </section>
-          )}
 
           {/* Composition (monsters in the fight) */}
           {hasMonsters && (

--- a/frontend/app/leaderboards/submit/SubmitRunClient.tsx
+++ b/frontend/app/leaderboards/submit/SubmitRunClient.tsx
@@ -166,7 +166,12 @@ export default function SubmitRunClient() {
             const result = await res.json().catch(() => null);
             if (result?.duplicate) {
               dupes++;
-              if (result?.run_hash) lastHash = result.run_hash;
+              if (result?.run_hash) {
+                lastHash = result.run_hash;
+                lastResult = result;
+                lastCharacter = String(data?.players?.[0]?.character || "");
+                lastWin = Boolean(data?.win);
+              }
             } else if (!res.ok) {
               errors++;
               failures.push({

--- a/frontend/app/monsters/[id]/MonsterDetail.tsx
+++ b/frontend/app/monsters/[id]/MonsterDetail.tsx
@@ -664,8 +664,8 @@ export default function MonsterDetail({
               <h2>{t("Builds", lang)}</h2>
               <p className="h-note">
                 Of the community archetypes that face {monster.name}, the share
-                of each build's runs that end here, next to that build's
-                overall win rate.
+                of each build&apos;s runs that end here, next to that
+                build&apos;s overall win rate.
               </p>
               <div style={{ display: "grid", gap: "1rem", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))" }}>
                 <div>

--- a/frontend/app/monsters/[id]/MonsterDetail.tsx
+++ b/frontend/app/monsters/[id]/MonsterDetail.tsx
@@ -291,6 +291,23 @@ function MoveCard({
   );
 }
 
+const BUILD_CHAR_DOT: Record<string, string> = {
+  IRONCLAD: "var(--color-ironclad)",
+  SILENT: "var(--color-silent)",
+  DEFECT: "var(--color-defect)",
+  NECROBINDER: "var(--color-necrobinder)",
+  REGENT: "var(--color-regent)",
+};
+
+interface EncounterBuild {
+  character: string;
+  name: string;
+  size: number;
+  win_rate: number;
+  deaths: number;
+  death_rate: number;
+}
+
 export default function MonsterDetail({
   initialMonster,
   encounterStats,
@@ -305,6 +322,44 @@ export default function MonsterDetail({
   const [notFound, setNotFound] = useState(false);
   const [betaArt, setBetaArt] = useState(false);
   const [activeSection, setActiveSection] = useState<string>("stats");
+  const [builds, setBuilds] = useState<EncounterBuild[]>([]);
+
+  useEffect(() => {
+    const encs = monster?.encounters?.map((e) => e.encounter_id) ?? [];
+    if (encs.length === 0) {
+      setBuilds([]);
+      return;
+    }
+    let dead = false;
+    Promise.all(
+      encs.map((eid) =>
+        cachedFetch<{ available: boolean; builds: EncounterBuild[] }>(
+          `${API}/api/runs/encounter-builds?encounter=${eid}&lang=${lang}`,
+        ).catch(() => null),
+      ),
+    ).then((results) => {
+      if (dead) return;
+      const merged = new Map<string, EncounterBuild>();
+      for (const r of results) {
+        if (!r?.available) continue;
+        for (const b of r.builds) {
+          const k = `${b.character}:${b.name}`;
+          const prev = merged.get(k);
+          if (prev) prev.deaths += b.deaths;
+          else merged.set(k, { ...b });
+        }
+      }
+      const rows = [...merged.values()].map((b) => ({
+        ...b,
+        death_rate: b.size ? Math.round((b.deaths / b.size) * 10000) / 100 : 0,
+      }));
+      rows.sort((x, y) => y.death_rate - x.death_rate);
+      setBuilds(rows);
+    });
+    return () => {
+      dead = true;
+    };
+  }, [monster, lang]);
 
   useEffect(() => {
     if (!id) return;
@@ -439,9 +494,18 @@ export default function MonsterDetail({
   const hasMoves = !!(monster.moves && monster.moves.length > 0);
   const hasEncounters = !!(monster.encounters && monster.encounters.length > 0);
 
+  const struggles = builds.filter((b) => b.deaths >= 5).slice(0, 5);
+  const struggleKeys = new Set(struggles.map((b) => `${b.character}:${b.name}`));
+  const handles = [...builds]
+    .sort((a, b) => a.death_rate - b.death_rate)
+    .filter((b) => b.size >= 500 && !struggleKeys.has(`${b.character}:${b.name}`))
+    .slice(0, 5);
+  const hasBuilds = struggles.length > 0;
+
   const tocItems: { id: string; label: string }[] = [
     ...(hasStats ? [{ id: "stats", label: t("Stats", lang) }] : []),
     ...(hasMoves ? [{ id: "moves", label: t("Moves", lang) }] : []),
+    ...(hasBuilds ? [{ id: "builds", label: t("Builds", lang) }] : []),
     ...(hasEncounters ? [{ id: "encounters", label: t("Encounters", lang) }] : []),
     { id: "history", label: t("Version history", lang) },
   ];
@@ -589,6 +653,61 @@ export default function MonsterDetail({
                 {monster.moves!.map((move) => (
                   <MoveCard key={move.id} move={move} powerData={powerData} lp={lp} isEnglish={isEnglish} />
                 ))}
+              </div>
+            </section>
+          )}
+
+          {/* Which archetypes die to this monster vs walk past, joined from
+              the nightly run-vector build across all of its encounters. */}
+          {hasBuilds && (
+            <section id="builds">
+              <h2>{t("Builds", lang)}</h2>
+              <p className="h-note">
+                Of the community archetypes that face {monster.name}, the share
+                of each build's runs that end here, next to that build's
+                overall win rate.
+              </p>
+              <div style={{ display: "grid", gap: "1rem", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))" }}>
+                <div>
+                  <p className="h-note" style={{ color: "var(--warn, #ef4444)" }}>
+                    {t("Dies here most", lang)}
+                  </p>
+                  {struggles.map((b) => (
+                    <div
+                      key={`s-${b.character}-${b.name}`}
+                      style={{ display: "flex", alignItems: "center", gap: "0.5rem", padding: "0.25rem 0", fontSize: "0.85rem" }}
+                    >
+                      <span
+                        style={{ width: 7, height: 7, borderRadius: "50%", background: BUILD_CHAR_DOT[b.character] || "#888", flexShrink: 0 }}
+                      />
+                      <span className="cn" style={{ flexGrow: 1 }}>{b.name}</span>
+                      <span style={{ color: "var(--text-muted)", fontVariantNumeric: "tabular-nums" }}>
+                        {b.death_rate}% {t("die here", lang)} · {b.win_rate}% WR
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                {handles.length > 0 && (
+                  <div>
+                    <p className="h-note" style={{ color: "var(--good, #22c55e)" }}>
+                      {t("Handles it best", lang)}
+                    </p>
+                    {handles.map((b) => (
+                      <div
+                        key={`h-${b.character}-${b.name}`}
+                        style={{ display: "flex", alignItems: "center", gap: "0.5rem", padding: "0.25rem 0", fontSize: "0.85rem" }}
+                      >
+                        <span
+                          style={{ width: 7, height: 7, borderRadius: "50%", background: BUILD_CHAR_DOT[b.character] || "#888", flexShrink: 0 }}
+                        />
+                        <span className="cn" style={{ flexGrow: 1 }}>{b.name}</span>
+                        <span style={{ color: "var(--text-muted)", fontVariantNumeric: "tabular-nums" }}>
+                          {b.death_rate}% {t("die here", lang)} · {b.win_rate}% WR
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
             </section>
           )}

--- a/frontend/lib/announcements.ts
+++ b/frontend/lib/announcements.ts
@@ -19,16 +19,8 @@ export const ANNOUNCEMENTS: Announcement[] = [
     date: "2026-07-20",
     title: "What beats each boss",
     body:
-      "Encounter pages now show which community builds die to a fight the most and which walk past it, joined from half a million analyzed runs. Check any boss page for the new Builds section.",
-    href: "/encounters/aeonglass_boss",
-  },
-  {
-    id: "deck-archetypes",
-    date: "2026-07-19",
-    title: "Community deck archetypes",
-    body:
-      "Every build the community actually pilots, discovered automatically from submitted runs: defining cards and relics, real win rates, popularity trends per patch, and the biggest meta movers.",
-    href: "/archetypes",
+      "Boss pages now show which community builds die to a fight the most and which walk past it, joined from half a million analyzed runs. Check any boss's page for the new Builds section.",
+    href: "/monsters/aeonglass",
   },
   {
     id: "score-by-patch",


### PR DESCRIPTION
The Builds section moves from encounter pages onto the boss's own monster page (merged across its encounter variants), the archetypes announcement is pulled until that page is ready, and duplicate run submissions now get the same archetype and seed enrichment so re-uploading a run shows the insight card instead of silently redirecting.