### PR TITLE
Harden the prod and monitoring compose files

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -15,7 +15,8 @@ name: spire-codex-monitoring
 
 services:
   node-exporter:
-    image: prom/node-exporter:latest
+    # Pinned: an unattended :latest pull can silently break metrics shipping.
+    image: prom/node-exporter:v1.12.1
     container_name: node-exporter
     restart: unless-stopped
     network_mode: host
@@ -44,7 +45,8 @@ services:
   #   CF_ACCESS_CLIENT_ID=<id>.access
   #   CF_ACCESS_CLIENT_SECRET=<secret>
   alloy:
-    image: grafana/alloy:latest
+    # Pinned: an unattended :latest pull can silently break log shipping.
+    image: grafana/alloy:v1.18.0
     container_name: alloy
     restart: unless-stopped
     command: run --server.http.listen-addr=0.0.0.0:12345 /etc/alloy/config.alloy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,9 +1,47 @@
 name: spire-codex
 
+# Env shared verbatim by the backend and rebuilder services: both must see
+# the same data dirs and stats knobs so they build the same snapshot shape.
+x-shared-env: &shared-env
+  DATA_DIR: /data
+  BETA_DATA_DIR: /data-beta
+  # Parallelize the entity-stats snapshot rebuild across N cores. 1 = off
+  # (the serial ~80min walk); capped at the box's CPU count. Set the value
+  # in the box .env after validating with scripts/validate_parallel_rebuild.py.
+  ENTITY_STATS_REBUILD_WORKERS: ${ENTITY_STATS_REBUILD_WORKERS:-1}
+  # Optional cap on how many release versions keep their own per-version
+  # stats bucket. Empty = code default (unbounded: every release version
+  # with a run stays in the stats-page version dropdowns). Setting N drops
+  # versions older than the newest N from the dropdowns and the
+  # /api/runs/list version filter, in exchange for fewer per-version Elo
+  # fits and blob shards per rebuild/persist.
+  ENTITY_STATS_RECENT_VERSIONS_N: ${ENTITY_STATS_RECENT_VERSIONS_N:-}
+  # How often the leader may rerun the heavy walk (seconds). Default 7200
+  # (2h). With the parallel rebuild on, lower it for fresher public numbers,
+  # but keep it well above the observed walk time so the box isn't always
+  # mid-rebuild. Floored at 300s in code.
+  ENTITY_STATS_REBUILD_INTERVAL_SECONDS: ${ENTITY_STATS_REBUILD_INTERVAL_SECONDS:-7200}
+  # One-shot files -> run_blobs backfill on the first lease cycle after
+  # boot; only the refresh-lease holder runs it. Set to off to skip (e.g.
+  # while diagnosing Mongo load).
+  RUN_BLOBS_STARTUP_BACKFILL: "${RUN_BLOBS_STARTUP_BACKFILL:-on}"
+  # MongoDB — when MONGO_URL is set, runs_db.py uses the Mongo path. Falls
+  # through to local /data/runs.db SQLite otherwise.
+  MONGO_URL: ${MONGO_URL:-}
+  # Application cache (issue #388). Fail-safe: unset or unreachable ->
+  # cache calls no-op and the existing data paths run unchanged. Uses the
+  # container name (not the service alias) because prod and beta share
+  # the external nginx_web-network and a bare "redis" alias would be
+  # ambiguous between the two stacks.
+  REDIS_URL: "${REDIS_URL:-redis://spire-codex-redis:6379/0}"
+  SENTRY_DSN: ${SENTRY_DSN:-}
+  ENVIRONMENT: ${ENVIRONMENT:-production}
+
 services:
   backend:
     image: ptrlrd/spire-codex-backend:latest
     container_name: spire-codex-backend
+    restart: unless-stopped
     # Multiple workers so a burst of POST /api/runs (Overwolf launch
     # backfills) doesn't serialise behind a single thread and block
     # everything else (GET /api/runs/stats, /api/runs/list etc.).
@@ -34,94 +72,59 @@ services:
       - ./backend/static:/app/static:ro
       - ./.secrets:/secrets:ro
     environment:
