### PR TITLE
Stats and profile consistency fixes

### DIFF
--- a/backend/app/services/user_insights.py
+++ b/backend/app/services/user_insights.py
@@ -172,6 +172,7 @@ def _card_pick_deltas(
     ascension: int | None = None,
     version: str | None = None,
     players: int | None = None,
+    bracket: str | None = None,
 ) -> dict[str, list[dict]]:
     """The player's card-reward keep rates vs the community's, split into the
     cards they take notably more / less often. Community side comes from the
@@ -189,7 +190,7 @@ def _card_pick_deltas(
         )
         or {}
     )
-    table = get_entity_metrics_table("cards")
+    table = get_entity_metrics_table("cards", bracket or "all")
     comm = {
         r["id"]: r["pick_rate"]
         for r in table.get("rows") or []
@@ -345,6 +346,7 @@ def _relic_carry_deltas(
     ascension: int | None = None,
     version: str | None = None,
     players: int | None = None,
+    bracket: str | None = None,
 ) -> dict[str, list[dict]]:
     """Relics the player ends runs with notably more / less often than the
     community. Relics have no offered/picked stream like cards, so the
@@ -364,7 +366,7 @@ def _relic_carry_deltas(
         )
         or {}
     )
-    table = get_entity_metrics_table("relics", "all", character)
+    table = get_entity_metrics_table("relics", bracket or "all", character)
     comm_total = (
         table.get("character_runs") if character else table.get("total_runs")
     ) or 0
@@ -416,6 +418,22 @@ _LOCK_TTL = 15 * 60
 
 _inflight: set[str] = set()
 _inflight_lock = threading.Lock()
+
+
+def _filters_bracket(
+    ascension: int | None, version: str | None, players: int | None
+) -> str | None:
+    """The materialized community bracket matching the active filters, or
+    None when nothing maps (character is not a bracket axis, and only A10
+    has a skill bracket). Composes player:skill:version in the same order
+    as the site's ?bracket= values, so the profile's community comparison
+    numbers match /leaderboards/stats for the same slice."""
+    player = {1: "solo", 2: "2p", 3: "3p", 4: "4p"}.get(players or 0, "")
+    skill = "a10" if ascension == 10 else ""
+    parts = [p for p in (player, skill) if p]
+    if version:
+        parts.append(version)
+    return ":".join(parts) or None
 
 
 def _apply_row_filters(
@@ -620,12 +638,13 @@ def _compute_insights(
                 )
 
     mine = community_stats._finalize_one(acc)
-    community = get_community_stats()
+    bracket = _filters_bracket(ascension, version, players)
+    community = get_community_stats(bracket)
     _attach_community(mine, community)
     mine["event_divergence"] = _event_divergence(mine)
     try:
         mine["card_picks"] = _card_pick_deltas(
-            user_id, character, ascension, version, players
+            user_id, character, ascension, version, players, bracket
         )
     except Exception:
         logger.warning("user-insights card deltas failed", exc_info=True)
@@ -638,6 +657,7 @@ def _compute_insights(
             ascension,
             version,
             players,
+            bracket,
         )
     except Exception:
         logger.warning("user-insights relic deltas failed", exc_info=True)

--- a/backend/tests/test_insights_filters.py
+++ b/backend/tests/test_insights_filters.py
@@ -37,3 +37,14 @@ def test_cache_keys_stay_backward_compatible():
     assert _filters_suffix("IRONCLAD", None, None, None) == ":IRONCLAD"
     assert _filters_suffix(None, 10, None, None) == "::a10:v:p"
     assert _filters_suffix("SILENT", 10, "v0.111.0", 2) == ":SILENT:a10:vv0.111.0:p2"
+
+
+def test_filters_map_to_materialized_brackets():
+    from app.services.user_insights import _filters_bracket
+
+    assert _filters_bracket(None, None, None) is None
+    assert _filters_bracket(10, None, None) == "a10"
+    assert _filters_bracket(None, None, 1) == "solo"
+    assert _filters_bracket(10, "v0.111.0", 1) == "solo:a10:v0.111.0"
+    assert _filters_bracket(7, None, None) is None  # only A10 has a bracket
+    assert _filters_bracket(None, "v0.110.1", 3) == "3p:v0.110.1"

--- a/backend/tests/test_user_insights.py
+++ b/backend/tests/test_user_insights.py
@@ -16,8 +16,8 @@ def _fake_backend(monkeypatch, rows, blobs, community, table, tallies):
         "get_user_card_pick_tallies",
         lambda uid, character=None, **kw: tallies,
     )
