### PR TITLE
Auto-hide one-turn-boss runs as cheated

### DIFF
--- a/backend/app/services/cheat_detect.py
+++ b/backend/app/services/cheat_detect.py
@@ -1,11 +1,11 @@
 """Submit-time cheated-run detection.
 
-Two high-confidence signals, both from real cheated submissions:
+Three high-confidence signals, all from real cheated submissions:
 stacked copies of one relic (a savegame editor artifact; 21x Infused Core),
-and boss-teleport wins where an act's visited path is a floor or two instead
-of the ~16 a real act takes. Flagged runs are stored hidden with a reason so
-they never enter leaderboards or stats but stay inspectable in the admin
-console."""
+boss-teleport wins where an act's visited path is a floor or two instead
+of the ~16 a real act takes, and boss fights cleared in a single turn.
+Flagged runs are stored hidden with a reason so they never enter
+leaderboards or stats but stay inspectable in the admin console."""
 
 from __future__ import annotations
 
@@ -24,6 +24,35 @@ MIN_WIN_SECONDS = 300
 def _bare(raw: str) -> str:
     parts = str(raw or "").split(".")
     return parts[-1] if parts else ""
+
+
+def one_turn_bosses(data: dict) -> list[str]:
+    """Boss rooms this run got PAST in a single turn — no legitimate build
+    does that. Dying (or abandoning) on turn 1 of a boss is legitimate, so
+    the run's final location only counts on a win; every earlier boss room
+    was necessarily cleared for the run to continue. Also used by the
+    rehide backfill, which feeds it a stored doc's projection instead of a
+    full submission blob."""
+    locations: list[tuple[int, dict]] = []
+    for i, act in enumerate(data.get("map_point_history") or []):
+        for fl in act or []:
+            if isinstance(fl, dict) and fl.get("rooms"):
+                locations.append((i, fl))
+    win = bool(data.get("win"))
+    reasons: list[str] = []
+    for pos, (i, fl) in enumerate(locations):
+        if not win and pos == len(locations) - 1:
+            continue
+        for room in fl.get("rooms") or []:
+            if not isinstance(room, dict):
+                continue
+            if (room.get("room_type") or "").lower() != "boss":
+                continue
+            turns = room.get("turns_taken")
+            if isinstance(turns, (int, float)) and turns == 1:
+                enc = _bare(str(room.get("model_id") or "")).upper() or "UNKNOWN"
+                reasons.append(f"one_turn_boss:act{i + 1}:{enc}")
+    return reasons
 
 
 def detect_cheats(data: dict) -> list[str]:
@@ -66,4 +95,5 @@ def detect_cheats(data: dict) -> list[str]:
             and str(data.get("game_mode") or "standard").lower() == "standard"
         ):
             reasons.append(f"missing_acts:{boss_acts}of3bosses")
+    reasons.extend(one_turn_bosses(data))
     return reasons

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -2262,11 +2262,13 @@ def list_runs(
 
 
 @_instrument("set_run_hidden")
-def set_run_hidden(run_hash: str, hidden: bool) -> dict:
+def set_run_hidden(run_hash: str, hidden: bool, reason: str | None = None) -> dict:
     """Flag or unflag every doc sharing this run_hash as ineligible. Hidden runs
     stay in the collection but drop out of leaderboards, /charts, the stats, and
     the run list on the next read. The materialized leaderboard/stats summaries
-    clear the run on their next ~60s rebuild. Returns how many docs changed."""
+    clear the run on their next ~60s rebuild. Returns how many docs changed.
+    Unhiding also clears any auto-hide reason — an accepted appeal leaves no
+    cheat marker behind."""
     coll = _get_collection()
     query = {"$or": [{"_id": run_hash}, {"run_hash": run_hash}]}
     # Single-player runs key on _id (= run hash) with no run_hash field;
@@ -2277,12 +2279,66 @@ def set_run_hidden(run_hash: str, hidden: bool) -> dict:
             {"hidden": 1, "character": 1, "win": 1, "was_abandoned": 1, "ascension": 1},
         )
     )
-    update = {"$set": {"hidden": True}} if hidden else {"$unset": {"hidden": ""}}
+    if hidden:
+        update: dict = {"$set": {"hidden": True}}
+        if reason:
+            update["$set"]["hidden_reason"] = reason
+    else:
+        update = {"$unset": {"hidden": "", "hidden_reason": ""}}
     result = coll.update_many(query, update)
     for row in rows:
         if bool(row.get("hidden")) != hidden:
             bump_stats_counters(row, -1 if hidden else 1)
     return {"matched": result.matched_count, "modified": result.modified_count}
