### PR TITLE
Deploy the rebuilder too, and fix the two lying dashboard metrics

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -99,6 +99,7 @@ from .metrics import (
     version_usage,
     widget_loads,
     compare_views,
+    sweep_dead_worker_gauges,
 )
 
 # ── Structured logging ────────────────────────────────────────
@@ -475,6 +476,8 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         if request.url.path in _SKIP_PATHS:
+            if request.url.path == "/metrics":
+                sweep_dead_worker_gauges()
             return await call_next(request)
 
         # Resolve the rate-limit tier BEFORE SlowAPIMiddleware runs (this
@@ -565,7 +568,14 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         # URLs bloated the counter and pegged memory/CPU until the
         # container OOM-killed. _normalize_path collapses to a bounded
         # template set regardless of traffic.
-        if response.status_code >= 400:
+        # Presence 404s are the protocol, not errors: the overlay and
+        # compendium poll /api/presence/<steam_id> and 404 means "not in
+        # a run right now". Counting them buried real errors (they were
+        # ~250/min of a 253/min "error" rate on 2026-08-11).
+        is_presence_miss = response.status_code == 404 and path.startswith(
+            "/api/presence/"
+        )
+        if response.status_code >= 400 and not is_presence_miss:
             api_errors.labels(
                 status_code=str(response.status_code),
                 method=request.method,

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -1,19 +1,72 @@
 """Prometheus metrics for Spire Codex."""
 
-from prometheus_client import Counter, Gauge, Histogram
+import os
+import time
+
+from prometheus_client import Counter, Gauge, Histogram, multiprocess
 
 # ── HTTP / Traffic ────────────────────────────────────────────
 # multiprocess_mode='livesum': under uvicorn --workers N, every worker
 # tracks its own in-flight gauge value. We want the fleet total, so
-# the multiproc collector sums each worker's value at scrape time and
-# ignores files from dead workers. Without an explicit mode, the
-# prometheus_client multiproc collector refuses to register the gauge
-# at all.
+# the multiproc collector sums each worker's value at scrape time.
+# "live" only excludes a dead worker once mark_process_dead() removes
+# its gauge files — uvicorn has no gunicorn-style child_exit hook, so
+# sweep_dead_worker_gauges() below does that cleanup on scrape.
+# Without an explicit mode, the prometheus_client multiproc collector
+# refuses to register the gauge at all.
 requests_in_flight = Gauge(
     "spire_codex_requests_in_flight",
     "Number of requests currently being processed",
     multiprocess_mode="livesum",
 )
+
+_SWEEP_INTERVAL = 60.0
+_last_sweep = 0.0
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def sweep_dead_worker_gauges() -> None:
+    """Drop gauge files left behind by dead uvicorn workers.
+
+    A worker that dies mid-request (recycle, OOM kill) leaves its last
+    in-flight value in the multiproc dir, and 'livesum' keeps summing it
+    forever — the fleet gauge only ever climbs (854 -> 1746 within a day
+    on 2026-08-11 while the box held ~240 real connections). Called from
+    the /metrics scrape path, at most once per _SWEEP_INTERVAL."""
+    global _last_sweep
+    now = time.monotonic()
+    if now - _last_sweep < _SWEEP_INTERVAL:
+        return
+    _last_sweep = now
+    mp_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR") or os.environ.get(
+        "prometheus_multiproc_dir"
+    )
+    if not mp_dir or not os.path.isdir(mp_dir):
+        return
+    me = os.getpid()
+    dead: set[int] = set()
+    for fname in os.listdir(mp_dir):
+        stem = fname.rsplit(".", 1)[0]
+        pid_part = stem.rsplit("_", 1)[-1]
+        if pid_part.isdigit():
+            pid = int(pid_part)
+            if pid != me and not _pid_alive(pid):
+                dead.add(pid)
+    for pid in dead:
+        try:
+            multiprocess.mark_process_dead(pid, mp_dir)
+        except OSError:
+            pass  # another worker swept it concurrently
+
 
 response_size = Histogram(
     "spire_codex_response_size_bytes",

--- a/backend/tests/test_metrics_hygiene.py
+++ b/backend/tests/test_metrics_hygiene.py
@@ -1,0 +1,51 @@
+"""The in-flight gauge must not accumulate values from dead uvicorn workers
+(uvicorn has no gunicorn child_exit hook, so 'livesum' needs our sweep), and
+presence-poll 404s must not count as API errors (they're the protocol's
+"not in a run right now" answer)."""
+
+import os
+
+from app import metrics
+
+
+def test_sweep_removes_dead_worker_gauge_files(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+    me = os.getpid()
+    # Find a PID that certainly isn't running.
+    dead_pid = 2
+    while _alive(dead_pid):
+        dead_pid += 1
+    live_file = tmp_path / f"gauge_livesum_{me}.db"
+    dead_file = tmp_path / f"gauge_livesum_{dead_pid}.db"
+    live_file.write_bytes(b"")
+    dead_file.write_bytes(b"")
+    monkeypatch.setattr(metrics, "_last_sweep", 0.0)
+
+    metrics.sweep_dead_worker_gauges()
+
+    assert live_file.exists(), "own gauge file must survive"
+    assert not dead_file.exists(), "dead worker's gauge file must be removed"
+
+
+def test_sweep_is_throttled(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+    dead_pid = 2
+    while _alive(dead_pid):
+        dead_pid += 1
+    monkeypatch.setattr(metrics, "_last_sweep", 0.0)
+    metrics.sweep_dead_worker_gauges()
+    # Second call inside the interval must not touch the dir.
+    stale = tmp_path / f"gauge_livesum_{dead_pid}.db"
+    stale.write_bytes(b"")
+    metrics.sweep_dead_worker_gauges()
+    assert stale.exists()
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True

--- a/infrastructure/ansible/files/autodeploy.sh
+++ b/infrastructure/ansible/files/autodeploy.sh
@@ -85,7 +85,10 @@ if [ "$RECREATE" = "1" ]; then
   # this stack (served at /beta from the same containers), so the old
   # second pass over docker-compose.beta.yml is gone.
   log "  deploying $COMPOSE_FILE"
-  docker compose -f "$COMPOSE_FILE" pull backend frontend >> "$LOG" 2>&1
+  # The rebuilder MUST ride along: it holds the stats-refresher lease, so
+  # leaving it on an old image keeps the fleet pinned to the old snapshot
+  # version forever (no v22 ever built after the 2026-08-11 deploy).
+  docker compose -f "$COMPOSE_FILE" pull backend frontend rebuilder >> "$LOG" 2>&1
 
   # Pre-warm the stats snapshot with the NEW image before swapping
   # containers. If the new code bumped SNAPSHOT_VERSION, this runs the
@@ -108,7 +111,7 @@ if [ "$RECREATE" = "1" ]; then
     fi
   fi
 
-  docker compose -f "$COMPOSE_FILE" up -d --force-recreate backend frontend >> "$LOG" 2>&1
+  docker compose -f "$COMPOSE_FILE" up -d --force-recreate backend frontend rebuilder >> "$LOG" 2>&1
 
   # Settle. 5s is enough for FastAPI startup; longer waits don't help.
   sleep 5

--- a/infrastructure/ansible/playbooks/deploy.yml
+++ b/infrastructure/ansible/playbooks/deploy.yml
@@ -43,7 +43,7 @@
 
     - name: Pull latest backend image
       become: true
-      command: docker compose -f {{ compose_file }} pull backend frontend
+      command: docker compose -f {{ compose_file }} pull backend frontend rebuilder
       args:
         chdir: "{{ spire_codex_dir }}"
       register: pull_result
@@ -51,7 +51,7 @@
 
     - name: Recreate backend + frontend containers
       become: true
-      command: docker compose -f {{ compose_file }} up -d --force-recreate backend frontend
+      command: docker compose -f {{ compose_file }} up -d --force-recreate backend frontend rebuilder
       args:
         chdir: "{{ spire_codex_dir }}"
 


### PR DESCRIPTION
Three ops fixes from today's investigation: the autodeploy script and deploy playbook now pull and recreate the rebuilder alongside backend+frontend (it holds the stats-refresher lease, so leaving it on an old image pinned the fleet to v21 all day after #832 merged); presence-poll 404s no longer count as API errors (they are the protocol's not-in-a-run answer and were ~250 of the 253 errors/min); and the in-flight gauge sweeps dead uvicorn workers' files on scrape so livesum stops accumulating values from killed workers (854 to 1,746 phantom in-flight on a box with ~240 real connections).