### PR TITLE
Add a daily average win time line chart under Combat

### DIFF
--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -186,6 +186,14 @@ CHARTS: dict[str, dict] = {
         "axis": {"x": "% of max HP lost", "y": "% of fights"},
         "desc": "Damage distribution for one encounter, in 5%-of-max-HP buckets. All ascensions and modes.",
     },
+    "avg-win-time-daily": {
+        "label": "Average win time by day",
+        "group": "Combat",
+        "kind": "frame",
+        "splits": _RATE_SPLITS,
+        "axis": {"x": "Day", "y": "Avg run length (minutes)"},
+        "desc": "Daily average length of winning runs. Days with under 10 wins are dropped.",
+    },
     # ── Strategy (blob) ──
     "elites-vs-winrate": {
         "label": "Elites fought vs win rate",
@@ -332,6 +340,8 @@ def _build_frame_chart(
         return cs.stat_histogram(rows, stat or "floors_reached", split)
     if key == "time-to-win":
         return cs.time_to_win(rows, split)
+    if key == "avg-win-time-daily":
+        return cs.time_to_win_daily(rows, split)
     if key == "stat-scatter":
         return cs.stat_scatter(rows, x or "floors_reached", y or "deck_size", split)
     if key == "acts-funnel":

--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -109,6 +109,10 @@ def _week_label(week: int) -> str:
     )
 
 
+def _day_label(day: int) -> str:
+    return datetime.fromtimestamp(day * 86400, tz=timezone.utc).strftime("%Y-%m-%d")
+
+
 def _daily_date(seed: str | None, game_mode: str) -> str:
     """Daily seeds encode their date as DD_MM_YYYY; '' for everything else."""
     if game_mode != "daily" or not seed:
@@ -631,6 +635,33 @@ def time_to_win(rows: list[tuple], split: str) -> list[dict]:
                 "median_minutes": round(med, 1),
             }
         )
+    return series
+
+
+def time_to_win_daily(rows: list[tuple], split: str) -> list[dict]:
+    """Average length of winning runs per day: the pace trend behind the
+    time-to-win distribution. Days with under 10 wins are dropped rather
+    than plotted as noise (mirrors winrate_over_time's per-point floor)."""
+    stat = STATS["run_minutes"]
+    series = []
+    for sid, label, sub in _series_split(rows, split):
+        days: dict[int, list[float]] = {}
+        for r in sub:
+            if not r[WIN] or r[DAY] <= 0:
+                continue
+            v = _stat_value(r, stat)
+            if v <= 0 or v > stat["max"]:
+                continue
+            cell = days.setdefault(r[DAY], [0, 0.0])
+            cell[0] += 1
+            cell[1] += v
+        points = [
+            {"x": _day_label(d), "y": round(total / n, 1), "n": n}
+            for d, (n, total) in sorted(days.items())
+            if n >= 10
+        ]
+        if points:
+            series.append({"id": sid, "label": label, "points": points})
     return series
 
 

--- a/backend/tests/test_time_to_win.py
+++ b/backend/tests/test_time_to_win.py
@@ -4,10 +4,11 @@ only, zero/missing timers excluded, average and median in the series label."""
 from app.services import charts_stats as cs
 
 
-def _row(win: bool, minutes: float) -> tuple:
+def _row(win: bool, minutes: float, day: int = 0) -> tuple:
     r = [0] * 15
     r[cs.WIN] = 1 if win else 0
     r[cs.TIME] = int(minutes * 60)
+    r[cs.DAY] = day
     return tuple(r)
 
 
@@ -33,3 +34,19 @@ def test_time_to_win_wins_only_with_avg_and_median():
 def test_time_to_win_needs_min_sample():
     rows = [_row(True, 40)] * (cs.MIN_POINT_N - 1)
     assert cs.time_to_win(rows, "") == []
+
+
+def test_daily_average_win_time_drops_thin_days():
+    day = 20675  # 2026-08-10 as an epoch day
+    rows = [_row(True, 40, day)] * 10 + [_row(True, 60, day)] * 10
+    rows += [_row(False, 300, day)] * 25  # losses never count
+    rows += [_row(True, 55, day + 1)] * 9  # 9 wins: under the 10-win floor
+
+    series = cs.time_to_win_daily(rows, "")
+
+    assert len(series) == 1
+    points = series[0]["points"]
+    assert len(points) == 1
+    assert points[0]["x"] == "2026-08-10"
+    assert points[0]["y"] == 50.0
+    assert points[0]["n"] == 20


### PR DESCRIPTION
Companion to the time-to-win distribution from #839: a Combat-group line chart plotting the average length of winning runs per day, splittable by character, players, and ascension, with days under 10 wins dropped so thin days don't plot as noise.