-      - DATA_DIR=/data
-      - BETA_DATA_DIR=/data-beta
-      # Parallelize the entity-stats snapshot rebuild across N cores. 1 = off
-      # (the serial ~80min walk); capped at the box's CPU count. Set the value
-      # in the box .env after validating with scripts/validate_parallel_rebuild.py.
-      - ENTITY_STATS_REBUILD_WORKERS=${ENTITY_STATS_REBUILD_WORKERS:-1}
-      # Optional cap on how many release versions keep their own per-version
-      # stats bucket. Empty = code default (unbounded: every release version
-      # with a run stays in the stats-page version dropdowns). Setting N drops
-      # versions older than the newest N from the dropdowns and the
-      # /api/runs/list version filter, in exchange for fewer per-version Elo
-      # fits and blob shards per rebuild/persist.
-      - ENTITY_STATS_RECENT_VERSIONS_N=${ENTITY_STATS_RECENT_VERSIONS_N:-}
-      # How often the leader may rerun the heavy walk (seconds). Default 7200
-      # (2h). With the parallel rebuild on, lower it for fresher public numbers,
-      # but keep it well above the observed walk time so the box isn't always
-      # mid-rebuild. Floored at 300s in code.
-      - ENTITY_STATS_REBUILD_INTERVAL_SECONDS=${ENTITY_STATS_REBUILD_INTERVAL_SECONDS:-7200}
-      - FEEDBACK_WEBHOOK_URL=${FEEDBACK_WEBHOOK_URL:-}
+      <<: *shared-env
+      FEEDBACK_WEBHOOK_URL: ${FEEDBACK_WEBHOOK_URL:-}
       # Cloudflare purge from the admin cache tab. Same token/zone the
       # autodeploy script uses; set them in the box's .env.
-      - CF_TOKEN=${CF_TOKEN:-}
-      - CF_ZONE=${CF_ZONE:-}
+      CF_TOKEN: ${CF_TOKEN:-}
+      CF_ZONE: ${CF_ZONE:-}
       # Umami analytics on the admin overview, proxied server-side.
-      - UMAMI_URL=${UMAMI_URL:-}
-      - UMAMI_USERNAME=${UMAMI_USERNAME:-}
-      - UMAMI_PASSWORD=${UMAMI_PASSWORD:-}
-      - UMAMI_WEBSITE_ID=${UMAMI_WEBSITE_ID:-}
-      - GUIDE_WEBHOOK_URL=${GUIDE_WEBHOOK_URL:-}
-      - RESEND_API_KEY=${RESEND_API_KEY:-}
-      - UNINSTALL_FORWARD_FROM=${UNINSTALL_FORWARD_FROM:-}
-      - UNINSTALL_FORWARD_TO=${UNINSTALL_FORWARD_TO:-}
-      - R2_ACCESS_KEY_ID=${R2_ACCESS_KEY_ID:-}
-      - R2_SECRET_ACCESS_KEY=${R2_SECRET_ACCESS_KEY:-}
-      - R2_ENDPOINT=${R2_ENDPOINT:-}
-      - R2_BUCKET=${R2_BUCKET:-}
-      - R2_PUBLIC_BASE_URL=${R2_PUBLIC_BASE_URL:-}
-      - SENTRY_DSN=${SENTRY_DSN:-}
-      - ADMIN_IDS=${ADMIN_IDS:-}
+      UMAMI_URL: ${UMAMI_URL:-}
+      UMAMI_USERNAME: ${UMAMI_USERNAME:-}
+      UMAMI_PASSWORD: ${UMAMI_PASSWORD:-}
+      UMAMI_WEBSITE_ID: ${UMAMI_WEBSITE_ID:-}
+      GUIDE_WEBHOOK_URL: ${GUIDE_WEBHOOK_URL:-}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      UNINSTALL_FORWARD_FROM: ${UNINSTALL_FORWARD_FROM:-}
+      UNINSTALL_FORWARD_TO: ${UNINSTALL_FORWARD_TO:-}
+      R2_ACCESS_KEY_ID: ${R2_ACCESS_KEY_ID:-}
+      R2_SECRET_ACCESS_KEY: ${R2_SECRET_ACCESS_KEY:-}
+      R2_ENDPOINT: ${R2_ENDPOINT:-}
+      R2_BUCKET: ${R2_BUCKET:-}
+      R2_PUBLIC_BASE_URL: ${R2_PUBLIC_BASE_URL:-}
+      ADMIN_IDS: ${ADMIN_IDS:-}
       # Server-side secret (in neither repo) so the stored daily DAU hashes
       # aren't brute-forceable back to steam ids. The count works without it,
       # but set it. See routers/telemetry.py.
-      - TELEMETRY_SALT=${TELEMETRY_SALT:-}
+      TELEMETRY_SALT: ${TELEMETRY_SALT:-}
       # Min times a relic must be offered at an Ancient screen before its
       # community take-rate is published to the in-game tip. Empty here ->
       # the code default (20); the beta .env sets it to 1 so take-rates show
       # on a small corpus. See services/community_stats.py.
