### PR TITLE
Prewarm profile insights on sign-in and keep them for a day

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -32,6 +32,13 @@ def me(request: Request):
     user = get_current_user(request)
     if not user:
         raise HTTPException(status_code=401, detail="Not authenticated")
+    if os.environ.get("MONGO_URL", "").strip():
+        try:
+            from ..services.user_insights import prewarm_user_insights
+
+            prewarm_user_insights(str(user["_id"]), username=user.get("username"))
+        except Exception:
+            pass  # prewarm is an optimization; /me must never fail on it
     return {
         "user_id": user["_id"],
         "username": user.get("username"),

--- a/backend/app/services/user_insights.py
+++ b/backend/app/services/user_insights.py
@@ -384,7 +384,7 @@ def _bare_character(raw: str | None) -> str:
 # live in Redis so all workers share them; a fresh marker with the old 120s
 # TTL decides when to re-walk, and stale copies keep serving instantly while
 # the refresh runs behind them.
-_STALE_REDIS_TTL = 6 * 3600
+_STALE_REDIS_TTL = 24 * 3600
 _LOCK_TTL = 15 * 60
 
 _inflight: set[str] = set()
@@ -421,6 +421,23 @@ def get_user_insights(
     if payload is not None:
         return payload
     return {"building": True}
+
+
+def prewarm_user_insights(user_id: str, username: str | None = None) -> None:
+    """Fill a cold cache before the user ever opens their profile (called from
+    /me, which fires on every page load). Kicks the background walk only when
+    NO payload exists at all — any cached copy, however stale, already serves
+    instantly and the view path handles refreshing it, so prewarming again
+    would just burn walks on every page view. Costs one local dict hit plus
+    at most one Redis GET per call."""
+    from . import cache as app_cache
+
+    cache_key = f"{user_id}:"
+    if _cache_get(cache_key) is not None:
+        return
+    if app_cache.get_json(_payload_key(cache_key)) is not None:
+        return
+    _kick_refresh(cache_key, user_id, username, None)
 
 
 def _kick_refresh(

--- a/backend/tests/test_user_insights.py
+++ b/backend/tests/test_user_insights.py
@@ -118,6 +118,33 @@ def test_insights_build_then_cache(monkeypatch):
     assert calls["n"] == 1
 
 
+def test_prewarm_kicks_only_when_cold(monkeypatch):
+    walks = {"n": 0}
+
+    def rows(uid, limit):
+        walks["n"] += 1
+        return []
+
+    monkeypatch.setattr(runs_db_mongo, "get_user_run_rows", rows)
+    monkeypatch.setattr(runs_db_mongo, "get_run_blobs", lambda h: {})
+    monkeypatch.setattr(
+        runs_db_mongo, "get_user_card_pick_tallies", lambda uid, character=None: {}
+    )
+    monkeypatch.setattr(user_insights, "get_community_stats", lambda: {})
+    monkeypatch.setattr(
+        user_insights, "get_entity_metrics_table", lambda etype: {"rows": []}
+    )
+    monkeypatch.setattr(user_insights.threading, "Thread", _InlineThread)
+    user_insights._cache.clear()
+
+    user_insights.prewarm_user_insights("u2")
+    assert walks["n"] == 1
+    # Warm cache: prewarm is a no-op, the profile serves without building.
+    user_insights.prewarm_user_insights("u2")
+    assert walks["n"] == 1
+    assert user_insights.get_user_insights("u2")["runs_walked"] == 0
+
+
 def test_event_divergence_needs_sample_and_gap():
     mine = {
         "events": [


### PR DESCRIPTION
Two follow-ups so nobody actually waits on the crunching notice: /me now kicks the background walk when the cache is cold (it fires on every page load, so the walk finishes before anyone reaches their profile) and the Redis payload lives 24 hours instead of 6 so any computed profile keeps serving instantly all day while refreshes run behind it.