### PR TITLE
Add a time-to-win chart so players can see how long winning runs take

### DIFF
--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -256,6 +256,14 @@ CHARTS: dict[str, dict] = {
         "axis": {"x": "stat", "y": "% of runs"},
         "desc": "How a run stat is distributed across the filtered runs.",
     },
+    "time-to-win": {
+        "label": "How long a winning run takes",
+        "group": "Distributions",
+        "kind": "frame",
+        "splits": _RATE_SPLITS,
+        "axis": {"x": "Run length (minutes)", "y": "% of wins"},
+        "desc": "Run length of victorious runs in 5-minute buckets. Each series shows its average and median in the legend. Wins only.",
+    },
     "stat-scatter": {
         "label": "Stat vs stat scatter",
         "group": "Distributions",
@@ -322,6 +330,8 @@ def _build_frame_chart(
         return cs.winrate_by_stat(rows, stat or "deck_size", split)
     if key == "stat-histogram":
         return cs.stat_histogram(rows, stat or "floors_reached", split)
+    if key == "time-to-win":
+        return cs.time_to_win(rows, split)
     if key == "stat-scatter":
         return cs.stat_scatter(rows, x or "floors_reached", y or "deck_size", split)
     if key == "acts-funnel":

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -593,6 +593,47 @@ def stat_histogram(rows: list[tuple], stat_key: str, split: str) -> list[dict]:
     return series
 
 
+def time_to_win(rows: list[tuple], split: str) -> list[dict]:
+    """How long winning runs take: run length of wins in 5-minute buckets,
+    with each series' average and median baked into its label so "how long
+    does it take to beat a run" is answered right in the legend. Zero-length
+    times are runs whose file carried no timer, not instant wins."""
+    stat = STATS["run_minutes"]
+    series = []
+    for sid, label, sub in _series_split(rows, split):
+        mins = sorted(
+            v
+            for r in sub
+            if r[WIN]
+            for v in (_stat_value(r, stat),)
+            if 0 < v <= stat["max"]
+        )
+        n = len(mins)
+        if n < MIN_POINT_N:
+            continue
+        buckets: dict[int, int] = {}
+        for v in mins:
+            b = int(v // stat["bucket"]) * stat["bucket"]
+            buckets[b] = buckets.get(b, 0) + 1
+        avg = sum(mins) / n
+        med = mins[n // 2] if n % 2 else (mins[n // 2 - 1] + mins[n // 2]) / 2
+        points = [
+            {"x": b, "y": round(c / n * 100, 2), "n": c}
+            for b, c in sorted(buckets.items())
+        ]
+        series.append(
+            {
+                "id": sid,
+                "label": f"{label} (avg {avg:.0f}m, median {med:.0f}m)",
+                "points": points,
+                "total": n,
+                "avg_minutes": round(avg, 1),
+                "median_minutes": round(med, 1),
+            }
+        )
+    return series
+
+
 def stat_scatter(rows: list[tuple], x_key: str, y_key: str, split: str) -> list[dict]:
     sx, sy = STATS[x_key], STATS[y_key]
     groups = [g for g in _series_split(rows, split) if g[0] != "ALL"]

--- a/backend/tests/test_time_to_win.py
+++ b/backend/tests/test_time_to_win.py
@@ -1,0 +1,35 @@
+"""The time-to-win chart answers "how long does it take to beat a run": wins
+only, zero/missing timers excluded, average and median in the series label."""
+
+from app.services import charts_stats as cs
+
+
+def _row(win: bool, minutes: float) -> tuple:
+    r = [0] * 15
+    r[cs.WIN] = 1 if win else 0
+    r[cs.TIME] = int(minutes * 60)
+    return tuple(r)
+
+
+def test_time_to_win_wins_only_with_avg_and_median():
+    rows = [_row(True, 40)] * 10 + [_row(True, 50)] * 10 + [_row(True, 90)]
+    rows += [_row(False, 300)] * 30  # losses never count
+    rows += [_row(True, 0)] * 30  # missing timers never count
+
+    series = cs.time_to_win(rows, "")
+
+    assert len(series) == 1
+    s = series[0]
+    assert s["id"] == "ALL"
+    assert s["total"] == 21
+    # (10*40 + 10*50 + 90) / 21; the odd-count middle (index 10) is 50.
+    assert s["avg_minutes"] == 47.1
+    assert s["median_minutes"] == 50.0
+    assert "avg 47m" in s["label"] and "median 50m" in s["label"]
+    assert [p["x"] for p in s["points"]] == [40, 50, 90]
+    assert s["points"][0]["n"] == 10
+
+
+def test_time_to_win_needs_min_sample():
+    rows = [_row(True, 40)] * (cs.MIN_POINT_N - 1)
+    assert cs.time_to_win(rows, "") == []


### PR DESCRIPTION
Answers the Discord ask for the average time to beat a run: a new Distributions chart on /charts plots winning runs' length in 5-minute buckets with the average and median right in each series label, splittable by character, players, and ascension, composing with the existing version and bracket filters.