### PR TITLE
Remove the dead Turso code path and unused backend deps

### DIFF
--- a/backend/app/services/runs_db.py
+++ b/backend/app/services/runs_db.py
@@ -1,12 +1,8 @@
-"""Community run database — local SQLite or Turso (libSQL).
+"""Community run database — legacy local SQLite fallback.
 
-Connection strategy: when TURSO_URL is set, `get_conn()` returns a
-libsql_experimental connection (drop-in sqlite3 API) pointed at Turso.
-Otherwise it falls back to the legacy local SQLite file at DATA_DIR/runs.db.
-
-This lets us flip a single host to Turso by setting an env var, with no
-changes at call sites. Once Turso has proven stable in prod, the sqlite
-fallback and the data/runs.db volume mount can be removed.
+Prod runs on MongoDB: the re-exports at the bottom of this module route the
+high-level entry points to runs_db_mongo when MONGO_URL is set. Without
+MONGO_URL everything falls back to the local SQLite file at DATA_DIR/runs.db.
 """
 
 import hashlib
@@ -31,112 +27,14 @@ def get_db_path() -> Path:
     return DB_PATH
 
 
-def _using_turso() -> bool:
-    """Single source of truth for "are we on Turso right now". Trimmed so
-    an accidental TURSO_URL=" " doesn't half-activate the libsql path.
-    """
-    return bool(os.environ.get("TURSO_URL", "").strip())
-
-
-class _DictRowCursor:
-    """Wraps a libsql cursor so fetchone()/fetchall() return dicts. The
-    underlying Connection in libsql_experimental doesn't accept a
-    `row_factory` attribute (it's a Rust-backed object), so we adapt at
-    the cursor level instead. Dict semantics match what sqlite3.Row gave
-    us, which the rest of this module relies on (`row["run_hash"]`).
-    """
-
-    def __init__(self, cursor):
-        self._cursor = cursor
-
-    def _to_dict(self, row):
-        if row is None:
-            return None
-        desc = self._cursor.description or ()
-        return {d[0]: row[i] for i, d in enumerate(desc)}
-
-    def fetchone(self):
-        return self._to_dict(self._cursor.fetchone())
-
-    def fetchall(self):
-        return [self._to_dict(r) for r in self._cursor.fetchall()]
-
-    def __iter__(self):
-        for row in self._cursor:
-            yield self._to_dict(row)
-
-    def __getattr__(self, name):
-        return getattr(self._cursor, name)
-
-
-class _DictRowConn:
-    """Wraps a libsql Connection so every .execute() returns a
-    _DictRowCursor. Everything else (commit, rollback, close,
-    executescript, executemany) passes through to the wrapped connection.
-    """
-
-    def __init__(self, conn):
-        self._conn = conn
-
-    def execute(self, *args, **kwargs):
-        return _DictRowCursor(self._conn.execute(*args, **kwargs))
-
-    def __getattr__(self, name):
-        return getattr(self._conn, name)
-
-
 @contextmanager
 def get_conn():
-    """Yield a DB connection. Commits on clean exit, rolls back on exception.
-    Routes to Turso when TURSO_URL is set, local SQLite otherwise.
-    """
-    if _using_turso():
-        # Lazy import so dev environments that haven't pip-installed
-        # libsql can still run on the sqlite path. Using the official
-        # `libsql` package (not `libsql-experimental`, which ships an
-        # empty cursor.description and breaks dict-row mapping).
-        import libsql
-
-        # Embedded replica mode: when TURSO_LOCAL_REPLICA is set to a
-        # filesystem path, libsql keeps a local SQLite copy of the
-        # database and syncs it from Turso in the background. All reads
-        # hit the local file (zero Turso row-reads metered — the whole
-        # point of moving here). Writes still go to Turso, then
-        # propagate back to this replica on the next sync tick.
-        #
-        # Unset → direct mode (every query is a network round-trip,
-        # every row read is metered). Kept as a fallback because the
-        # first time this code runs we want it to be flippable per host
-        # via the .env file rather than a code change.
-        local_replica = os.environ.get("TURSO_LOCAL_REPLICA", "").strip()
-        if local_replica:
-            raw = libsql.connect(
-                local_replica,
-                sync_url=os.environ["TURSO_URL"],
-                auth_token=os.environ.get("TURSO_AUTH_TOKEN", ""),
-                # 30s sync is a reasonable balance for our case: writes
-                # from one origin appear on the other origin's reads
-                # within half a minute, which is fine for community
-                # stats and run-share flows (the run hash is immediately
-                # available to the submitter via the response; only
-                # third-party viewers of a shared URL would notice the
-                # window, and session affinity pins them anyway).
-                sync_interval=30,
-            )
-        else:
-            raw = libsql.connect(
-                os.environ["TURSO_URL"],
-                auth_token=os.environ.get("TURSO_AUTH_TOKEN", ""),
-            )
-        conn = _DictRowConn(raw)
-        # Skip PRAGMA journal_mode=WAL — Turso handles concurrency
-        # natively, and the pragma would burn a network round-trip.
-        # Foreign keys are enforced by default on Turso.
-    else:
-        conn = sqlite3.connect(str(get_db_path()), timeout=10)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute("PRAGMA foreign_keys=ON")
+    """Yield a SQLite connection. Commits on clean exit, rolls back on
+    exception."""
+    conn = sqlite3.connect(str(get_db_path()), timeout=10)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
     try:
         yield conn
         conn.commit()
@@ -416,12 +314,9 @@ def _submit_player_run(
         run_id = cursor.lastrowid
 
         # Batch all child-table inserts via executemany. A typical run has
-        # ~25 cards + ~5 relics + ~35 card choices + ~8 potions, and the
-        # previous per-row `conn.execute(INSERT ...)` loops sent each row
-        # as its own libsql operation — ~70 round trips per submission.
-        # executemany collapses each table's inserts into one batched op,
-        # cutting submission latency 3-5× and making Overwolf launch
-        # backlog uploads (users with 100+ saved runs) plausible.
+        # ~25 cards + ~5 relics + ~35 card choices + ~8 potions; batching
+        # each table's inserts into one op cuts submission latency 3-5×
+        # versus per-row execute loops.
 
         # Cards
         card_rows = [
@@ -876,7 +771,7 @@ init_db()
 # elsewhere in the codebase resolves to the Mongo version. The SQLite
 # defs above still exist as fallbacks and are kept reachable via
 # get_conn() for the few routers that issue raw SQL against the legacy
-# tables during the migration window.
+# tables.
 if os.environ.get("MONGO_URL", "").strip():
     # noqa: F401, F811 — these rebind module-level names defined above
     # so callers doing `from .runs_db import submit_run` get the Mongo

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,5 @@
 fastapi==0.135.1
 uvicorn==0.41.0
-sqlalchemy==2.0.48
-aiosqlite==0.22.1
 pydantic==2.12.5
 slowapi==0.1.9
 httpx==0.28.1
@@ -9,7 +7,6 @@ python-frontmatter==1.1.0
 sentry-sdk[fastapi]==2.19.2
 prometheus-fastapi-instrumentator==7.0.2
 pyjwt[crypto]==2.10.1
-libsql==0.1.11
 pymongo==4.10.1
 python-multipart==0.0.20
 boto3>=1.34,<2

--- a/backend/tests/test_runs_db.py
+++ b/backend/tests/test_runs_db.py
@@ -1,0 +1,54 @@
+"""The SQLite fallback stands alone: schema init plus a read/write round
+trip through get_conn(), against a throwaway DATA_DIR."""
+
+import importlib
+import sqlite3
+
+
+def _load_runs_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("MONGO_URL", raising=False)
+    import app.services.runs_db as runs_db
+
+    return importlib.reload(runs_db)
+
+
+def test_get_conn_round_trip(tmp_path, monkeypatch):
+    runs_db = _load_runs_db(tmp_path, monkeypatch)
+    assert (tmp_path / "runs.db").exists()
+
+    with runs_db.get_conn() as conn:
+        assert isinstance(conn, sqlite3.Connection)
+        conn.execute(
+            "INSERT INTO runs (run_hash, seed, character, win) VALUES (?, ?, ?, ?)",
+            ("abc123", "SEED1", "IRONCLAD", 1),
+        )
+
+    with runs_db.get_conn() as conn:
+        row = conn.execute(
+            "SELECT run_hash, character, win FROM runs WHERE run_hash = ?",
+            ("abc123",),
+        ).fetchone()
+    assert row["run_hash"] == "abc123"
+    assert row["character"] == "IRONCLAD"
+    assert row["win"] == 1
+
+
+def test_get_conn_rolls_back_on_error(tmp_path, monkeypatch):
+    runs_db = _load_runs_db(tmp_path, monkeypatch)
+
+    try:
+        with runs_db.get_conn() as conn:
+            conn.execute(
+                "INSERT INTO runs (run_hash, seed, character, win) VALUES (?, ?, ?, ?)",
+                ("rollback1", "SEED2", "SILENT", 0),
+            )
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+
+    with runs_db.get_conn() as conn:
+        row = conn.execute(
+            "SELECT 1 FROM runs WHERE run_hash = ?", ("rollback1",)
+        ).fetchone()
+    assert row is None


### PR DESCRIPTION
I deleted the unreachable Turso/libSQL branch from runs_db.py (get_conn is plain SQLite again), dropped libsql plus the never-imported sqlalchemy and aiosqlite from requirements, and added tests covering the SQLite fallback round trip and rollback.