### PR TITLE
Exclude hidden runs from export, rank, seed, and profile surfaces

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -271,6 +271,7 @@ def _compute_personal_bests(username: str) -> dict:
     base_match = {
         "username_lower": username.lower() if username else None,
         "win": {"$in": [True, 1]},
+        "hidden": {"$ne": True},
     }
     proj = {
         "_id": 1,

--- a/backend/app/routers/exports.py
+++ b/backend/app/routers/exports.py
@@ -106,6 +106,7 @@ def _build_match(start, end, cursor) -> dict:
     clauses: list[dict] = [
         {"character": {"$in": list(OFFICIAL_CHARACTERS)}},
         {"ascension": {"$gte": 0, "$lte": 10}},
+        {"hidden": {"$ne": True}},
     ]
 
     range_q: dict = {}

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -1417,7 +1417,7 @@ def build_user_blob_stats(username: str) -> dict[str, Any]:
         cursor = (
             _get_collection()
             .find(
-                {"username_lower": u.lower()},
+                {"username_lower": u.lower(), "hidden": {"$ne": True}},
                 {
                     "_id": 1,
                     "character": 1,

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -2382,19 +2382,21 @@ def _leaderboard_live(
 
 @_instrument("get_run_rank")
 def get_run_rank(run_hash: str, category: str = "fastest") -> dict:
-    """Rank of a single winning run within its character's leaderboard."""
+    """Rank of a single winning run within its character's leaderboard.
+    Hidden runs neither rank nor count as ahead, matching /leaderboard."""
     coll = _get_collection()
     row = coll.find_one(
         {"_id": run_hash},
-        {"win": 1, "character": 1, "run_time": 1, "ascension": 1},
+        {"win": 1, "character": 1, "run_time": 1, "ascension": 1, "hidden": 1},
     )
-    if not row or not row.get("win"):
+    if not row or not row.get("win") or row.get("hidden"):
         return {"rank": None}
 
     if category == "highest_ascension":
         ahead = coll.count_documents(
             {
                 "win": {"$in": [True, 1]},
+                "hidden": {"$ne": True},
                 "character": row["character"],
                 "$or": [
                     {"ascension": {"$gt": row.get("ascension", 0)}},
@@ -2409,6 +2411,7 @@ def get_run_rank(run_hash: str, category: str = "fastest") -> dict:
         ahead = coll.count_documents(
             {
                 "win": {"$in": [True, 1]},
+                "hidden": {"$ne": True},
                 "character": row["character"],
                 "run_time": {"$lt": row.get("run_time", 0)},
             }
@@ -2427,7 +2430,7 @@ def seed_rank_for(steam_id: str | None, seed: str) -> dict:
     winning run in that pool.
     """
     coll = _get_collection()
-    base = {"seed": seed, "was_abandoned": {"$ne": True}}
+    base = {"seed": seed, "was_abandoned": {"$ne": True}, "hidden": {"$ne": True}}
     seed_total = coll.count_documents(base)
     seed_wins = coll.count_documents({**base, "win": {"$in": [True, 1]}})
 
@@ -2436,7 +2439,12 @@ def seed_rank_for(steam_id: str | None, seed: str) -> dict:
     percentile = None
     if steam_id:
         mine = coll.find_one(
-            {"seed": seed, "win": {"$in": [True, 1]}, "steam_id": steam_id},
+            {
+                "seed": seed,
+                "win": {"$in": [True, 1]},
+                "hidden": {"$ne": True},
+                "steam_id": steam_id,
+            },
             {"run_time": 1},
             sort=[("run_time", 1)],
         )
@@ -2446,6 +2454,7 @@ def seed_rank_for(steam_id: str | None, seed: str) -> dict:
                     {
                         "seed": seed,
                         "win": {"$in": [True, 1]},
+                        "hidden": {"$ne": True},
                         "run_time": {"$lt": mine.get("run_time", 0)},
                     }
                 )
@@ -2453,16 +2462,19 @@ def seed_rank_for(steam_id: str | None, seed: str) -> dict:
             )
 
         best = coll.find_one(
-            {"win": {"$in": [True, 1]}, "steam_id": steam_id},
+            {"win": {"$in": [True, 1]}, "hidden": {"$ne": True}, "steam_id": steam_id},
             {"run_time": 1},
             sort=[("run_time", 1)],
         )
-        global_total = coll.count_documents({"win": {"$in": [True, 1]}})
+        global_total = coll.count_documents(
+            {"win": {"$in": [True, 1]}, "hidden": {"$ne": True}}
+        )
         if best and global_total:
             global_rank = (
                 coll.count_documents(
                     {
                         "win": {"$in": [True, 1]},
+                        "hidden": {"$ne": True},
                         "run_time": {"$lt": best.get("run_time", 0)},
                     }
                 )
@@ -2470,7 +2482,9 @@ def seed_rank_for(steam_id: str | None, seed: str) -> dict:
             )
             percentile = round(global_rank * 100.0 / global_total, 1)
     else:
-        global_total = coll.count_documents({"win": {"$in": [True, 1]}})
+        global_total = coll.count_documents(
+            {"win": {"$in": [True, 1]}, "hidden": {"$ne": True}}
+        )
 
     return {
         "seed": seed,
@@ -2656,12 +2670,12 @@ def get_run_rank_scoped(
     coll = _get_collection()
     row = coll.find_one(
         {"_id": run_hash},
-        {"win": 1, "character": 1, "run_time": 1, "ascension": 1},
+        {"win": 1, "character": 1, "run_time": 1, "ascension": 1, "hidden": 1},
     )
-    if not row or not row.get("win"):
+    if not row or not row.get("win") or row.get("hidden"):
         return {"rank": None, "total": 0}
 
-    scope: dict[str, Any] = {"win": {"$in": [True, 1]}}
+    scope: dict[str, Any] = {"win": {"$in": [True, 1]}, "hidden": {"$ne": True}}
     if not today_only:
         scope["character"] = row["character"]
     if game_mode:
@@ -2700,7 +2714,12 @@ def get_win_rate_comparison(username: str) -> list[dict]:
     user_chars = list(
         coll.aggregate(
             [
-                {"$match": {"username_lower": username.lower()}},
+                {
+                    "$match": {
+                        "username_lower": username.lower(),
+                        "hidden": {"$ne": True},
+                    }
+                },
                 {
                     "$group": {
                         "_id": "$character",

--- a/backend/tests/test_export_helpers.py
+++ b/backend/tests/test_export_helpers.py
@@ -24,6 +24,7 @@ from app.routers.exports import (
 
 # --- _parse_iso ------------------------------------------------------------
 
+
 def test_parse_iso_aware_passthrough():
     dt = _parse_iso("2026-06-22T19:51:28+00:00", "start")
     assert dt == datetime(2026, 6, 22, 19, 51, 28, tzinfo=timezone.utc)
@@ -41,6 +42,7 @@ def test_parse_iso_rejects_garbage():
 
 
 # --- cursor codec ----------------------------------------------------------
+
 
 def test_cursor_roundtrip_with_timestamp():
     dt = datetime(2026, 6, 22, 19, 51, 28, 664000, tzinfo=timezone.utc)
@@ -79,22 +81,26 @@ def test_decode_cursor_rejects_missing_separator():
 
 # --- _build_match ----------------------------------------------------------
 
+
 def _char_clause(match):
     """Pull the official-character clause out of a match (order-independent)."""
-    clause = match if "character" in match else next(
-        c for c in match["$and"] if "character" in c
+    clause = (
+        match
+        if "character" in match
+        else next(c for c in match["$and"] if "character" in c)
     )
     return set(clause["character"]["$in"])
 
 
 def test_build_match_no_params_is_official_runs_filter():
     match = _build_match(None, None, None)
-    # No range/cursor -> only the baseline official-runs clauses:
-    # official characters and the official ascension range (A11+ is modded).
+    # No range/cursor -> only the baseline clauses: official characters,
+    # the official ascension range (A11+ is modded), and not hidden.
     assert _char_clause(match) == OFFICIAL_CHARACTERS
     ascension_clause = next(c for c in match["$and"] if "ascension" in c)
     assert ascension_clause["ascension"] == {"$gte": 0, "$lte": 10}
-    assert len(match["$and"]) == 2
+    assert {"hidden": {"$ne": True}} in match["$and"]
+    assert len(match["$and"]) == 3
 
 
 def test_build_match_half_open_range():
@@ -131,6 +137,7 @@ def test_build_match_cursor_past_nulls():
 
 # --- _page_params ------------------------------------------------------------
 
+
 def test_page_params_all_absent():
     # Called directly (not via FastAPI), Query defaults are the sentinel
     # objects, so pass the absent values explicitly.
@@ -158,6 +165,7 @@ def test_page_params_rejects_malformed_before_handler():
 
 
 # --- _export_cost ----------------------------------------------------------
+
 
 class _FakeRequest:
     def __init__(self, query):

--- a/backend/tests/test_hidden_filters.py
+++ b/backend/tests/test_hidden_filters.py
@@ -1,0 +1,66 @@
+"""Hidden (cheated/moderated) runs must stay out of every public ranking
+surface: the bulk export, single-run ranks, and the mod's seed panel."""
+
+from app.routers.exports import _build_match
+from app.services import runs_db_mongo
+
+HIDDEN_CLAUSE = {"hidden": {"$ne": True}}
+
+
+class FakeColl:
+    """Captures the filters each query runs with."""
+
+    def __init__(self, row=None):
+        self.row = row
+        self.find_one_queries = []
+        self.count_queries = []
+
+    def find_one(self, q, projection=None, **kwargs):
+        self.find_one_queries.append(q)
+        return self.row
+
+    def count_documents(self, q):
+        self.count_queries.append(q)
+        return 0
+
+
+def test_export_match_excludes_hidden():
+    match = _build_match(None, None, None)
+    assert HIDDEN_CLAUSE in match["$and"]
+
+
+def test_get_run_rank_refuses_hidden_run(monkeypatch):
+    fake = FakeColl(
+        {"win": True, "hidden": True, "character": "IRONCLAD", "run_time": 90}
+    )
+    monkeypatch.setattr(runs_db_mongo, "_get_collection", lambda: fake)
+    assert runs_db_mongo.get_run_rank("h1")["rank"] is None
+    assert fake.count_queries == []
+
+
+def test_get_run_rank_counts_exclude_hidden(monkeypatch):
+    fake = FakeColl({"win": True, "character": "IRONCLAD", "run_time": 90})
+    monkeypatch.setattr(runs_db_mongo, "_get_collection", lambda: fake)
+    out = runs_db_mongo.get_run_rank("h1")
+    assert out["rank"] == 1
+    assert fake.count_queries
+    for q in fake.count_queries:
+        assert q.get("hidden") == {"$ne": True}
+
+
+def test_get_run_rank_scoped_excludes_hidden(monkeypatch):
+    fake = FakeColl({"win": True, "character": "SILENT", "run_time": 120})
+    monkeypatch.setattr(runs_db_mongo, "_get_collection", lambda: fake)
+    out = runs_db_mongo.get_run_rank_scoped("h2", game_mode="standard")
+    assert out["rank"] == 1
+    for q in fake.count_queries:
+        assert q.get("hidden") == {"$ne": True}
+
+
+def test_seed_rank_for_excludes_hidden_everywhere(monkeypatch):
+    fake = FakeColl(None)
+    monkeypatch.setattr(runs_db_mongo, "_get_collection", lambda: fake)
+    runs_db_mongo.seed_rank_for("7656119", "SEEDX")
+    assert fake.count_queries and fake.find_one_queries
+    for q in fake.count_queries + fake.find_one_queries:
+        assert q.get("hidden") == {"$ne": True}, q


### PR DESCRIPTION
I added the hidden filter to the bulk run export, get_run_rank / get_run_rank_scoped (a hidden run no longer ranks or counts as ahead), the mod's seed/global standing panel, per-user win-rate comparison, personal bests, and per-user blob charts, with tests asserting every query carries the clause.