### PR TITLE
Run the cheat sweep in the background, drop ads and replay noise from admin

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -15,6 +15,8 @@ Every hit is audit-logged with the admin's identity.
 
 import logging
 import os
+import threading
+import time
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, Request
@@ -382,99 +384,166 @@ def runs_search(
     return result
 
 
-@router.post("/runs/cheat-sweep")
-def runs_cheat_sweep(request: Request, dry_run: bool = True, limit: int = 500):
-    """Scan existing runs for the submit-time cheat signals (stacked relic
-    copies, boss-teleport wins) and hide the matches. dry_run=true (the
-    default) only lists what would be hidden."""
-    _audit(request)
-    if not os.environ.get("MONGO_URL", "").strip():
-        return {"dry_run": dry_run, "flagged": [], "hidden": 0}
+_SWEEP_STATE_KEY = "cheatsweep:state"
+_SWEEP_STARTING = threading.Lock()
+
+
+def _sweep_set(state: dict) -> None:
+    app_cache.set_json(_SWEEP_STATE_KEY, state, ttl_seconds=3600)
+
+
+def _run_cheat_sweep(dry_run: bool, limit: int) -> None:
+    """The actual scans, on a background thread: they walk the whole runs
+    collection (minutes, not seconds), and a synchronous response died at
+    Cloudflare's 100-second ceiling. State lives in Redis so any worker can
+    answer the status poll."""
     from ..services.cheat_detect import MAX_RELIC_COPIES, MIN_WIN_SECONDS
     from ..services.runs_db_mongo import get_database, set_run_hidden
 
-    db = get_database()["runs"]
-    flagged: dict[str, str] = {}
+    t0 = time.time()
+    try:
+        db = get_database()["runs"]
+        flagged: dict[str, str] = {}
 
-    # Stacked relics: any doc whose relics.id list has duplicates at all
-    # (cheap server-side set test), then verify the real ceiling in Python.
-    dupe_candidates = db.find(
-        {
-            "hidden": {"$ne": True},
-            "$expr": {
-                "$gt": [
-                    {"$size": {"$ifNull": ["$relics", []]}},
-                    {"$size": {"$setUnion": [{"$ifNull": ["$relics.id", []]}, []]}},
-                ]
-            },
-        },
-        {"relics.id": 1, "run_hash": 1},
-    ).limit(2000)
-    for d in dupe_candidates:
-        counts: dict[str, int] = {}
-        for r in d.get("relics") or []:
-            rid = str(r.get("id") or "")
-            counts[rid] = counts.get(rid, 0) + 1
-        worst = max(counts.items(), key=lambda kv: kv[1], default=("", 0))
-        if worst[1] > MAX_RELIC_COPIES:
+        # Stacked relics: any doc whose relics.id list has duplicates at all
+        # (cheap server-side set test), then verify the real ceiling in Python.
+        dupe_candidates = (
+            db.find(
+                {
+                    "hidden": {"$ne": True},
+                    "$expr": {
+                        "$gt": [
+                            {"$size": {"$ifNull": ["$relics", []]}},
+                            {
+                                "$size": {
+                                    "$setUnion": [{"$ifNull": ["$relics.id", []]}, []]
+                                }
+                            },
+                        ]
+                    },
+                },
+                {"relics.id": 1, "run_hash": 1},
+            )
+            .limit(2000)
+            .max_time_ms(300_000)
+        )
+        for d in dupe_candidates:
+            counts: dict[str, int] = {}
+            for r in d.get("relics") or []:
+                rid = str(r.get("id") or "")
+                counts[rid] = counts.get(rid, 0) + 1
+            worst = max(counts.items(), key=lambda kv: kv[1], default=("", 0))
+            if worst[1] > MAX_RELIC_COPIES:
+                h = d.get("run_hash") or d["_id"]
+                flagged[h] = f"duplicate_relics:{worst[0]}x{worst[1]}"
+
+        # Path-shaped win cheats (boss teleports, missing act bosses): cheap doc
+        # prefilters, then the exact submit-time detector over the stored history.
+        from ..services.cheat_detect import detect_cheats
+
+        win_candidates = (
+            db.find(
+                {
+                    "hidden": {"$ne": True},
+                    "win": True,
+                    "$or": [
+                        {"floors_reached": {"$gt": 0, "$lt": 40}},
+                        {"acts_completed": {"$lt": 3}},
+                    ],
+                },
+                {"map_point_history": 1, "run_time": 1, "game_mode": 1, "run_hash": 1},
+            )
+            .limit(4000)
+            .max_time_ms(300_000)
+        )
+        for d in win_candidates:
+            reasons = detect_cheats(
+                {
+                    "win": True,
+                    "run_time": d.get("run_time"),
+                    "game_mode": d.get("game_mode"),
+                    "map_point_history": d.get("map_point_history") or [],
+                }
+            )
+            if reasons:
+                h = d.get("run_hash") or d["_id"]
+                flagged.setdefault(h, reasons[0])
+
+        # Impossible-time wins: pure doc query, no verification needed.
+        for d in (
+            db.find(
+                {
+                    "hidden": {"$ne": True},
+                    "win": True,
+                    "run_time": {"$gt": 0, "$lt": MIN_WIN_SECONDS},
+                },
+                {"run_time": 1, "run_hash": 1},
+            )
+            .limit(2000)
+            .max_time_ms(300_000)
+        ):
             h = d.get("run_hash") or d["_id"]
-            flagged[h] = f"duplicate_relics:{worst[0]}x{worst[1]}"
+            flagged.setdefault(h, f"impossible_time:{int(d.get('run_time') or 0)}s")
 
-    # Path-shaped win cheats (boss teleports, missing act bosses): cheap doc
-    # prefilters, then the exact submit-time detector over the stored history.
-    from ..services.cheat_detect import detect_cheats
-
-    win_candidates = db.find(
-        {
-            "hidden": {"$ne": True},
-            "win": True,
-            "$or": [
-                {"floors_reached": {"$gt": 0, "$lt": 40}},
-                {"acts_completed": {"$lt": 3}},
-            ],
-        },
-        {"map_point_history": 1, "run_time": 1, "game_mode": 1, "run_hash": 1},
-    ).limit(4000)
-    for d in win_candidates:
-        reasons = detect_cheats(
+        items = sorted(flagged.items())[:limit]
+        hidden = 0
+        if not dry_run:
+            for h, reason in items:
+                set_run_hidden(h, True)
+                db.update_many(
+                    {"$or": [{"_id": h}, {"run_hash": h}]},
+                    {"$set": {"hidden_reason": "auto:" + reason}},
+                )
+                hidden += 1
+        _sweep_set(
             {
-                "win": True,
-                "run_time": d.get("run_time"),
-                "game_mode": d.get("game_mode"),
-                "map_point_history": d.get("map_point_history") or [],
+                "state": "done",
+                "dry_run": dry_run,
+                "flagged": [{"run_hash": h, "reason": r} for h, r in items],
+                "hidden": hidden,
+                "seconds": round(time.time() - t0, 1),
             }
         )
-        if reasons:
-            h = d.get("run_hash") or d["_id"]
-            flagged.setdefault(h, reasons[0])
+    except Exception as exc:
+        logger.warning("cheat sweep failed", exc_info=True)
+        _sweep_set(
+            {
+                "state": "error",
+                "error": str(exc),
+                "seconds": round(time.time() - t0, 1),
+            }
+        )
 
-    # Impossible-time wins: pure doc query, no verification needed.
-    for d in db.find(
-        {
-            "hidden": {"$ne": True},
-            "win": True,
-            "run_time": {"$gt": 0, "$lt": MIN_WIN_SECONDS},
-        },
-        {"run_time": 1, "run_hash": 1},
-    ).limit(2000):
-        h = d.get("run_hash") or d["_id"]
-        flagged.setdefault(h, f"impossible_time:{int(d.get('run_time') or 0)}s")
 
-    items = sorted(flagged.items())[:limit]
-    hidden = 0
-    if not dry_run:
-        for h, reason in items:
-            set_run_hidden(h, True)
-            db.update_many(
-                {"$or": [{"_id": h}, {"run_hash": h}]},
-                {"$set": {"hidden_reason": "auto:" + reason}},
-            )
-            hidden += 1
-    return {
-        "dry_run": dry_run,
-        "flagged": [{"run_hash": h, "reason": r} for h, r in items],
-        "hidden": hidden,
-    }
+@router.post("/runs/cheat-sweep")
+def runs_cheat_sweep(request: Request, dry_run: bool = True, limit: int = 500):
+    """Kick the cheat sweep on a background thread; poll the GET endpoint for
+    progress and results. dry_run=true (the default) only lists what would
+    be hidden."""
+    _audit(request)
+    if not os.environ.get("MONGO_URL", "").strip():
+        return {"state": "unavailable"}
+    with _SWEEP_STARTING:
+        current = app_cache.get_json(_SWEEP_STATE_KEY) or {}
+        if current.get("state") == "running":
+            return current
+        state = {"state": "running", "dry_run": dry_run, "started_at": time.time()}
+        _sweep_set(state)
+    threading.Thread(
+        target=_run_cheat_sweep, args=(dry_run, limit), daemon=True
+    ).start()
+    return state
+
+
+@router.get("/runs/cheat-sweep")
+def runs_cheat_sweep_status(request: Request):
+    """Current sweep state: running (with elapsed seconds), done (with the
+    flagged list), error, or idle if none has been kicked."""
+    _audit(request)
+    out = app_cache.get_json(_SWEEP_STATE_KEY) or {"state": "idle"}
+    if out.get("state") == "running" and out.get("started_at"):
+        out["seconds"] = round(time.time() - out["started_at"], 1)
+    return out
 
 
 @router.delete("/runs/{run_hash}")

--- a/frontend/app/admin/runs/RunsClient.tsx
+++ b/frontend/app/admin/runs/RunsClient.tsx
@@ -158,23 +158,60 @@ export default function RunsClient() {
     }
   }
 
+  interface SweepState {
+    state: "idle" | "running" | "done" | "error" | "unavailable";
+    dry_run?: boolean;
+    flagged?: { run_hash: string; reason: string }[];
+    hidden?: number;
+    seconds?: number;
+    error?: string;
+  }
+
   async function cheatSweep(dryRun: boolean) {
     if (!dryRun && !confirm("Hide every run the sweep flags? They leave all stats and leaderboards.")) return;
     setBusy(true);
     setNote(null);
     try {
-      const data = await adminFetch<{ flagged: { run_hash: string; reason: string }[]; hidden: number; dry_run: boolean }>(
-        `/api/admin/runs/cheat-sweep?dry_run=${dryRun}`,
-        { method: "POST" },
-      );
-      setRows(
-        data.flagged.map((f) => ({ run_hash: f.run_hash, hidden_reason: f.reason, hidden: !data.dry_run })),
-      );
-      setNote(
-        data.dry_run
-          ? `Sweep would hide ${data.flagged.length} runs (stacked relics, boss teleports). Run it for real to hide them.`
-          : `Hid ${data.hidden} runs.`,
-      );
+      // The sweep walks the whole collection on a background thread; poll
+      // the status endpoint instead of holding one request open past the
+      // edge's 100s ceiling.
+      await adminFetch<SweepState>(`/api/admin/runs/cheat-sweep?dry_run=${dryRun}`, {
+        method: "POST",
+      });
+      const t0 = Date.now();
+      for (;;) {
+        await new Promise((r) => setTimeout(r, 3000));
+        const st = await adminFetch<SweepState>(`/api/admin/runs/cheat-sweep`);
+        if (st.state === "done") {
+          setRows(
+            (st.flagged ?? []).map((f) => ({
+              run_hash: f.run_hash,
+              hidden_reason: f.reason,
+              hidden: !st.dry_run,
+            })),
+          );
+          setNote(
+            st.dry_run
+              ? `Sweep would hide ${st.flagged?.length ?? 0} runs (took ${st.seconds}s). Run it for real to hide them.`
+              : `Hid ${st.hidden ?? 0} runs in ${st.seconds}s.`,
+          );
+          return;
+        }
+        if (st.state === "error") {
+          setNote(`Sweep failed: ${st.error ?? "unknown"}`);
+          return;
+        }
+        if (st.state !== "running") {
+          setNote("Sweep state lost; kick it again.");
+          return;
+        }
+        const elapsed = Math.round((Date.now() - t0) / 1000);
+        setNote(`Sweep running… ${elapsed}s`);
+        if (elapsed > 600) {
+          setNote("Sweep still running after 10 minutes; reload later to check.");
+          return;
+        }
+      }
     } catch (e) {
       setNote(String((e as Error)?.message || e));
     } finally {

--- a/frontend/app/components/NitroAnchor.tsx
+++ b/frontend/app/components/NitroAnchor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { usePathname } from "next/navigation";
 
 declare global {
   interface Window {
@@ -14,8 +15,15 @@ declare global {
  * floating bottom anchor. The head stub queues this call if the loader
  * hasn't arrived yet, and data-spa="auto" keeps it fresh across
  * client-side navigations. Config mirrors the placement builder output. */
+const AD_FREE_PREFIXES = ["/admin", "/deck-lab", "/seed-lab"];
+
 export default function NitroAnchor() {
+  const pathname = usePathname();
+  const adFree = AD_FREE_PREFIXES.some((p) => pathname?.startsWith(p));
   useEffect(() => {
+    // Landing on an operator or hidden-lab page skips the unit entirely;
+    // ads have no business on the admin console.
+    if (adFree) return;
     window.nitroAds?.createAd("scnp-anchor", {
       format: "anchor-v2",
       anchor: "bottom",
@@ -31,6 +39,6 @@ export default function NitroAnchor() {
         position: "top-right",
       },
     });
-  }, []);
+  }, [adFree]);
   return null;
 }

--- a/frontend/instrumentation-client.ts
+++ b/frontend/instrumentation-client.ts
@@ -17,10 +17,9 @@ Sentry.init({
   // Enable logs to be sent to Sentry
   enableLogs: true,
 
-  // Define how likely Replay events are sampled.
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
+  // Error replays only: sampling 10% of ALL sessions burned the Sentry
+  // quota, and every visitor's console then filled with envelope 429s.
+  replaysSessionSampleRate: 0,
 
   // Define how likely Replay events are sampled when an error occurs.
   replaysOnErrorSampleRate: 1.0,


### PR DESCRIPTION
The cheat sweep's full-collection scans now run on a background thread with Redis-backed state and a polling status endpoint (the synchronous version died at Cloudflare's 100-second ceiling, which is why the button appeared to do nothing), the ad anchor no longer loads on admin or hidden lab pages, and session replays sample at zero so the Sentry quota stops filling every visitor's console with 429s.