### PR TITLE
Read the run hash from _id so profile insights actually find runs

### DIFF
--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -2520,8 +2520,6 @@ def get_user_run_rows(user_id: str, limit: int = 2000) -> list[dict]:
                 "hidden": {"$ne": True},
             },
             {
-                "_id": 0,
-                "run_hash": 1,
                 "win": 1,
                 "character": 1,
                 "ascension": 1,
@@ -2533,7 +2531,14 @@ def get_user_run_rows(user_id: str, limit: int = 2000) -> list[dict]:
         .sort("submitted_at", DESCENDING)
         .limit(max(1, limit))
     )
-    return [r for r in cursor if r.get("run_hash")]
+    # The run hash is the document _id (same as get_user_runs); there is no
+    # run_hash field, so projecting one returns rows with no hash and the
+    # insights walk sees zero runs.
+    rows = []
+    for r in cursor:
+        r["run_hash"] = r.pop("_id")
+        rows.append(r)
+    return rows
 
 
 @_instrument("get_user_card_pick_tallies")

--- a/backend/tests/test_user_run_rows.py
+++ b/backend/tests/test_user_run_rows.py
@@ -1,0 +1,67 @@
+"""get_user_run_rows must surface the run hash from the document _id: runs
+have no run_hash field (the hash IS _id, see get_user_runs), and projecting a
+nonexistent run_hash returned rows without hashes — the insights walk then
+loaded zero blobs and every profile rendered the "No insights yet" empty
+state (found live on 2026-08-11)."""
+
+from datetime import datetime, timedelta
+
+from app.services import runs_db_mongo
+
+
+def _apply_projection(doc, projection):
+    projection = projection or {}
+    out = {k: doc[k] for k, v in projection.items() if v and k != "_id" and k in doc}
+    if projection.get("_id", 1):
+        out["_id"] = doc["_id"]
+    return out
+
+
+class FakeCursor:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def sort(self, *a, **k):
+        return self
+
+    def limit(self, n):
+        self.docs = self.docs[:n]
+        return self
+
+    def __iter__(self):
+        return iter(self.docs)
+
+
+class FakeColl:
+    """Mongo-faithful on the one point that matters here: documents carry
+    _id and no run_hash, and the projection is applied literally."""
+
+    def __init__(self, docs):
+        self.docs = docs
+
+    def find(self, q, projection=None, **kwargs):
+        return FakeCursor([_apply_projection(d, projection) for d in self.docs])
+
+
+def test_run_hash_comes_from_document_id(monkeypatch):
+    now = datetime.utcnow()
+    docs = [
+        {
+            "_id": f"hash{i}",
+            "user_id": "ignored-by-fake",
+            "win": i % 2 == 0,
+            "character": "IRONCLAD",
+            "ascension": 10,
+            "submitted_at": now - timedelta(hours=i),
+            "game_mode": "standard",
+            "player_count": 1,
+        }
+        for i in range(3)
+    ]
+    monkeypatch.setattr(runs_db_mongo, "_get_collection", lambda: FakeColl(docs))
+
+    rows = runs_db_mongo.get_user_run_rows("0" * 24)
+
+    assert [r["run_hash"] for r in rows] == ["hash0", "hash1", "hash2"]
+    assert all("_id" not in r for r in rows)
+    assert rows[0]["character"] == "IRONCLAD"


### PR DESCRIPTION
The insights walk projected a run_hash field that does not exist (the hash is the document _id, same as get_user_runs reads it), so get_user_run_rows returned nothing and every profile showed the No-insights empty state despite claimed runs - the hash now comes from _id and a regression test fakes the real document shape.