### PR TITLE
Co-op run page player fix and export run ids

### DIFF
--- a/backend/app/routers/exports.py
+++ b/backend/app/routers/exports.py
@@ -210,10 +210,13 @@ def _stream_runs_jsonl(hashes):
             continue
         try:
             raw = run_file.read_text(encoding="utf-8").strip()
-            json.loads(raw)
+            obj = json.loads(raw)
         except (json.JSONDecodeError, OSError):
             continue
-        gz.write(raw.encode("utf-8"))
+        # The blob has no identifier of its own (the hash is derived), so
+        # stamp it in — consumers link back to /runs/<run_hash> with it.
+        obj["run_hash"] = run_hash
+        gz.write(json.dumps(obj, separators=(",", ":")).encode("utf-8"))
         gz.write(b"\n")
         if buf.tell() > 65536:
             gz.flush()

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -908,6 +908,13 @@ def get_shared_run(run_hash: str, request: Request):
         primary = primary_share_hash(blob)
         if primary and primary != run_hash:
             blob["primary_hash"] = primary
+        # Which players[] entry this hash belongs to, so the page renders the
+        # viewed player's character instead of the host's on co-op siblings.
+        from ..services.runs_db_mongo import player_index_for_hash
+
+        idx = player_index_for_hash(blob, run_hash)
+        if idx is not None:
+            blob["player_index"] = idx
         if using_mongo:
             from ..services.runs_db_mongo import get_username_for_hash
 

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -2787,6 +2787,25 @@ def get_user_picks(steam_id: str) -> dict[str, dict]:
 
 
 @_instrument("primary_share_hash")
+def player_index_for_hash(data: dict, run_hash: str) -> int | None:
+    """Which players[] entry a per-player share hash belongs to. Co-op runs
+    store one doc per player and every sibling serves the same blob, so the
+    page needs this to show the viewed player's character instead of the
+    host's. Same key recipe as _submit_player_run; None when nothing matches
+    (malformed blob, or a legacy hash scheme)."""
+    try:
+        for idx, p in enumerate(data.get("players") or []):
+            key = (
+                f"{data.get('seed', '')}:{p['character']}:{data.get('start_time', '')}:"
+                f"{data.get('run_time', 0)}:{len(p.get('deck', []))}:{idx}"
+            )
+            if hashlib.sha256(key.encode()).hexdigest()[:16] == run_hash:
+                return idx
+    except Exception:
+        pass
+    return None
+
+
 def primary_share_hash(data: dict) -> str | None:
     """The player-0 share hash recomputed from a submitted run blob.
 

--- a/backend/tests/test_player_index_for_hash.py
+++ b/backend/tests/test_player_index_for_hash.py
@@ -1,0 +1,42 @@
+"""player_index_for_hash must invert _submit_player_run's hash recipe, so
+co-op share pages can show the viewed player's character instead of the
+host's (reported live 2026-08-17)."""
+
+import hashlib
+
+from app.services.runs_db_mongo import player_index_for_hash, primary_share_hash
+
+BLOB = {
+    "seed": "ABC123",
+    "start_time": 1776393693,
+    "run_time": 2400,
+    "players": [
+        {"character": "CHARACTER.IRONCLAD", "deck": [{"id": "BASH"}] * 12},
+        {"character": "CHARACTER.SILENT", "deck": [{"id": "NEUTRALIZE"}] * 15},
+        {"character": "CHARACTER.REGENT", "deck": [{"id": "POKE"}] * 9},
+    ],
+}
+
+
+def _hash_for(idx: int) -> str:
+    p = BLOB["players"][idx]
+    key = (
+        f"{BLOB['seed']}:{p['character']}:{BLOB['start_time']}:"
+        f"{BLOB['run_time']}:{len(p['deck'])}:{idx}"
+    )
+    return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+def test_each_sibling_hash_maps_to_its_player():
+    for idx in range(3):
+        assert player_index_for_hash(BLOB, _hash_for(idx)) == idx
+
+
+def test_primary_hash_is_player_zero():
+    assert primary_share_hash(BLOB) == _hash_for(0)
+    assert player_index_for_hash(BLOB, primary_share_hash(BLOB)) == 0
+
+
+def test_unknown_hash_returns_none():
+    assert player_index_for_hash(BLOB, "deadbeefdeadbeef") is None
+    assert player_index_for_hash({}, "deadbeefdeadbeef") is None

--- a/frontend/app/runs/[hash]/SharedRunClient.tsx
+++ b/frontend/app/runs/[hash]/SharedRunClient.tsx
@@ -154,7 +154,9 @@ export default function SharedRunClient({ initialRun }: { initialRun?: any }) {
     </div>
   );
 
-  const player = run.players[0];
+  // Co-op siblings all serve the same blob; player_index says which
+  // players[] entry the viewed hash belongs to (0 = host / single-player).
+  const player = run.players[run.player_index ?? 0] ?? run.players[0];
   const charId = cleanId(player.character);
   const charColor = CHAR_CSS_VAR[charId.toUpperCase()] || "var(--accent-gold)";
   const totalFloors = run.map_point_history?.reduce((sum: number, act: any[]) => sum + act.length, 0) || 0;


### PR DESCRIPTION
I added player_index to the shared-run payload by inverting the submit-time hash recipe so co-op sibling pages show the viewed player's character instead of the host's, and stamped run_hash into each /api/exports/runs JSONL line so consumers can link back to run pages without recomputing hashes.