### PR TITLE
Per-entity game-patch history in the Version history sections

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,6 +43,7 @@ from .routers import (
     names,
     exports,
     entity_history,
+    update_history,
     ancient_pools,
     runs,
     pairings,
@@ -660,6 +661,7 @@ app.include_router(ascensions.router)
 app.include_router(names.router)
 app.include_router(exports.router)
 app.include_router(entity_history.router)
+app.include_router(update_history.router)
 app.include_router(ancient_pools.router)
 app.include_router(runs.router)
 app.include_router(pairings.router)

--- a/backend/app/routers/update_history.py
+++ b/backend/app/routers/update_history.py
@@ -1,0 +1,35 @@
+"""Per-entity game-patch update history from data/entity_history.json
+(maintained by tools/entity_history_sync.py). English-only."""
+
+import json
+from functools import lru_cache
+
+from fastapi import APIRouter, HTTPException
+
+from ..services.data_service import DATA_DIR
+
+router = APIRouter(prefix="/api/update-history", tags=["Update History"])
+
+
+@lru_cache(maxsize=1)
+def _histories() -> dict[str, dict[str, list]]:
+    try:
+        with open(DATA_DIR / "entity_history.json", "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {}
+    types = data.get("types") if isinstance(data, dict) else None
+    return types if isinstance(types, dict) else {}
+
+
+@router.get("/{entity_type}/{entity_id}")
+def get_update_history(entity_type: str, entity_id: str):
+    """Game-patch changes for one entity, newest first. 404s when nothing is
+    recorded, so the frontend can fall back to the changelog timeline."""
+    entries = _histories().get(entity_type, {}).get(entity_id.upper())
+    if not entries:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No update history for '{entity_type}/{entity_id}'",
+        )
+    return entries

--- a/backend/tests/test_update_history.py
+++ b/backend/tests/test_update_history.py
@@ -1,0 +1,65 @@
+"""The per-entity update-history endpoint serves the game-patch tables in
+data/entity_history.json; unknown entities 404 so the frontend can fall
+back to the site-changelog timeline."""
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers.update_history import _histories, get_update_history
+
+
+def test_history_file_loads_and_is_well_formed():
+    types = _histories()
+    assert len(types["cards"]) > 400
+    assert len(types["relics"]) > 150
+    for entity_type, entities in types.items():
+        for entity_id, entries in list(entities.items())[:30]:
+            assert entity_id == entity_id.upper(), (entity_type, entity_id)
+            assert entries
+            for entry in entries:
+                assert set(entry) == {"version", "type", "date", "changes"}
+                assert isinstance(entry["changes"], list)
+                assert all(isinstance(c, str) and c for c in entry["changes"])
+
+
+def test_dated_entries_are_newest_first():
+    checked = 0
+    for entities in _histories().values():
+        for entries in entities.values():
+            dates = [e["date"] for e in entries if e["date"]]
+            if len(dates) > 1:
+                assert dates == sorted(dates, reverse=True)
+                checked += 1
+    assert checked > 50
+
+
+def test_known_entity_returns_its_entries():
+    types = _histories()
+    card_id = next(iter(types["cards"]))
+    assert get_update_history("cards", card_id.lower()) == types["cards"][card_id]
+
+
+def test_unknown_entity_404s():
+    for entity_type, entity_id in [
+        ("cards", "NOT_A_REAL_CARD"),
+        ("no_such_type", "WHATEVER"),
+    ]:
+        with pytest.raises(HTTPException) as exc:
+            get_update_history(entity_type, entity_id)
+        assert exc.value.status_code == 404
+
+
+def test_starter_variants_have_history():
+    # Duplicate-named starters resolve to per-character pages
+    # (e.g. "Strike (Ironclad)"), which regressed once already.
+    cards = _histories()["cards"]
+    assert "STRIKE_IRONCLAD" in cards
+    assert "DEFEND_IRONCLAD" in cards
+
+
+def test_name_collisions_stay_in_their_type():
+    types = _histories()
+    # Accelerant is both a card and a power; the power page lookup must not
+    # pick up the card page's history.
+    assert "ACCELERANT" in types["cards"]
+    assert "ACCELERANT" not in types.get("powers", {})

--- a/data/entity_history.json
+++ b/data/entity_history.json
@@ -1,0 +1,16065 @@
+{
+ "_meta": {
+  "fetched": "2026-07-29"
+ },
+ "types": {
+  "cards": {
+   "ACCELERANT": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Changed  Accelerant card: rarity decreased from Rare -> Uncommon"
+     ]
+    },
+    {
+     "version": "V0.89.0",
+     "type": "Pre-release",
+     "date": "2026-01-08",
+     "changes": [
+      "The green Poison overlay on the health bar now properly accounts for the player having both Accelerant card and Soup Recipe relic at the same time"
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Changed Accelerant card: rarity increased from Uncommon -> Rare"
+     ]
+    },
+    {
+     "version": "V0.65.0",
+     "type": "Pre-release",
+     "date": "2025-07-10",
+     "changes": [
+      "Fixed an issue where killing an enemy with Poison and Accelerant could cause a softlock"
+     ]
+    },
+    {
+     "version": "V0.60.0",
+     "type": "Pre-release",
+     "date": "2025-06-12",
+     "changes": [
+      "Accelerant power no longer softlocks combat if poison ends the combat"
+     ]
+    },
+    {
+     "version": "V0.58.0",
+     "type": "Pre-release",
+     "date": "2025-05-29",
+     "changes": [
+      "Changed Accelerant card: rarity decreased from Rare -> Uncommon"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Changed Accelerant card: rarity increased from Uncommon -> Rare"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Buffed Accelerant card: cost decreased from 2 -> 1"
+     ]
+    },
+    {
+     "version": "V0.23.0",
+     "type": "Pre-release",
+     "date": "2024-08-16",
+     "changes": [
+      "Cost lowered from 3 -> 2",
+      "Upgrade changed from cost reduction -> triggering an additional time"
+     ]
+    },
+    {
+     "version": "V0.15.0",
+     "type": "Pre-release",
+     "date": "2024-06-07",
+     "changes": [
+      "When you have Accelerant and an enemy has exactly 2 Poison, their Poison now properly triggers twice"
+     ]
+    },
+    {
+     "version": "2023-05-26",
+     "type": "Pre-release",
+     "date": "2023-05-26",
+     "changes": [
+      "Make Poison health bar overlay reflect Accelerant"
+     ]
+    },
+    {
+     "version": "2023-05-05",
+     "type": "Pre-release",
+     "date": "2023-05-05",
+     "changes": [
+      "Accelerant nerf. Cost from 2 -> 3."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Accelerant to the game."
+     ]
+    }
+   ],
+   "ACCURACY": [
+    {
+     "version": "V0.86.0",
+     "type": "Pre-release",
+     "date": "2025-12-11",
+     "changes": [
+      "Accuracy and Execution cards now properly show Shiv card hovertip"
+     ]
+    },
+    {
+     "version": "2023-05-05",
+     "type": "Pre-release",
+     "date": "2023-05-05",
+     "changes": [
+      "Updated Accuracy card portrait"
+     ]
+    },
+    {
+     "version": "2023-04-29",
+     "type": "Pre-release",
+     "date": "2023-04-29",
+     "changes": [
+      "Fixed Accuracy not showing upgrade in smith"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Accuracy to the game"
+     ]
+    }
+   ],
+   "ACROBATICS": [
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Rarity increased from Common to Uncommon"
+     ]
+    },
+    {
+     "version": "V0.65.0",
+     "type": "Pre-release",
+     "date": "2025-07-10",
+     "changes": [
+      "Fixed softlock when playing Sly Acrobatics from Tools of the Trade power"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Acrobatics to the game"
+     ]
+    }
+   ],
+   "ADAPTIVE_STRIKE": [
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Added portrait art for Adaptive Strike"
+     ]
+    },
+    {
+     "version": "V0.89.0",
+     "type": "Pre-release",
+     "date": "2026-01-08",
+     "changes": [
+      "Buffed Adaptive Strike card: damage increased from 17(21) -> 18(23)"
+     ]
+    },
+    {
+     "version": "V0.76.0",
+     "type": "Pre-release",
+     "date": "2025-09-25",
+     "changes": [
+      "Adaptive Strike card now says \"Add a 0 (energy symbol) copy...\" instead of \"Add a 0 cost copy...\""
+     ]
+    },
+    {
+     "version": "V0.65.0",
+     "type": "Pre-release",
+     "date": "2025-07-10",
+     "changes": [
+      "Changed Adaptive Strike card: rarity increased from Uncommon -> Rare"
+     ]
+    },
+    {
+     "version": "V0.61.0",
+     "type": "Pre-release",
+     "date": "2025-06-20",
+     "changes": [
+      "Added beta art for Adaptive Strike"
+     ]
+    },
+    {
+     "version": "V0.60.0",
+     "type": "Pre-release",
+     "date": "2025-06-12",
+     "changes": [
+      "Added Adaptive Strike to the game"
+     ]
+    }
+   ],
+   "ADRENALINE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "AFTERIMAGE": [
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed After Image -> Afterimage"
+     ]
+    },
+    {
+     "version": "V0.65.0",
+     "type": "Pre-release",
+     "date": "2025-07-10",
+     "changes": [
+      "After Image power and Barnacled Pipe relic now grant block much faster"
+     ]
+    },
+    {
+     "version": "V0.48.0",
+     "type": "Pre-release",
+     "date": "2025-03-06",
+     "changes": [
+      "After Image power should now trigger significantly faster"
+     ]
+    },
+    {
+     "version": "V0.16.0",
+     "type": "Pre-release",
+     "date": "2024-06-14",
+     "changes": [
+      "Shadowmeld card now affects block gain from After Image power"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added After Image to the game"
+     ]
+    }
+   ],
+   "AGGRESSION": [
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Aggression card now specifies that the upgrade lasts for the rest of combat"
+     ]
+    },
+    {
+     "version": "V0.37.0",
+     "type": "Pre-release",
+     "date": "2024-11-21",
+     "changes": [
+      "Aggression now triggers before cards are drawn"
+     ]
+    },
+    {
+     "version": "V0.24.0",
+     "type": "Pre-release",
+     "date": "2024-08-23",
+     "changes": [
+      "Fixed Aggression power description"
+     ]
+    },
+    {
+     "version": "V0.19.0",
+     "type": "Pre-release",
+     "date": "2024-07-05",
+     "changes": [
+      "Aggression card clarified to state that it does not draw cards (doesn't trigger Hellraiser)"
+     ]
+    },
+    {
+     "version": "V0.10.0",
+     "type": "Pre-release",
+     "date": "2024-05-04",
+     "changes": [
+      "Aggression no longer gives you Strength"
+     ]
+    },
+    {
+     "version": "2023-09-08",
+     "type": "Pre-release",
+     "date": "2023-09-08",
+     "changes": [
+      "Added Aggression power icon"
+     ]
+    },
+    {
+     "version": "2023-04-21",
+     "type": "Pre-release",
+     "date": "2023-04-21",
+     "changes": [
+      "Added Aggression card art"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Aggression to the game"
+     ]
+    }
+   ],
+   "ALCHEMIZE": [
+    {
+     "version": "V0.53.0",
+     "type": "Pre-release",
+     "date": "2025-04-25",
+     "changes": [
+      "Changed Alchemize card: pool changed from Silent -> Colorless"
+     ]
+    },
+    {
+     "version": "V0.40.0",
+     "type": "Pre-release",
+     "date": "2025-01-09",
+     "changes": [
+      "Nerfed Alchemize card: can no longer procure Fruit Juice, Regen Potion, or Fairy in a Bottle potions"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Alchemize to the game"
+     ]
+    }
+   ],
+   "ALIGNMENT": [
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Star cost increased from 2 -> 3"
+     ]
+    },
+    {
+     "version": "V0.63.0",
+     "type": "Pre-release",
+     "date": "2025-07-03",
+     "changes": [
+      "Changed Alignment card:",
+      "Star cost decreased from 3 -> 2",
+      "Energy gain decreased from 3(4) -> 2(3)"
+     ]
+    },
+    {
+     "version": "V0.51.0",
+     "type": "Pre-release",
+     "date": "2025-04-10",
+     "changes": [
+      "Buffed Alignment card: Energy gain increased from 2(3) -> 3(4)"
+     ]
+    },
+    {
+     "version": "V0.39.0",
+     "type": "Pre-release",
+     "date": "2024-12-12",
+     "changes": [
+      "Buffed Alignment card: energy gain increased from 1(2) -> 2(3)"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Reworked Alignment card:",
+      "Skill - Uncommon - 0 Energy, 3 Stars",
+      "Gain 2 Energy"
+     ]
+    },
+    {
+     "version": "V0.23.0",
+     "type": "Pre-release",
+     "date": "2024-08-16",
+     "changes": [
+      "Alignment card buffed from 3(4) stars -> 4(5) stars"
+     ]
+    },
+    {
+     "version": "V0.16.0",
+     "type": "Pre-release",
+     "date": "2024-06-14",
+     "changes": [
+      "Changed Alignment card: rarity downgraded from Rare -> Uncommon"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Alignment to the game"
+     ]
+    }
+   ],
+   "ALL_FOR_ONE": [
+    {
+     "version": "V0.76.0",
+     "type": "Pre-release",
+     "date": "2025-09-25",
+     "changes": [
+      "All For One and Jackpot cards now say \"0 (energy symbol) cards\" instead of \"cost 0 cards\""
+     ]
+    },
+    {
+     "version": "V0.65.0",
+     "type": "Pre-release",
+     "date": "2025-07-10",
+     "changes": [
+      "All For One card now properly retrieves cards from the discard pile if their cost has been reduced to 0 via a passive effect like Feral card"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added All for One to the game"
+     ]
+    }
+   ],
+   "ANGER": [
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "Changes from the beta branch were incorporated into the main branch"
+     ]
+    },
+    {
+     "version": "V0.104.0",
+     "type": "Beta Patch",
+     "date": "2026-04-23",
+     "changes": [
+      "Fixed Anger card played by Havoc also Exhausting on play"
+     ]
+    },
+    {
+     "version": "V0.22.0",
+     "type": "Pre-release",
+     "date": "2024-08-09",
+     "changes": [
+      "Fixed incorrect newline on Anger card"
+     ]
+    },
+    {
+     "version": "V0.10.0",
+     "type": "Pre-release",
+     "date": "2024-05-04",
+     "changes": [
+      "Anger and Leading Strike no longer generate their cards if combat is finished"
+     ]
+    },
+    {
+     "version": "2023-07-21",
+     "type": "Pre-release",
+     "date": "2023-07-21",
+     "changes": [
+      "Anger spawn card no longer pauses card queue for as long (2.35s -> 0.75s)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Anger to the game"
+     ]
+    }
+   ],
+   "ANOINTED": [
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "Fixed a softlock when playing Anointed card with a Draw Pile larger than your hand can hold"
+     ]
+    },
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Fixed a softlock when playing Anointed card when your Draw Pile contains more cards than can fit in your hand"
+     ]
+    },
+    {
+     "version": "V0.28.0",
+     "type": "Pre-release",
+     "date": "2024-09-19",
+     "changes": [
+      "Added Anointed, Eternal Armor, Ultimate Strike card art + misc touch ups"
+     ]
+    },
+    {
+     "version": "V0.26.0",
+     "type": "Pre-release",
+     "date": "2024-09-06",
+     "changes": [
+      "Changed Anointed card: upgrade changed from Innate -> Retain"
+     ]
+    },
+    {
+     "version": "V0.23.0",
+     "type": "Pre-release",
+     "date": "2024-08-16",
+     "changes": [
+      "Added Anointed to the game"
+     ]
+    }
+   ],
+   "ANTICIPATE": [
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Dexterity gain increased from 2(3) → 2(4)"
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Dexterity gain decreased from 3(5) -> 2(3)."
+     ]
+    },
+    {
+     "version": "V0.74.0",
+     "type": "Pre-release",
+     "date": "2025-09-11",
+     "changes": [
+      "Dexterity gain decreased from 4(6) -> 3(5)"
+     ]
+    },
+    {
+     "version": "V0.42.0",
+     "type": "Pre-release",
+     "date": "2025-01-23",
+     "changes": [
+      "Dexterity gain increased from 3(5) -> 4(6)"
+     ]
+    },
+    {
+     "version": "V0.24.0",
+     "type": "Pre-release",
+     "date": "2024-08-23",
+     "changes": [
+      "Dexterity gain increased from 2(4) -> 3(5)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Anticipate to the game"
+     ]
+    }
+   ],
+   "APOTHEOSIS": [
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Buffed Apotheosis card:",
+      "Now has Innate",
+      "Moved pools from Darv -> Nonupeipe"
+     ]
+    },
+    {
+     "version": "V0.66.0",
+     "type": "Pre-release",
+     "date": "2025-07-17",
+     "changes": [
+      "Apotheosis card can no longer show up in the Neow's colorless card blessing"
+     ]
+    },
+    {
+     "version": "V0.49.0",
+     "type": "Pre-release",
+     "date": "2025-03-13",
+     "changes": [
+      "Added vertical card portrait for Apotheosis"
+     ]
+    },
+    {
+     "version": "V0.18.0",
+     "type": "Pre-release",
+     "date": "2024-06-29",
+     "changes": [
+      "Playing Apotheosis is no longer super laggy"
+     ]
+    },
+    {
+     "version": "2023-09-01",
+     "type": "Pre-release",
+     "date": "2023-09-01",
+     "changes": [
+      "Updated Apotheosis card art"
+     ]
+    },
+    {
+     "version": "2023-04-21",
+     "type": "Pre-release",
+     "date": "2023-04-21",
+     "changes": [
+      "Fixed crash on apotheosis"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Apotheosis to the game"
+     ]
+    }
+   ],
+   "APPARITION": [
+    {
+     "version": "V0.104.0",
+     "type": "Beta Patch",
+     "date": "2026-04-23",
+     "changes": [
+      "Added vertical portrait art for Apparition"
+     ]
+    },
+    {
+     "version": "V0.94.0",
+     "type": "Pre-release",
+     "date": "2026-02-12",
+     "changes": [
+      "Buffed Vakuu's Crimson Pendant relic: Apparitions increased from 2 -> 3"
+     ]
+    },
+    {
+     "version": "V0.66.0",
+     "type": "Pre-release",
+     "date": "2025-07-17",
+     "changes": [
+      "Added beta portrait art for Apparition"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Apparition to the game"
+     ]
+    }
+   ],
+   "ARMAMENTS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Armaments to the game"
+     ]
+    }
+   ],
+   "ARSENAL": [
+    {
+     "version": "V0.104.0",
+     "type": "Beta Patch",
+     "date": "2026-04-23",
+     "changes": [
+      "Pillar of Creation, Supermassive, and Arsenal cards now proc for the player that played Largesse card rather than the player who gets the generated card"
+     ]
+    },
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Changed Regalite relic: now grants Block for any card created, not just Colorless cards",
+      "This change makes Regalite consistent with Arsenal, and gives more love to the Regent's Status-generating cards."
+     ]
+    },
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Reworked Arsenal card: \"Power - Rare - Cost 1 Whenever you play a Colorless Card, gain 1(2) Strength.\" -> \"Power - Rare - Cost 1 (Innate.) Whenever you create a card, gain 1 Strength.\""
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Added portrait art for Arsenal"
+     ]
+    },
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "Added Arsenal to the game"
+     ]
+    }
+   ],
+   "ASCENDERS_BANE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Ascender's Bane to the game"
+     ]
+    }
+   ],
+   "ASHEN_STRIKE": [
+    {
+     "version": "V0.60.0",
+     "type": "Pre-release",
+     "date": "2025-06-12",
+     "changes": [
+      "Buffed Ashen Strike card: damage scaling buffed from 2(3) additional damage per exhausted card -> 3(4)"
+     ]
+    },
+    {
+     "version": "V0.47.0",
+     "type": "Pre-release",
+     "date": "2025-02-27",
+     "changes": [
+      "Updated portrait art for Ashen Strike"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Changed Ashen Strike card: now highlights the correct number in green when you have Strength"
+     ]
+    },
+    {
+     "version": "V0.16.0",
+     "type": "Pre-release",
+     "date": "2024-06-14",
+     "changes": [
+      "Reworked Ashen Strike card: now deals 6 upfront damage, but damage per card in exhaust is reduced to 2(3)"
+     ]
+    },
+    {
+     "version": "V0.9.0",
+     "type": "Pre-release",
+     "date": "2024-04-26",
+     "changes": [
+      "Ashen Strike rarity changed from Common -> Uncommon"
+     ]
+    },
+    {
+     "version": "2023-04-29",
+     "type": "Pre-release",
+     "date": "2023-04-29",
+     "changes": [
+      "Bugfix: softlock when buying ashen strike from shop"
+     ]
+    },
+    {
+     "version": "2023-04-21",
+     "type": "Pre-release",
+     "date": "2023-04-21",
+     "changes": [
+      "Bugfix: softlock on when ashen strike has ringing"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Ashen Strike to the game"
+     ]
+    }
+   ],
+   "ASSASSINATE": [
+    {
+     "version": "V0.39.0",
+     "type": "Pre-release",
+     "date": "2024-12-12",
+     "changes": [
+      "Assassinate now has Vulnerable hovertip"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Reworked Assassinate card: “Innate. Deal 10(13) damage. Apply 1(2) Vulnerable. Exhaust.”"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Reworked Assassinate card:",
+      "Attack - Rare - 0 Energy",
+      "“Innate(Retain). Deal damage to the enemy equal to the amount of damage they have already taken this turn. Exhaust.”"
+     ]
+    },
+    {
+     "version": "V0.15.0",
+     "type": "Pre-release",
+     "date": "2024-06-07",
+     "changes": [
+      "Reworked Assassinate card:",
+      "Attack - 3 - Rare",
+      "“Deal 12 damage. When you discard this card, increase its damage by 6(9) this combat. Exhaust.”"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Assassinate to the game"
+     ]
+    }
+   ],
+   "ASTRAL_PULSE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Astral Pulse to the game"
+     ]
+    }
+   ],
+   "AUTOMATION": [
+    {
+     "version": "V0.65.0",
+     "type": "Pre-release",
+     "date": "2025-07-10",
+     "changes": [
+      "Fixed delay after Automation power would trigger"
+     ]
+    },
+    {
+     "version": "V0.55.0",
+     "type": "Pre-release",
+     "date": "2025-05-08",
+     "changes": [
+      "Added portrait art for Automation"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Added Automation to the game"
+     ]
+    }
+   ],
+   "BEGONE": [
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Changed BEGONE! card:",
+      "Now a Skill that no longer deals damage",
+      "Now creates Minion Strike instead of Minion Dive Bomb"
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Nerfed BEGONE! card: damage decreased from 6(7) -> 4(5)"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "Regent's last card unlock set unlocks Begone rather than Quasar"
+     ]
+    },
+    {
+     "version": "V0.76.0",
+     "type": "Pre-release",
+     "date": "2025-09-25",
+     "changes": [
+      "Changed BEGONE! card:",
+      "Damage increased from 4(4) -> 6(7)",
+      "Rarity decreased from Uncommon -> Common",
+      "Minion Dive Bomb card's damage decreased from 16(21) -> 13(16)"
+     ]
+    },
+    {
+     "version": "V0.50.0",
+     "type": "Pre-release",
+     "date": "2025-04-03",
+     "changes": [
+      "Buffed Begone/Minion Dive Bomb card: damage increased from 14(19) -> 16(21)"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Begone card no longer shows a misleading Transform hovertip"
+     ]
+    },
+    {
+     "version": "V0.43.0",
+     "type": "Pre-release",
+     "date": "2025-01-30",
+     "changes": [
+      "Added portrait art for BEGONE!, Heavenly Drill, Heirloom Hammer, Parry Regent cards"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added BEGONE! to the game"
+     ]
+    }
+   ],
+   "BACKFLIP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Backflip to the game"
+     ]
+    }
+   ],
+   "BACKSTAB": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Backstab to the game"
+     ]
+    }
+   ],
+   "BAD_LUCK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bad Luck to the game"
+     ]
+    }
+   ],
+   "BALL_LIGHTNING": [
+    {
+     "version": "V0.62.0",
+     "type": "Pre-release",
+     "date": "2025-06-26",
+     "changes": [
+      "Added Lightning Orb hovertip to Ball Lightning card"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Ball Lightning to the game"
+     ]
+    }
+   ],
+   "BANSHEES_CRY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Banshee's Cry to the game"
+     ]
+    }
+   ],
+   "BARRAGE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Barrage to the game"
+     ]
+    }
+   ],
+   "BARRICADE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Barricade to the game"
+     ]
+    }
+   ],
+   "BASH": [
+    {
+     "version": "V0.55.0",
+     "type": "Pre-release",
+     "date": "2025-05-08",
+     "changes": [
+      "Fixed an issue where killing an enemy with an attack that also applied a power to them (like Bash) caused a softlock"
+     ]
+    },
+    {
+     "version": "V0.43.0",
+     "type": "Pre-release",
+     "date": "2025-01-30",
+     "changes": [
+      "Added special transformed starter cards for Orobas’ Transcendence blessing:",
+      "Ironclad: Bash -> Break"
+     ]
+    },
+    {
+     "version": "2023-04-21",
+     "type": "Pre-release",
+     "date": "2023-04-21",
+     "changes": [
+      "Bug Fixes: Unable to play bash after unrelenting"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bash to the game"
+     ]
+    }
+   ],
+   "BATTLE_TRANCE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Battle Trance to the game"
+     ]
+    }
+   ],
+   "BEACON_OF_HOPE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Beacon of Hope to the game"
+     ]
+    }
+   ],
+   "BEAM_CELL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Beam Cell to the game"
+     ]
+    }
+   ],
+   "BEAT_DOWN": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Beat Down to the game"
+     ]
+    }
+   ],
+   "BEAT_INTO_SHAPE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Beat into Shape to the game"
+     ]
+    }
+   ],
+   "BECKON": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Beckon to the game"
+     ]
+    }
+   ],
+   "BELIEVE_IN_YOU": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Believe in You to the game"
+     ]
+    }
+   ],
+   "BIASED_COGNITION": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Biased Cognition to the game"
+     ]
+    }
+   ],
+   "BIG_BANG": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Big Bang to the game"
+     ]
+    }
+   ],
+   "BLACK_HOLE": [
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Black Hole card now properly triggers at the end of a Star-cost card play rather than the beginning"
+     ]
+    },
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Reworked Black Hole card:",
+      "No longer gains Innate on upgrade",
+      "No longer costs stars"
+     ]
+    },
+    {
+     "version": "V0.86.0",
+     "type": "Pre-release",
+     "date": "2025-12-11",
+     "changes": [
+      "Buffed Black Hole card:",
+      "Energy cost decreased from 2(1) -> 1",
+      "Upgrade changed to gain Innate"
+     ]
+    },
+    {
+     "version": "V0.69.0",
+     "type": "Pre-release",
+     "date": "2025-08-07",
+     "changes": [
+      "Nerfed Black Hole card: Energy cost increased from 0 -> 1"
+     ]
+    },
+    {
+     "version": "V0.66.0",
+     "type": "Pre-release",
+     "date": "2025-07-17",
+     "changes": [
+      "Black Hole card no longer hits enemy for 0 if no damage was dealt to them this turn"
+     ]
+    },
+    {
+     "version": "V0.65.0",
+     "type": "Pre-release",
+     "date": "2025-07-10",
+     "changes": [
+      "Black Hole card now decreases Star cost on upgrade"
+     ]
+    },
+    {
+     "version": "V0.63.0",
+     "type": "Pre-release",
+     "date": "2025-07-03",
+     "changes": [
+      "Reworked Black Hole card:",
+      "Now deals 3(4) damage to ALL enemies both on gaining and spending Stars"
+     ]
+    },
+    {
+     "version": "V0.61.0",
+     "type": "Pre-release",
+     "date": "2025-06-20",
+     "changes": [
+      "Buffed Black Hole card: damage increased from 9(13) -> 10(14)"
+     ]
+    },
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "Added portrait art for Black Hole"
+     ]
+    },
+    {
+     "version": "V0.49.0",
+     "type": "Pre-release",
+     "date": "2025-03-13",
+     "changes": [
+      "Black Hole card buffed: damage increased from 8(11) -> 9(13)"
+     ]
+    },
+    {
+     "version": "V0.45.0",
+     "type": "Pre-release",
+     "date": "2025-02-13",
+     "changes": [
+      "Buffed Black Hole card: damage increased from 7(9) -> 8(11)"
+     ]
+    },
+    {
+     "version": "V0.43.0",
+     "type": "Pre-release",
+     "date": "2025-01-30",
+     "changes": [
+      "Nerfed Black Hole card: damage decreased from 9(12) -> 7(9)"
+     ]
+    },
+    {
+     "version": "V0.41.0",
+     "type": "Pre-release",
+     "date": "2025-01-16",
+     "changes": [
+      "Reworked Black Hole card (details unknown)"
+     ]
+    },
+    {
+     "version": "V0.40.0",
+     "type": "Pre-release",
+     "date": "2025-01-09",
+     "changes": [
+      "Buffed Black Hole card: damage increased from 2(3) -> 3(4)",
+      "Black Hole card now clarifies that it deals damage for each Star spent"
+     ]
+    },
+    {
+     "version": "V0.16.0",
+     "type": "Pre-release",
+     "date": "2024-06-14",
+     "changes": [
+      "Nerfed Black Hole card: damage decreased from 5(7) -> 2(3)"
+     ]
+    },
+    {
+     "version": "V0.14.0",
+     "type": "Pre-release",
+     "date": "2024-05-31",
+     "changes": [
+      "Black Hole card's text is no longer affected by Weak"
+     ]
+    },
+    {
+     "version": "V0.13.0",
+     "type": "Pre-release",
+     "date": "2024-05-24",
+     "changes": [
+      "Reworked Black Hole card: Now deals 5(7) damage to all enemies when a star is gained"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Energy cost increased from 1 -> 2(1)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Black Hole card now also deals damage when spending Stars"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Black Hole card"
+     ]
+    }
+   ],
+   "BLADE_DANCE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Blade Dance to the game"
+     ]
+    }
+   ],
+   "BLADE_OF_INK": [
+    {
+     "version": "V0.105.0",
+     "type": "Beta Patch",
+     "date": "2026-05-08",
+     "changes": [
+      "Nerfed Blade of Ink card: Inky enchantment damage decreased from +2 -> +1"
+     ]
+    },
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Fixed Blade of Ink card listing the generated Enchanted Shivs in the Run History combat rewards"
+     ]
+    },
+    {
+     "version": "V0.102.0",
+     "type": "Beta Patch",
+     "date": "2026-04-02",
+     "changes": [
+      "Reworked Blade of Ink card: \"Rare - Cost 1 - Skill"
+     ]
+    },
+    {
+     "version": "V0.74.0",
+     "type": "Pre-release",
+     "date": "2025-09-11",
+     "changes": [
+      "Blade of Ink card now properly triggers only when a Shiv is generated, instead of also triggering when a Shiv is played"
+     ]
+    },
+    {
+     "version": "V0.57.0",
+     "type": "Pre-release",
+     "date": "2025-05-22",
+     "changes": [
+      "When you play Blade of Ink card and then create a Shiv card in your hand, it no longer briefly displays with the title \"Broken Card\""
+     ]
+    },
+    {
+     "version": "V0.41.0",
+     "type": "Pre-release",
+     "date": "2025-01-16",
+     "changes": [
+      "Reworked Blade of Ink card"
+     ]
+    },
+    {
+     "version": "2023-05-05",
+     "type": "Pre-release",
+     "date": "2023-05-05",
+     "changes": [
+      "New card portrait for Blade of Ink"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Blade of Ink to the game"
+     ]
+    }
+   ],
+   "BLOOD_WALL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Blood Wall to the game"
+     ]
+    }
+   ],
+   "BLOODLETTING": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Changed Bloodletting: Rarity increased from Common to Uncommon."
+     ]
+    },
+    {
+     "version": "V0.73.0",
+     "type": "Pre-release",
+     "date": "2025-09-04",
+     "changes": [
+      "Changed Bloodletting card: rarity decreased from Uncommon -> Common"
+     ]
+    },
+    {
+     "version": "V0.40.0",
+     "type": "Pre-release",
+     "date": "2025-01-09",
+     "changes": [
+      "Cleaned up card portrait art for: Armaments, Bloodletting, Dismantle, Forgotten Ritual, Mangle, Shockwave, Tremble"
+     ]
+    },
+    {
+     "version": "V0.19.0",
+     "type": "Pre-release",
+     "date": "2024-07-05",
+     "changes": [
+      "Bloodletting card now plays the cast animation"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bloodletting  to the game"
+     ]
+    }
+   ],
+   "BLUDGEON": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bludgeon to the game"
+     ]
+    }
+   ],
+   "BLUR": [
+    {
+     "version": "V0.30.0",
+     "type": "Pre-release",
+     "date": "2024-10-03",
+     "changes": [
+      "Barricade no longer blocks Blur from ticking down"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Blur card to the game"
+     ]
+    }
+   ],
+   "BODY_SLAM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Body Slam to the game"
+     ]
+    }
+   ],
+   "BOLAS": [
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Changed Bolas card: rarity increased from Uncommon -> Rare"
+     ]
+    },
+    {
+     "version": "V0.32.0",
+     "type": "Pre-release",
+     "date": "2024-10-17",
+     "changes": [
+      "Fixed softlock when One, Two Punch + Bolas card kills a creature"
+     ]
+    },
+    {
+     "version": "V0.28.0",
+     "type": "Pre-release",
+     "date": "2024-09-19",
+     "changes": [
+      "Added Bolas VFX"
+     ]
+    },
+    {
+     "version": "V0.27.0",
+     "type": "Pre-release",
+     "date": "2024-09-12",
+     "changes": [
+      "Added new card art for Bolas"
+     ]
+    },
+    {
+     "version": "V0.24.0",
+     "type": "Pre-release",
+     "date": "2024-08-23",
+     "changes": [
+      "Duped Bolas cards that disappear from battle no longer return to your hand"
+     ]
+    },
+    {
+     "version": "V0.23.0",
+     "type": "Pre-release",
+     "date": "2024-08-16",
+     "changes": [
+      "Added Bolas to the game"
+     ]
+    }
+   ],
+   "BOMBARDMENT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bombardment to the game"
+     ]
+    }
+   ],
+   "BOOST_AWAY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "BOOT_SEQUENCE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "BORROWED_TIME": [
+    {
+     "version": "V0.104.0",
+     "type": "Beta Patch",
+     "date": "2026-04-23",
+     "changes": [
+      "Effects that make the next card free to play (Unrelenting card, Void Form card, etc.) now properly take precedence over effects that increase the cost of all cards (Entangled affliction, Spiked Gauntlets relic, Borrowed Time card, etc.)"
+     ]
+    },
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Fixed Borrowed Time+ card not having green text in the upgrade preview"
+     ]
+    },
+    {
+     "version": "V0.102.0",
+     "type": "Beta Patch",
+     "date": "2026-04-02",
+     "changes": [
+      "Reworked Borrowed Time card: \"Uncommon - Cost 0 - Skill  Apply 3 Doom to yourself. Gain 1(2) Energy.\" -> \"Uncommon - Cost 1 - Skill  Gain 4(6) energy. Cards cost an additional energy this turn.\""
+     ]
+    },
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Reverted (Buffed) Borrowed Time to its previous version: \"Uncommon - Skill - Cost 0 - Apply 6(3) Doom to yourself. Gain 1 Energy.\" -> \"Uncommon - Skill - Cost 0 - Apply 3 Doom to yourself. Gain 1(2) Energy.\""
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Nerfed Borrowed Time card:",
+      "Self-Doom increased from 3(3) -> 6(3)",
+      "Energy gain no longer increases on Upgrade"
+     ]
+    },
+    {
+     "version": "V0.77.0",
+     "type": "Pre-release",
+     "date": "2025-10-02",
+     "changes": [
+      "Buffed Borrowed Time card: self-Doom decreased from 6 -> 3"
+     ]
+    },
+    {
+     "version": "V0.43.0",
+     "type": "Pre-release",
+     "date": "2025-01-30",
+     "changes": [
+      "Buffed Borrowed Time card: self Doom decreased from 9 -> 6"
+     ]
+    },
+    {
+     "version": "V0.39.0",
+     "type": "Pre-release",
+     "date": "2024-12-12",
+     "changes": [
+      "Buffed Borrowed Time card:",
+      "No longer Exhausts",
+      "Upgrade now grants 1 additional energy",
+      "Improved wording on cards which apply Doom to yourself like Borrowed Time and Eidolon"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Reworked card: Borrowed Time"
+     ]
+    },
+    {
+     "version": "V0.12.0",
+     "type": "Pre-release",
+     "date": "2024-05-17",
+     "changes": [
+      "Borrowed time card now correctly glows when it would be lethal."
+     ]
+    },
+    {
+     "version": "V0.10.0",
+     "type": "Pre-release",
+     "date": "2024-05-04",
+     "changes": [
+      "Changed Borrowed Time: gain 9 Doom -> lose 2 HP"
+     ]
+    },
+    {
+     "version": "2023-02-09",
+     "type": "Pre-release",
+     "date": "2023-02-09",
+     "changes": [
+      "WORDING: Added Doom keyword to Borrowed Time."
+     ]
+    }
+   ],
+   "BOUNCING_FLASK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bouncing Flask to the game"
+     ]
+    }
+   ],
+   "BRAND": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Brand to the game"
+     ]
+    }
+   ],
+   "BREAK": [
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Buffed Break card:",
+      "Energy cost decreased from 2 -> 1",
+      "Damage increased from 20(25) -> 20(30)"
+     ]
+    },
+    {
+     "version": "V0.68.0",
+     "type": "Pre-release",
+     "date": "2025-07-31",
+     "changes": [
+      "Buffed Break card:",
+      "Damage increased from 18(22) -> 20(25)",
+      "Vulnerable increased from 4(6) -> 5(7)"
+     ]
+    },
+    {
+     "version": "V0.51.0",
+     "type": "Pre-release",
+     "date": "2025-04-10",
+     "changes": [
+      "Added portrait art for Break"
+     ]
+    },
+    {
+     "version": "V0.43.0",
+     "type": "Pre-release",
+     "date": "2025-01-30",
+     "changes": [
+      "Added special transformed starter cards for Orobas’ Transcendence blessing:",
+      "Ironclad: Bash -> Break"
+     ]
+    }
+   ],
+   "BREAKTHROUGH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Breakthrough to the game"
+     ]
+    }
+   ],
+   "BRIGHTEST_FLAME": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Brightest Flame to the game"
+     ]
+    }
+   ],
+   "BUBBLE_BUBBLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bubble Bubble to the game"
+     ]
+    }
+   ],
+   "BULK_UP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bulk Up to the game"
+     ]
+    }
+   ],
+   "BULLET_TIME": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bullet Time to the game"
+     ]
+    }
+   ],
+   "BULLY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bully to the game"
+     ]
+    }
+   ],
+   "BULWARK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bulwark to the game"
+     ]
+    }
+   ],
+   "BUNDLE_OF_JOY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bundle of Joy to the game"
+     ]
+    }
+   ],
+   "BURN": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Burn to the game"
+     ]
+    }
+   ],
+   "BURNING_PACT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Burning Pact to the game"
+     ]
+    }
+   ],
+   "BURST": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Burst to the game"
+     ]
+    }
+   ],
+   "BYRD_SWOOP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Byrd Swoop to the game"
+     ]
+    }
+   ],
+   "BYRDONIS_EGG": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Byrdonis Egg to the game"
+     ]
+    }
+   ],
+   "CHARGE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CHARGE!! to the game"
+     ]
+    }
+   ],
+   "CALAMITY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Calamity to the game"
+     ]
+    }
+   ],
+   "CALCULATED_GAMBLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Calculated Gamble to the game"
+     ]
+    }
+   ],
+   "CALL_OF_THE_VOID": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Call of the Void to the game"
+     ]
+    }
+   ],
+   "CALTROPS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Caltrops to the game"
+     ]
+    }
+   ],
+   "CAPACITOR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Capacitor to the game"
+     ]
+    }
+   ],
+   "CAPTURE_SPIRIT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Capture Spirit to the game"
+     ]
+    }
+   ],
+   "CASCADE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Cascade to the game"
+     ]
+    }
+   ],
+   "CATASTROPHE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Catastrophe to the game"
+     ]
+    }
+   ],
+   "CELESTIAL_MIGHT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Celestial Might to the game"
+     ]
+    }
+   ],
+   "CHAOS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Chaos to the game"
+     ]
+    }
+   ],
+   "CHARGE_BATTERY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "CHILD_OF_THE_STARS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "CHILL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Chill to the game"
+     ]
+    }
+   ],
+   "CINDER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Cinder to the game"
+     ]
+    }
+   ],
+   "CLASH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Clash to the game"
+     ]
+    }
+   ],
+   "CLAW": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Claw to the game"
+     ]
+    }
+   ],
+   "CLEANSE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Cleanse to the game"
+     ]
+    }
+   ],
+   "CLOAK_AND_DAGGER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Cloak and Dagger to the game"
+     ]
+    }
+   ],
+   "CLOAK_OF_STARS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Cloak of Stars to the game"
+     ]
+    }
+   ],
+   "CLUMSY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Clumsy to the game"
+     ]
+    }
+   ],
+   "COLD_SNAP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Cold Snap to the game"
+     ]
+    }
+   ],
+   "COLLISION_COURSE": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Nerfed Collision Course card: damage decreased from 11(15) -> 10(14)"
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Buffed Collision Course card: Damage increased from 9(12) -> 11(15)"
+     ]
+    },
+    {
+     "version": "V0.71.0",
+     "type": "Pre-release",
+     "date": "2025-08-21",
+     "changes": [
+      "Added portrait art for Collision Course"
+     ]
+    },
+    {
+     "version": "V0.57.0",
+     "type": "Pre-release",
+     "date": "2025-05-22",
+     "changes": [
+      "Changed Collision Course card:",
+      "Damage decreased from 9(13) -> 9(12)",
+      "Debris status card cost decreased from 2 -> 1"
+     ]
+    },
+    {
+     "version": "V0.46.0",
+     "type": "Pre-release",
+     "date": "2025-02-20",
+     "changes": [
+      "Buffed Collision Course card: damage increased from 8(11) -> 9(13)"
+     ]
+    },
+    {
+     "version": "V0.45.0",
+     "type": "Pre-release",
+     "date": "2025-02-13",
+     "changes": [
+      "Added Collision Course to the game"
+     ]
+    }
+   ],
+   "COLOSSUS": [
+    {
+     "version": "V0.99.1",
+     "type": "Beta Hotfix",
+     "date": "2026-03-14",
+     "changes": [
+      "Fixed an issue with Colossus card's hovertips when playing in German"
+     ]
+    },
+    {
+     "version": "V0.99.0",
+     "type": "Beta Patch",
+     "date": "2026-03-12",
+     "changes": [
+      "Fixed an issue with Colossus card's hovertips when playing in German"
+     ]
+    },
+    {
+     "version": "V0.74.0",
+     "type": "Pre-release",
+     "date": "2025-09-11",
+     "changes": [
+      "Ironclad Epoch 2 now unlocks Cruelty instead of Colossus"
+     ]
+    },
+    {
+     "version": "V0.61.0",
+     "type": "Pre-release",
+     "date": "2025-06-20",
+     "changes": [
+      "Added portrait art for Colossus"
+     ]
+    },
+    {
+     "version": "V0.54.0",
+     "type": "Pre-release",
+     "date": "2025-05-01",
+     "changes": [
+      "Colossus card now specifies that it only reduces damage for the player who played it"
+     ]
+    },
+    {
+     "version": "V0.43.0",
+     "type": "Pre-release",
+     "date": "2025-01-30",
+     "changes": [
+      "Nerfed Colossus card: block decreased from 6(10) -> 5(8)"
+     ]
+    },
+    {
+     "version": "V0.31.0",
+     "type": "Pre-release",
+     "date": "2024-10-10",
+     "changes": [
+      "Added Colossus to the game"
+     ]
+    },
+    {
+     "version": "v0.108.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Block gain decreased from 5(8) → 4(7)"
+     ]
+    },
+    {
+     "version": "v0.103.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Rarity decreased from Rare to Uncommon."
+     ]
+    }
+   ],
+   "COMET": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Comet to the game"
+     ]
+    }
+   ],
+   "COMPACT": [
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Nerfed Compact card's Fuel token:",
+      "No longer draws cards",
+      "Upgrade changed from increasing card draw → granting 1 additional energy"
+     ]
+    },
+    {
+     "version": "V0.105.0",
+     "type": "Beta Patch",
+     "date": "2026-05-08",
+     "changes": [
+      "Fixed rare softlock when playing Compact with status cards in hand"
+     ]
+    },
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Added Portrait art for Compact"
+     ]
+    },
+    {
+     "version": "V0.89.0",
+     "type": "Pre-release",
+     "date": "2026-01-08",
+     "changes": [
+      "Added beta portrait art for Compact"
+     ]
+    },
+    {
+     "version": "V0.88.0",
+     "type": "Pre-release",
+     "date": "2026-01-01",
+     "changes": [
+      "Compactor card renamed to Compact"
+     ]
+    },
+    {
+     "version": "V0.86.0",
+     "type": "Pre-release",
+     "date": "2025-12-11",
+     "changes": [
+      "Changed Compactor card: now affects Status cards in your Hand instead of Discard pile"
+     ]
+    },
+    {
+     "version": "V0.85.0",
+     "type": "Pre-release",
+     "date": "2025-12-04",
+     "changes": [
+      "Hovering over Compactor+ card now properly shows a preview of Fuel+"
+     ]
+    },
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Changed Compactor card: changed from transforming Statuses in Hand -> Discard Pile"
+     ]
+    },
+    {
+     "version": "V0.83.0",
+     "type": "Pre-release",
+     "date": "2025-11-13",
+     "changes": [
+      "Reworked Compactor"
+     ]
+    },
+    {
+     "version": "V0.79.0",
+     "type": "Pre-release",
+     "date": "2025-10-16",
+     "changes": [
+      "Added Compactor to the game"
+     ]
+    }
+   ],
+   "COMPILE_DRIVER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "CONFLAGRATION": [
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "Reworked Conflagration card: now deals 2 damage to ALL enemies 4(5) times (was: 8(9) AOE damage plus 2(3) per other Attack played this turn)"
+     ]
+    },
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Fixed Exterminate card's wording to be more consistent with Conflagration card"
+     ]
+    },
+    {
+     "version": "V0.68.0",
+     "type": "Pre-release",
+     "date": "2025-07-31",
+     "changes": [
+      "Conflagration card no longer plays the attack animation twice"
+     ]
+    },
+    {
+     "version": "V0.61.0",
+     "type": "Pre-release",
+     "date": "2025-06-20",
+     "changes": [
+      "Added portrait art for Conflagration"
+     ]
+    },
+    {
+     "version": "V0.43.0",
+     "type": "Pre-release",
+     "date": "2025-01-30",
+     "changes": [
+      "Nerfed Conflagration card: damage decreased from 8(11) + 3(4) -> 8(9) + 2(3)"
+     ]
+    },
+    {
+     "version": "V0.32.0",
+     "type": "Pre-release",
+     "date": "2024-10-17",
+     "changes": [
+      "The wording on Conflagration, Crescent Spear, and Perfected Strike has been changed to make it clearer when they'll deal more damage than their base damage values",
+      "Fixed Conflagration dynamic vars"
+     ]
+    },
+    {
+     "version": "V0.31.0",
+     "type": "Pre-release",
+     "date": "2024-10-10",
+     "changes": [
+      "Added Conflagration to the game"
+     ]
+    },
+    {
+     "version": "v0.104.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Reworked Conflagration card:",
+      "Old: Conflagration - Attack - Cost 1 - Rare - Deal 8(9) damage to ALL enemies. Deals 2(3) additional damage for each other Attack you've played this turn.",
+      "New: Conflagration - Attack - Cost 1 - Rare - Deal 2 damage to ALL enemies 4(5) times."
+     ]
+    }
+   ],
+   "CONQUEROR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Conqueror to the game"
+     ]
+    }
+   ],
+   "CONSUMING_SHADOW": [
+    {
+     "version": "V0.103.3",
+     "type": "Patch",
+     "date": "2026-05-29",
+     "changes": [
+      "Fixed a spacing issue in the Consuming Shadow power's hovertip"
+     ]
+    },
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Fixed spacing issue in the Consuming Shadow power hovertip"
+     ]
+    },
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Added Portrait art for Consuming Shadow"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Updated wording for the following powers: Consuming Shadow"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Nerfed Consuming Shadow card: energy cost increased from 1 -> 2"
+     ]
+    },
+    {
+     "version": "V0.56.0",
+     "type": "Pre-release",
+     "date": "2025-05-15",
+     "changes": [
+      "Added Consuming Shadow to the game"
+     ]
+    }
+   ],
+   "CONVERGENCE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Convergence to the game"
+     ]
+    }
+   ],
+   "COOLANT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Coolant to the game"
+     ]
+    }
+   ],
+   "COOLHEADED": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Coolheaded to the game"
+     ]
+    }
+   ],
+   "COORDINATE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Coordinate to the game"
+     ]
+    }
+   ],
+   "CORROSIVE_WAVE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Corrosive Wave to the game"
+     ]
+    }
+   ],
+   "CORRUPTION": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Corruption to the game"
+     ]
+    }
+   ],
+   "COSMIC_INDIFFERENCE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Cosmic Indifference to the game"
+     ]
+    }
+   ],
+   "COUNTDOWN": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Countdown to the game"
+     ]
+    }
+   ],
+   "CRASH_LANDING": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Crash Landing to the game"
+     ]
+    }
+   ],
+   "CREATIVE_AI": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Creative AI to the game"
+     ]
+    }
+   ],
+   "CRESCENT_SPEAR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Crescent Spear to the game"
+     ]
+    }
+   ],
+   "CRIMSON_MANTLE": [
+    {
+     "version": "V0.87.0",
+     "type": "Pre-release",
+     "date": "2025-12-18",
+     "changes": [
+      "Nerfed Crimson Mantle card: block decreased from 8(11) -> 8(10)"
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Unmovable card is now properly triggered by delayed Block gain effects from cards like Crimson Mantle"
+     ]
+    },
+    {
+     "version": "V0.61.0",
+     "type": "Pre-release",
+     "date": "2025-06-20",
+     "changes": [
+      "Added portrait art for Crimson Mantle"
+     ]
+    },
+    {
+     "version": "V0.43.0",
+     "type": "Pre-release",
+     "date": "2025-01-30",
+     "changes": [
+      "Nerfed Crimson Mantle card: Block from 9(13) -> 8(11)"
+     ]
+    },
+    {
+     "version": "V0.32.0",
+     "type": "Pre-release",
+     "date": "2024-10-17",
+     "changes": [
+      "If you've played multiple copies of Crimson Mantle in the same turn, its hovertip now properly reflects the amount of HP you'll lose",
+      "The Crimson Mantle power's hovertip now properly reads \"At the start of your turn\" instead of \"At the end of your turn\""
+     ]
+    },
+    {
+     "version": "V0.31.0",
+     "type": "Pre-release",
+     "date": "2024-10-10",
+     "changes": [
+      "Added Crimson Mantle to the game"
+     ]
+    },
+    {
+     "version": "v0.108.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Block gain decreased from 8(10) → 7(10)"
+     ]
+    }
+   ],
+   "CRUELTY": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Changed Cruelty card: rarity decreased from Rare -> Uncommon"
+     ]
+    },
+    {
+     "version": "V0.74.0",
+     "type": "Pre-release",
+     "date": "2025-09-11",
+     "changes": [
+      "Ironclad Epoch 2 now unlocks Cruelty instead of Colossus"
+     ]
+    },
+    {
+     "version": "V0.30.0",
+     "type": "Pre-release",
+     "date": "2024-10-03",
+     "changes": [
+      "Added Corruption, Dominate, Cruelty (old Cruelty art has replaced Stomp’s art) card art"
+     ]
+    },
+    {
+     "version": "V0.29.0",
+     "type": "Pre-release",
+     "date": "2024-09-26",
+     "changes": [
+      "Fixed typo in Cruelty card’s description"
+     ]
+    },
+    {
+     "version": "V0.10.0",
+     "type": "Pre-release",
+     "date": "2024-05-04",
+     "changes": [
+      "Cruelty rarity increased from Uncommon -> Rare"
+     ]
+    },
+    {
+     "version": "2023-09-15",
+     "type": "Pre-release",
+     "date": "2023-09-15",
+     "changes": [
+      "Damage values in card text now properly reflect when the player has Cruelty"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Cruelty to the game"
+     ]
+    }
+   ],
+   "CRUSH_UNDER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Crush Under to the game"
+     ]
+    }
+   ],
+   "CURSE_OF_THE_BELL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Curse of the Bell to the game"
+     ]
+    }
+   ],
+   "DAGGER_SPRAY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dagger Spray to the game"
+     ]
+    }
+   ],
+   "DAGGER_THROW": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dagger Throw to the game"
+     ]
+    }
+   ],
+   "DANSE_MACABRE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Danse Macabre to the game"
+     ]
+    }
+   ],
+   "DARK_EMBRACE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "DARK_SHACKLES": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dark Shackles to the game"
+     ]
+    }
+   ],
+   "DARKNESS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Darkness to the game"
+     ]
+    }
+   ],
+   "DASH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "DAZED": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dazed to the game"
+     ]
+    }
+   ],
+   "DEADLY_POISON": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Deadly Poison to the game"
+     ]
+    }
+   ],
+   "DEATH_MARCH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Death March to the game"
+     ]
+    }
+   ],
+   "DEATHS_DOOR": [
+    {
+     "version": "V0.76.0",
+     "type": "Pre-release",
+     "date": "2025-09-25",
+     "changes": [
+      "Death's Door card now properly glows gold after using Potion of Doom"
+     ]
+    },
+    {
+     "version": "V0.58.0",
+     "type": "Pre-release",
+     "date": "2025-05-29",
+     "changes": [
+      "Added Portrait art for Death's Door"
+     ]
+    },
+    {
+     "version": "V0.42.0",
+     "type": "Pre-release",
+     "date": "2025-01-23",
+     "changes": [
+      "Cleaned up Death's Door card wording"
+     ]
+    },
+    {
+     "version": "V0.41.0",
+     "type": "Pre-release",
+     "date": "2025-01-16",
+     "changes": [
+      "Added Death's Door to the game"
+     ]
+    }
+   ],
+   "DEATHBRINGER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Deathbringer to the game"
+     ]
+    }
+   ],
+   "DEBILITATE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Debilitate to the game"
+     ]
+    }
+   ],
+   "DEBRIS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Debris to the game"
+     ]
+    }
+   ],
+   "DEBT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Debt to the game"
+     ]
+    }
+   ],
+   "DECAY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Decay to the game"
+     ]
+    }
+   ],
+   "DECISIONS_DECISIONS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Decisions, Decisions to the game"
+     ]
+    }
+   ],
+   "DEFEND_IRONCLAD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Defend to the game"
+     ]
+    }
+   ],
+   "DEFEND_SILENT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Defend to the game"
+     ]
+    }
+   ],
+   "DEFEND_REGENT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Defend to the game"
+     ]
+    }
+   ],
+   "DEFEND_NECROBINDER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Defend to the game"
+     ]
+    }
+   ],
+   "DEFEND_DEFECT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Defend to the game"
+     ]
+    }
+   ],
+   "DEFLECT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Deflect to the game"
+     ]
+    }
+   ],
+   "DEFRAGMENT": [
+    {
+     "version": "V0.74.0",
+     "type": "Pre-release",
+     "date": "2025-09-11",
+     "changes": [
+      "Changed Defragment card: rarity increased from Uncommon -> Rare"
+     ]
+    },
+    {
+     "version": "V0.10.0",
+     "type": "Pre-release",
+     "date": "2024-05-04",
+     "changes": [
+      "Fixed Reprogram being named Defragment"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Defragment to the game"
+     ]
+    }
+   ],
+   "DEFY": [
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Changed Defy card: upgrade no longer increases Weak, but increases Block by +3 instead of +1"
+     ]
+    },
+    {
+     "version": "V0.87.0",
+     "type": "Pre-release",
+     "date": "2025-12-18",
+     "changes": [
+      "Renamed the following cards:",
+      "Death's Visage -> Fear",
+      "Fear -> Defy (no longer Dirge)"
+     ]
+    },
+    {
+     "version": "V0.79.0",
+     "type": "Pre-release",
+     "date": "2025-10-16",
+     "changes": [
+      "Buffed Fear card: Block increased from 5(6) -> 6(7)"
+     ]
+    },
+    {
+     "version": "V0.76.0",
+     "type": "Pre-release",
+     "date": "2025-09-25",
+     "changes": [
+      "Fear card can now be enchanted by Nimble"
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Reworked card: Fear"
+     ]
+    },
+    {
+     "version": "V0.37.0",
+     "type": "Pre-release",
+     "date": "2024-11-21",
+     "changes": [
+      "Buffed Fear card: Weak applied increased from 2(3) -> 3(4)"
+     ]
+    },
+    {
+     "version": "V0.36.0",
+     "type": "Pre-release",
+     "date": "2024-11-14",
+     "changes": [
+      "Added new card: Fear"
+     ]
+    }
+   ],
+   "DEMESNE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Demesne to the game"
+     ]
+    }
+   ],
+   "DEMON_FORM": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Buffed  Demon Form: Strength gain increased from 2(3) -> 3(4)."
+     ]
+    },
+    {
+     "version": "V0.43.0",
+     "type": "Pre-release",
+     "date": "2025-01-30",
+     "changes": [
+      "Changed Demon Form card: rarity decreased from Legendary -> Rare"
+     ]
+    },
+    {
+     "version": "V0.31.0",
+     "type": "Pre-release",
+     "date": "2024-10-10",
+     "changes": [
+      "Changed Demon Form: rarity increased from Rare ➝ Legendary"
+     ]
+    },
+    {
+     "version": "2023-05-05",
+     "type": "Pre-release",
+     "date": "2023-05-05",
+     "changes": [
+      "Update Demon Form card portrait"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Demon Form to the game"
+     ]
+    }
+   ],
+   "DEMONIC_SHIELD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Demonic Shield to the game"
+     ]
+    }
+   ],
+   "DIRGE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dirge to the game"
+     ]
+    }
+   ],
+   "DISCOVERY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Discovery to the game"
+     ]
+    }
+   ],
+   "DISINTEGRATION": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Disintegration to the game"
+     ]
+    }
+   ],
+   "DISMANTLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dismantle to the game"
+     ]
+    }
+   ],
+   "DISTRACTION": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Distraction to the game"
+     ]
+    }
+   ],
+   "DODGE_AND_ROLL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dodge and Roll to the game"
+     ]
+    }
+   ],
+   "DOMINATE": [
+    {
+     "version": "V0.102.0",
+     "type": "Beta Patch",
+     "date": "2026-04-02",
+     "changes": [
+      "Fixed Unsettling Lamp relic doubling the Strength you get from Dominate card"
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Reworked Dominate card: Skill - Cost 1 - Uncommon - \"Apply 1(2) Vulnerable. Gain 1 Strength for each Vulnerable on the enemy. Exhaust.\""
+     ]
+    },
+    {
+     "version": "V0.85.0",
+     "type": "Pre-release",
+     "date": "2025-12-04",
+     "changes": [
+      "Dominate card now glows gold if an enemy has Vulnerable"
+     ]
+    },
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Changed Dominate card:",
+      "Energy cost decreased from 2(1) -> 1",
+      "Upgrade changed to remove Exhaust"
+     ]
+    },
+    {
+     "version": "V0.82.0",
+     "type": "Pre-release",
+     "date": "2025-11-06",
+     "changes": [
+      "Changed The Ironclad Epoch: unlocked card changed from Grapple -> Dominate"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Changed Dominate card:",
+      "Cost increased from 1 -> 2",
+      "Upgrade changed from deal damage to all enemies -> decrease cost by 1"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Buffed Dominate card: cost decreased from 2 -> 1"
+     ]
+    },
+    {
+     "version": "V0.30.0",
+     "type": "Pre-release",
+     "date": "2024-10-03",
+     "changes": [
+      "Added Corruption, Dominate, Cruelty (old Cruelty art has replaced Stomp’s art) card art"
+     ]
+    },
+    {
+     "version": "V0.17.0",
+     "type": "Pre-release",
+     "date": "2024-06-21",
+     "changes": [
+      "Nerfed Dominate card: cost increased from 1 -> 2"
+     ]
+    },
+    {
+     "version": "V0.16.0",
+     "type": "Pre-release",
+     "date": "2024-06-14",
+     "changes": [
+      "Added Dominate card"
+     ]
+    },
+    {
+     "version": "v0.109.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Rarity increased from Uncommon to Rare."
+     ]
+    }
+   ],
+   "DOUBLE_ENERGY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Double Energy to the game"
+     ]
+    }
+   ],
+   "DOUBT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Doubt to the game"
+     ]
+    }
+   ],
+   "DRAIN_POWER": [
+    {
+     "version": "V0.107.0",
+     "type": "Beta Patch",
+     "date": "2026-06-04",
+     "changes": [
+      "Can no longer upgrade Wither status card with Armaments or Drain Power cards"
+     ]
+    },
+    {
+     "version": "V0.89.0",
+     "type": "Pre-release",
+     "date": "2026-01-08",
+     "changes": [
+      "Changed Drain Power and Reave cards: swapped damage values"
+     ]
+    },
+    {
+     "version": "V0.69.0",
+     "type": "Pre-release",
+     "date": "2025-08-07",
+     "changes": [
+      "Buffed Drain Power card: upgraded cards increased from 1(2) -> 2(3)"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Nerfed Drain Power card: damage decreased from 9(12) -> 9(11)"
+     ]
+    },
+    {
+     "version": "V0.37.0",
+     "type": "Pre-release",
+     "date": "2024-11-21",
+     "changes": [
+      "Buffed Drain Power card: damage increased from 6(9) -> 9(12)"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Reworked cards: Drain Life (now called Drain Power)",
+      "Now Upgrades cards in discard pile instead of healing",
+      "Rarity changed: Uncommon -> Common"
+     ]
+    },
+    {
+     "version": "V0.10.0",
+     "type": "Pre-release",
+     "date": "2024-05-04",
+     "changes": [
+      "Reworked Drain Life:",
+      "Attack - 1 - Uncommon",
+      "“Deal 6(9) damage. Heal 1(2) HP. Exhaust.”"
+     ]
+    },
+    {
+     "version": "2023-09-15",
+     "type": "Pre-release",
+     "date": "2023-09-15",
+     "changes": [
+      "Fixed an issue where playing 2 Drain Life in a row would leave you with 0 Vigor instead of 14"
+     ]
+    },
+    {
+     "version": "2023-09-08",
+     "type": "Pre-release",
+     "date": "2023-09-08",
+     "changes": [
+      "Added \"Drain Life\" Necrobinder card",
+      "Type: Uncommon Attack",
+      "Energy cost: 1",
+      "\"Deal 7(9) damage. Gain Vigor equal to unblocked damage dealt.\""
+     ]
+    }
+   ],
+   "DRAMATIC_ENTRANCE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dramatic Entrance to the game"
+     ]
+    }
+   ],
+   "DREDGE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dredge to the game"
+     ]
+    }
+   ],
+   "DRUM_OF_BATTLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Drum of Battle to the game"
+     ]
+    }
+   ],
+   "DUAL_WIELD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dual Wield to the game"
+     ]
+    }
+   ],
+   "DUALCAST": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dualcast to the game"
+     ]
+    }
+   ],
+   "DYING_STAR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dying Star to the game"
+     ]
+    }
+   ],
+   "ECHO_FORM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Echo Form to the game"
+     ]
+    }
+   ],
+   "ECHOING_SLASH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Echoing Slash to the game"
+     ]
+    }
+   ],
+   "EIDOLON": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Effect changed. Now plays all Ethereal cards in your Exhaust pile."
+     ]
+    },
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Eidolon card now glows gold if you have 9+ other cards in your hand"
+     ]
+    },
+    {
+     "version": "V0.88.0",
+     "type": "Pre-release",
+     "date": "2026-01-01",
+     "changes": [
+      "Reworked Eidolon"
+     ]
+    },
+    {
+     "version": "V0.83.0",
+     "type": "Pre-release",
+     "date": "2025-11-13",
+     "changes": [
+      "Reworked Eidolon"
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Nerfed Eidolon card: now Exhausts"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Buffed Eidolon card: no longer Exhausts, now has Retain"
+     ]
+    },
+    {
+     "version": "V0.69.0",
+     "type": "Pre-release",
+     "date": "2025-08-07",
+     "changes": [
+      "Added portrait art for Eidolon"
+     ]
+    },
+    {
+     "version": "V0.62.0",
+     "type": "Pre-release",
+     "date": "2025-06-26",
+     "changes": [
+      "Reworked Eidolon"
+     ]
+    },
+    {
+     "version": "V0.39.0",
+     "type": "Pre-release",
+     "date": "2024-12-12",
+     "changes": [
+      "Improved wording on cards which apply Doom to yourself like Borrowed Time and Eidolon"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Reworked Eidolon: prevents all HP loss until next turn -> grants 1 Intangible"
+     ]
+    },
+    {
+     "version": "V0.37.0",
+     "type": "Pre-release",
+     "date": "2024-11-21",
+     "changes": [
+      "Nerfed Eidolon card:",
+      "Energy cost increased from 1 -> 2(1)",
+      "Self-Doom applied increased from 12(8) -> 13(13)"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Added Eidolon to the game"
+     ]
+    }
+   ],
+   "END_OF_DAYS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added End of Days to the game"
+     ]
+    }
+   ],
+   "ENERGY_SURGE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Energy Surge to the game"
+     ]
+    }
+   ],
+   "ENFEEBLING_TOUCH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Enfeebling Touch to the game"
+     ]
+    }
+   ],
+   "ENLIGHTENMENT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Enlightenment to the game"
+     ]
+    }
+   ],
+   "ENTHRALLED": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Enthralled to the game"
+     ]
+    }
+   ],
+   "ENTRENCH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Entrench to the game"
+     ]
+    }
+   ],
+   "ENTROPY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Entropy to the game"
+     ]
+    }
+   ],
+   "ENVENOM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Envenom to the game"
+     ]
+    }
+   ],
+   "EQUILIBRIUM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Equilibrium to the game"
+     ]
+    }
+   ],
+   "ERADICATE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Eradicate to the game"
+     ]
+    }
+   ],
+   "ESCAPE_PLAN": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Escape Plan to the game"
+     ]
+    }
+   ],
+   "ETERNAL_ARMOR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Eternal Armor to the game"
+     ]
+    }
+   ],
+   "EVIL_EYE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Evil Eye to the game"
+     ]
+    }
+   ],
+   "EXPECT_A_FIGHT": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Buffed Expect a Fight: Now no longer says can no longer gain IE this turn."
+     ]
+    },
+    {
+     "version": "V0.103.2",
+     "type": "Major Update",
+     "date": "2026-04-16",
+     "changes": [
+      "BETA changes incorporated into main branch."
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Reworked Expect a Fight card: Skill - Cost 2(1) - Uncommon - \"Gain [E] for each Attack in your Hand. You cannot gain additional [E] this turn.\""
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "When a card will cause you to gain 0 energy (such as Expect a Fight card with 0 attacks in hand), the text now reads as \"Gain 0 Energy\" instead of \"Gain .\""
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Expect a Fight to the game"
+     ]
+    }
+   ],
+   "EXPERTISE": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Reworked Expertise card: \"Draw cards until you have 6(7) in your hand.\" -> \"Draw 2(3) cards. They gain Retain this turn.\""
+     ]
+    },
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Added returning card from StS1, Expertise"
+     ]
+    },
+    {
+     "version": "V0.23.0",
+     "type": "Pre-release",
+     "date": "2024-08-16",
+     "changes": [
+      "Deprecated Expertise and Quick Slash cards"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Expertise to the game"
+     ]
+    }
+   ],
+   "EXPOSE": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Expose card now properly triggers Hand Drill relic"
+     ]
+    },
+    {
+     "version": "V0.17.0",
+     "type": "Pre-release",
+     "date": "2024-06-21",
+     "changes": [
+      "Expose now interacts correctly with Burrowed (in Tunneler encounter)"
+     ]
+    },
+    {
+     "version": "V0.15.0",
+     "type": "Pre-release",
+     "date": "2024-06-07",
+     "changes": [
+      "Reworked Expose card:",
+      "Rarity downgraded to Uncommon",
+      "Cost changed to 0",
+      "No longer applies Weak",
+      "Vulnerable gain increased from 1(2) -> 2(3)"
+     ]
+    },
+    {
+     "version": "2023-05-19",
+     "type": "Pre-release",
+     "date": "2023-05-19",
+     "changes": [
+      "Updated card portrait for Expose"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Expose to the game"
+     ]
+    }
+   ],
+   "EXTERMINATE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Exterminate to the game"
+     ]
+    }
+   ],
+   "FTL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "FALLING_STAR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Falling Star to the game"
+     ]
+    }
+   ],
+   "FAN_OF_KNIVES": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fan of Knives to the game"
+     ]
+    }
+   ],
+   "FASTEN": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fasten to the game"
+     ]
+    }
+   ],
+   "FEEDING_FRENZY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Feeding Frenzy to the game"
+     ]
+    }
+   ],
+   "FERAL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Feral to the game"
+     ]
+    }
+   ],
+   "FETCH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fetch to the game"
+     ]
+    }
+   ],
+   "FIEND_FIRE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fiend Fire to the game"
+     ]
+    }
+   ],
+   "FIGHT_ME": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fight Me! to the game"
+     ]
+    }
+   ],
+   "FIGHT_THROUGH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fight Through to the game"
+     ]
+    }
+   ],
+   "FINESSE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Finesse to the game"
+     ]
+    }
+   ],
+   "FINISHER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "FISTICUFFS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fisticuffs to the game"
+     ]
+    }
+   ],
+   "FLAK_CANNON": [
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Flak Cannon card description now highlights \"Status\" in gold"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "Defect's 2nd card unlock set unlocks Flak Cannon rather than Iteration"
+     ]
+    },
+    {
+     "version": "V0.91.0",
+     "type": "Pre-release",
+     "date": "2026-01-22",
+     "changes": [
+      "Nerfed Flak Cannon card: Energy cost increased from 1 -> 2"
+     ]
+    },
+    {
+     "version": "V0.86.0",
+     "type": "Pre-release",
+     "date": "2025-12-11",
+     "changes": [
+      "Nerfed Flak Cannon card: Energy cost increased from 0 -> 1"
+     ]
+    },
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Added Flak Cannon to the game"
+     ]
+    }
+   ],
+   "FLAME_BARRIER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Flame Barrier to the game"
+     ]
+    }
+   ],
+   "FLANKING": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Flanking to the game"
+     ]
+    }
+   ],
+   "FLASH_OF_STEEL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Flash of Steel to the game"
+     ]
+    }
+   ],
+   "FLECHETTES": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "FLICK_FLACK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Flick-Flack to the game"
+     ]
+    }
+   ],
+   "FOCUSED_STRIKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "FOLLY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Folly to the game"
+     ]
+    }
+   ],
+   "FOOTWORK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Footwork to the game"
+     ]
+    }
+   ],
+   "FORBIDDEN_GRIMOIRE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Forbidden Grimoire to the game"
+     ]
+    }
+   ],
+   "FOREGONE_CONCLUSION": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Foregone Conclusion to the game"
+     ]
+    }
+   ],
+   "FORGOTTEN_RITUAL": [
+    {
+     "version": "V0.103.2",
+     "type": "Major Update",
+     "date": "2026-04-16",
+     "changes": [
+      "BETA changes incorporated into main branch."
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Nerfed Forgotten Ritual card: now Exhausts"
+     ]
+    },
+    {
+     "version": "V0.88.0",
+     "type": "Pre-release",
+     "date": "2026-01-01",
+     "changes": [
+      "Reworked Forgotten Ritual into a Skill"
+     ]
+    },
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "Reworked Forgotten Ritual card"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Forgotten Ritual card only counts cards exhausted by you in multiplayer"
+     ]
+    },
+    {
+     "version": "V0.40.0",
+     "type": "Pre-release",
+     "date": "2025-01-09",
+     "changes": [
+      "Cleaned up card portrait art for: Armaments, Bloodletting, Dismantle, Forgotten Ritual, Mangle, Shockwave, Tremble"
+     ]
+    },
+    {
+     "version": "2023-04-21",
+     "type": "Pre-release",
+     "date": "2023-04-21",
+     "changes": [
+      "Bug Fixes: Forgotten ritual not becoming gold when playable"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Forgotten Ritual to the game"
+     ]
+    }
+   ],
+   "FRANTIC_ESCAPE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Frantic Escape to the game"
+     ]
+    }
+   ],
+   "FRIENDSHIP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Friendship to the game"
+     ]
+    }
+   ],
+   "FUEL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fuel to the game"
+     ]
+    }
+   ],
+   "FURNACE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Furnace to the game"
+     ]
+    }
+   ],
+   "FUSION": [
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Changed Fusion card:",
+      "Energy cost decreased from 2(1) -> 1",
+      "Now Exhausts, and loses Exhaust on upgrade"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fusion to the game"
+     ]
+    }
+   ],
+   "GUARDS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added GUARDS!!! to the game"
+     ]
+    }
+   ],
+   "GAMMA_BLAST": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Gamma Blast to the game"
+     ]
+    }
+   ],
+   "GANG_UP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Gang Up to the game"
+     ]
+    }
+   ],
+   "GATHER_LIGHT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Gather Light to the game"
+     ]
+    }
+   ],
+   "GENESIS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Genesis to the game"
+     ]
+    }
+   ],
+   "GENETIC_ALGORITHM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "GIANT_ROCK": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Buffed Primal Force card: Giant Rock token damage increased from 16(20) -> 20(24)"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Viewing an upgrade preview of Primal Force+ card in the deck view now properly shows a hovertip for Giant Rock+ card"
+     ]
+    },
+    {
+     "version": "V0.36.0",
+     "type": "Pre-release",
+     "date": "2024-11-14",
+     "changes": [
+      "Reworked Primal Force card:",
+      "Skill - Rare - Cost 0",
+      "“Transform all Attacks in your Hand into (Upgraded) Giant Rocks.”"
+     ]
+    },
+    {
+     "version": "V0.12.0",
+     "type": "Pre-release",
+     "date": "2024-05-17",
+     "changes": [
+      "Giant rock is no longer affected by strike dummy."
+     ]
+    },
+    {
+     "version": "V0.11.0",
+     "type": "Pre-release",
+     "date": "2024-05-10",
+     "changes": [
+      "Hovering over Primal Force+ now shows a preview for Giant Rock+"
+     ]
+    },
+    {
+     "version": "2023-09-15",
+     "type": "Pre-release",
+     "date": "2023-09-15",
+     "changes": [
+      "Primal Force now shows a hovertip for Giant Rock+ when previewing its upgrade in the deck screen, as does Storm of Steel with Shiv+"
+     ]
+    },
+    {
+     "version": "2023-06-09",
+     "type": "Pre-release",
+     "date": "2023-06-09",
+     "changes": [
+      "Primal Force+ card now previews Giant Rock+"
+     ]
+    },
+    {
+     "version": "2023-05-26",
+     "type": "Pre-release",
+     "date": "2023-05-26",
+     "changes": [
+      "Primal Force+ card now previews Giant Rock+"
+     ]
+    },
+    {
+     "version": "2023-05-12",
+     "type": "Pre-release",
+     "date": "2023-05-12",
+     "changes": [
+      "Giant Rock card doesn't play ironclad animation"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Giant Rock to the game"
+     ]
+    }
+   ],
+   "GLACIER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Glacier to the game"
+     ]
+    }
+   ],
+   "GLIMMER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Glimmer to the game"
+     ]
+    }
+   ],
+   "GLITTERSTREAM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Glitterstream to the game"
+     ]
+    }
+   ],
+   "GLOW": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Glow to the game"
+     ]
+    }
+   ],
+   "GO_FOR_THE_EYES": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Go for the Eyes to the game"
+     ]
+    }
+   ],
+   "GOLD_AXE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Gold Axe to the game"
+     ]
+    }
+   ],
+   "GRAND_FINALE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Grand Finale to the game"
+     ]
+    }
+   ],
+   "GRAVE_WARDEN": [
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Fixed Grave Warden+ showing Soul+ in its hovertip preview"
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Changed Grave Warden card: upgrade changed from 8(10) Block -> 8(11) Block and no longer upgrades the Soul"
+     ]
+    },
+    {
+     "version": "V0.76.0",
+     "type": "Pre-release",
+     "date": "2025-09-25",
+     "changes": [
+      "Buffed Grave Warden card: Block increased from 7(8) -> 8(10)"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Buffed Grave Warden card:",
+      "Block increased from 6(7) -> 7(8)",
+      "Soul added to Discard Pile -> Soul added to Draw Pile"
+     ]
+    },
+    {
+     "version": "V0.68.0",
+     "type": "Pre-release",
+     "date": "2025-07-31",
+     "changes": [
+      "Changed Grave Warden card: upgrade changed from +1 Soul -> creating Soul+"
+     ]
+    },
+    {
+     "version": "V0.67.0",
+     "type": "Pre-release",
+     "date": "2025-07-24",
+     "changes": [
+      "Nerfed Grave Warden card: now adds Souls to your Discard Pile instead of your Hand"
+     ]
+    },
+    {
+     "version": "V0.41.0",
+     "type": "Pre-release",
+     "date": "2025-01-16",
+     "changes": [
+      "Nerfed Grave Warden card: Block gain decreased from 7(8) -> 6(7)"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Changed Grave Warden card:",
+      "Damage changed from 6(9) -> 7(8)",
+      "Souls added to hand changed from 1 -> 1(2)"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Reworked card: Grave Warden"
+     ]
+    },
+    {
+     "version": "V0.10.0",
+     "type": "Pre-release",
+     "date": "2024-05-04",
+     "changes": [
+      "Buffed Grave Warden: cost changed from 1 -> 0"
+     ]
+    },
+    {
+     "version": "2023-09-08",
+     "type": "Pre-release",
+     "date": "2023-09-08",
+     "changes": [
+      "Added \"Grave Warden\" Necrobinder card",
+      "Type: Common Skill",
+      "Energy cost: 1",
+      "You and Osty each gain 5(8) Shield."
+     ]
+    }
+   ],
+   "GREED": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Greed to the game"
+     ]
+    }
+   ],
+   "GUIDING_STAR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Guiding Star to the game"
+     ]
+    }
+   ],
+   "GUILTY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Guilty to the game"
+     ]
+    }
+   ],
+   "GUNK_UP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Gunk Up to the game"
+     ]
+    }
+   ],
+   "HAILSTORM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Hailstorm to the game"
+     ]
+    }
+   ],
+   "HAMMER_TIME": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Hammer Time to the game"
+     ]
+    }
+   ],
+   "HAND_TRICK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "HANG": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Hang to the game"
+     ]
+    }
+   ],
+   "HAUNT": [
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Buffed Haunt card: HP loss increased from 6(8) → 7(9)"
+     ]
+    },
+    {
+     "version": "V0.89.0",
+     "type": "Pre-release",
+     "date": "2026-01-08",
+     "changes": [
+      "Nerfed Haunt card: hits ALL enemies -> hits a random enemy",
+      "Changed Necrobinder's Haunt Neow bundle: replaced Haunt card -> Death March"
+     ]
+    },
+    {
+     "version": "V0.85.0",
+     "type": "Pre-release",
+     "date": "2025-12-04",
+     "changes": [
+      "Nerfed Haunt card: enemy HP loss decreased from 9(11) -> 6(8)"
+     ]
+    },
+    {
+     "version": "V0.77.0",
+     "type": "Pre-release",
+     "date": "2025-10-02",
+     "changes": [
+      "Buffed Haunt card: HP loss increased from 5(7) -> 9(11)"
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Buffed Haunt card: HP loss from 4(6) -> 5(7)"
+     ]
+    },
+    {
+     "version": "V0.71.0",
+     "type": "Pre-release",
+     "date": "2025-08-21",
+     "changes": [
+      "Buffed Haunt card: HP loss increased from 3(4) -> 4(6)"
+     ]
+    },
+    {
+     "version": "V0.68.0",
+     "type": "Pre-release",
+     "date": "2025-07-31",
+     "changes": [
+      "Added card portraits for Haunt"
+     ]
+    },
+    {
+     "version": "V0.46.0",
+     "type": "Pre-release",
+     "date": "2025-02-20",
+     "changes": [
+      "Haunt power is now properly categorized as a buff"
+     ]
+    },
+    {
+     "version": "V0.45.0",
+     "type": "Pre-release",
+     "date": "2025-02-13",
+     "changes": [
+      "Reworked Haunt"
+     ]
+    },
+    {
+     "version": "V0.41.0",
+     "type": "Pre-release",
+     "date": "2025-01-16",
+     "changes": [
+      "Improved wording on Devour Life, Haunt, and Second Wind cards"
+     ]
+    },
+    {
+     "version": "V0.35.0",
+     "type": "Pre-release",
+     "date": "2024-11-07",
+     "changes": [
+      "Haunt card's text now properly reflects that the enemy will lose 6 HP instead of 3, and properly reflects that upgrading Haunt increases the enemy HP loss to 9"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Added new Skill card Haunt to the game"
+     ]
+    }
+   ],
+   "HAVOC": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Havoc to the game"
+     ]
+    }
+   ],
+   "HAZE": [
+    {
+     "version": "V0.91.0",
+     "type": "Pre-release",
+     "date": "2026-01-22",
+     "changes": [
+      "Changed Poison Neow Bundle: replaced Haze card -> Deadly Poison"
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Nerfed Haze card: Poison decreased from 5(7) -> 4(6)"
+     ]
+    },
+    {
+     "version": "V0.56.0",
+     "type": "Pre-release",
+     "date": "2025-05-15",
+     "changes": [
+      "Added portrait art for Haze"
+     ]
+    },
+    {
+     "version": "V0.35.0",
+     "type": "Pre-release",
+     "date": "2024-11-07",
+     "changes": [
+      "Added new cards: Corrosive, Cower, Execution, Haze, Rite of Initiation"
+     ]
+    }
+   ],
+   "HEADBUTT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Headbutt to the game"
+     ]
+    }
+   ],
+   "HEAVENLY_DRILL": [
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Reworked Heavenly Drill card"
+     ]
+    },
+    {
+     "version": "V0.71.0",
+     "type": "Pre-release",
+     "date": "2025-08-21",
+     "changes": [
+      "Sharp Enchantment now applies properly to Heavenly Drill card"
+     ]
+    },
+    {
+     "version": "V0.65.0",
+     "type": "Pre-release",
+     "date": "2025-07-10",
+     "changes": [
+      "Heavenly Drill card no longer hits all enemies"
+     ]
+    },
+    {
+     "version": "V0.63.0",
+     "type": "Pre-release",
+     "date": "2025-07-03",
+     "changes": [
+      "Reworked Heavenly Drill card"
+     ]
+    },
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "Buffed Heavenly Drill card: Energy cost decreased from 3 -> 2"
+     ]
+    },
+    {
+     "version": "V0.53.0",
+     "type": "Pre-release",
+     "date": "2025-04-25",
+     "changes": [
+      "Changed Heavenly Drill:",
+      "Damage increased from 6(8) -> 8(10)",
+      "Only counts this turn instead of the whole combat"
+     ]
+    },
+    {
+     "version": "V0.47.0",
+     "type": "Pre-release",
+     "date": "2025-02-27",
+     "changes": [
+      "Buffed Heavenly Drill card: damage increased from 6(7) -> 6(8) per spent Star"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Reworked Heavenly Drill card"
+     ]
+    },
+    {
+     "version": "V0.43.0",
+     "type": "Pre-release",
+     "date": "2025-01-30",
+     "changes": [
+      "Added Portrait Art for Heavenly Drill"
+     ]
+    },
+    {
+     "version": "V0.31.0",
+     "type": "Pre-release",
+     "date": "2024-10-10",
+     "changes": [
+      "Added temporary art for Heavenly Drill card"
+     ]
+    },
+    {
+     "version": "V0.27.0",
+     "type": "Pre-release",
+     "date": "2024-09-12",
+     "changes": [
+      "Added Heavenly Drill Legendarynow Ancient card"
+     ]
+    }
+   ],
+   "HEGEMONY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Hegemony to the game"
+     ]
+    }
+   ],
+   "HEIRLOOM_HAMMER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Heirloom Hammer to the game"
+     ]
+    }
+   ],
+   "HELIX_DRILL": [
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Helix Drill card's wording has been updated to be clearer that it only counts energy spent on other cards"
+     ]
+    },
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Added Portrait art for Helix Drill"
+     ]
+    },
+    {
+     "version": "V0.86.0",
+     "type": "Pre-release",
+     "date": "2025-12-11",
+     "changes": [
+      "Changed Helix Drill card:",
+      "Energy cost increased from 0 -> 1",
+      "Damage decreased from 7-> 3"
+     ]
+    },
+    {
+     "version": "V0.80.0",
+     "type": "Pre-release",
+     "date": "2025-10-23",
+     "changes": [
+      "Buffed Helix Drill card: damage increased from 6(8) -> 7(9)"
+     ]
+    },
+    {
+     "version": "V0.71.0",
+     "type": "Pre-release",
+     "date": "2025-08-21",
+     "changes": [
+      "Fixed softlock when Helix Drill card was created via Splash card",
+      "Helix Drill card now properly deals its damage over multiple hits"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Reworked Helix Drill Card"
+     ]
+    },
+    {
+     "version": "V0.67.0",
+     "type": "Pre-release",
+     "date": "2025-07-24",
+     "changes": [
+      "Added Beta Portrait art for Helix Drill"
+     ]
+    },
+    {
+     "version": "V0.66.0",
+     "type": "Pre-release",
+     "date": "2025-07-17",
+     "changes": [
+      "Added Helix Drill to the game"
+     ]
+    }
+   ],
+   "HELLO_WORLD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Hello World to the game"
+     ]
+    }
+   ],
+   "HELLRAISER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Hellraiser to the game"
+     ]
+    }
+   ],
+   "HEMOKINESIS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Hemokinesis to the game"
+     ]
+    }
+   ],
+   "HIDDEN_CACHE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Hidden Cache to the game"
+     ]
+    }
+   ],
+   "HIDDEN_DAGGERS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added  to the game"
+     ]
+    }
+   ],
+   "HIDDEN_GEM": [
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Reworked Hidden Gem: \"A random card in your Draw Pile gains Replay 2(3).\" -> \"A random card in your Draw Pile without Replay gains Replay 2(3).\"",
+      "Can no longer be generated in combat by effects like Skill Potion."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Hidden Gem to the game"
+     ]
+    }
+   ],
+   "HIGH_FIVE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added High Five to the game"
+     ]
+    }
+   ],
+   "HOLOGRAM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "HOTFIX": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Hotfix to the game. Upgrade increases Focus gained from 2 -> 3"
+     ]
+    }
+   ],
+   "HOWL_FROM_BEYOND": [
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Buffed Howl From Beyond card: Damage increased from 16(21) → 18(24)"
+     ]
+    },
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Buffed Howl From Beyond: Trigger moved from start of turn -> end of turn."
+     ]
+    },
+    {
+     "version": "V0.104.0",
+     "type": "Beta Patch",
+     "date": "2026-04-23",
+     "changes": [
+      "Howl from Beyond now plays from the Exhaust pile after drawing each hand, instead of before."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Howl from Beyond to the game"
+     ]
+    }
+   ],
+   "HUDDLE_UP": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "If Huddle Up triggers a choice for another player, the playing player is no longer blocked from playing cards"
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Nerfed Huddle Up card: now Exhausts"
+     ]
+    },
+    {
+     "version": "V0.99.1",
+     "type": "Beta Hotfix",
+     "date": "2026-03-14",
+     "changes": [
+      "Fixed state divergence related to playing Huddle Up during another player's card selection"
+     ]
+    },
+    {
+     "version": "V0.99.0",
+     "type": "Beta Patch",
+     "date": "2026-03-12",
+     "changes": [
+      "Fixed state divergence related to playing Huddle Up during another player's card selection"
+     ]
+    },
+    {
+     "version": "V0.91.0",
+     "type": "Pre-release",
+     "date": "2026-01-22",
+     "changes": [
+      "Added portrait art for Huddle Up"
+     ]
+    },
+    {
+     "version": "V0.58.0",
+     "type": "Pre-release",
+     "date": "2025-05-29",
+     "changes": [
+      "Added new multiplayer-exclusive cards: Huddle Up"
+     ]
+    }
+   ],
+   "HYPERBEAM": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Buffed Hyperbeam card: damage increased from 28(36) -> 30(38)"
+     ]
+    },
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "BETA changes incorporated into main branch."
+     ]
+    },
+    {
+     "version": "V0.105.0",
+     "type": "Beta Patch",
+     "date": "2026-05-08",
+     "changes": [
+      "Buffed Hyperbeam: damage increased from 26(34) -> 28(36)"
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "shiny new VFX for Defect's Hyperbeam move"
+     ]
+    },
+    {
+     "version": "V0.89.0",
+     "type": "Pre-release",
+     "date": "2026-01-08",
+     "changes": [
+      "Changed Hyperbeam card:",
+      "Energy cost decreased from 3 -> 2",
+      "Damage decreased from 30(40) -> 26(34)"
+     ]
+    },
+    {
+     "version": "V0.56.0",
+     "type": "Pre-release",
+     "date": "2025-05-15",
+     "changes": [
+      "Changed Hyperbeam card:",
+      "Energy cost increased from 2 -> 3",
+      "Damage increased from 26(34) -> 30(40)"
+     ]
+    },
+    {
+     "version": "V0.15.0",
+     "type": "Pre-release",
+     "date": "2024-06-07",
+     "changes": [
+      "Hyperbeam now includes Focus hovertip"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Hyperbeam to the game."
+     ]
+    }
+   ],
+   "I_AM_INVINCIBLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added I Am Invincible to the game"
+     ]
+    }
+   ],
+   "ICE_LANCE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "IGNITION": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Ignition to the game"
+     ]
+    }
+   ],
+   "IMPATIENCE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Impatience to the game"
+     ]
+    }
+   ],
+   "IMPERVIOUS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Impervious to the game"
+     ]
+    }
+   ],
+   "INFECTION": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Infection to the game"
+     ]
+    }
+   ],
+   "INFERNAL_BLADE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Infernal Blade to the game"
+     ]
+    }
+   ],
+   "INFERNO": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Inferno to the game"
+     ]
+    }
+   ],
+   "INFINITE_BLADES": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Infinite Blades to the game"
+     ]
+    }
+   ],
+   "INFLAME": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Inflame to the game"
+     ]
+    }
+   ],
+   "INJURY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Injury to the game"
+     ]
+    }
+   ],
+   "INTERCEPT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Intercept to the game"
+     ]
+    }
+   ],
+   "IRON_WAVE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Iron Wave to the game"
+     ]
+    }
+   ],
+   "ITERATION": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Iteration to the game"
+     ]
+    }
+   ],
+   "JACK_OF_ALL_TRADES": [
+    {
+     "version": "2023-07-21",
+     "type": "Pre-release",
+     "date": "2023-07-21",
+     "changes": [
+      "Updated Jack of All Trades card art"
+     ]
+    },
+    {
+     "version": "2023-06-30",
+     "type": "Pre-release",
+     "date": "2023-06-30",
+     "changes": [
+      "Jack of All Trades card can no longer spawn itself"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Jack of All Trades to the game"
+     ]
+    }
+   ],
+   "JACKPOT": [
+    {
+     "version": "V0.76.0",
+     "type": "Pre-release",
+     "date": "2025-09-25",
+     "changes": [
+      "All For One and Jackpot cards now say \"0 (energy symbol) cards\" instead of \"cost 0 cards\""
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Updated wording for Jackpot"
+     ]
+    },
+    {
+     "version": "V0.66.0",
+     "type": "Pre-release",
+     "date": "2025-07-17",
+     "changes": [
+      "Added portrait art for Jackpot"
+     ]
+    },
+    {
+     "version": "V0.63.0",
+     "type": "Pre-release",
+     "date": "2025-07-03",
+     "changes": [
+      "Added beta portrait art for Jackpot"
+     ]
+    },
+    {
+     "version": "V0.50.0",
+     "type": "Pre-release",
+     "date": "2025-04-03",
+     "changes": [
+      "Changed Jackpot, Metamorphosis, and Calamity cards: now have a chance of generating multiple copies of the same card"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Added Jackpot to the game"
+     ]
+    }
+   ],
+   "JUGGERNAUT": [
+    {
+     "version": "V0.107.0",
+     "type": "Beta Patch",
+     "date": "2026-06-04",
+     "changes": [
+      "Buffed Juggernaut card: damage increased from 5(7) -> 6(8)"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "Re-added Juggernaut card"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Deprecated Juggernaut"
+     ]
+    },
+    {
+     "version": "V0.33.0",
+     "type": "Pre-release",
+     "date": "2024-10-24",
+     "changes": [
+      "Killing an enemy with Juggernaut + Toric Toughness card combo no longer softlocks"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Juggernaut to the game"
+     ]
+    }
+   ],
+   "JUGGLING": [
+    {
+     "version": "V0.105.0",
+     "type": "Beta Patch",
+     "date": "2026-05-08",
+     "changes": [
+      "Fixed state divergence related to Mad Science, Juggling, and mixed combat speeds"
+     ]
+    },
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "When Stomp card is played after Juggling card, its clones now properly receive the cost reduction from itself being played"
+     ]
+    },
+    {
+     "version": "V0.88.0",
+     "type": "Pre-release",
+     "date": "2026-01-01",
+     "changes": [
+      "Reworked Juggling"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Updated wording for the following powers Juggling"
+     ]
+    },
+    {
+     "version": "V0.61.0",
+     "type": "Pre-release",
+     "date": "2025-06-20",
+     "changes": [
+      "Added portrait art for Juggling"
+     ]
+    },
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "Added Juggling to the game"
+     ]
+    }
+   ],
+   "KINGLY_KICK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Kingly Kick to the game"
+     ]
+    }
+   ],
+   "KINGLY_PUNCH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Kingly Punch to the game"
+     ]
+    }
+   ],
+   "KNIFE_TRAP": [
+    {
+     "version": "V0.103.2",
+     "type": "Major Update",
+     "date": "2026-04-16",
+     "changes": [
+      "Changes from beta branch incorporated into main branch"
+     ]
+    },
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Fixed Knife Trap card causing the Exhaust Pile UI to display an incorrect number of cards"
+     ]
+    },
+    {
+     "version": "V0.87.0",
+     "type": "Pre-release",
+     "date": "2025-12-18",
+     "changes": [
+      "Name changed from Execution -> Knife Trap"
+     ]
+    },
+    {
+     "version": "V0.86.0",
+     "type": "Pre-release",
+     "date": "2025-12-11",
+     "changes": [
+      "Accuracy and Execution cards now properly show Shiv card hovertip"
+     ]
+    },
+    {
+     "version": "V0.76.0",
+     "type": "Pre-release",
+     "date": "2025-09-25",
+     "changes": [
+      "Execution card now specifies that Shivs will only be played on the targeted enemy"
+     ]
+    },
+    {
+     "version": "V0.68.0",
+     "type": "Pre-release",
+     "date": "2025-07-31",
+     "changes": [
+      "Execution no longer Exhausts"
+     ]
+    },
+    {
+     "version": "V0.57.0",
+     "type": "Pre-release",
+     "date": "2025-05-22",
+     "changes": [
+      "Added portrait art for Execution"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Changed Execution card:",
+      "Cost increased from 2 -> 3",
+      "Rarity changed to Rare"
+     ]
+    },
+    {
+     "version": "V0.35.0",
+     "type": "Pre-release",
+     "date": "2024-11-07",
+     "changes": [
+      "Added Execution card"
+     ]
+    }
+   ],
+   "KNOCKDOWN": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Knockdown to the game"
+     ]
+    }
+   ],
+   "KNOCKOUT_BLOW": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Knockout Blow to the game"
+     ]
+    }
+   ],
+   "KNOW_THY_PLACE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Hidden Cache to the game"
+     ]
+    }
+   ],
+   "LANTERN_KEY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Lantern Key to the game"
+     ]
+    }
+   ],
+   "LEADING_STRIKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Leading Strike to the game"
+     ]
+    }
+   ],
+   "LEAP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Leap to the game"
+     ]
+    }
+   ],
+   "LEG_SWEEP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "LEGION_OF_BONE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Legion of Bone to the game"
+     ]
+    }
+   ],
+   "LETHALITY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Lethality to the game"
+     ]
+    }
+   ],
+   "LIFT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Lift to the game"
+     ]
+    }
+   ],
+   "LOOP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Loop to the game"
+     ]
+    }
+   ],
+   "LUMINESCE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Luminesce to the game"
+     ]
+    }
+   ],
+   "LUNAR_BLAST": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Lunar Blast to the game"
+     ]
+    }
+   ],
+   "MACHINE_LEARNING": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "MAD_SCIENCE": [
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Fixed an issue where Vigor was only applying to the first of Mad Science card's 3 hits when it was created with the Violence option",
+      "Fixed Supermassive card not scaling from cards generated by Mad Science card"
+     ]
+    },
+    {
+     "version": "V0.105.0",
+     "type": "Beta Patch",
+     "date": "2026-05-08",
+     "changes": [
+      "Fixed state divergences when related to event combats, the Crystal Sphere event, long event option resolution, Mad Science/Juggling cards with mized combat speeds, and Stampede + Headbutt cards"
+     ]
+    },
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Mad Science Skill Chaos option (In the Tinker Time event) now uses \"Free to play\" instead of \"Costs 0 Energy\""
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Nerfed Mad Science event: Skill option decreased from 10 -> 8 Block"
+     ]
+    },
+    {
+     "version": "V0.78.0",
+     "type": "Pre-release",
+     "date": "2025-10-09",
+     "changes": [
+      "Mad Science card no longer sets generated cards' star costs to 0 when the Soul option is chosen"
+     ]
+    },
+    {
+     "version": "V0.77.0",
+     "type": "Pre-release",
+     "date": "2025-10-02",
+     "changes": [
+      "Mad Science card with Focus option can now randomly select Eternal cards to transform"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Changed Mad Science event: power option can no longer roll the cost 1 option"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Changed Tinker Time event: Mad Science card default cost increased from 1 -> 2; base damage and block values are changed accordingly"
+     ]
+    },
+    {
+     "version": "V0.40.0",
+     "type": "Pre-release",
+     "date": "2025-01-09",
+     "changes": [
+      "Changed Mad Science card:",
+      "Now starts un-upgraded",
+      "Upgrading it gives it Innate",
+      "Mad Science card no longer breaks when downgraded"
+     ]
+    },
+    {
+     "version": "V0.35.0",
+     "type": "Pre-release",
+     "date": "2024-11-07",
+     "changes": [
+      "Mad Science transformation cards no longer stay on screen forever"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Changed Tinker Time event:",
+      "\"Speed\" choice no longer gives Innate to power cards",
+      "\"Heart\" choice energy granted on next turn decreased from 5 -> 3",
+      "\"Body\" choice temporary Strength gain decreased from 5 -> 3",
+      "\"Stability\" choice temporary Dexterity gain decreased from 5 -> 3"
+     ]
+    },
+    {
+     "version": "V0.30.0",
+     "type": "Pre-release",
+     "date": "2024-10-03",
+     "changes": [
+      "Discovery, Mad Science, and Stars in His Eyes cards can no longer generate healing cards"
+     ]
+    },
+    {
+     "version": "V0.19.0",
+     "type": "Pre-release",
+     "date": "2024-07-05",
+     "changes": [
+      "Non-power Tinker Time cards no longer corrupt save files",
+      "Tinker Time's Power card focus now properly saves and persists"
+     ]
+    },
+    {
+     "version": "V0.8.0",
+     "type": "Pre-release",
+     "date": "2024-04-19",
+     "changes": [
+      "Mad Science now properly displays hovertips for all of its effects",
+      "New card art has been added for Mad Science, Loyalty, and many Regent cards"
+     ]
+    },
+    {
+     "version": "2023-09-15",
+     "type": "Pre-release",
+     "date": "2023-09-15",
+     "changes": [
+      "Made Mad Science non-upgradeable instead of being upgraded when gained"
+     ]
+    },
+    {
+     "version": "2023-09-01",
+     "type": "Pre-release",
+     "date": "2023-09-01",
+     "changes": [
+      "Mad Science can no longer be enchanted by Nimble when it's not a Skill"
+     ]
+    },
+    {
+     "version": "2023-08-25",
+     "type": "Pre-release",
+     "date": "2023-08-25",
+     "changes": [
+      "Added \"Tinker Time\" event to Act 3"
+     ]
+    }
+   ],
+   "MAKE_IT_SO": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Make It So to the game"
+     ]
+    }
+   ],
+   "MALAISE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Malaise to the gameThis card was not mentioned in any patch notes"
+     ]
+    }
+   ],
+   "MANGLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Mangle to the game"
+     ]
+    }
+   ],
+   "MANIFEST_AUTHORITY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Manifest Authority to the game"
+     ]
+    }
+   ],
+   "MASTER_PLANNER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Master Planner to the game"
+     ]
+    }
+   ],
+   "MASTER_OF_STRATEGY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Master of Strategy to the game"
+     ]
+    }
+   ],
+   "MAUL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Maul to the game"
+     ]
+    }
+   ],
+   "MAYHEM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Mayhem to the game"
+     ]
+    }
+   ],
+   "MELANCHOLY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Melancholy to the game"
+     ]
+    }
+   ],
+   "MEMENTO_MORI": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Memento Mori to the game"
+     ]
+    }
+   ],
+   "METAMORPHOSIS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Metamorphosis to the game"
+     ]
+    }
+   ],
+   "METEOR_SHOWER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Meteor Shower to the game"
+     ]
+    }
+   ],
+   "METEOR_STRIKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "MIMIC": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Mimic to the game"
+     ]
+    }
+   ],
+   "MIND_BLAST": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Mind Blast to the game"
+     ]
+    }
+   ],
+   "MIND_ROT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Mind Rot to the game"
+     ]
+    }
+   ],
+   "MINION_DIVE_BOMB": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Minion Dive Bomb to the game"
+     ]
+    }
+   ],
+   "MINION_SACRIFICE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Minion Sacrifice to the game"
+     ]
+    }
+   ],
+   "MINION_STRIKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Minion Strike to the game"
+     ]
+    }
+   ],
+   "MIRAGE": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Reworked Mirage card: Uncommon - Skill - 1(0) - \"Gain Block equal to Poison on ALL enemies. Exhaust.\" -> Uncommon - Skill - 0 - \"Next turn, gain 1(2) Energy.\""
+     ]
+    },
+    {
+     "version": "V0.36.0",
+     "type": "Pre-release",
+     "date": "2024-11-14",
+     "changes": [
+      "Changed Mirage card:",
+      "Cost increased from 0 -> 1",
+      "Upgrade changed from losing Exhaust to lowering cost to 0"
+     ]
+    },
+    {
+     "version": "2023-06-09",
+     "type": "Pre-release",
+     "date": "2023-06-09",
+     "changes": [
+      "Fix wording for Mirage"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Mirage to the game"
+     ]
+    }
+   ],
+   "MISERY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Misery to the game"
+     ]
+    }
+   ],
+   "MODDED": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "MOLTEN_FIST": [
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "The 7th card reward you receive on your first-ever run now contains Tremble instead of Molten Fist"
+     ]
+    },
+    {
+     "version": "V0.85.0",
+     "type": "Pre-release",
+     "date": "2025-12-04",
+     "changes": [
+      "Changed Ironclad's Vulnerable Neow bundle: Molten Fist -> Tremble"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Changed Molten Fist card: now Exhausts"
+     ]
+    },
+    {
+     "version": "V0.26.0",
+     "type": "Pre-release",
+     "date": "2024-09-06",
+     "changes": [
+      "Added Molten Fist card VFX"
+     ]
+    },
+    {
+     "version": "2023-07-21",
+     "type": "Pre-release",
+     "date": "2023-07-21",
+     "changes": [
+      "Molten Fist damage buffed from 8(11) -> 10(14)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Molten Fist card to the game"
+     ]
+    }
+   ],
+   "MOMENTUM_STRIKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Momentum Strike to the game"
+     ]
+    }
+   ],
+   "MONARCHS_GAZE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Monarch's Gaze to the game"
+     ]
+    }
+   ],
+   "MONOLOGUE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Monologue to the game"
+     ]
+    }
+   ],
+   "MULTI_CAST": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Multi-Cast to the game"
+     ]
+    }
+   ],
+   "MURDER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "NECRO_MASTERY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Necro Mastery to the game"
+     ]
+    }
+   ],
+   "NEOWS_FURY": [
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "Changes from beta branch incorporated into main branch"
+     ]
+    },
+    {
+     "version": "V0.104.0",
+     "type": "Beta Patch",
+     "date": "2026-04-23",
+     "changes": [
+      "Buffed Neow's Fury card: now lets you choose which 2 cards (or fewer) to return from your Discard Pile instead of selecting randomly",
+      "Revised Neow's Fury artwork (now centered)"
+     ]
+    },
+    {
+     "version": "V0.103.2",
+     "type": "Major Update",
+     "date": "2026-04-16",
+     "changes": [
+      "Changes from beta branch incorporated into main branch"
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Buffed Neow's Fury card: the number of cards returned to your hand now upgrades from 2 -> 3"
+     ]
+    },
+    {
+     "version": "V0.96.0",
+     "type": "Pre-release",
+     "date": "2026-02-26",
+     "changes": [
+      "Added portrait art for Neow's Fury and Wish cards"
+     ]
+    },
+    {
+     "version": "V0.94.0",
+     "type": "Pre-release",
+     "date": "2026-02-12",
+     "changes": [
+      "Reworked Neow's Fury card (details unknown)"
+     ]
+    },
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Nerfed Neow's Fury card: no longer heals HP",
+      "Neow's Fury card now shows up in the Compendium"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "Added Neow's Fury card (for new Neow blessing)"
+     ]
+    }
+   ],
+   "NEUTRALIZE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Neutralize to the game"
+     ]
+    }
+   ],
+   "NEUTRON_AEGIS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "NIGHTMARE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Nightmare to the game"
+     ]
+    }
+   ],
+   "NO_ESCAPE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added No Escape to the game"
+     ]
+    }
+   ],
+   "NORMALITY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Normality to the game"
+     ]
+    }
+   ],
+   "NOSTALGIA": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Nostalgia to the game"
+     ]
+    }
+   ],
+   "NOXIOUS_FUMES": [
+    {
+     "version": "V0.32.0",
+     "type": "Pre-release",
+     "date": "2024-10-17",
+     "changes": [
+      "Added green smoke puff VFX to Poison Potion, Deadly Poison, and Noxious Fumes"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Noxious Fumes to the game"
+     ]
+    }
+   ],
+   "NULL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Null to the game"
+     ]
+    }
+   ],
+   "OBLIVION": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Oblivion to the game"
+     ]
+    }
+   ],
+   "OFFERING": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Offering to the game"
+     ]
+    }
+   ],
+   "OMNISLICE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Omnislice to the game"
+     ]
+    }
+   ],
+   "ONE_TWO_PUNCH": [
+    {
+     "version": "V0.36.0",
+     "type": "Pre-release",
+     "date": "2024-11-14",
+     "changes": [
+      "Changed One-Two Punch card: no longer Exhausts"
+     ]
+    },
+    {
+     "version": "2023-04-21",
+     "type": "Pre-release",
+     "date": "2023-04-21",
+     "changes": [
+      "one-two punch power desscription error"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added One-Two Punch to the game."
+     ]
+    }
+   ],
+   "ORBIT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Orbit to the game"
+     ]
+    }
+   ],
+   "OUTBREAK": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Buffed: Outbreak card: damage increased from 3(4) -> 4(5)"
+     ]
+    },
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Reworked Outbreak card: \"Every 3 times you apply Poison, deal 15 damage to ALL enemies.\" → \"Whenever you apply Poison, deal 3(4) damage to ALL enemies.\""
+     ]
+    },
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Added portrait art for Outbreak."
+     ]
+    },
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Changed Outbreak card:",
+      "Every 10 applications of Poison -> every 3",
+      "Damage decreased from 30(40) -> 15(20)"
+     ]
+    },
+    {
+     "version": "V0.83.0",
+     "type": "Pre-release",
+     "date": "2025-11-13",
+     "changes": [
+      "Added Outbreak to the game"
+     ]
+    }
+   ],
+   "OUTMANEUVER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Outmaneuver to the game"
+     ]
+    }
+   ],
+   "OVERCLOCK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Overclock to the game"
+     ]
+    }
+   ],
+   "PACTS_END": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pact's End to the game"
+     ]
+    }
+   ],
+   "PAGESTORM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pagestorm to the game"
+     ]
+    }
+   ],
+   "PALE_BLUE_DOT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pale Blue Dot to the game"
+     ]
+    }
+   ],
+   "PANIC_BUTTON": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Panic Button to the game"
+     ]
+    }
+   ],
+   "PARRY": [
+    {
+     "version": "V0.104.0",
+     "type": "Beta Patch",
+     "date": "2026-04-23",
+     "changes": [
+      "Reworked Parry: \"Uncommon - Power - Cost 1 - Whenever you play Sovereign Blade, gain 10(14) Block.\" -> \"Uncommon - Power - Cost 1 - Sovereign Blade now gains 10(14) Block.\"",
+      "This means Parry's Block is displayed on the Sovereign Blade card and is now also affected by powers like Dexterity and Frail."
+     ]
+    },
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Block increased from 8(11) -> 10(14)."
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Block increased from 6(9) -> 8(11)."
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Nerfed Parry card:",
+      "No longer Forges",
+      "Block decreased from 10(13) -> 6(9)"
+     ]
+    },
+    {
+     "version": "V0.50.0",
+     "type": "Pre-release",
+     "date": "2025-04-03",
+     "changes": [
+      "Buffed Parry card: Block increased from 8(11) -> 10(13)"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Parry card now includes a hovertip for the Forge keyword"
+     ]
+    },
+    {
+     "version": "V0.43.0",
+     "type": "Pre-release",
+     "date": "2025-01-30",
+     "changes": [
+      "Added portrait art for Parry"
+     ]
+    },
+    {
+     "version": "V0.41.0",
+     "type": "Pre-release",
+     "date": "2025-01-16",
+     "changes": [
+      "Reworked Parry"
+     ]
+    },
+    {
+     "version": "V0.40.0",
+     "type": "Pre-release",
+     "date": "2025-01-09",
+     "changes": [
+      "Parry card now properly specifies that it gains block equal to unblocked damage dealt instead of all damage dealt",
+      "Parry card now gains block for all creatures hit by AOE Sovereign Blade"
+     ]
+    },
+    {
+     "version": "V0.39.0",
+     "type": "Pre-release",
+     "date": "2024-12-12",
+     "changes": [
+      "Fixed Parry card wording error"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Reworked Parry card:",
+      "Uncommon - Skill - Cost 1",
+      "“The next time you play Sovereign Blade, gain Block equal to the damage dealt. Exhaust. (Loses Exhaust)”"
+     ]
+    },
+    {
+     "version": "V0.26.0",
+     "type": "Pre-release",
+     "date": "2024-09-06",
+     "changes": [
+      "Nerfed Parry card: no longer Forges"
+     ]
+    },
+    {
+     "version": "V0.24.0",
+     "type": "Pre-release",
+     "date": "2024-08-23",
+     "changes": [
+      "Reworked Parry card:",
+      "Skill - Rare - 2",
+      "“Forge 3(5). Put Sovereign Blade on the bottom of your draw pile. Gain Block equal to its damage. Exhaust”"
+     ]
+    },
+    {
+     "version": "V0.23.0",
+     "type": "Pre-release",
+     "date": "2024-08-16",
+     "changes": [
+      "Added new Skill card: Parry"
+     ]
+    }
+   ],
+   "PARSE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Parse to the game"
+     ]
+    }
+   ],
+   "PARTICLE_WALL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Particle Wall to the game"
+     ]
+    }
+   ],
+   "PATTER": [
+    {
+     "version": "V0.105.0",
+     "type": "Beta Patch",
+     "date": "2026-05-08",
+     "changes": [
+      "Nerfed Patter card: Block gain decreased from 9(11) -> 8(10)"
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Block increased from 8(10) -> 9(11)"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "Regent's 2nd card unlock set unlocks Patter rather than Radiate"
+     ]
+    },
+    {
+     "version": "V0.67.0",
+     "type": "Pre-release",
+     "date": "2025-07-24",
+     "changes": [
+      "Added portrait art for Patter"
+     ]
+    },
+    {
+     "version": "V0.45.0",
+     "type": "Pre-release",
+     "date": "2025-02-13",
+     "changes": [
+      "Added new card: Patter"
+     ]
+    }
+   ],
+   "PECK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Peck to the game"
+     ]
+    }
+   ],
+   "PERFECTED_STRIKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Perfected Strike to the game without any changes from Slay the Spire"
+     ]
+    }
+   ],
+   "PHOTON_CUT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Photon Cut to the game"
+     ]
+    }
+   ],
+   "PIERCING_WAIL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Piercing Wail to the game"
+     ]
+    }
+   ],
+   "PILLAGE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pillage to the game"
+     ]
+    }
+   ],
+   "PILLAR_OF_CREATION": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Reworked  Pillar of Creation card: \"Whenever you create a card, gain 3 Block.\" -> \"The first time you create a card each turn, gain 5(7) Block.\""
+     ]
+    },
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "Pillar of Creation, Supermassive, and Arsenal cards now proc for the player who played Largesse rather than the recipient"
+     ]
+    },
+    {
+     "version": "V0.104.0",
+     "type": "Beta Patch",
+     "date": "2026-04-23",
+     "changes": [
+      "Pillar of Creation, Supermassive, and Arsenal cards now proc for the player that played Largesse card rather than the player who gets the generated card"
+     ]
+    },
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Pillar of Creation card is now properly triggered by Severance card"
+     ]
+    },
+    {
+     "version": "V0.73.0",
+     "type": "Pre-release",
+     "date": "2025-09-04",
+     "changes": [
+      "Added portrait art for Pillar of Creation"
+     ]
+    },
+    {
+     "version": "V0.68.0",
+     "type": "Pre-release",
+     "date": "2025-07-31",
+     "changes": [
+      "Nerfed Pillar of Creation card: Block decreased from 5(7) -> 3(4)"
+     ]
+    },
+    {
+     "version": "V0.65.0",
+     "type": "Pre-release",
+     "date": "2025-07-10",
+     "changes": [
+      "Pillar of Creation card now properly triggers when a card is transformed"
+     ]
+    },
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "Reworked Pillar of Creation"
+     ]
+    },
+    {
+     "version": "V0.40.0",
+     "type": "Pre-release",
+     "date": "2025-01-09",
+     "changes": [
+      "Status cards are no longer counted towards Pillar of Creation's block gain"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Buffed Pillar of Creation card: cost decreased from 2 -> 1"
+     ]
+    },
+    {
+     "version": "V0.25.0",
+     "type": "Pre-release",
+     "date": "2024-08-30",
+     "changes": [
+      "Pillar of Creation card now counts Sovereign Blade as colorless"
+     ]
+    },
+    {
+     "version": "V0.24.0",
+     "type": "Pre-release",
+     "date": "2024-08-23",
+     "changes": [
+      "Buffed Pillar of Creation card: Block gain increased from 2(3) -> 3(4)"
+     ]
+    },
+    {
+     "version": "V0.23.0",
+     "type": "Pre-release",
+     "date": "2024-08-16",
+     "changes": [
+      "Added new Skill card: Pillar of Creation"
+     ]
+    }
+   ],
+   "PINPOINT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pinpoint to the game"
+     ]
+    }
+   ],
+   "POISONED_STAB": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Poisoned Stab to the game"
+     ]
+    }
+   ],
+   "POMMEL_STRIKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pommel Strike to the game without any changes from Slay the Spire"
+     ]
+    }
+   ],
+   "POOR_SLEEP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Poor Sleep to the game"
+     ]
+    }
+   ],
+   "POUNCE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pounce to the game"
+     ]
+    }
+   ],
+   "PRECISE_CUT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "PREDATOR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Predator to the game"
+     ]
+    }
+   ],
+   "PREP_TIME": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Prep Time to the game"
+     ]
+    }
+   ],
+   "PRIMAL_FORCE": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Buffed Primal Force card: Giant Rock token damage increased from 16(20) -> 20(24)"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Viewing an upgrade preview of Primal Force+ card in the deck view now properly shows a hovertip for Giant Rock+ card"
+     ]
+    },
+    {
+     "version": "V0.36.0",
+     "type": "Pre-release",
+     "date": "2024-11-14",
+     "changes": [
+      "Reworked Primal Force card:",
+      "Skill - Rare - Cost 0",
+      "“Transform all Attacks in your Hand into (Upgraded) Giant Rocks.”"
+     ]
+    },
+    {
+     "version": "V0.11.0",
+     "type": "Pre-release",
+     "date": "2024-05-10",
+     "changes": [
+      "Hovering over Primal Force+ now shows a preview for Giant Rock+"
+     ]
+    },
+    {
+     "version": "2023-09-15",
+     "type": "Pre-release",
+     "date": "2023-09-15",
+     "changes": [
+      "Primal Force now shows a hovertip for Giant Rock+ when previewing its upgrade in the deck screen, as does Storm of Steel with Shiv+"
+     ]
+    },
+    {
+     "version": "2023-06-09",
+     "type": "Pre-release",
+     "date": "2023-06-09",
+     "changes": [
+      "Primal Force+ card now previews Giant Rock+"
+     ]
+    },
+    {
+     "version": "2023-05-12",
+     "type": "Pre-release",
+     "date": "2023-05-12",
+     "changes": [
+      "Fix Primal Force upgrade description highlighting"
+     ]
+    },
+    {
+     "version": "2023-04-21",
+     "type": "Pre-release",
+     "date": "2023-04-21",
+     "changes": [
+      "Make Primal Force a Skill and convert to action seq"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Primal Force to the game"
+     ]
+    }
+   ],
+   "PRODUCTION": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Production to the game"
+     ]
+    }
+   ],
+   "PROLONG": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Prolong to the game"
+     ]
+    }
+   ],
+   "PROPHESIZE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Prophesize to the game"
+     ]
+    }
+   ],
+   "PROTECTOR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Protector to the game"
+     ]
+    }
+   ],
+   "PROWESS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Prowess to the game"
+     ]
+    }
+   ],
+   "PULL_FROM_BELOW": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pull from Below to the game"
+     ]
+    }
+   ],
+   "PURITY": [
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Fixed being able to highlight creatures while the Purity card selection screen is open"
+     ]
+    },
+    {
+     "version": "V0.17.0",
+     "type": "Pre-release",
+     "date": "2024-06-21",
+     "changes": [
+      "Purity's selection screen prompt now specifies the number of cards to choose"
+     ]
+    },
+    {
+     "version": "V0.15.0",
+     "type": "Pre-release",
+     "date": "2024-06-07",
+     "changes": [
+      "Changed Purity: now Retains"
+     ]
+    },
+    {
+     "version": "2023-08-25",
+     "type": "Pre-release",
+     "date": "2023-08-25",
+     "changes": [
+      "Updated Purity card art"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Purity to the game"
+     ]
+    }
+   ],
+   "PUTREFY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Putrefy to the game"
+     ]
+    }
+   ],
+   "PYRE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Juggernaut to the game"
+     ]
+    }
+   ],
+   "QUADCAST": [
+    {
+     "version": "V0.89.0",
+     "type": "Pre-release",
+     "date": "2026-01-08",
+     "changes": [
+      "Added portrait art for Quadcast card"
+     ]
+    },
+    {
+     "version": "V0.68.0",
+     "type": "Pre-release",
+     "date": "2025-07-31",
+     "changes": [
+      "Reworked the following cards: Triplecast (now Quadcast)"
+     ]
+    },
+    {
+     "version": "V0.55.0",
+     "type": "Pre-release",
+     "date": "2025-05-08",
+     "changes": [
+      "Triplecast card can no longer be given by Darv"
+     ]
+    },
+    {
+     "version": "V0.54.0",
+     "type": "Pre-release",
+     "date": "2025-05-01",
+     "changes": [
+      "Added Triplecast to the game"
+     ]
+    }
+   ],
+   "RADIATE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Radiate to the game"
+     ]
+    }
+   ],
+   "RAGE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Rage to the game"
+     ]
+    }
+   ],
+   "RAINBOW": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "RALLY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Rally to the game"
+     ]
+    }
+   ],
+   "RAMPAGE": [
+    {
+     "version": "V0.68.0",
+     "type": "Pre-release",
+     "date": "2025-07-31",
+     "changes": [
+      "Rampage card no longer resets its damage value when it gets downgraded"
+     ]
+    },
+    {
+     "version": "V0.31.0",
+     "type": "Pre-release",
+     "date": "2024-10-10",
+     "changes": [
+      "Buffed Rampage: damage increased from 8+5(8) ramp ➝ 9+5(9) ramp"
+     ]
+    },
+    {
+     "version": "V0.9.0",
+     "type": "Pre-release",
+     "date": "2024-04-26",
+     "changes": [
+      "Re-added Rampage"
+     ]
+    },
+    {
+     "version": "2023-06-09",
+     "type": "Pre-release",
+     "date": "2023-06-09",
+     "changes": [
+      "New card portrait for Rampage"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Rampage to the game"
+     ]
+    }
+   ],
+   "RATTLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Rattle to the game"
+     ]
+    }
+   ],
+   "REAPER_FORM": [
+    {
+     "version": "V0.104.0",
+     "type": "Beta Patch",
+     "date": "2026-04-23",
+     "changes": [
+      "Reaper Form card wording has been changed to make it clear that the Doom is applied by Reaper Form's power rather than by the played card:",
+      "Old: \"Whenever Attacks deal damage, they also apply that much Doom.\"",
+      "New: \"Whenever Attacks deal damage, apply that much Doom.\""
+     ]
+    },
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Reaper Form and Lethality card wording changed to imply Osty attacks also benefit"
+     ]
+    },
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Changed Reaper Form card: upgrade changed from reducing Energy cost -> gaining Retain"
+     ]
+    },
+    {
+     "version": "V0.82.0",
+     "type": "Pre-release",
+     "date": "2025-11-06",
+     "changes": [
+      "Reworked Reaper Form card"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Reaper Form card no longer does stupid amounts of damage to invincible enemies"
+     ]
+    },
+    {
+     "version": "V0.69.0",
+     "type": "Pre-release",
+     "date": "2025-08-07",
+     "changes": [
+      "Added portrait art for Reaper Form"
+     ]
+    },
+    {
+     "version": "V0.54.0",
+     "type": "Pre-release",
+     "date": "2025-05-01",
+     "changes": [
+      "Reaper Form card now properly states that enemies take damage instead of losing HP",
+      "Reaper Form card can no longer kill illusions like Parafright"
+     ]
+    },
+    {
+     "version": "V0.53.0",
+     "type": "Pre-release",
+     "date": "2025-04-25",
+     "changes": [
+      "Reworked Reaper Form card"
+     ]
+    },
+    {
+     "version": "V0.48.0",
+     "type": "Pre-release",
+     "date": "2025-03-06",
+     "changes": [
+      "Reaper Form card's portrait dimensions have been fixed."
+     ]
+    },
+    {
+     "version": "V0.45.0",
+     "type": "Pre-release",
+     "date": "2025-02-13",
+     "changes": [
+      "Nerfed Reaper Form card: Doom decreased from 6(9) -> 4(5)"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Added new Power cards: Guillotine, Necro Mastery, Nine Lives, Read the Bones, Reaper Form"
+     ]
+    }
+   ],
+   "REAVE": [
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Buffed Reave card: damage increased from 9(11) → 10(13)"
+     ]
+    },
+    {
+     "version": "V0.104.0",
+     "type": "Beta Patch",
+     "date": "2026-04-23",
+     "changes": [
+      "Fixed Reave card always bottom-decking the Soul card it creates"
+     ]
+    },
+    {
+     "version": "V0.89.0",
+     "type": "Pre-release",
+     "date": "2026-01-08",
+     "changes": [
+      "Changed Drain Power and Reave cards: swapped damage values"
+     ]
+    },
+    {
+     "version": "V0.87.0",
+     "type": "Pre-release",
+     "date": "2025-12-18",
+     "changes": [
+      "Renamed card: Carve Ghost -> Reave"
+     ]
+    },
+    {
+     "version": "V0.80.0",
+     "type": "Pre-release",
+     "date": "2025-10-23",
+     "changes": [
+      "Buffed Carve Ghost card:",
+      "Place Soul into Discard Pile -> Draw Pile",
+      "Upgraded damage increased by 1"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Buffed Carve Ghost card: damage increased from 8(9) -> 10(11)"
+     ]
+    },
+    {
+     "version": "V0.68.0",
+     "type": "Pre-release",
+     "date": "2025-07-31",
+     "changes": [
+      "Changed Carve Ghost card: upgrade changed from +1 Soul -> creating Soul+"
+     ]
+    },
+    {
+     "version": "V0.67.0",
+     "type": "Pre-release",
+     "date": "2025-07-24",
+     "changes": [
+      "Nerfed Carve Ghost card: now adds Souls to your Discard Pile instead of your Hand"
+     ]
+    },
+    {
+     "version": "V0.39.0",
+     "type": "Pre-release",
+     "date": "2024-12-12",
+     "changes": [
+      "Updated art Thrumming Hatchet and Carve Ghost cards",
+      "Carve Ghost card's description now properly says that it adds Souls to your Hand instead of your Discard Pile",
+      "Fixed visual issue when Carve Ghost adds Souls to your hand"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Changed Carve Ghost card: now adds Souls to your Hand instead of your Discard Pile, and its damage has been reduced from 9(11) to 8(9)"
+     ]
+    },
+    {
+     "version": "V0.36.0",
+     "type": "Pre-release",
+     "date": "2024-11-14",
+     "changes": [
+      "Changed Carve Ghost card: now adds Soul(s) to your discard pile instead of your hand"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Added new Attack card: Carve Ghost,"
+     ]
+    }
+   ],
+   "REBOOT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Reboot to the game"
+     ]
+    }
+   ],
+   "REBOUND": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Rebound to the game"
+     ]
+    }
+   ],
+   "REFINE_BLADE": [
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Buffed Refine Blade card: Forge increased from 6(10) -> 9(13)"
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Nerfed Refine Blade card:",
+      "Forge decreased from 10(11) -> 6(10)",
+      "Energy no longer upgrades"
+     ]
+    },
+    {
+     "version": "V0.87.0",
+     "type": "Pre-release",
+     "date": "2025-12-18",
+     "changes": [
+      "Changed Refine Blade card: upgrade changed from +5 Forge -> +1 Forge and +1 Energy next turn"
+     ]
+    },
+    {
+     "version": "V0.40.0",
+     "type": "Pre-release",
+     "date": "2025-01-09",
+     "changes": [
+      "Reworked Refine Blade"
+     ]
+    },
+    {
+     "version": "V0.37.0",
+     "type": "Pre-release",
+     "date": "2024-11-21",
+     "changes": [
+      "Buffed Refine Blade card: Forge increased from 10(15) -> 15(20)"
+     ]
+    },
+    {
+     "version": "V0.15.0",
+     "type": "Pre-release",
+     "date": "2024-06-07",
+     "changes": [
+      "Added Refine Blade card to the game",
+      "Skill - 1 - Common",
+      "“Forge 10(15).”"
+     ]
+    }
+   ],
+   "REFLECT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Reflect to the game"
+     ]
+    }
+   ],
+   "REFLEX": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "REFRACT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Refract to the game"
+     ]
+    }
+   ],
+   "REGRET": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Regret to the game"
+     ]
+    }
+   ],
+   "RELAX": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Relax to the game"
+     ]
+    }
+   ],
+   "REND": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Rend to the game"
+     ]
+    }
+   ],
+   "RESONANCE": [
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Buffed Resonance card: Star cost decreased from 3 → 2"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Resonance to the game."
+     ]
+    }
+   ],
+   "RESTLESSNESS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Restlessness to the game"
+     ]
+    }
+   ],
+   "RICOCHET": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Ricochet to the game"
+     ]
+    }
+   ],
+   "RIGHT_HAND_HAND": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Right Hand Hand to the game"
+     ]
+    }
+   ],
+   "RIP_AND_TEAR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Rip and Tear to the game without any changes from Slay the Spire"
+     ]
+    }
+   ],
+   "ROCKET_PUNCH": [
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Iteration, Rocket Punch, and Trash to Treasure card descriptions now say \"Status\" instead of \"Status card\""
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Buffed Rocket Punch card: cost reduction effect now lasts until it is played, instead of just until the end of the turn"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "Nerfed Rocket Punch card: damage decreased from 15(18) -> 13(14)"
+     ]
+    },
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Nerfed Rocket Punch card: upgrade damage decreased from 15(20) -> 15(18)"
+     ]
+    },
+    {
+     "version": "V0.79.0",
+     "type": "Pre-release",
+     "date": "2025-10-16",
+     "changes": [
+      "Changed Rocket Punch card: rarity decreased from Rare -> Uncommon"
+     ]
+    },
+    {
+     "version": "V0.78.0",
+     "type": "Pre-release",
+     "date": "2025-10-09",
+     "changes": [
+      "Added portrait art for Rocket Punch"
+     ]
+    },
+    {
+     "version": "V0.67.0",
+     "type": "Pre-release",
+     "date": "2025-07-24",
+     "changes": [
+      "Rocket Punch card no longer counts Statuses given by the enemy"
+     ]
+    },
+    {
+     "version": "V0.66.0",
+     "type": "Pre-release",
+     "date": "2025-07-17",
+     "changes": [
+      "Added Rocket Punch to the game"
+     ]
+    }
+   ],
+   "ROLLING_BOULDER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Rolling Boulder to the game"
+     ]
+    }
+   ],
+   "ROYAL_GAMBLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Royal Gamble to the game"
+     ]
+    }
+   ],
+   "ROYALTIES": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Royalties to the game"
+     ]
+    }
+   ],
+   "RUPTURE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Rupture to the game"
+     ]
+    }
+   ],
+   "SACRIFICE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sacrifice to the game"
+     ]
+    }
+   ],
+   "SALVO": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Salvo to the game"
+     ]
+    }
+   ],
+   "SCARE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "SCAVENGE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Scavenge to the game"
+     ]
+    }
+   ],
+   "SCRAWL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Scrawl to the game"
+     ]
+    }
+   ],
+   "SCULPTING_STRIKE": [
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Buffed Sculpting Strike card: Damage increased from 8(11) -> 9(12)"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "Necrobinder's last card unlock set is now Sculpting Strike, Veilpiercer and Banshee's Cry"
+     ]
+    },
+    {
+     "version": "V0.79.0",
+     "type": "Pre-release",
+     "date": "2025-10-16",
+     "changes": [
+      "Buffed Bodyguard card:",
+      "Damage increased from 10(13) -> 10(14)",
+      "Summon increased from 5(6) -> 5(7)"
+     ]
+    },
+    {
+     "version": "V0.76.0",
+     "type": "Pre-release",
+     "date": "2025-09-25",
+     "changes": [
+      "Nerfed Sculpting Strike card:",
+      "Damage decreased from 9(12) -> 8(11)",
+      "Rarity decreased from Uncommon -> Common"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Added portrait art for the following Necrobinder cards:",
+      "Sculpting strike"
+     ]
+    },
+    {
+     "version": "V0.68.0",
+     "type": "Pre-release",
+     "date": "2025-07-31",
+     "changes": [
+      "Changed Sculpting Strike card: rarity changed from Rare -> Uncommon"
+     ]
+    },
+    {
+     "version": "V0.67.0",
+     "type": "Pre-release",
+     "date": "2025-07-24",
+     "changes": [
+      "Reworked the following cards:",
+      "Sculpting Strike"
+     ]
+    },
+    {
+     "version": "V0.60.0",
+     "type": "Pre-release",
+     "date": "2025-06-12",
+     "changes": [
+      "Nerfed Sculpting Strike card: Energy cost increased from 0 -> 1"
+     ]
+    },
+    {
+     "version": "V0.57.0",
+     "type": "Pre-release",
+     "date": "2025-05-22",
+     "changes": [
+      "Added new cards:",
+      "Sculpting Strike"
+     ]
+    }
+   ],
+   "SEANCE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Seance to the game"
+     ]
+    }
+   ],
+   "SECOND_WIND": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Second Wind to the game"
+     ]
+    }
+   ],
+   "SECRET_TECHNIQUE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Secret Technique to the game"
+     ]
+    }
+   ],
+   "SECRET_WEAPON": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Secret Weapon to the game"
+     ]
+    }
+   ],
+   "SEEKER_STRIKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Seeker Strike to the game"
+     ]
+    }
+   ],
+   "SENTRY_MODE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sentry Mode to the game"
+     ]
+    }
+   ],
+   "SERPENT_FORM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Serpent Form to the game"
+     ]
+    }
+   ],
+   "SETUP_STRIKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Setup Strike to the game"
+     ]
+    }
+   ],
+   "SEVEN_STARS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Seven Stars to the game"
+     ]
+    }
+   ],
+   "SEVERANCE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Severance to the game"
+     ]
+    }
+   ],
+   "SHADOW_SHIELD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Shadow Shield to the game"
+     ]
+    }
+   ],
+   "SHADOW_STEP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Shadow Step to the game"
+     ]
+    }
+   ],
+   "SHADOWMELD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Shadowmeld to the game"
+     ]
+    }
+   ],
+   "SHAME": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Shame to the game"
+     ]
+    }
+   ],
+   "SHATTER": [
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Changed Shatter card: now Exhausts"
+     ]
+    },
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Nerfed Shatter: Damage decreased from 11(15) -> 7(11)."
+     ]
+    },
+    {
+     "version": "V0.105.0",
+     "type": "Beta Patch",
+     "date": "2026-05-08",
+     "changes": [
+      "Buffed Shatter: Now Evokes all of your Orbs twice."
+     ]
+    },
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Added Portrait art for Shatter"
+     ]
+    },
+    {
+     "version": "V0.83.0",
+     "type": "Pre-release",
+     "date": "2025-11-13",
+     "changes": [
+      "Buffed Shatter card: now hits ALL enemies"
+     ]
+    },
+    {
+     "version": "V0.71.0",
+     "type": "Pre-release",
+     "date": "2025-08-21",
+     "changes": [
+      "Updated wording for Shatter"
+     ]
+    },
+    {
+     "version": "V0.63.0",
+     "type": "Pre-release",
+     "date": "2025-07-03",
+     "changes": [
+      "Added Shatter to the game"
+     ]
+    }
+   ],
+   "SHINING_STRIKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Shining Strike to the game"
+     ]
+    }
+   ],
+   "SHIV": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Shiv to the game"
+     ]
+    }
+   ],
+   "SHOCKWAVE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Shockwave to the game"
+     ]
+    }
+   ],
+   "SHROUD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Shroud to the game"
+     ]
+    }
+   ],
+   "SHRUG_IT_OFF": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Shrug It Off to the game"
+     ]
+    }
+   ],
+   "SIC_EM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sic 'Em to the game"
+     ]
+    }
+   ],
+   "SIGNAL_BOOST": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Signal Boost to the game"
+     ]
+    }
+   ],
+   "SKEWER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Skewer to the game"
+     ]
+    }
+   ],
+   "SKIM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Skim to the game"
+     ]
+    }
+   ],
+   "SLEIGHT_OF_FLESH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sleight of Flesh to the game"
+     ]
+    }
+   ],
+   "SLICE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Slice to the game"
+     ]
+    }
+   ],
+   "SLIMED": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Slimed to the game"
+     ]
+    }
+   ],
+   "SLOTH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sloth to the game"
+     ]
+    }
+   ],
+   "SMOKESTACK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Smokestack to the game"
+     ]
+    }
+   ],
+   "SNAKEBITE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Snakebite to the game"
+     ]
+    }
+   ],
+   "SNAP": [
+    {
+     "version": "V0.77.0",
+     "type": "Pre-release",
+     "date": "2025-10-02",
+     "changes": [
+      "Snap card now allows you to apply Retain to Statuses and Curses"
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Reworked card: Snap"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Buffed Snap card: upgrade damage increased from +1 -> +3"
+     ]
+    },
+    {
+     "version": "V0.71.0",
+     "type": "Pre-release",
+     "date": "2025-08-21",
+     "changes": [
+      "Reworked Swipe card -> Snap"
+     ]
+    },
+    {
+     "version": "V0.63.0",
+     "type": "Pre-release",
+     "date": "2025-07-03",
+     "changes": [
+      "Nerfed Swipe card: damage decreased from 10(14) -> 9(12)"
+     ]
+    },
+    {
+     "version": "V0.46.0",
+     "type": "Pre-release",
+     "date": "2025-02-20",
+     "changes": [
+      "Added portrait art for Graveblast, Reap, and Soul cards, and re-added portrait art for Swipe card",
+      "Fixed Swipe card hovertip",
+      "Fixed softlock that occurred when playing Swipe card while Osty is dead"
+     ]
+    },
+    {
+     "version": "V0.45.0",
+     "type": "Pre-release",
+     "date": "2025-02-13",
+     "changes": [
+      "Added new card: Swipe"
+     ]
+    },
+    {
+     "version": "V0.37.0",
+     "type": "Pre-release",
+     "date": "2024-11-21",
+     "changes": [
+      "Deprecated card: Swipe"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Added new Attack card: SwipeThis might be a mistake in the Patch Notes as being listed as a new attack, when it probably should have been in the rework section as the card hadn't been deprecated before this point of time."
+     ]
+    },
+    {
+     "version": "V0.10.0",
+     "type": "Pre-release",
+     "date": "2024-05-04",
+     "changes": [
+      "Added Swipe card",
+      "Attack - 1 - Common",
+      "Osty deals 10(15) damage to ALL enemies."
+     ]
+    },
+    {
+     "version": "2023-06-09",
+     "type": "Pre-release",
+     "date": "2023-06-09",
+     "changes": [
+      "Deprecate Swipe card"
+     ]
+    },
+    {
+     "version": "2023-05-05",
+     "type": "Pre-release",
+     "date": "2023-05-05",
+     "changes": [
+      "New card portrait for Swipe"
+     ]
+    },
+    {
+     "version": "2023-02-09",
+     "type": "Pre-release",
+     "date": "2023-02-09",
+     "changes": [
+      "BUGFIX: Fix typo in Swipe+ card description"
+     ]
+    }
+   ],
+   "SNEAKY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sneaky to the game"
+     ]
+    }
+   ],
+   "SOLAR_STRIKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Solar Strike to the game"
+     ]
+    }
+   ],
+   "SOOT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Soot to the game"
+     ]
+    }
+   ],
+   "SOUL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Soul to the game"
+     ]
+    }
+   ],
+   "SOVEREIGN_BLADE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sovereign Blade to the game"
+     ]
+    }
+   ],
+   "SPECTRUM_SHIFT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Spectrum Shift to the game"
+     ]
+    }
+   ],
+   "SPEEDSTER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Speedster to the game"
+     ]
+    }
+   ],
+   "SPINNER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "SPITE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Spite to the game"
+     ]
+    }
+   ],
+   "SPLASH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Splash to the game"
+     ]
+    }
+   ],
+   "SPOILS_MAP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Spoils Map to the game"
+     ]
+    }
+   ],
+   "SPOILS_OF_BATTLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Spoils of Battle to the game"
+     ]
+    }
+   ],
+   "SPORE_MIND": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Spore Mind to the game"
+     ]
+    }
+   ],
+   "SPUR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Spur to the game"
+     ]
+    }
+   ],
+   "SQUASH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Squash to the game"
+     ]
+    }
+   ],
+   "SQUEEZE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Squeeze to the game"
+     ]
+    }
+   ],
+   "STACK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Stack to the game"
+     ]
+    }
+   ],
+   "STAMPEDE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Stampede to the game"
+     ]
+    }
+   ],
+   "STOKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Stoke to the game"
+     ]
+    }
+   ],
+   "STOMP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Stomp to the game"
+     ]
+    }
+   ],
+   "STORM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Storm to the game"
+     ]
+    }
+   ],
+   "STORM_OF_STEEL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Storm of Steel to the game"
+     ]
+    }
+   ],
+   "STRANGLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Strangle to the game"
+     ]
+    }
+   ],
+   "STRATAGEM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Stratagem to the game"
+     ]
+    }
+   ],
+   "STRIKE_IRONCLAD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Strike to the game"
+     ]
+    }
+   ],
+   "STRIKE_SILENT": [
+    {
+     "version": "V0.91.0",
+     "type": "Pre-release",
+     "date": "2026-01-22",
+     "changes": [
+      "Updated portrait art for Silent's Strike card"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Strike to the game"
+     ]
+    }
+   ],
+   "STRIKE_REGENT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Strike to the game"
+     ]
+    }
+   ],
+   "STRIKE_NECROBINDER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Strike to the game"
+     ]
+    }
+   ],
+   "STRIKE_DEFECT": [
+    {
+     "version": "2023-09-01",
+     "type": "Pre-release",
+     "date": "2023-09-01",
+     "changes": [
+      "Updated Defect's Strike card art"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Strike to the game"
+     ]
+    }
+   ],
+   "SUBROUTINE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Subroutine to the game"
+     ]
+    }
+   ],
+   "SUCKER_PUNCH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sucker Punch to the game"
+     ]
+    }
+   ],
+   "SUMMON_FORTH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Summon Forth to the game"
+     ]
+    }
+   ],
+   "SUNDER": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Buffed Sunder card: damage increased from 24(32) -> 26(34)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sunder to the game"
+     ]
+    }
+   ],
+   "SUPERMASSIVE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Supermassive to the game"
+     ]
+    }
+   ],
+   "SUPPRESS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Suppress to the game"
+     ]
+    }
+   ],
+   "SWEEPING_BEAM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sweeping Beam to the game"
+     ]
+    }
+   ],
+   "SWEEPING_GAZE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sweeping Gaze to the game"
+     ]
+    }
+   ],
+   "SWORD_BOOMERANG": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sword Boomerang to the game"
+     ]
+    }
+   ],
+   "SWORD_SAGE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sword Sage to the game"
+     ]
+    }
+   ],
+   "SYNCHRONIZE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Synchronize to the game"
+     ]
+    }
+   ],
+   "SYNTHESIS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Synthesis to the game"
+     ]
+    }
+   ],
+   "TURBO": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added TURBO to the game"
+     ]
+    }
+   ],
+   "TACTICIAN": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "TAG_TEAM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Tag Team to the game"
+     ]
+    }
+   ],
+   "TANK": [
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Buffed and slightly reworked Tank card: \"Take double damage from enemies. Allies take half damage from enemies.\" → \"Take 50% additional damage from enemies. Allies take 50% less damage from enemies.\""
+     ]
+    },
+    {
+     "version": "V0.94.0",
+     "type": "Pre-release",
+     "date": "2026-02-12",
+     "changes": [
+      "Nerfed Tank card: no longer stacks"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "Added portrait art for Tank"
+     ]
+    },
+    {
+     "version": "V0.87.0",
+     "type": "Pre-release",
+     "date": "2025-12-18",
+     "changes": [
+      "Renamed the following cards:",
+      "The Tank -> Tank"
+     ]
+    },
+    {
+     "version": "V0.83.0",
+     "type": "Pre-release",
+     "date": "2025-11-13",
+     "changes": [
+      "Added new character-specific multiplayer cards:",
+      "Ironclad: Body Block, The Tank (no longer colorless)"
+     ]
+    },
+    {
+     "version": "V0.74.0",
+     "type": "Pre-release",
+     "date": "2025-09-11",
+     "changes": [
+      "Buffed The Tank card: Energy cost decreased from 2(1) -> 1(0)"
+     ]
+    },
+    {
+     "version": "V0.58.0",
+     "type": "Pre-release",
+     "date": "2025-05-29",
+     "changes": [
+      "Added new multiplayer-exclusive cards: Tank"
+     ]
+    }
+   ],
+   "TAUNT": [
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "Nerfed Taunt: now targets a specific enemy to apply Vulnerable on"
+     ]
+    },
+    {
+     "version": "V0.47.0",
+     "type": "Pre-release",
+     "date": "2025-02-27",
+     "changes": [
+      "Dybbuk Cube relic now properly doubles Vulnerable applied by Taunt card"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Taunt card can no longer target dead Decemillipede segment",
+      "Taunt card’s Vulnerable is now affected by Dybbuk Cube relic"
+     ]
+    },
+    {
+     "version": "V0.24.0",
+     "type": "Pre-release",
+     "date": "2024-08-23",
+     "changes": [
+      "Decree of Unmaking, Grapple, Taunt, and Monarch’s Gaze cards now refer to enemies with it/its"
+     ]
+    },
+    {
+     "version": "V0.17.0",
+     "type": "Pre-release",
+     "date": "2024-06-21",
+     "changes": [
+      "Nerfed Taunt card: Block gain and Vulnerable applied decreased from 8(12) Block and 2(3) Vulnerable -> 7(8) Block and 1(2) Vulnerable"
+     ]
+    },
+    {
+     "version": "V0.16.0",
+     "type": "Pre-release",
+     "date": "2024-06-14",
+     "changes": [
+      "Reworked Taunt card: now applies 2(3) Vulnerable immediately, instead of when you are hit"
+     ]
+    },
+    {
+     "version": "V0.15.0",
+     "type": "Pre-release",
+     "date": "2024-06-07",
+     "changes": [
+      "Buffed Taunt card: Block gain increased from 6(9) -> 8(11)"
+     ]
+    },
+    {
+     "version": "V0.10.0",
+     "type": "Pre-release",
+     "date": "2024-05-04",
+     "changes": [
+      "Stoke and Taunt now correctly use cast animation"
+     ]
+    },
+    {
+     "version": "v0.109.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Block gain decreased from 7(8) -> 6(7)",
+      "Rarity decreased from Uncommon to Common."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Taunt to the game"
+     ]
+    }
+   ],
+   "TEAR_ASUNDER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Tear Asunder to the game"
+     ]
+    }
+   ],
+   "TEMPEST": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Tempest to the game"
+     ]
+    }
+   ],
+   "TERRAFORMING": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Terraforming to the game"
+     ]
+    }
+   ],
+   "TESLA_COIL": [
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Added portrait art for Tesla Coil"
+     ]
+    },
+    {
+     "version": "V0.66.0",
+     "type": "Pre-release",
+     "date": "2025-07-17",
+     "changes": [
+      "Reworked Tesla Coil card into an Attack"
+     ]
+    },
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "Buffed Tesla Coil card: Energy cost decreased from 1 -> 0"
+     ]
+    },
+    {
+     "version": "V0.57.0",
+     "type": "Pre-release",
+     "date": "2025-05-22",
+     "changes": [
+      "Reworked Tesla Coil card"
+     ]
+    },
+    {
+     "version": "V0.54.0",
+     "type": "Pre-release",
+     "date": "2025-05-01",
+     "changes": [
+      "Reworked Tesla Coil card"
+     ]
+    },
+    {
+     "version": "V0.53.0",
+     "type": "Pre-release",
+     "date": "2025-04-25",
+     "changes": [
+      "Added Tesla Coil to the game"
+     ]
+    },
+    {
+     "version": "v0.105.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Buffed Tesla Coil+: damage decreased from 6 -> 4, but Lightning Triggers increased from once -> twice"
+     ]
+    }
+   ],
+   "THE_BOMB": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added The Bomb to the game"
+     ]
+    }
+   ],
+   "THE_GAMBIT": [
+    {
+     "version": "V0.78.0",
+     "type": "Pre-release",
+     "date": "2025-10-09",
+     "changes": [
+      "The Gambit card now specifies that only unblocked attack damage will kill you"
+     ]
+    },
+    {
+     "version": "V0.29.0",
+     "type": "Pre-release",
+     "date": "2024-09-26",
+     "changes": [
+      "Added card art for The Gambit"
+     ]
+    },
+    {
+     "version": "V0.25.0",
+     "type": "Pre-release",
+     "date": "2024-08-30",
+     "changes": [
+      "Changed The Gambit card:",
+      "No longer a Silent card, now a Colorless card",
+      "Block gain increased from 16(24) -> 50(75)"
+     ]
+    },
+    {
+     "version": "2023-04-21",
+     "type": "Pre-release",
+     "date": "2023-04-21",
+     "changes": [
+      "Fix The Gambit death"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added The Gambit to the game"
+     ]
+    }
+   ],
+   "THE_HUNT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added The Hunt to the game"
+     ]
+    }
+   ],
+   "THE_SCYTHE": [
+    {
+     "version": "V0.107.0",
+     "type": "Beta Patch",
+     "date": "2026-06-04",
+     "changes": [
+      "Buffed The Scythe: Damage increased from 3(4) -> 4(5)."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added The Scythe to the game"
+     ]
+    }
+   ],
+   "THE_SMITH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added The Smith to the game"
+     ]
+    }
+   ],
+   "THINKING_AHEAD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Thinking Ahead to the game"
+     ]
+    }
+   ],
+   "THRASH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Thrash to the game"
+     ]
+    }
+   ],
+   "THRUMMING_HATCHET": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Thrumming Hatchet to the game"
+     ]
+    }
+   ],
+   "THUNDER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "THUNDERCLAP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Thunderclap to the game"
+     ]
+    }
+   ],
+   "TIMES_UP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Time's Up to the game"
+     ]
+    }
+   ],
+   "TOOLS_OF_THE_TRADE": [
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "Changes from beta branch incorporated into main branch"
+     ]
+    },
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "You can no longer play cards before Tools of the Trade power triggers"
+     ]
+    },
+    {
+     "version": "V0.65.0",
+     "type": "Pre-release",
+     "date": "2025-07-10",
+     "changes": [
+      "Fixed softlock when playing Sly Acrobatics from Tools of the Trade power",
+      "Fixed stuck cards when playing them before Tools of the Trade power triggers"
+     ]
+    },
+    {
+     "version": "V0.40.0",
+     "type": "Pre-release",
+     "date": "2025-01-09",
+     "changes": [
+      "Tools of the Trade card now cancels any card plays that occur before it"
+     ]
+    },
+    {
+     "version": "V0.29.0",
+     "type": "Pre-release",
+     "date": "2024-09-26",
+     "changes": [
+      "Fixed softlock when card play gets canceled by Tools of the Trade"
+     ]
+    },
+    {
+     "version": "V0.9.0",
+     "type": "Pre-release",
+     "date": "2024-04-26",
+     "changes": [
+      "Eviscerate's energy cost now updates properly after discarding a card via Tools of the Trade"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Tools of the Trade to the game"
+     ]
+    }
+   ],
+   "TORIC_TOUGHNESS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Toric Toughness to the game"
+     ]
+    }
+   ],
+   "TOXIC": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Toxic to the game"
+     ]
+    }
+   ],
+   "TRACKING": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Tracking to the game"
+     ]
+    }
+   ],
+   "TRASH_TO_TREASURE": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Changed Trash to Treasure card: upgrade changed from gains Innate -> lowers cost by 1"
+     ]
+    },
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Iteration, Rocket Punch, and Trash to Treasure card descriptions now say \"Status\" instead of \"Status card\""
+     ]
+    },
+    {
+     "version": "V0.102.0",
+     "type": "Beta Patch",
+     "date": "2026-04-02",
+     "changes": [
+      "Trash to Treasure power no longer procs from other player's generated statuses"
+     ]
+    },
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Added Portrait art"
+     ]
+    },
+    {
+     "version": "V0.87.0",
+     "type": "Pre-release",
+     "date": "2025-12-18",
+     "changes": [
+      "Trash To Treasure and Refactor now only trigger on statuses you create"
+     ]
+    },
+    {
+     "version": "V0.86.0",
+     "type": "Pre-release",
+     "date": "2025-12-11",
+     "changes": [
+      "Trash to Treasure power now stacks and channels Orbs based on amount"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Trash to Treasure to the game."
+     ]
+    }
+   ],
+   "TREMBLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Tremble to the game"
+     ]
+    }
+   ],
+   "TRUE_GRIT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added True Grit to the game"
+     ]
+    }
+   ],
+   "TWIN_STRIKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Twin Strike to the game"
+     ]
+    }
+   ],
+   "TYRANNY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Tyranny to the game"
+     ]
+    }
+   ],
+   "ULTIMATE_DEFEND": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Ultimate Defend to the game"
+     ]
+    }
+   ],
+   "ULTIMATE_STRIKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Ultimate Strike to the game"
+     ]
+    }
+   ],
+   "UNDEATH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Undeath to the game"
+     ]
+    }
+   ],
+   "UNMOVABLE": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Fixed Unmovable card causing other players to receive double Block from Demonic Shield card when it was not the first Block card played"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "Unmovable card now properly doubles all Block from multi-Block cards like Second Wind"
+     ]
+    },
+    {
+     "version": "V0.79.0",
+     "type": "Pre-release",
+     "date": "2025-10-16",
+     "changes": [
+      "For example, one-off effects triggered by block gain (ex. Unmovable card) will no longer be accidentally consumed by automatic Block gain (ex. After Image card), while permanent effects triggered by Block gain (ex. Beacon of Hope) will be affected by new sources of Block gain (ex. Plating power)"
+     ]
+    },
+    {
+     "version": "V0.76.0",
+     "type": "Pre-release",
+     "date": "2025-09-25",
+     "changes": [
+      "Unmovable card no longer doubles enemy Block gain"
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Unmovable card is now properly triggered by delayed Block gain effects from cards like Crimson Mantle"
+     ]
+    },
+    {
+     "version": "V0.74.0",
+     "type": "Pre-release",
+     "date": "2025-09-11",
+     "changes": [
+      "Fixed Unmovable card missing its upgrade",
+      "Glitterstream card now properly doubles its Block next turn if you've previously played Unmovable card"
+     ]
+    },
+    {
+     "version": "V0.73.0",
+     "type": "Pre-release",
+     "date": "2025-09-04",
+     "changes": [
+      "Reworked Unmovable card"
+     ]
+    },
+    {
+     "version": "V0.61.0",
+     "type": "Pre-release",
+     "date": "2025-06-20",
+     "changes": [
+      "Added portrait art for Unmovable"
+     ]
+    },
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "Changed Unmovable card:",
+      "Block gain increased from 4(6) -> 6(8)",
+      "Cost increased from 1 -> 2"
+     ]
+    },
+    {
+     "version": "V0.31.0",
+     "type": "Pre-release",
+     "date": "2024-10-10",
+     "changes": [
+      "Added Unmovable to the game"
+     ]
+    }
+   ],
+   "UNRELENTING": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Unrelenting to the game"
+     ]
+    }
+   ],
+   "UNTOUCHABLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Untouchable to the game"
+     ]
+    }
+   ],
+   "UPPERCUT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Uppercut to the game"
+     ]
+    }
+   ],
+   "UPROAR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Uproar to the game"
+     ]
+    }
+   ],
+   "VEILPIERCER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Veilpiercer to the game"
+     ]
+    }
+   ],
+   "VENERATE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Venerate to the game"
+     ]
+    }
+   ],
+   "VICIOUS": [
+    {
+     "version": "V0.88.0",
+     "type": "Pre-release",
+     "date": "2026-01-01",
+     "changes": [
+      "Buffed Vicious card:",
+      "Card draw increased from 1 -> 1(2)",
+      "Energy cost decreased from 2(1) -> 1"
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Nerfed Vicious card:",
+      "Energy cost increased from 1(1) -> 2(1)",
+      "Card draw amount no longer upgrades"
+     ]
+    },
+    {
+     "version": "V0.61.0",
+     "type": "Pre-release",
+     "date": "2025-06-20",
+     "changes": [
+      "Added portrait art for Vicious"
+     ]
+    },
+    {
+     "version": "V0.60.0",
+     "type": "Pre-release",
+     "date": "2025-06-12",
+     "changes": [
+      "Added beta art for Vicious"
+     ]
+    },
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "Added Vicious to the game"
+     ]
+    }
+   ],
+   "VOID": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Void status to the game"
+     ]
+    }
+   ],
+   "VOID_FORM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Void Form to the game"
+     ]
+    }
+   ],
+   "VOLLEY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Volley to the game"
+     ]
+    }
+   ],
+   "VOLTAIC": [
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Energy cost increased from 2 -> 3"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Voltaic to the game"
+     ]
+    }
+   ],
+   "WASTE_AWAY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Waste Away to the game"
+     ]
+    }
+   ],
+   "WELL_LAID_PLANS": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Reworked Well-Laid Plans card:",
+      "Uncommon - Power - Cost 1 - \"At the end of your turn, Retain up to 1(2) card(s).\" -> Rare - Power - Cost 1(0) - \"At the end of your turn, you no longer discard your Hand.\"",
+      "Now also available in multiplayer, was previously singleplayer-only"
+     ]
+    },
+    {
+     "version": "V0.83.0",
+     "type": "Pre-release",
+     "date": "2025-11-13",
+     "changes": [
+      "Changed Well Laid Plans card: no longer appears in Multiplayer"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Updated wording for Well Laid Plans"
+     ]
+    },
+    {
+     "version": "V0.47.0",
+     "type": "Pre-release",
+     "date": "2025-02-27",
+     "changes": [
+      "When a remote player is picking a card, the card/power/relic they're choosing for is displayed (applies to things like Survivor, Gambling Chip, Choice's Paradox, and Well-Laid Plans)"
+     ]
+    },
+    {
+     "version": "V0.25.0",
+     "type": "Pre-release",
+     "date": "2024-08-30",
+     "changes": [
+      "You can no longer use the Well Laid Plans card to retain a Toxic status card"
+     ]
+    },
+    {
+     "version": "V0.22.0",
+     "type": "Pre-release",
+     "date": "2024-08-09",
+     "changes": [
+      "Well Laid Plans power pluralizes the selection prompt"
+     ]
+    },
+    {
+     "version": "V0.21.0",
+     "type": "Pre-release",
+     "date": "2024-07-12",
+     "changes": [
+      "Well Laid Plans card’s description is now correctly pluralized"
+     ]
+    },
+    {
+     "version": "V0.13.0",
+     "type": "Pre-release",
+     "date": "2024-05-24",
+     "changes": [
+      "Well Laid Plans card no longer prompts you if your hand is empty",
+      "Well Laid Plans card now disallows selecting cards already expected to be retained"
+     ]
+    },
+    {
+     "version": "V0.9.0",
+     "type": "Pre-release",
+     "date": "2024-04-26",
+     "changes": [
+      "Well Laid Plans power now lets you select 0 cards to retain & no longer has Retain itself"
+     ]
+    },
+    {
+     "version": "2023-07-14",
+     "type": "Pre-release",
+     "date": "2023-07-14",
+     "changes": [
+      "Well-laid Plans will no long auto-retain cards if its amount and the number of cards in your hand are equal"
+     ]
+    },
+    {
+     "version": "2023-05-05",
+     "type": "Pre-release",
+     "date": "2023-05-05",
+     "changes": [
+      "Fixing selection bug for Well-laid Plans"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Well-Laid Plans to the game"
+     ]
+    }
+   ],
+   "WHIRLWIND": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Whirlwind to the game"
+     ]
+    }
+   ],
+   "WHISTLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Whistle to the game"
+     ]
+    }
+   ],
+   "WHITE_NOISE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added White Noise to the game"
+     ]
+    }
+   ],
+   "WITHER": [
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Added portrait art for Wither status card"
+     ]
+    },
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "Replaced the Act 3 boss Doormaker with a brand-new boss, Aeonglass (its moveset and Wither / Withering Presence mechanics were refined throughout the beta)"
+     ]
+    },
+    {
+     "version": "v0.106.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Adjusted moveset",
+      "Reworked Wither status and Withering Presence power",
+      "1 cost Retain. At the end of your turn, if this is in your Hand, take 2(4) damage. -> Unplayable. At the end of your turn, if this is in your Hand, take 3(6) damage."
+     ]
+    },
+    {
+     "version": "v0.105.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Doormaker has been replaced with a brand new boss, Aeonglass!",
+      "While Doormaker had interesting micro decisions in the fight, he was over the complexity threshold of what we want and had lingering issues. We decided that starting over fresh will let us hit what we actually want for an Act 3 boss."
+     ]
+    }
+   ],
+   "WOUND": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Wound to the game"
+     ]
+    }
+   ],
+   "WRAITH_FORM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Wraith Form to the game"
+     ]
+    }
+   ],
+   "WRITHE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Writhe to the game"
+     ]
+    }
+   ],
+   "WROUGHT_IN_WAR": [
+    {
+     "version": "V0.103.2",
+     "type": "Major Update",
+     "date": "2026-04-16",
+     "changes": [
+      "Changes from the beta branch incorporated into the main branch"
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Buffed Wrought in War card: Forge increased from 5(7) -> 7(9)"
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Nerfed Wrought in War card: Forge decreased from 8 -> 5"
+     ]
+    },
+    {
+     "version": "V0.68.0",
+     "type": "Pre-release",
+     "date": "2025-07-31",
+     "changes": [
+      "Added portrait art for Wrought in War"
+     ]
+    },
+    {
+     "version": "V0.65.0",
+     "type": "Pre-release",
+     "date": "2025-07-10",
+     "changes": [
+      "Regent no longer has a Neow bundle with a rare card; Beat Into Shape card replaced by Wrought in War card"
+     ]
+    },
+    {
+     "version": "V0.63.0",
+     "type": "Pre-release",
+     "date": "2025-07-03",
+     "changes": [
+      "Reworked Wrought in War card (details unknown)"
+     ]
+    },
+    {
+     "version": "V0.53.0",
+     "type": "Pre-release",
+     "date": "2025-04-25",
+     "changes": [
+      "When Wrought in War card is downgraded, it no longer loses buffs that it received from previous plays this combat"
+     ]
+    },
+    {
+     "version": "V0.46.0",
+     "type": "Pre-release",
+     "date": "2025-02-20",
+     "changes": [
+      "Improved Wrought in War card's clarity"
+     ]
+    },
+    {
+     "version": "V0.45.0",
+     "type": "Pre-release",
+     "date": "2025-02-13",
+     "changes": [
+      "Reworked Wrought in War card (details unknown)"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Changed Wrought in War card: rarity increased from Uncommon -> Rare"
+     ]
+    },
+    {
+     "version": "V0.25.0",
+     "type": "Pre-release",
+     "date": "2024-08-30",
+     "changes": [
+      "Wrought in War card preview now shows upgraded Sovereign Blade card"
+     ]
+    },
+    {
+     "version": "V0.24.0",
+     "type": "Pre-release",
+     "date": "2024-08-23",
+     "changes": [
+      "Fixed Wrought in War card description to match new behavior"
+     ]
+    },
+    {
+     "version": "V0.23.0",
+     "type": "Pre-release",
+     "date": "2024-08-16",
+     "changes": [
+      "Changed Wrought in War card: reworked to not care about killing enemies and to exhaust"
+     ]
+    },
+    {
+     "version": "V0.18.0",
+     "type": "Pre-release",
+     "date": "2024-06-29",
+     "changes": [
+      "Wrought in War card no longer has Fatal keyword"
+     ]
+    },
+    {
+     "version": "V0.17.0",
+     "type": "Pre-release",
+     "date": "2024-06-21",
+     "changes": [
+      "Added Wrought in War card"
+     ]
+    }
+   ],
+   "ZAP": [
+    {
+     "version": "2023-09-01",
+     "type": "Pre-release",
+     "date": "2023-09-01",
+     "changes": [
+      "Updated Zap card art"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Zap to the game"
+     ]
+    }
+   ]
+  },
+  "relics": {
+   "AKABEKO": [
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Added asset for Akabeko"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "Akabeko relic from STS1 returns to the game, but is now Uncommon"
+     ]
+    }
+   ],
+   "AMETHYST_AUBERGINE": [
+    {
+     "version": "V0.103.2",
+     "type": "Major Update",
+     "date": "2026-04-16",
+     "changes": [
+      "BETA changes incorporated into main branch."
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Relics that generate Gold (such as Bowler Hat and Amethyst Aubergine) no longer appear at the Merchant",
+      "Buffed Amethyst Aubergine relic: Gold gain increased from 10 -> 15"
+     ]
+    },
+    {
+     "version": "V0.81.0",
+     "type": "Pre-release",
+     "date": "2025-10-30",
+     "changes": [
+      "Amethyst Aubergine relic no longer creates a reward after the final boss"
+     ]
+    },
+    {
+     "version": "V0.79.0",
+     "type": "Pre-release",
+     "date": "2025-10-16",
+     "changes": [
+      "Reworked Amethyst Aubergine relic"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Added placeholder assets for Amethyst Aubergine"
+     ]
+    },
+    {
+     "version": "V0.68.0",
+     "type": "Pre-release",
+     "date": "2025-07-31",
+     "changes": [
+      "Added Amethyst Aubergine to the game"
+     ]
+    }
+   ],
+   "ANCHOR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Anchor to the gameThis relic is not mentioned in any patch notes"
+     ]
+    }
+   ],
+   "FAKE_ANCHOR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Anchor??? to the gameThis relic is not mentioned in any patch notes"
+     ]
+    }
+   ],
+   "ARCANE_SCROLL": [
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed Relic: Shiny Monocle -> Arcane Scroll"
+     ]
+    },
+    {
+     "version": "V0.87.0",
+     "type": "Pre-release",
+     "date": "2025-12-18",
+     "changes": [
+      "Removed redundant \"to add to your Deck\" from The Chosen One"
+     ]
+    },
+    {
+     "version": "V0.86.0",
+     "type": "Pre-release",
+     "date": "2025-12-11",
+     "changes": [
+      "Changed Neow's Chosen One blessing: now obtains a single random rare card instead of being pick 1 of 2"
+     ]
+    },
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Fixed Neow's Shiny Monocle relic offering wrong card count and enabling upgrade rolling"
+     ]
+    },
+    {
+     "version": "V0.78.0",
+     "type": "Pre-release",
+     "date": "2025-10-09",
+     "changes": [
+      "Nerfed Neow's Chosen One blessing: card selection decreased from 1 of 3 Rares -> 1 of 2 Rares"
+     ]
+    },
+    {
+     "version": "V0.56.0",
+     "type": "Pre-release",
+     "date": "2025-05-15",
+     "changes": [
+      "Fixed an issue where another player's card choices for the Shiny Monocle relic would be recorded as your choices"
+     ]
+    },
+    {
+     "version": "V0.50.0",
+     "type": "Pre-release",
+     "date": "2025-04-03",
+     "changes": [
+      "Added new relics for associated Ancient blessings:",
+      "Neow's Chosen One blessing now gives Shiny Monocle relic"
+     ]
+    },
+    {
+     "version": "V0.49.0",
+     "type": "Pre-release",
+     "date": "2025-03-13",
+     "changes": [
+      "Cards selected for Neow's Chosen One choice now appears in the Run History"
+     ]
+    },
+    {
+     "version": "V0.41.0",
+     "type": "Pre-release",
+     "date": "2025-01-16",
+     "changes": [
+      "Buffed Neow’s Chosen One blessing: “Choose 1 of 2 Rare Cards” -> “Choose 1 of 3 Rare cards”"
+     ]
+    },
+    {
+     "version": "2023-09-01",
+     "type": "Pre-release",
+     "date": "2023-09-01",
+     "changes": [
+      "Neow 'chosen one' choice offers less rare card choices 3 -> 2"
+     ]
+    }
+   ],
+   "ARCHAIC_TOOTH": [
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed Relic: Vibrant Halo -> Archaic Tooth",
+      "Orobas' Transcendence blessing now transforms Unleash instead of Bodyguard"
+     ]
+    },
+    {
+     "version": "V0.89.0",
+     "type": "Pre-release",
+     "date": "2026-01-08",
+     "changes": [
+      "Changed Orobas' Vibrant Halo description to say \"Transform\" instead of \"Replace\""
+     ]
+    },
+    {
+     "version": "V0.71.0",
+     "type": "Pre-release",
+     "date": "2025-08-21",
+     "changes": [
+      "Fixed Orobas' Transcendence blessing run history entry",
+      "Orobas' Transcendence card hovertips no longer go off screen"
+     ]
+    },
+    {
+     "version": "V0.55.0",
+     "type": "Pre-release",
+     "date": "2025-05-08",
+     "changes": [
+      "Fixed a state divergence caused by Vibrant Halo relic",
+      "Vibrant Halo relic hovertips no longer include your teammates' characters' card and relic hovertips",
+      "Buffed Orobas' Transcendence blessing: now maintains enchantments on the transformed card"
+     ]
+    },
+    {
+     "version": "V0.51.0",
+     "type": "Pre-release",
+     "date": "2025-04-10",
+     "changes": [
+      "Orobas' Transcendence option now gives Vibrant Halo relic"
+     ]
+    },
+    {
+     "version": "V0.43.0",
+     "type": "Pre-release",
+     "date": "2025-01-30",
+     "changes": [
+      "Added new Orobas blessing: Transcendence",
+      "Added special transformed starter cards for Orobas’ Transcendence blessing:",
+      "Ironclad: Bash -> Break",
+      "Silent: Neutralize -> Suppress",
+      "Necrobinder: Bodyguard -> Sentinel",
+      "Regent: Falling Star -> Meteor Shower"
+     ]
+    }
+   ],
+   "ART_OF_WAR": [
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Art of War relic now properly disables Energy gain for the turn when an effect like Mayhem auto-plays an attack on turn start"
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Changed Bellows and Art of War relics: swapped rarity"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Art of War relic now never looks disabled"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Changed Art of War relic: rarity increased from Common -> Uncommon"
+     ]
+    },
+    {
+     "version": "2023-05-19",
+     "type": "Pre-release",
+     "date": "2023-05-19",
+     "changes": [
+      "Art of War no longer flashes after every attack"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Art of War to the game"
+     ]
+    }
+   ],
+   "ASTROLABE": [
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Astrolabe and New Leaf relic descriptions now say \"Transform cards\" instead of \"Choose and Transform cards\""
+     ]
+    },
+    {
+     "version": "V0.82.0",
+     "type": "Pre-release",
+     "date": "2025-11-06",
+     "changes": [
+      "Astrolabe relic now displays the transformed cards in a grid instead of randomly scattered"
+     ]
+    },
+    {
+     "version": "V0.8.0",
+     "type": "Pre-release",
+     "date": "2024-04-19",
+     "changes": [
+      "Bugfixes: Astrolabe no longer softlocks on next combat"
+     ]
+    },
+    {
+     "version": "2023-09-01",
+     "type": "Pre-release",
+     "date": "2023-09-01",
+     "changes": [
+      "You can no longer skip choosing cards when obtaining Astrolabe from a boss chest"
+     ]
+    },
+    {
+     "version": "2023-06-30",
+     "type": "Pre-release",
+     "date": "2023-06-30",
+     "changes": [
+      "Updated relic art for Astrolabe"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Astrolabe to the game"
+     ]
+    }
+   ],
+   "BAG_OF_MARBLES": [
+    {
+     "version": "V0.103.2",
+     "type": "Major Update",
+     "date": "2026-04-16",
+     "changes": [
+      "BETA changes incorporated into main branch."
+     ]
+    },
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Changed Bag of Marbles relic: Rarity moved from Uncommon -> Common"
+     ]
+    },
+    {
+     "version": "V0.61.0",
+     "type": "Pre-release",
+     "date": "2025-06-20",
+     "changes": [
+      "Bag of Marbles and Red Mask relics now properly remove Artifact power from enemies that start with it"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Changed Bag of Marbles relic: rarity increased from Common -> Uncommon"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bag of Marbles to the game"
+     ]
+    }
+   ],
+   "BAG_OF_PREPARATION": [
+    {
+     "version": "V0.19.0",
+     "type": "Pre-release",
+     "date": "2024-07-05",
+     "changes": [
+      "Added Bag of Preparation to the game"
+     ]
+    }
+   ],
+   "BEAUTIFUL_BRACELET": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Beautiful Bracelet to the game"
+     ]
+    }
+   ],
+   "BELLOWS": [
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Changed Bellows relic: Rarity moved from Uncommon -> Rare"
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Toolbox relic no longer blocks Bellows relic from upgrading your opening hand"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "The 3rd relic unlock set now unlocks Vexing Puzzlebox rather than Bellows"
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Changed Bellows and Art of War relics: swapped rarity"
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Bellows is now locked until its respective Epochs have been revealed"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Updated wording for Bellows"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Renamed the following relics: Pein Hammer -> Bellows"
+     ]
+    },
+    {
+     "version": "V0.42.0",
+     "type": "Pre-release",
+     "date": "2025-01-23",
+     "changes": [
+      "Changed Pein Hammer relic: rarity increased from Uncommon -> Rare"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Reworked Pein Hammer relic:",
+      "Uncommon - “The first hand you draw each combat is upgraded.”"
+     ]
+    },
+    {
+     "version": "V0.36.0",
+     "type": "Pre-release",
+     "date": "2024-11-14",
+     "changes": [
+      "Added Pein Hammer to the game"
+     ]
+    }
+   ],
+   "BELT_BUCKLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Belt Buckle to the game"
+     ]
+    }
+   ],
+   "BIG_HAT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Big Hat to the game"
+     ]
+    }
+   ],
+   "BIIIG_HUG": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Biiig Hug to the game"
+     ]
+    }
+   ],
+   "BING_BONG": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bing Bong to the game"
+     ]
+    }
+   ],
+   "BLACK_BLOOD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Black Blood to the game"
+     ]
+    }
+   ],
+   "BLACK_STAR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Black Star to the game"
+     ]
+    }
+   ],
+   "BLESSED_ANTLER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Blessed Antler to the game"
+     ]
+    }
+   ],
+   "BLOOD_VIAL": [
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Blood Vial and Blood Vial??? relics now properly trigger after Royal Poison relic"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Blood Vial to the game"
+     ]
+    }
+   ],
+   "FAKE_BLOOD_VIAL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Blood Vial??? to the game"
+     ]
+    }
+   ],
+   "BLOOD_SOAKED_ROSE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Blood-Soaked Rose to the game"
+     ]
+    }
+   ],
+   "BONE_FLUTE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bone Flute to the game"
+     ]
+    }
+   ],
+   "BONE_TEA": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bone Tea to the game"
+     ]
+    }
+   ],
+   "BOOK_REPAIR_KNIFE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Book Repair Knife to the game"
+     ]
+    }
+   ],
+   "BOOK_OF_FIVE_RINGS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Book of Five Rings to the game"
+     ]
+    }
+   ],
+   "BOOKMARK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bookmark to the game"
+     ]
+    }
+   ],
+   "BOOMING_CONCH": [
+    {
+     "version": "V0.104.0",
+     "type": "Beta Patch",
+     "date": "2026-04-23",
+     "changes": [
+      "Buffed Neow's Booming Conch relic: in addition to drawing extra cards, now gains 1 Energy at the start of Elite combats"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "Changed Neow's Booming Conch relic: changed from 1 Strength and 1 Dex -> 2 Strength and no Dex"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Renamed Relic: Bounty Box -> Booming Conch"
+     ]
+    },
+    {
+     "version": "V0.37.0",
+     "type": "Pre-release",
+     "date": "2024-11-21",
+     "changes": [
+      "Reworked Bounty Box relic: now gain 1 Strength and 1 Dexterity at the start of Elite combats"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Reworked Neow Bounty Box choice: no longer heals, Elites drop 50 additional Gold"
+     ]
+    },
+    {
+     "version": "V0.16.0",
+     "type": "Pre-release",
+     "date": "2024-06-14",
+     "changes": [
+      "Changed Bounty Box relic: HP gain lowered from 15 -> 10"
+     ]
+    },
+    {
+     "version": "2023-04-29",
+     "type": "Pre-release",
+     "date": "2023-04-29",
+     "changes": [
+      "Bug Fix: bounty box description was off"
+     ]
+    },
+    {
+     "version": "2023-04-21",
+     "type": "Pre-release",
+     "date": "2023-04-21",
+     "changes": [
+      "Bug Fix: tungesten rod and bounty box relics not flashing when procced"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bounty Box to the game"
+     ]
+    }
+   ],
+   "BOUND_PHYLACTERY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bound Phylactery to the game"
+     ]
+    }
+   ],
+   "BOWLER_HAT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bowler Hat to the game"
+     ]
+    }
+   ],
+   "BREAD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bread to the game"
+     ]
+    }
+   ],
+   "BRILLIANT_SCARF": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Brilliant Scarf to the game"
+     ]
+    }
+   ],
+   "BRONZE_SCALES": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bronze Scales to the game"
+     ]
+    }
+   ],
+   "BURNING_BLOOD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Burning Blood to the game"
+     ]
+    }
+   ],
+   "BYRDPIP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Byrdpip to the game"
+     ]
+    }
+   ],
+   "CALLING_BELL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Calling Bell to the game"
+     ]
+    }
+   ],
+   "CANDELABRA": [
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "Relics with turn-specific triggers like StS2 Candelabra.png Candelabra no longer skip their trigger when another player takes an extra turn with StS2 PaelsEye.png Pael's Eye"
+     ]
+    },
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Relics with turn-number-specific triggers like Candelabra no longer skip their trigger when another player takes an extra turn with Pael's Eye relic on the triggering turn"
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Renamed the following relics: Flashlight -> Candelabra"
+     ]
+    },
+    {
+     "version": "V0.86.0",
+     "type": "Pre-release",
+     "date": "2025-12-11",
+     "changes": [
+      "Added Flashlight to the game"
+     ]
+    }
+   ],
+   "CENTENNIAL_PUZZLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Centennial Puzzle to the game"
+     ]
+    }
+   ],
+   "CHEMICAL_X": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Chemical X to the game"
+     ]
+    }
+   ],
+   "CHOICES_PARADOX": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Choices Paradox to the game"
+     ]
+    }
+   ],
+   "CLAWS": [
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed the following relics: Retractable Claws -> Claws"
+     ]
+    },
+    {
+     "version": "V0.87.0",
+     "type": "Pre-release",
+     "date": "2025-12-18",
+     "changes": [
+      "Retractable Claws now preserves upgrades and enchantments when transforming to Mauls"
+     ]
+    },
+    {
+     "version": "V0.51.0",
+     "type": "Pre-release",
+     "date": "2025-04-10",
+     "changes": [
+      "Changed Retractable Claws relic: now only lets you transform up to 9 cards into Maul"
+     ]
+    },
+    {
+     "version": "V0.50.0",
+     "type": "Pre-release",
+     "date": "2025-04-03",
+     "changes": [
+      "Tanx 's Spar With Tanx blessing now gives Retractable Claws relic"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Retractable Claws to the game"
+     ]
+    }
+   ],
+   "CRACKED_CORE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Cracked Core to the game"
+     ]
+    }
+   ],
+   "CROSSBOW": [
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Changed Crossbow Tanx relic: Now uses Free to Play instead of Costs 0 Energy"
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Crossbow relic no longer makes cards cost 0 stars to play"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "Reworked Crossbow relic"
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed the following relics: War Effigy -> Crossbow"
+     ]
+    },
+    {
+     "version": "V0.37.0",
+     "type": "Pre-release",
+     "date": "2024-11-21",
+     "changes": [
+      "Reworked Tanx options:",
+      "War Effigy relic now works at elites too, but it now gains only 2 energy and draws 2 cards"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added War Effigy to the game"
+     ]
+    }
+   ],
+   "CURSED_PEARL": [
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed relic: Golden Idol -> Cursed Pearl"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Golden Idol to the game."
+     ]
+    }
+   ],
+   "DARKSTONE_PERIAPT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Darkstone Periapt to the game"
+     ]
+    }
+   ],
+   "DAUGHTER_OF_THE_WIND": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Daughter of the Wind to the game"
+     ]
+    }
+   ],
+   "DELICATE_FROND": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Delicate Frond to the game"
+     ]
+    }
+   ],
+   "DIAMOND_DIADEM": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Reworked Nonupeipe's Diamond Diadem relic: \"Whenever you play 2 or fewer cards in a turn, take half damage from enemies.\" -> \"Start combat with 20 Block. Block is not removed at the start of your next turn.\""
+     ]
+    },
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "Fixed Nonupeipe's Diamond Diadem relic resetting its count after Hellraiser power plays cards at the start of the turn."
+     ]
+    },
+    {
+     "version": "V0.107.0",
+     "type": "Beta Patch",
+     "date": "2026-06-04",
+     "changes": [
+      "Fixed Nonupeipe's Diamond Diadem relic resetting its count after Hellraiser power plays cards at the start of the turn."
+     ]
+    },
+    {
+     "version": "V0.89.0",
+     "type": "Pre-release",
+     "date": "2026-01-08",
+     "changes": [
+      "Removed Diamond Diadem power title."
+     ]
+    },
+    {
+     "version": "V0.85.0",
+     "type": "Pre-release",
+     "date": "2025-12-04",
+     "changes": [
+      "Reworked and renamed Nonupeipe's Carnivorous Terrarium relic -> Diamond Diadem"
+     ]
+    },
+    {
+     "version": "V0.65.0",
+     "type": "Pre-release",
+     "date": "2025-07-10",
+     "changes": [
+      "Added Carnivorous Terrarium to the game."
+     ]
+    }
+   ],
+   "DINGY_RUG": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dingy Rug to the game"
+     ]
+    }
+   ],
+   "DISTINGUISHED_CAPE": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Distinguished Cape relic: swapped downsides with Sere Talon"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Distinguished Cape to the game."
+     ]
+    }
+   ],
+   "DIVINE_RIGHT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Divine Right to the game"
+     ]
+    }
+   ],
+   "DOLLYS_MIRROR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dolly's Mirror to the game"
+     ]
+    }
+   ],
+   "DREAM_CATCHER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dream Catcher to the game"
+     ]
+    }
+   ],
+   "DRIFTWOOD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Driftwood to the game"
+     ]
+    }
+   ],
+   "DUSTY_TOME": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Dusty Tome to the game"
+     ]
+    }
+   ],
+   "ECTOPLASM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Ectoplasm to the game"
+     ]
+    }
+   ],
+   "ELECTRIC_SHRYMP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Electric Shrymp to the game"
+     ]
+    }
+   ],
+   "EMBER_TEA": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Ember Tea to the game"
+     ]
+    }
+   ],
+   "EMPTY_CAGE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Empty Cage to the game"
+     ]
+    }
+   ],
+   "ETERNAL_FEATHER": [
+    {
+     "version": "2023-02-09",
+     "type": "Pre-release",
+     "date": "2023-02-09",
+     "changes": [
+      "BUGFIX: Fix broken Eternal Feather relic description"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Eternal Feather to the game"
+     ]
+    }
+   ],
+   "FENCING_MANUAL": [
+    {
+     "version": "V0.82.0",
+     "type": "Pre-release",
+     "date": "2025-11-06",
+     "changes": [
+      "Reworked Fencing Manual relic"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Sword Sage card no longer causes an infinite damage loop when it's triggered while you have Fencing Manual relic"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Changed Fencing Manual and Royal Perfume relics: swapped rarities"
+     ]
+    },
+    {
+     "version": "V0.54.0",
+     "type": "Pre-release",
+     "date": "2025-05-01",
+     "changes": [
+      "Added Fencing Manual to the game"
+     ]
+    }
+   ],
+   "FESTIVE_POPPER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Festive Popper to the game"
+     ]
+    }
+   ],
+   "FIDDLE": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Fiddle relic: card draw increased from 2 -> 3"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fiddle  to the game."
+     ]
+    }
+   ],
+   "FISHING_ROD": [
+    {
+     "version": "V0.105.0",
+     "type": "Beta Patch",
+     "date": "2026-05-08",
+     "changes": [
+      "Added Fishing Rod to the game."
+     ]
+    }
+   ],
+   "FORGOTTEN_SOUL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Forgotten Soul to the game"
+     ]
+    }
+   ],
+   "FRAGRANT_MUSHROOM": [
+    {
+     "version": "v0.102.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Upgraded cards decreased from 3 -> 2."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fragrant Mushroom to the game"
+     ]
+    }
+   ],
+   "FRESNEL_LENS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fresnel Lens to the game"
+     ]
+    }
+   ],
+   "FUNERARY_MASK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Funerary Mask to the game"
+     ]
+    }
+   ],
+   "FUR_COAT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fur Coat to the game"
+     ]
+    }
+   ],
+   "GALACTIC_DUST": [
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Renamed the following relics:",
+      "My Mantle -> Galactic Dust",
+      "Galactic Dust -> Divine Destiny"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Updated wording for My Mantle"
+     ]
+    },
+    {
+     "version": "V0.67.0",
+     "type": "Pre-release",
+     "date": "2025-07-24",
+     "changes": [
+      "Buffed My Mantle relic: Block increased from 5 -> 10"
+     ]
+    },
+    {
+     "version": "V0.54.0",
+     "type": "Pre-release",
+     "date": "2025-05-01",
+     "changes": [
+      "Added My Mantle to the game"
+     ]
+    }
+   ],
+   "GAMBLING_CHIP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Gambling Chip to the Game."
+     ]
+    }
+   ],
+   "GLASS_EYE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Glass Eye to the game"
+     ]
+    }
+   ],
+   "GLITTER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Glitter to the game"
+     ]
+    }
+   ],
+   "GNARLED_HAMMER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Gnarled Hammer to the game"
+     ]
+    }
+   ],
+   "GOLD_PLATED_CABLES": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Gold-Plated Cables to the game"
+     ]
+    }
+   ],
+   "GOLDEN_COMPASS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Golden Compass to the game"
+     ]
+    }
+   ],
+   "GOLDEN_PEARL": [
+    {
+     "version": "V0.91.0",
+     "type": "Pre-release",
+     "date": "2026-01-22",
+     "changes": [
+      "Changed Neow's Golden Pearl relic: changed back from gaining 50 Gold upon entering Shop rooms -> immediately obtain 150 Gold"
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed Relic: Neow's Note -> Golden Pearl"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Updated wording for Neow's Note"
+     ]
+    },
+    {
+     "version": "V0.36.0",
+     "type": "Pre-release",
+     "date": "2024-11-14",
+     "changes": [
+      "Changed Windfall/Neow's Note: now gives 150 gold"
+     ]
+    },
+    {
+     "version": "V0.10.0",
+     "type": "Pre-release",
+     "date": "2024-05-04",
+     "changes": [
+      "Neow's Note nerfed: Shop price reduction decreased from 75% -> 50%"
+     ]
+    },
+    {
+     "version": "2023-06-30",
+     "type": "Pre-release",
+     "date": "2023-06-30",
+     "changes": [
+      "Rename Coupon Book relic to Neow's Note"
+     ]
+    },
+    {
+     "version": "2023-05-05",
+     "type": "Pre-release",
+     "date": "2023-05-05",
+     "changes": [
+      "Fixed Coupon Book relic also proccing on second shop entered"
+     ]
+    },
+    {
+     "version": "2023-04-21",
+     "type": "Pre-release",
+     "date": "2023-04-21",
+     "changes": [
+      "Coupon Book now flashes on use"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Neow's Note now gives 50 Gold upon entering Shop rooms"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Coupon Book to the game"
+     ]
+    }
+   ],
+   "GORGET": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Gorget to the game"
+     ]
+    }
+   ],
+   "GREMLIN_HORN": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added CARDNAME to the game"
+     ]
+    }
+   ],
+   "HAND_DRILL": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Expose card now properly triggers Hand Drill relic"
+     ]
+    },
+    {
+     "version": "V0.99.1",
+     "type": "Beta Hotfix",
+     "date": "2026-03-14",
+     "changes": [
+      "Changes from beta branch incorporated into main branch"
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Fixed the Hand Drill card disappearing if it would proc both Echo Form and Feral"
+     ]
+    },
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Hand Drill relic now properly triggers when breaking an enemy's block with non-attack damage"
+     ]
+    },
+    {
+     "version": "V0.71.0",
+     "type": "Pre-release",
+     "date": "2025-08-21",
+     "changes": [
+      "Updated art for Hand Drill"
+     ]
+    },
+    {
+     "version": "V0.65.0",
+     "type": "Pre-release",
+     "date": "2025-07-10",
+     "changes": [
+      "Hand Drill relic is now properly triggered when Osty breaks an enemy's block"
+     ]
+    },
+    {
+     "version": "v0.99.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Fixed Hand Drill relic applying Vulnerable to the player if Burn card breaks their block"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Hand Drill to the game"
+     ]
+    }
+   ],
+   "HAPPY_FLOWER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Happy Flower to the game"
+     ]
+    }
+   ],
+   "FAKE_HAPPY_FLOWER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Happy Flower??? to the game"
+     ]
+    }
+   ],
+   "HEFTY_TABLET": [
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Added new art for Hefy Tablet"
+     ]
+    },
+    {
+     "version": "V0.102.0",
+     "type": "Beta Patch",
+     "date": "2026-04-02",
+     "changes": [
+      "Removed the peek button from the card selection via Neow's Hefty Tablet relic"
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Added Hefty Tablet to the game."
+     ]
+    }
+   ],
+   "HISTORY_COURSE": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Now only repeats Attacks and does not affect Skills."
+     ]
+    },
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Fixed History Course copy of Shining Strike card going back into your Draw Pile",
+      "Feral card no longer puts History Course copy of Helix Drill card back into your hand"
+     ]
+    },
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Fixed History Course relic playing Believe in You card before the start-of-turn Energy reset"
+     ]
+    },
+    {
+     "version": "V0.102.0",
+     "type": "Beta Patch",
+     "date": "2026-04-02",
+     "changes": [
+      "When it plays a copy of an X-cost card, it now uses your current energy for its X-value instead of the energy spent the last time the card was played.",
+      "Note: It still plays the copy for free."
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Changed History Course relic: when it auto-plays a copy of a Bound card, it no longer counts towards Chains of Binding's one-Bound-card limit that turn",
+      "Added assets for History Course"
+     ]
+    },
+    {
+     "version": "V0.73.0",
+     "type": "Pre-release",
+     "date": "2025-09-04",
+     "changes": [
+      "History Course relic no longer causes cards to get stuck on screen"
+     ]
+    },
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "Changed The Lantern Key event's History Course relic: no longer plays cards from two turns ago if you did not play cards the previous turn",
+      "Nostalgia card's power no longer triggers when playing cards that were duplicated by effects like History Course relic"
+     ]
+    },
+    {
+     "version": "V0.48.1",
+     "type": "Pre-release",
+     "date": "2025-03-07",
+     "changes": [
+      "Fixed an issue where History Course relic could replay a Scrutinized version of a card after Scrutiny had worn off"
+     ]
+    },
+    {
+     "version": "V0.47.0",
+     "type": "Pre-release",
+     "date": "2025-02-27",
+     "changes": [
+      "Added beta art for History Course",
+      "History Course relic now properly displays the card that it's autoplaying"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added History Course to the game"
+     ]
+    }
+   ],
+   "HORN_CLEAT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Horn Cleat to the game"
+     ]
+    }
+   ],
+   "ICE_CREAM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Ice Cream to the game"
+     ]
+    }
+   ],
+   "INFUSED_CORE": [
+    {
+     "version": "V0.105.0",
+     "type": "Beta Patch",
+     "date": "2026-05-08",
+     "changes": [
+      "Buffed Infused Core: Now also gains \"Lightning Orbs deal 1 additional damage.\""
+     ]
+    },
+    {
+     "version": "V0.54.0",
+     "type": "Pre-release",
+     "date": "2025-05-01",
+     "changes": [
+      "Added new relic: Infused Core"
+     ]
+    }
+   ],
+   "INTIMIDATING_HELMET": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Intimidating Helmet to the game"
+     ]
+    }
+   ],
+   "IRON_CLUB": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Iron Club to the game"
+     ]
+    }
+   ],
+   "IVORY_TILE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Ivory Tile to the game"
+     ]
+    }
+   ],
+   "JEWELED_MASK": [
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Fixed some inconsistencies in Jeweled Mask relic's wording"
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Renamed the following relics: Music Box -> Jeweled Mask"
+     ]
+    },
+    {
+     "version": "V0.89.0",
+     "type": "Pre-release",
+     "date": "2026-01-08",
+     "changes": [
+      "Reworked Vakuu's Music Box relic"
+     ]
+    },
+    {
+     "version": "V0.88.0",
+     "type": "Pre-release",
+     "date": "2026-01-01",
+     "changes": [
+      "Added new Vakuu options: Music Box"
+     ]
+    }
+   ],
+   "JEWELRY_BOX": [
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Reworked Nonupeipe's Jewelry Box blessing: now adds Apotheosis to your Deck"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Added placeholder assets for Jewelry Box"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Improved wording for Jewelry Box"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Jewelry Box to the game"
+     ]
+    }
+   ],
+   "JOSS_PAPER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Joss Paper to the game"
+     ]
+    }
+   ],
+   "JUZU_BRACELET": [
+    {
+     "version": "V0.79.0",
+     "type": "Pre-release",
+     "date": "2025-10-16",
+     "changes": [
+      "Changed Juzu Bracelet relic: rarity changed from Shop -> Common"
+     ]
+    },
+    {
+     "version": "V0.19.0",
+     "type": "Pre-release",
+     "date": "2024-07-05",
+     "changes": [
+      "Enemy combats can now be rolled again after trading Juzu Bracelet in the Relic Trader event"
+     ]
+    },
+    {
+     "version": "V0.13.0",
+     "type": "Pre-release",
+     "date": "2024-05-24",
+     "changes": [
+      "Juzu Bracelet is now a shop relic"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Juzu Bracelet to the game"
+     ]
+    }
+   ],
+   "KALEIDOSCOPE": [
+    {
+     "version": "V0.105.0",
+     "type": "Beta Patch",
+     "date": "2026-05-08",
+     "changes": [
+      "Added Kaleidoscope to the game."
+     ]
+    }
+   ],
+   "KUSARIGAMA": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Kusarigama to the game"
+     ]
+    }
+   ],
+   "LANTERN": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Lantern to the game"
+     ]
+    }
+   ],
+   "LARGE_CAPSULE": [
+    {
+     "version": "V0.94.0",
+     "type": "Pre-release",
+     "date": "2026-02-12",
+     "changes": [
+      "Changed Neow's blessings: Scavenger (one random relic) and Large Capsule (two random relics for Strike+Defend) blessings are now exclusive from each other"
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed relic: Gift Box -> Large Capsule"
+     ]
+    },
+    {
+     "version": "V0.77.0",
+     "type": "Pre-release",
+     "date": "2025-10-02",
+     "changes": [
+      "Buffed Neow's Gift Box blessing: now gives you the relics before the cards, giving the chance for the relics to affect the cards (ex. if one of the relics is Molten Egg, the Strike you receive will be upgraded)"
+     ]
+    },
+    {
+     "version": "V0.62.0",
+     "type": "Pre-release",
+     "date": "2025-06-26",
+     "changes": [
+      "Added red coloring to Neow's Gift Box blessing"
+     ]
+    },
+    {
+     "version": "V0.60.0",
+     "type": "Pre-release",
+     "date": "2025-06-12",
+     "changes": [
+      "Gift Box relic now gives you the bonus relics automatically rather than through a reward screen"
+     ]
+    },
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "Added Gift Box to the game."
+     ]
+    }
+   ],
+   "LASTING_CANDY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Lasting Candy to the game"
+     ]
+    }
+   ],
+   "LAVA_ROCK": [
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Changed Lava Rock and Sandcastle relics: swapped effects and Sandcastle is now a Neow relic instead of Lava Rock"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sand Castle to the game"
+     ]
+    }
+   ],
+   "LEAD_PAPERWEIGHT": [
+    {
+     "version": "V0.86.0",
+     "type": "Pre-release",
+     "date": "2025-12-11",
+     "changes": [
+      "Changed Neow's Monochrome blessing: is now a pick 1 of 2 instead of pick 1 of 3"
+     ]
+    },
+    {
+     "version": "V0.60.0",
+     "type": "Pre-release",
+     "date": "2025-06-12",
+     "changes": [
+      "Reworked Neow's Monochrome blessing"
+     ]
+    },
+    {
+     "version": "V0.50.0",
+     "type": "Pre-release",
+     "date": "2025-04-03",
+     "changes": [
+      "Added new relics for associated Ancient blessings:",
+      "Neow's Monochrome blessing now gives Lead Paperweight relic"
+     ]
+    },
+    {
+     "version": "V0.31.0",
+     "type": "Pre-release",
+     "date": "2024-10-10",
+     "changes": [
+      "Added Monochrome Neow choice"
+     ]
+    }
+   ],
+   "LEAFY_POULTICE": [
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "Leafy Poultice relic no longer transforms the upgraded Strikes/Defends from Neow's Talisman when both come from Neow's Bones"
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Max HP loss increased from 10 -> 12."
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Modified asset of Leafy Poultice"
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed Relic: Pungent Poultice -> Leafy Poultice"
+     ]
+    },
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Buffed Neow's Transform 2 blessing: HP cost decreased from 12 -> 10"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Renamed Relic: Chaotic Plasma -> Pungent Poultice"
+     ]
+    },
+    {
+     "version": "V0.61.0",
+     "type": "Pre-release",
+     "date": "2025-06-20",
+     "changes": [
+      "Changed Neow's Transformation blessing: now also has the downside \"Lose 12 Max HP.\""
+     ]
+    },
+    {
+     "version": "V0.50.0",
+     "type": "Pre-release",
+     "date": "2025-04-03",
+     "changes": [
+      "Added new relics for associated Ancient Blessings:",
+      "Neow's Transformation blessing now gives Chaotic Plasma relic"
+     ]
+    }
+   ],
+   "LEES_WAFFLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Lee's Waffle to the game"
+     ]
+    }
+   ],
+   "FAKE_LEES_WAFFLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Lee's Waffle??? to the game"
+     ]
+    }
+   ],
+   "LETTER_OPENER": [
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Fixed state divergence related to Imbued enchantment and Letter Opener relic"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Letter Opener to the game"
+     ]
+    }
+   ],
+   "LOOMING_FRUIT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Looming Fruit to the game"
+     ]
+    }
+   ],
+   "LORDS_PARASOL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Lord's Parasol to the game"
+     ]
+    }
+   ],
+   "LOST_COFFER": [
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Added Asset for Lost Coffer"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Lost Coffer to the game"
+     ]
+    }
+   ],
+   "LOST_WISP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Lost Wisp to the game"
+     ]
+    }
+   ],
+   "LUCKY_FYSH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Lucky Fysh to the game"
+     ]
+    }
+   ],
+   "FAKE_MANGO": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Mango??? to the game"
+     ]
+    }
+   ],
+   "MASSIVE_SCROLL": [
+    {
+     "version": "V0.99.0",
+     "type": "Beta Patch",
+     "date": "2026-03-12",
+     "changes": [
+      "Fixed Massive Scroll relic description saying that it can only give you Colorless multiplayer cards"
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed Relic: Cleric's Headpiece -> Massive Scroll"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Cleric's Headpiece to the game"
+     ]
+    }
+   ],
+   "MAW_BANK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Maw Bank to the game"
+     ]
+    }
+   ],
+   "MEAL_TICKET": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Meal Ticket to the game"
+     ]
+    }
+   ],
+   "MEAT_CLEAVER": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "HP gain decreased from 9 -> 5"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Meat Cleaver to the game."
+     ]
+    }
+   ],
+   "MEMBERSHIP_CARD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Membership Card to the game"
+     ]
+    }
+   ],
+   "MERCURY_HOURGLASS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Mercury Hourglass to the game"
+     ]
+    }
+   ],
+   "MINIATURE_CANNON": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Miniature Cannon to the game"
+     ]
+    }
+   ],
+   "MINIATURE_TENT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Miniature Tent to the game"
+     ]
+    }
+   ],
+   "MR_STRUGGLES": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Mr. Struggles to the game"
+     ]
+    }
+   ],
+   "MUMMIFIED_HAND": [
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Buffed Mummified Hand relic: now randomly chooses cards in a way that's more favorable to the player",
+      "Priority 1 is cards that currently cost 1+ AND with a base cost of 1+ before any current cost modifications",
+      "Priority 2 is cards that currently cost 1+ regardless of base cost",
+      "Priority 3 is cards with a base cost of 1+ that have been temporarily modified to cost 0",
+      "If none of these priorities match, a completely random card in the player's hand is chosen"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Effects that set a card's energy cost to a new absolute value (ex. Mummified Hand relic, Enlightenment card) now interact properly with effects that offset a card's existing cost (ex. Transfigure card)"
+     ]
+    },
+    {
+     "version": "V0.54.0",
+     "type": "Pre-release",
+     "date": "2025-05-01",
+     "changes": [
+      "Fixed an unexpected interaction between Enthralled curse card and effects that set a random card in your hand to free (such as Mummified Hand relic and Touch of Insanity potion). Previously, these effects would look for any card whose current energy cost was above 0, which could be due to a temporary cost-increasing effect like Enthralled. Now, these effects will prefer cards with a base energy cost above 0, and will only consider the modified cost if all cards in hand have a base energy cost of 0"
+     ]
+    },
+    {
+     "version": "V0.29.0",
+     "type": "Pre-release",
+     "date": "2024-09-26",
+     "changes": [
+      "Mummified Hand relic no longer can pick Tezcatara's Ember cards"
+     ]
+    },
+    {
+     "version": "V0.16.0",
+     "type": "Pre-release",
+     "date": "2024-06-14",
+     "changes": [
+      "Changed Mummified Hand relic: rarity increased from Uncommon -> Rare"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Mummified Hand to the game"
+     ]
+    }
+   ],
+   "MUSIC_BOX": [
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Fixed divergence when player has Music Box relic and combat ends while making a choice"
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Renamed the following relics: Little Ghost -> Music Box"
+     ]
+    },
+    {
+     "version": "V0.78.0",
+     "type": "Pre-release",
+     "date": "2025-10-09",
+     "changes": [
+      "Playing Perfected Strike card while you have Little Ghost relic no longer buffs Perfected Strike before it deals damage"
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Changed Zlatir's Little Ghost relic: now affects Attacks instead of Skills"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Changed Little Ghost relic: is now a Zlatir blessing"
+     ]
+    },
+    {
+     "version": "V0.68.0",
+     "type": "Pre-release",
+     "date": "2025-07-31",
+     "changes": [
+      "Added new relic Little Ghost to the game"
+     ]
+    }
+   ],
+   "MYSTIC_LIGHTER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Mystic Lighter to the game"
+     ]
+    }
+   ],
+   "NEOWS_BONES": [
+    {
+     "version": "V0.103.1",
+     "type": "Beta Patch",
+     "date": "2026-04-15",
+     "changes": [
+      "Fixed curse mismatching when some players would take Neow's Bones relic",
+      "Fixed state divergence when Neow's Bones relic would trigger multiple reward screens"
+     ]
+    },
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Added Neow's Bones to the game."
+     ]
+    }
+   ],
+   "NEOWS_TALISMAN": [
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Added Neow's Talisman to the game."
+     ]
+    }
+   ],
+   "NEOWS_TORMENT": [
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Added asset for Neow's Torment"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "Added Neow's Fury card (for New Neow blessing)"
+     ]
+    }
+   ],
+   "NEW_LEAF": [
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Added asset for New Leaf"
+     ]
+    },
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "New Leaf relic description now says \"Transform cards\" instead of \"Choose and Transform cards\""
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added New Leaf to the game."
+     ]
+    }
+   ],
+   "NUNCHAKU": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Nunchaku to the game"
+     ]
+    }
+   ],
+   "NUTRITIOUS_OYSTER": [
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed Relic: Sturdy Brace -> Nutritious Oyster"
+     ]
+    },
+    {
+     "version": "V0.66.0",
+     "type": "Pre-release",
+     "date": "2025-07-17",
+     "changes": [
+      "Neow's Sturdy Brace blessing no longer includes the unnecessary \"Upon pickup\" wording"
+     ]
+    },
+    {
+     "version": "V0.61.0",
+     "type": "Pre-release",
+     "date": "2025-06-20",
+     "changes": [
+      "Buffed Neow's Sturdy Brace relic: HP gain increased from 10 -> 11"
+     ]
+    },
+    {
+     "version": "V0.60.0",
+     "type": "Pre-release",
+     "date": "2025-06-12",
+     "changes": [
+      "Changed Neow's Sturdy Brace blessing:",
+      "Is now a positive boon",
+      "No longer gives Greed",
+      "HP decreased from 20 -> 10"
+     ]
+    },
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "* Added new Neow blessing: Sturdy Brace"
+     ]
+    }
+   ],
+   "NUTRITIOUS_SOUP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Nutritious Soup to the game"
+     ]
+    }
+   ],
+   "ODDLY_SMOOTH_STONE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Oddly Smooth Stone to the game"
+     ]
+    }
+   ],
+   "OLD_COIN": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Old Coin to the game"
+     ]
+    }
+   ],
+   "ORICHALCUM": [
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Orichalcum??? relic now triggers at the same time as Orichalcum relic"
+     ]
+    },
+    {
+     "version": "V0.85.0",
+     "type": "Pre-release",
+     "date": "2025-12-04",
+     "changes": [
+      "Changed Orichalcum relic: rarity increased from Common -> Uncommon"
+     ]
+    },
+    {
+     "version": "V0.82.0",
+     "type": "Pre-release",
+     "date": "2025-11-06",
+     "changes": [
+      "Orichalcum and Orichalcum??? relics now stack properly"
+     ]
+    },
+    {
+     "version": "V0.8.0",
+     "type": "Pre-release",
+     "date": "2024-04-19",
+     "changes": [
+      "Orichalcum relic now triggers before Plating and other end-of-turn effects"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Orichalcum to the game"
+     ]
+    }
+   ],
+   "FAKE_ORICHALCUM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Orichalcum??? to the game"
+     ]
+    }
+   ],
+   "ORNAMENTAL_FAN": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added RELICNAME to the game"
+     ]
+    }
+   ],
+   "PAELS_BLOOD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pael's Blood to the game"
+     ]
+    }
+   ],
+   "PAELS_CLAW": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pael's Claw to the game"
+     ]
+    }
+   ],
+   "PAELS_EYE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pael's Eye to the game"
+     ]
+    }
+   ],
+   "PAELS_FLESH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pael's Flesh to the game"
+     ]
+    }
+   ],
+   "PAELS_GROWTH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pael's Growth to the game"
+     ]
+    }
+   ],
+   "PAELS_HORN": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pael's Horn to the game"
+     ]
+    }
+   ],
+   "PAELS_LEGION": [
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "Fixed Pael's Legion and Vambrace relics not proccing when the owner applies Block to other players"
+     ]
+    },
+    {
+     "version": "V0.103.3",
+     "type": "Patch",
+     "date": "2026-05-29",
+     "changes": [
+      "Fixed the Pael's Legion and Vambrace relics not triggering when their owner applies Block to other players"
+     ]
+    },
+    {
+     "version": "V0.104.0",
+     "type": "Beta Patch",
+     "date": "2026-04-23",
+     "changes": [
+      "Fixed Pael's Legion and Vambrace relics not proccing from the owner applying Block to other players"
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Implemented animation for Pael's Legion",
+      "Pael's Legion relic now doubles all Block gain when a card that gains Block multiple times is played"
+     ]
+    },
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Melancholy card now properly gains Block from Pael's Legion relic"
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed Pael's Friend -> Pael's Legion"
+     ]
+    },
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Reworked Pael's Friend relic"
+     ]
+    },
+    {
+     "version": "V0.76.0",
+     "type": "Pre-release",
+     "date": "2025-09-25",
+     "changes": [
+      "Added new Pael blessing, Pael's Friend"
+     ]
+    }
+   ],
+   "PAELS_TEARS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pael's Tears to the game"
+     ]
+    }
+   ],
+   "PAELS_TOOTH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pael's Tooth to the game"
+     ]
+    }
+   ],
+   "PAELS_WING": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pael's Wing to the game"
+     ]
+    }
+   ],
+   "PANDORAS_BOX": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pandora's Box to the game"
+     ]
+    }
+   ],
+   "PANTOGRAPH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pantograph to the game"
+     ]
+    }
+   ],
+   "PAPER_KRANE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Paper Krane to the game"
+     ]
+    }
+   ],
+   "PAPER_PHROG": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Paper Phrog to the game"
+     ]
+    }
+   ],
+   "PARRYING_SHIELD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Parrying Shield to the game"
+     ]
+    }
+   ],
+   "PEAR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pear to the game"
+     ]
+    }
+   ],
+   "PEN_NIB": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pen Nib to the game"
+     ]
+    }
+   ],
+   "PENDULUM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pendulum to the game"
+     ]
+    }
+   ],
+   "PERMAFROST": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Permafrost to the game"
+     ]
+    }
+   ],
+   "PETRIFIED_TOAD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Petrified Toad to the game"
+     ]
+    }
+   ],
+   "PHIAL_HOLSTER": [
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Added Phial Holster to the game."
+     ]
+    }
+   ],
+   "PHILOSOPHERS_STONE": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Now also available in Act 2"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Philosopher's Stone to the game."
+     ]
+    }
+   ],
+   "PHYLACTERY_UNBOUND": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Phylactery Unbound to the game"
+     ]
+    }
+   ],
+   "PLANISPHERE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Planisphere to the game"
+     ]
+    }
+   ],
+   "POLLINOUS_CORE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pollinous Core to the game"
+     ]
+    }
+   ],
+   "POMANDER": [
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Renamed Relic: Fishing Rod -> Pomander"
+     ]
+    },
+    {
+     "version": "V0.94.0",
+     "type": "Pre-release",
+     "date": "2026-02-12",
+     "changes": [
+      "Reworked Neow's Fishing Rod relic"
+     ]
+    },
+    {
+     "version": "V0.89.0",
+     "type": "Pre-release",
+     "date": "2026-01-08",
+     "changes": [
+      "Fishing Rod relic now uses player-scoped RNG to prevent potential multiplayer desync"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fishing Rod to the game."
+     ]
+    }
+   ],
+   "POTION_BELT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Potion Belt to the game"
+     ]
+    }
+   ],
+   "POWER_CELL": [
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Added assets for Power Cell",
+      "Renamed the following relics: Lidar -> Power Cell"
+     ]
+    },
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Lidar relic description now properly ends with a period"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Lidar relic no longer has the Shiv hovertip"
+     ]
+    },
+    {
+     "version": "V0.68.0",
+     "type": "Pre-release",
+     "date": "2025-07-31",
+     "changes": [
+      "Added Lidar to the game"
+     ]
+    }
+   ],
+   "PRECARIOUS_SHEARS": [
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Fixed being able to save and load at Neow to avoid the damage taken from Precarious Shears"
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Self-damage increased from 13 -> 16."
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed Relic: Spiraled Lens -> Precarious Shears"
+     ]
+    },
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Buffed Neow's Remove 2 blessing: downside changed from lose 8 max HP -> take 13 damage"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Precarious Shears to the game"
+     ]
+    }
+   ],
+   "PRECISE_SCISSORS": [
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed Relic: Scissors -> Precise Scissors"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Scissors to the game"
+     ]
+    }
+   ],
+   "PRESERVED_FOG": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Preserved Fog to the game"
+     ]
+    }
+   ],
+   "PRISMATIC_GEM": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Prismatic Gem to the game"
+     ]
+    }
+   ],
+   "PUMPKIN_CANDLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Pumpkin Candle to the game"
+     ]
+    }
+   ],
+   "PUNCH_DAGGER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Punch Dagger to the game"
+     ]
+    }
+   ],
+   "RADIANT_PEARL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Radiant Pearl to the game"
+     ]
+    }
+   ],
+   "RAINBOW_RING": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Rainbow Ring to the game"
+     ]
+    }
+   ],
+   "RAZOR_TOOTH": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Razor Tooth to the game"
+     ]
+    }
+   ],
+   "RED_MASK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Red Mask to the game"
+     ]
+    }
+   ],
+   "RED_SKULL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Red Skull to the game"
+     ]
+    }
+   ],
+   "REGAL_PILLOW": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Regal Pillow to the game"
+     ]
+    }
+   ],
+   "REGALITE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Regalite to the game"
+     ]
+    }
+   ],
+   "REPTILE_TRINKET": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Reptile Trinket to the game"
+     ]
+    }
+   ],
+   "RING_OF_THE_DRAKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Ring of the Drake to the game"
+     ]
+    }
+   ],
+   "RING_OF_THE_SNAKE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Ring of the Snake to the game"
+     ]
+    }
+   ],
+   "RIPPLE_BASIN": [
+    {
+     "version": "V0.91.0",
+     "type": "Pre-release",
+     "date": "2026-01-22",
+     "changes": [
+      "Buffed Ripple Basin relic: Block gain increased from 3 -> 4"
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Nerfed Ripple Basin relic: Block decreased from 5 -> 3"
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Ripple Basin is now locked until [its] respective Epochs have been revealed"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Stampede card's autoplay effect now properly prevents Ripple Basin relic from triggering"
+     ]
+    },
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Renamed the following relics: Illusory Wall -> Ripple Basin"
+     ]
+    },
+    {
+     "version": "V0.56.0",
+     "type": "Pre-release",
+     "date": "2025-05-15",
+     "changes": [
+      "Illusory Wall now flashes while it is active"
+     ]
+    },
+    {
+     "version": "V0.52.0",
+     "type": "Pre-release",
+     "date": "2025-04-17",
+     "changes": [
+      "Added Illusory Wall relic"
+     ]
+    }
+   ],
+   "ROYAL_POISON": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Royal Poison to the game"
+     ]
+    }
+   ],
+   "RUNIC_CAPACITOR": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Runic Capacitor to the game"
+     ]
+    }
+   ],
+   "RUNIC_PYRAMID": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Runic Pyramid to the game"
+     ]
+    }
+   ],
+   "SAI": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sai to the game"
+     ]
+    }
+   ],
+   "SAND_CASTLE": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Moved Orobas' Sand Castle relic from Pool 1 -> Pool 2 (second option instead of first option)"
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Changed Lava Rock and Sandcastle relics: swapped effects and Sandcastle is now a Neow relic instead of Lava Rock"
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed Relic: Kaleidoscope -> Lava Rock"
+     ]
+    },
+    {
+     "version": "V0.86.0",
+     "type": "Pre-release",
+     "date": "2025-12-11",
+     "changes": [
+      "Buffed Orobas Kaleidoscope relic: cards increased from 5 -> 6"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Kaleidoscope to the game."
+     ]
+    }
+   ],
+   "SCROLL_BOXES": [
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Changed Neow's Scroll Boxes and Silken Tress relics: swapped downsides and pools",
+      "Scroll Boxes no longer makes player lose all gold"
+     ]
+    },
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Neow's Scroll Boxes relic hovertip now properly mentions that the player loses all Gold upon pickup"
+     ]
+    },
+    {
+     "version": "V0.92.0",
+     "type": "Pre-release",
+     "date": "2026-01-29",
+     "changes": [
+      "Neow Bundles are random once again"
+     ]
+    },
+    {
+     "version": "V0.91.0",
+     "type": "Pre-release",
+     "date": "2026-01-22",
+     "changes": [
+      "Changed Poison Neow bundle: replaced Haze card -> Deadly Poison"
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed Relic: Ancient Booster Pack -> Scroll Boxes"
+     ]
+    },
+    {
+     "version": "V0.89.0",
+     "type": "Pre-release",
+     "date": "2026-01-08",
+     "changes": [
+      "Changed Necrobinder's Haunt Neow bundle: replaced Haunt card -> Death March"
+     ]
+    },
+    {
+     "version": "V0.87.0",
+     "type": "Pre-release",
+     "date": "2025-12-18",
+     "changes": [
+      "Changed Ironclad Inflame bundle: Stomp replaced with Twin Strike"
+     ]
+    },
+    {
+     "version": "V0.85.0",
+     "type": "Pre-release",
+     "date": "2025-12-04",
+     "changes": [
+      "Added new Ironclad Grapple Neow bundle",
+      "Changed Ironclad's Pillage Neow bundle: Tremble -> Iron Wave",
+      "Changed Ironclad's Vulnerable Neow bundle: Molten Fist -> Tremble",
+      "Changed Ironclad's Rupture bundle: Rupture -> Inferno",
+      "Rattle card now appears in from of the Necrobinder's Rattle/Flatten/Poke Neow card bundle"
+     ]
+    },
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Changed Ironclad's Vulnerable Neow bundle: card content changed from Dominate -> Dismantle"
+     ]
+    },
+    {
+     "version": "V0.83.0",
+     "type": "Pre-release",
+     "date": "2025-11-13",
+     "changes": [
+      "Changed Neow's Bundle blessing: Defect's Evolve/Turbo/Boost Away bundle changed -> Compactor/Gunk Up/Boost Away"
+     ]
+    },
+    {
+     "version": "V0.82.0",
+     "type": "Pre-release",
+     "date": "2025-11-06",
+     "changes": [
+      "Changed Defect's Claw Neow Bundle: now contains 3 Claw cards",
+      "Changed Necrobinder's Flatten Neow Bundle: Afterlife card replace with Rattle"
+     ]
+    },
+    {
+     "version": "V0.80.0",
+     "type": "Pre-release",
+     "date": "2025-10-23",
+     "changes": [
+      "Changed Neow's Regent Quasar bundle: replaced Quasar card with Devastate"
+     ]
+    },
+    {
+     "version": "V0.79.0",
+     "type": "Pre-release",
+     "date": "2025-10-16",
+     "changes": [
+      "Changed Defect's Neow Bundle: replaced Blizzard card with Deep Freeze"
+     ]
+    },
+    {
+     "version": "V0.78.0",
+     "type": "Pre-release",
+     "date": "2025-10-09",
+     "changes": [
+      "Changed Defect's Neow Bundle blessing: replaced Reprogram card with Bulk Up"
+     ]
+    },
+    {
+     "version": "V0.74.0",
+     "type": "Pre-release",
+     "date": "2025-09-11",
+     "changes": [
+      "Updated Neow bundles for all characters"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Neow's Bundle choice now only appears if there are enough bundles with all of their cards unlocked"
+     ]
+    },
+    {
+     "version": "V0.71.0",
+     "type": "Pre-release",
+     "date": "2025-08-21",
+     "changes": [
+      "Changed Necrobinder's Neow Bundle blessing: bundle with Fetch now instead includes Flatten",
+      "Changed Regent's Neow Bundle blessing: no longer has a double Uncommon card bundle"
+     ]
+    },
+    {
+     "version": "V0.65.0",
+     "type": "Pre-release",
+     "date": "2025-07-10",
+     "changes": [
+      "Regent no longer has a Neow bundle with a rare card; Beat Into Shape card replaced by Wrought In War card"
+     ]
+    },
+    {
+     "version": "V0.60.0",
+     "type": "Pre-release",
+     "date": "2025-06-12",
+     "changes": [
+      "Nerfed Neow's Bundle blessing: now a cursed boon that sets the player's gold to 0"
+     ]
+    },
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "Changed Necrobinder's Veilpiercer Neow bundle: Defile -> Death's Visage"
+     ]
+    },
+    {
+     "version": "V0.58.0",
+     "type": "Pre-release",
+     "date": "2025-05-29",
+     "changes": [
+      "Updated all Neow Bundles"
+     ]
+    },
+    {
+     "version": "V0.50.0",
+     "type": "Pre-release",
+     "date": "2025-04-03",
+     "changes": [
+      "Added new relics for associated Ancient blessings:",
+      "Neow's Bundle blessing now gives Ancient Booster Pack relic"
+     ]
+    },
+    {
+     "version": "V0.49.0",
+     "type": "Pre-release",
+     "date": "2025-03-13",
+     "changes": [
+      "Fixed hovering issue when you first open the card bundle preview"
+     ]
+    },
+    {
+     "version": "V0.46.0",
+     "type": "Pre-release",
+     "date": "2025-02-20",
+     "changes": [
+      "Changed Regent's Neow blessing bundle: no longer contains Seven Stars card, replaced with Shining Strike card"
+     ]
+    },
+    {
+     "version": "V0.42.0",
+     "type": "Pre-release",
+     "date": "2025-01-23",
+     "changes": [
+      "Changed Neow's Bundle blessing: tweaked Silent bundles"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Reworked Neow's bundles: now offers 2 of 5 preset bundles"
+     ]
+    },
+    {
+     "version": "V0.11.0",
+     "type": "Pre-release",
+     "date": "2024-05-10",
+     "changes": [
+      "Can now preview cards in Neow bundle screen"
+     ]
+    },
+    {
+     "version": "V0.9.0",
+     "type": "Pre-release",
+     "date": "2024-04-26",
+     "changes": [
+      "Hovertips are now positioned correctly in card bundle preview screen"
+     ]
+    }
+   ],
+   "SEA_GLASS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sea Glass to the game"
+     ]
+    }
+   ],
+   "SEAL_OF_GOLD": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Seal of Gold to the game"
+     ]
+    }
+   ],
+   "SELF_FORMING_CLAY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Self-Forming Clay to the game"
+     ]
+    }
+   ],
+   "SERE_TALON": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Sere Talon relic: swapped downsides with Distinguished Cape"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sere Talon  to the game."
+     ]
+    }
+   ],
+   "SILKEN_TRESS": [
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Clarified that Silken Tress relic applies only to the player who chose it in multiplayer",
+      "\"in the first card reward\" -> \"in your first card reward\""
+     ]
+    },
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Changed Neow's Silken Tress and Scroll Box relics: swapped downsides and pools",
+      "Silken Tress now makes the player lose all gold",
+      "Fixed Neow's Silken Tress relic in multiplayer only affecting card rewards for the host"
+     ]
+    },
+    {
+     "version": "V0.105.0",
+     "type": "Beta Patch",
+     "date": "2026-05-08",
+     "changes": [
+      "Added Silken Tress - \"Enchant all cards in the first card reward with Glam.\""
+     ]
+    }
+   ],
+   "SILVER_CRUCIBLE": [
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Fixed Neow's Kaleidescope relic using up all of Silver Crucible relic's charges"
+     ]
+    },
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Treasure rooms no longer give the player Gold if they have Neow's Silver Crucible relic"
+     ]
+    },
+    {
+     "version": "V0.77.0",
+     "type": "Pre-release",
+     "date": "2025-10-02",
+     "changes": [
+      "Multiplayer: Neow's Silver Crucible relic now applies even when the FTUE is active for the local player"
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Neow's Silver Crucible relic now only applies to combat card rewards"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Neow’s Silver Crucible relic no longer goes into the negatives"
+     ]
+    },
+    {
+     "version": "V0.43.0",
+     "type": "Pre-release",
+     "date": "2025-01-30",
+     "changes": [
+      "Reworked Silver Crucible relic"
+     ]
+    },
+    {
+     "version": "V0.35.0",
+     "type": "Pre-release",
+     "date": "2024-11-07",
+     "changes": [
+      "Nerfed Neow’s Silver Crucible relic: cards upgraded decreased from 3 -> 2"
+     ]
+    },
+    {
+     "version": "V0.15.0",
+     "type": "Pre-release",
+     "date": "2024-06-07",
+     "changes": [
+      "Molten Egg relic now takes priority over Silver Crucible relic when an attack is added to your deck"
+     ]
+    },
+    {
+     "version": "2023-05-05",
+     "type": "Pre-release",
+     "date": "2023-05-05",
+     "changes": [
+      "Bug Fix: Silver Crucible was counting up instead of down"
+     ]
+    },
+    {
+     "version": "2023-04-29",
+     "type": "Pre-release",
+     "date": "2023-04-29",
+     "changes": [
+      "Bug Fix: Make Silver Crucible skip un-upgradable cards"
+     ]
+    },
+    {
+     "version": "2023-04-21",
+     "type": "Pre-release",
+     "date": "2023-04-21",
+     "changes": [
+      "Fixed silver crucible upgrading transformed cards"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Silver Crucible to the game."
+     ]
+    }
+   ],
+   "SLING_OF_COURAGE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sling of Courage to the game"
+     ]
+    }
+   ],
+   "SMALL_CAPSULE": [
+    {
+     "version": "V0.94.0",
+     "type": "Pre-release",
+     "date": "2026-02-12",
+     "changes": [
+      "Changed Neow's blessings: Scavenger (one random relic) and Large Capsule (two random relics for Strike+Defend) blessings are now exclusive from each other"
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed Relic: Rusty Chest -> Small Capsule"
+     ]
+    },
+    {
+     "version": "V0.50.0",
+     "type": "Pre-release",
+     "date": "2025-04-03",
+     "changes": [
+      "Added new relics for associated Ancient blessings:",
+      "Neow's Scavenger blessing now gives Rusty Chest relic"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Reworked Neow Scavenger choice: obtain 2 common relics -> obtain a random relic"
+     ]
+    },
+    {
+     "version": "V0.19.0",
+     "type": "Pre-release",
+     "date": "2024-07-05",
+     "changes": [
+      "Neow Hoarder option renamed -> Scavenger"
+     ]
+    },
+    {
+     "version": "V0.13.0",
+     "type": "Pre-release",
+     "date": "2024-05-24",
+     "changes": [
+      "Added new Neow choice: Hoarder: “Obtain 2 random common relics”"
+     ]
+    }
+   ],
+   "FAKE_SNECKO_EYE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Snecko Eye??? to the game"
+     ]
+    }
+   ],
+   "SNECKO_SKULL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Snecko Skull to the game"
+     ]
+    }
+   ],
+   "SOZU": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sozu to the game"
+     ]
+    }
+   ],
+   "SPARKLING_ROUGE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sparkling Rouge to the game"
+     ]
+    }
+   ],
+   "SPIKED_GAUNTLETS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Spiked Gauntlets to the game"
+     ]
+    }
+   ],
+   "STONE_CRACKER": [
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Now works in ALL combats but only upgrades 2 cards."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Stone Cracker to the game"
+     ]
+    }
+   ],
+   "STONE_HUMIDIFIER": [
+    {
+     "version": "V0.93.0",
+     "type": "Pre-release",
+     "date": "2026-02-05",
+     "changes": [
+      "Selecting the Nap option at Dense Vegetation event now properly triggers Stone Humidifier relic"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Stone Humidifier relic now has extra text in the Rest Site rest option"
+     ]
+    },
+    {
+     "version": "V0.36.0",
+     "type": "Pre-release",
+     "date": "2024-11-14",
+     "changes": [
+      "Rethemed Relic: Scented Candle -> Stone Humidifier"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Scented Candle to the game"
+     ]
+    }
+   ],
+   "STORYBOOK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Storybook to the game"
+     ]
+    }
+   ],
+   "STRAWBERRY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Strawberry to the game"
+     ]
+    }
+   ],
+   "STRIKE_DUMMY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Strike Dummy to the game"
+     ]
+    }
+   ],
+   "FAKE_STRIKE_DUMMY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Strike Dummy??? to the game"
+     ]
+    }
+   ],
+   "STURDY_CLAMP": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added RELICNAME to the game"
+     ]
+    }
+   ],
+   "SWORD_OF_JADE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sword of Jade to the game"
+     ]
+    }
+   ],
+   "SWORD_OF_STONE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Sword of Stone to the game"
+     ]
+    }
+   ],
+   "SYMBIOTIC_VIRUS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Symbiotic Virus to the game"
+     ]
+    }
+   ],
+   "TANXS_WHISTLE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Tanx's Whistle to the game"
+     ]
+    }
+   ],
+   "TEA_OF_DISCOURTESY": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Tea of Discourtesy to the game"
+     ]
+    }
+   ],
+   "THE_BOOT": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added The Boot to the game"
+     ]
+    }
+   ],
+   "CHOSEN_CHEESE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added The Chosen Cheese to the game"
+     ]
+    }
+   ],
+   "THE_COURIER": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added The Courier to the game"
+     ]
+    }
+   ],
+   "FAKE_MERCHANTS_RUG": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added The Merchant's Rug??? to the game"
+     ]
+    }
+   ],
+   "THROWING_AXE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Throwing Axe to the game"
+     ]
+    }
+   ],
+   "TINY_MAILBOX": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Tiny Mailbox to the game"
+     ]
+    }
+   ],
+   "TOASTY_MITTENS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Toasty Mittens to the game"
+     ]
+    }
+   ],
+   "TOUCH_OF_OROBAS": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Touch of Orobas to the game"
+     ]
+    }
+   ],
+   "TOUGH_BANDAGES": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Tough Bandages to the game"
+     ]
+    }
+   ],
+   "TOY_BOX": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Relics gained increased from 4 -> 5"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Toy Box to the game."
+     ]
+    }
+   ],
+   "TRI_BOOMERANG": [
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Instinct enchantment no longer reduces cost, instead doubles damage on enchanted Attacks."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Tri-Boomerang to the game"
+     ]
+    }
+   ],
+   "TUNING_FORK": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Tuning Fork to the game"
+     ]
+    }
+   ],
+   "TWISTED_FUNNEL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Snecko Skull to the game"
+     ]
+    }
+   ],
+   "UNDYING_SIGIL": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Undying Sigil to the game"
+     ]
+    }
+   ],
+   "UNSETTLING_LAMP": [
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Unsettling Lamp relic no longer gets used up if the target's Artifact blocks the debuff"
+     ]
+    },
+    {
+     "version": "V0.107.0",
+     "type": "Beta Patch",
+     "date": "2026-06-04",
+     "changes": [
+      "Snecko Skull relic now always triggers before Unsettling Lamp relic"
+     ]
+    },
+    {
+     "version": "V0.102.0",
+     "type": "Beta Patch",
+     "date": "2026-04-02",
+     "changes": [
+      "Fixed Unsettling Lamp relic doubling the Strength you get from Dominate card"
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Renamed Dybbuk Cube -> Unsettling Lamp",
+      "Added assets for Unsettling Lamp relic"
+     ]
+    },
+    {
+     "version": "V0.80.0",
+     "type": "Pre-release",
+     "date": "2025-10-23",
+     "changes": [
+      "Dybbuk Cube relic now properly doubles temporary Strength/Dexterity/Focus loss instead of quadrupling it"
+     ]
+    },
+    {
+     "version": "V0.75.0",
+     "type": "Pre-release",
+     "date": "2025-09-18",
+     "changes": [
+      "Dybbuk Cube relic is now locked until its respective Epoch has been revealed"
+     ]
+    },
+    {
+     "version": "V0.47.0",
+     "type": "Pre-release",
+     "date": "2025-02-27",
+     "changes": [
+      "Dybbuk Cube relic now properly doubles Vulnerable applied by Taunt card"
+     ]
+    },
+    {
+     "version": "V0.42.0",
+     "type": "Pre-release",
+     "date": "2025-01-23",
+     "changes": [
+      "Reworked Dybbuk Cube relic:",
+      "Now only triggers on debuffs applied by cards",
+      "When a debuff is applied to multiple enemies at the same time, Dybbuk Cube now doubles all those debuffs"
+     ]
+    },
+    {
+     "version": "V0.41.0",
+     "type": "Pre-release",
+     "date": "2025-01-16",
+     "changes": [
+      "Dybbuk Cube relic now specifies that it does not double the effects of debuffs applied to players"
+     ]
+    },
+    {
+     "version": "V0.39.0",
+     "type": "Pre-release",
+     "date": "2024-12-12",
+     "changes": [
+      "Oblivion card and Dybbuk Cube relic now modify the power amounts displayed in card descriptions"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Changed Dybbuk Cube relic: rarity increased from Uncommon -> Rare",
+      "Taunt card's Vulnerable is now affected by Dybbuk Cube relic"
+     ]
+    },
+    {
+     "version": "V0.35.0",
+     "type": "Pre-release",
+     "date": "2024-11-07",
+     "changes": [
+      "Added Dybbuk Cube to the game"
+     ]
+    }
+   ],
+   "VAJRA": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Vajra to the game"
+     ]
+    }
+   ],
+   "VAMBRACE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Vambrace to the game"
+     ]
+    }
+   ],
+   "VELVET_CHOKER": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Now also available in Act 2"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Velvet Choker to the game."
+     ]
+    }
+   ],
+   "VENERABLE_TEA_SET": [
+    {
+     "version": "V0.70.0",
+     "type": "Pre-release",
+     "date": "2025-08-14",
+     "changes": [
+      "Renamed the following relics:",
+      "Ancient Tea Set -> Venerable Tea Set"
+     ]
+    },
+    {
+     "version": "V0.69.0",
+     "type": "Pre-release",
+     "date": "2025-08-07",
+     "changes": [
+      "Nye Essence and Ancient Tea Set relics now display the Energy hovertip"
+     ]
+    },
+    {
+     "version": "V0.14.0",
+     "type": "Pre-release",
+     "date": "2024-05-31",
+     "changes": [
+      "Added StS1 Ancient Tea Set relic asset"
+     ]
+    },
+    {
+     "version": "V0.13.0",
+     "type": "Pre-release",
+     "date": "2024-05-24",
+     "changes": [
+      "Implemented relics from StS1: Ancient Tea Set, Potion Belt, White Beast Statue"
+     ]
+    }
+   ],
+   "FAKE_VENERABLE_TEA_SET": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Venerable Tea Set??? to the game"
+     ]
+    }
+   ],
+   "VEXING_PUZZLEBOX": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Vexing Puzzlebox to the game"
+     ]
+    }
+   ],
+   "VITRUVIAN_MINION": [
+    {
+     "version": "V0.84.0",
+     "type": "Pre-release",
+     "date": "2025-11-20",
+     "changes": [
+      "Reworked the following relics:",
+      "Regalite",
+      "Vitruvian Minion"
+     ]
+    },
+    {
+     "version": "V0.79.0",
+     "type": "Pre-release",
+     "date": "2025-10-16",
+     "changes": [
+      "Vitruvian Minion relic now properly removes Exhaust from Minion Strike card"
+     ]
+    },
+    {
+     "version": "V0.54.0",
+     "type": "Pre-release",
+     "date": "2025-05-01",
+     "changes": [
+      "Added Vitruvian Minion to the game"
+     ]
+    }
+   ],
+   "WAR_HAMMER": [
+    {
+     "version": "V0.85.0",
+     "type": "Pre-release",
+     "date": "2025-12-04",
+     "changes": [
+      "Carnivorous Terrarium effect moved to Tanx - War Hammer"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added War Hammer to the game"
+     ]
+    }
+   ],
+   "WHETSTONE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Whetstone to the game"
+     ]
+    }
+   ],
+   "WHISPERING_EARRING": [
+    {
+     "version": "V0.107.0",
+     "type": "Beta Patch",
+     "date": "2026-06-04",
+     "changes": [
+      "Fixed an issue where, if the player has Vakuu's Whispering Earring relic and it auto-plays Regent Void Form card, it could sometimes continue auto-playing cards on the player's next turn"
+     ]
+    },
+    {
+     "version": "V0.103.3",
+     "type": "Patch",
+     "date": "2026-05-29",
+     "changes": [
+      "Fixed the Whispering Earring relic replaying Stardust for 0 Stars instead of the correct amount"
+     ]
+    },
+    {
+     "version": "V0.104.0",
+     "type": "Beta Patch",
+     "date": "2026-04-23",
+     "changes": [
+      "Fixed Vakuu's Whispering Earring not correctly playing Stardust card",
+      "Unceasing Top relic now triggers properly when Vakuu's Whispering Earring relic plays the last card in your hand"
+     ]
+    },
+    {
+     "version": "V0.102.0",
+     "type": "Beta Patch",
+     "date": "2026-04-02",
+     "changes": [
+      "Effects that occur before your turn now interact correctly with Vakuu's Whispering Earring relic",
+      "Fixed Vakuu's Whispering Earring relic continuing to play cards after Void Form power ended the turn"
+     ]
+    },
+    {
+     "version": "V0.101.0",
+     "type": "Beta Patch",
+     "date": "2026-03-26",
+     "changes": [
+      "Fixed softlock when you play an Imbued card that prompts a card selection and Vakuu's Whispering Earring relic"
+     ]
+    },
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Fixed card prompts auto-selecting without player input after a run with Vakuu's Whispering Earring relic",
+      "Fixed softlock when Vakuu's Whispering Earring relic would auto-play Hand Trick card with 2+ eligible Skills"
+     ]
+    },
+    {
+     "version": "V0.99.0",
+     "type": "Beta Patch",
+     "date": "2026-03-12",
+     "changes": [
+      "Fixed players being unable to end their turn when they die while the Whispering Earring relic autoplays their cards"
+     ]
+    },
+    {
+     "version": "V0.98.2",
+     "type": "Hotfix",
+     "date": "2026-03-06",
+     "changes": [
+      "Fixed softlock from Whispering Earring relic trying to play ally-targeted cards on Osty"
+     ]
+    },
+    {
+     "version": "V0.89.0",
+     "type": "Pre-release",
+     "date": "2026-01-08",
+     "changes": [
+      "Potion slot no longer locks up when using potion during Whispering Earring relic auto-play"
+     ]
+    },
+    {
+     "version": "V0.88.0",
+     "type": "Pre-release",
+     "date": "2026-01-01",
+     "changes": [
+      "Reworked Ruby Earrings into Whispering Earring"
+     ]
+    },
+    {
+     "version": "V0.74.0",
+     "type": "Pre-release",
+     "date": "2025-09-11",
+     "changes": [
+      "Future of Potions event is no longer affected by Ruby Earrings relic"
+     ]
+    },
+    {
+     "version": "V0.72.0",
+     "type": "Pre-release",
+     "date": "2025-08-27",
+     "changes": [
+      "Updated wording for the following relic: Ruby Earrings"
+     ]
+    },
+    {
+     "version": "V0.51.0",
+     "type": "Pre-release",
+     "date": "2025-04-10",
+     "changes": [
+      "Fixed softlock between Ruby Earrings and Amethyst Bangle relics"
+     ]
+    },
+    {
+     "version": "V0.45.0",
+     "type": "Pre-release",
+     "date": "2025-02-13",
+     "changes": [
+      "Ruby Earrings relic now properly generates Uncommon and Rare card rewards"
+     ]
+    },
+    {
+     "version": "V0.44.0",
+     "type": "Pre-release",
+     "date": "2025-02-06",
+     "changes": [
+      "Changed Zlatir’s Ruby Earrings blessing: “All combat card rewards contain one card of each Rarity”"
+     ]
+    },
+    {
+     "version": "V0.22.0",
+     "type": "Pre-release",
+     "date": "2024-08-09",
+     "changes": [
+      "Card reward icon changes to gold if you have Ruby Earrings"
+     ]
+    },
+    {
+     "version": "V0.19.0",
+     "type": "Pre-release",
+     "date": "2024-07-05",
+     "changes": [
+      "Ruby Earrings relic now gives you Rare cards for non-combat (non-custom) card rewards"
+     ]
+    },
+    {
+     "version": "V0.14.0",
+     "type": "Pre-release",
+     "date": "2024-05-31",
+     "changes": [
+      "Updated Vlad’s Earring relic - “All card rewards and cards in the shop are Rare.”"
+     ]
+    },
+    {
+     "version": "V0.12.0",
+     "type": "Pre-release",
+     "date": "2024-05-17",
+     "changes": [
+      "VladNow Vakuu offers two new boons, his Brooch and Earring."
+     ]
+    }
+   ],
+   "WINGED_BOOTS": [
+    {
+     "version": "V0.103.0",
+     "type": "Beta Patch",
+     "date": "2026-04-09",
+     "changes": [
+      "Added Winged Boots to the game."
+     ]
+    }
+   ],
+   "WONGO_CUSTOMER_APPRECIATION_BADGE": [
+    {
+     "version": "V0.86.0",
+     "type": "Pre-release",
+     "date": "2025-12-11",
+     "changes": [
+      "Wongo badge is now awarded when reaching exactly 2000 points"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Wongo Customer Appreciation Badge to the game"
+     ]
+    }
+   ],
+   "WONGOS_MYSTERY_TICKET": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Wongo's Mystery Ticket to the game"
+     ]
+    }
+   ]
+  },
+  "monsters": {
+   "AEONGLASS": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Nerfed Aeonglass: Ebb move damage decreased from 26(32) -> 22(26) to lower its front-loaded damage"
+     ]
+    },
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Added Aeonglass animations."
+     ]
+    },
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "Replaced the Act 3 boss Doormaker with a brand-new boss, Aeonglass (its moveset and Wither / Withering Presence mechanics were refined throughout the beta)."
+     ]
+    },
+    {
+     "version": "V0.107.0",
+     "type": "Beta Patch",
+     "date": "2026-06-04",
+     "changes": [
+      "No longer applies the Ebb debuff",
+      "Now gains Block on its Ebb move (single hit) instead of its Increasing Intensity move"
+     ]
+    },
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Adjusted moveset",
+      "Reworked Wither status and Withering Presence power",
+      "1 cost Retain. At the end of your turn, if this is in your Hand, take 2(4) damage. -> Unplayable. At the end of your turn, if this is in your Hand, take 3(6) damage."
+     ]
+    },
+    {
+     "version": "V0.105.0",
+     "type": "Beta Patch",
+     "date": "2026-05-08",
+     "changes": [
+      "Doormaker has been replaced with a brand new boss, Aeonglass!",
+      "While Doormaker had interesting micro decisions in the fight, he was over the complexity threshold of what we want and had lingering issues. We decided that starting over fresh will let us hit what we actually want for an Act 3 boss."
+     ]
+    }
+   ],
+   "AXEBOT": [
+    {
+     "version": "v0.104.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Two Axebots -> One Axebot",
+      "Reworked Axebots combat to have just a single, more challenging Axebot."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Axebot to the game"
+     ]
+    }
+   ],
+   "BYGONE_EFFIGY": [
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Damage decreased from 15(17) -> 13(15) (still attacks with 10 Strength)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bygone Effigy to the game"
+     ]
+    }
+   ],
+   "BYRDONIS": [
+    {
+     "version": "v0.103.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "HP reduced from 91(99)-94(99) to 81(90)-84(90)"
+     ]
+    },
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Swoop attack damage increased from 16(18) -> 17(19)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Byrdonis to the game"
+     ]
+    }
+   ],
+   "DECIMILLIPEDE_SEGMENT": [
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "HP decreased from 42-48 8 to 40-46 8"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Decimillipede to the game"
+     ]
+    }
+   ],
+   "FABRICATOR": [
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "HP value of all bots decreased by 5"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fabricatorto the game"
+     ]
+    }
+   ],
+   "FAT_GREMLIN": [
+    {
+     "version": "v0.107.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "If Gremlin Merc didn't steal any gold but Fat Gremlin escaped, the player now receives 50% of the normal gold reward instead of 0%"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added to the game"
+     ]
+    }
+   ],
+   "FOSSIL_STALKER": [
+    {
+     "version": "v0.105.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "In multiplayer, now gains a set amount of Strength if it hits any player, instead of gaining Strength for each player hit."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fossil Stalker to the game"
+     ]
+    }
+   ],
+   "GREMLIN_MERC": [
+    {
+     "version": "v0.107.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "If Gremlin Merc didn't steal any gold but Fat Gremlin escaped, the player now receives 50% of the normal gold reward instead of 0%"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added to the game"
+     ]
+    }
+   ],
+   "HAUNTED_SHIP": [
+    {
+     "version": "v0.106.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Ramming Speed move removed, now alternates between Swipe and Stomp instead (always starting with Swipe after Haunt)."
+     ]
+    },
+    {
+     "version": "v0.105.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Now applies 3 Weak on Turn 1 instead of applying Weak when it attacks."
+     ]
+    },
+    {
+     "version": "v0.101.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Now applies Dazed status cards to the player"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Haunted Ship to the game"
+     ]
+    }
+   ],
+   "INFESTED_PRISM": [
+    {
+     "version": "v0.106.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Vital Spark changed The first time it takes Attack damage each turn, the attacker gains CE -> All Skills are Tainted 2(3).",
+      "Health reduced 200(215) -> 161(171)",
+      "Jab reduced 22(24) -> 15(17)",
+      "Radiate reduced 16(18) -> 11(13)",
+      "Whirlwind reduced 9(10) -> 5(6)",
+      "Pulsate Changed Gains 20(22) Block and 4(5) Strength -> Deal 8(10) Damage. Gain 20(22) Block and Vital Spark 2(3)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Infested Prism to the game"
+     ]
+    }
+   ],
+   "LIVING_FOG": [
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Gas Bomb HP decreased from 10(12) -> 7(8)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Living Fog to the game"
+     ]
+    }
+   ],
+   "NIBBIT": [
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Hiss move now scales from 2 -> 3 Strength on A9",
+      "Slice move damage now scales from 6 -> 7 on A9",
+      "Slice move Block now scales from 5 -> 6 on A8"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Nibbit to the game"
+     ]
+    }
+   ],
+   "PHANTASMAL_GARDENER": [
+    {
+     "version": "V0.100.0",
+     "type": "Beta Patch",
+     "date": "2026-03-19",
+     "changes": [
+      "Nerfed Phantasmal Gardeners: HP decreased from 28(29)-32(33) -> 26(27)-31(32)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Phantasmal Gardener to the game"
+     ]
+    }
+   ],
+   "PUNCH_CONSTRUCT": [
+    {
+     "version": "v0.106.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Ready now leads into Fast Punch",
+      "Fast Punch now leads into Strong Punch instead of Strong Punch leading into Fast Punch",
+      "Fast Punch now applies Frail instead of Weak"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Punch Construct to the game"
+     ]
+    }
+   ],
+   "QUEEN": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Buffed Torch Head Amalgam: now starts with a new Strong Tackle move on turn 1 to increase front-loaded damage from 18(22) -> 26(32)"
+     ]
+    },
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Buffed Torch Head Amalgam: increased damage at Ascension 9",
+      "Weak Tackle damage increased from 14(15) → 14(16)",
+      "Tackle damage increased from 18(19) → 18(22)"
+     ]
+    }
+   ],
+   "SEAPUNK": [
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Sea Kick move damage increased from 11(12) -> 11(13)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Seapunk to the game"
+     ]
+    }
+   ],
+   "SKULKING_COLONY": [
+    {
+     "version": "v0.106.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "HP increased from 70(75) -> 75(80)",
+      "Hardened Shell power increased from 15 -> 20",
+      "Smash move removed, now uses Zoom move turns 1 and 2 instead",
+      "No longer gains Block"
+     ]
+    },
+    {
+     "version": "v0.103.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "HP reduced from 74(79) to 70(75)"
+     ]
+    },
+    {
+     "version": "v0.102.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Now attacks on all turns",
+      "Deals slightly more damage"
+     ]
+    },
+    {
+     "version": "v0.101.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Deals less damage, damage scales slower, and no longer applies Dazed status cards"
+     ]
+    },
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Lowered Hardened Shell to 15 and made Smash shuffle 5 Dazed instead of 4."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Skulking Colony to the game"
+     ]
+    }
+   ],
+   "SNEAKY_GREMLIN": [
+    {
+     "version": "v0.107.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "If Gremlin Merc didn't steal any gold but Fat Gremlin escaped, the player now receives 50% of the normal gold reward instead of 0%"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added to the game"
+     ]
+    }
+   ],
+   "SOUL_FYSH": [
+    {
+     "version": "v0.105.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Scream move damage increased from 11(12) -> 13(15)."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Soul Fysh to the game"
+     ]
+    }
+   ],
+   "TERROR_EEL": [
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Crash damage now scales from 17(19) -> 16(18)",
+      "Thrash Vigor now scales from 7 -> 6"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Terror Eel to the game"
+     ]
+    }
+   ],
+   "TEST_SUBJECT": [
+    {
+     "version": "v0.106.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Corrected HP scaling in multiplayer. Previously, phase 2 and 3 would respawn with  BaseHP * PlayerCount instead of  BaseHP * PlayerCount * ActScaling Multiplayer#Enemy Scaling"
+     ]
+    },
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Phase 2 no longer has the Pounce move, instead will repeat Multi Claw move every turn"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Test Subject to the game"
+     ]
+    }
+   ],
+   "WATERFALL_GIANT": [
+    {
+     "version": "v0.101.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "HP decreased from 250(260) -> 240(250)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Waterfall Giant to the game"
+     ]
+    }
+   ]
+  },
+  "encounters": {
+   "AEONGLASS_BOSS": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Nerfed Aeonglass: Ebb move damage decreased from 26(32) -> 22(26) to lower its front-loaded damage"
+     ]
+    },
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Added Aeonglass animations."
+     ]
+    },
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "Replaced the Act 3 boss Doormaker with a brand-new boss, Aeonglass (its moveset and Wither / Withering Presence mechanics were refined throughout the beta)."
+     ]
+    },
+    {
+     "version": "V0.107.0",
+     "type": "Beta Patch",
+     "date": "2026-06-04",
+     "changes": [
+      "No longer applies the Ebb debuff",
+      "Now gains Block on its Ebb move (single hit) instead of its Increasing Intensity move"
+     ]
+    },
+    {
+     "version": "V0.106.0",
+     "type": "Beta Patch",
+     "date": "2026-05-21",
+     "changes": [
+      "Adjusted moveset",
+      "Reworked Wither status and Withering Presence power",
+      "1 cost Retain. At the end of your turn, if this is in your Hand, take 2(4) damage. -> Unplayable. At the end of your turn, if this is in your Hand, take 3(6) damage."
+     ]
+    },
+    {
+     "version": "V0.105.0",
+     "type": "Beta Patch",
+     "date": "2026-05-08",
+     "changes": [
+      "Doormaker has been replaced with a brand new boss, Aeonglass!",
+      "While Doormaker had interesting micro decisions in the fight, he was over the complexity threshold of what we want and had lingering issues. We decided that starting over fresh will let us hit what we actually want for an Act 3 boss."
+     ]
+    }
+   ],
+   "AXEBOTS_NORMAL": [
+    {
+     "version": "v0.104.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Two Axebots -> One Axebot",
+      "Reworked Axebots combat to have just a single, more challenging Axebot."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Axebot to the game"
+     ]
+    }
+   ],
+   "BYGONE_EFFIGY_ELITE": [
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Damage decreased from 15(17) -> 13(15) (still attacks with 10 Strength)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Bygone Effigy to the game"
+     ]
+    }
+   ],
+   "BYRDONIS_ELITE": [
+    {
+     "version": "v0.103.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "HP reduced from 91(99)-94(99) to 81(90)-84(90)"
+     ]
+    },
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Swoop attack damage increased from 16(18) -> 17(19)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Byrdonis to the game"
+     ]
+    }
+   ],
+   "DECIMILLIPEDE_ELITE": [
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "HP decreased from 42-48 8 to 40-46 8"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Decimillipede to the game"
+     ]
+    }
+   ],
+   "FABRICATOR_NORMAL": [
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "HP value of all bots decreased by 5"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fabricatorto the game"
+     ]
+    }
+   ],
+   "FOSSIL_STALKER_NORMAL": [
+    {
+     "version": "v0.105.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "In multiplayer, now gains a set amount of Strength if it hits any player, instead of gaining Strength for each player hit."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Fossil Stalker to the game"
+     ]
+    }
+   ],
+   "HAUNTED_SHIP_NORMAL": [
+    {
+     "version": "v0.106.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Ramming Speed move removed, now alternates between Swipe and Stomp instead (always starting with Swipe after Haunt)."
+     ]
+    },
+    {
+     "version": "v0.105.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Now applies 3 Weak on Turn 1 instead of applying Weak when it attacks."
+     ]
+    },
+    {
+     "version": "v0.101.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Now applies Dazed status cards to the player"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Haunted Ship to the game"
+     ]
+    }
+   ],
+   "INFESTED_PRISMS_ELITE": [
+    {
+     "version": "v0.106.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Vital Spark changed The first time it takes Attack damage each turn, the attacker gains CE -> All Skills are Tainted 2(3).",
+      "Health reduced 200(215) -> 161(171)",
+      "Jab reduced 22(24) -> 15(17)",
+      "Radiate reduced 16(18) -> 11(13)",
+      "Whirlwind reduced 9(10) -> 5(6)",
+      "Pulsate Changed Gains 20(22) Block and 4(5) Strength -> Deal 8(10) Damage. Gain 20(22) Block and Vital Spark 2(3)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Infested Prism to the game"
+     ]
+    }
+   ],
+   "KAISER_CRAB_BOSS": [
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Buffed Rocket Claw:",
+      "Charge Up move Strength gain now scales with Ascension from 2(2) -> 2(3)",
+      "HP increased from 189(199) -> 199(209)",
+      "Rage power Strength buffed from 5 -> 6",
+      "Buffed Crusher Claw:",
+      "Adapt move Strength gain now scales with Ascension from 2(2) -> 2(3)",
+      "HP increased from 199(209) -> 209(219)",
+      "Rage power Strength buffed from 5 -> 6"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Kaiser Crab to the game"
+     ]
+    }
+   ],
+   "LIVING_FOG_NORMAL": [
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Gas Bomb HP decreased from 10(12) -> 7(8)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Living Fog to the game"
+     ]
+    }
+   ],
+   "PUNCH_CONSTRUCT_NORMAL": [
+    {
+     "version": "v0.106.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Ready now leads into Fast Punch",
+      "Fast Punch now leads into Strong Punch instead of Strong Punch leading into Fast Punch",
+      "Fast Punch now applies Frail instead of Weak"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Punch Construct to the game"
+     ]
+    }
+   ],
+   "QUEEN_BOSS": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Buffed Torch Head Amalgam: now starts with a new Strong Tackle move on turn 1 to increase front-loaded damage from 18(22) -> 26(32)"
+     ]
+    },
+    {
+     "version": "V0.108.0",
+     "type": "Beta Patch",
+     "date": "2026-07-03",
+     "changes": [
+      "Buffed Torch Head Amalgam: increased damage at Ascension 9",
+      "Weak Tackle damage increased from 14(15) → 14(16)",
+      "Tackle damage increased from 18(19) → 18(22)"
+     ]
+    }
+   ],
+   "RUBY_RAIDERS_NORMAL": [
+    {
+     "version": "v0.104.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Nerfed Ruby Raider Assassin: damage decreased from 11(12) -> 10(11)."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Ruby Raiders to the game"
+     ]
+    }
+   ],
+   "SEAPUNK_WEAK": [
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Sea Kick move damage increased from 11(12) -> 11(13)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Seapunk to the game"
+     ]
+    }
+   ],
+   "SKULKING_COLONY_ELITE": [
+    {
+     "version": "v0.106.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "HP increased from 70(75) -> 75(80)",
+      "Hardened Shell power increased from 15 -> 20",
+      "Smash move removed, now uses Zoom move turns 1 and 2 instead",
+      "No longer gains Block"
+     ]
+    },
+    {
+     "version": "v0.103.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "HP reduced from 74(79) to 70(75)"
+     ]
+    },
+    {
+     "version": "v0.102.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Now attacks on all turns",
+      "Deals slightly more damage"
+     ]
+    },
+    {
+     "version": "v0.101.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Deals less damage, damage scales slower, and no longer applies Dazed status cards"
+     ]
+    },
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Lowered Hardened Shell to 15 and made Smash shuffle 5 Dazed instead of 4."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Skulking Colony to the game"
+     ]
+    }
+   ],
+   "SOUL_FYSH_BOSS": [
+    {
+     "version": "v0.105.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Scream move damage increased from 11(12) -> 13(15)."
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Soul Fysh to the game"
+     ]
+    }
+   ],
+   "TERROR_EEL_ELITE": [
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Crash damage now scales from 17(19) -> 16(18)",
+      "Thrash Vigor now scales from 7 -> 6"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Terror Eel to the game"
+     ]
+    }
+   ],
+   "TEST_SUBJECT_BOSS": [
+    {
+     "version": "v0.106.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Corrected HP scaling in multiplayer. Previously, phase 2 and 3 would respawn with  BaseHP * PlayerCount instead of  BaseHP * PlayerCount * ActScaling Multiplayer#Enemy Scaling"
+     ]
+    },
+    {
+     "version": "v0.100.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "Phase 2 no longer has the Pounce move, instead will repeat Multi Claw move every turn"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Test Subject to the game"
+     ]
+    }
+   ],
+   "WATERFALL_GIANT_BOSS": [
+    {
+     "version": "v0.101.0",
+     "type": null,
+     "date": null,
+     "changes": [
+      "HP decreased from 250(260) -> 240(250)"
+     ]
+    },
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Waterfall Giant to the game"
+     ]
+    }
+   ]
+  },
+  "events": {
+   "NEOW": [
+    {
+     "version": "V0.109.0",
+     "type": "Beta Patch",
+     "date": "2026-07-17",
+     "changes": [
+      "Added new Neow relics:",
+      "Dowsing Rod - Upon pickup, add 1 Dowsing to your Deck.",
+      "Neow's Sacrifice - Upon pickup, procure 1 Ambergris and 1 Guilty to your Deck."
+     ]
+    },
+    {
+     "version": "V0.107.1",
+     "type": "Major Update",
+     "date": "2026-06-19",
+     "changes": [
+      "Added new Neow relics:",
+      "Kaleidoscope - \"Upon pickup, gain 2 card rewards with cards from other characters.\"",
+      "Fishing Rod - \"Every 3 normal combats, Upgrade a random card in your Deck.\"",
+      "Silken Tress - \"Enchant all cards in the first card reward with Glam. Upon pickup, lose all gold.\"",
+      "Scroll Boxes no longer make you lose all your gold."
+     ]
+    }
+   ],
+   "SLIPPERY_BRIDGE": [
+    {
+     "version": null,
+     "type": null,
+     "date": null,
+     "changes": [
+      "Added Slippery Bridge to the game"
+     ]
+    }
+   ],
+   "TEZCATARA": [
+    {
+     "version": "V0.105.0",
+     "type": "Beta Patch",
+     "date": "2026-05-08",
+     "changes": [
+      "Moved Tezcatara's Seal of Gold relic to pool 3 so that it is in the same pool as Pumpkin Candle."
+     ]
+    },
+    {
+     "version": "V0.95.0",
+     "type": "Pre-release",
+     "date": "2026-02-19",
+     "changes": [
+      "Changed Tezcatara's Toasty Mittens relic: now shuffles your discard pile into your draw pile if it's empty"
+     ]
+    },
+    {
+     "version": "V0.94.0",
+     "type": "Pre-release",
+     "date": "2026-02-12",
+     "changes": [
+      "Reworked Tezcatara's Seal of Gold relic",
+      "Tezcatara blessings are now pooled",
+      "The line \"You can trust me\" is now properly said by Tezcatara to Silent instead of vice versa"
+     ]
+    },
+    {
+     "version": "V0.91.0",
+     "type": "Pre-release",
+     "date": "2026-01-22",
+     "changes": [
+      "Buffed Tezcatara's Brightest Flame card: Energy gain increased from 1(2) -> 2(3)",
+      "Buffed Tezcatara's Golden Compass relic: added ? rooms before the first Treasure Chest and after the second Treasure Chest, making it 2 nodes longer than the typical Act 2 length"
+     ]
+    },
+    {
+     "version": "V0.90.0",
+     "type": "Pre-release",
+     "date": "2026-01-15",
+     "changes": [
+      "Renamed the following relics:",
+      "Dust Bunny -> Biiig Hug",
+      "Heap of Coals -> Nutritious Soup",
+      "Pitch Black Oil -> Yummy Cookie",
+      "Matchbox -> Very Hot Cocoa",
+      "Tezcatara's Candle -> Pumpkin Candle"
+     ]
+    },
+    {
+     "version": "V0.86.0",
+     "type": "Pre-release",
+     "date": "2025-12-11",
+     "changes": [
+      "Buffed Tezcatara's Pitch Black Oil relic: cards increased from 3 -> 4"
+     ]
+    },
+    {
+     "version": "V0.85.0",
+     "type": "Pre-release",
+     "date": "2025-12-04",
+     "changes": [
+      "Renamed Hungering Portrait -> Toasty Mittens and added to Tezcatara's relics"
+     ]
+    },
+    {
+     "version": "V0.77.0",
+     "type": "Pre-release",
+     "date": "2025-10-02",
+     "changes": [
+      "Tezcatara's Dust Bunny relic hovertip now includes preview for Soot card"
+     ]
+    },
+    {
+     "version": "V0.59.0",
+     "type": "Pre-release",
+     "date": "2025-06-05",
+     "changes": [
+      "Nerfed Tezcatara's Brightest Flame card: Energy gain decreased from 2(3) -> 1(2)"
+     ]
+    },
+    {
+     "version": "V0.54.0",
+     "type": "Pre-release",
+     "date": "2025-05-01",
+     "changes": [
+      "Shrunk Neow, Pael, and Tezcatara Ancient background assets"
+     ]
+    },
+    {
+     "version": "V0.52.0",
+     "type": "Pre-release",
+     "date": "2025-04-17",
+     "changes": [
+      "Tezcatara's Ember blessing now properly shows up in event room hovertips"
+     ]
+    },
+    {
+     "version": "V0.50.0",
+     "type": "Pre-release",
+     "date": "2025-04-03",
+     "changes": [
+      "Tezcatara's Ember relic has been renamed to Bucket of Coals (but Tezcatara's Ember enchantment retains the name)"
+     ]
+    },
+    {
+     "version": "V0.48.0",
+     "type": "Pre-release",
+     "date": "2025-03-06",
+     "changes": [
+      "Tezcatara's Brightest Flame buffed. Now also gains 2(3) energy"
+     ]
+    },
+    {
+     "version": "V0.47.0",
+     "type": "Pre-release",
+     "date": "2025-02-27",
+     "changes": [
+      "Buffed Tezcatara's Brightest Flame card:",
+      "Max HP loss on play decreased from 2 -> 1",
+      "Damage increased from 11(13) -> 11(15)",
+      "Fixed state divergence in multiplayer related to Tezcatara's Wax Choker relic"
+     ]
+    },
+    {
+     "version": "V0.46.0",
+     "type": "Pre-release",
+     "date": "2025-02-20",
+     "changes": [
+      "Added new Tezcatara blessing, Smoldering Wick"
+     ]
+    },
+    {
+     "version": "V0.45.0",
+     "type": "Pre-release",
+     "date": "2025-02-13",
+     "changes": [
+      "Tezcatara's Ember blessing now displays Eternal hovertip"
+     ]
+    },
+    {
+     "version": "V0.41.0",
+     "type": "Pre-release",
+     "date": "2025-01-16",
+     "changes": [
+      "Reworked Tezcatara’s Pitch Black Oil relic"
+     ]
+    },
+    {
+     "version": "V0.40.0",
+     "type": "Pre-release",
+     "date": "2025-01-09",
+     "changes": [
+      "Improved Tezcatara’s Golden Path route: Shop now appears earlier",
+      "The Golden Path from Tezcatara’s blessing is now centered on the map"
+     ]
+    },
+    {
+     "version": "V0.38.0",
+     "type": "Pre-release",
+     "date": "2024-12-05",
+     "changes": [
+      "Added tracking relic for Tezcatara's Ember option"
+     ]
+    },
+    {
+     "version": "V0.36.0",
+     "type": "Pre-release",
+     "date": "2024-11-14",
+     "changes": [
+      "Changed Tezacatara’s Golden Compass relic: ensures that ? are always events (this is implicit)",
+      "Changed Tezcatara’s Golden Path choice: number of elites on map decreased from 3 -> 2",
+      "Changed Tezcatara’s Wax Choker relic: now only gives 4 relics"
+     ]
+    },
+    {
+     "version": "V0.35.0",
+     "type": "Pre-release",
+     "date": "2024-11-07",
+     "changes": [
+      "Tezcatara’s Wax Choker choice now correctly reads \"5 relics\" instead of 6"
+     ]
+    },
+    {
+     "version": "V0.34.0",
+     "type": "Pre-release",
+     "date": "2024-11-01",
+     "changes": [
+      "Changed Tezcatara’s Wax Choker: Wax relics given decreased from 6 -> 5"
+     ]
+    },
+    {
+     "version": "V0.31.0",
+     "type": "Pre-release",
+     "date": "2024-10-10",
+     "changes": [
+      "CPU to GPU VFX conversion for Insatiable and Tezcatara"
+     ]
+    },
+    {
+     "version": "V0.29.0",
+     "type": "Pre-release",
+     "date": "2024-09-26",
+     "changes": [
+      "Tweaked Tezcatara’s Ember description now that Eternal is its own keyword",
+      "Mummified Hand relic no longer can pick Tezcatara's Ember cards"
+     ]
+    },
+    {
+     "version": "V0.27.0",
+     "type": "Pre-release",
+     "date": "2024-09-12",
+     "changes": [
+      "Buffed Tezcatara's Pitch Black Oil relic: upgraded cards increased from 3 -> 4 cards"
+     ]
+    },
+    {
+     "version": "V0.26.0",
+     "type": "Pre-release",
+     "date": "2024-09-06",
+     "changes": [
+      "Removed Tezcatara’s Kindle options",
+      "Reworked Tezcatara’s Ember choice: now only affects basic Strikes",
+      "Added Tezcatara animations"
+     ]
+    },
+    {
+     "version": "V0.25.0",
+     "type": "Pre-release",
+     "date": "2024-08-30",
+     "changes": [
+      "Replaced the placeholder Tezcatara art with a new static background"
+     ]
+    },
+    {
+     "version": "V0.22.0",
+     "type": "Pre-release",
+     "date": "2024-08-09",
+     "changes": [
+      "Tezcatara’s Ember enchantment no longer softlocks Pandora’s Box relic"
+     ]
+    },
+    {
+     "version": "V0.18.0",
+     "type": "Pre-release",
+     "date": "2024-06-29",
+     "changes": [
+      "Added The Golden Path Tezcatara choice",
+      "Decree of Entropy card can now transform Tezcatara’s Ember cards",
+      "Fixed punctuation on Tezcatara’s Candle relic description",
+      "Tezcatara's first choice now shows the Kindle hovertip"
+     ]
+    },
+    {
+     "version": "V0.17.0",
+     "type": "Pre-release",
+     "date": "2024-06-21",
+     "changes": [
+      "Added Kindle card keyword",
+      "Added Scourging Cleanse Tezcatara choice",
+      "Reworked Flame in the Dark card:",
+      "Skill  0  Event",
+      "“Kindle 3. Ethereal. Gain 3(4) energy. Draw 2(3) cards.”",
+      "Reworked Tezcataras Might:",
+      "Power  2  Event",
+      "“Kindle 2. Ethereal. Gain 11(15) Strength. At the end of your turn, lose 1 Strength.”",
+      "Reworked Brightest Light:",
+      "Attack  1  Event",
+      "\"Kindle 4. Ethereal. Deal 30(40) damage.\"",
+      "Reworked Pitch Black Oil relic: “The next time you Smith, upgrade 3 cards. Afterwards, you may not Smith again.”",
+      "Reworked Wax Choker relic: “Obtain 6 wax relics. Every three combats, one wax relic melts away.”",
+      "Reworked Seal of Gold relic: “Obtain 777 Gold. You can no longer obtain Gold.”"
+     ]
+    },
+    {
+     "version": "V0.14.0",
+     "type": "Pre-release",
+     "date": "2024-05-31",
+     "changes": [
+      "Removed boss relic option from Ancients",
+      "Ancients now offer 3 choices instead of 2",
+      "Added Flame in the Dark Tezcatara card - “Gain 3 Energy. Draw 2 cards. Exhaust. Remove this card from your deck.”",
+      "Pitch Black Oil Tezcatara relic - “The next time you rest, heal to full HP and gain 15 Max HP. Afterwards you may not rest again.”",
+      "Added Seal of Gold Tezcatara relic - “Obtain 777 gold. When you enter a new room, lose 20 Gold.”",
+      "Added Tezcatara’s Might card - “Gain 5(7) Strength. Permanently increase this card's cost by 1.”"
+     ]
+    },
+    {
+     "version": "V0.12.0",
+     "type": "Pre-release",
+     "date": "2024-05-17",
+     "changes": [
+      "A new Ancient, Tezcatara enters the Spire."
+     ]
+    }
+   ]
+  }
+ }
+}

