### PR TITLE
Remove finished startup backfills and dead backend helpers

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -234,28 +234,6 @@ def _warm_run_entity_stats() -> None:
             kick_snapshot_load()
         except Exception:
             pass
-        # One-time field backfills for runs that predate a field
-        # (username_lower normalization, the `bought` shop-purchase list),
-        # off the request path (the runs collection is large). Idempotent
-        # via their $exists guards, so running them on every worker is
-        # safe — all but the first are a bounded no-op.
-        import threading
-
-        def _backfill_run_fields():
-            try:
-                from .services.runs_db_mongo import (
-                    backfill_bought,
-                    backfill_username_lower,
-                )
-
-                backfill_username_lower()
-                backfill_bought()
-            except Exception:
-                pass
-
-        threading.Thread(
-            target=_backfill_run_fields, daemon=True, name="run-field-backfill"
-        ).start()
         return
     import threading
 

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -149,18 +149,6 @@ run_export_pages = Counter(
     "Paginated run export page fetches (a bounded ?limit= request)",
 )
 
-# ── Auth ────────────────────────────────────────────────────
-auth_logins = Counter(
-    "spire_codex_auth_logins_total",
-    "User logins",
-    ["provider"],
-)
-auth_signups = Counter(
-    "spire_codex_auth_signups_total",
-    "New account creations",
-    ["provider"],
-)
-
 # ── Compare pages ───────────────────────────────────────────
 compare_views = Counter(
     "spire_codex_compare_views_total",

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -500,25 +500,3 @@ class GuideSummary(BaseModel):
 
 class Guide(GuideSummary):
     content: str
-
-
-class StatsResponse(BaseModel):
-    cards: int
-    characters: int
-    relics: int
-    monsters: int
-    potions: int
-    enchantments: int
-    encounters: int
-    events: int
-    powers: int
-    keywords: int
-    intents: int
-    orbs: int
-    afflictions: int
-    modifiers: int
-    achievements: int
-    epochs: int
-    acts: int
-    ascensions: int
-    images: int

--- a/backend/app/services/rate_limit_config.py
+++ b/backend/app/services/rate_limit_config.py
@@ -267,15 +267,6 @@ def endpoint_defaults() -> dict[str, str]:
     return dict(_ENDPOINT_DEFAULTS)
 
 
-# Back-compat: the browse cap on its own (a handy helper; the limiter uses
-# tier_limit_value now).
-def default_limit_value(*_args, **_kwargs) -> str:
-    cfg = get_config()
-    if not cfg.get("enabled", True):
-        return _DISABLED_LIMIT
-    return cfg.get("default_limit") or _DEFAULT_LIMIT
-
-
 def _validate_limit(value: str, field: str) -> str:
     from limits import parse
 

--- a/backend/app/services/run_vectors.py
+++ b/backend/app/services/run_vectors.py
@@ -462,30 +462,6 @@ def load_archetypes() -> dict | None:
         return None
 
 
-def anomalous_runs(limit: int = 30) -> list[dict]:
-    """Runs farthest from every archetype centroid: nothing else looks like them."""
-    import numpy as np
-
-    out: list[dict] = []
-    for ch in _OFFICIAL_CHARACTERS:
-        try:
-            dists = np.load(_VEC_DIR / f"{ch}_dists.npy")
-            with np.load(_VEC_DIR / f"{ch}_meta.npz") as z:
-                hashes = z["hash"]
-        except OSError:
-            continue
-        n = min(len(hashes), len(dists))
-        for i in np.argsort(dists[:n])[::-1][:limit]:
-            out.append(
-                {
-                    "run_hash": hashes[int(i)].decode(),
-                    "distance": round(float(dists[int(i)]), 3),
-                }
-            )
-    out.sort(key=lambda r: -r["distance"])
-    return out[:limit]
-
-
 def _load_labels(character: str):
     import numpy as np
 

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1178,31 +1178,6 @@ def _item_stats_pipeline(field: str) -> list[dict]:
     ]
 
 
-def _scalar_item_stats_pipeline(field: str) -> list[dict]:
-    """Like _item_stats_pipeline, but for arrays of scalar strings
-    (relics, potions might be stored either way — keeping flexibility).
-    Currently unused; documents store relics + potions as objects with
-    `.id`, so _item_stats_pipeline covers it."""
-    return [
-        {"$unwind": f"${field}"},
-        {
-            "$group": {
-                "_id": {"run": "$_id", "item": f"${field}"},
-                "win": {"$first": "$win"},
-                "copies": {"$sum": 1},
-            }
-        },
-        {
-            "$group": {
-                "_id": "$_id.item",
-                "count": {"$sum": "$copies"},
-                "total_runs_with": {"$sum": 1},
-                "win_runs": {"$sum": {"$cond": ["$win", 1, 0]}},
-            }
-        },
-    ]
-
-
 @_instrument("get_stats")
 def get_stats(
     character: str | None = None,
@@ -2192,7 +2167,7 @@ def list_runs(
     }
 
 
-@_instrument("leaderboard")
+@_instrument("set_run_hidden")
 def set_run_hidden(run_hash: str, hidden: bool) -> dict:
     """Flag or unflag every doc sharing this run_hash as ineligible. Hidden runs
     stay in the collection but drop out of leaderboards, /charts, the stats, and
@@ -2557,7 +2532,7 @@ def get_user_picks(steam_id: str) -> dict[str, dict]:
     return {"cards": tally(cards), "ancients": tally(ancients)}
 
 
-@_instrument("get_username_for_hash")
+@_instrument("primary_share_hash")
 def primary_share_hash(data: dict) -> str | None:
     """The player-0 share hash recomputed from a submitted run blob.
 


### PR DESCRIPTION
I stopped the long-finished username_lower/bought backfills from re-running on all four workers at every boot (the functions stay callable manually), deleted the caller-less _scalar_item_stats_pipeline, default_limit_value, anomalous_runs, StatsResponse, and the never-incremented auth metrics, and fixed the two _instrument decorators that were mislabeling set_run_hidden and primary_share_hash.