-    monkeypatch.setattr(user_insights, "get_community_stats", lambda: community)
-    monkeypatch.setattr(user_insights, "get_entity_metrics_table", lambda etype: table)
+    monkeypatch.setattr(user_insights, "get_community_stats", lambda *a, **k: community)
+    monkeypatch.setattr(user_insights, "get_entity_metrics_table", lambda *a, **k: table)
     user_insights._cache.clear()
 
 
@@ -104,9 +104,9 @@ def test_insights_build_then_cache(monkeypatch):
         "get_user_card_pick_tallies",
         lambda uid, character=None, **kw: {},
     )
-    monkeypatch.setattr(user_insights, "get_community_stats", lambda: {})
+    monkeypatch.setattr(user_insights, "get_community_stats", lambda *a, **k: {})
     monkeypatch.setattr(
-        user_insights, "get_entity_metrics_table", lambda etype: {"rows": []}
+        user_insights, "get_entity_metrics_table", lambda *a, **k: {"rows": []}
     )
     monkeypatch.setattr(user_insights.threading, "Thread", _InlineThread)
     user_insights._cache.clear()
@@ -136,9 +136,9 @@ def test_prewarm_kicks_only_when_cold(monkeypatch):
         "get_user_card_pick_tallies",
         lambda uid, character=None, **kw: {},
     )
-    monkeypatch.setattr(user_insights, "get_community_stats", lambda: {})
+    monkeypatch.setattr(user_insights, "get_community_stats", lambda *a, **k: {})
     monkeypatch.setattr(
-        user_insights, "get_entity_metrics_table", lambda etype: {"rows": []}
+        user_insights, "get_entity_metrics_table", lambda *a, **k: {"rows": []}
     )
     monkeypatch.setattr(user_insights.threading, "Thread", _InlineThread)
     user_insights._cache.clear()
@@ -265,9 +265,9 @@ def test_character_filter_scopes_walk_and_cache(monkeypatch):
         runs_db_mongo, "get_run_blobs", lambda hashes: {h: blobs[h] for h in hashes}
     )
     monkeypatch.setattr(runs_db_mongo, "get_user_card_pick_tallies", tallies)
