### PR TITLE
Show L, not R, for losses in the recent runs column

### DIFF
--- a/frontend/app/components/HomeLeaderboardLive.tsx
+++ b/frontend/app/components/HomeLeaderboardLive.tsx
@@ -294,7 +294,7 @@ export default function HomeLeaderboardLive({
                           </td>
                           <td className="num">
                             {result === "win" && <span className="wr-sg" title="Win">W</span>}
-                            {result === "loss" && <span className="wr-loss" title="Loss">R</span>}
+                            {result === "loss" && <span className="wr-loss" title="Loss">L</span>}
                             {result === "abandoned" && <span className="dim" title="Abandoned">A</span>}
                           </td>
                           <td className="num dim">{formatRelativeDate(r.submitted_at)}</td>


### PR DESCRIPTION
The recent-runs result column on the home leaderboard now shows W/L/A instead of W/R/A; the R was a typo.