### PR TITLE
Stop force-rendering localized pages that never read request data

### DIFF
--- a/frontend/app/[lang]/about/page.tsx
+++ b/frontend/app/[lang]/about/page.tsx
@@ -11,8 +11,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const CATEGORY = "about";
 const CATEGORY_LABEL = "About";
 

--- a/frontend/app/[lang]/achievements/[id]/page.tsx
+++ b/frontend/app/[lang]/achievements/[id]/page.tsx
@@ -6,8 +6,6 @@ import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
-export const dynamic = "force-dynamic";
-
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 type Props = { params: Promise<{ lang: string; id: string }> };

--- a/frontend/app/[lang]/acts/[id]/page.tsx
+++ b/frontend/app/[lang]/acts/[id]/page.tsx
@@ -6,7 +6,7 @@ import { buildDetailPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 

--- a/frontend/app/[lang]/afflictions/[id]/page.tsx
+++ b/frontend/app/[lang]/afflictions/[id]/page.tsx
@@ -6,8 +6,6 @@ import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
-export const dynamic = "force-dynamic";
-
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 type Props = { params: Promise<{ lang: string; id: string }> };

--- a/frontend/app/[lang]/ancients/page.tsx
+++ b/frontend/app/[lang]/ancients/page.tsx
@@ -13,7 +13,7 @@ import { t } from "@/lib/ui-translations";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 const CATEGORY = "ancients";
 const CATEGORY_LABEL = "Ancients";

--- a/frontend/app/[lang]/ascensions/[id]/page.tsx
+++ b/frontend/app/[lang]/ascensions/[id]/page.tsx
@@ -6,7 +6,7 @@ import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 

--- a/frontend/app/[lang]/cards/page.tsx
+++ b/frontend/app/[lang]/cards/page.tsx
@@ -17,7 +17,7 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 60;
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 

--- a/frontend/app/[lang]/changelog/page.tsx
+++ b/frontend/app/[lang]/changelog/page.tsx
@@ -11,8 +11,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const CATEGORY = "changelog";
 const CATEGORY_LABEL = "Changelog";
 

--- a/frontend/app/[lang]/characters/[id]/page.tsx
+++ b/frontend/app/[lang]/characters/[id]/page.tsx
@@ -7,8 +7,6 @@ import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { imageUrl } from "@/lib/image-url";
 
-export const dynamic = "force-dynamic";
-
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const API_PUBLIC = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_API_URL || "";
 

--- a/frontend/app/[lang]/characters/page.tsx
+++ b/frontend/app/[lang]/characters/page.tsx
@@ -14,8 +14,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 const CATEGORY = "characters";

--- a/frontend/app/[lang]/compare/[pair]/page.tsx
+++ b/frontend/app/[lang]/compare/[pair]/page.tsx
@@ -7,7 +7,7 @@ import CompareDetail from "@/app/compare/[pair]/CompareDetail";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 const API_INTERNAL =
   process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";

--- a/frontend/app/[lang]/compare/page.tsx
+++ b/frontend/app/[lang]/compare/page.tsx
@@ -13,8 +13,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const CATEGORY = "compare";
 const CATEGORY_LABEL = "Character Comparisons";
 

--- a/frontend/app/[lang]/developers/page.tsx
+++ b/frontend/app/[lang]/developers/page.tsx
@@ -12,8 +12,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const CATEGORY = "developers";
 const CATEGORY_LABEL = "Developers";
 

--- a/frontend/app/[lang]/enchantments/[id]/page.tsx
+++ b/frontend/app/[lang]/enchantments/[id]/page.tsx
@@ -8,8 +8,6 @@ import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { imageUrl } from "@/lib/image-url";
 import { cardsForEnchantment } from "@/lib/card-enchantments";
 
-export const dynamic = "force-dynamic";
-
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const API_PUBLIC = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_API_URL || "";
 

--- a/frontend/app/[lang]/enchantments/page.tsx
+++ b/frontend/app/[lang]/enchantments/page.tsx
@@ -15,8 +15,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 const CATEGORY = "enchantments";

--- a/frontend/app/[lang]/encounters/[id]/page.tsx
+++ b/frontend/app/[lang]/encounters/[id]/page.tsx
@@ -6,8 +6,6 @@ import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
-export const dynamic = "force-dynamic";
-
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 type Props = { params: Promise<{ lang: string; id: string }> };

--- a/frontend/app/[lang]/encounters/page.tsx
+++ b/frontend/app/[lang]/encounters/page.tsx
@@ -15,8 +15,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 const CATEGORY = "encounters";

--- a/frontend/app/[lang]/events/[id]/page.tsx
+++ b/frontend/app/[lang]/events/[id]/page.tsx
@@ -7,8 +7,6 @@ import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { imageUrl } from "@/lib/image-url";
 
-export const dynamic = "force-dynamic";
-
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const API_PUBLIC = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_API_URL || "";
 

--- a/frontend/app/[lang]/events/page.tsx
+++ b/frontend/app/[lang]/events/page.tsx
@@ -15,8 +15,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 const CATEGORY = "events";

--- a/frontend/app/[lang]/guides/[slug]/page.tsx
+++ b/frontend/app/[lang]/guides/[slug]/page.tsx
@@ -1,7 +1,5 @@
 import { permanentRedirect } from "next/navigation";
 
-export const dynamic = "force-dynamic";
-
 type Props = { params: Promise<{ lang: string; slug: string }> };
 
 // Guides are English-language content; the localized wrappers served the

--- a/frontend/app/[lang]/images/page.tsx
+++ b/frontend/app/[lang]/images/page.tsx
@@ -11,8 +11,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const CATEGORY = "images";
 const CATEGORY_LABEL = "Images";
 

--- a/frontend/app/[lang]/intents/[id]/page.tsx
+++ b/frontend/app/[lang]/intents/[id]/page.tsx
@@ -6,8 +6,6 @@ import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
-export const dynamic = "force-dynamic";
-
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 type Props = { params: Promise<{ lang: string; id: string }> };

--- a/frontend/app/[lang]/knowledge-demon/page.tsx
+++ b/frontend/app/[lang]/knowledge-demon/page.tsx
@@ -9,8 +9,6 @@ import {
 } from "@/lib/languages";
 import { buildLanguageAlternates, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 
-export const dynamic = "force-dynamic";
-
 const CATEGORY = "knowledge-demon";
 
 export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {

--- a/frontend/app/[lang]/merchant/page.tsx
+++ b/frontend/app/[lang]/merchant/page.tsx
@@ -18,8 +18,6 @@ import "../../card-revamp.css";
 import "../../meta-extra.css";
 import "../../relic-potion-extra.css";
 
-export const dynamic = "force-dynamic";
-
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 const CATEGORY = "merchant";

--- a/frontend/app/[lang]/mod/page.tsx
+++ b/frontend/app/[lang]/mod/page.tsx
@@ -10,8 +10,6 @@ import {
 import { buildLanguageAlternates, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const CATEGORY = "mod";
 
 export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {

--- a/frontend/app/[lang]/modifiers/[id]/page.tsx
+++ b/frontend/app/[lang]/modifiers/[id]/page.tsx
@@ -6,8 +6,6 @@ import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
-export const dynamic = "force-dynamic";
-
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 type Props = { params: Promise<{ lang: string; id: string }> };

--- a/frontend/app/[lang]/monsters/[id]/page.tsx
+++ b/frontend/app/[lang]/monsters/[id]/page.tsx
@@ -7,7 +7,7 @@ import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { imageUrl } from "@/lib/image-url";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const API_PUBLIC = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_API_URL || "";

--- a/frontend/app/[lang]/monsters/page.tsx
+++ b/frontend/app/[lang]/monsters/page.tsx
@@ -15,8 +15,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 const CATEGORY = "monsters";

--- a/frontend/app/[lang]/orbs/[id]/page.tsx
+++ b/frontend/app/[lang]/orbs/[id]/page.tsx
@@ -6,8 +6,6 @@ import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
-export const dynamic = "force-dynamic";
-
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 type Props = { params: Promise<{ lang: string; id: string }> };

--- a/frontend/app/[lang]/overlay/page.tsx
+++ b/frontend/app/[lang]/overlay/page.tsx
@@ -10,8 +10,6 @@ import {
 import { buildLanguageAlternates, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const CATEGORY = "overlay";
 
 export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {

--- a/frontend/app/[lang]/potions/[id]/page.tsx
+++ b/frontend/app/[lang]/potions/[id]/page.tsx
@@ -7,8 +7,6 @@ import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { imageUrl } from "@/lib/image-url";
 
-export const dynamic = "force-dynamic";
-
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const API_PUBLIC = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_API_URL || "";
 

--- a/frontend/app/[lang]/potions/page.tsx
+++ b/frontend/app/[lang]/potions/page.tsx
@@ -16,8 +16,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 const CATEGORY = "potions";

--- a/frontend/app/[lang]/powers/[id]/page.tsx
+++ b/frontend/app/[lang]/powers/[id]/page.tsx
@@ -7,8 +7,6 @@ import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { imageUrl } from "@/lib/image-url";
 
-export const dynamic = "force-dynamic";
-
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const API_PUBLIC = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_API_URL || "";
 

--- a/frontend/app/[lang]/powers/page.tsx
+++ b/frontend/app/[lang]/powers/page.tsx
@@ -15,8 +15,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 const CATEGORY = "powers";

--- a/frontend/app/[lang]/reference/page.tsx
+++ b/frontend/app/[lang]/reference/page.tsx
@@ -22,8 +22,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 const CATEGORY = "reference";

--- a/frontend/app/[lang]/relics/page.tsx
+++ b/frontend/app/[lang]/relics/page.tsx
@@ -17,8 +17,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {

--- a/frontend/app/[lang]/tier-list/page.tsx
+++ b/frontend/app/[lang]/tier-list/page.tsx
@@ -13,7 +13,7 @@ import { t } from "@/lib/ui-translations";
 
 // Render per request like the English route (avoids a build-time empty bake
 // when the backend is unreachable); the shared body's fetches stay cached.
-export const dynamic = "force-dynamic";
+export const revalidate = 300;
 
 export async function generateMetadata({
   params,

--- a/frontend/app/[lang]/timeline/page.tsx
+++ b/frontend/app/[lang]/timeline/page.tsx
@@ -14,8 +14,6 @@ import {
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
-export const dynamic = "force-dynamic";
-
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 const CATEGORY = "timeline";

--- a/frontend/app/[lang]/unlocks/page.tsx
+++ b/frontend/app/[lang]/unlocks/page.tsx
@@ -13,8 +13,6 @@ import { t } from "@/lib/ui-translations";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 
-export const dynamic = "force-dynamic";
-
 const CATEGORY = "unlocks";
 const CATEGORY_LABEL = "Unlocks";
 


### PR DESCRIPTION
I removed force-dynamic from 39 localized pages and mirrored each English counterpart's exact route config instead (revalidate 60/300/3600 or default static with fetch-level revalidation), leaving the 21 that read searchParams, redirect, or are deliberately dynamic on the English side untouched; a full production build passes.