### PR TITLE
Collapse the retired beta-host branches and fix the zht noindex regex

### DIFF
--- a/frontend/app/[lang]/page.tsx
+++ b/frontend/app/[lang]/page.tsx
@@ -13,7 +13,7 @@ import SearchTrigger from "@/app/components/SearchTrigger";
 import { buildWebSiteJsonLd, buildVideoGameJsonLd } from "@/lib/jsonld";
 import { fetchSteamMeta } from "@/lib/steam-meta";
 import { t } from "@/lib/ui-translations";
-import { SITE_URL, SITE_NAME, IS_BETA, HOME_OG_IMAGE } from "@/lib/seo";
+import { SITE_URL, SITE_NAME, HOME_OG_IMAGE } from "@/lib/seo";
 import "@/app/home-revamp.css";
 import {
   isValidLang,
@@ -122,16 +122,9 @@ export default async function Home({ params }: { params: Promise<{ lang: string 
           <section className="hero">
             <h1 className="wordmark">
               SPIRE <span>CODEX</span>
-              {IS_BETA && (
-                <sup className="ml-2 align-super text-xs font-semibold px-2 py-0.5 rounded bg-emerald-500/20 text-emerald-400">
-                  BETA
-                </sup>
-              )}
             </h1>
             <p className="htag">
-              {IS_BETA
-                ? t("Preview of upcoming Slay the Spire 2 content", lang)
-                : t("The complete database for Slay the Spire 2", lang)}
+              {t("The complete database for Slay the Spire 2", lang)}
             </p>
             <div style={{ maxWidth: 540, margin: "18px auto 0" }}>
               <SearchTrigger variant="hero" />

--- a/frontend/app/components/HomeLeaderboardSection.tsx
+++ b/frontend/app/components/HomeLeaderboardSection.tsx
@@ -1,16 +1,12 @@
-import { IS_BETA } from "@/lib/seo";
 import HomeLeaderboardLive from "./HomeLeaderboardLive";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-// Beta has run submissions disabled, so its local runs data is essentially
-// empty. Fetch leaderboard + recent-runs data from stable instead so the
-// section actually has content to show; in-page links point at stable too.
-const RUNS_HOST = IS_BETA ? "https://spire-codex.com" : "";
-const RUNS_API = IS_BETA ? "https://spire-codex.com" : API;
+const RUNS_HOST = "";
+const RUNS_API = API;
 // Browser-side polling must use the PUBLIC API base; API_INTERNAL_URL only
 // resolves inside the Docker network during server render.
 const PUBLIC_API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
-const POLL_BASE = IS_BETA ? "https://spire-codex.com" : PUBLIC_API;
+const POLL_BASE = PUBLIC_API;
 
 const REVALIDATE = 300;
 const TARGET_ASCENSION = 10;

--- a/frontend/app/components/HomeStatsSection.tsx
+++ b/frontend/app/components/HomeStatsSection.tsx
@@ -1,14 +1,10 @@
-import { IS_BETA } from "@/lib/seo";
 import HomeStatsLive from "./HomeStatsLive";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-// Beta has run submissions disabled, so its stats endpoint reports near
-// zero. Pull from stable on beta so the section matches the community
-// leaderboards above. Server-side fetch, no CORS hop.
-const RUNS_HOST = IS_BETA ? "https://spire-codex.com" : "";
-const RUNS_API = IS_BETA ? "https://spire-codex.com" : API;
+const RUNS_HOST = "";
+const RUNS_API = API;
 const PUBLIC_API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
-const POLL_BASE = IS_BETA ? "https://spire-codex.com" : PUBLIC_API;
+const POLL_BASE = PUBLIC_API;
 
 const REVALIDATE = 300;
 

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -15,7 +15,7 @@ import ThemeToggle from "./ThemeToggle";
 import { recordRecent, getRecent, isRecentType, ENTITY_SINGULAR, prettyRecentName, type RecentEntity } from "@/lib/recent-entities";
 import { t } from "@/lib/ui-translations";
 import { cachedFetch } from "@/lib/fetch-cache";
-import { IS_BETA, SITE_URL } from "@/lib/seo";
+import { SITE_URL } from "@/lib/seo";
 import { LANG_PREFIXES } from "@/lib/languages";
 
 const LANG_CODES = LANG_PREFIXES;
@@ -26,8 +26,6 @@ interface NavGroup {
   label: string;
   links: { href: string; label: string; badge?: "discord-bot" }[];
 }
-
-const BETA_HIDDEN = new Set(["/guides", "/showcase", "/leaderboards", "/leaderboards/submit", "/leaderboards/stats", "/leaderboards/scoring", "/tier-list"]);
 
 // Routes that should only highlight on exact match (not prefix match)
 const EXACT_MATCH = new Set(["/leaderboards"]);
@@ -266,7 +264,7 @@ export default function Navbar() {
   }, [strippedPath]);
 
   const renderMega = (group: NavGroup, isLast: boolean) => {
-    const links = IS_BETA ? group.links.filter((l) => !BETA_HIDDEN.has(l.href)) : group.links;
+    const links = group.links;
     if (links.length === 0) return null;
     const hasActive = links.some((link) => !link.href.startsWith("http") && isLinkActive(strippedPath, link.href));
     const linkByLabel = new Map(links.map((l) => [l.label, l]));
@@ -423,8 +421,7 @@ export default function Navbar() {
               <SearchTrigger variant="icon" />
             </div>
 
-          {/* User menu, hidden on beta (accounts are stable-only for now) */}
-          {!authLoading && !IS_BETA && (
+          {!authLoading && (
             <div className="relative">
               <button
                 ref={userButtonRef}
@@ -590,7 +587,7 @@ export default function Navbar() {
 
                 <div className="flex-1 overflow-y-auto pb-10">
                   {NAV_GROUPS.map((group) => {
-                    const links = IS_BETA ? group.links.filter((l) => !BETA_HIDDEN.has(l.href)) : group.links;
+                    const links = group.links;
                     if (links.length === 0) return null;
                     const isExpanded = expandedGroups.has(group.label);
                     const hasActive = links.some((link) => !link.href.startsWith("http") && isLinkActive(strippedPath, link.href));

--- a/frontend/app/contexts/BetaVersionContext.tsx
+++ b/frontend/app/contexts/BetaVersionContext.tsx
@@ -4,14 +4,11 @@ import {
   createContext,
   useContext,
   useState,
-  useEffect,
   type ReactNode,
 } from "react";
 import { useRouter, usePathname } from "next/navigation";
-import { IS_BETA } from "@/lib/seo";
 import { setBetaVersion, clearCache } from "@/lib/fetch-cache";
 
-const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 const STORAGE_KEY = "spire-codex-beta-version";
 
 interface VersionInfo {
@@ -33,7 +30,7 @@ const BetaVersionContext = createContext<BetaVersionContextType>({
 
 export function BetaVersionProvider({ children }: { children: ReactNode }) {
   const [version, setVersionState] = useState<string | null>(null);
-  const [versions, setVersions] = useState<VersionInfo[]>([]);
+  const [versions] = useState<VersionInfo[]>([]);
   const router = useRouter();
   const pathname = usePathname();
   // window.location.search instead of useSearchParams() on purpose: the
@@ -44,39 +41,6 @@ export function BetaVersionProvider({ children }: { children: ReactNode }) {
   // crawlers (no h1, no text in the raw HTML).
   const currentParams = () =>
     new URLSearchParams(typeof window === "undefined" ? "" : window.location.search);
-
-  // Fetch available versions on mount (only on beta)
-  useEffect(() => {
-    if (!IS_BETA) return;
-    fetch(`${API}/api/versions`)
-      .then((r) => r.json())
-      .then((data: VersionInfo[]) => {
-        setVersions(data);
-      })
-      .catch(() => {});
-  }, []);
-
-  // On mount + URL change: URL param takes priority, then localStorage
-  useEffect(() => {
-    if (!IS_BETA) return;
-    const params = currentParams();
-    const urlVersion = params.get("version");
-    if (urlVersion && urlVersion !== "latest") {
-      setVersionState(urlVersion);
-      setBetaVersion(urlVersion);
-      localStorage.setItem(STORAGE_KEY, urlVersion);
-    } else if (!urlVersion) {
-      const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored && stored !== "latest") {
-        setVersionState(stored);
-        setBetaVersion(stored);
-        // Re-add version to URL so links are always shareable
-        params.set("version", stored);
-        router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pathname]);
 
   const setVersion = (v: string | null) => {
     setVersionState(v);

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -65,17 +65,11 @@ const kreon = Kreon({
   weight: ["300", "400", "500", "600", "700"],
 });
 
-// Belt-and-suspenders alongside the beta branch in robots.ts. Some bots
-// honor robots.txt only partially; an explicit noindex meta on every
-// beta page makes it impossible for a beta URL to enter the index.
-const IS_BETA = /beta\./i.test(SITE_URL);
-
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: `Database - Slay the Spire 2 (sts2) | ${SITE_NAME}`,
   description:
     "Fan-built database for Slay the Spire 2 (sts2). Browse cards, relics, monsters, potions, events, powers, plus run stats and tier lists.",
-  ...(IS_BETA && { robots: { index: false, follow: false } }),
   icons: {
     icon: [
       { url: "/favicon.ico", sizes: "32x32" },

--- a/frontend/app/leaderboards/submit/SubmitRunClient.tsx
+++ b/frontend/app/leaderboards/submit/SubmitRunClient.tsx
@@ -7,7 +7,6 @@ import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { useAuth } from "@/app/contexts/AuthContext";
 import { t } from "@/lib/ui-translations";
-import { IS_BETA } from "@/lib/seo";
 import RunDropZone from "@/app/components/RunDropZone";
 import DiscordIcon from "@/app/components/DiscordIcon";
 import { characterHex } from "@/lib/character-colors";
@@ -243,39 +242,6 @@ export default function SubmitRunClient() {
     if (user) fetchRuns();
   }, [user, fetchRuns]);
 
-
-  // Run submissions are server-side rejected on beta (the backend returns
-  // 403 with "Submit to spire-codex.com instead"). The Navbar already
-  // hides this route on beta, but bookmarks / external links can still
-  // land here, show an upfront notice instead of letting users drag in
-  // files only to get a 403 per file. Two open bug reports (#104, #105)
-  // came from exactly this flow before this gate existed.
-  if (IS_BETA) {
-    return (
-      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <h1 className="text-3xl font-bold mb-3">
-          <span className="text-[var(--accent-gold)]">{t("Submit a Run", lang)}</span>
-        </h1>
-        <div className="rounded-xl border border-[var(--accent-gold)]/30 bg-[var(--accent-gold)]/5 p-6">
-          <p className="text-base text-[var(--text-primary)] mb-4">
-            Run submissions are disabled on the beta site so the leaderboards
-            and community stats stay aligned with the stable game build.
-          </p>
-          <p className="text-sm text-[var(--text-secondary)] mb-5">
-            Head to the stable site to upload your runs, they&apos;ll appear
-            on the public leaderboards within a minute.
-          </p>
-          <a
-            href="https://spire-codex.com/leaderboards/submit"
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[var(--accent-gold)] text-[var(--bg-primary)] font-medium hover:opacity-90 transition-opacity"
-          >
-            Submit on spire-codex.com
-            <span aria-hidden>→</span>
-          </a>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="mx-auto max-w-[1400px] px-3 sm:px-5 py-6 space-y-8">

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -12,15 +12,14 @@ import JsonLd from "./components/JsonLd";
 import SearchTrigger from "./components/SearchTrigger";
 import { buildWebSiteJsonLd, buildVideoGameJsonLd } from "@/lib/jsonld";
 import { fetchSteamMeta } from "@/lib/steam-meta";
-import { SITE_NAME, IS_BETA, buildLanguageAlternates, HOME_OG_IMAGE } from "@/lib/seo";
+import { SITE_NAME, buildLanguageAlternates, HOME_OG_IMAGE } from "@/lib/seo";
 import "./home-revamp.css";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
-const title = `${IS_BETA ? "Beta " : ""}Database, Wiki & Guide - Slay the Spire 2 (sts2) | ${SITE_NAME}`;
-const description = IS_BETA
-  ? "Beta preview of upcoming Slay the Spire 2 (sts2) content. Browse new cards, relics, characters, monsters, potions, events, powers, and more."
-  : "The complete Slay the Spire 2 (sts2) database. Browse cards, relics, characters, monsters, potions, events, and powers. Filter by character, rarity, and keyword.";
+const title = `Database, Wiki & Guide - Slay the Spire 2 (sts2) | ${SITE_NAME}`;
+const description =
+  "The complete Slay the Spire 2 (sts2) database. Browse cards, relics, characters, monsters, potions, events, and powers. Filter by character, rarity, and keyword.";
 
 // ISR with 60s revalidation. The HTML caches at CF edge for 60s so
 // most visits return without hitting Next.js at all. After 60s the
@@ -91,16 +90,10 @@ export default async function Home() {
           <section className="hero">
             <h1 className="wordmark">
               SPIRE <span>CODEX</span>
-              {IS_BETA && (
-                <sup className="ml-2 align-super text-xs font-semibold px-2 py-0.5 rounded bg-emerald-500/20 text-emerald-400">
-                  BETA
-                </sup>
-              )}
             </h1>
             <p className="htag">
-              {IS_BETA
-                ? "Preview of upcoming Slay the Spire 2 content, every card, relic, monster, and run."
-                : "The complete database for Slay the Spire 2, every card, relic, monster, and run, searchable and cross-referenced."}
+              The complete database for Slay the Spire 2, every card, relic,
+              monster, and run, searchable and cross-referenced.
             </p>
             <div style={{ maxWidth: 540, margin: "18px auto 0" }}>
               <SearchTrigger variant="hero" />

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -3,17 +3,7 @@ import type { MetadataRoute } from "next";
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://spire-codex.com";
 
 export default function robots(): MetadataRoute.Robots {
-  // Beta serves near-identical data to prod (different game build) and was
-  // showing up in GSC competing with the canonical prod URLs as
-  // "Duplicate without user-selected canonical." Disallow all on the
-  // beta host so Googlebot stops indexing it.
-  if (/beta\./i.test(SITE_URL)) {
-    return {
-      rules: [{ userAgent: "*", disallow: "/" }],
-    };
-  }
-
-  // Prod: GSC was logging "Crawled - currently not indexed" against
+  // GSC was logging "Crawled - currently not indexed" against
   // thousands of /api/images/<type>/download URLs and a handful of
   // /static/ asset trees, they're either binary downloads or raw
   // assets, not pages worth indexing. Disallow them so Googlebot stops

--- a/frontend/lib/seo.ts
+++ b/frontend/lib/seo.ts
@@ -2,8 +2,7 @@ import { SUPPORTED_LANGS, LANG_HREFLANG } from "./languages";
 
 export const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL || "https://spire-codex.com";
-export const IS_BETA = SITE_URL.includes("beta.");
-export const SITE_NAME = IS_BETA ? "Spire Codex (Beta)" : "Spire Codex";
+export const SITE_NAME = "Spire Codex";
 // Default social card for all non-home pages. The black-background
 // silent logo composition reads as a self-contained brand asset on any
 // surface (Twitter, Discord, FB) and replaces the older

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
-const LANGS = "deu|esp|fra|ita|jpn|kor|pol|ptb|rus|spa|tha|tur|zhs";
+const LANGS = "deu|esp|fra|ita|jpn|kor|pol|ptb|rus|spa|tha|tur|zhs|zht";
 
 const nextConfig: NextConfig = {
   output: "standalone",


### PR DESCRIPTION
I removed the permanently-false IS_BETA flag and every branch keyed on the retired beta.spire-codex.com host (robots disallow, layout noindex, navbar BETA_HIDDEN filtering, beta submit gate, cross-host home-section fallbacks, dead BetaVersionContext effects), and added zht to the next.config LANGS regex so /zht/beta/* pages get the X-Robots-Tag noindex header like every other language.