-    monkeypatch.setattr(user_insights, "get_community_stats", lambda: {})
+    monkeypatch.setattr(user_insights, "get_community_stats", lambda *a, **k: {})
     monkeypatch.setattr(
-        user_insights, "get_entity_metrics_table", lambda etype: {"rows": []}
+        user_insights, "get_entity_metrics_table", lambda *a, **k: {"rows": []}
     )
     monkeypatch.setattr(
         runs_db_mongo, "get_user_winrates", lambda: {"p": [10, 5], "q": [10, 4]}

--- a/frontend/app/components/ProfileInsights.tsx
+++ b/frontend/app/components/ProfileInsights.tsx
@@ -203,6 +203,8 @@ const CHARACTER_HEX: Record<string, string> = {
 };
 
 const CHARACTERS = ["ironclad", "silent", "defect", "necrobinder", "regent"] as const;
+// Same canonical order the stats page uses, so both lists line up.
+const CHAR_ORDER = ["IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"];
 
 // Insight scope filters: character (icon dropdown), ascension, players, and
 // game version, all defaulting to All. Each change re-fetches the whole
@@ -705,9 +707,9 @@ function DeathColumn({ title, rows, lang }: { title: string; rows: ComparableRow
           <div key={d.id} className="flex items-center justify-between text-sm">
             <span className="text-[var(--text-primary)] truncate">{d.name || d.id.replace(/_/g, " ")}</span>
             <span className="text-xs text-[var(--text-tertiary)] tabular-nums shrink-0 ml-2">
-              {d.count} · {d.pct}%
+              {d.count} · {d.pct.toFixed(1)}%
               {d.community_pct != null && (
-                <span className="text-[var(--text-muted)]"> ({d.community_pct}%)</span>
+                <span className="text-[var(--text-muted)]"> ({d.community_pct.toFixed(1)}%)</span>
               )}
             </span>
           </div>
@@ -776,7 +778,12 @@ export function InsightsPanels({
   const streaks = data.streaks;
   const hasRecords = records.fastest_win || records.longest_run || records.biggest_deck;
   const hasBests = bests && Object.values(bests).some(Boolean);
-  const characters = (data.by_character || []).filter((c) => c.runs > 0);
+  const characters = (data.by_character || [])
+    .filter((c) => c.runs > 0)
+    .sort(
+      (a, b) =>
+        CHAR_ORDER.indexOf(a.id.toUpperCase()) - CHAR_ORDER.indexOf(b.id.toUpperCase()),
+    );
   const losses = data.total_losses ?? (data.total_wins != null ? data.total_runs - data.total_wins : null);
 
   return (
@@ -859,7 +866,7 @@ export function InsightsPanels({
                 <div key={c.id} className="space-y-1">
                   <div className="flex items-center justify-between text-sm">
                     <span className="font-medium" style={{ color: hex }}>
-                      {c.name || displayCharacter(c.id)}
+                      {(c.name || displayCharacter(c.id)).replace(/^The\s+/i, "")}
                     </span>
                     <span className="text-xs text-[var(--text-tertiary)] tabular-nums">
                       {c.runs} {t("runs", lang)} · {c.share}%

--- a/frontend/app/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/leaderboards/stats/StatsClient.tsx
@@ -14,6 +14,9 @@ import { CONTENT_BRACKETS, combineBracket } from "@/lib/content-brackets";
 import { Pills, PLAYER_OPTS } from "@/app/components/PlayerCountPills";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+// Canonical character order, shared with the profile page so the two lists
+// always line up (was: sorted by total runs here, payload order there).
+const CHAR_ORDER = ["IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"];
 
 // One entity's per-bracket slice from /api/runs/scores/{type}?bracket= (or,
 // with a character selected, from /api/runs/metrics/{type} mapped to the same
@@ -1167,7 +1170,13 @@ function OverviewTab({
             {t("Character Win Rates", lang)}
           </h2>
           <div className="space-y-2">
-            {stats.characters.map((c) => {
+            {[...stats.characters]
+              .sort(
+                (a, b) =>
+                  CHAR_ORDER.indexOf(a.character.toUpperCase()) -
+                  CHAR_ORDER.indexOf(b.character.toUpperCase()),
+              )
+              .map((c) => {
               const charColor = characterHex(c.character) || "var(--text-muted)";
               const totalPct = (c.total / maxCharTotal) * 100;
               const winPct = c.total > 0 ? (c.wins / c.total) * 100 : 0;
@@ -1182,7 +1191,7 @@ function OverviewTab({
                       className="text-sm font-medium group-hover:text-[var(--accent-gold)] transition-colors"
                       style={{ color: charColor }}
                     >
-                      {displayName(`CHARACTER.${c.character}`)}
+                      {displayName(`CHARACTER.${c.character}`).replace(/^The\s+/i, "")}
                     </span>
                     <div className="flex items-center gap-3 text-xs">
                       <span className="text-[var(--text-muted)]">


### PR DESCRIPTION
I scope the profile's community comparison numbers to the bracket the active filters map to (solo/a10/version compose) so they match /leaderboards/stats, pin both pages to the canonical character order, strip the stray The prefix, and give the what-kills-you percentages a fixed decimal.