### PR TITLE
Fix the Search Console indexing issues

### DIFF
--- a/frontend/app/[lang]/achievements/[id]/page.tsx
+++ b/frontend/app/[lang]/achievements/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -51,7 +52,7 @@ export default async function Page({ params }: Props) {
   let data = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/achievements/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/achievements/${id}?lang=${lang}`);
     if (res.ok) {
       data = await res.json();
       const desc = stripTags(data.description || "");
@@ -69,7 +70,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!data && !apiUnreachable) redirectMissingEntity("achievements", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!data) redirectMissingEntity("achievements", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/acts/[id]/page.tsx
+++ b/frontend/app/[lang]/acts/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 export const revalidate = 3600;
 
@@ -53,7 +54,7 @@ export default async function Page({ params }: Props) {
   let act = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/acts/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/acts/${id}?lang=${lang}`);
     if (res.ok) {
       act = await res.json();
       jsonLd = buildDetailPageJsonLd({
@@ -72,7 +73,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!act && !apiUnreachable) redirectMissingEntity("acts", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!act) redirectMissingEntity("acts", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/afflictions/[id]/page.tsx
+++ b/frontend/app/[lang]/afflictions/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -51,7 +52,7 @@ export default async function Page({ params }: Props) {
   let data = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/afflictions/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/afflictions/${id}?lang=${lang}`);
     if (res.ok) {
       data = await res.json();
       const desc = stripTags(data.description || "");
@@ -69,7 +70,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!data && !apiUnreachable) redirectMissingEntity("afflictions", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!data) redirectMissingEntity("afflictions", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/ascensions/[id]/page.tsx
+++ b/frontend/app/[lang]/ascensions/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 export const revalidate = 3600;
 
@@ -54,7 +55,7 @@ export default async function Page({ params }: Props) {
   let asc = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/ascensions/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/ascensions/${id}?lang=${lang}`);
     if (res.ok) {
       asc = await res.json();
       const desc = stripTags(asc.description);
@@ -80,7 +81,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!asc && !apiUnreachable) redirectMissingEntity("ascensions", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!asc) redirectMissingEntity("ascensions", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/cards/[id]/page.tsx
+++ b/frontend/app/[lang]/cards/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { cardOgImages } from "@/lib/image-url";
 import { enchantmentsForCard } from "@/lib/card-enchantments";
 
@@ -70,7 +71,7 @@ export default async function Page({ params, searchParams }: Props) {
   let card = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/cards/${id}?lang=${lang}${qs}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/cards/${id}?lang=${lang}${qs}`);
     if (res.ok) {
       card = await res.json();
       const desc = stripTags(card.description || "");
@@ -90,7 +91,9 @@ export default async function Page({ params, searchParams }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!card && !apiUnreachable) redirectMissingEntity("cards", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!card) redirectMissingEntity("cards", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/characters/[id]/page.tsx
+++ b/frontend/app/[lang]/characters/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { imageUrl } from "@/lib/image-url";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -53,7 +54,7 @@ export default async function Page({ params }: Props) {
   let data = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/characters/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/characters/${id}?lang=${lang}`);
     if (res.ok) {
       data = await res.json();
       const desc = stripTags(data.description || "");
@@ -72,7 +73,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!data && !apiUnreachable) redirectMissingEntity("characters", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!data) redirectMissingEntity("characters", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/enchantments/[id]/page.tsx
+++ b/frontend/app/[lang]/enchantments/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { imageUrl } from "@/lib/image-url";
 import { cardsForEnchantment } from "@/lib/card-enchantments";
 
@@ -55,7 +56,7 @@ export default async function Page({ params }: Props) {
   let data = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/enchantments/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/enchantments/${id}?lang=${lang}`);
     if (res.ok) {
       data = await res.json();
       const desc = stripTags(data.description || "");
@@ -74,7 +75,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!data && !apiUnreachable) redirectMissingEntity("enchantments", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!data) redirectMissingEntity("enchantments", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/encounters/[id]/page.tsx
+++ b/frontend/app/[lang]/encounters/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -57,7 +58,7 @@ export default async function Page({ params }: Props) {
   let data = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/encounters/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/encounters/${id}?lang=${lang}`);
     if (res.ok) {
       data = await res.json();
       const name = data.name || id;
@@ -78,7 +79,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!data && !apiUnreachable) redirectMissingEntity("encounters", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!data) redirectMissingEntity("encounters", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/events/[id]/page.tsx
+++ b/frontend/app/[lang]/events/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { imageUrl } from "@/lib/image-url";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -53,7 +54,7 @@ export default async function Page({ params }: Props) {
   let data = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/events/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/events/${id}?lang=${lang}`);
     if (res.ok) {
       data = await res.json();
       const desc = stripTags(data.description || "");
@@ -72,7 +73,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!data && !apiUnreachable) redirectMissingEntity("events", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!data) redirectMissingEntity("events", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/intents/[id]/page.tsx
+++ b/frontend/app/[lang]/intents/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -51,7 +52,7 @@ export default async function Page({ params }: Props) {
   let data = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/intents/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/intents/${id}?lang=${lang}`);
     if (res.ok) {
       data = await res.json();
       const desc = stripTags(data.description || "");
@@ -69,7 +70,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!data && !apiUnreachable) redirectMissingEntity("intents", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!data) redirectMissingEntity("intents", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/keywords/[id]/page.tsx
+++ b/frontend/app/[lang]/keywords/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 export const dynamic = "force-dynamic";
 
@@ -51,7 +52,7 @@ export default async function Page({ params }: Props) {
   let kw = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/keywords/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/keywords/${id}?lang=${lang}`);
     if (res.ok) {
       kw = await res.json();
       const desc = stripTags(kw.description);
@@ -83,7 +84,9 @@ export default async function Page({ params }: Props) {
   // through to the same redirect (the English version tries glossary
   // first because the URL space is shared, but the localized routes
   // are keyword-only).
-  if (!kw && !apiUnreachable) redirectMissingEntity("keywords", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!kw) redirectMissingEntity("keywords", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/leaderboards/stats/page.tsx
+++ b/frontend/app/[lang]/leaderboards/stats/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 import StatsClient from "@/app/leaderboards/stats/StatsClient";
+import { fetchInitialStats } from "@/app/leaderboards/stats/fetch-initial-stats";
 import {
   isValidLang,
   LANG_GAME_NAME,
@@ -72,7 +73,7 @@ export default async function LangStatsPage({
   return (
     <>
       <JsonLd data={jsonLd} />
-      <StatsClient />
+      <StatsClient initialStats={await fetchInitialStats()} />
     </>
   );
 }

--- a/frontend/app/[lang]/mechanics/[slug]/page.tsx
+++ b/frontend/app/[lang]/mechanics/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE, clipMetaDescription } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd } from "@/lib/jsonld";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import Link from "next/link";
 import MechanicMarkdown from "@/app/mechanics/[slug]/MechanicMarkdown";
 import { isValidLang, LANG_HREFLANG, type LangCode } from "@/lib/languages";
@@ -19,17 +20,13 @@ interface MechanicSectionDetail extends MechanicSectionMeta {
 }
 
 async function fetchSection(slug: string): Promise<MechanicSectionDetail | null> {
-  // See note in app/mechanics/[slug]/page.tsx, generateStaticParams
-  // dropped, fetch hardened against build-time ECONNREFUSED.
-  try {
-    const res = await fetch(`${API_INTERNAL}/api/mechanics/sections/${slug}`, {
-      next: { revalidate: 300 },
-    });
-    if (!res.ok) return null;
-    return (await res.json()) as MechanicSectionDetail;
-  } catch {
-    return null;
-  }
+  // See note in app/mechanics/[slug]/page.tsx: 404 → null (notFound), 5xx or
+  // network failure → throw (500) so an outage can't mass-404 real pages.
+  const res = await fetchEntityRes(`${API_INTERNAL}/api/mechanics/sections/${slug}`, {
+    next: { revalidate: 300 },
+  });
+  if (!res.ok) return null;
+  return (await res.json()) as MechanicSectionDetail;
 }
 
 export async function generateMetadata({

--- a/frontend/app/[lang]/modifiers/[id]/page.tsx
+++ b/frontend/app/[lang]/modifiers/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -51,7 +52,7 @@ export default async function Page({ params }: Props) {
   let data = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/modifiers/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/modifiers/${id}?lang=${lang}`);
     if (res.ok) {
       data = await res.json();
       const desc = stripTags(data.description || "");
@@ -69,7 +70,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!data && !apiUnreachable) redirectMissingEntity("modifiers", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!data) redirectMissingEntity("modifiers", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/monsters/[id]/page.tsx
+++ b/frontend/app/[lang]/monsters/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { imageUrl } from "@/lib/image-url";
 
 export const revalidate = 3600;
@@ -55,7 +56,7 @@ export default async function Page({ params }: Props) {
   let data = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/monsters/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/monsters/${id}?lang=${lang}`);
     if (res.ok) {
       data = await res.json();
       const desc = stripTags(data.description || "");
@@ -74,7 +75,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!data && !apiUnreachable) redirectMissingEntity("monsters", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!data) redirectMissingEntity("monsters", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/orbs/[id]/page.tsx
+++ b/frontend/app/[lang]/orbs/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -54,7 +55,7 @@ export default async function Page({ params }: Props) {
   let data = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/orbs/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/orbs/${id}?lang=${lang}`);
     if (res.ok) {
       data = await res.json();
       const desc = stripTags(data.description || "");
@@ -72,7 +73,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!data && !apiUnreachable) redirectMissingEntity("orbs", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!data) redirectMissingEntity("orbs", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/potions/[id]/page.tsx
+++ b/frontend/app/[lang]/potions/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { imageUrl } from "@/lib/image-url";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -53,7 +54,7 @@ export default async function Page({ params }: Props) {
   let data = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/potions/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/potions/${id}?lang=${lang}`);
     if (res.ok) {
       data = await res.json();
       const desc = stripTags(data.description || "");
@@ -72,7 +73,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!data && !apiUnreachable) redirectMissingEntity("potions", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!data) redirectMissingEntity("potions", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/powers/[id]/page.tsx
+++ b/frontend/app/[lang]/powers/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { imageUrl } from "@/lib/image-url";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -53,7 +54,7 @@ export default async function Page({ params }: Props) {
   let data = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/powers/${id}?lang=${lang}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/powers/${id}?lang=${lang}`);
     if (res.ok) {
       data = await res.json();
       const desc = stripTags(data.description || "");
@@ -72,7 +73,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!data && !apiUnreachable) redirectMissingEntity("powers", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!data) redirectMissingEntity("powers", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/relics/[id]/page.tsx
+++ b/frontend/app/[lang]/relics/[id]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { imageUrl } from "@/lib/image-url";
 
 export const dynamic = "force-dynamic";
@@ -63,7 +64,7 @@ export default async function Page({ params, searchParams }: Props) {
   let data = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/relics/${id}?lang=${lang}${qs}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/relics/${id}?lang=${lang}${qs}`);
     if (res.ok) {
       data = await res.json();
       const desc = stripTags(data.description || "");
@@ -83,7 +84,9 @@ export default async function Page({ params, searchParams }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!data && !apiUnreachable) redirectMissingEntity("relics", id, lang);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!data) redirectMissingEntity("relics", id, lang);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/achievements/[id]/page.tsx
+++ b/frontend/app/achievements/[id]/page.tsx
@@ -4,6 +4,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -45,7 +46,7 @@ export default async function Page({ params }: Props) {
   let achievement = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/achievements/${id}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/achievements/${id}`);
     if (res.ok) {
       achievement = await res.json();
       const desc = stripTags(achievement.description || "");
@@ -68,7 +69,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!achievement && !apiUnreachable) redirectMissingEntity("achievements", id);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!achievement) redirectMissingEntity("achievements", id);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/acts/[id]/page.tsx
+++ b/frontend/app/acts/[id]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import ActDetail from "./ActDetail";
 import JsonLd from "@/app/components/JsonLd";
+import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { buildDetailPageJsonLd } from "@/lib/jsonld";
 import { stripTags, clipMetaDescription, buildLanguageAlternates, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 
@@ -46,8 +48,9 @@ export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
   let act = null;
+  let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/acts/${id}`, {
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/acts/${id}`, {
       next: { revalidate: 3600 },
     });
     if (res.ok) {
@@ -64,7 +67,12 @@ export default async function Page({ params }: Props) {
         ],
       });
     }
-  } catch {}
+  } catch {
+    apiUnreachable = true;
+  }
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!act) redirectMissingEntity("acts", id);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/afflictions/[id]/page.tsx
+++ b/frontend/app/afflictions/[id]/page.tsx
@@ -4,6 +4,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -45,7 +46,7 @@ export default async function Page({ params }: Props) {
   let affliction = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/afflictions/${id}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/afflictions/${id}`);
     if (res.ok) {
       affliction = await res.json();
       const desc = stripTags(affliction.description || "");
@@ -69,7 +70,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!affliction && !apiUnreachable) redirectMissingEntity("afflictions", id);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!affliction) redirectMissingEntity("afflictions", id);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/ascensions/[id]/page.tsx
+++ b/frontend/app/ascensions/[id]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import AscensionDetail from "./AscensionDetail";
 import JsonLd from "@/app/components/JsonLd";
+import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates, DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/seo";
 
@@ -47,8 +49,9 @@ export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
   let asc = null;
+  let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/ascensions/${id}`, {
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/ascensions/${id}`, {
       next: { revalidate: 3600 },
     });
     if (res.ok) {
@@ -70,7 +73,12 @@ export default async function Page({ params }: Props) {
       ]);
       jsonLd = [...detailJsonLd, faqJsonLd];
     }
-  } catch {}
+  } catch {
+    apiUnreachable = true;
+  }
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!asc) redirectMissingEntity("ascensions", id);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/cards/[id]/page.tsx
+++ b/frontend/app/cards/[id]/page.tsx
@@ -6,6 +6,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { cardOgImages } from "@/lib/image-url";
 import { enchantmentsForCard } from "@/lib/card-enchantments";
 
@@ -66,7 +67,7 @@ export default async function Page({ params }: Props) {
   let card = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/cards/${id}`, {
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/cards/${id}`, {
       next: { revalidate: 3600 },
     });
     if (res.ok) {
@@ -104,7 +105,9 @@ export default async function Page({ params }: Props) {
   }
   // 308 unknown IDs to the cards list so search engines transfer
   // link equity and humans land on something useful.
-  if (!card && !apiUnreachable) redirectMissingEntity("cards", id);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!card) redirectMissingEntity("cards", id);
   // Server-render the community stats into the HTML (unique, crawlable data).
   const initialStats: EntityStats | null = card ? await fetchEntityStats("cards", id) : null;
   return (

--- a/frontend/app/characters/[id]/page.tsx
+++ b/frontend/app/characters/[id]/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import CharacterDetail from "./CharacterDetail";
 import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates, SITE_NAME, SITE_URL } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
+import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 
 import { imageUrl } from "@/lib/image-url";
@@ -46,8 +48,9 @@ export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
   let char = null;
+  let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/characters/${id}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/characters/${id}`);
     if (res.ok) {
       char = await res.json();
       const desc = stripTags(char.description || "");
@@ -70,7 +73,12 @@ export default async function Page({ params }: Props) {
       ];
       jsonLd = [...detailJsonLd, buildFAQPageJsonLd(faqQuestions)];
     }
-  } catch {}
+  } catch {
+    apiUnreachable = true;
+  }
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!char) redirectMissingEntity("characters", id);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/enchantments/[id]/page.tsx
+++ b/frontend/app/enchantments/[id]/page.tsx
@@ -4,6 +4,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { imageUrl } from "@/lib/image-url";
 import { cardsForEnchantment } from "@/lib/card-enchantments";
 
@@ -49,7 +50,7 @@ export default async function Page({ params }: Props) {
   let enchantment = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/enchantments/${id}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/enchantments/${id}`);
     if (res.ok) {
       enchantment = await res.json();
       const desc = stripTags(enchantment.description || "");
@@ -74,7 +75,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!enchantment && !apiUnreachable)
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!enchantment)
     redirectMissingEntity("enchantments", id);
   return (
     <>

--- a/frontend/app/encounters/[id]/page.tsx
+++ b/frontend/app/encounters/[id]/page.tsx
@@ -4,6 +4,7 @@ import { stripTags, clipMetaDescription, DEFAULT_OG_IMAGE, buildLanguageAlternat
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { fetchEncounterStats } from "@/lib/encounter-stats";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -50,7 +51,7 @@ export default async function Page({ params }: Props) {
   let encounter = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/encounters/${id}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/encounters/${id}`);
     if (res.ok) {
       encounter = await res.json();
       const desc = encounter.monsters?.length
@@ -76,7 +77,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!encounter && !apiUnreachable) redirectMissingEntity("encounters", id);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!encounter) redirectMissingEntity("encounters", id);
   // Community "how deadly" numbers for this fight (encountered / killed), SSR'd.
   const stats = encounter?.id ? await fetchEncounterStats([encounter.id]) : [];
   const encounterStat = stats[0] ?? null;

--- a/frontend/app/events/[id]/page.tsx
+++ b/frontend/app/events/[id]/page.tsx
@@ -5,6 +5,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { imageUrl } from "@/lib/image-url";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -48,7 +49,7 @@ export default async function Page({ params }: Props) {
   let event = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/events/${id}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/events/${id}`);
     if (res.ok) {
       event = await res.json();
       const desc = stripTags(event.description || "");
@@ -76,7 +77,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!event && !apiUnreachable) redirectMissingEntity("events", id);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!event) redirectMissingEntity("events", id);
   // Server-render the community choice distribution (unique, crawlable data).
   const voteStats = event ? await fetchEventVotes(id) : null;
   return (

--- a/frontend/app/guides/[slug]/page.tsx
+++ b/frontend/app/guides/[slug]/page.tsx
@@ -5,6 +5,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import GuideDetail from "./GuideDetail";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -40,12 +41,14 @@ export default async function GuideDetailPage({ params }: { params: Promise<{ sl
   let guide: Guide | null = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API}/api/guides/${slug}`, { next: { revalidate: 300 } });
+    const res = await fetchEntityRes(`${API}/api/guides/${slug}`, { next: { revalidate: 300 } });
     if (res.ok) guide = await res.json();
   } catch {
     apiUnreachable = true;
   }
-  if (!guide && !apiUnreachable) redirectMissingEntity("guides", slug);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!guide) redirectMissingEntity("guides", slug);
 
   const jsonLd = guide
     ? [

--- a/frontend/app/intents/[id]/page.tsx
+++ b/frontend/app/intents/[id]/page.tsx
@@ -4,6 +4,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -45,7 +46,7 @@ export default async function Page({ params }: Props) {
   let intent = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/intents/${id}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/intents/${id}`);
     if (res.ok) {
       intent = await res.json();
       const desc = stripTags(intent.description || "");
@@ -68,7 +69,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!intent && !apiUnreachable) redirectMissingEntity("intents", id);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!intent) redirectMissingEntity("intents", id);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/leaderboards/stats/StatsClient.tsx
@@ -92,7 +92,7 @@ interface PotionInfo {
   image_url: string | null;
 }
 
-interface CommunityStats {
+export interface CommunityStats {
   total_runs: number;
   total_wins: number;
   total_abandoned: number;
@@ -288,10 +288,16 @@ function pickRateColor(pr: number): string {
   return "var(--text-muted)";
 }
 
-export default function StatsClient() {
+export default function StatsClient({
+  initialStats = null,
+}: {
+  initialStats?: CommunityStats | null;
+} = {}) {
   const lp = useLangPrefix();
   const { lang } = useLanguage();
-  const [stats, setStats] = useState<CommunityStats | null>(null);
+  // Server-fetched unfiltered payload so the initial HTML carries real
+  // numbers (crawlable); the mount effect still refetches live data.
+  const [stats, setStats] = useState<CommunityStats | null>(initialStats);
   const [cardData, setCardData] = useState<Record<string, CardInfo>>({});
   const [relicData, setRelicData] = useState<Record<string, RelicInfo>>({});
   const [potionData, setPotionData] = useState<Record<string, PotionInfo>>({});
@@ -299,7 +305,7 @@ export default function StatsClient() {
   // Codex Elo per card id, from the scores endpoint (reward-pick cards only;
   // curses, statuses, events, tokens, and starters have none).
   const [eloMap, setEloMap] = useState<Record<string, number | null>>({});
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!initialStats);
 
   // Top-level filters
   const [character, setCharacter] = useState("");

--- a/frontend/app/leaderboards/stats/fetch-initial-stats.ts
+++ b/frontend/app/leaderboards/stats/fetch-initial-stats.ts
@@ -1,0 +1,22 @@
+import type { CommunityStats } from "./StatsClient";
+
+const API_INTERNAL =
+  process.env.API_INTERNAL_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://localhost:8000";
+
+// Server-fetch the unfiltered stats payload so the initial HTML carries real
+// numbers — Google stamped /leaderboards/stats Soft 404 because the only
+// crawlable content was the client "Loading..." state. 5-min data cache; the
+// client refetches live data on mount either way, so a failure here just
+// falls back to the old client-only behaviour.
+export async function fetchInitialStats(): Promise<CommunityStats | null> {
+  try {
+    const res = await fetch(`${API_INTERNAL}/api/runs/stats`, {
+      next: { revalidate: 300 },
+    });
+    return res.ok ? await res.json() : null;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/app/leaderboards/stats/page.tsx
+++ b/frontend/app/leaderboards/stats/page.tsx
@@ -3,6 +3,7 @@ import JsonLd from "@/app/components/JsonLd";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import StatsClient from "./StatsClient";
+import { fetchInitialStats } from "./fetch-initial-stats";
 
 export const dynamic = "force-dynamic";
 
@@ -28,7 +29,7 @@ export const metadata: Metadata = {
   twitter: { card: "summary_large_image", title, description },
 };
 
-export default function StatsPage() {
+export default async function StatsPage() {
   const jsonLd = [
     buildBreadcrumbJsonLd([
       { name: "Home", href: "/" },
@@ -45,7 +46,7 @@ export default function StatsPage() {
   return (
     <>
       <JsonLd data={jsonLd} />
-      <StatsClient />
+      <StatsClient initialStats={await fetchInitialStats()} />
     </>
   );
 }

--- a/frontend/app/mechanics/[slug]/page.tsx
+++ b/frontend/app/mechanics/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE, clipMetaDescription, buildLanguageAlternates} from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd } from "@/lib/jsonld";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import Link from "next/link";
 import MechanicMarkdown from "./MechanicMarkdown";
 import type { MechanicSectionMeta } from "../page";
@@ -17,20 +18,14 @@ interface MechanicSectionDetail extends MechanicSectionMeta {
 }
 
 async function fetchSection(slug: string): Promise<MechanicSectionDetail | null> {
-  // Tolerates ECONNREFUSED so the Docker frontend build doesn't fail when
-  // the backend container isn't running yet. Pages are rendered on demand
-  // post-deploy with the `revalidate` cache below, same pattern as every
-  // other entity detail page (cards, relics, monsters, etc.) which never
-  // had generateStaticParams in the first place.
-  try {
-    const res = await fetch(`${API_INTERNAL}/api/mechanics/sections/${slug}`, {
-      next: { revalidate: 300 },
-    });
-    if (!res.ok) return null;
-    return (await res.json()) as MechanicSectionDetail;
-  } catch {
-    return null;
-  }
+  // notFound() only on a definitive 404; backend 5xx or network failure
+  // throws (500) so an outage window cannot mass-404 real pages. Detail
+  // routes have no generateStaticParams, so nothing fetches at build time.
+  const res = await fetchEntityRes(`${API_INTERNAL}/api/mechanics/sections/${slug}`, {
+    next: { revalidate: 300 },
+  });
+  if (!res.ok) return null;
+  return (await res.json()) as MechanicSectionDetail;
 }
 
 export async function generateMetadata({

--- a/frontend/app/modifiers/[id]/page.tsx
+++ b/frontend/app/modifiers/[id]/page.tsx
@@ -4,6 +4,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -45,7 +46,7 @@ export default async function Page({ params }: Props) {
   let modifier = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/modifiers/${id}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/modifiers/${id}`);
     if (res.ok) {
       modifier = await res.json();
       const desc = stripTags(modifier.description || "");
@@ -68,7 +69,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!modifier && !apiUnreachable) redirectMissingEntity("modifiers", id);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!modifier) redirectMissingEntity("modifiers", id);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/monsters/[id]/page.tsx
+++ b/frontend/app/monsters/[id]/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import MonsterDetail from "./MonsterDetail";
 import { fetchEncounterStats } from "@/lib/encounter-stats";
 import JsonLd from "@/app/components/JsonLd";
