### PR TITLE
Fix the Elo board 504

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1092,3 +1092,17 @@ def admin_player_elo(refresh: bool = False):
     from ..services.player_elo import get_player_elos
 
     return get_player_elos(refresh=refresh)
+
+
+@router.get("/player-elo/{user_id}/history")
+def admin_player_elo_history(user_id: str):
+    """One player's Elo trajectory (a point per rated A10 run) for the
+    admin board's chart."""
+    from fastapi import HTTPException
+
+    from ..services.player_elo import compute_player_history
+
+    rec = compute_player_history(user_id)
+    if rec is None:
+        raise HTTPException(status_code=404, detail="No rated runs")
+    return rec

--- a/backend/app/services/player_elo.py
+++ b/backend/app/services/player_elo.py
@@ -10,6 +10,7 @@ doc and serve ONLY through the admin router — no public endpoint reads them.
 
 import logging
 import math
+import threading
 import time
 from datetime import datetime
 from typing import Any
@@ -73,9 +74,14 @@ def compute_player_elos(persist: bool = True) -> list[dict]:
     from .users_db import _get_collection as _users_coll
 
     p_by_char, default_p = _difficulty_anchors()
+    from bson import ObjectId
+
+    # $gt over the ObjectId floor rides the (user_id, ...) index and skips
+    # every unlinked doc; {$ne: None} forced a 1.2M-doc collection scan,
+    # which is what 504'd the first admin request.
     rows = _get_collection().find(
         {
-            "user_id": {"$ne": None},
+            "user_id": {"$gt": ObjectId("0" * 24)},
             "ascension": 10,
             "game_mode": "standard",
             "deleted_at": None,
@@ -125,20 +131,56 @@ def compute_player_elos(persist: bool = True) -> list[dict]:
     return out
 
 
-def get_player_elos(refresh: bool = False) -> dict:
-    """Cached admin view. refresh=True recomputes and re-persists."""
+_inflight_lock = threading.Lock()
+_inflight = False
+
+
+def _kick_compute() -> None:
+    global _inflight
     from . import cache as app_cache
 
-    if not refresh:
-        cached = app_cache.get_json(_CACHE_KEY)
-        if cached is not None:
-            return cached
-    started = time.time()
-    board = compute_player_elos()
-    payload = {
-        "players": board,
-        "computed_at": time.time(),
-        "compute_seconds": round(time.time() - started, 1),
-    }
-    app_cache.set_json(_CACHE_KEY, payload, _CACHE_TTL)
-    return payload
+    with _inflight_lock:
+        if _inflight:
+            return
+        _inflight = True
+    if not app_cache.acquire_lock(f"{_CACHE_KEY}:lock", 600):
+        with _inflight_lock:
+            _inflight = False
+        return
+
+    def _run() -> None:
+        global _inflight
+        try:
+            started = time.time()
+            board = compute_player_elos()
+            app_cache.set_json(
+                _CACHE_KEY,
+                {
+                    "players": board,
+                    "computed_at": time.time(),
+                    "compute_seconds": round(time.time() - started, 1),
+                },
+                _CACHE_TTL,
+            )
+        except Exception:
+            logger.warning("player elo compute failed", exc_info=True)
+        finally:
+            app_cache.delete(f"{_CACHE_KEY}:lock")
+            with _inflight_lock:
+                _inflight = False
+
+    threading.Thread(target=_run, daemon=True, name="player-elo").start()
+
+
+def get_player_elos(refresh: bool = False) -> dict:
+    """Cached admin view. Never computes on the request path — the walk can
+    outlive the gateway timeout, so a cold or refreshed board returns
+    {"building": true} and the client polls until the background compute
+    lands."""
+    from . import cache as app_cache
+
+    cached = None if refresh else app_cache.get_json(_CACHE_KEY)
+    if cached is not None:
+        return cached
+    _kick_compute()
+    return {"building": True}

--- a/backend/app/services/player_elo.py
+++ b/backend/app/services/player_elo.py
@@ -39,17 +39,64 @@ def _expected(player: float, anchor: float) -> float:
     return 1.0 / (1.0 + 10.0 ** ((anchor - player) / 400.0))
 
 
-def rate_runs(runs: list[dict], p_by_char: dict[str, float], default_p: float) -> dict:
-    """Fold one player's chronologically ordered A10 runs into a rating."""
-    elo, wins = START_ELO, 0
+def wilson_lower_bound(wins: int, n: int, z: float = 1.96) -> float:
+    """95% lower confidence bound on a win rate — the volume-honest lifetime
+    number (74 runs at 92% scores below 310 runs at 89%)."""
+    if n == 0:
+        return 0.0
+    p = wins / n
+    denom = 1 + z * z / n
+    center = p + z * z / (2 * n)
+    spread = z * math.sqrt((p * (1 - p) + z * z / (4 * n)) / n)
+    return max(0.0, (center - spread) / denom)
+
+
+def rate_runs(
+    runs: list[dict],
+    p_by_char: dict[str, float],
+    default_p: float,
+    collect_history: bool = False,
+) -> dict:
+    """Fold one player's chronologically ordered A10 runs into a rating.
+
+    Besides the sequential Elo, emits a "lifetime" performance rating: the
+    Wilson lower bound of the whole record solved against the player's mean
+    anchor — same scale as Elo, but order-independent and volume-punishing,
+    so it answers "best proven record" while Elo answers "best right now"."""
+    elo, wins, anchor_sum = START_ELO, 0, 0.0
+    history: list[dict] = []
     for i, r in enumerate(runs):
         char = (r.get("character") or "").split(".")[-1].lower()
         p = p_by_char.get(char, default_p)
+        anchor = _anchor_rating(p)
+        anchor_sum += anchor
         k = K_PLACEMENT if i < PLACEMENT_RUNS else K_SETTLED
         score = 1.0 if r.get("win") else 0.0
-        elo += k * (score - _expected(elo, _anchor_rating(p)))
+        elo += k * (score - _expected(elo, anchor))
         wins += int(score)
-    return {"elo": round(elo, 1), "runs": len(runs), "wins": wins}
+        if collect_history:
+            ts = r.get("played_at") or r.get("submitted_at")
+            history.append(
+                {
+                    "n": i + 1,
+                    "t": ts.isoformat() if hasattr(ts, "isoformat") else None,
+                    "elo": round(elo, 1),
+                    "win": bool(score),
+                }
+            )
+    rec: dict = {"elo": round(elo, 1), "runs": len(runs), "wins": wins}
+    if runs:
+        p_lb = wilson_lower_bound(wins, len(runs))
+        p_lb = min(max(p_lb, 0.01), 0.99)
+        mean_anchor = anchor_sum / len(runs)
+        rec["lifetime"] = round(
+            mean_anchor + 400.0 * math.log10(p_lb / (1.0 - p_lb)), 1
+        )
+    else:
+        rec["lifetime"] = START_ELO
+    if collect_history:
+        rec["history"] = history
+    return rec
 
 
 def _difficulty_anchors() -> tuple[dict[str, float], float]:
@@ -170,6 +217,43 @@ def _kick_compute() -> None:
                 _inflight = False
 
     threading.Thread(target=_run, daemon=True, name="player-elo").start()
+
+
+def compute_player_history(user_id: str) -> dict | None:
+    """One player's full Elo trajectory (a point per rated run), computed on
+    demand — cheap via the (user_id, played_at) index. None when the id is
+    malformed or the account has no rated runs."""
+    from bson import ObjectId
+
+    from .runs_db_mongo import _get_collection
+    from .users_db import _get_collection as _users_coll
+
+    try:
+        oid = ObjectId(user_id)
+    except Exception:
+        return None
+    p_by_char, default_p = _difficulty_anchors()
+    runs = list(
+        _get_collection().find(
+            {
+                "user_id": oid,
+                "ascension": 10,
+                "game_mode": "standard",
+                "deleted_at": None,
+                "hidden": {"$ne": True},
+            },
+            {"win": 1, "character": 1, "played_at": 1, "submitted_at": 1},
+        )
+    )
+    if not runs:
+        return None
+    floor = datetime(1970, 1, 1)
+    runs.sort(key=lambda r: r.get("played_at") or r.get("submitted_at") or floor)
+    rec = rate_runs(runs, p_by_char, default_p, collect_history=True)
+    user = _users_coll().find_one({"_id": oid}, {"username": 1})
+    rec["user_id"] = user_id
+    rec["username"] = (user or {}).get("username")
+    return rec
 
 
 def get_player_elos(refresh: bool = False) -> dict:

--- a/backend/tests/test_player_elo.py
+++ b/backend/tests/test_player_elo.py
@@ -35,3 +35,28 @@ def test_settled_k_after_placement():
     rec = rate_runs(runs, {"ironclad": 0.2}, 0.2)
     assert rec["runs"] == 32 and rec["wins"] == 32
     assert rec["elo"] > START_ELO
+
+
+def test_wilson_punishes_small_samples():
+    from app.services.player_elo import wilson_lower_bound
+
+    # 92% over 74 runs must score below 89% over 310 runs.
+    assert wilson_lower_bound(68, 74) < wilson_lower_bound(277, 310)
+    assert wilson_lower_bound(0, 0) == 0.0
+    assert 0.9 < wilson_lower_bound(9400, 10000) < 0.94
+
+
+def test_lifetime_is_order_independent_and_history_collects():
+    anchors = {"ironclad": 0.2}
+    early_wins = [
+        {"character": "IRONCLAD", "win": w} for w in [True] * 50 + [False] * 50
+    ]
+    late_wins = [
+        {"character": "IRONCLAD", "win": w} for w in [False] * 50 + [True] * 50
+    ]
+    a = rate_runs(early_wins, anchors, 0.2, collect_history=True)
+    b = rate_runs(late_wins, anchors, 0.2)
+    assert a["lifetime"] == b["lifetime"]  # same record, same lifetime
+    assert b["elo"] > a["elo"]  # but recent form separates the Elo
+    assert len(a["history"]) == 100
+    assert a["history"][0]["n"] == 1 and a["history"][-1]["elo"] == a["elo"]

--- a/frontend/app/admin/elo/EloClient.tsx
+++ b/frontend/app/admin/elo/EloClient.tsx
@@ -1,16 +1,32 @@
 "use client";
 
 // Hidden player Elo board: A10 standard runs rated against per-character
-// community difficulty anchors. Display experiment — nothing public links
-// or serves this; the numbers live only on user docs and this page.
+// community difficulty anchors. Elo answers "best right now" (sequential,
+// recency-weighted); Lifetime answers "best proven record" (Wilson lower
+// bound vs the same anchors, order-independent). Clicking a row charts the
+// player's full Elo trajectory. Display experiment — nothing public serves
+// any of this.
 
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
+import {
+  Chart as ChartJS,
+  LineElement,
+  PointElement,
+  LinearScale,
+  CategoryScale,
+  Tooltip,
+  Filler,
+} from "chart.js";
+import { Line } from "react-chartjs-2";
 import { AdminShell, adminFetch } from "../shared";
+
+ChartJS.register(LineElement, PointElement, LinearScale, CategoryScale, Tooltip, Filler);
 
 interface EloRow {
   user_id: string;
   username: string | null;
   elo: number;
+  lifetime?: number;
   runs: number;
   wins: number;
 }
@@ -22,9 +38,93 @@ interface Board {
   building?: boolean;
 }
 
+interface HistoryPoint {
+  n: number;
+  t: string | null;
+  elo: number;
+  win: boolean;
+}
+
+interface History {
+  username: string | null;
+  history: HistoryPoint[];
+}
+
+function TrajectoryChart({ userId }: { userId: string }) {
+  const [hist, setHist] = useState<History | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    adminFetch<History>(`/api/admin/player-elo/${userId}/history`)
+      .then(setHist)
+      .catch((e) => setErr(String((e as Error)?.message || e)));
+  }, [userId]);
+
+  if (err) return <p className="text-xs text-rose-400 py-3">{err}</p>;
+  if (!hist) return <p className="text-xs text-[var(--text-muted)] py-3">Loading trajectory…</p>;
+
+  const pts = hist.history;
+  return (
+    <div style={{ height: 200 }} className="py-2">
+      <Line
+        data={{
+          labels: pts.map((p) => p.n),
+          datasets: [
+            {
+              data: pts.map((p) => p.elo),
+              borderColor: "#e8b830",
+              backgroundColor: "rgba(232, 184, 48, 0.12)",
+              fill: true,
+              borderWidth: 2,
+              tension: 0.2,
+              pointRadius: 0,
+              pointHitRadius: 8,
+            },
+          ],
+        }}
+        options={{
+          responsive: true,
+          maintainAspectRatio: false,
+          animation: false,
+          interaction: { mode: "index", intersect: false },
+          scales: {
+            x: {
+              grid: { display: false },
+              border: { display: false },
+              ticks: { color: "#8a8a93", font: { size: 10 }, maxTicksLimit: 14 },
+              title: { display: true, text: "rated run #", color: "#8a8a93", font: { size: 10 } },
+            },
+            y: {
+              border: { display: false },
+              grid: { color: "rgba(138,138,147,0.15)" },
+              ticks: { color: "#8a8a93", font: { size: 10 } },
+            },
+          },
+          plugins: {
+            tooltip: {
+              callbacks: {
+                title: (items) => {
+                  const p = pts[items[0]?.dataIndex ?? 0];
+                  return `Run ${p?.n}${p?.t ? ` · ${new Date(p.t).toLocaleDateString()}` : ""}`;
+                },
+                label: (item) => {
+                  const p = pts[item.dataIndex];
+                  return `${Math.round(item.parsed.y ?? 0)} Elo · ${p?.win ? "win" : "loss"}`;
+                },
+              },
+            },
+          },
+        }}
+      />
+    </div>
+  );
+}
+
 export default function EloClient() {
   const [board, setBoard] = useState<Board | null>(null);
   const [minRuns, setMinRuns] = useState(10);
+  const [sortKey, setSortKey] = useState<"elo" | "lifetime">("elo");
+  const [expanded, setExpanded] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState<string | null>(null);
 
@@ -51,12 +151,24 @@ export default function EloClient() {
   };
   useEffect(() => load(), []);
 
-  const rows = (board?.players || []).filter((p) => p.runs >= minRuns);
+  const rows = (board?.players || [])
+    .filter((p) => p.runs >= minRuns)
+    .sort((a, b) => (b[sortKey] ?? 0) - (a[sortKey] ?? 0));
+
+  const sortHeader = (key: "elo" | "lifetime", label: string) => (
+    <button
+      onClick={() => setSortKey(key)}
+      className={sortKey === key ? "text-[var(--accent-gold)]" : "hover:text-[var(--text-primary)]"}
+    >
+      {label}
+      {sortKey === key ? " ↓" : ""}
+    </button>
+  );
 
   return (
     <AdminShell
       title="Player Elo"
-      subtitle="A10 standard runs, rated against per-character community difficulty. Hidden — admin eyes only."
+      subtitle="A10 standard runs, rated against per-character community difficulty. Elo = current form; Lifetime = Wilson-bounded whole record. Hidden — admin eyes only."
     >
       <div className="flex items-center gap-3 mb-4 text-sm">
         <label className="text-[var(--text-muted)]">
@@ -89,12 +201,13 @@ export default function EloClient() {
       </div>
 
       <div className="overflow-x-auto">
-        <table className="text-sm tabular-nums w-full max-w-2xl">
+        <table className="text-sm tabular-nums w-full max-w-3xl">
           <thead>
             <tr className="text-left text-xs uppercase tracking-wider text-[var(--text-muted)]">
               <th className="py-1.5 pr-4">#</th>
               <th className="py-1.5 pr-4">Player</th>
-              <th className="py-1.5 pr-4 text-right">Elo</th>
+              <th className="py-1.5 pr-4 text-right">{sortHeader("elo", "Elo")}</th>
+              <th className="py-1.5 pr-4 text-right">{sortHeader("lifetime", "Lifetime")}</th>
               <th className="py-1.5 pr-4 text-right">A10 runs</th>
               <th className="py-1.5 pr-4 text-right">Wins</th>
               <th className="py-1.5 text-right">WR</th>
@@ -102,20 +215,35 @@ export default function EloClient() {
           </thead>
           <tbody>
             {rows.slice(0, 200).map((p, i) => (
-              <tr key={p.user_id} className="border-t border-[var(--border-subtle)]">
-                <td className="py-1.5 pr-4 text-[var(--text-muted)]">{i + 1}</td>
-                <td className="py-1.5 pr-4 text-[var(--text-primary)]">
-                  {p.username || <span className="text-[var(--text-muted)]">{p.user_id.slice(0, 8)}…</span>}
-                </td>
-                <td className="py-1.5 pr-4 text-right font-semibold text-[var(--accent-gold)]">
-                  {Math.round(p.elo)}
-                </td>
-                <td className="py-1.5 pr-4 text-right">{p.runs.toLocaleString()}</td>
-                <td className="py-1.5 pr-4 text-right">{p.wins.toLocaleString()}</td>
-                <td className="py-1.5 text-right">
-                  {p.runs ? ((p.wins / p.runs) * 100).toFixed(1) : "0.0"}%
-                </td>
-              </tr>
+              <Fragment key={p.user_id}>
+                <tr
+                  onClick={() => setExpanded(expanded === p.user_id ? null : p.user_id)}
+                  className="border-t border-[var(--border-subtle)] cursor-pointer hover:bg-[var(--bg-card)]"
+                >
+                  <td className="py-1.5 pr-4 text-[var(--text-muted)]">{i + 1}</td>
+                  <td className="py-1.5 pr-4 text-[var(--text-primary)]">
+                    {p.username || <span className="text-[var(--text-muted)]">{p.user_id.slice(0, 8)}…</span>}
+                  </td>
+                  <td className="py-1.5 pr-4 text-right font-semibold text-[var(--accent-gold)]">
+                    {Math.round(p.elo)}
+                  </td>
+                  <td className="py-1.5 pr-4 text-right text-[var(--text-secondary)]">
+                    {p.lifetime != null ? Math.round(p.lifetime) : "–"}
+                  </td>
+                  <td className="py-1.5 pr-4 text-right">{p.runs.toLocaleString()}</td>
+                  <td className="py-1.5 pr-4 text-right">{p.wins.toLocaleString()}</td>
+                  <td className="py-1.5 text-right">
+                    {p.runs ? ((p.wins / p.runs) * 100).toFixed(1) : "0.0"}%
+                  </td>
+                </tr>
+                {expanded === p.user_id && (
+                  <tr className="border-t border-[var(--border-subtle)]">
+                    <td colSpan={7}>
+                      <TrajectoryChart userId={p.user_id} />
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
             ))}
           </tbody>
         </table>

--- a/frontend/app/admin/elo/EloClient.tsx
+++ b/frontend/app/admin/elo/EloClient.tsx
@@ -16,9 +16,10 @@ interface EloRow {
 }
 
 interface Board {
-  players: EloRow[];
-  computed_at: number;
-  compute_seconds: number;
+  players?: EloRow[];
+  computed_at?: number;
+  compute_seconds?: number;
+  building?: boolean;
 }
 
 export default function EloClient() {
@@ -27,12 +28,26 @@ export default function EloClient() {
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState<string | null>(null);
 
+  // First-ever load (and every Recompute) kicks a background walk
+  // server-side; poll until it lands instead of holding a request open
+  // past the gateway timeout.
   const load = (refresh = false) => {
     setBusy(true);
     adminFetch<Board>(`/api/admin/player-elo${refresh ? "?refresh=1" : ""}`)
-      .then(setBoard)
-      .catch((e) => setNote(String((e as Error)?.message || e)))
-      .finally(() => setBusy(false));
+      .then((d) => {
+        if (d.building) {
+          setNote("Computing the board in the background…");
+          setTimeout(() => load(false), 5000);
+          return;
+        }
+        setNote(null);
+        setBoard(d);
+        setBusy(false);
+      })
+      .catch((e) => {
+        setNote(String((e as Error)?.message || e));
+        setBusy(false);
+      });
   };
   useEffect(() => load(), []);
 
@@ -61,11 +76,13 @@ export default function EloClient() {
         >
           {busy ? "Computing…" : "Recompute"}
         </button>
-        {board && (
+        {board?.players && (
           <span className="text-xs text-[var(--text-muted)]">
             {board.players.length.toLocaleString()} rated players · computed in{" "}
-            {board.compute_seconds}s ·{" "}
-            {new Date(board.computed_at * 1000).toLocaleTimeString()}
+            {board.compute_seconds ?? "?"}s ·{" "}
+            {board.computed_at
+              ? new Date(board.computed_at * 1000).toLocaleTimeString()
+              : ""}
           </span>
         )}
         {note && <span className="text-xs text-rose-400">{note}</span>}


### PR DESCRIPTION
I moved the Elo compute off the request path onto a background thread with a building/poll flow, swapped the unindexable user_id filter for an ObjectId range that rides the existing index, added a Wilson-lower-bound lifetime rating column (order-independent, volume-punishing, same scale as Elo) with sortable headers, and made each board row expand into the player's full Elo trajectory chart served by a new per-player history endpoint.