### PR TITLE
Make hidden-run exclusion index-only on the ranking counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install ruff
         # Ruff needs no project deps; installing requirements.txt here
         # wasted minutes per run.
-        run: pip install ruff
+        run: pip install "ruff==0.15.14"
 
       - name: Ruff lint
         run: ruff check app/

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -189,6 +189,15 @@ def _ensure_indexes(coll) -> None:
     # ~740k-doc collection.
     coll.create_index([("run_hash", ASCENDING)], sparse=True)
     coll.create_index([("run_time", ASCENDING)])
+    # Tiny partial index over just the hidden (cheated/moderated) docs so
+    # _count_visible can subtract them index-only. A bare hidden: {$ne: True}
+    # clause on the big win counts disqualifies the covering index and fetches
+    # every candidate doc — the 60s counts that 504'd submit enrichment.
+    coll.create_index(
+        [("win", ASCENDING), ("run_time", ASCENDING)],
+        name="hidden_win_runtime",
+        partialFilterExpression={"hidden": True},
+    )
     coll.create_index([("ascension", DESCENDING), ("run_time", ASCENDING)])
     coll.create_index([("character", ASCENDING), ("submitted_at", DESCENDING)])
     coll.create_index([("character", ASCENDING), ("run_time", ASCENDING)])
@@ -2355,6 +2364,15 @@ def _leaderboard_live(
     }
 
 
+def _count_visible(coll, query: dict) -> int:
+    """count_documents excluding hidden runs, index-only: count the full set,
+    then subtract the hidden subset (served by the tiny hidden_win_runtime
+    partial index). Never put hidden: {$ne: True} straight into a large
+    count — it disqualifies the covering index and fetches every candidate
+    doc, which is what stalled submit enrichment into gateway 504s."""
+    return coll.count_documents(query) - coll.count_documents({**query, "hidden": True})
+
+
 @_instrument("get_run_rank")
 def get_run_rank(run_hash: str, category: str = "fastest") -> dict:
     """Rank of a single winning run within its character's leaderboard.
@@ -2368,10 +2386,10 @@ def get_run_rank(run_hash: str, category: str = "fastest") -> dict:
         return {"rank": None}
 
     if category == "highest_ascension":
-        ahead = coll.count_documents(
+        ahead = _count_visible(
+            coll,
             {
                 "win": {"$in": [True, 1]},
-                "hidden": {"$ne": True},
                 "character": row["character"],
                 "$or": [
                     {"ascension": {"$gt": row.get("ascension", 0)}},
@@ -2380,16 +2398,16 @@ def get_run_rank(run_hash: str, category: str = "fastest") -> dict:
                         "run_time": {"$lt": row.get("run_time", 0)},
                     },
                 ],
-            }
+            },
         )
     else:
-        ahead = coll.count_documents(
+        ahead = _count_visible(
+            coll,
             {
                 "win": {"$in": [True, 1]},
-                "hidden": {"$ne": True},
                 "character": row["character"],
                 "run_time": {"$lt": row.get("run_time", 0)},
-            }
+            },
         )
     return {"rank": ahead + 1, "category": category}
 
@@ -2405,9 +2423,9 @@ def seed_rank_for(steam_id: str | None, seed: str) -> dict:
     winning run in that pool.
     """
     coll = _get_collection()
-    base = {"seed": seed, "was_abandoned": {"$ne": True}, "hidden": {"$ne": True}}
-    seed_total = coll.count_documents(base)
-    seed_wins = coll.count_documents({**base, "win": {"$in": [True, 1]}})
+    base = {"seed": seed, "was_abandoned": {"$ne": True}}
+    seed_total = _count_visible(coll, base)
+    seed_wins = _count_visible(coll, {**base, "win": {"$in": [True, 1]}})
 
     seed_rank = None
     global_rank = None
@@ -2425,13 +2443,13 @@ def seed_rank_for(steam_id: str | None, seed: str) -> dict:
         )
         if mine:
             seed_rank = (
-                coll.count_documents(
+                _count_visible(
+                    coll,
                     {
                         "seed": seed,
                         "win": {"$in": [True, 1]},
-                        "hidden": {"$ne": True},
                         "run_time": {"$lt": mine.get("run_time", 0)},
-                    }
+                    },
                 )
                 + 1
             )
@@ -2441,25 +2459,21 @@ def seed_rank_for(steam_id: str | None, seed: str) -> dict:
             {"run_time": 1},
             sort=[("run_time", 1)],
         )
-        global_total = coll.count_documents(
-            {"win": {"$in": [True, 1]}, "hidden": {"$ne": True}}
-        )
+        global_total = _count_visible(coll, {"win": {"$in": [True, 1]}})
         if best and global_total:
             global_rank = (
-                coll.count_documents(
+                _count_visible(
+                    coll,
                     {
                         "win": {"$in": [True, 1]},
-                        "hidden": {"$ne": True},
                         "run_time": {"$lt": best.get("run_time", 0)},
-                    }
+                    },
                 )
                 + 1
             )
             percentile = round(global_rank * 100.0 / global_total, 1)
     else:
