### PR TITLE
Add slight letter-spacing to small Kreon text

### DIFF
--- a/frontend/app/card-revamp.css
+++ b/frontend/app/card-revamp.css
@@ -291,3 +291,15 @@ a.kw { text-decoration: none; }
   font-variant-numeric: tabular-nums;
 }
 .card-rvmp .draft-lift { color: var(--accent-gold); font-weight: 600; }
+
+/* Kreon tracks tight at these small sizes; open the non-mono small text up
+   slightly (the mono labels carry their own wider tracking already). */
+.card-rvmp .toc a,
+.card-rvmp .h-note,
+.card-rvmp .frow,
+.card-rvmp .kw,
+.card-rvmp .mini .ml,
+.card-rvmp .brkt-pill,
+.card-rvmp .ench-desc {
+  letter-spacing: 0.015em;
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -197,6 +197,13 @@ select.filter-select optgroup {
   padding-block: 3px;
 }
 
+/* Kreon sets tight below ~14px; a touch of tracking keeps dense UI text
+   readable. :where() keeps specificity at zero so any explicit tracking-*
+   utility on the same element still wins. */
+:where(.text-xs, .text-sm) {
+  letter-spacing: 0.015em;
+}
+
 /* Site-wide atmospheric background: the main-menu art, fixed to the viewport
    and kept faint so it reads as a textured ground behind every page. It paints
    above the body's base color (var(--bg-primary)) but behind all content, so it


### PR DESCRIPTION
Kreon reads tight at small sizes, so the small text utilities and the card-page small styles get 0.015em of tracking (zero-specificity selector, so explicit tracking utilities still win). Covers the letter-spacing item in #795.