+import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { clipMetaDescription, buildLanguageAlternates, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { imageUrl } from "@/lib/image-url";
@@ -52,8 +54,9 @@ export default async function Page({ params }: Props) {
   const { id } = await params;
   let jsonLd = null;
   let monster = null;
+  let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/monsters/${id}`, {
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/monsters/${id}`, {
       next: { revalidate: 3600 },
     });
     if (res.ok) {
@@ -78,7 +81,12 @@ export default async function Page({ params }: Props) {
       ];
       jsonLd = [...detailJsonLd, buildFAQPageJsonLd(faqQuestions)];
     }
-  } catch {}
+  } catch {
+    apiUnreachable = true;
+  }
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!monster) redirectMissingEntity("monsters", id);
   // Server-render the community "how deadly" stats for this monster's fights.
   const encounterStats = monster?.encounters?.length
     ? await fetchEncounterStats(

--- a/frontend/app/orbs/[id]/page.tsx
+++ b/frontend/app/orbs/[id]/page.tsx
@@ -4,6 +4,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -45,7 +46,7 @@ export default async function Page({ params }: Props) {
   let orb = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/orbs/${id}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/orbs/${id}`);
     if (res.ok) {
       orb = await res.json();
       const desc = stripTags(orb.description || "");
@@ -68,7 +69,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!orb && !apiUnreachable) redirectMissingEntity("orbs", id);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!orb) redirectMissingEntity("orbs", id);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/potions/[id]/page.tsx
+++ b/frontend/app/potions/[id]/page.tsx
@@ -6,6 +6,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { imageUrl } from "@/lib/image-url";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -49,7 +50,7 @@ export default async function Page({ params }: Props) {
   let potion = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/potions/${id}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/potions/${id}`);
     if (res.ok) {
       potion = await res.json();
       const desc = stripTags(potion.description || "");
@@ -74,7 +75,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!potion && !apiUnreachable) redirectMissingEntity("potions", id);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!potion) redirectMissingEntity("potions", id);
   // Server-render the community stats into the HTML (unique, crawlable data).
   const initialStats: EntityStats | null = potion ? await fetchEntityStats("potions", id) : null;
   return (

--- a/frontend/app/powers/[id]/page.tsx
+++ b/frontend/app/powers/[id]/page.tsx
@@ -4,6 +4,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { imageUrl } from "@/lib/image-url";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -47,7 +48,7 @@ export default async function Page({ params }: Props) {
   let power = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/powers/${id}`);
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/powers/${id}`);
     if (res.ok) {
       power = await res.json();
       const desc = stripTags(power.description || "");
@@ -72,7 +73,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!power && !apiUnreachable) redirectMissingEntity("powers", id);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!power) redirectMissingEntity("powers", id);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/relics/[id]/page.tsx
+++ b/frontend/app/relics/[id]/page.tsx
@@ -6,6 +6,7 @@ import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates,
 import JsonLd from "@/app/components/JsonLd";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import { imageUrl } from "@/lib/image-url";
 
 // Relic data only changes on deploy. force-static + revalidate