-      - COMMUNITY_ANCIENT_MIN_OFFERS=${COMMUNITY_ANCIENT_MIN_OFFERS:-}
-      - STEAM_WEB_API_KEY=${STEAM_WEB_API_KEY:-}
-      - GITHUB_APP_ID=${GITHUB_APP_ID:-}
-      - GITHUB_APP_INSTALLATION_ID=${GITHUB_APP_INSTALLATION_ID:-}
-      - GITHUB_APP_REPO=${GITHUB_APP_REPO:-}
-      - GITHUB_APP_PRIVATE_KEY_PATH=${GITHUB_APP_PRIVATE_KEY_PATH:-/secrets/knowledge-demon.private-key.pem}
+      COMMUNITY_ANCIENT_MIN_OFFERS: ${COMMUNITY_ANCIENT_MIN_OFFERS:-}
+      STEAM_WEB_API_KEY: ${STEAM_WEB_API_KEY:-}
+      GITHUB_APP_ID: ${GITHUB_APP_ID:-}
+      GITHUB_APP_INSTALLATION_ID: ${GITHUB_APP_INSTALLATION_ID:-}
+      GITHUB_APP_REPO: ${GITHUB_APP_REPO:-}
+      GITHUB_APP_PRIVATE_KEY_PATH: ${GITHUB_APP_PRIVATE_KEY_PATH:-/secrets/knowledge-demon.private-key.pem}
       # Card-render QA mount. Set to /data/qa once the rendered PNGs +
       # index.html are rsync'd onto the host volume. Empty/missing →
       # the /qa endpoint isn't registered.
-      - QA_DIR=${QA_DIR:-}
-      # Turso (libSQL) — retired post-Overwolf-launch (round-trip per
-      # write was untenable under burst). Hardcoded empty so the
-      # libsql path stays off.
-      - TURSO_URL=
-      - TURSO_AUTH_TOKEN=
-      - TURSO_LOCAL_REPLICA=
-      # MongoDB — when MONGO_URL is set, runs_db.py uses the Mongo
-      # path. Falls through to local /data/runs.db SQLite otherwise
-      # (the current state while the migration is in progress).
-      - MONGO_URL=${MONGO_URL:-}
-      # Application cache (issue #388). Fail-safe: unset or unreachable ->
-      # cache calls no-op and the existing data paths run unchanged. Uses the
-      # container name (not the service alias) because prod and beta share
-      # the external nginx_web-network and a bare "redis" alias would be
-      # ambiguous between the two stacks.
-      - REDIS_URL=${REDIS_URL:-redis://spire-codex-redis:6379/0}
+      QA_DIR: ${QA_DIR:-}
       # User accounts (Steam/Discord/Twitch OAuth + JWT sessions). Values live
       # in the host .env; passed through so the auth endpoints work.
-      - JWT_SECRET=${JWT_SECRET:-}
-      - DISCORD_CLIENT_ID=${DISCORD_CLIENT_ID:-}
-      - DISCORD_CLIENT_SECRET=${DISCORD_CLIENT_SECRET:-}
-      - TWITCH_CLIENT_ID=${TWITCH_CLIENT_ID:-}
-      - TWITCH_CLIENT_SECRET=${TWITCH_CLIENT_SECRET:-}
+      JWT_SECRET: ${JWT_SECRET:-}
+      DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID:-}
+      DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET:-}
+      TWITCH_CLIENT_ID: ${TWITCH_CLIENT_ID:-}
+      TWITCH_CLIENT_SECRET: ${TWITCH_CLIENT_SECRET:-}
       # Patreon link for the paid API-key tier (auth_patreon router). Unset =
       # the feature stays dormant (connect bounces with patreon_unconfigured).
