### PR TITLE
Game-mode bracket filter

### DIFF
--- a/backend/app/services/community_stats.py
+++ b/backend/app/services/community_stats.py
@@ -79,10 +79,14 @@ COMMUNITY_VERSION = 1
 # _COMPOSITE_BRACKETS in run_entity_stats.py.
 _PLAYER_BRACKETS = ("solo", "2p", "3p", "4p")
 _SKILL_BRACKETS = ("a10", "wr30", "wr50", "wr75")
+# Game-mode keys share the single ?bracket= slot (a mode replaces the
+# player/skill selection, like daily/custom always did on the entity side).
+_MODE_BRACKETS = ("standard", "daily", "custom")
 _BLOB_BRACKETS = (
     ["all"]
     + list(_PLAYER_BRACKETS)
     + list(_SKILL_BRACKETS)
+    + list(_MODE_BRACKETS)
     + [f"{p}:{c}" for p in _PLAYER_BRACKETS for c in _SKILL_BRACKETS]
 )
 

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -122,6 +122,7 @@ _BRACKET_KEYS = [
     "3p",
     "4p",
     "a10",
+    "standard",
     "daily",
     "custom",
     # Win-rate skill brackets (see _winrate_brackets).
@@ -152,6 +153,8 @@ def _run_extra_brackets(player_count: int, ascension: int, game_mode: str) -> li
         out.append("daily")
     elif gm == "custom":
         out.append("custom")
+    else:
+        out.append("standard")
     return out
 
 
@@ -296,7 +299,7 @@ _HISTORY_RETENTION_DAYS = 90
 # Version 22: the official-id filters accept beta-catalog entities (beta-only
 # cards/relics were read as modded and vanished from the tier list); the bump
 # forces the rebuild that restores their walk-time per-act relic data.
-SNAPSHOT_VERSION = 23
+SNAPSHOT_VERSION = 24
 # Serialized-byte budget per persisted chunk doc. With version-composable
 # brackets a popular entity carries hundreds of per-bracket blocks and
 # entity sizes vary wildly (a card dwarfs an affliction), so chunks are

--- a/backend/tests/test_insights_filters.py
+++ b/backend/tests/test_insights_filters.py
@@ -48,3 +48,16 @@ def test_filters_map_to_materialized_brackets():
     assert _filters_bracket(10, "v0.111.0", 1) == "solo:a10:v0.111.0"
     assert _filters_bracket(7, None, None) is None  # only A10 has a bracket
     assert _filters_bracket(None, "v0.110.1", 3) == "3p:v0.110.1"
+
+
+def test_mode_brackets_materialize():
+    from app.services.community_stats import new_accumulator
+    from app.services.run_entity_stats import _run_extra_brackets
+
+    acc = new_accumulator(("v0.111.0",))
+    for key in ("standard", "daily", "custom", "standard:v0.111.0"):
+        assert key in acc
+    assert "standard" in _run_extra_brackets(1, 0, "standard")
+    assert "standard" in _run_extra_brackets(1, 0, "")
+    assert "daily" in _run_extra_brackets(1, 0, "daily")
+    assert "standard" not in _run_extra_brackets(1, 0, "custom")

--- a/frontend/app/components/BracketFilter.tsx
+++ b/frontend/app/components/BracketFilter.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import {
   CONTENT_BRACKETS,
   PLAYER_BRACKETS,
+  MODE_BRACKETS,
   normalizeBracket,
   splitBracket,
   combineBracket,
@@ -77,6 +78,30 @@ export default function BracketFilter({
           <span className="text-xs text-[var(--text-muted)] mx-1">Players</span>
           {PLAYER_BRACKETS.map(renderPill)}
         </div>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="w-14 text-xs text-[var(--text-muted)]">Mode</span>
+        <Link
+          href={hrefFor(
+            base && !MODE_BRACKETS.some((m) => m.key === base)
+              ? version
+                ? `${base}:${version}`
+                : base
+              : version || "all",
+          )}
+          className={pillCls(!MODE_BRACKETS.some((m) => m.key === base))}
+        >
+          All
+        </Link>
+        {MODE_BRACKETS.map((m) => (
+          <Link
+            key={m.key}
+            href={hrefFor(version ? `${m.key}:${version}` : m.key)}
+            className={pillCls(base === m.key)}
+          >
+            {m.label}
+          </Link>
+        ))}
+      </div>
         <VersionSelectNav
           basePath={basePath}
           current={active}
@@ -88,7 +113,9 @@ export default function BracketFilter({
   }
 
   // Composite: each skill pill keeps the current player and vice versa, so the
-  // two axes combine into a player:skill bracket.
+  // two axes combine into a player:skill bracket. Modes occupy the whole base
+  // slot instead (they don't compose with player/skill).
+  const base = stripVersion(active);
   const playerOpts = [{ key: "", label: "All" }, ...PLAYER_BRACKETS];
   return (
     <div className="mb-5 space-y-1.5">
@@ -119,13 +146,37 @@ export default function BracketFilter({
           </Link>
         ))}
       </div>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="w-14 text-xs text-[var(--text-muted)]">Mode</span>
+        <Link
+          href={hrefFor(
+            base && !MODE_BRACKETS.some((m) => m.key === base)
+              ? version
+                ? `${base}:${version}`
+                : base
+              : version || "all",
+          )}
+          className={pillCls(!MODE_BRACKETS.some((m) => m.key === base))}
+        >
+          All
+        </Link>
+        {MODE_BRACKETS.map((m) => (
+          <Link
+            key={m.key}
+            href={hrefFor(version ? `${m.key}:${version}` : m.key)}
+            className={pillCls(base === m.key)}
+          >
+            {m.label}
+          </Link>
+        ))}
+      </div>
       {/* Game version is a third axis: it composes with the player and
           skill selections instead of replacing them. */}
       <VersionSelectNav
         basePath={basePath}
         current={active}
         extraParams={extraParams}
-        base={combineBracket(player, skill) === "all" ? "" : combineBracket(player, skill)}
+        base={base === "all" ? "" : base}
       />
     </div>
   );

--- a/frontend/lib/content-brackets.ts
+++ b/frontend/lib/content-brackets.ts
@@ -28,9 +28,18 @@ export const PLAYER_BRACKETS: ContentBracket[] = [
   { key: "4p", param: "4p", label: "4P" },
 ];
 
+// Game-mode brackets. Like the player axis they share the single ?bracket=
+// slot: picking a mode replaces the player/skill selection (only the version
+// composes on top). "All" is the absence of a mode key.
+export const MODE_BRACKETS: ContentBracket[] = [
+  { key: "standard", param: "standard", label: "Standard" },
+  { key: "daily", param: "daily", label: "Daily" },
+  { key: "custom", param: "custom", label: "Custom" },
+];
+
 // Both axes are valid ?bracket= values, so normalizeBracket must recognize them.
 const _BY_KEY = new Map(
-  [...CONTENT_BRACKETS, ...PLAYER_BRACKETS].map((b) => [b.key, b]),
+  [...CONTENT_BRACKETS, ...PLAYER_BRACKETS, ...MODE_BRACKETS].map((b) => [b.key, b]),
 );
 
 const _PLAYER_KEYS = new Set(PLAYER_BRACKETS.map((b) => b.key));


### PR DESCRIPTION
I added standard as a bracket key alongside daily and custom, materialized all three in the community blob, and put a Mode pill row (All/Standard/Daily/Custom) on the bracket filter so community stats and tier lists can exclude daily and custom runs; the snapshot bumps to 24, so the mode slices fill in after the first rebuild post-deploy.