### PR TITLE
Keep toolchain artifacts out of the orphan filter's staleness clock

### DIFF
--- a/backend/app/parsers/orphan_filter.py
+++ b/backend/app/parsers/orphan_filter.py
@@ -50,6 +50,13 @@ def _scan() -> tuple[frozenset[str], float]:
     referenced: set[str] = set()
     newest_mtime = 0.0
     for cs_file in DECOMPILED.rglob("*.cs"):
+        # Toolchain artifacts must not steer the staleness clock: opening the
+        # decompiled csproj in an IDE writes obj/**/AssemblyAttributes.cs with
+        # a fresh mtime, which made every REAL file look >24h stale and
+        # orphan-filtered fully-implemented unreferenced classes (the whole
+        # Adversary/Gravity batch vanished from a reparse this way).
+        if any(part in ("obj", "bin", "Properties") for part in cs_file.parts):
+            continue
         try:
             text = cs_file.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):

--- a/backend/tests/test_orphan_filter.py
+++ b/backend/tests/test_orphan_filter.py
@@ -1,0 +1,56 @@
+"""The orphan filter's staleness clock must ignore toolchain artifacts:
+one obj/ file written by an IDE days after extraction made every real
+file look stale and silently dropped fully-implemented unreferenced
+classes (the Adversary/Gravity batch) from a reparse."""
+
+import os
+import sys
+from pathlib import Path
+
+PARSERS = Path(__file__).resolve().parents[1] / "app" / "parsers"
+sys.path.insert(0, str(PARSERS))
+
+
+def _write(p: Path, text: str, mtime: float) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    os.utime(p, (mtime, mtime))
+
+
+def _load_filter(tmp_path, monkeypatch):
+    import orphan_filter
+
+    monkeypatch.setattr(orphan_filter, "DECOMPILED", tmp_path)
+    orphan_filter._scan.cache_clear()
+    return orphan_filter
+
+
+def test_toolchain_artifact_does_not_poison_staleness(tmp_path, monkeypatch):
+    base = 1_700_000_000.0
+    week_later = base + 7 * 86400
+    # Real extraction: uniform mtimes, one unreferenced class.
+    _write(
+        tmp_path / "Models/UnreferencedMonster.cs", "class UnreferencedMonster {}", base
+    )
+    _write(tmp_path / "Models/Referenced.cs", "var x = Model<Referenced>();", base)
+    # IDE artifact written a week later: must not become the clock.
+    _write(
+        tmp_path / "obj/Debug/net9.0/AssemblyAttributes.cs",
+        "// tool artifact",
+        week_later,
+    )
+
+    orphan_filter = _load_filter(tmp_path, monkeypatch)
+    assert not orphan_filter.is_orphan(tmp_path / "Models/UnreferencedMonster.cs")
+
+
+def test_genuine_leftover_is_still_flagged(tmp_path, monkeypatch):
+    base = 1_700_000_000.0
+    week_later = base + 7 * 86400
+    # A real re-extraction wrote current files a week after the leftover.
+    _write(tmp_path / "Models/Leftover.cs", "class Leftover {}", base)
+    _write(tmp_path / "Models/Current.cs", "var x = Model<Current>();", week_later)
+
+    orphan_filter = _load_filter(tmp_path, monkeypatch)
+    assert orphan_filter.is_orphan(tmp_path / "Models/Leftover.cs")
+    assert not orphan_filter.is_orphan(tmp_path / "Models/Current.cs")