-      - PATREON_CLIENT_ID=${PATREON_CLIENT_ID:-}
-      - PATREON_CLIENT_SECRET=${PATREON_CLIENT_SECRET:-}
-      - PATREON_WEBHOOK_SECRET=${PATREON_WEBHOOK_SECRET:-}
-      - FRONTEND_URL=${FRONTEND_URL:-https://spire-codex.com}
-      - SPIRE_CODEX_PUBLIC_BASE=${SPIRE_CODEX_PUBLIC_BASE:-https://spire-codex.com}
-      - ENVIRONMENT=${ENVIRONMENT:-production}
+      PATREON_CLIENT_ID: ${PATREON_CLIENT_ID:-}
+      PATREON_CLIENT_SECRET: ${PATREON_CLIENT_SECRET:-}
+      PATREON_WEBHOOK_SECRET: ${PATREON_WEBHOOK_SECRET:-}
+      FRONTEND_URL: "${FRONTEND_URL:-https://spire-codex.com}"
+      SPIRE_CODEX_PUBLIC_BASE: "${SPIRE_CODEX_PUBLIC_BASE:-https://spire-codex.com}"
       # prometheus_client multiprocess mode. Set in the env (not the
       # CMD) so it's exported into every worker as a real env var
       # before prometheus_client is imported. The dir is recreated +
@@ -133,20 +136,17 @@ services:
       # per-pid. Any Grafana panel reading those metrics must switch
       # to node_exporter (`node_cpu_*`, `node_memory_*`) or cAdvisor
       # (`container_cpu_*`, `container_memory_*`).
-      - PROMETHEUS_MULTIPROC_DIR=/tmp/prom_multiproc
+      PROMETHEUS_MULTIPROC_DIR: /tmp/prom_multiproc
       # The heavy stats walk runs only in the rebuilder service below, so a
       # web deploy recreating this container no longer kills an in-flight
       # rebuild (which is how the snapshot sat stale for days). Set
       # BACKEND_STATS_REFRESHER=on in the box .env to revert to the old
       # single-container behavior.
-      - STATS_REFRESHER=${BACKEND_STATS_REFRESHER:-off}
-      # Only matters if BACKEND_STATS_REFRESHER=on (lease holders run the
-      # run_blobs startup backfill); see the rebuilder service.
-      - RUN_BLOBS_STARTUP_BACKFILL=${RUN_BLOBS_STARTUP_BACKFILL:-on}
+      STATS_REFRESHER: "${BACKEND_STATS_REFRESHER:-off}"
       # Workers AI credentials for /api/search/semantic and the
       # build_embeddings corpus script; unset leaves semantic search off.
-      - WORKERS_AI_TOKEN=${WORKERS_AI_TOKEN:-}
-      - CF_ACCOUNT_ID=${CF_ACCOUNT_ID:-}
+      WORKERS_AI_TOKEN: ${WORKERS_AI_TOKEN:-}
+      CF_ACCOUNT_ID: ${CF_ACCOUNT_ID:-}
     # Ordering only (no health condition): the backend must boot fine with
     # Redis down, since the cache layer is fail-safe by design.
     depends_on:
@@ -169,6 +169,7 @@ services:
   rebuilder:
     image: ptrlrd/spire-codex-backend:latest
     container_name: spire-codex-rebuilder
+    restart: unless-stopped
     command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001"]
     volumes:
       - ./data:/data
@@ -176,21 +177,8 @@ services:
       - ./backend/static:/app/static:ro
       - ./.secrets:/secrets:ro
     environment:
-      - DATA_DIR=/data
-      - BETA_DATA_DIR=/data-beta
-      - STATS_REFRESHER=on
-      # One-shot files -> run_blobs backfill on the first lease cycle after
-      # boot. Set to off to skip (e.g. while diagnosing Mongo load).
-      - RUN_BLOBS_STARTUP_BACKFILL=${RUN_BLOBS_STARTUP_BACKFILL:-on}
-      - ENTITY_STATS_REBUILD_WORKERS=${ENTITY_STATS_REBUILD_WORKERS:-1}
-      # See the backend service: optional cap on per-version stats buckets.
-      # Must match the backend's value so both build the same snapshot shape.
-      - ENTITY_STATS_RECENT_VERSIONS_N=${ENTITY_STATS_RECENT_VERSIONS_N:-}
-      - ENTITY_STATS_REBUILD_INTERVAL_SECONDS=${ENTITY_STATS_REBUILD_INTERVAL_SECONDS:-7200}
-      - MONGO_URL=${MONGO_URL:-}
-      - REDIS_URL=${REDIS_URL:-redis://spire-codex-redis:6379/0}
-      - SENTRY_DSN=${SENTRY_DSN:-}
-      - ENVIRONMENT=${ENVIRONMENT:-production}
+      <<: *shared-env
+      STATS_REFRESHER: "on"
     depends_on:
       - redis
     networks:
@@ -226,6 +214,7 @@ services:
   frontend:
     image: ptrlrd/spire-codex-frontend:latest
     container_name: spire-codex-frontend
+    restart: unless-stopped
     depends_on:
       - backend
     volumes:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,3 +1,3 @@
 node_modules
 .next
-.env.local
+.env*


### PR DESCRIPTION
I added restart: unless-stopped to backend/rebuilder/frontend (a reboot or OOM-kill no longer leaves the site down until the next deploy), deduplicated the backend/rebuilder env into a shared YAML anchor, dropped the dead TURSO_* lines, pinned the monitoring images, and widened frontend/.dockerignore to .env*; a semantic diff of the rendered config confirms the env sets are unchanged.