### PR TITLE
Hidden player Elo

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1082,3 +1082,13 @@ async def analytics(request: Request):
         # UMAMI_URL (http://umami:3000) the proxy itself may use.
         "dashboard_url": "https://analytics.spire-codex.com",
     }
+
+
+@router.get("/player-elo")
+def admin_player_elo(refresh: bool = False):
+    """Hidden player Elo board (A10 standard runs), admin-only. Cached an
+    hour; ?refresh=1 recomputes and re-persists hidden_elo on the user docs.
+    Deliberately unexposed anywhere public — display experiment only."""
+    from ..services.player_elo import get_player_elos
+
+    return get_player_elos(refresh=refresh)

--- a/backend/app/services/player_elo.py
+++ b/backend/app/services/player_elo.py
@@ -1,0 +1,144 @@
+"""Hidden per-player Elo over A10 standard runs.
+
+Each rated run is a match against a per-character difficulty anchor: the
+anchor rating is chosen so a 1000-rated player's expected win chance equals
+the community's A10 win rate for that character (from the snapshot's
+ascension_matrix). Runs are walked in played order; K is 32 for a player's
+first 30 rated runs, 16 after. Results persist as ``hidden_elo`` on the user
+doc and serve ONLY through the admin router — no public endpoint reads them.
+"""
+
+import logging
+import math
+import time
+from datetime import datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+START_ELO = 1000.0
+K_PLACEMENT = 32.0
+K_SETTLED = 16.0
+PLACEMENT_RUNS = 30
+# Below this many community A10 runs a character's win rate is too thin to
+# anchor on; fall back to the average of the anchored characters.
+MIN_ANCHOR_RUNS = 100
+_CACHE_KEY = "admin:player_elo"
+_CACHE_TTL = 3600
+
+
+def _anchor_rating(p: float) -> float:
+    """The rating an opponent would need so a START_ELO player's expected
+    score equals p (the community win rate for the slice)."""
+    p = min(max(p, 0.01), 0.99)
+    return START_ELO + 400.0 * math.log10((1.0 - p) / p)
+
+
+def _expected(player: float, anchor: float) -> float:
+    return 1.0 / (1.0 + 10.0 ** ((anchor - player) / 400.0))
+
+
+def rate_runs(runs: list[dict], p_by_char: dict[str, float], default_p: float) -> dict:
+    """Fold one player's chronologically ordered A10 runs into a rating."""
+    elo, wins = START_ELO, 0
+    for i, r in enumerate(runs):
+        char = (r.get("character") or "").split(".")[-1].lower()
+        p = p_by_char.get(char, default_p)
+        k = K_PLACEMENT if i < PLACEMENT_RUNS else K_SETTLED
+        score = 1.0 if r.get("win") else 0.0
+        elo += k * (score - _expected(elo, _anchor_rating(p)))
+        wins += int(score)
+    return {"elo": round(elo, 1), "runs": len(runs), "wins": wins}
+
+
+def _difficulty_anchors() -> tuple[dict[str, float], float]:
+    from .run_entity_stats import get_community_stats
+
+    matrix = (get_community_stats() or {}).get("ascension_matrix") or {}
+    p_by_char: dict[str, float] = {}
+    for cid, per_asc in matrix.items():
+        cell = (per_asc or {}).get("10")
+        if cell and cell.get("runs", 0) >= MIN_ANCHOR_RUNS:
+            p_by_char[cid] = cell["win_rate"] / 100.0
+    default_p = sum(p_by_char.values()) / len(p_by_char) if p_by_char else 0.2
+    return p_by_char, default_p
+
+
+def compute_player_elos(persist: bool = True) -> list[dict]:
+    """Rate every account with at least one linked A10 standard run. Pulls
+    the rated rows once, orders them in Python (played_at with submitted_at
+    as the legacy fallback), and optionally persists hidden_elo on each user
+    doc. One scan of the A10 slice — callers cache."""
+    from .runs_db_mongo import _get_collection
+    from .users_db import _get_collection as _users_coll
+
+    p_by_char, default_p = _difficulty_anchors()
+    rows = _get_collection().find(
+        {
+            "user_id": {"$ne": None},
+            "ascension": 10,
+            "game_mode": "standard",
+            "deleted_at": None,
+            "hidden": {"$ne": True},
+        },
+        {"user_id": 1, "win": 1, "character": 1, "played_at": 1, "submitted_at": 1},
+    )
+    by_user: dict[Any, list[dict]] = {}
+    for r in rows:
+        by_user.setdefault(r["user_id"], []).append(r)
+
+    floor = datetime(1970, 1, 1)
+    out: list[dict] = []
+    raw_id: dict[str, Any] = {}
+    for uid, runs in by_user.items():
+        runs.sort(key=lambda r: r.get("played_at") or r.get("submitted_at") or floor)
+        rec = rate_runs(runs, p_by_char, default_p)
+        rec["user_id"] = str(uid)
+        raw_id[str(uid)] = uid
+        out.append(rec)
+    out.sort(key=lambda r: -r["elo"])
+
+    users = _users_coll()
+    names = {
+        str(u["_id"]): u.get("username")
+        for u in users.find({"_id": {"$in": list(raw_id.values())}}, {"username": 1})
+    }
+    for r in out:
+        r["username"] = names.get(r["user_id"])
+
+    if persist and out:
+        try:
+            from pymongo import UpdateOne
+
+            users.bulk_write(
+                [
+                    UpdateOne(
+                        {"_id": raw_id[r["user_id"]]},
+                        {"$set": {"hidden_elo": r["elo"]}},
+                    )
+                    for r in out
+                ],
+                ordered=False,
+            )
+        except Exception:
+            logger.warning("hidden_elo persist failed", exc_info=True)
+    return out
+
+
+def get_player_elos(refresh: bool = False) -> dict:
+    """Cached admin view. refresh=True recomputes and re-persists."""
+    from . import cache as app_cache
+
+    if not refresh:
+        cached = app_cache.get_json(_CACHE_KEY)
+        if cached is not None:
+            return cached
+    started = time.time()
+    board = compute_player_elos()
+    payload = {
+        "players": board,
+        "computed_at": time.time(),
+        "compute_seconds": round(time.time() - started, 1),
+    }
+    app_cache.set_json(_CACHE_KEY, payload, _CACHE_TTL)
+    return payload

