### PR TITLE
Tighten hot Mongo read paths

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -58,7 +58,7 @@ _STAT_FILTER_TO_BRACKET = {
 
 
 @lru_cache(maxsize=256)
-def _load_run_blob(run_hash: str) -> str | None:
+def _load_run_blob_cached(run_hash: str) -> str:
     """Read a run JSON file once and serve from memory thereafter.
 
     Run files are immutable once submitted, so a cache is safe — the only
@@ -67,7 +67,11 @@ def _load_run_blob(run_hash: str) -> str | None:
     `run_hash` (the next request hits the file directly). Returning the
     raw text keeps FastAPI from re-serializing on every request, which
     matters when a scraper enumerates hashes and turns the worker into a
-    json.dumps loop. `None` means file missing.
+    json.dumps loop.
+
+    Raises FileNotFoundError on a miss so lru_cache never stores it: a
+    cached None used to serve stale 404s for a hash requested moments
+    before its run finished submitting, until eviction or an admin action.
     """
     run_file = _data_dir / "runs" / f"{run_hash}.json"
     if run_file.exists():
@@ -79,7 +83,17 @@ def _load_run_blob(run_hash: str) -> str | None:
         blob = get_run_blob(run_hash)
         if blob is not None:
             return json.dumps(blob, ensure_ascii=False)
-    return None
+    raise FileNotFoundError(run_hash)
+
+
+def _load_run_blob(run_hash: str) -> str | None:
+    try:
+        return _load_run_blob_cached(run_hash)
+    except FileNotFoundError:
+        return None
+
+
+_load_run_blob.cache_clear = _load_run_blob_cached.cache_clear  # type: ignore[attr-defined]
 
 
 @router.post("", tags=["Runs"])

--- a/backend/app/services/live_overlay.py
+++ b/backend/app/services/live_overlay.py
@@ -116,7 +116,20 @@ def _write(r, fields: dict[tuple[str, str], int], cursor: tuple | None) -> None:
 def fetch_row(run_hash: str) -> dict | None:
     from .runs_db_mongo import _get_collection
 
-    d = _get_collection().find_one({"_id": run_hash})
+    d = _get_collection().find_one(
+        {"_id": run_hash},
+        {
+            "character": 1,
+            "win": 1,
+            "submitted_at": 1,
+            "player_count": 1,
+            "ascension": 1,
+            "game_mode": 1,
+            "killed_by": 1,
+            "username": 1,
+            "build_id": 1,
+        },
+    )
     if not d:
         return None
     return {

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -2589,12 +2589,28 @@ def get_username_for_hash(run_hash: str) -> str | None:
 
 @_instrument("find_sibling_hashes")
 def find_sibling_hashes(run_hash: str) -> list[str]:
-    """For a multiplayer run, find sibling player runs (same seed)."""
+    """For a multiplayer run, find sibling player runs (same seed and party
+    size). Solo and daily runs return nothing: on a shared daily seed "same
+    seed" is every other player's run, and the caller copies a sibling's
+    file in as this run's blob."""
     coll = _get_collection()
-    row = coll.find_one({"_id": run_hash}, {"seed": 1})
+    row = coll.find_one(
+        {"_id": run_hash}, {"seed": 1, "player_count": 1, "game_mode": 1}
+    )
     if not row or not row.get("seed"):
         return []
-    siblings = coll.find({"seed": row["seed"], "_id": {"$ne": run_hash}}, {"_id": 1})
+    if (row.get("player_count") or 1) <= 1:
+        return []
+    if (row.get("game_mode") or "standard").lower() == "daily":
+        return []
+    siblings = coll.find(
+        {
+            "seed": row["seed"],
+            "player_count": row.get("player_count"),
+            "_id": {"$ne": run_hash},
+        },
+        {"_id": 1},
+    ).limit(20)
     return [s["_id"] for s in siblings]
 
 
@@ -2754,11 +2770,23 @@ def get_user_runs(
     total = coll.count_documents(match)
     skip = (page - 1) * limit
 
+    # Include-projection of exactly the fields emitted below — the old
+    # {"raw": 0} exclude hauled full docs (deck, card_choices,
+    # map_point_history) to serve ~11 scalars per row.
+    proj = {
+        "character": 1,
+        "win": 1,
+        "was_abandoned": 1,
+        "ascension": 1,
+        "game_mode": 1,
+        "player_count": 1,
+        "floors_reached": 1,
+        "killed_by": 1,
+        "username": 1,
+        "submitted_at": 1,
+    }
     rows = list(
-        coll.find(match, {"raw": 0})
-        .sort("submitted_at", DESCENDING)
-        .skip(skip)
-        .limit(limit)
+        coll.find(match, proj).sort("submitted_at", DESCENDING).skip(skip).limit(limit)
     )
 
     runs = []

--- a/backend/tests/test_run_read_paths.py
+++ b/backend/tests/test_run_read_paths.py
@@ -1,0 +1,83 @@
+"""Read-path behavior: sibling lookup stays scoped to real multiplayer
+parties, and a blob-cache miss is never cached as a permanent 404."""
+
+import json
+
+from app.services import runs_db_mongo
+
+
+class FakeCursor:
+    def __init__(self, docs):
+        self.docs = docs
+        self.limited = None
+
+    def limit(self, n):
+        self.limited = n
+        return self
+
+    def __iter__(self):
+        return iter(self.docs)
+
+
+class FakeColl:
+    def __init__(self, row, sibling_docs=()):
+        self.row = row
+        self.sibling_docs = list(sibling_docs)
+        self.find_queries = []
+
+    def find_one(self, q, projection=None, **kwargs):
+        return self.row
+
+    def find(self, q, projection=None, **kwargs):
+        self.find_queries.append(q)
+        return FakeCursor(self.sibling_docs)
+
+
+def _patch(monkeypatch, coll):
+    monkeypatch.setattr(runs_db_mongo, "_get_collection", lambda: coll)
+
+
+def test_solo_run_has_no_siblings(monkeypatch):
+    coll = FakeColl({"seed": "S1", "player_count": 1, "game_mode": "standard"})
+    _patch(monkeypatch, coll)
+    assert runs_db_mongo.find_sibling_hashes("h") == []
+    assert coll.find_queries == []
+
+
+def test_daily_run_has_no_siblings(monkeypatch):
+    # A daily seed is shared by every player that day; "same seed" there
+    # would let the caller copy an unrelated player's file in.
+    coll = FakeColl({"seed": "24_07_2026", "player_count": 2, "game_mode": "daily"})
+    _patch(monkeypatch, coll)
+    assert runs_db_mongo.find_sibling_hashes("h") == []
+    assert coll.find_queries == []
+
+
+def test_multiplayer_siblings_match_party_size(monkeypatch):
+    coll = FakeColl(
+        {"seed": "S2", "player_count": 2, "game_mode": "standard"},
+        sibling_docs=[{"_id": "sib1"}],
+    )
+    _patch(monkeypatch, coll)
+    assert runs_db_mongo.find_sibling_hashes("h") == ["sib1"]
+    (q,) = coll.find_queries
+    assert q["seed"] == "S2"
+    assert q["player_count"] == 2
+    assert q["_id"] == {"$ne": "h"}
+
+
+def test_blob_cache_does_not_cache_misses(tmp_path, monkeypatch):
+    from app.routers import runs as runs_router
+
+    monkeypatch.setattr(runs_router, "_data_dir", tmp_path)
+    monkeypatch.delenv("MONGO_URL", raising=False)
+    runs_router._load_run_blob.cache_clear()
+    (tmp_path / "runs").mkdir()
+
+    assert runs_router._load_run_blob("abc") is None
+
+    blob = {"seed": "S3"}
+    (tmp_path / "runs" / "abc.json").write_text(json.dumps(blob), encoding="utf-8")
+    cached = runs_router._load_run_blob("abc")
+    assert cached is not None
+    assert json.loads(cached) == blob


### PR DESCRIPTION
I scoped multiplayer sibling lookup to real parties (same seed AND party size, never solo or daily runs, capped at 20) so the shared-run fallback can't copy an unrelated player's file in, switched get_user_runs and the live-overlay row fetch to include-projections instead of hauling full docs with map_point_history, and stopped the run-blob LRU from caching misses (a hash requested just before its run finished submitting used to serve stale 404s until eviction), with tests for each.