--- a/data-beta/v0.109.1/changelogs/0.109.1.json
+++ b/data-beta/v0.109.1/changelogs/0.109.1.json
@@ -8,33 +8,16 @@
   "from_ref": "/tmp/claude-1000/-mnt-c-Users-peter-Documents-prima-codex-spire-codex/fe7248d4-d6f7-4489-a6e2-4ea989d7103f/scratchpad/data-beta-0109-reparse/eng",
   "to_ref": "/tmp/claude-1000/-mnt-c-Users-peter-Documents-prima-codex-spire-codex/fe7248d4-d6f7-4489-a6e2-4ea989d7103f/scratchpad/data-beta-new/eng",
   "summary": {
-    "added": 10,
+    "added": 0,
     "removed": 0,
-    "changed": 5
+    "changed": 3
   },
   "categories": [
     {
       "id": "monsters",
       "name": "Monsters",
-      "old_count": 112,
+      "old_count": 115,
       "new_count": 115,
-      "added": [
-        {
-          "id": "THE_ADVERSARY_MK_ONE",
-          "name": "The Adversary Mk 1",
-          "min_hp": 100
-        },
-        {
-          "id": "THE_ADVERSARY_MK_THREE",
-          "name": "The Adversary Mk 3",
-          "min_hp": 300
-        },
-        {
-          "id": "THE_ADVERSARY_MK_TWO",
-          "name": "The Adversary Mk 2",
-          "min_hp": 200
-        }
-      ],
       "changed": [
         {
           "id": "BYRDONIS",
@@ -59,32 +42,6 @@
               "field": "attack_pattern.states[SWOOP_MOVE].next",
               "old": "none",
               "new": "PECK_MOVE"
-            }
-          ]
-        },
-        {
-          "id": "CHOMPER",
-          "name": "Chomper",
-          "changes": [
-            {
-              "field": "encounters[1].encounter_id",
-              "old": "none",
-              "new": "TUNNELER_NORMAL"
-            },
-            {
-              "field": "encounters[1].encounter_name",
-              "old": "none",
-              "new": "Tunneling Twosome"
-            },
-            {
-              "field": "encounters[1].is_weak",
-              "old": "none",
-              "new": "no"
-            },
-            {
-              "field": "encounters[1].room_type",
-              "old": "none",
-              "new": "Monster"
             }
           ]
         },
@@ -129,113 +86,6 @@
               "new": "CLUMP_SHOT"
             }
           ]
-        },
-        {
-          "id": "TUNNELER",
-          "name": "Tunneler",
-          "changes": [
-            {
-              "field": "encounters[0].act",
-              "old": "Act 2 - Hive",
-              "new": "none"
-            },
-            {
-              "field": "encounters[0].encounter_id",
-              "old": "TUNNELER_WEAK",
-              "new": "TUNNELER_NORMAL"
-            },
-            {
-              "field": "encounters[0].encounter_name",
-              "old": "Tunneler",
-              "new": "Tunneling Twosome"
-            },
-            {
-              "field": "encounters[0].is_weak",
-              "old": "yes",
-              "new": "no"
-            },
-            {
-              "field": "encounters[1].act",
-              "old": "none",
-              "new": "Act 2 - Hive"
-            },
-            {
-              "field": "encounters[1].encounter_id",
-              "old": "none",
-              "new": "TUNNELER_WEAK"
-            },
-            {
-              "field": "encounters[1].encounter_name",
-              "old": "none",
-              "new": "Tunneler"
-            },
-            {
-              "field": "encounters[1].is_weak",
-              "old": "none",
-              "new": "yes"
-            },
-            {
-              "field": "encounters[1].room_type",
-              "old": "none",
-              "new": "Monster"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "enchantments",
-      "name": "Enchantments",
-      "old_count": 21,
-      "new_count": 22,
-      "added": [
-        {
-          "id": "SLUMBERING_ESSENCE",
-          "name": "Slumbering Essence"
-        }
-      ]
-    },
-    {
-      "id": "encounters",
-      "name": "Encounters",
-      "old_count": 88,
-      "new_count": 90,
-      "added": [
-        {
-          "id": "BATTLEWORN_DUMMY_EVENT_ENCOUNTER",
-          "name": "Battleworn Dummy Event Encounter"
-        },
-        {
-          "id": "TUNNELER_NORMAL",
-          "name": "Tunneling Twosome"
-        }
-      ]
-    },
-    {
-      "id": "powers",
-      "name": "Powers",
-      "old_count": 261,
-      "new_count": 265,
-      "added": [
-        {
-          "id": "GRAVITY",
-          "name": "Gravity",
-          "type": "Buff"
-        },
-        {
-          "id": "LEADERSHIP",
-          "name": "Leadership",
-          "type": "Buff"
-        },
-        {
-          "id": "MAGIC_BOMB",
-          "name": "Magic Bomb",
-          "type": "Debuff"
-        },
-        {
-          "id": "NO_ENERGY_GAIN",
-          "name": "No Energy Gain",
-          "type": "Debuff"
         }
       ]
     }


### PR DESCRIPTION
I made the orphan filter ignore obj/, bin/, and Properties/ when finding the newest mtime (a single IDE-written obj/ artifact had made every real file look stale, silently dropping the whole unreferenced-but-implemented Adversary/Gravity batch from parses), added regression tests for both the artifact case and the genuine-leftover case, and replaced the v0.109.1 changelog with one generated against a clean baseline: the true delta is three monsters gaining attack-pattern definitions, with the Adversary batch removed since it has shipped in the files since at least v0.108.0.