--- a/backend/tests/test_player_elo.py
+++ b/backend/tests/test_player_elo.py
@@ -1,0 +1,37 @@
+"""The hidden player Elo: anchors reproduce the community win rate at the
+starting rating, ratings move the right way, and upsets pay more."""
+
+from app.services.player_elo import (
+    START_ELO,
+    _anchor_rating,
+    _expected,
+    rate_runs,
+)
+
+
+def test_anchor_reproduces_community_rate():
+    for p in (0.1, 0.207, 0.5, 0.9):
+        assert abs(_expected(START_ELO, _anchor_rating(p)) - p) < 1e-9
+
+
+def test_wins_raise_and_losses_lower():
+    p = {"ironclad": 0.2}
+    win = rate_runs([{"character": "IRONCLAD", "win": True}], p, 0.2)
+    loss = rate_runs([{"character": "IRONCLAD", "win": False}], p, 0.2)
+    assert win["elo"] > START_ELO > loss["elo"]
+    # Winning at 20% odds pays ~4x what losing costs.
+    assert (win["elo"] - START_ELO) > (START_ELO - loss["elo"]) * 3
+
+
+def test_harder_characters_pay_more():
+    anchors = {"defect": 0.15, "regent": 0.3}
+    hard = rate_runs([{"character": "CHARACTER.DEFECT", "win": True}], anchors, 0.2)
+    easy = rate_runs([{"character": "CHARACTER.REGENT", "win": True}], anchors, 0.2)
+    assert hard["elo"] > easy["elo"]
+
+
+def test_settled_k_after_placement():
+    runs = [{"character": "IRONCLAD", "win": True}] * 32
+    rec = rate_runs(runs, {"ironclad": 0.2}, 0.2)
+    assert rec["runs"] == 32 and rec["wins"] == 32
+    assert rec["elo"] > START_ELO