@@ -57,7 +58,7 @@ export default async function Page({ params }: Props) {
   let relic = null;
   let apiUnreachable = false;
   try {
-    const res = await fetch(`${API_INTERNAL}/api/relics/${id}`, {
+    const res = await fetchEntityRes(`${API_INTERNAL}/api/relics/${id}`, {
       next: { revalidate: 3600 },
     });
     if (res.ok) {
@@ -85,7 +86,9 @@ export default async function Page({ params }: Props) {
   } catch {
     apiUnreachable = true;
   }
-  if (!relic && !apiUnreachable) redirectMissingEntity("relics", id);
+  // Fail the render (500) instead of ISR-caching a contentless shell.
+  if (apiUnreachable) throw new Error("entity API unreachable");
+  if (!relic) redirectMissingEntity("relics", id);
   // Server-render the community stats into the HTML (unique, crawlable data).
   const initialStats: EntityStats | null = relic ? await fetchEntityStats("relics", id) : null;
   return (

--- a/frontend/lib/entity-fetch.ts
+++ b/frontend/lib/entity-fetch.ts
@@ -1,0 +1,14 @@
+// fetch() wrapper for entity detail SSR. Backend 5xx throws (landing in the
+// caller's apiUnreachable catch) so a sick backend is treated as transient,
+// not as "this entity doesn't exist" — only a definitive 404 may 308 the
+// URL back to its hub.
+export async function fetchEntityRes(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const res = await fetch(url, init);
+  if (res.status >= 500) {
+    throw new Error(`entity API ${res.status} for ${url}`);
+  }
+  return res;
+}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -46,6 +46,35 @@ function gidFromEncoded(seg: string): string | null {
 
 const LANG_CODES = LANG_PREFIXES;
 
+// Detail routes whose slugs are canonically lowercase (what the sitemap
+// declares). Any other casing serves the same page and self-canonicalises,
+// so Google treats /cards/ABRASIVE and /cards/abrasive as competing
+// duplicates — 308 every non-lowercase variant onto the canonical instead.
+// Deliberately excludes user-content routes with case-significant ids
+// (/runs hashes, /users, /tier-list-maker).
+const LOWERCASE_DETAIL_TYPES = new Set([
+  "achievements", "acts", "afflictions", "ascensions", "badges", "cards",
+  "characters", "enchantments", "encounters", "events", "guides", "intents",
+  "keywords", "mechanics", "modifiers", "monsters", "orbs", "potions",
+  "powers", "relics", "timeline",
+]);
+
+function lowercaseRedirect(req: NextRequest): NextResponse | null {
+  const parts = req.nextUrl.pathname.split("/");
+  let i = 1;
+  if (LANG_CODES.has(parts[i])) i++;
+  if (parts[i] === "beta") i++;
+  if (!LOWERCASE_DETAIL_TYPES.has(parts[i])) return null;
+  const slug = parts.slice(i + 1);
+  if (slug.length === 0 || !slug.some((s) => /[A-Z]/.test(s))) return null;
+  const url = req.nextUrl.clone();
+  url.pathname = [
+    ...parts.slice(0, i + 1),
+    ...slug.map((s) => s.toLowerCase()),
+  ].join("/");
+  return NextResponse.redirect(url, 308);
+}
+
 // Entity types with a real /beta/<type>/[id] detail route (force-dynamic
 // pages under app/beta/), exempt from the rewrite below.
 const BETA_DETAIL_TYPES = new Set([
@@ -93,6 +122,10 @@ function betaRewrite(req: NextRequest): NextResponse | null {
 }
 
 export function middleware(req: NextRequest) {
+  // Redirect before the beta rewrite so the browser lands on the corrected
+  // URL and only then gets rewritten.
+  const lower = lowercaseRedirect(req);
+  if (lower) return lower;
   const beta = betaRewrite(req);
   if (beta) return beta;
   const m = req.nextUrl.pathname.match(NEWS_PATH);
@@ -115,5 +148,8 @@ export const config = {
     "/:lang/news/:slug*",
     "/beta/:path*",
     "/:lang/beta/:path*",
+    // Keep in sync with LOWERCASE_DETAIL_TYPES above.
+    "/:type(achievements|acts|afflictions|ascensions|badges|cards|characters|enchantments|encounters|events|guides|intents|keywords|mechanics|modifiers|monsters|orbs|potions|powers|relics|timeline)/:slug+",
+    "/:lang/:type(achievements|acts|afflictions|ascensions|badges|cards|characters|enchantments|encounters|events|guides|intents|keywords|mechanics|modifiers|monsters|orbs|potions|powers|relics|timeline)/:slug+",
   ],
 };


### PR DESCRIPTION
I 308 non-lowercase entity URLs to their canonical casing, make detail pages 500 instead of ISR-caching an empty shell when the backend is unreachable (a real 404 still redirects to the hub), and server-render the initial /leaderboards/stats payload so Google stops soft-404ing it.