### PR TITLE
Build hreflang alternates through the shared helper

### DIFF
--- a/frontend/app/[lang]/about/page.tsx
+++ b/frontend/app/[lang]/about/page.tsx
@@ -5,10 +5,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const CATEGORY = "about";
@@ -25,13 +24,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${t(CATEGORY_LABEL, lang)} Spire Codex - ${gameName} | (${nativeName})`;
   const description = t("about_tagline", lang);
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/achievements/[id]/page.tsx
+++ b/frontend/app/[lang]/achievements/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import AchievementDetail from "@/app/achievements/[id]/AchievementDetail";
-import { stripTags, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription } from "@/lib/seo";
+import { stripTags, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -22,8 +22,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const gameName = LANG_GAME_NAME[langCode];
     const name = entity.name || id;
     const title = `${gameName} ${name} - Achievement | Spire Codex (${LANG_NAMES[langCode]})`;
-    const languages: Record<string, string> = { "en": `${SITE_URL}/achievements/${id}`, "x-default": `${SITE_URL}/achievements/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/achievements/${id}`;
+    const languages = buildLanguageAlternates(`/achievements/${id}`);
     return {
       title,
       description: clipMetaDescription(`${gameName} achievement, ${name}${desc ? `: ${desc}` : ""}`),

--- a/frontend/app/[lang]/acts/[id]/page.tsx
+++ b/frontend/app/[lang]/acts/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import ActDetail from "@/app/acts/[id]/ActDetail";
-import { clipMetaDescription, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { clipMetaDescription, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
 export const revalidate = 3600;
@@ -25,8 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const desc = clipMetaDescription(
       `${gameName} act, ${act.name}. ${act.num_rooms || "?"} rooms, ${act.bosses.length} bosses, ${act.encounters.length} encounters.`,
     );
-    const languages: Record<string, string> = { "en": `${SITE_URL}/acts/${id}`, "x-default": `${SITE_URL}/acts/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/acts/${id}`;
+    const languages = buildLanguageAlternates(`/acts/${id}`);
     return {
       title, description: desc,
       openGraph: {

--- a/frontend/app/[lang]/afflictions/[id]/page.tsx
+++ b/frontend/app/[lang]/afflictions/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import AfflictionDetail from "@/app/afflictions/[id]/AfflictionDetail";
-import { stripTags, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription } from "@/lib/seo";
+import { stripTags, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -22,8 +22,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const gameName = LANG_GAME_NAME[langCode];
     const name = entity.name || id;
     const title = `${gameName} ${name} - Affliction | Spire Codex (${LANG_NAMES[langCode]})`;
-    const languages: Record<string, string> = { "en": `${SITE_URL}/afflictions/${id}`, "x-default": `${SITE_URL}/afflictions/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/afflictions/${id}`;
+    const languages = buildLanguageAlternates(`/afflictions/${id}`);
     return {
       title,
       description: clipMetaDescription(`${gameName} affliction, ${name}${desc ? `: ${desc}` : ""}`),

--- a/frontend/app/[lang]/ancients/page.tsx
+++ b/frontend/app/[lang]/ancients/page.tsx
@@ -5,10 +5,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
@@ -29,13 +28,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} Ancient relic pools (${nativeName}). Every offering and condition for all 8 Ancients, Neow, Tezcatara, Pael, Orobas, Darv, Nonupeipe, and more.`;
 