--- a/frontend/app/admin/elo/EloClient.tsx
+++ b/frontend/app/admin/elo/EloClient.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+// Hidden player Elo board: A10 standard runs rated against per-character
+// community difficulty anchors. Display experiment — nothing public links
+// or serves this; the numbers live only on user docs and this page.
+
+import { useEffect, useState } from "react";
+import { AdminShell, adminFetch } from "../shared";
+
+interface EloRow {
+  user_id: string;
+  username: string | null;
+  elo: number;
+  runs: number;
+  wins: number;
+}
+
+interface Board {
+  players: EloRow[];
+  computed_at: number;
+  compute_seconds: number;
+}
+
+export default function EloClient() {
+  const [board, setBoard] = useState<Board | null>(null);
+  const [minRuns, setMinRuns] = useState(10);
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+
+  const load = (refresh = false) => {
+    setBusy(true);
+    adminFetch<Board>(`/api/admin/player-elo${refresh ? "?refresh=1" : ""}`)
+      .then(setBoard)
+      .catch((e) => setNote(String((e as Error)?.message || e)))
+      .finally(() => setBusy(false));
+  };
+  useEffect(() => load(), []);
+
+  const rows = (board?.players || []).filter((p) => p.runs >= minRuns);
+
+  return (
+    <AdminShell
+      title="Player Elo"
+      subtitle="A10 standard runs, rated against per-character community difficulty. Hidden — admin eyes only."
+    >
+      <div className="flex items-center gap-3 mb-4 text-sm">
+        <label className="text-[var(--text-muted)]">
+          Min rated runs{" "}
+          <input
+            type="number"
+            min={1}
+            value={minRuns}
+            onChange={(e) => setMinRuns(Math.max(1, Number(e.target.value) || 1))}
+            className="w-16 ml-1 px-2 py-1 rounded border border-[var(--border-subtle)] bg-[var(--bg-card)] text-[var(--text-primary)]"
+          />
+        </label>
+        <button
+          onClick={() => load(true)}
+          disabled={busy}
+          className="px-3 py-1.5 rounded-lg border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)] disabled:opacity-50"
+        >
+          {busy ? "Computing…" : "Recompute"}
+        </button>
+        {board && (
+          <span className="text-xs text-[var(--text-muted)]">
+            {board.players.length.toLocaleString()} rated players · computed in{" "}
+            {board.compute_seconds}s ·{" "}
+            {new Date(board.computed_at * 1000).toLocaleTimeString()}
+          </span>
+        )}
+        {note && <span className="text-xs text-rose-400">{note}</span>}
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="text-sm tabular-nums w-full max-w-2xl">
+          <thead>
+            <tr className="text-left text-xs uppercase tracking-wider text-[var(--text-muted)]">
+              <th className="py-1.5 pr-4">#</th>
+              <th className="py-1.5 pr-4">Player</th>
+              <th className="py-1.5 pr-4 text-right">Elo</th>
+              <th className="py-1.5 pr-4 text-right">A10 runs</th>
+              <th className="py-1.5 pr-4 text-right">Wins</th>
+              <th className="py-1.5 text-right">WR</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.slice(0, 200).map((p, i) => (
+              <tr key={p.user_id} className="border-t border-[var(--border-subtle)]">
+                <td className="py-1.5 pr-4 text-[var(--text-muted)]">{i + 1}</td>
+                <td className="py-1.5 pr-4 text-[var(--text-primary)]">
+                  {p.username || <span className="text-[var(--text-muted)]">{p.user_id.slice(0, 8)}…</span>}
+                </td>
+                <td className="py-1.5 pr-4 text-right font-semibold text-[var(--accent-gold)]">
+                  {Math.round(p.elo)}
+                </td>
+                <td className="py-1.5 pr-4 text-right">{p.runs.toLocaleString()}</td>
+                <td className="py-1.5 pr-4 text-right">{p.wins.toLocaleString()}</td>
+                <td className="py-1.5 text-right">
+                  {p.runs ? ((p.wins / p.runs) * 100).toFixed(1) : "0.0"}%
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </AdminShell>
+  );
+}

--- a/frontend/app/admin/elo/page.tsx
+++ b/frontend/app/admin/elo/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import EloClient from "./EloClient";
+
+export const metadata: Metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminEloPage() {
+  return <EloClient />;
+}

--- a/frontend/app/admin/shared.tsx
+++ b/frontend/app/admin/shared.tsx
@@ -120,6 +120,7 @@ const SECTIONS = [
   { href: "/admin/searches", label: "Searches" },
   { href: "/admin/cache", label: "Cache" },
   { href: "/admin/rate-limits", label: "Rate limits" },
+  { href: "/admin/elo", label: "Elo" },
   { href: "/admin/keys", label: "API keys" },
 ];
 


### PR DESCRIPTION
I added a hidden per-account Elo rated over A10 standard runs against per-character community difficulty anchors, persisted as hidden_elo on user docs and visible only on the new admin-gated /admin/elo board — nothing public serves it.