--- a/frontend/app/achievements/[id]/AchievementDetail.tsx
+++ b/frontend/app/achievements/[id]/AchievementDetail.tsx
@@ -9,7 +9,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
-import EntityHistory from "@/app/components/EntityHistory";
+import EntityUpdateHistory from "@/app/components/EntityUpdateHistory";
 import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import "../../card-revamp.css";
@@ -131,7 +131,7 @@ export default function AchievementDetail({ initialAchievement }: { initialAchie
 
           {/* Version history + localized names */}
           <LocalizedNames entityType="achievements" entityId={id} />
-          <EntityHistory entityType="achievements" entityId={id} />
+          <EntityUpdateHistory entityType="achievements" entityId={id} />
         </main>
       </div>
     </div>

--- a/frontend/app/acts/[id]/ActDetail.tsx
+++ b/frontend/app/acts/[id]/ActDetail.tsx
@@ -8,7 +8,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import LocalizedNames from "@/app/components/LocalizedNames";
-import EntityHistory from "@/app/components/EntityHistory";
+import EntityUpdateHistory from "@/app/components/EntityUpdateHistory";
 import EntityProse from "@/app/components/EntityProse";
 import "../../card-revamp.css";
 import "../../meta-extra.css";
@@ -190,7 +190,7 @@ export default function ActDetail({ initialAct }: { initialAct?: Act | null } = 
 
           {/* Version history + localized names */}
           <LocalizedNames entityType="acts" entityId={id} />
-          <EntityHistory entityType="acts" entityId={id} />
+          <EntityUpdateHistory entityType="acts" entityId={id} />
         </main>
       </div>
     </div>

--- a/frontend/app/afflictions/[id]/AfflictionDetail.tsx
+++ b/frontend/app/afflictions/[id]/AfflictionDetail.tsx
@@ -9,7 +9,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
-import EntityHistory from "@/app/components/EntityHistory";
+import EntityUpdateHistory from "@/app/components/EntityUpdateHistory";
 import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import "../../card-revamp.css";
@@ -95,7 +95,7 @@ export default function AfflictionDetail({ initialAffliction }: { initialAfflict
           )}
 
           <LocalizedNames entityType="afflictions" entityId={id} />
-          <EntityHistory entityType="afflictions" entityId={id} />
+          <EntityUpdateHistory entityType="afflictions" entityId={id} />
         </main>
       </div>
     </div>

--- a/frontend/app/ascensions/[id]/AscensionDetail.tsx
+++ b/frontend/app/ascensions/[id]/AscensionDetail.tsx
@@ -9,7 +9,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import LocalizedNames from "@/app/components/LocalizedNames";
-import EntityHistory from "@/app/components/EntityHistory";
+import EntityUpdateHistory from "@/app/components/EntityUpdateHistory";
 import EntityProse from "@/app/components/EntityProse";
 import "../../card-revamp.css";
 import "../../meta-extra.css";
@@ -167,7 +167,7 @@ export default function AscensionDetail({ initialAscension }: { initialAscension
 
           {/* Version history + localized names */}
           <LocalizedNames entityType="ascensions" entityId={id} />
-          <EntityHistory entityType="ascensions" entityId={id} />
+          <EntityUpdateHistory entityType="ascensions" entityId={id} />
         </main>
       </div>
     </div>

--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -11,7 +11,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
-import EntityHistory from "@/app/components/EntityHistory";
+import EntityUpdateHistory from "@/app/components/EntityUpdateHistory";
 import RelatedCards from "@/app/components/RelatedCards";
 import EntityProse from "@/app/components/EntityProse";
 import EntityPairings from "@/app/components/EntityPairings";
@@ -684,7 +684,7 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
 
           {/* Version history + localized names */}
           <LocalizedNames entityType="cards" entityId={id} />
-          <EntityHistory entityType="cards" entityId={id} />
+          <EntityUpdateHistory entityType="cards" entityId={id} />
         </main>
 
         {/* ===== INFOBOX column (sticky) ===== */}

--- a/frontend/app/components/EntityUpdateHistory.tsx
+++ b/frontend/app/components/EntityUpdateHistory.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { cachedFetch } from "@/lib/fetch-cache";
+import { useLanguage } from "@/app/contexts/LanguageContext";
+import { t } from "@/lib/ui-translations";
+import EntityHistory from "./EntityHistory";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+interface UpdateEntry {
+  version: string | null;
+  type: string | null;
+  date: string | null;
+  changes: string[];
+}
+
+// Beta patches land green, main-branch releases gold, pre-release gray —
+// same hue language as the channel pill and the changelog page.
+function patchKind(type: string | null): "beta" | "main" | "pre" {
+  if (!type || type === "Pre-release") return "pre";
+  if (type.startsWith("Beta")) return "beta";
+  return "main";
+}
+
+const kindText: Record<string, string> = {
+  beta: "text-emerald-400",
+  main: "text-[var(--accent-gold)]",
+  pre: "text-[var(--text-muted)]",
+};
+
+const kindDot: Record<string, string> = {
+  beta: "bg-emerald-500",
+  main: "bg-[var(--accent-gold)]",
+  pre: "bg-gray-500",
+};
+
+/**
+ * The "Version history" section on entity pages: the entity's own game-patch
+ * changes (data/entity_history.json), replacing the site-changelog diffs
+ * that used to masquerade as its history. Entities with nothing recorded
+ * fall back to the changelog timeline.
+ */
+export default function EntityUpdateHistory({
+  entityType,
+  entityId,
+}: {
+  entityType: string;
+  entityId: string;
+}) {
+  const { lang } = useLanguage();
+  const [entries, setEntries] = useState<UpdateEntry[] | null | "none">(null);
+
+  useEffect(() => {
+    cachedFetch<UpdateEntry[]>(`${API}/api/update-history/${entityType}/${entityId}`)
+      .then((d) => setEntries(d.length > 0 ? d : "none"))
+      .catch(() => setEntries("none"));
+  }, [entityType, entityId]);
+
+  if (entries === "none") {
+    return <EntityHistory entityType={entityType} entityId={entityId} />;
+  }
+
+  return (
+    <section id="history">
+      <h2>{t("Version history", lang)}</h2>
+      {entries === null ? (
+        <p className="text-xs text-[var(--text-muted)] m-0">Loading…</p>
+      ) : (
+        <div className="relative ml-2">
+          <div className="absolute left-[5px] top-2 bottom-2 w-px bg-[var(--border-subtle)]" />
+          <div className="space-y-4">
+            {entries.map((entry, i) => {
+              const kind = patchKind(entry.type);
+              return (
+                <div key={`${entry.version}-${i}`} className="relative pl-6">
+                  <div
+                    className={`absolute left-0 top-1.5 w-[11px] h-[11px] rounded-full border-2 border-[var(--bg-primary)] ${kindDot[kind]}`}
+                  />
+                  <div className="flex items-center gap-2 text-xs">
+                    <span className="font-semibold text-[var(--text-primary)]">
+                      {entry.version ?? t("Unknown", lang)}
+                    </span>
+                    {entry.type && <span className={kindText[kind]}>{entry.type}</span>}
+                    {entry.date && (
+                      <span className="text-[var(--text-muted)]">{entry.date}</span>
+                    )}
+                  </div>
+                  <ul className="mt-1.5 space-y-1 list-none m-0 p-0">
+                    {entry.changes.map((change, j) => (
+                      <li key={j} className="text-xs text-[var(--text-muted)]">
+                        {change}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/app/developers/page.tsx
+++ b/frontend/app/developers/page.tsx
@@ -282,6 +282,7 @@ export default async function DevelopersPage() {
                 { method: "GET", path: "/api/ancient-pools/{id}", desc: "Pools for a single ancient" },
                 { method: "GET", path: "/api/unlocks", desc: "Unlockable entities grouped by type with epoch context" },
                 { method: "GET", path: "/api/history/{entity_type}/{entity_id}", desc: "Per-entity version history from changelogs" },
+                { method: "GET", path: "/api/update-history/{entity_type}/{entity_id}", desc: "Per-entity game-patch update history" },
                 { method: "GET", path: "/api/names/{entity_type}/{entity_id}", desc: "Cross-language name lookup for an entity" },
                 { method: "GET", path: "/api/search", desc: "Unified site search across entities, reference entries, mechanics, guides, and news (q, lang)" },
                 { method: "GET", path: "/api/changelogs", desc: "All changelogs" },

--- a/frontend/app/enchantments/[id]/EnchantmentDetail.tsx
+++ b/frontend/app/enchantments/[id]/EnchantmentDetail.tsx
@@ -14,7 +14,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
-import EntityHistory from "@/app/components/EntityHistory";
+import EntityUpdateHistory from "@/app/components/EntityUpdateHistory";
 import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { imageUrl, enchantedCardUrl } from "@/lib/image-url";
@@ -199,7 +199,7 @@ export default function EnchantmentDetail({
           )}
 
           <LocalizedNames entityType="enchantments" entityId={id} />
-          <EntityHistory entityType="enchantments" entityId={id} />
+          <EntityUpdateHistory entityType="enchantments" entityId={id} />
         </main>
 
         {/* ===== INFOBOX column (sticky) ===== */}

--- a/frontend/app/encounters/[id]/EncounterDetail.tsx
+++ b/frontend/app/encounters/[id]/EncounterDetail.tsx
@@ -9,7 +9,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
-import EntityHistory from "@/app/components/EntityHistory";
+import EntityUpdateHistory from "@/app/components/EntityUpdateHistory";
 import EntityProse from "@/app/components/EntityProse";
 import type { EncounterStat } from "@/lib/encounter-stats";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
@@ -207,7 +207,7 @@ export default function EncounterDetail({ initialEncounter, encounterStat }: { i
 
           {/* Version history + localized names */}
           <LocalizedNames entityType="encounters" entityId={id} />
-          <EntityHistory entityType="encounters" entityId={id} />
+          <EntityUpdateHistory entityType="encounters" entityId={id} />
         </main>
 
         {/* ===== INFOBOX column (sticky) ===== */}

--- a/frontend/app/intents/[id]/IntentDetail.tsx
+++ b/frontend/app/intents/[id]/IntentDetail.tsx
@@ -9,7 +9,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
-import EntityHistory from "@/app/components/EntityHistory";
+import EntityUpdateHistory from "@/app/components/EntityUpdateHistory";
 import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { imageUrl } from "@/lib/image-url";
@@ -81,7 +81,7 @@ export default function IntentDetail({ initialIntent }: { initialIntent?: Intent
           </section>
 
           <LocalizedNames entityType="intents" entityId={id} />
-          <EntityHistory entityType="intents" entityId={id} />
+          <EntityUpdateHistory entityType="intents" entityId={id} />
         </main>
 
         {intent.image_url && (

--- a/frontend/app/modifiers/[id]/ModifierDetail.tsx
+++ b/frontend/app/modifiers/[id]/ModifierDetail.tsx
@@ -9,7 +9,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
-import EntityHistory from "@/app/components/EntityHistory";
+import EntityUpdateHistory from "@/app/components/EntityUpdateHistory";
 import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import "../../card-revamp.css";
@@ -80,7 +80,7 @@ export default function ModifierDetail({ initialModifier }: { initialModifier?: 
           </section>
 
           <LocalizedNames entityType="modifiers" entityId={id} />
-          <EntityHistory entityType="modifiers" entityId={id} />
+          <EntityUpdateHistory entityType="modifiers" entityId={id} />
         </main>
       </div>
     </div>

--- a/frontend/app/monsters/[id]/MonsterDetail.tsx
+++ b/frontend/app/monsters/[id]/MonsterDetail.tsx
@@ -11,7 +11,7 @@ import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { t } from "@/lib/ui-translations";
 import RichDescription from "@/app/components/RichDescription";
 import LocalizedNames from "@/app/components/LocalizedNames";
-import EntityHistory from "@/app/components/EntityHistory";
+import EntityUpdateHistory from "@/app/components/EntityUpdateHistory";
 import EntityProse from "@/app/components/EntityProse";
 import { imageUrl } from "@/lib/image-url";
 import "../../card-revamp.css";
@@ -762,7 +762,7 @@ export default function MonsterDetail({
 
           {/* Version history + localized names */}
           <LocalizedNames entityType="monsters" entityId={id} />
-          <EntityHistory entityType="monsters" entityId={id} />
+          <EntityUpdateHistory entityType="monsters" entityId={id} />
         </main>
 
         {/* ===== INFOBOX column (sticky) ===== */}

--- a/frontend/app/orbs/[id]/OrbDetail.tsx
+++ b/frontend/app/orbs/[id]/OrbDetail.tsx
@@ -9,7 +9,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
-import EntityHistory from "@/app/components/EntityHistory";
+import EntityUpdateHistory from "@/app/components/EntityUpdateHistory";
 import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { imageUrl } from "@/lib/image-url";
@@ -116,7 +116,7 @@ export default function OrbDetail({ initialOrb }: { initialOrb?: Orb | null } = 
           )}
 
           <LocalizedNames entityType="orbs" entityId={id} />
-          <EntityHistory entityType="orbs" entityId={id} />
+          <EntityUpdateHistory entityType="orbs" entityId={id} />
         </main>
 
         {orb.image_url && (

--- a/frontend/app/potions/[id]/PotionDetail.tsx
+++ b/frontend/app/potions/[id]/PotionDetail.tsx
@@ -9,7 +9,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
-import EntityHistory from "@/app/components/EntityHistory";
+import EntityUpdateHistory from "@/app/components/EntityUpdateHistory";
 import RelatedItems from "@/app/components/RelatedItems";
 import EntityProse from "@/app/components/EntityProse";
 import EntityPairings from "@/app/components/EntityPairings";
@@ -260,7 +260,7 @@ export default function PotionDetail({
 
           {/* Version history + localized names */}
           <LocalizedNames entityType="potions" entityId={id} />
-          <EntityHistory entityType="potions" entityId={id} />
+          <EntityUpdateHistory entityType="potions" entityId={id} />
         </main>
 
         {/* ===== INFOBOX column (sticky) ===== */}

--- a/frontend/app/powers/[id]/PowerDetail.tsx
+++ b/frontend/app/powers/[id]/PowerDetail.tsx
@@ -15,7 +15,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
-import EntityHistory from "@/app/components/EntityHistory";
+import EntityUpdateHistory from "@/app/components/EntityUpdateHistory";
 import EntityProse from "@/app/components/EntityProse";
 import { useLangPrefix } from "@/lib/use-lang-prefix";
 import { imageUrl } from "@/lib/image-url";
@@ -231,7 +231,7 @@ export default function PowerDetail({ initialPower }: { initialPower?: Power | n
 
           {/* Version history + localized names */}
           <LocalizedNames entityType="powers" entityId={id} />
-          <EntityHistory entityType="powers" entityId={id} />
+          <EntityUpdateHistory entityType="powers" entityId={id} />
         </main>
 
         {/* ===== INFOBOX column (sticky) ===== */}

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -9,7 +9,7 @@ import { cachedFetch } from "@/lib/fetch-cache";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 import LocalizedNames from "@/app/components/LocalizedNames";
-import EntityHistory from "@/app/components/EntityHistory";
+import EntityUpdateHistory from "@/app/components/EntityUpdateHistory";
 import RelatedItems from "@/app/components/RelatedItems";
 import EntityProse from "@/app/components/EntityProse";
 import EntityPairings from "@/app/components/EntityPairings";
@@ -297,7 +297,7 @@ export default function RelicDetail({
 
           {/* Version history + localized names */}
           <LocalizedNames entityType="relics" entityId={id} />
-          <EntityHistory entityType="relics" entityId={id} />
+          <EntityUpdateHistory entityType="relics" entityId={id} />
         </main>
 
         {/* ===== INFOBOX column (sticky) ===== */}

--- a/tools/entity_history_sync.py
+++ b/tools/entity_history_sync.py
@@ -1,0 +1,323 @@
+"""Sync per-entity game-patch update histories into data/entity_history.json.
+
+Pulls the templated "Update History" tables from the community wiki's
+MediaWiki API for every entity type that has pages there (cards, relics,
+monsters, events, powers, orbs, ...), joins patch type/date from the Cargo
+Patches table, and writes one JSON keyed by entity type and id. Types or
+entities without a page are simply absent; the site falls back to the
+changelog-derived timeline for those.
+
+Usage: python tools/entity_history_sync.py [--out data/entity_history.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import time
+import urllib.parse
+import urllib.request
+from datetime import date
+from pathlib import Path
+
+API = "https://slaythespire.wiki.gg/api.php"
+NAMESPACE = "Slay the Spire 2"
+USER_AGENT = "spire-codex.com entity history sync (im@ptrlrd.com)"
+BATCH = 50
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Category names identify the page's entity type, so a name shared across
+# types (e.g. the Accelerant card vs the Accelerant power) can't attach the
+# wrong page's history. Pages with no recognized category are accepted.
+TYPES: dict[str, dict] = {
+    "cards": {"file": "cards.json", "categories": {"Cards"}},
+    "relics": {"file": "relics.json", "categories": {"Relics"}},
+    "potions": {"file": "potions.json", "categories": {"Potions"}},
+    "monsters": {
+        "file": "monsters.json",
+        "categories": {"Monsters", "Elites", "Bosses", "Ancients"},
+    },
+    "encounters": {
+        "file": "encounters.json",
+        "categories": {"Monsters", "Elites", "Bosses", "Ancients", "Events"},
+    },
+    # The named story events are the Ancients themselves (Neow, Darv, ...),
+    # so their pages carry the Ancients category, not Events.
+    "events": {"file": "events.json", "categories": {"Events", "Ancients"}},
+    "powers": {
+        "file": "powers.json",
+        "categories": {"Game Mechanics", "Buffs", "Debuffs", "Powers"},
+    },
+    "orbs": {"file": "orbs.json", "categories": {"Orbs"}},
+    "keywords": {"file": "keywords.json", "categories": {"Game Mechanics", "Keywords"}},
+    "enchantments": {
+        "file": "enchantments.json",
+        "categories": {"Enchantments", "Game Mechanics"},
+    },
+    "characters": {
+        "file": "characters.json",
+        "categories": {"Character", "Characters"},
+    },
+}
+
+KNOWN_CATEGORIES: set[str] = set().union(*(t["categories"] for t in TYPES.values()))
+
+
+def api_get(params: dict) -> dict:
+    params = {**params, "format": "json"}
+    url = API + "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.load(resp)
+
+
+def fetch_patch_index() -> dict[str, dict]:
+    """Version -> {type, date}; first row per version wins."""
+    data = api_get(
+        {
+            "action": "cargoquery",
+            "tables": "Patches",
+            "fields": "Version,Type,ReleaseDate",
+            "where": 'Sequel="2"',
+            "limit": "500",
+        }
+    )
+    index: dict[str, dict] = {}
+    for row in data.get("cargoquery", []):
+        t = row["title"]
+        index.setdefault(t["Version"], {"type": t["Type"], "date": t["ReleaseDate"]})
+    return index
+
+
+def fetch_pages(titles: list[str]) -> dict[str, dict]:
+    """Title -> {"text": wikitext, "categories": set} for existing pages."""
+    data = api_get(
+        {
+            "action": "query",
+            "prop": "revisions|categories",
+            "rvprop": "content",
+            "rvslots": "main",
+            "cllimit": "max",
+            "redirects": "1",
+            "titles": "|".join(titles),
+        }
+    )
+    query = data.get("query", {})
+    redirect_map = {r["from"]: r["to"] for r in query.get("redirects", [])}
+    normalized = {n["from"]: n["to"] for n in query.get("normalized", [])}
+    by_title: dict[str, dict] = {}
+    for page in query.get("pages", {}).values():
+        if "revisions" not in page:
+            continue
+        by_title[page["title"]] = {
+            "text": page["revisions"][0]["slots"]["main"]["*"],
+            "categories": {
+                c["title"].removeprefix("Category:") for c in page.get("categories", [])
+            },
+        }
+    out: dict[str, dict] = {}
+    for title in titles:
+        resolved = normalized.get(title, title)
+        resolved = redirect_map.get(resolved, resolved)
+        if resolved in by_title:
+            out[title] = by_title[resolved]
+    return out
+
+
+def split_template_args(body: str) -> list[str]:
+    """Split template arg string on top-level pipes, respecting {{ }} and [[ ]]."""
+    args, depth, current = [], 0, []
+    i = 0
+    while i < len(body):
+        two = body[i : i + 2]
+        if two in ("{{", "[["):
+            depth += 1
+            current.append(two)
+            i += 2
+        elif two in ("}}", "]]"):
+            depth -= 1
+            current.append(two)
+            i += 2
+        elif body[i] == "|" and depth == 0:
+            args.append("".join(current))
+            current = []
+            i += 1
+        else:
+            current.append(body[i])
+            i += 1
+    args.append("".join(current))
+    return args
+
+
+TEMPLATE_RE = re.compile(r"\{\{([^{}|]+)(?:\|((?:[^{}]|\{\{[^{}]*\}\})*))?\}\}")
+
+
+def clean_wikitext(text: str) -> str:
+    """Flatten inline wiki markup to plain text."""
+    prev = None
+    while prev != text:
+        prev = text
+        text = TEMPLATE_RE.sub(_template_text, text)
+    text = re.sub(r"\[\[(?:[^\]|]*\|)?([^\]|]*)\]\]", r"\1", text)
+    text = text.replace("'''", "").replace("''", "")
+    text = re.sub(r"<[^>]+>", "", text)
+    return text
+
+
+def _template_text(match: re.Match) -> str:
+    name = match.group(1).strip().lower()
+    args = split_template_args(match.group(2) or "")
+    positional = [a for a in args if "=" not in a.split("{{")[0].split("[[")[0]]
+    if name == "tooltip":
+        return positional[0].strip() if positional else ""
+    if positional:
+        return positional[0].strip()
+    return ""
+
+
+ROW_RE = re.compile(r"\{\{Update History Table/row\s*\|", re.IGNORECASE)
+
+
+def parse_history(wikitext: str) -> list[dict]:
+    """Extract rows from the Update History section of a page."""
+    rows = []
+    for match in ROW_RE.finditer(wikitext):
+        start = match.end()
+        depth, i = 1, start
+        while i < len(wikitext) and depth:
+            if wikitext[i : i + 2] == "{{":
+                depth += 1
+                i += 2
+            elif wikitext[i : i + 2] == "}}":
+                depth -= 1
+                i += 2
+            else:
+                i += 1
+        body = wikitext[start : i - 2]
+        args = split_template_args(body)
+        positional = [a for a in args if not re.match(r"\s*\w+\s*=", a)]
+        if len(positional) < 2:
+            continue
+        version = positional[0].strip()
+        changes = [
+            re.sub(r"^\*+\s*", "", clean_wikitext(line)).strip()
+            for line in positional[1].splitlines()
+            if line.strip().lstrip("*").strip()
+        ]
+        overrides = {
+            k.strip().lower(): v.strip()
+            for k, v in (a.split("=", 1) for a in args if re.match(r"\s*\w+\s*=", a))
+        }
+        rows.append(
+            {
+                "version": None if version == "?" else version,
+                "changes": [c for c in changes if c],
+                "overrides": overrides,
+            }
+        )
+    return rows
+
+
+def load_entities(file_name: str) -> list[dict]:
+    data = json.loads((REPO / "data" / "eng" / file_name).read_text("utf-8"))
+    items = data if isinstance(data, list) else list(data.values())
+    return [i for i in items if isinstance(i, dict) and i.get("id") and i.get("name")]
+
+
+def title_candidates(entity_type: str, entity: dict, dup_names: set[str]) -> list[str]:
+    """Wiki page titles to try for an entity, most specific first."""
+    name = entity["name"]
+    candidates = []
+    if entity_type == "cards" and name in dup_names:
+        # Shared starter names resolve to per-character pages.
+        candidates.append(f"{name} ({entity.get('color', '').title()})")
+    candidates.append(name)
+    if name.startswith("The "):
+        candidates.append(name.removeprefix("The "))
+    return [f"{NAMESPACE}:{c}" for c in candidates]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", default=str(REPO / "data" / "entity_history.json"))
+    args = parser.parse_args()
+
+    patch_index = fetch_patch_index()
+    print(f"{len(patch_index)} patches")
+
+    # (type, id) -> candidate titles, plus the global unique title list.
+    wanted: dict[str, list[tuple[str, str]]] = {}
+    candidates_by_entity: dict[tuple[str, str], list[str]] = {}
+    for entity_type, spec in TYPES.items():
+        try:
+            entities = load_entities(spec["file"])
+        except OSError:
+            continue
+        names = [e["name"] for e in entities]
+        dup_names = {n for n in names if names.count(n) > 1}
+        for entity in entities:
+            key = (entity_type, entity["id"])
+            titles = title_candidates(entity_type, entity, dup_names)
+            candidates_by_entity[key] = titles
+            for title in titles:
+                wanted.setdefault(title, []).append(key)
+
+    titles = list(wanted)
+    pages: dict[str, dict] = {}
+    for offset in range(0, len(titles), BATCH):
+        chunk = titles[offset : offset + BATCH]
+        pages.update(fetch_pages(chunk))
+        print(f"  fetched {min(offset + BATCH, len(titles))}/{len(titles)}")
+        time.sleep(1)
+
+    histories: dict[str, dict[str, list]] = {}
+    skipped_wrong_type: list[str] = []
+    for (entity_type, entity_id), candidates in candidates_by_entity.items():
+        expected = TYPES[entity_type]["categories"]
+        for title in candidates:
+            page = pages.get(title)
+            if page is None:
+                continue
+            cats = page["categories"] & KNOWN_CATEGORIES
+            if cats and not (cats & expected):
+                skipped_wrong_type.append(f"{entity_type}/{entity_id} -> {title}")
+                continue
+            rows = parse_history(page["text"])
+            if not rows:
+                break
+            entries = []
+            for row in rows:
+                patch = patch_index.get(row["version"] or "", {})
+                entries.append(
+                    {
+                        "version": row["version"],
+                        "type": row["overrides"].get("type") or patch.get("type"),
+                        "date": row["overrides"].get("date") or patch.get("date"),
+                        "changes": row["changes"],
+                    }
+                )
+            # Hand-edited tables aren't reliably ordered; guarantee newest
+            # first, undated rows last.
+            entries.sort(key=lambda e: e["date"] or "", reverse=True)
+            histories.setdefault(entity_type, {})[entity_id] = entries
+            break
+
+    out = {
+        "_meta": {"fetched": date.today().isoformat()},
+        "types": histories,
+    }
+    Path(args.out).write_text(
+        json.dumps(out, ensure_ascii=False, indent=1) + "\n", "utf-8"
+    )
+    counts = {t: len(v) for t, v in histories.items()}
+    print(f"wrote {args.out}: {counts}")
+    if skipped_wrong_type:
+        print(f"skipped wrong-type pages ({len(skipped_wrong_type)}):")
+        for line in skipped_wrong_type[:20]:
+            print(f"  {line}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The Version history section on entity pages showed site-changelog diffs rather than the entity's actual balance history; I now maintain real per-patch histories in data/entity_history.json (811 entities across cards, relics, monsters, encounters, and events; refresh via tools/entity_history_sync.py), serve them at /api/update-history/{type}/{id}, and render them on every detail page with a fallback to the old timeline where nothing is recorded. Covers the version-history item in #795.