### PR TITLE
Share one endpoint-scoped limiter across all routers

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,6 +1,7 @@
 """Shared FastAPI dependencies."""
 
 from fastapi import Query, Request
+from slowapi import Limiter
 from slowapi.util import get_remote_address
 
 
@@ -26,6 +27,26 @@ def client_ip(request: Request) -> str:
     if xff:
         return xff.split(",", 1)[0].strip()
     return get_remote_address(request)
+
+
+def _make_shared_limiter() -> Limiter:
+    # Imported lazily: rate_limit_config itself imports client_ip from this
+    # module inside a function, so a top-level import here would be the only
+    # thing turning that into a cycle.
+    from .services import rate_limit_config
+
+    # One per-IP limiter shared by every router. key_style="endpoint" scopes
+    # each counter by ROUTE — slowapi's default "url" gave every concrete
+    # path its own bucket, so caps on parameterized routes like
+    # /shared/{run_hash} were per-hash and never actually bit.
+    return Limiter(
+        key_func=client_ip,
+        key_style="endpoint",
+        **rate_limit_config.storage_kwargs(),
+    )
+
+
+shared_limiter = _make_shared_limiter()
 
 
 VALID_LANGUAGES = {

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -7,9 +7,8 @@ import os
 
 from fastapi import APIRouter, HTTPException, Request, UploadFile, File
 from fastapi.responses import JSONResponse
-from slowapi import Limiter
 
-from ..dependencies import client_ip
+from ..dependencies import shared_limiter
 from ..services import rate_limit_config
 from ..services.auth_jwt import (
     get_current_user,
@@ -19,7 +18,7 @@ from ..services.auth_jwt import (
 )
 
 router = APIRouter(prefix="/api/auth", tags=["Auth"])
-limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
+limiter = shared_limiter
 
 _MAX_UPLOAD_SIZE = 512 * 1024  # 512 KB per file
 _MAX_UPLOAD_FILES = 100

--- a/backend/app/routers/auth_discord.py
+++ b/backend/app/routers/auth_discord.py
@@ -14,9 +14,8 @@ import urllib.parse
 import httpx
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
-from slowapi import Limiter
 
-from ..dependencies import client_ip
+from ..dependencies import shared_limiter
 from ..services import rate_limit_config
 from ..services.auth_jwt import (
     clear_oauth_state_cookie,
@@ -29,7 +28,7 @@ from ..services.auth_jwt import (
 logger = logging.getLogger("spire-codex.auth")
 
 router = APIRouter(prefix="/api/auth/discord", tags=["Auth"])
-limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
+limiter = shared_limiter
 
 _DISCORD_API = "https://discord.com/api/v10"
 _DISCORD_AUTHORIZE = "https://discord.com/api/oauth2/authorize"

--- a/backend/app/routers/auth_patreon.py
+++ b/backend/app/routers/auth_patreon.py
@@ -29,9 +29,8 @@ import urllib.parse
 import httpx
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import RedirectResponse
-from slowapi import Limiter
 
-from ..dependencies import client_ip
+from ..dependencies import shared_limiter
 from ..services import rate_limit_config
 from ..services.auth_jwt import (
     clear_oauth_state_cookie,
@@ -45,7 +44,7 @@ from ..services.auth_jwt import (
 logger = logging.getLogger("spire-codex.auth")
 
 router = APIRouter(prefix="/api/auth/patreon", tags=["Auth"])
-limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
+limiter = shared_limiter
 
 _PATREON_AUTHORIZE = "https://www.patreon.com/oauth2/authorize"
 _PATREON_TOKEN = "https://www.patreon.com/api/oauth2/token"

--- a/backend/app/routers/auth_steam.py
+++ b/backend/app/routers/auth_steam.py
@@ -35,9 +35,8 @@ import httpx
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from pydantic import BaseModel
-from slowapi import Limiter
 
-from ..dependencies import client_ip
+from ..dependencies import shared_limiter
 from ..services import rate_limit_config
 from ..services import auth_session_store
 from ..services.auth_session_store import SESSION_TTL_SECONDS
@@ -45,7 +44,7 @@ from ..services.auth_session_store import SESSION_TTL_SECONDS
 logger = logging.getLogger("spire-codex.auth")
 
 router = APIRouter(prefix="/api/auth/steam", tags=["Auth"])
-limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
+limiter = shared_limiter
 
 _REALM_ENV_KEY = "SPIRE_CODEX_PUBLIC_BASE"
 

--- a/backend/app/routers/auth_twitch.py
+++ b/backend/app/routers/auth_twitch.py
@@ -20,9 +20,8 @@ import urllib.parse
 import httpx
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
-from slowapi import Limiter
 
-from ..dependencies import client_ip
+from ..dependencies import shared_limiter
 from ..services import rate_limit_config
 from ..services.auth_jwt import (
     clear_oauth_state_cookie,
@@ -35,7 +34,7 @@ from ..services.auth_jwt import (
 logger = logging.getLogger("spire-codex.auth")
 
 router = APIRouter(prefix="/api/auth/twitch", tags=["Auth"])
-limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
+limiter = shared_limiter
 
 _TWITCH_AUTHORIZE = "https://id.twitch.tv/oauth2/authorize"
 _TWITCH_TOKEN = "https://id.twitch.tv/oauth2/token"

--- a/backend/app/routers/beta.py
+++ b/backend/app/routers/beta.py
@@ -6,8 +6,7 @@ VersionMiddleware). What lives here is the metadata about the beta branch.
 """
 
 from fastapi import APIRouter, Request
-from slowapi import Limiter
-from ..dependencies import client_ip
+from ..dependencies import shared_limiter
 from ..services import rate_limit_config
 
 from ..services.beta_diff import get_beta_diff
@@ -17,7 +16,7 @@ router = APIRouter(prefix="/api/beta", tags=["Beta"])
 # client_ip, not slowapi's get_remote_address: behind Cloudflare -> nginx
 # the latter reads the proxy address, so every visitor would share ONE
 # bucket and these limits would trip fleet-wide (see dependencies.client_ip).
-limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
+limiter = shared_limiter
 
 
 @router.get("/diff")

--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -17,8 +17,7 @@ import re
 import time
 
 from fastapi import APIRouter, HTTPException, Query, Request, Response
-from slowapi import Limiter
-from ..dependencies import client_ip
+from ..dependencies import shared_limiter
 from ..services import rate_limit_config
 
 from ..services import cache as app_cache
@@ -33,7 +32,7 @@ router = APIRouter(prefix="/api/charts", tags=["Charts"])
 # client_ip, not slowapi's get_remote_address: behind Cloudflare -> nginx
 # the latter reads the proxy address, so every visitor would share ONE
 # bucket and these limits would trip fleet-wide (see dependencies.client_ip).
-limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
+limiter = shared_limiter
 logger = logging.getLogger(__name__)
 
 # On-demand entries. Chart data only changes when the snapshot does (one

--- a/backend/app/routers/exports.py
+++ b/backend/app/routers/exports.py
@@ -10,16 +10,15 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pymongo import ASCENDING
-from slowapi import Limiter
 
-from ..dependencies import VALID_LANGUAGES, client_ip
+from ..dependencies import VALID_LANGUAGES, shared_limiter
 from ..services import rate_limit_config
 from ..metrics import data_exports, run_export_pages, run_exports
 from ..services.data_service import DATA_DIR
 
 router = APIRouter(prefix="/api/exports", tags=["Exports"])
 
-limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
+limiter = shared_limiter
 
 ENTITY_FILES = [
     "cards",

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -6,9 +6,8 @@ import os
 import httpx
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
-from slowapi import Limiter
 
-from ..dependencies import client_ip
+from ..dependencies import shared_limiter
 from ..services import rate_limit_config
 from ..metrics import feedback_submissions
 from ..services import github_issues
@@ -19,7 +18,7 @@ router = APIRouter(prefix="/api/feedback", tags=["Feedback"])
 
 WEBHOOK_URL = os.environ.get("FEEDBACK_WEBHOOK_URL", "")
 
-limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
+limiter = shared_limiter
 
 
 class FeedbackRequest(BaseModel):

--- a/backend/app/routers/guides.py
+++ b/backend/app/routers/guides.py
@@ -8,9 +8,8 @@ from datetime import date
 import httpx
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
-from slowapi import Limiter
 
-from ..dependencies import client_ip
+from ..dependencies import shared_limiter
 from ..services import rate_limit_config
 from ..models.schemas import GuideSummary, Guide
 from ..services.data_service import load_guides
@@ -20,7 +19,7 @@ router = APIRouter(prefix="/api/guides", tags=["Guides"])
 
 WEBHOOK_URL = os.environ.get("GUIDE_WEBHOOK_URL", "")
 
-limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
+limiter = shared_limiter
 
 
 @router.get("", response_model=list[GuideSummary])

--- a/backend/app/routers/qa_feedback.py
+++ b/backend/app/routers/qa_feedback.py
@@ -20,15 +20,14 @@ import os
 import httpx
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
-from slowapi import Limiter
 
-from ..dependencies import client_ip
+from ..dependencies import shared_limiter
 from ..services import rate_limit_config
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/qa-feedback", tags=["Feedback"])
-limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
+limiter = shared_limiter
 
 
 class QAFeedback(BaseModel):

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -7,9 +7,8 @@ import time
 from functools import lru_cache
 from pathlib import Path
 from fastapi import APIRouter, HTTPException, Query, Request, Response
-from slowapi import Limiter
 from starlette.concurrency import run_in_threadpool
-from ..dependencies import client_ip
+from ..dependencies import shared_limiter
 from ..services import rate_limit_config
 from ..services.runs_db import submit_run, get_stats, claim_runs
 from ..services import cache as app_cache
@@ -43,7 +42,7 @@ router = APIRouter(prefix="/api/runs", tags=["Runs"])
 # client_ip, not slowapi's get_remote_address: behind Cloudflare -> nginx
 # the latter reads the proxy address, so every visitor would share ONE
 # bucket and these limits would trip fleet-wide (see dependencies.client_ip).
-limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
+limiter = shared_limiter
 
 MAX_BODY_SIZE = 512 * 1024  # 512 KB
 

--- a/backend/app/routers/uninstall.py
+++ b/backend/app/routers/uninstall.py
@@ -21,15 +21,14 @@ import os
 import httpx
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
-from slowapi import Limiter
 
-from ..dependencies import client_ip
+from ..dependencies import shared_limiter
 from ..services import rate_limit_config
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/uninstall-feedback", tags=["Feedback"])
-limiter = Limiter(key_func=client_ip, **rate_limit_config.storage_kwargs())
+limiter = shared_limiter
 
 RESEND_ENDPOINT = "https://api.resend.com/emails"
 

--- a/backend/tests/test_shared_limiter.py
+++ b/backend/tests/test_shared_limiter.py
@@ -1,0 +1,36 @@
+"""Every router must use the one shared per-IP limiter, and it must be
+endpoint-scoped: slowapi's default key_style="url" buckets per concrete
+URL, so caps on parameterized routes (/shared/{run_hash}, /stats/{type}/{id})
+never actually bit."""
+
+import importlib
+
+import pytest
+
+from app.dependencies import shared_limiter
+
+ROUTERS = [
+    "auth",
+    "auth_discord",
+    "auth_patreon",
+    "auth_steam",
+    "auth_twitch",
+    "beta",
+    "charts",
+    "exports",
+    "feedback",
+    "guides",
+    "qa_feedback",
+    "runs",
+    "uninstall",
+]
+
+
+def test_shared_limiter_is_endpoint_scoped():
+    assert shared_limiter._key_style == "endpoint"
+
+
+@pytest.mark.parametrize("name", ROUTERS)
+def test_router_uses_shared_limiter(name):
+    mod = importlib.import_module(f"app.routers.{name}")
+    assert mod.limiter is shared_limiter


### PR DESCRIPTION
I replaced the 13 per-router Limiter instances with one shared per-IP limiter carrying key_style="endpoint", so caps on parameterized routes like /shared/{run_hash} count per route instead of per concrete URL (the default "url" style silently gave every hash its own bucket), with tests pinning both the style and that every router uses the shared instance.