-        global_total = coll.count_documents(
-            {"win": {"$in": [True, 1]}, "hidden": {"$ne": True}}
-        )
+        global_total = _count_visible(coll, {"win": {"$in": [True, 1]}})
 
     return {
         "seed": seed,
@@ -2666,7 +2680,7 @@ def get_run_rank_scoped(
     if not row or not row.get("win") or row.get("hidden"):
         return {"rank": None, "total": 0}
 
-    scope: dict[str, Any] = {"win": {"$in": [True, 1]}, "hidden": {"$ne": True}}
+    scope: dict[str, Any] = {"win": {"$in": [True, 1]}}
     if not today_only:
         scope["character"] = row["character"]
     if game_mode:
@@ -2692,8 +2706,8 @@ def get_run_rank_scoped(
     else:
         ahead_q = {**scope, "run_time": {"$lt": row.get("run_time", 0)}}
 
-    ahead = coll.count_documents(ahead_q)
-    total = coll.count_documents(scope)
+    ahead = _count_visible(coll, ahead_q)
+    total = _count_visible(coll, scope)
     return {"rank": ahead + 1, "total": total}
 
 

--- a/backend/tests/test_hidden_filters.py
+++ b/backend/tests/test_hidden_filters.py
@@ -1,5 +1,8 @@
 """Hidden (cheated/moderated) runs must stay out of every public ranking
-surface: the bulk export, single-run ranks, and the mod's seed panel."""
+surface — and the exclusion must stay index-only. Putting hidden: {$ne: True}
+directly into a large count disqualifies the covering index and fetches every
+candidate doc (the 60s counts that 504'd submit enrichment), so the counting
+paths use _count_visible: count(all) - count(hidden subset)."""
 
 from app.routers.exports import _build_match
 from app.services import runs_db_mongo
@@ -10,8 +13,9 @@ HIDDEN_CLAUSE = {"hidden": {"$ne": True}}
 class FakeColl:
     """Captures the filters each query runs with."""
 
-    def __init__(self, row=None):
+    def __init__(self, row=None, counts=None):
         self.row = row
+        self.counts = list(counts or [])
         self.find_one_queries = []
         self.count_queries = []
 
@@ -21,7 +25,23 @@ class FakeColl:
 
     def count_documents(self, q):
         self.count_queries.append(q)
-        return 0
+        return self.counts.pop(0) if self.counts else 0
+
+
+def _assert_subtractive_pairs(count_queries):
+    """Counts must come in (base, base+hidden:True) pairs, with $ne nowhere."""
+    assert len(count_queries) % 2 == 0
+    for base, hidden in zip(count_queries[::2], count_queries[1::2]):
+        assert "hidden" not in base, base
+        assert hidden == {**base, "hidden": True}
+    for q in count_queries:
+        assert q.get("hidden") != {"$ne": True}, q
+
+
+def test_count_visible_subtracts_hidden_subset():
+    fake = FakeColl(counts=[10, 3])
+    assert runs_db_mongo._count_visible(fake, {"win": True}) == 7
+    _assert_subtractive_pairs(fake.count_queries)
 
 
 def test_export_match_excludes_hidden():
@@ -38,29 +58,32 @@ def test_get_run_rank_refuses_hidden_run(monkeypatch):
     assert fake.count_queries == []
 
 
-def test_get_run_rank_counts_exclude_hidden(monkeypatch):
-    fake = FakeColl({"win": True, "character": "IRONCLAD", "run_time": 90})
+def test_get_run_rank_counts_subtract_hidden(monkeypatch):
+    fake = FakeColl(
+        {"win": True, "character": "IRONCLAD", "run_time": 90}, counts=[8, 2]
+    )
     monkeypatch.setattr(runs_db_mongo, "_get_collection", lambda: fake)
     out = runs_db_mongo.get_run_rank("h1")
-    assert out["rank"] == 1
-    assert fake.count_queries
-    for q in fake.count_queries:
-        assert q.get("hidden") == {"$ne": True}
+    assert out["rank"] == 7  # (8 visible-or-hidden ahead) - (2 hidden) + 1
+    _assert_subtractive_pairs(fake.count_queries)
 
 
-def test_get_run_rank_scoped_excludes_hidden(monkeypatch):
+def test_get_run_rank_scoped_subtracts_hidden(monkeypatch):
     fake = FakeColl({"win": True, "character": "SILENT", "run_time": 120})
     monkeypatch.setattr(runs_db_mongo, "_get_collection", lambda: fake)
     out = runs_db_mongo.get_run_rank_scoped("h2", game_mode="standard")
     assert out["rank"] == 1
-    for q in fake.count_queries:
-        assert q.get("hidden") == {"$ne": True}
+    assert len(fake.count_queries) == 4  # ahead pair + total pair
+    _assert_subtractive_pairs(fake.count_queries)
 
 
-def test_seed_rank_for_excludes_hidden_everywhere(monkeypatch):
+def test_seed_rank_for_stays_index_only(monkeypatch):
     fake = FakeColl(None)
     monkeypatch.setattr(runs_db_mongo, "_get_collection", lambda: fake)
     runs_db_mongo.seed_rank_for("7656119", "SEEDX")
-    assert fake.count_queries and fake.find_one_queries
-    for q in fake.count_queries + fake.find_one_queries:
+    _assert_subtractive_pairs(fake.count_queries)
+    # The steam_id find_ones are single-doc lookups; they keep the direct
+    # hidden exclusion.
+    assert fake.find_one_queries
+    for q in fake.find_one_queries:
         assert q.get("hidden") == {"$ne": True}, q


### PR DESCRIPTION
I replaced the hidden $ne clause on the big ranking counts (get_run_rank, get_run_rank_scoped, seed_rank_for) with count-all-minus-count-hidden backed by a tiny partial index over just the hidden docs, because the $ne clause was disqualifying the covering indexes and fetching every winning document per count, which stalled submit enrichment into the 504s reported this morning.