### PR TITLE
Merge patch diffs into per-entity Version history

### DIFF
--- a/backend/app/routers/entity_history.py
+++ b/backend/app/routers/entity_history.py
@@ -10,14 +10,24 @@ router = APIRouter(prefix="/api/history", tags=["Entity History"])
 
 
 def _load_changelogs() -> list[dict]:
-    """Load all changelog JSON files, sorted oldest first by date then tag."""
+    """Load all changelog JSON files, sorted oldest first by date then tag.
+
+    The resolved tree only carries the site-release logs (and a beta version
+    dir only its own patch), so union in the per-patch game diffs from the
+    data-beta archive — without them every entity's history froze before the
+    current beta version."""
+    from ..services.entity_changelog import load_game_changelogs
+
     d = _resolve_base(_get_version()) / "changelogs"
-    if not d.exists():
-        return []
     logs = []
-    for f in d.glob("*.json"):
-        with open(f, "r", encoding="utf-8") as fh:
-            logs.append(json.load(fh))
+    if d.exists():
+        for f in d.glob("*.json"):
+            with open(f, "r", encoding="utf-8") as fh:
+                logs.append(json.load(fh))
+    seen = {(log.get("game_version"), log.get("tag")) for log in logs}
+    for log in load_game_changelogs():
+        if (log.get("game_version"), log.get("tag")) not in seen:
+            logs.append(log)
     logs.sort(key=lambda log: (log.get("date", ""), log.get("tag", "")))
     return logs
 

--- a/backend/app/routers/update_history.py
+++ b/backend/app/routers/update_history.py
@@ -24,9 +24,20 @@ def _histories() -> dict[str, dict[str, list]]:
 
 @router.get("/{entity_type}/{entity_id}")
 def get_update_history(entity_type: str, entity_id: str):
