### PR TITLE
Stop response models from stripping shipped fields

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -101,6 +101,8 @@ class Card(BaseModel):
     # and a handful of utility cards. The C# default is `true`, so we only
     # surface the field when it's explicitly `false` to keep the payload tight.
     can_be_generated_in_combat: bool | None = None
+    # Present (true) on the 21 co-op-only cards; absent otherwise.
+    multiplayer_only: bool | None = None
     compendium_order: int = 0
     # Which monsters generate this card in combat (parsed from the game code —
     # see card_parser.build_card_sources). Absent on cards with no source.
@@ -157,6 +159,7 @@ class Character(BaseModel):
     quotes: dict[str, str] | None = None
     dialogues: list[CharacterDialogue] | None = None
     image_url: str | None = None
+    animation_url: str | None = None
 
 
 class MerchantPrice(BaseModel):
@@ -286,6 +289,7 @@ class Potion(BaseModel):
 class Act(BaseModel):
     id: str
     name: str
+    index: int | None = None
     num_rooms: int | None = None
     bosses: list[str]
     ancients: list[str]
@@ -468,6 +472,7 @@ class Epoch(BaseModel):
     unlocks_relics: list[str] | None = None
     unlocks_potions: list[str] | None = None
     expands_timeline: list[str] | None = None
+    image_url: str | None = None
 
 
 class Story(BaseModel):

--- a/backend/tests/test_schema_fields.py
+++ b/backend/tests/test_schema_fields.py
@@ -1,0 +1,35 @@
+"""Response models must not strip fields the parsers ship: FastAPI's
+response_model silently drops anything undeclared, which already bit
+name_variants and channel once."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.models.schemas import Act, Card, Character, Epoch
+
+DATA = Path(__file__).resolve().parents[2] / "data" / "eng"
+
+
+def _first_with(entities, key):
+    entity = next((e for e in entities if key in e), None)
+    if entity is None:
+        pytest.skip(f"no {key} in shipped data")
+    return entity
+
+
+@pytest.mark.parametrize(
+    "filename,model,key",
+    [
+        ("cards.json", Card, "multiplayer_only"),
+        ("characters.json", Character, "animation_url"),
+        ("epochs.json", Epoch, "image_url"),
+        ("acts.json", Act, "index"),
+    ],
+)
+def test_model_keeps_shipped_field(filename, model, key):
+    entities = json.loads((DATA / filename).read_text(encoding="utf-8"))
+    entity = _first_with(entities, key)
+    dumped = model.model_validate(entity).model_dump()
+    assert dumped[key] == entity[key]


### PR DESCRIPTION
I declared multiplayer_only on Card, animation_url on Character, image_url on Epoch, and index on Act, all of which the parsers ship but response_model was silently dropping, with a data-driven test that validates each against the real eng catalogs.