### PR TITLE
Inherit stable image_url on beta rows so portraits stop 404ing

### DIFF
--- a/backend/app/services/data_service.py
+++ b/backend/app/services/data_service.py
@@ -155,7 +155,39 @@ def _load_json_beta(lang: str, entity: str, beta_version: str) -> list[dict]:
     with open(filepath, "r", encoding="utf-8") as f:
         data = json.load(f)
     data_load_duration.labels(entity_type=entity).observe(time.perf_counter() - start)
+    _inherit_stable_image_urls(data, lang, entity)
     return data
+
+
+def _inherit_stable_image_urls(rows: list[dict], lang: str, entity: str) -> None:
+    """Beta catalogs ship image_url null across the board (the beta parsers
+    never stamp it), and the versioned beta portrait tree on the CDN was
+    retired with the flat layout — so clients that guess an old
+    /static/images/beta/v<ver>/ path 404 on every portrait (the Overwolf
+    overlay did exactly that, 2026-08-11). Portrait art is shared across
+    channels, so fill the gap from the stable row with the same id.
+    Beta-only ids with no stable counterpart stay null, same as before.
+    Runs once per (lang, entity, beta_version) thanks to the caller's cache.
+    Full card renders (image_url_card and friends) are left alone: those are
+    channel-specific and clients build the versioned beta paths themselves."""
+    missing = [
+        r
+        for r in rows
+        if isinstance(r, dict) and "image_url" in r and r.get("image_url") is None
+    ]
+    if not missing:
+        return
+    stable_urls = {
+        r.get("id"): r.get("image_url")
+        for r in _load_json_versioned(lang, entity, None)
+        if isinstance(r, dict) and r.get("image_url")
+    }
+    if not stable_urls:
+        return
+    for r in missing:
+        url = stable_urls.get(r.get("id"))
+        if url:
+            r["image_url"] = url
 
 
 def _load_json(lang: str, entity: str) -> list[dict]:

--- a/backend/tests/test_beta_image_inherit.py
+++ b/backend/tests/test_beta_image_inherit.py
@@ -1,0 +1,62 @@
+"""Beta rows must inherit the stable image_url by id: the beta catalogs ship
+image_url null everywhere and the CDN's versioned beta portrait tree is gone,
+so without inheritance every beta portrait 404s (broke the Overwolf overlay
+on 2026-08-11). Beta-only ids stay null; stable rows must not be mutated."""
+
+from app.services import data_service
+
+
+def _fake_stable(rows):
+    def loader(lang, entity, version):
+        return rows
+
+    return loader
+
+
+def test_null_image_urls_inherit_from_stable_by_id(monkeypatch):
+    stable = [
+        {
+            "id": "MUMMIFIED_HAND",
+            "image_url": "/static/images/relics/mummified_hand.webp",
+        },
+        {"id": "PEN_NIB", "image_url": "/static/images/relics/pen_nib.webp"},
+    ]
+    monkeypatch.setattr(data_service, "_load_json_versioned", _fake_stable(stable))
+    beta = [
+        {"id": "MUMMIFIED_HAND", "image_url": None},
+        {"id": "BRAND_NEW_BETA_RELIC", "image_url": None},
+    ]
+
+    data_service._inherit_stable_image_urls(beta, "eng", "relics")
+
+    assert beta[0]["image_url"] == "/static/images/relics/mummified_hand.webp"
+    assert beta[1]["image_url"] is None, "beta-only ids have no art to inherit"
+    assert stable[0]["image_url"] == "/static/images/relics/mummified_hand.webp"
+
+
+def test_rows_without_image_url_key_are_untouched(monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        data_service,
+        "_load_json_versioned",
+        lambda *a: called.append(a) or [],
+    )
+    rows = [{"id": "KEYWORD_X", "text": "no image field on this schema"}]
+
+    data_service._inherit_stable_image_urls(rows, "eng", "keywords")
+
+    assert rows == [{"id": "KEYWORD_X", "text": "no image field on this schema"}]
+    assert not called, "no stable load when nothing is missing"
+
+
+def test_present_beta_image_urls_are_kept(monkeypatch):
+    stable = [{"id": "CHOMPER", "image_url": "/static/images/monsters/chomper.webp"}]
+    monkeypatch.setattr(data_service, "_load_json_versioned", _fake_stable(stable))
+    beta = [
+        {"id": "CHOMPER", "image_url": "/static/images/monsters/chomper_v2.webp"},
+        {"id": "AEONGLASS", "image_url": None},
+    ]
+
+    data_service._inherit_stable_image_urls(beta, "eng", "monsters")
+
+    assert beta[0]["image_url"] == "/static/images/monsters/chomper_v2.webp"


### PR DESCRIPTION
Beta catalogs ship image_url null for every entity and the versioned beta portrait tree is gone from the CDN, so the Overwolf overlay's guessed /static/images/beta/v0.110.0/ paths 404 on the entire catalog - beta rows now inherit the stable row's image_url by id at load time, which fixes the overlay (it prefers image_url when present) and the beta site without an overlay release.