### PR TITLE
Remove card trivia

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -107,9 +107,6 @@ class Card(BaseModel):
     # Which monsters generate this card in combat (parsed from the game code —
     # see card_parser.build_card_sources). Absent on cards with no source.
     sources: list[CardSource] | None = None
-    # A short "did you know" note — a curated line (data/card_trivia.json) or a
-    # derived one, merged in by the card endpoint. English-only, like the prose.
-    trivia: str | None = None
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/backend/app/routers/cards.py
+++ b/backend/app/routers/cards.py
@@ -1,44 +1,11 @@
 """Card API endpoints."""
 
-import json
-from functools import lru_cache
-
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from ..models.schemas import Card
-from ..services.data_service import DATA_DIR, load_cards, load_translation_maps
+from ..services.data_service import load_cards, load_translation_maps
 from ..dependencies import get_lang, matches_search
 
 router = APIRouter(prefix="/api/cards", tags=["Cards"])
-
-# Card types with few enough members that "one of N" reads as a fun fact.
-_TRIVIA_TYPES = {"Status", "Curse", "Power"}
-
-
-@lru_cache(maxsize=1)
-def _curated_trivia() -> dict[str, str]:
-    """Hand-written 'did you know' lines keyed by card id, from a flat file the
-    card parser can't overwrite on regen. English-only; empty if the file's
-    absent."""
-    try:
-        with open(DATA_DIR / "card_trivia.json", "r", encoding="utf-8") as f:
-            data = json.load(f)
-            return data if isinstance(data, dict) else {}
-    except (OSError, ValueError):
-        return {}
-
-
-def _resolve_trivia(card: dict, cards: list[dict]) -> str | None:
-    """A curated line if we have one, else a derived 'one of N <type>' fact for
-    the special card types (Status/Curse/Power)."""
-    curated = _curated_trivia().get(card["id"])
-    if curated:
-        return curated
-    ctype = card.get("type")
-    if ctype in _TRIVIA_TYPES:
-        n = sum(1 for c in cards if c.get("type") == ctype)
-        if n > 1:
-            return f"{card['name']} is one of {n} {ctype} cards in Slay the Spire 2."
-    return None
 
 
 def _matches_cost(card: dict, want: str) -> bool:
@@ -141,7 +108,5 @@ def get_card(request: Request, card_id: str, lang: str = Depends(get_lang)):
     cards = load_cards(lang)
     for card in cards:
         if card["id"] == card_id.upper():
-            trivia = _resolve_trivia(card, cards)
-            # Copy so the trivia we add doesn't stick to the lru-cached list.
-            return {**card, "trivia": trivia} if trivia else card
+            return card
     raise HTTPException(status_code=404, detail=f"Card '{card_id}' not found")

--- a/backend/tests/test_schema_fields.py
+++ b/backend/tests/test_schema_fields.py
@@ -12,6 +12,10 @@ from app.models.schemas import Act, Card, Character, Epoch
 DATA = Path(__file__).resolve().parents[2] / "data" / "eng"
 
 
+def test_trivia_stays_removed():
+    assert "trivia" not in Card.model_fields
+
+
 def _first_with(entities, key):
     entity = next((e for e in entities if key in e), None)
     if entity is None:

--- a/data/card_trivia.json
+++ b/data/card_trivia.json
@@ -1,3 +1,0 @@
-{
-  "WITHER": "Wither can't be played; it just sits in your hand, dealing damage at the end of every turn. Aeonglass keeps handing you more of them (already upgraded) the longer the fight drags on."
-}

--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -419,14 +419,6 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
             {/* Overview prose as the hero lead (replaces the old token-stripped
                 description lede, which rendered blanks like "Gain ."). */}
             <EntityProse kind="card" card={card} lead />
-            {card.trivia && (
-              <p className="mt-3 rounded-md border-l-2 border-[var(--accent-gold)]/50 bg-[var(--accent-gold)]/5 px-3 py-2 text-sm leading-relaxed text-[var(--text-secondary)]">
-                <span className="font-semibold text-[var(--accent-gold)]">
-                  {t("Did you know?", lang)}{" "}
-                </span>
-                {card.trivia}
-              </p>
-            )}
           </div>
 
           {/* Sticky ToC */}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -87,8 +87,6 @@ export interface Card {
   /** Monsters that generate this card in combat (status cards etc.), parsed
    *  from the game code. Absent on cards with no in-combat source. */
   sources?: { type: string; id: string; name: string }[] | null;
-  /** A short "did you know" note (curated or derived), merged by the API. */
-  trivia?: string | null;
 }
 
 export interface CharacterDialogueLine {


### PR DESCRIPTION
The trivia lines were placeholder filler from building out the JSON and not helping anywhere, so I removed the section, the API field, and the data file entirely. Covers the trivia item in #795.