-  const languages: Record<string, string> = {
-    en: `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/ascensions/[id]/page.tsx
+++ b/frontend/app/[lang]/ascensions/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import AscensionDetail from "@/app/ascensions/[id]/AscensionDetail";
-import { stripTags, stripTagsFlat, clipMetaDescription, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { stripTags, stripTagsFlat, clipMetaDescription, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
 export const revalidate = 3600;
@@ -26,8 +26,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const description = clipMetaDescription(
       `${gameName} Ascension ${asc.level}, ${asc.name}${desc ? `: ${desc}` : ""}`,
     );
-    const languages: Record<string, string> = { "en": `${SITE_URL}/ascensions/${id}`, "x-default": `${SITE_URL}/ascensions/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/ascensions/${id}`;
+    const languages = buildLanguageAlternates(`/ascensions/${id}`);
     return {
       title,
       description,

--- a/frontend/app/[lang]/badges/[id]/page.tsx
+++ b/frontend/app/[lang]/badges/[id]/page.tsx
@@ -4,13 +4,12 @@ import JsonLd from "@/app/components/JsonLd";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import RichDescription from "@/app/components/RichDescription";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { stripTags, stripTagsFlat, clipMetaDescription, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { stripTags, stripTagsFlat, clipMetaDescription, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import {
   isValidLang,
   LANG_HREFLANG,
   LANG_NAMES,
   LANG_GAME_NAME,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
 import { t } from "@/lib/ui-translations";
@@ -75,13 +74,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     `${gameName} run-end badge, ${badge.name}${desc ? `: ${desc}` : ""}`,
   );
 
-  const languages: Record<string, string> = {
-    en: `${SITE_URL}/badges/${id}`,
-    "x-default": `${SITE_URL}/badges/${id}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/badges/${id}`;
-  }
+  const languages = buildLanguageAlternates(`/badges/${id}`);
 
   return {
     title,

--- a/frontend/app/[lang]/badges/page.tsx
+++ b/frontend/app/[lang]/badges/page.tsx
@@ -11,10 +11,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 import type { Badge } from "@/lib/api";
 import { imageUrl } from "@/lib/image-url";
@@ -48,13 +47,7 @@ export async function generateMetadata({
   const title = `${gameName} ${t("Badges", lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} ${t("Badges", lang)}, ${t("badges_tagline", lang)}`;
 
-  const languages: Record<string, string> = {
-    en: `${SITE_URL}/badges`,
-    "x-default": `${SITE_URL}/badges`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/badges`;
-  }
+  const languages = buildLanguageAlternates(`/badges`);
 
   return {
     title,

--- a/frontend/app/[lang]/cards/[id]/page.tsx
+++ b/frontend/app/[lang]/cards/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import CardDetail from "@/app/cards/[id]/CardDetail";
-import { stripTags, stripTagsFlat, clipMetaDescription, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { stripTags, stripTagsFlat, clipMetaDescription, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { cardOgImages } from "@/lib/image-url";
 import { enchantmentsForCard } from "@/lib/card-enchantments";
@@ -38,8 +38,7 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
     const metaDesc = clipMetaDescription(
       `${gameName}, ${card.name} (${card.cost ?? "X"}-cost ${card.rarity} ${card.type}, ${color}). ${descFlat}${keywords}`,
     );
-    const languages: Record<string, string> = { "en": `${SITE_URL}/cards/${id}`, "x-default": `${SITE_URL}/cards/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/cards/${id}`;
+    const languages = buildLanguageAlternates(`/cards/${id}`);
     const ogImages = cardOgImages(card, lang);
     return {
       title,

--- a/frontend/app/[lang]/cards/page.tsx
+++ b/frontend/app/[lang]/cards/page.tsx
@@ -11,10 +11,9 @@ import {
   LANG_CARDS,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 export const revalidate = 60;
@@ -33,13 +32,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${cardsWord} | Spire Codex (${nativeName})`;
   const description = `${gameName} ${cardsWord} (${nativeName}). Every card across Ironclad, Silent, Defect, Necrobinder, and Regent, art, stats, upgrades, and keywords.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/cards`,
-    "x-default": `${SITE_URL}/cards`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/cards`;
-  }
+  const languages = buildLanguageAlternates(`/cards`);
 
   return {
     title,

--- a/frontend/app/[lang]/changelog/page.tsx
+++ b/frontend/app/[lang]/changelog/page.tsx
@@ -5,10 +5,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const CATEGORY = "changelog";
@@ -25,13 +24,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `Track what changes between ${gameName} game updates, new cards, balance tweaks, removed content, and more. ${nativeName}.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/characters/[id]/page.tsx
+++ b/frontend/app/[lang]/characters/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import CharacterDetail from "@/app/characters/[id]/CharacterDetail";
-import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription } from "@/lib/seo";
+import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { imageUrl } from "@/lib/image-url";
 
@@ -24,8 +24,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const gameName = LANG_GAME_NAME[langCode];
     const name = entity.name || entity.title || id;
     const title = `${gameName} ${name} - Character | Spire Codex (${LANG_NAMES[langCode]})`;
-    const languages: Record<string, string> = { "en": `${SITE_URL}/characters/${id}`, "x-default": `${SITE_URL}/characters/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/characters/${id}`;
+    const languages = buildLanguageAlternates(`/characters/${id}`);
     return {
       title,
       description: clipMetaDescription(`${gameName} playable character, ${name}${desc ? `: ${desc}` : ""}`),

--- a/frontend/app/[lang]/characters/page.tsx
+++ b/frontend/app/[lang]/characters/page.tsx
@@ -8,10 +8,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -30,13 +29,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} ${t(CATEGORY_LABEL, lang)} (${nativeName}). All five playable characters, Ironclad, Silent, Defect, Necrobinder, Regent. Starting decks and stats.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/community-stats/page.tsx
+++ b/frontend/app/[lang]/community-stats/page.tsx
@@ -6,10 +6,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 // Render per request like the English route (avoids a build-time empty bake
@@ -30,13 +29,7 @@ export async function generateMetadata({
   const title = `${gameName} ${t("Community Stats", lang)} | Spire Codex (${nativeName})`;
   const description = `Fun ${gameName} community stats: how players vote at every event, what kills runs most, win rates by ascension and character, and run records, all from community-submitted runs. ${nativeName}.`;
 
-  const languages: Record<string, string> = {
-    en: `${SITE_URL}/community-stats`,
-    "x-default": `${SITE_URL}/community-stats`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/community-stats`;
-  }
+  const languages = buildLanguageAlternates(`/community-stats`);
 
   return {
     title,

--- a/frontend/app/[lang]/compare/[pair]/page.tsx
+++ b/frontend/app/[lang]/compare/[pair]/page.tsx
@@ -4,8 +4,8 @@ import type { Character, Card } from "@/lib/api";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd } from "@/lib/jsonld";
 import CompareDetail from "@/app/compare/[pair]/CompareDetail";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 
 export const revalidate = 3600;
 
@@ -46,8 +46,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const title = `${gameName} ${nameA} vs ${nameB} - Character Comparison | Spire Codex (${LANG_NAMES[langCode]})`;
   const description = `Compare ${nameA} and ${nameB} in ${gameName}. Side-by-side stats, card pool breakdowns by type and rarity, keyword distributions, and starting decks.`;
 
-  const languages: Record<string, string> = { "en": `${SITE_URL}/compare/${pair}`, "x-default": `${SITE_URL}/compare/${pair}` };
-  for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/compare/${pair}`;
+  const languages = buildLanguageAlternates(`/compare/${pair}`);
 
   return {
     title,

--- a/frontend/app/[lang]/compare/page.tsx
+++ b/frontend/app/[lang]/compare/page.tsx
@@ -7,10 +7,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const CATEGORY = "compare";
@@ -63,13 +62,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `Compare all ${gameName} characters side by side. Stats, card pools, keywords, and starting decks. ${nativeName}.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/developers/page.tsx
+++ b/frontend/app/[lang]/developers/page.tsx
@@ -6,10 +6,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const CATEGORY = "developers";
@@ -28,13 +27,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} Developer API & Tooltip Widget | Spire Codex (${nativeName})`;
   const description = `Integrate ${gameName} game data into your projects. Public REST API with 22+ endpoints, embeddable tooltip widget, and multi-language support. ${nativeName}.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/enchantments/[id]/page.tsx
+++ b/frontend/app/[lang]/enchantments/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import EnchantmentDetail from "@/app/enchantments/[id]/EnchantmentDetail";
-import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription } from "@/lib/seo";
+import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { imageUrl } from "@/lib/image-url";
 import { cardsForEnchantment } from "@/lib/card-enchantments";
@@ -25,8 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const gameName = LANG_GAME_NAME[langCode];
     const name = entity.name || id;
     const title = `${gameName} ${name} - Enchantment | Spire Codex (${LANG_NAMES[langCode]})`;
-    const languages: Record<string, string> = { "en": `${SITE_URL}/enchantments/${id}`, "x-default": `${SITE_URL}/enchantments/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/enchantments/${id}`;
+    const languages = buildLanguageAlternates(`/enchantments/${id}`);
     return {
       title,
       description: clipMetaDescription(`${gameName} card enchantment, ${name}${desc ? `: ${desc}` : ""}`),

--- a/frontend/app/[lang]/enchantments/page.tsx
+++ b/frontend/app/[lang]/enchantments/page.tsx
@@ -9,10 +9,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -31,13 +30,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} ${t(CATEGORY_LABEL, lang)} (${nativeName}). Every enchantment, effects, card-type restrictions, stackability, and added card text.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/encounters/[id]/page.tsx
+++ b/frontend/app/[lang]/encounters/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import EncounterDetail from "@/app/encounters/[id]/EncounterDetail";
-import { clipMetaDescription, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { clipMetaDescription, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -28,8 +28,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const description = clipMetaDescription(
       `${gameName} ${roomType}encounter, ${name}.${monsterList}`,
     );
-    const languages: Record<string, string> = { "en": `${SITE_URL}/encounters/${id}`, "x-default": `${SITE_URL}/encounters/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/encounters/${id}`;
+    const languages = buildLanguageAlternates(`/encounters/${id}`);
     return {
       title,
       description,

--- a/frontend/app/[lang]/encounters/page.tsx
+++ b/frontend/app/[lang]/encounters/page.tsx
@@ -9,10 +9,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -31,13 +30,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} ${t(CATEGORY_LABEL, lang)} (${nativeName}). Every combat encounter, normal fights, elites, and bosses with monster compositions and act placement.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/events/[id]/page.tsx
+++ b/frontend/app/[lang]/events/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import EventDetail from "@/app/events/[id]/EventDetail";
-import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription } from "@/lib/seo";
+import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { imageUrl } from "@/lib/image-url";
 
@@ -24,8 +24,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const gameName = LANG_GAME_NAME[langCode];
     const name = entity.name || entity.title || id;
     const title = `${gameName} ${name} - Event | Spire Codex (${LANG_NAMES[langCode]})`;
-    const languages: Record<string, string> = { "en": `${SITE_URL}/events/${id}`, "x-default": `${SITE_URL}/events/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/events/${id}`;
+    const languages = buildLanguageAlternates(`/events/${id}`);
     return {
       title,
       description: clipMetaDescription(`${gameName} event, ${name}${desc ? `: ${desc}` : ""}`),

--- a/frontend/app/[lang]/events/page.tsx
+++ b/frontend/app/[lang]/events/page.tsx
@@ -9,10 +9,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -31,13 +30,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} ${t(CATEGORY_LABEL, lang)} (${nativeName}). Every shrine, Ancient, and story event, choices, dialogue, relic offerings, and outcomes.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/guides/page.tsx
+++ b/frontend/app/[lang]/guides/page.tsx
@@ -10,10 +10,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -31,13 +30,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t("Guides", lang)} | Spire Codex (${nativeName})`;
   const description = `${t("guides_tagline", lang)} ${nativeName}.`;
 
-  const languages: Record<string, string> = {
-    en: `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/images/page.tsx
+++ b/frontend/app/[lang]/images/page.tsx
@@ -5,10 +5,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const CATEGORY = "images";
@@ -25,13 +24,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} ${t(CATEGORY_LABEL, lang)} (${nativeName}). Browse and download game assets, card portraits, relic icons, monster sprites, and character art.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/intents/[id]/page.tsx
+++ b/frontend/app/[lang]/intents/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import IntentDetail from "@/app/intents/[id]/IntentDetail";
-import { stripTags, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription } from "@/lib/seo";
+import { stripTags, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -22,8 +22,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const gameName = LANG_GAME_NAME[langCode];
     const name = entity.name || id;
     const title = `${gameName} ${name} - Intent | Spire Codex (${LANG_NAMES[langCode]})`;
-    const languages: Record<string, string> = { "en": `${SITE_URL}/intents/${id}`, "x-default": `${SITE_URL}/intents/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/intents/${id}`;
+    const languages = buildLanguageAlternates(`/intents/${id}`);
     return {
       title,
       description: clipMetaDescription(`${gameName} monster intent, ${name}${desc ? `: ${desc}` : ""}`),

--- a/frontend/app/[lang]/keywords/[id]/page.tsx
+++ b/frontend/app/[lang]/keywords/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import KeywordDetail from "@/app/keywords/[id]/KeywordDetail";
-import { stripTags, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription } from "@/lib/seo";
+import { stripTags, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
 export const dynamic = "force-dynamic";
@@ -23,8 +23,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const langCode = lang as LangCode;
     const gameName = LANG_GAME_NAME[langCode];
     const title = `${gameName} ${kw.name} Cards - All ${kw.name} Cards | Spire Codex (${LANG_NAMES[langCode]})`;
-    const languages: Record<string, string> = { "en": `${SITE_URL}/keywords/${id}`, "x-default": `${SITE_URL}/keywords/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/keywords/${id}`;
+    const languages = buildLanguageAlternates(`/keywords/${id}`);
     return {
       title,
       description: `${desc} Browse all ${kw.name} cards in ${gameName}.`,

--- a/frontend/app/[lang]/keywords/page.tsx
+++ b/frontend/app/[lang]/keywords/page.tsx
@@ -8,10 +8,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 export const dynamic = "force-dynamic";
@@ -55,13 +54,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} Card ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} Card ${t(CATEGORY_LABEL, lang)} (${nativeName}). Every keyword and game term, Exhaust, Ethereal, Innate, Retain, Sly, Eternal, and more, with all cards using each.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/leaderboards/encounters/page.tsx
+++ b/frontend/app/[lang]/leaderboards/encounters/page.tsx
@@ -7,10 +7,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 export const dynamic = "force-dynamic";
@@ -29,13 +28,7 @@ export async function generateMetadata({
   const title = `${gameName} ${t("Encounter Stats", lang)} | Spire Codex (${nativeName})`;
   const description = t("encounter_stats_tagline", lang);
 
-  const languages: Record<string, string> = {
-    en: `${SITE_URL}/leaderboards/encounters`,
-    "x-default": `${SITE_URL}/leaderboards/encounters`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/leaderboards/encounters`;
-  }
+  const languages = buildLanguageAlternates(`/leaderboards/encounters`);
 
   return {
     title,

--- a/frontend/app/[lang]/leaderboards/metrics/page.tsx
+++ b/frontend/app/[lang]/leaderboards/metrics/page.tsx
@@ -8,10 +8,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 // Render per request like the English route (avoids a build-time empty
@@ -37,13 +36,7 @@ export async function generateMetadata({
   const title = `${gameName} ${t("Card Metrics", lang)} | Spire Codex (${nativeName})`;
   const description = t("metrics_tagline", lang);
 
-  const languages: Record<string, string> = {
-    en: `${SITE_URL}/leaderboards/metrics`,
-    "x-default": `${SITE_URL}/leaderboards/metrics`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/leaderboards/metrics`;
-  }
+  const languages = buildLanguageAlternates(`/leaderboards/metrics`);
 
   return {
     title,

--- a/frontend/app/[lang]/leaderboards/page.tsx
+++ b/frontend/app/[lang]/leaderboards/page.tsx
@@ -7,10 +7,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 export const dynamic = "force-dynamic";
@@ -29,13 +28,7 @@ export async function generateMetadata({
   const title = `${gameName} ${t("Leaderboards", lang)} | Spire Codex (${nativeName})`;
   const description = t("leaderboards_tagline", lang);
 
-  const languages: Record<string, string> = {
-    en: `${SITE_URL}/leaderboards`,
-    "x-default": `${SITE_URL}/leaderboards`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/leaderboards`;
-  }
+  const languages = buildLanguageAlternates(`/leaderboards`);
 
   return {
     title,

--- a/frontend/app/[lang]/leaderboards/scoring/page.tsx
+++ b/frontend/app/[lang]/leaderboards/scoring/page.tsx
@@ -5,10 +5,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 // The stats, tier-list, and metrics pages all link "How scoring works" with
@@ -30,13 +29,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `Codex Score - ${t("How scoring works", lang)} - ${gameName} | Spire Codex (${nativeName})`;
   const description = `How Codex Score ranks every ${gameName} card, relic, and potion. Bayesian-shrunk win rate, S-through-F tier bands, and full formula methodology. ${nativeName}.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${PATH}`,
-    "x-default": `${SITE_URL}/${PATH}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${PATH}`;
-  }
+  const languages = buildLanguageAlternates(`/${PATH}`);
 
   return {
     title,

--- a/frontend/app/[lang]/leaderboards/stats/page.tsx
+++ b/frontend/app/[lang]/leaderboards/stats/page.tsx
@@ -7,10 +7,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 export const dynamic = "force-dynamic";
@@ -29,13 +28,7 @@ export async function generateMetadata({
   const title = `${gameName} ${t("Stats", lang)} | Spire Codex (${nativeName})`;
   const description = t("stats_tagline", lang);
 
-  const languages: Record<string, string> = {
-    en: `${SITE_URL}/leaderboards/stats`,
-    "x-default": `${SITE_URL}/leaderboards/stats`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/leaderboards/stats`;
-  }
+  const languages = buildLanguageAlternates(`/leaderboards/stats`);
 
   return {
     title,

--- a/frontend/app/[lang]/leaderboards/submit/page.tsx
+++ b/frontend/app/[lang]/leaderboards/submit/page.tsx
@@ -7,10 +7,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 export const dynamic = "force-dynamic";
@@ -29,13 +28,7 @@ export async function generateMetadata({
   const title = `${gameName} ${t("Submit a Run", lang)} | Spire Codex (${nativeName})`;
   const description = t("submit_tagline", lang);
 
-  const languages: Record<string, string> = {
-    en: `${SITE_URL}/leaderboards/submit`,
-    "x-default": `${SITE_URL}/leaderboards/submit`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/leaderboards/submit`;
-  }
+  const languages = buildLanguageAlternates(`/leaderboards/submit`);
 
   return {
     title,

--- a/frontend/app/[lang]/mechanics/page.tsx
+++ b/frontend/app/[lang]/mechanics/page.tsx
@@ -7,10 +7,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE } from "@/lib/seo";
+import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 import type { MechanicSectionMeta } from "@/app/mechanics/page";
 
@@ -45,13 +44,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t("Game Mechanics", lang)} | Spire Codex (${nativeName})`;
   const description = t("mechanics_tagline", lang);
 
-  const languages: Record<string, string> = {
-    en: `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/merchant/page.tsx
+++ b/frontend/app/[lang]/merchant/page.tsx
@@ -7,10 +7,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 import { imageUrl } from "@/lib/image-url";
 import MerchantToc from "../../merchant/MerchantToc";
@@ -34,13 +33,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `Complete ${gameName} merchant price guide with card, relic, and potion costs, card removal pricing, and Fake Merchant relic details. ${nativeName}.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/modifiers/[id]/page.tsx
+++ b/frontend/app/[lang]/modifiers/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import ModifierDetail from "@/app/modifiers/[id]/ModifierDetail";
-import { stripTags, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription } from "@/lib/seo";
+import { stripTags, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -22,8 +22,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const gameName = LANG_GAME_NAME[langCode];
     const name = entity.name || id;
     const title = `${gameName} ${name} - Modifier | Spire Codex (${LANG_NAMES[langCode]})`;
-    const languages: Record<string, string> = { "en": `${SITE_URL}/modifiers/${id}`, "x-default": `${SITE_URL}/modifiers/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/modifiers/${id}`;
+    const languages = buildLanguageAlternates(`/modifiers/${id}`);
     return {
       title,
       description: clipMetaDescription(`${gameName} custom-run modifier, ${name}${desc ? `: ${desc}` : ""}`),

--- a/frontend/app/[lang]/modifiers/page.tsx
+++ b/frontend/app/[lang]/modifiers/page.tsx
@@ -7,10 +7,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 // The localized reference hub and footer link /<lang>/modifiers on every
@@ -31,13 +30,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} ${t(CATEGORY_LABEL, lang)} (${nativeName}). All 16 custom-mode modifiers, Draft, Sealed Deck, Insanity, and more. Effects, deck rules, and Neow interactions for each.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/monsters/[id]/page.tsx
+++ b/frontend/app/[lang]/monsters/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import MonsterDetail from "@/app/monsters/[id]/MonsterDetail";
-import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription } from "@/lib/seo";
+import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { imageUrl } from "@/lib/image-url";
 
@@ -26,8 +26,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const gameName = LANG_GAME_NAME[langCode];
     const name = entity.name || entity.title || id;
     const title = `${gameName} ${name} - Monster | Spire Codex (${LANG_NAMES[langCode]})`;
-    const languages: Record<string, string> = { "en": `${SITE_URL}/monsters/${id}`, "x-default": `${SITE_URL}/monsters/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/monsters/${id}`;
+    const languages = buildLanguageAlternates(`/monsters/${id}`);
     return {
       title,
       description: clipMetaDescription(`${gameName} monster, ${name}${desc ? `: ${desc}` : ""}`),

--- a/frontend/app/[lang]/monsters/page.tsx
+++ b/frontend/app/[lang]/monsters/page.tsx
@@ -9,10 +9,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -31,13 +30,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} ${t(CATEGORY_LABEL, lang)} (${nativeName}). Every monster, HP ranges, attack patterns, innate powers, and ascension scaling.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/news/page.tsx
+++ b/frontend/app/[lang]/news/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
-import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE } from "@/lib/seo";
+import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE, buildLanguageAlternates } from "@/lib/seo";
 import type { NewsArticle, NewsListResponse } from "@/lib/api";
 import { newsExcerpt, formatNewsDate, newsSlugForArticle } from "@/lib/steam-news";
 import {
@@ -10,7 +10,6 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
 import { t } from "@/lib/ui-translations";
@@ -50,13 +49,7 @@ export async function generateMetadata({
   const title = `${gameName} ${t("News", lang)} - ${t("News - Subtitle", lang)} | ${SITE_NAME} (${nativeName})`;
   const description = t("news_meta_description", lang);
 
-  const languages: Record<string, string> = {
-    en: `${SITE_URL}/news`,
-    "x-default": `${SITE_URL}/news`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/news`;
-  }
+  const languages = buildLanguageAlternates(`/news`);
 
   return {
     title,

--- a/frontend/app/[lang]/orbs/[id]/page.tsx
+++ b/frontend/app/[lang]/orbs/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import OrbDetail from "@/app/orbs/[id]/OrbDetail";
-import { stripTags, stripTagsFlat, clipMetaDescription, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { stripTags, stripTagsFlat, clipMetaDescription, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -25,8 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const description = clipMetaDescription(
       `${gameName} orb, ${name}${desc ? `: ${desc}` : ""}`,
     );
-    const languages: Record<string, string> = { "en": `${SITE_URL}/orbs/${id}`, "x-default": `${SITE_URL}/orbs/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/orbs/${id}`;
+    const languages = buildLanguageAlternates(`/orbs/${id}`);
     return {
       title,
       description: description,

--- a/frontend/app/[lang]/page.tsx
+++ b/frontend/app/[lang]/page.tsx
@@ -13,7 +13,7 @@ import SearchTrigger from "@/app/components/SearchTrigger";
 import { buildWebSiteJsonLd, buildVideoGameJsonLd } from "@/lib/jsonld";
 import { fetchSteamMeta } from "@/lib/steam-meta";
 import { t } from "@/lib/ui-translations";
-import { SITE_URL, SITE_NAME, HOME_OG_IMAGE } from "@/lib/seo";
+import { SITE_URL, SITE_NAME, HOME_OG_IMAGE, buildLanguageAlternates } from "@/lib/seo";
 import "@/app/home-revamp.css";
 import {
   isValidLang,
@@ -69,13 +69,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   // page reads as a language mismatch to crawlers (flagged on all 13 homes).
   const description = `${gameName} ${dbWord} (${nativeName}), Spire Codex. ${t("Browse cards, relics, characters, monsters, potions, events, and powers.", lang)}`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/`,
-    "x-default": `${SITE_URL}/`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}`;
-  }
+  const languages = buildLanguageAlternates("/");
 
   // Mirror `/page.tsx`: localized landing pages also use the bare-logo
   // OG asset rather than the branded composition that detail/list

--- a/frontend/app/[lang]/potions/[id]/page.tsx
+++ b/frontend/app/[lang]/potions/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import PotionDetail from "@/app/potions/[id]/PotionDetail";
-import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription } from "@/lib/seo";
+import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { imageUrl } from "@/lib/image-url";
 
@@ -24,8 +24,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const gameName = LANG_GAME_NAME[langCode];
     const name = entity.name || entity.title || id;
     const title = `${gameName} ${name} - Potion | Spire Codex (${LANG_NAMES[langCode]})`;
-    const languages: Record<string, string> = { "en": `${SITE_URL}/potions/${id}`, "x-default": `${SITE_URL}/potions/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/potions/${id}`;
+    const languages = buildLanguageAlternates(`/potions/${id}`);
     return {
       title,
       description: clipMetaDescription(`${gameName} potion, ${name}${desc ? `: ${desc}` : ""}`),

--- a/frontend/app/[lang]/potions/page.tsx
+++ b/frontend/app/[lang]/potions/page.tsx
@@ -10,10 +10,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -32,13 +31,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} ${t(CATEGORY_LABEL, lang)} (${nativeName}). Every potion by rarity and character pool, effects, shop prices, and use timing.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/powers/[id]/page.tsx
+++ b/frontend/app/[lang]/powers/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import PowerDetail from "@/app/powers/[id]/PowerDetail";
-import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription } from "@/lib/seo";
+import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { imageUrl } from "@/lib/image-url";
 
@@ -24,8 +24,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const gameName = LANG_GAME_NAME[langCode];
     const name = entity.name || entity.title || id;
     const title = `${gameName} ${name} - Power | Spire Codex (${LANG_NAMES[langCode]})`;
-    const languages: Record<string, string> = { "en": `${SITE_URL}/powers/${id}`, "x-default": `${SITE_URL}/powers/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/powers/${id}`;
+    const languages = buildLanguageAlternates(`/powers/${id}`);
     return {
       title,
       description: clipMetaDescription(`${gameName} power, ${name}${desc ? `: ${desc}` : ""}`),

--- a/frontend/app/[lang]/powers/page.tsx
+++ b/frontend/app/[lang]/powers/page.tsx
@@ -9,10 +9,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -31,13 +30,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} ${t(CATEGORY_LABEL, lang)} (${nativeName}). Every buff, debuff, and neutral power with descriptions, icons, and stack behaviour.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/reference/page.tsx
+++ b/frontend/app/[lang]/reference/page.tsx
@@ -16,10 +16,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -48,13 +47,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} ${t(CATEGORY_LABEL, lang)} (${nativeName}). Keywords, orbs, afflictions, intents, modifiers, achievements, acts, and ascension levels all in one place.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/relics/[id]/page.tsx
+++ b/frontend/app/[lang]/relics/[id]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import RelicDetail from "@/app/relics/[id]/RelicDetail";
-import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription } from "@/lib/seo";
+import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
-import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, SUPPORTED_LANGS, type LangCode } from "@/lib/languages";
+import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { imageUrl } from "@/lib/image-url";
 
@@ -33,8 +33,7 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
     const gameName = LANG_GAME_NAME[langCode];
     const name = entity.name || entity.title || id;
     const title = `${gameName} ${name} - Relic | Spire Codex (${LANG_NAMES[langCode]})`;
-    const languages: Record<string, string> = { "en": `${SITE_URL}/relics/${id}`, "x-default": `${SITE_URL}/relics/${id}` };
-    for (const code of SUPPORTED_LANGS) languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/relics/${id}`;
+    const languages = buildLanguageAlternates(`/relics/${id}`);
     return {
       title,
       description: clipMetaDescription(`${gameName} relic, ${name}${desc ? `: ${desc}` : ""}`),

--- a/frontend/app/[lang]/relics/page.tsx
+++ b/frontend/app/[lang]/relics/page.tsx
@@ -11,10 +11,9 @@ import {
   LANG_RELICS,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -31,13 +30,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${relicsWord} | Spire Codex (${nativeName})`;
   const description = `${gameName} ${relicsWord} (${nativeName}). Every relic by rarity and character pool, effects, flavor text, shop prices, and upgraded starters.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/relics`,
-    "x-default": `${SITE_URL}/relics`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/relics`;
-  }
+  const languages = buildLanguageAlternates(`/relics`);
 
   return {
     title,

--- a/frontend/app/[lang]/showcase/page.tsx
+++ b/frontend/app/[lang]/showcase/page.tsx
@@ -6,10 +6,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
@@ -57,13 +56,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} community projects (${nativeName}). Bots, widgets, apps, and tools built with the Spire Codex API by the Slay the Spire 2 community.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/tier-list/page.tsx
+++ b/frontend/app/[lang]/tier-list/page.tsx
@@ -5,10 +5,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 // Render per request like the English route (avoids a build-time empty bake
@@ -29,13 +28,7 @@ export async function generateMetadata({
   const title = `${gameName} ${t("Tier List", lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} tier list ranking every card, relic, and potion S through F. Codex Score from community win rates. ${nativeName}.`;
 
-  const languages: Record<string, string> = {
-    en: `${SITE_URL}/tier-list`,
-    "x-default": `${SITE_URL}/tier-list`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/tier-list`;
-  }
+  const languages = buildLanguageAlternates(`/tier-list`);
 
   return {
     title,

--- a/frontend/app/[lang]/timeline/page.tsx
+++ b/frontend/app/[lang]/timeline/page.tsx
@@ -8,10 +8,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -30,13 +29,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} ${t(CATEGORY_LABEL, lang)} (${nativeName}). All epochs, eras, and story arcs with cards, relics, and potions unlocked at each step.`;
 
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,

--- a/frontend/app/[lang]/unlocks/page.tsx
+++ b/frontend/app/[lang]/unlocks/page.tsx
@@ -5,10 +5,9 @@ import {
   LANG_GAME_NAME,
   LANG_NAMES,
   LANG_HREFLANG,
-  SUPPORTED_LANGS,
   type LangCode,
 } from "@/lib/languages";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import { t } from "@/lib/ui-translations";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
@@ -27,13 +26,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${t(CATEGORY_LABEL, lang)} | Spire Codex (${nativeName})`;
   const description = `${gameName} unlocks (${nativeName}). All unlockable cards, relics, potions, and characters with their epoch progression and score thresholds.`;
 
-  const languages: Record<string, string> = {
-    en: `${SITE_URL}/${CATEGORY}`,
-    "x-default": `${SITE_URL}/${CATEGORY}`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}/${CATEGORY}`;
-  }
+  const languages = buildLanguageAlternates(`/${CATEGORY}`);
 
   return {
     title,


### PR DESCRIPTION
I replaced the hand-rolled SUPPORTED_LANGS alternates loops in 54 localized pages with buildLanguageAlternates (byte-identical output, verified against both loop shapes), so adding zht only touches lib/languages.ts instead of 50+ files.