+
+
+def rehide_one_turn_boss_runs(dry_run: bool = False) -> dict:
+    """Backfill for the one-turn-boss cheat signal: sweep already-stored runs
+    (submit-time detection only covers new uploads) and hide every run that
+    cleared a boss in a single turn. The Mongo prefilter is loose (any boss
+    room with turns_taken 1, hidden runs excluded); the shared detector then
+    applies the real rule per doc — a turn-1 death at the run's final boss is
+    legitimate and stays visible. Returns counts; dry_run only reports."""
+    from .cheat_detect import one_turn_bosses
+
+    coll = _get_collection()
+    cursor = coll.find(
+        {
+            "hidden": {"$ne": True},
+            "map_point_history": {
+                "$elemMatch": {
+                    "$elemMatch": {
+                        "rooms": {
+                            "$elemMatch": {
+                                "room_type": {"$regex": "^boss$", "$options": "i"},
+                                "turns_taken": 1,
+                            }
+                        }
+                    }
+                }
+            },
+        },
+        {"map_point_history": 1, "win": 1, "run_hash": 1},
+    )
+    checked = 0
+    hidden_runs: list[str] = []
+    done: set[str] = set()
+    for doc in cursor:
+        checked += 1
+        run_hash = doc.get("run_hash") or doc["_id"]
+        if run_hash in done:
+            continue
+        reasons = one_turn_bosses(
+            {"map_point_history": doc.get("map_point_history"), "win": doc.get("win")}
+        )
+        if not reasons:
+            continue
+        done.add(run_hash)
+        hidden_runs.append(run_hash)
+        if not dry_run:
+            set_run_hidden(run_hash, True, reason="auto:" + ",".join(reasons[:4]))
+            logger.info("auto-hid one-turn-boss run %s: %s", run_hash, reasons[:4])
+    return {"candidates": checked, "hidden": len(hidden_runs), "hashes": hidden_runs}
 
 
 def leaderboard(

--- a/backend/scripts/rehide_one_turn_boss.py
+++ b/backend/scripts/rehide_one_turn_boss.py
@@ -1,0 +1,32 @@
+"""Hide already-stored runs that cleared a boss in a single turn (the
+one-turn-boss cheat signal; new uploads are caught at submit time).
+Idempotent — hidden runs are skipped on re-runs.
+
+    python -m scripts.rehide_one_turn_boss [--dry-run]
+"""
+
+import os
+import sys
+
+
+def main() -> int:
+    if not os.environ.get("MONGO_URL", "").strip():
+        print("MONGO_URL unset; nothing to do")
+        return 1
+    dry_run = "--dry-run" in sys.argv[1:]
+    from app.services.runs_db_mongo import rehide_one_turn_boss_runs
+
+    result = rehide_one_turn_boss_runs(dry_run=dry_run)
+    verb = "would hide" if dry_run else "hid"
+    print(
+        f"{result['candidates']} candidate doc(s) checked, "
+        f"{verb} {result['hidden']} run(s)",
+        flush=True,
+    )
+    for h in result["hashes"]:
+        print(f"  {h}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_cheat_detect.py
+++ b/backend/tests/test_cheat_detect.py
@@ -1,0 +1,61 @@
+"""One-turn-boss detection: a boss the run got past in one turn flags, a
+turn-1 death at the final boss does not."""
+
+from app.services.cheat_detect import detect_cheats, one_turn_bosses
+
+
+def _location(room_type: str, turns: int | None, model_id: str = "ENCOUNTER.BOSS_X"):
+    room: dict = {"room_type": room_type, "model_id": model_id}
+    if turns is not None:
+        room["turns_taken"] = turns
+    return {"rooms": [room]}
+
+
+def _act(*locations: dict) -> list[dict]:
+    return list(locations)
+
+
+def test_one_turn_boss_mid_run_flags_even_on_a_loss():
+    data = {
+        "win": False,
+        "map_point_history": [
+            _act(_location("monster", 5), _location("boss", 1)),
+            _act(_location("monster", 4)),  # the run continued past the boss
+        ],
+    }
+    assert one_turn_bosses(data) == ["one_turn_boss:act1:BOSS_X"]
+    assert "one_turn_boss:act1:BOSS_X" in detect_cheats(data)
+
+
+def test_turn_one_death_at_final_boss_is_clean():
+    data = {
+        "win": False,
+        "map_point_history": [
+            _act(_location("monster", 5), _location("boss", 1)),
+        ],
+    }
+    assert one_turn_bosses(data) == []
+
+
+def test_won_run_counts_its_final_boss():
+    data = {
+        "win": True,
+        "map_point_history": [
+            _act(_location("boss", 4)),
+            _act(_location("boss", 3)),
+            _act(_location("boss", 1, model_id="ENCOUNTER.AEONGLASS_BOSS")),
+        ],
+    }
+    assert one_turn_bosses(data) == ["one_turn_boss:act3:AEONGLASS_BOSS"]
+
+
+def test_normal_turn_counts_and_non_boss_rooms_are_clean():
+    data = {
+        "win": True,
+        "map_point_history": [
+            _act(_location("monster", 1), _location("elite", 1), _location("boss", 2)),
+            _act(_location("boss", None)),  # missing turns never flags
+            _act(_location("boss", 12)),
+        ],
+    }
+    assert one_turn_bosses(data) == []


### PR DESCRIPTION
I added a one-turn-boss cheat signal that auto-hides flagged runs at submit time (turn-1 deaths at a final boss stay clean), and a backfill script to sweep existing runs.