-    """Game-patch changes for one entity, newest first. 404s when nothing is
-    recorded, so the frontend can fall back to the changelog timeline."""
-    entries = _histories().get(entity_type, {}).get(entity_id.upper())
+    """Game-patch changes for one entity, newest first. Wiki-sourced entries
+    first-class, topped up with our own per-patch diff entries for versions
+    the wiki hasn't documented yet (it lags each patch by days, which froze
+    every history at the wiki's newest covered version). 404s when neither
+    source has anything, so the frontend can fall back to the changelog
+    timeline."""
+    from ..services.entity_changelog import game_history_entries, version_key
+
+    wiki = _histories().get(entity_type, {}).get(entity_id.upper()) or []
+    game = game_history_entries(entity_type, entity_id)
+    if wiki:
+        newest_wiki = max((version_key(e.get("version")) for e in wiki), default=())
+        game = [e for e in game if version_key(e.get("version")) > newest_wiki]
+    entries = game + wiki
     if not entries:
         raise HTTPException(
             status_code=404,

--- a/backend/app/services/entity_changelog.py
+++ b/backend/app/services/entity_changelog.py
@@ -1,0 +1,93 @@
+"""Per-entity Version-history entries derived from the game-version diff
+changelogs (data-beta/<version>/changelogs/*.json, the per-patch archive).
+
+Complements the wiki-sourced data/entity_history.json: the wiki lags a patch
+by however long its editors take, these land the moment an ingest merges."""
+
+import json
+import re
+from functools import lru_cache
+
+from .data_service import BETA_DATA_DIR
+
+# Noise in a player-facing history entry: raw template text, ordering
+# ripples, and art paths.
+_SKIP_FIELDS = {
+    "description_raw",
+    "compendium_order",
+    "sort_order",
+    "era_position",
+    "image_url",
+    "beta_image_url",
+}
+# Game markup ([gold]..[/gold], [energy:1]) and template vars ({Damage:...})
+# render as literal text in the history list, so strip them here.
+_MARKUP_RE = re.compile(r"\[/?[a-zA-Z_]+(?::[^\]]*)?\]|\{[^}]*\}")
+
+
+def version_key(version: str | None) -> tuple[int, ...]:
+    """Sortable key for "V0.111.0" / "v0.111.0" / "0.111.0" style strings."""
+    return tuple(int(n) for n in re.findall(r"\d+", version or ""))
+
+
+def _clean(value) -> str:
+    text = _MARKUP_RE.sub("", str(value if value is not None else "none"))
+    return re.sub(r"\s+", " ", text).strip() or "none"
+
+
+@lru_cache(maxsize=1)
+def load_game_changelogs() -> list[dict]:
+    """Every per-patch diff changelog, deduped by game version (the `latest`
+    symlink doubles one dir), newest first. Cached for the process lifetime —
+    the files only change on deploy, which restarts the workers."""
+    by_version: dict[str, dict] = {}
+    for path in sorted(BETA_DATA_DIR.glob("*/changelogs/*.json")):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                log = json.load(f)
+        except (OSError, ValueError):
+            continue
+        version = str(log.get("game_version") or "").strip()
+        if version:
+            by_version[version] = log
+    return [by_version[v] for v in sorted(by_version, key=version_key, reverse=True)]
+
+
+def game_history_entries(entity_type: str, entity_id: str) -> list[dict]:
+    """Update-history rows (same shape as the wiki entries: version / type /
+    date / changes[str]) for one entity across every archived patch diff,
+    newest first."""
+    target_type = entity_type.lower()
+    target_id = entity_id.upper()
+    out: list[dict] = []
+    for log in load_game_changelogs():
+        version = str(log.get("game_version") or "")
+        head = {
+            "version": f"V{version}",
+            "type": "Beta Patch",
+            "date": log.get("date"),
+        }
+        for cat in log.get("categories", []):
+            if str(cat.get("id", "")).lower() != target_type:
+                continue
+            for item in cat.get("added", []):
+                if str(item.get("id", "")).upper() == target_id:
+                    out.append({**head, "changes": ["Added."]})
+            for item in cat.get("removed", []):
+                if str(item.get("id", "")).upper() == target_id:
+                    out.append({**head, "changes": ["Removed."]})
+            for item in cat.get("changed", []):
+                if str(item.get("id", "")).upper() != target_id:
+                    continue
+                changes = []
+                for ch in item.get("changes", []):
+                    field = str(ch.get("field", ""))
+                    if field in _SKIP_FIELDS:
+                        continue
+                    label = field.replace("_", " ").capitalize()
+                    changes.append(
+                        f"{label}: {_clean(ch.get('old'))} → {_clean(ch.get('new'))}"
+                    )
+                if changes:
+                    out.append({**head, "changes": changes})
+    return out

--- a/backend/tests/test_entity_update_history.py
+++ b/backend/tests/test_entity_update_history.py
@@ -1,0 +1,34 @@
+"""Per-entity Version history must include the current beta patch. The
+wiki-sourced entity_history.json lags each patch by days and used to win
+outright whenever an entity had any wiki entries, freezing every history at
+the wiki's newest covered version (found live 2026-08-16: 0.111.0 changes
+invisible on every card page)."""
+
+from app.routers.update_history import get_update_history
+from app.services.entity_changelog import game_history_entries, version_key
+
+
+def test_version_key_orders_numerically():
+    assert version_key("V0.111.0") > version_key("V0.99.1")
+    assert version_key("0.111.0") == version_key("V0.111.0")
+    assert version_key(None) == ()
+
+
+def test_game_entries_cover_the_current_beta():
+    entries = game_history_entries("cards", "expect_a_fight")
+    v111 = [e for e in entries if e["version"] == "V0.111.0"]
+    assert v111, "0.111.0 diff changelog should yield an entry"
+    changes = v111[0]["changes"]
+    assert any(c.startswith("Cost: 2 → 3") for c in changes)
+    # Noise fields stay out and markup is stripped from what remains.
+    assert not any("description raw" in c.lower() for c in changes)
+    assert not any("[gold]" in c for c in changes)
+
+
+def test_merged_history_tops_up_wiki_with_newer_patches():
+    entries = get_update_history("cards", "expect_a_fight")
+    versions = [e.get("version") for e in entries]
+    assert "V0.111.0" in versions
+    assert "V0.109.0" in versions  # wiki-sourced entries survive the merge
+    keys = [version_key(v) for v in versions]
+    assert keys == sorted(keys, reverse=True), "newest first"


### PR DESCRIPTION
I top up the wiki-sourced update history with entries built from our own per-patch diff changelogs for versions the wiki hasn't documented yet, since the wiki data ends at 0.109.0 and was freezing every entity's history there while the 0.111.0 changes sat unread in data-beta.