### PR TITLE
Add impossible-time and missing-act-boss cheat rules

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -390,11 +390,7 @@ def runs_cheat_sweep(request: Request, dry_run: bool = True, limit: int = 500):
     _audit(request)
     if not os.environ.get("MONGO_URL", "").strip():
         return {"dry_run": dry_run, "flagged": [], "hidden": 0}
-    from ..services.cheat_detect import (
-        MAX_RELIC_COPIES,
-        MIN_ACT_FLOORS,
-        MIN_WIN_SECONDS,
-    )
+    from ..services.cheat_detect import MAX_RELIC_COPIES, MIN_WIN_SECONDS
     from ..services.runs_db_mongo import get_database, set_run_hidden
 
     db = get_database()["runs"]
@@ -424,30 +420,33 @@ def runs_cheat_sweep(request: Request, dry_run: bool = True, limit: int = 500):
             h = d.get("run_hash") or d["_id"]
             flagged[h] = f"duplicate_relics:{worst[0]}x{worst[1]}"
 
-    # Boss-teleport wins: cheap floors_reached prefilter, then the same
-    # per-act check submit-time detection uses, from the stored history.
-    tele_candidates = db.find(
+    # Path-shaped win cheats (boss teleports, missing act bosses): cheap doc
+    # prefilters, then the exact submit-time detector over the stored history.
+    from ..services.cheat_detect import detect_cheats
+
+    win_candidates = db.find(
         {
             "hidden": {"$ne": True},
             "win": True,
-            "floors_reached": {"$gt": 0, "$lt": 40},
+            "$or": [
+                {"floors_reached": {"$gt": 0, "$lt": 40}},
+                {"acts_completed": {"$lt": 3}},
+            ],
         },
-        {"map_point_history": 1, "run_hash": 1},
-    ).limit(2000)
-    for d in tele_candidates:
-        for i, act in enumerate(d.get("map_point_history") or []):
-            floors = act or []
-            has_boss = any(
-                (room.get("room_type") or "").lower() == "boss"
-                for fl in floors
-                if isinstance(fl, dict)
-                for room in fl.get("rooms") or []
-                if isinstance(room, dict)
-            )
-            if has_boss and len(floors) < MIN_ACT_FLOORS:
-                h = d.get("run_hash") or d["_id"]
-                flagged[h] = f"boss_teleport:act{i + 1}:{len(floors)}floors"
-                break
+        {"map_point_history": 1, "run_time": 1, "game_mode": 1, "run_hash": 1},
+    ).limit(4000)
+    for d in win_candidates:
+        reasons = detect_cheats(
+            {
+                "win": True,
+                "run_time": d.get("run_time"),
+                "game_mode": d.get("game_mode"),
+                "map_point_history": d.get("map_point_history") or [],
+            }
+        )
+        if reasons:
+            h = d.get("run_hash") or d["_id"]
+            flagged.setdefault(h, reasons[0])
 
     # Impossible-time wins: pure doc query, no verification needed.
     for d in db.find(

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -390,7 +390,11 @@ def runs_cheat_sweep(request: Request, dry_run: bool = True, limit: int = 500):
     _audit(request)
     if not os.environ.get("MONGO_URL", "").strip():
         return {"dry_run": dry_run, "flagged": [], "hidden": 0}
-    from ..services.cheat_detect import MAX_RELIC_COPIES, MIN_ACT_FLOORS
+    from ..services.cheat_detect import (
+        MAX_RELIC_COPIES,
+        MIN_ACT_FLOORS,
+        MIN_WIN_SECONDS,
+    )
     from ..services.runs_db_mongo import get_database, set_run_hidden
 
     db = get_database()["runs"]
@@ -444,6 +448,18 @@ def runs_cheat_sweep(request: Request, dry_run: bool = True, limit: int = 500):
                 h = d.get("run_hash") or d["_id"]
                 flagged[h] = f"boss_teleport:act{i + 1}:{len(floors)}floors"
                 break
+
+    # Impossible-time wins: pure doc query, no verification needed.
+    for d in db.find(
+        {
+            "hidden": {"$ne": True},
+            "win": True,
+            "run_time": {"$gt": 0, "$lt": MIN_WIN_SECONDS},
+        },
+        {"run_time": 1, "run_hash": 1},
+    ).limit(2000):
+        h = d.get("run_hash") or d["_id"]
+        flagged.setdefault(h, f"impossible_time:{int(d.get('run_time') or 0)}s")
 
     items = sorted(flagged.items())[:limit]
     hidden = 0

--- a/backend/app/services/cheat_detect.py
+++ b/backend/app/services/cheat_detect.py
@@ -16,6 +16,10 @@ MAX_RELIC_COPIES = 5
 # A completed act's visited path is ~16 floors; the teleport cheat shows 1.
 MIN_ACT_FLOORS = 8
 
+# Fastest conceivable legitimate win is well past this; a 51-second "win"
+# from a savegame edit is not.
+MIN_WIN_SECONDS = 300
+
 
 def _bare(raw: str) -> str:
     parts = str(raw or "").split(".")
@@ -35,6 +39,9 @@ def detect_cheats(data: dict) -> list[str]:
             if n > MAX_RELIC_COPIES:
                 reasons.append(f"duplicate_relics:{rid}x{n}")
     if data.get("win"):
+        run_time = data.get("run_time") or 0
+        if 0 < run_time < MIN_WIN_SECONDS:
+            reasons.append(f"impossible_time:{int(run_time)}s")
         for i, act in enumerate(data.get("map_point_history") or []):
             floors = act or []
             has_boss = any(

--- a/backend/app/services/cheat_detect.py
+++ b/backend/app/services/cheat_detect.py
@@ -42,7 +42,9 @@ def detect_cheats(data: dict) -> list[str]:
         run_time = data.get("run_time") or 0
         if 0 < run_time < MIN_WIN_SECONDS:
             reasons.append(f"impossible_time:{int(run_time)}s")
-        for i, act in enumerate(data.get("map_point_history") or []):
+        acts = data.get("map_point_history") or []
+        boss_acts = 0
+        for i, act in enumerate(acts):
             floors = act or []
             has_boss = any(
                 (room.get("room_type") or "").lower() == "boss"
@@ -51,6 +53,17 @@ def detect_cheats(data: dict) -> list[str]:
                 for room in fl.get("rooms") or []
                 if isinstance(room, dict)
             )
-            if has_boss and len(floors) < MIN_ACT_FLOORS:
-                reasons.append(f"boss_teleport:act{i + 1}:{len(floors)}floors")
+            if has_boss:
+                boss_acts += 1
+                if len(floors) < MIN_ACT_FLOORS:
+                    reasons.append(f"boss_teleport:act{i + 1}:{len(floors)}floors")
+        # A standard win goes through all three act bosses; a history with
+        # fewer is a savegame edit that skipped ahead. Gated to standard mode
+        # so a future short game mode can't false-positive.
+        if (
+            acts
+            and boss_acts < 3
+            and str(data.get("game_mode") or "standard").lower() == "standard"
+        ):
+            reasons.append(f"missing_acts:{boss_acts}of3bosses")
     return reasons


### PR DESCRIPTION
Recovers the two detector commits pushed after #772 merged: wins under five minutes and standard-mode wins with fewer than three act bosses now auto-hide, and the retroactive sweep runs the exact submit-time detector over stored histories instead of duplicating the logic.