### PR TITLE
Publish site news from the admin dashboard with a markdown editor

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,6 +51,7 @@ from .routers import (
     beta,
     admin,
     admin_searches,
+    admin_news,
     admin_rate_limits,
     admin_api_keys,
     api_keys,
@@ -691,6 +692,7 @@ app.include_router(beta.router)
 app.include_router(admin.router, include_in_schema=False)
 app.include_router(admin_searches.router, include_in_schema=False)
 app.include_router(admin_rate_limits.router, include_in_schema=False)
+app.include_router(admin_news.router, include_in_schema=False)
 app.include_router(admin_api_keys.router, include_in_schema=False)
 # Key management (create/list/revoke) is session-authed and site-internal, so
 # it stays out of /docs; only the public tier info (/api/rate-limits) shows.

--- a/backend/app/routers/admin_news.py
+++ b/backend/app/routers/admin_news.py
@@ -1,0 +1,75 @@
+"""Admin CRUD for Spire Codex site news: the announcements and markdown
+articles surfaced on /news's Spire Codex tab and behind the navbar megaphone.
+Publishing here replaces committing to the repo for every announcement."""
+
+import re
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from ..services import admin_db
+from ..services import cache as app_cache
+from ..services.auth_jwt import require_admin
+from .admin import _audit
+
+router = APIRouter(
+    prefix="/api/admin/news",
+    tags=["Admin"],
+    dependencies=[Depends(require_admin)],
+)
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _bust_cache() -> None:
+    for key in ("sitenews:feed", "sitenews:latest"):
+        try:
+            app_cache.delete(key)
+        except Exception:
+            pass
+
+
+@router.get("")
+def list_news(request: Request):
+    """Every entry, drafts included, newest first."""
+    _audit(request)
+    return {"items": admin_db.list_site_news(published_only=False)}
+
+
+class NewsEntry(BaseModel):
+    id: str = Field(description="Slug, e.g. 'deck-archetypes'. Lowercase, dashes.")
+    title: str
+    date: str = Field(description="YYYY-MM-DD")
+    body: str = Field(default="", description="Markdown article body.")
+    href: str = Field(
+        default="",
+        description="Optional link target; set = the card links there instead of an article page.",
+    )
+    published: bool = False
+
+
+@router.put("")
+def upsert_news(body: NewsEntry, request: Request):
+    """Create or update one entry (matched by slug)."""
+    _audit(request)
+    if not _SLUG_RE.match(body.id):
+        raise HTTPException(400, "slug must be lowercase letters/digits/dashes")
+    if not body.title.strip():
+        raise HTTPException(400, "title is required")
+    if not _DATE_RE.match(body.date.strip()):
+        raise HTTPException(400, "date must be YYYY-MM-DD")
+    if not body.body.strip() and not body.href.strip():
+        raise HTTPException(400, "give the entry a body or a link target")
+    saved = admin_db.upsert_site_news(body.model_dump())
+    _bust_cache()
+    return saved
+
+
+@router.delete("/{slug}")
+def delete_news(slug: str, request: Request):
+    _audit(request)
+    if not admin_db.delete_site_news(slug):
+        raise HTTPException(404, "no such entry")
+    _bust_cache()
+    return {"deleted": slug}

--- a/backend/app/routers/news.py
+++ b/backend/app/routers/news.py
@@ -6,11 +6,44 @@ router is a thin read-only view over that archive plus a couple of
 filters; everything is in-memory after first load.
 """
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, Response
 
+from ..services import cache as app_cache
 from ..services.data_service import load_news_index, load_news_item
 
 router = APIRouter(prefix="/api/news", tags=["News"])
+
+
+@router.get("/codex")
+def codex_news(response: Response) -> dict:
+    """Published Spire Codex site news (admin-authored), newest first, plus
+    the newest entry's id for the navbar unread megaphone."""
+    cached = app_cache.get_json("sitenews:feed")
+    if cached is not None:
+        response.headers["Cache-Control"] = "public, max-age=60"
+        return cached
+    from ..services import admin_db
+
+    items = admin_db.list_site_news(published_only=True)
+    result = {
+        "items": items,
+        "latest_id": items[0]["id"] if items else None,
+    }
+    app_cache.set_json("sitenews:feed", result, ttl_seconds=120)
+    response.headers["Cache-Control"] = "public, max-age=60"
+    return result
+
+
+@router.get("/codex/{slug}")
+def codex_news_entry(slug: str, response: Response) -> dict:
+    """One published Spire Codex news entry, for article pages."""
+    from ..services import admin_db
+
+    doc = admin_db.get_site_news(slug)
+    if not doc:
+        raise HTTPException(status_code=404, detail="No such entry")
+    response.headers["Cache-Control"] = "public, max-age=120"
+    return doc
 
 
 @router.get("")

--- a/backend/app/services/admin_db.py
+++ b/backend/app/services/admin_db.py
@@ -173,6 +173,55 @@ def delete_run(run_hash: str, runs_dir: Path) -> dict[str, Any]:
 # ── Announcements (the site banner) ──────────────────────────
 
 
+_SITE_NEWS_COLLECTION = "site_news"
+
+
+def list_site_news(published_only: bool = False) -> list[dict]:
+    """Spire Codex news entries (announcements and articles), newest first.
+    _id is the slug; `href` set = link card, `body` set = markdown article."""
+    if not _enabled():
+        return []
+    query = {"published": True} if published_only else {}
+    rows = list(_db()[_SITE_NEWS_COLLECTION].find(query).sort("date", -1).limit(200))
+    for r in rows:
+        r["id"] = r.pop("_id")
+        r.pop("updated_at", None)
+    return rows
+
+
+def get_site_news(slug: str, published_only: bool = True) -> dict | None:
+    if not _enabled():
+        return None
+    doc = _db()[_SITE_NEWS_COLLECTION].find_one({"_id": slug})
+    if not doc or (published_only and not doc.get("published")):
+        return None
+    doc["id"] = doc.pop("_id")
+    doc.pop("updated_at", None)
+    return doc
+
+
+def upsert_site_news(entry: dict) -> dict:
+    slug = entry["id"]
+    doc = {
+        "title": entry.get("title", "").strip(),
+        "date": entry.get("date", "").strip(),
+        "body": entry.get("body", ""),
+        "href": entry.get("href", "").strip(),
+        "published": bool(entry.get("published")),
+        "updated_at": datetime.now(timezone.utc),
+    }
+    _db()[_SITE_NEWS_COLLECTION].replace_one(
+        {"_id": slug}, {"_id": slug, **doc}, upsert=True
+    )
+    return {"id": slug, **{k: v for k, v in doc.items() if k != "updated_at"}}
+
+
+def delete_site_news(slug: str) -> bool:
+    if not _enabled():
+        return False
+    return _db()[_SITE_NEWS_COLLECTION].delete_one({"_id": slug}).deleted_count > 0
+
+
 _ANNOUNCEMENTS_COLLECTION = "announcements"
 
 

--- a/frontend/app/admin/news/NewsAdminClient.tsx
+++ b/frontend/app/admin/news/NewsAdminClient.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+// Publish Spire Codex news without a deploy: announcements (title + link)
+// and full markdown articles. Saving a new entry as published is what
+// lights the navbar megaphone for every visitor.
+
+import { useEffect, useRef, useState } from "react";
+import { AdminShell, adminFetch } from "../shared";
+import CodexMarkdown from "@/app/components/CodexMarkdown";
+
+interface NewsEntry {
+  id: string;
+  title: string;
+  date: string;
+  body: string;
+  href: string;
+  published: boolean;
+}
+
+const EMPTY: NewsEntry = {
+  id: "",
+  title: "",
+  date: new Date().toISOString().slice(0, 10),
+  body: "",
+  href: "",
+  published: false,
+};
+
+const TOOLBAR: { label: string; title: string; before: string; after: string; block?: boolean }[] = [
+  { label: "B", title: "Bold", before: "**", after: "**" },
+  { label: "I", title: "Italic", before: "*", after: "*" },
+  { label: "H2", title: "Heading", before: "## ", after: "", block: true },
+  { label: "H3", title: "Subheading", before: "### ", after: "", block: true },
+  { label: "Link", title: "Link", before: "[", after: "](https://)" },
+  { label: "List", title: "Bullet list", before: "- ", after: "", block: true },
+  { label: "Quote", title: "Quote", before: "> ", after: "", block: true },
+  { label: "Code", title: "Inline code", before: "`", after: "`" },
+];
+
+export default function NewsAdminClient() {
+  const [entries, setEntries] = useState<NewsEntry[]>([]);
+  const [draft, setDraft] = useState<NewsEntry>({ ...EMPTY });
+  const [editingExisting, setEditingExisting] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
+
+  const load = () =>
+    adminFetch<{ items: NewsEntry[] }>("/api/admin/news")
+      .then((d) => setEntries(d.items ?? []))
+      .catch((e) => setNote(String((e as Error)?.message || e)));
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const applyMark = (m: (typeof TOOLBAR)[number]) => {
+    const el = bodyRef.current;
+    if (!el) return;
+    const { selectionStart: s, selectionEnd: e, value } = el;
+    let before = m.before;
+    if (m.block && s > 0 && value[s - 1] !== "\n") before = "\n" + m.before;
+    const next = value.slice(0, s) + before + value.slice(s, e) + m.after + value.slice(e);
+    setDraft((d) => ({ ...d, body: next }));
+    requestAnimationFrame(() => {
+      el.focus();
+      el.setSelectionRange(s + before.length, e + before.length);
+    });
+  };
+
+  const save = () => {
+    setSaving(true);
+    setNote(null);
+    adminFetch<NewsEntry>("/api/admin/news", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(draft),
+    })
+      .then(() => {
+        setNote(
+          draft.published
+            ? "Published. Live within ~2 minutes; the megaphone lights up for anyone who hasn't seen it."
+            : "Saved as draft.",
+        );
+        setEditingExisting(true);
+        load();
+      })
+      .catch((e) => setNote(String((e as Error)?.message || e)))
+      .finally(() => setSaving(false));
+  };
+
+  const remove = (slug: string) => {
+    if (!confirm(`Delete "${slug}"? This is permanent.`)) return;
+    adminFetch(`/api/admin/news/${slug}`, { method: "DELETE" })
+      .then(() => {
+        if (draft.id === slug) {
+          setDraft({ ...EMPTY });
+          setEditingExisting(false);
+        }
+        load();
+      })
+      .catch((e) => setNote(String((e as Error)?.message || e)));
+  };
+
+  const card = "rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4";
+  const input =
+    "rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-3 py-2 text-sm text-[var(--text-primary)] w-full";
+  const goldBtn =
+    "px-4 py-2 rounded-lg text-sm border border-[var(--accent-gold)]/40 bg-[var(--accent-gold)]/15 text-[var(--accent-gold)] disabled:opacity-50";
+
+  return (
+    <AdminShell title="Site news" subtitle="announcements + articles, no deploy needed">
+      <p className="text-sm text-[var(--text-secondary)] mb-4 max-w-2xl">
+        Entries appear on the news page&apos;s Spire Codex tab. A link target makes the card
+        point straight at a feature; a markdown body makes it a full article page. Publishing
+        a new entry lights the navbar megaphone for everyone who hasn&apos;t seen it.
+      </p>
+
+      {note && <p className="text-sm text-[var(--text-secondary)] mb-4">{note}</p>}
+
+      <div className="grid gap-4 xl:grid-cols-[320px_1fr]">
+        <div className="space-y-2">
+          <button
+            type="button"
+            onClick={() => {
+              setDraft({ ...EMPTY, date: new Date().toISOString().slice(0, 10) });
+              setEditingExisting(false);
+            }}
+            className={`w-full ${goldBtn}`}
+          >
+            + New entry
+          </button>
+          {entries.map((e) => (
+            <div
+              key={e.id}
+              className={`${card} !p-3 cursor-pointer ${draft.id === e.id ? "border-[var(--accent-gold)]/50" : ""}`}
+              onClick={() => {
+                setDraft({ ...e });
+                setEditingExisting(true);
+              }}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="text-sm text-[var(--text-primary)] truncate">{e.title}</div>
+                  <div className="text-[11px] text-[var(--text-muted)]">
+                    {e.date} · {e.id} · {e.published ? "published" : "draft"}
+                    {e.href ? " · link" : " · article"}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={(ev) => {
+                    ev.stopPropagation();
+                    remove(e.id);
+                  }}
+                  className="px-2 py-1 rounded text-xs border border-red-500/40 bg-red-500/10 text-red-400 shrink-0"
+                >
+                  ✕
+                </button>
+              </div>
+            </div>
+          ))}
+          {entries.length === 0 && (
+            <p className="text-xs text-[var(--text-muted)]">Nothing published yet.</p>
+          )}
+        </div>
+
+        <div className="space-y-3">
+          <div className={card}>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <label className="block text-xs text-[var(--text-muted)] mb-1">
+                  Slug (the URL id; can&apos;t change after publish)
+                </label>
+                <input
+                  type="text"
+                  value={draft.id}
+                  disabled={editingExisting}
+                  onChange={(e) =>
+                    setDraft((d) => ({
+                      ...d,
+                      id: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "-"),
+                    }))
+                  }
+                  placeholder="my-announcement"
+                  className={`${input} font-mono disabled:opacity-60`}
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-[var(--text-muted)] mb-1">Date</label>
+                <input
+                  type="date"
+                  value={draft.date}
+                  onChange={(e) => setDraft((d) => ({ ...d, date: e.target.value }))}
+                  className={input}
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <label className="block text-xs text-[var(--text-muted)] mb-1">Title</label>
+                <input
+                  type="text"
+                  value={draft.title}
+                  onChange={(e) => setDraft((d) => ({ ...d, title: e.target.value }))}
+                  placeholder="What beats each boss"
+                  className={input}
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <label className="block text-xs text-[var(--text-muted)] mb-1">
+                  Link target (optional; set = the card links there instead of an article page)
+                </label>
+                <input
+                  type="text"
+                  value={draft.href}
+                  onChange={(e) => setDraft((d) => ({ ...d, href: e.target.value }))}
+                  placeholder="/monsters/aeonglass"
+                  className={`${input} font-mono`}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className={card}>
+            <div className="flex flex-wrap items-center gap-1.5 mb-2">
+              {TOOLBAR.map((m) => (
+                <button
+                  key={m.label}
+                  type="button"
+                  title={m.title}
+                  onClick={() => applyMark(m)}
+                  className="px-2.5 py-1 rounded-md text-xs border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:border-[var(--border-accent)]"
+                >
+                  {m.label}
+                </button>
+              ))}
+              <span className="text-[11px] text-[var(--text-muted)] ml-auto">
+                Markdown; live preview below
+              </span>
+            </div>
+            <textarea
+              ref={bodyRef}
+              value={draft.body}
+              onChange={(e) => setDraft((d) => ({ ...d, body: e.target.value }))}
+              placeholder={"Body (markdown). For a pure announcement card you can leave this as a one-liner, the card shows it as the excerpt."}
+              rows={12}
+              className={`${input} font-mono text-xs leading-relaxed resize-y`}
+            />
+          </div>
+
+          {draft.body.trim() && (
+            <div className={card}>
+              <div className="text-xs text-[var(--text-muted)] mb-3 uppercase tracking-wider">
+                Preview
+              </div>
+              <CodexMarkdown>{draft.body}</CodexMarkdown>
+            </div>
+          )}
+
+          <div className="flex items-center gap-3">
+            <label className="flex items-center gap-2 text-sm text-[var(--text-secondary)]">
+              <input
+                type="checkbox"
+                checked={draft.published}
+                onChange={(e) => setDraft((d) => ({ ...d, published: e.target.checked }))}
+              />
+              Published
+            </label>
+            <button
+              type="button"
+              disabled={saving || !draft.id || !draft.title.trim()}
+              onClick={save}
+              className={goldBtn}
+            >
+              {saving ? "Saving…" : draft.published ? "Save & publish" : "Save draft"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </AdminShell>
+  );
+}

