### PR TITLE
Honor soft deletes on profile surfaces and restore runs on re-upload

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -271,6 +271,7 @@ def _compute_personal_bests(username: str) -> dict:
         "username_lower": username.lower() if username else None,
         "win": {"$in": [True, 1]},
         "hidden": {"$ne": True},
+        "deleted_at": None,
     }
     proj = {
         "_id": 1,

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -1417,7 +1417,11 @@ def build_user_blob_stats(username: str) -> dict[str, Any]:
         cursor = (
             _get_collection()
             .find(
-                {"username_lower": u.lower(), "hidden": {"$ne": True}},
+                {
+                    "username_lower": u.lower(),
+                    "hidden": {"$ne": True},
+                    "deleted_at": None,
+                },
                 {
                     "_id": 1,
                     "character": 1,

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -836,6 +836,11 @@ def _submit_player_run(
         if not doc.get("hidden"):
             bump_stats_counters(doc)
     except DuplicateKeyError:
+        # Re-uploading the exact run file restores a soft-deleted run:
+        # holding the file is ownership proof, and delete only ever meant
+        # "hide from my profile" — without this, a delete-then-reupload
+        # leaves the list empty while every upload reports "duplicate".
+        _undelete_on_reupload(coll, run_hash)
         # The run already exists (commonly: it was submitted anonymously
         # before the client started sending an identity). Re-submitting with
         # a steam_id / discord_id becomes a migration path — tag the existing
@@ -1130,6 +1135,12 @@ def _build_match(
     if username:
         # Case-insensitive, exact (anchored) match on the normalized field.
         m["username_lower"] = username.lower()
+        # A user's own stats honor their soft deletes (None matches missing
+        # or null). Username-scoped only: the lookup is index-narrowed to one
+        # player, so the non-indexable null-match stays cheap, and community
+        # aggregates keep counting the runs (delete means "off my profile",
+        # not "out of the community data").
+        m["deleted_at"] = None
     # Drop admin-flagged cheated runs from every stat (absent field = eligible).
     m["hidden"] = {"$ne": True}
     return m
@@ -2723,6 +2734,7 @@ def get_win_rate_comparison(username: str) -> list[dict]:
                     "$match": {
                         "username_lower": username.lower(),
                         "hidden": {"$ne": True},
+                        "deleted_at": None,
                     }
                 },
                 {
@@ -2816,6 +2828,16 @@ def get_user_runs(
         )
 
     return {"runs": runs, "total": total, "page": page, "limit": limit}
+
+
+def _undelete_on_reupload(coll, run_hash: str) -> None:
+    """Clear a soft delete when the same run file comes back in. Guarded on
+    deleted_at being set so the common duplicate (never-deleted) is a no-op
+    matching zero docs."""
+    coll.update_one(
+        {"_id": run_hash, "deleted_at": {"$ne": None}},
+        {"$unset": {"deleted_at": ""}},
+    )
 
 
 def soft_delete_run(run_hash: str, user_id: str) -> dict:

--- a/backend/tests/test_deleted_runs.py
+++ b/backend/tests/test_deleted_runs.py
@@ -1,0 +1,35 @@
+"""Soft-deleted runs disappear from the OWNER's surfaces (profile stats,
+bests) but stay in community aggregates, and re-uploading the exact file
+restores them — without this, delete-then-reupload left an empty list, a
+stale stat tile, and every upload reporting "duplicate"."""
+
+from app.services import runs_db_mongo
+
+
+class FakeColl:
+    def __init__(self):
+        self.update_calls = []
+
+    def update_one(self, q, update, **kwargs):
+        self.update_calls.append((q, update))
+
+
+def test_profile_scoped_stats_exclude_deleted():
+    m = runs_db_mongo._build_match(None, None, None, None, None, "Lucas_9845")
+    assert m["username_lower"] == "lucas_9845"
+    assert m["deleted_at"] is None
+
+
+def test_global_stats_keep_deleted_runs():
+    # Community aggregates still count them: delete means "off my profile",
+    # not "out of the community data".
+    m = runs_db_mongo._build_match(None, None, None, None, None, None)
+    assert "deleted_at" not in m
+
+
+def test_reupload_restores_soft_deleted_run():
+    coll = FakeColl()
+    runs_db_mongo._undelete_on_reupload(coll, "abc123")
+    ((q, update),) = coll.update_calls
+    assert q == {"_id": "abc123", "deleted_at": {"$ne": None}}
+    assert update == {"$unset": {"deleted_at": ""}}


### PR DESCRIPTION
I made username-scoped stats, personal bests, win-rate comparison, and per-user charts exclude soft-deleted runs (deleted_at only ever filtered the profile's run list, so a cleared history still showed all its stats), and made re-uploading the exact file clear the soft delete, since before this a delete-then-reupload left the list empty while every upload reported duplicate.