### PR TITLE
Keep card categories out of the Colors filter

### DIFF
--- a/frontend/app/cards/CardsClient.tsx
+++ b/frontend/app/cards/CardsClient.tsx
@@ -28,9 +28,6 @@ const colorOptions = [
   { label: "Necrobinder", value: "necrobinder" },
   { label: "Regent", value: "regent" },
   { label: "Colorless", value: "colorless" },
-  { label: "Event", value: "event" },
-  { label: "Token", value: "token" },
-  { label: "Curse", value: "curse" },
 ];
 
 const typeOptions = [
@@ -48,7 +45,11 @@ const rarityOptions = [
   { label: "Uncommon", value: "Uncommon" },
   { label: "Rare", value: "Rare" },
   { label: "Ancient", value: "Ancient" },
+  { label: "Event", value: "Event" },
+  { label: "Status", value: "Status" },
+  { label: "Curse", value: "Curse" },
   { label: "Token", value: "Token" },
+  { label: "Quest", value: "Quest" },
 ];
 
 const costOptions = [

--- a/frontend/app/cards/browse/[slug]/BrowseDetail.tsx
+++ b/frontend/app/cards/browse/[slug]/BrowseDetail.tsx
@@ -21,8 +21,6 @@ const colorOptions = [
   { label: "Necrobinder", value: "necrobinder" },
   { label: "Regent", value: "regent" },
   { label: "Colorless", value: "colorless" },
-  { label: "Token", value: "token" },
-  { label: "Curse", value: "curse" },
 ];
 
 const typeOptions = [

--- a/frontend/app/cards/page.tsx
+++ b/frontend/app/cards/page.tsx
@@ -129,7 +129,7 @@ export default async function CardsPage() {
     {
       question: t("What are the card rarities in sts2?", lang),
       answer:
-        "Cards come in four rarities, Common, Uncommon, Rare, and Boss, plus Starter cards in each character's opening deck. Rarity affects merchant pricing, card-reward drop odds, and tier-list balance: Boss cards can swing a run, while Common pickability matters more in long campaigns.",
+        "Draftable cards come in Common, Uncommon, and Rare, alongside the Basic cards in each character's opening deck and the star-cost Ancient cards. Event, Status, Curse, Token, and Quest cards round out the special categories. Rarity affects merchant pricing, card-reward drop odds, and tier-list balance: Ancient cards can swing a run, while Common pickability matters more in long campaigns.",
     },
     {
       question: t("Where does the card data come from?", lang),


### PR DESCRIPTION
Event, Token, and Curse were listed as colors in the cards compendium filter; I moved them (plus Status and Quest) into the Rarity dropdown where they belong, and fixed the card-rarity FAQ answer that claimed a Boss rarity exists. Closes the Colors item in #795.