--- a/frontend/app/admin/news/page.tsx
+++ b/frontend/app/admin/news/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import NewsAdminClient from "./NewsAdminClient";
+
+export const metadata: Metadata = {
+  title: "News admin",
+  robots: { index: false, follow: false },
+};
+
+export default function NewsAdminPage() {
+  return <NewsAdminClient />;
+}

--- a/frontend/app/admin/shared.tsx
+++ b/frontend/app/admin/shared.tsx
@@ -115,6 +115,7 @@ const SECTIONS = [
   { href: "/admin/feedback", label: "Feedback" },
   { href: "/admin/guides", label: "Guides" },
   { href: "/admin/banners", label: "Banners" },
+  { href: "/admin/news", label: "Site news" },
   { href: "/admin/analytics", label: "Analytics" },
   { href: "/admin/searches", label: "Searches" },
   { href: "/admin/cache", label: "Cache" },

--- a/frontend/app/components/AnnouncementBadge.tsx
+++ b/frontend/app/components/AnnouncementBadge.tsx
@@ -9,6 +9,8 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { ANNOUNCEMENT_SEEN_KEY, LATEST_ANNOUNCEMENT_ID } from "@/lib/announcements";
 
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
 function MegaphoneIcon() {
   return (
     <svg
@@ -35,19 +37,32 @@ export default function AnnouncementBadge({
   variant?: "desktop" | "mobile";
 }) {
   const [unread, setUnread] = useState(false);
+  const [latestId, setLatestId] = useState(LATEST_ANNOUNCEMENT_ID);
 
   useEffect(() => {
+    let current = LATEST_ANNOUNCEMENT_ID;
     const check = () => {
       try {
         setUnread(
-          !!LATEST_ANNOUNCEMENT_ID &&
-            localStorage.getItem(ANNOUNCEMENT_SEEN_KEY) !== LATEST_ANNOUNCEMENT_ID,
+          !!current && localStorage.getItem(ANNOUNCEMENT_SEEN_KEY) !== current,
         );
       } catch {
         setUnread(false);
       }
     };
     check();
+    // Admin-published entries beat the committed seed list: ask the API for
+    // the newest id so publishing lights the megaphone without a deploy.
+    fetch(`${API}/api/news/codex`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (d?.latest_id) {
+          current = d.latest_id;
+          setLatestId(d.latest_id);
+          check();
+        }
+      })
+      .catch(() => {});
     window.addEventListener("sc-news-seen", check);
     return () => window.removeEventListener("sc-news-seen", check);
   }, []);
@@ -56,7 +71,7 @@ export default function AnnouncementBadge({
 
   const markSeen = () => {
     try {
-      localStorage.setItem(ANNOUNCEMENT_SEEN_KEY, LATEST_ANNOUNCEMENT_ID);
+      localStorage.setItem(ANNOUNCEMENT_SEEN_KEY, latestId);
     } catch {}
     setUnread(false);
   };

--- a/frontend/app/components/CodexMarkdown.tsx
+++ b/frontend/app/components/CodexMarkdown.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+// Shared markdown renderer for site news articles and the admin editor
+// preview. Mirrors the guide-page styling so admin-authored articles read
+// like the rest of the site.
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+export default function CodexMarkdown({ children }: { children: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      components={{
+        h1: ({ children }) => <h1 className="text-2xl font-bold text-[var(--accent-gold)] mt-8 mb-4 first:mt-0">{children}</h1>,
+        h2: ({ children }) => <h2 className="text-xl font-bold text-[var(--accent-gold)] mt-8 mb-3 first:mt-0">{children}</h2>,
+        h3: ({ children }) => <h3 className="text-lg font-semibold text-[var(--text-primary)] mt-6 mb-2">{children}</h3>,
+        h4: ({ children }) => <h4 className="text-base font-semibold text-[var(--text-primary)] mt-4 mb-2">{children}</h4>,
+        p: ({ children }) => <p className="text-sm text-[var(--text-secondary)] leading-relaxed mb-4">{children}</p>,
+        ul: ({ children }) => <ul className="list-disc list-inside text-sm text-[var(--text-secondary)] mb-4 space-y-1">{children}</ul>,
+        ol: ({ children }) => <ol className="list-decimal list-inside text-sm text-[var(--text-secondary)] mb-4 space-y-1">{children}</ol>,
+        li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+        strong: ({ children }) => <strong className="text-[var(--text-primary)] font-semibold">{children}</strong>,
+        em: ({ children }) => <em className="text-[var(--text-secondary)] italic">{children}</em>,
+        a: ({ href, children }) => (
+          <a
+            href={href}
+            className="text-[var(--accent-gold)] hover:underline"
+            {...(href?.startsWith("/") ? {} : { target: "_blank", rel: "noopener noreferrer" })}
+          >
+            {children}
+          </a>
+        ),
+        blockquote: ({ children }) => <blockquote className="border-l-2 border-[var(--accent-gold)] pl-4 my-4 text-sm text-[var(--text-muted)] italic">{children}</blockquote>,
+        code: ({ children, className }) => {
+          const isBlock = className?.includes("language-");
+          if (isBlock) return <code className={`block bg-[var(--bg-primary)] rounded-lg p-4 text-xs text-[var(--text-secondary)] overflow-x-auto mb-4 ${className}`}>{children}</code>;
+          return <code className="bg-[var(--bg-primary)] px-1.5 py-0.5 rounded text-xs text-[var(--accent-gold)]">{children}</code>;
+        },
+        pre: ({ children }) => <pre className="mb-4">{children}</pre>,
+        hr: () => <hr className="border-[var(--border-subtle)] my-8" />,
+        table: ({ children }) => <div className="overflow-x-auto mb-4"><table className="w-full text-sm text-[var(--text-secondary)]">{children}</table></div>,
+        th: ({ children }) => <th className="text-left font-semibold text-[var(--text-primary)] border-b border-[var(--border-subtle)] px-3 py-2">{children}</th>,
+        td: ({ children }) => <td className="border-b border-[var(--border-subtle)] px-3 py-2">{children}</td>,
+      }}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+}

--- a/frontend/app/news/MarkAnnouncementsSeen.tsx
+++ b/frontend/app/news/MarkAnnouncementsSeen.tsx
@@ -5,12 +5,12 @@ import { ANNOUNCEMENT_SEEN_KEY, LATEST_ANNOUNCEMENT_ID } from "@/lib/announcemen
 
 /** Rendered on the Spire Codex news tab: viewing it clears the navbar
  * megaphone by recording the newest announcement id as seen. */
-export default function MarkAnnouncementsSeen() {
+export default function MarkAnnouncementsSeen({ latestId }: { latestId?: string }) {
   useEffect(() => {
     try {
-      localStorage.setItem(ANNOUNCEMENT_SEEN_KEY, LATEST_ANNOUNCEMENT_ID);
+      localStorage.setItem(ANNOUNCEMENT_SEEN_KEY, latestId || LATEST_ANNOUNCEMENT_ID);
       window.dispatchEvent(new Event("sc-news-seen"));
     } catch {}
-  }, []);
+  }, [latestId]);
   return null;
 }

--- a/frontend/app/news/codex/[slug]/page.tsx
+++ b/frontend/app/news/codex/[slug]/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import JsonLd from "@/app/components/JsonLd";
+import { buildBreadcrumbJsonLd } from "@/lib/jsonld";
+import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE } from "@/lib/seo";
+import CodexMarkdown from "@/app/components/CodexMarkdown";
+
+const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export const revalidate = 300;
+
+interface CodexEntry {
+  id: string;
+  title: string;
+  date: string;
+  body: string;
+  href: string;
+}
+
+async function loadEntry(slug: string): Promise<CodexEntry | null> {
+  try {
+    const res = await fetch(`${API}/api/news/codex/${slug}`, { next: { revalidate } });
+    if (!res.ok) return null;
+    return (await res.json()) as CodexEntry;
+  } catch {
+    return null;
+  }
+}
+
+type Props = { params: Promise<{ slug: string }> };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = await loadEntry(slug);
+  if (!entry) return { title: `News | ${SITE_NAME}` };
+  const title = `${entry.title} | ${SITE_NAME}`;
+  return {
+    title,
+    description: entry.body.slice(0, 200).replace(/[#*_>`]/g, "").trim(),
+    alternates: { canonical: `${SITE_URL}/news/codex/${slug}` },
+    openGraph: {
+      title,
+      type: "article",
+      siteName: SITE_NAME,
+      url: `${SITE_URL}/news/codex/${slug}`,
+      images: [{ url: DEFAULT_OG_IMAGE }],
+    },
+  };
+}
+
+export default async function CodexNewsEntryPage({ params }: Props) {
+  const { slug } = await params;
+  const entry = await loadEntry(slug);
+  if (!entry) notFound();
+
+  const jsonLd = buildBreadcrumbJsonLd([
+    { name: "Home", href: "/" },
+    { name: "News", href: "/news" },
+    { name: entry.title, href: `/news/codex/${slug}` },
+  ]);
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <JsonLd data={jsonLd} />
+      <Link href="/news?tab=codex" className="text-sm text-[var(--accent-gold)] hover:underline">
+        ← All Spire Codex news
+      </Link>
+      <h1 className="text-3xl font-bold mt-4 mb-1 text-[var(--text-primary)]">{entry.title}</h1>
+      <p className="text-sm text-[var(--text-muted)] mb-8">
+        Spire Codex · {entry.date}
+      </p>
+      <div className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-6">
+        <CodexMarkdown>{entry.body}</CodexMarkdown>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/news/page.tsx
+++ b/frontend/app/news/page.tsx
@@ -5,8 +5,22 @@ import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE, buildLanguageAlternates } from "@/lib/seo";
 import type { NewsArticle, NewsListResponse } from "@/lib/api";
 import { newsExcerpt, formatNewsDate, newsSlugForArticle } from "@/lib/steam-news";
-import { ANNOUNCEMENTS } from "@/lib/announcements";
+import { ANNOUNCEMENTS, type Announcement } from "@/lib/announcements";
 import MarkAnnouncementsSeen from "./MarkAnnouncementsSeen";
+
+async function loadCodexNews(): Promise<{ items: Announcement[]; latestId: string }> {
+  try {
+    const res = await fetch(`${API}/api/news/codex`, { next: { revalidate: 300 } });
+    if (res.ok) {
+      const data = await res.json();
+      if (Array.isArray(data.items) && data.items.length > 0) {
+        return { items: data.items as Announcement[], latestId: data.latest_id ?? "" };
+      }
+    }
+  } catch {}
+  // Fallback: the committed seed list, until admin-published entries exist.
+  return { items: ANNOUNCEMENTS, latestId: ANNOUNCEMENTS[0]?.id ?? "" };
+}
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -79,6 +93,7 @@ export default async function NewsPage({
   const activeTab = tabFromParam(sp.tab);
   const tabConfig = TABS.find((t) => t.key === activeTab) ?? TABS[0];
   const isCodex = activeTab === "codex";
+  const codex = isCodex ? await loadCodexNews() : { items: [], latestId: "" };
   const data = isCodex
     ? { total: 0, limit: 0, offset: 0, items: [] }
     : await loadNews(tabConfig.feedType);
@@ -136,12 +151,12 @@ export default async function NewsPage({
 
       {isCodex ? (
         <>
-          <MarkAnnouncementsSeen />
+          <MarkAnnouncementsSeen latestId={codex.latestId} />
           <ul className="space-y-3">
-            {ANNOUNCEMENTS.map((a) => (
+            {codex.items.map((a) => (
               <li key={a.id}>
                 <Link
-                  href={a.href}
+                  href={a.href || `/news/codex/${a.id}`}
                   className="block bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] p-5 hover:border-[var(--border-accent)] transition-colors"
                 >
                   <div className="flex items-baseline justify-between gap-3 mb-1">
@@ -149,9 +164,11 @@ export default async function NewsPage({
                     <time className="text-xs text-[var(--text-muted)] shrink-0">{a.date}</time>
                   </div>
                   <p className="text-xs text-[var(--text-muted)] mb-2">Spire Codex</p>
-                  <p className="text-sm text-[var(--text-secondary)] leading-relaxed">{a.body}</p>
+                  <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
+                    {newsExcerpt(a.body, 220)}
+                  </p>
                   <span className="inline-block mt-3 text-sm text-[var(--accent-gold)]">
-                    Check it out →
+                    {a.href ? "Check it out →" : "Read more →"}
                   </span>
                 </Link>
               </li>


### PR DESCRIPTION
Site announcements and full markdown articles now live in Mongo behind an admin editor (toolbar, live preview, drafts, publish toggle) instead of requiring a commit, the news page's Spire Codex tab and the navbar megaphone read from the new endpoint (falling back to the committed seed list until entries exist), and bodied entries get their own article page at /news/codex/slug.