### PR TITLE
Give What's new its own mobile row and dot the burger when unread

### DIFF
--- a/frontend/app/components/AnnouncementBadge.tsx
+++ b/frontend/app/components/AnnouncementBadge.tsx
@@ -11,31 +11,9 @@ import { ANNOUNCEMENT_SEEN_KEY, LATEST_ANNOUNCEMENT_ID } from "@/lib/announcemen
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
-function MegaphoneIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
-    >
-      <path d="M3 11v3a1 1 0 0 0 1 1h2l3.5 4.5a1 1 0 0 0 1.8-.6V5.1a1 1 0 0 0-1.8-.6L6 9H4a1 1 0 0 0-1 1z" />
-      <path d="M15 9c1.2 1.6 1.2 4.4 0 6" />
-      <path d="M18 6c2.7 3.2 2.7 8.8 0 12" />
-    </svg>
-  );
-}
-
-export default function AnnouncementBadge({
-  variant = "desktop",
-}: {
-  variant?: "desktop" | "mobile";
-}) {
+/** Shared unread state for the megaphone and the mobile burger dot: latest
+ * announcement id (API-first, committed seed as fallback) vs localStorage. */
+export function useAnnouncementUnread() {
   const [unread, setUnread] = useState(false);
   const [latestId, setLatestId] = useState(LATEST_ANNOUNCEMENT_ID);
 
@@ -67,25 +45,62 @@ export default function AnnouncementBadge({
     return () => window.removeEventListener("sc-news-seen", check);
   }, []);
 
-  if (!unread) return null;
-
   const markSeen = () => {
     try {
       localStorage.setItem(ANNOUNCEMENT_SEEN_KEY, latestId);
     } catch {}
     setUnread(false);
+    window.dispatchEvent(new Event("sc-news-seen"));
   };
+
+  return { unread, markSeen };
+}
+
+function MegaphoneIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M3 11v3a1 1 0 0 0 1 1h2l3.5 4.5a1 1 0 0 0 1.8-.6V5.1a1 1 0 0 0-1.8-.6L6 9H4a1 1 0 0 0-1 1z" />
+      <path d="M15 9c1.2 1.6 1.2 4.4 0 6" />
+      <path d="M18 6c2.7 3.2 2.7 8.8 0 12" />
+    </svg>
+  );
+}
+
+export default function AnnouncementBadge({
+  variant = "desktop",
+}: {
+  variant?: "desktop" | "mobile";
+}) {
+  const { unread, markSeen } = useAnnouncementUnread();
+
+  if (!unread) return null;
 
   if (variant === "mobile") {
     return (
-      <Link
-        href="/news?tab=codex"
-        onClick={markSeen}
-        className="flex items-center gap-2 text-lg font-semibold text-[var(--accent-gold)]"
-      >
-        <MegaphoneIcon />
-        <span>What&apos;s new</span>
-      </Link>
+      <div className="border-b border-[var(--border-subtle)] px-5 py-3">
+        <Link
+          href="/news?tab=codex"
+          onClick={markSeen}
+          className="flex items-center gap-2 text-lg font-semibold text-[var(--accent-gold)]"
+        >
+          <MegaphoneIcon />
+          <span>What&apos;s new</span>
+          <span className="relative flex h-2 w-2">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-[var(--accent-gold)] opacity-75" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-[var(--accent-gold)]" />
+          </span>
+        </Link>
+      </div>
     );
   }
 

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -7,7 +7,7 @@ import LanguageSelector from "./LanguageSelector";
 import SearchTrigger from "./SearchTrigger";
 import SiteSwitcher from "./SiteSwitcher";
 import LiveNavButton from "./LiveNavButton";
-import AnnouncementBadge from "./AnnouncementBadge";
+import AnnouncementBadge, { useAnnouncementUnread } from "./AnnouncementBadge";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { useAuth } from "@/app/contexts/AuthContext";
 import DiscordIcon from "./DiscordIcon";
@@ -196,6 +196,7 @@ export default function Navbar() {
   const { user, loading: authLoading, loginSteam, loginDiscord, logout } = useAuth();
   const [open, setOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
+  const { unread: newsUnread } = useAnnouncementUnread();
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const menuRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -540,7 +541,7 @@ export default function Navbar() {
             <button
               ref={buttonRef}
               onClick={() => setOpen(!open)}
-              className="inline-flex items-center justify-center h-9 w-9 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:border-[var(--border-accent)] transition-colors"
+              className="relative inline-flex items-center justify-center h-9 w-9 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:border-[var(--border-accent)] transition-colors"
               aria-label={t("Toggle menu", lang)}
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -550,6 +551,12 @@ export default function Navbar() {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
                 )}
               </svg>
+              {newsUnread && !open && (
+                <span className="absolute -top-1 -right-1 flex h-2.5 w-2.5" aria-hidden>
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-[var(--accent-gold)] opacity-75" />
+                  <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-[var(--accent-gold)]" />
+                </span>
+              )}
             </button>
 
             {/* Dropdown menu, `right-0` anchors to the burger's relative
@@ -648,9 +655,10 @@ export default function Navbar() {
                     );
                   })}
 
+                  <AnnouncementBadge variant="mobile" />
+
                   <div className="border-b border-[var(--border-subtle)] px-5 py-3">
                     <LiveNavButton variant="mobile" />
-                    <AnnouncementBadge variant="mobile" />
                   </div>
 
                   <ThemeToggle variant="segmented" />


### PR DESCRIPTION
The mobile What's new link moves out of the Live row into its own bordered row with a pulse dot, and the burger button itself shows a small gold ping while there's an unseen announcement so mobile users know to open the menu.