### PR TITLE
Chart dates: played date in Pacific time

### DIFF
--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -28,7 +28,6 @@ import math
 import os
 import threading
 import time
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -89,28 +88,22 @@ def _bare(raw: str | None) -> str | None:
 
 
 def _epoch_day(submitted: Any) -> int:
-    if submitted is None:
-        return 0
-    if hasattr(submitted, "timestamp"):
-        return int(submitted.timestamp() // 86400)
-    s = str(submitted)
-    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
-        try:
-            dt = datetime.strptime(s[:19], fmt).replace(tzinfo=timezone.utc)
-            return int(dt.timestamp() // 86400)
-        except ValueError:
-            continue
-    return 0
+    """Pacific-calendar day bucket (site policy: never UTC boundaries)."""
+    from .timeutil import pacific_epoch_day
+
+    return pacific_epoch_day(submitted)
 
 
 def _week_label(week: int) -> str:
-    return datetime.fromtimestamp(week * 7 * 86400, tz=timezone.utc).strftime(
-        "%Y-%m-%d"
-    )
+    from .timeutil import epoch_day_label
+
+    return epoch_day_label(week * 7)
 
 
 def _day_label(day: int) -> str:
-    return datetime.fromtimestamp(day * 86400, tz=timezone.utc).strftime("%Y-%m-%d")
+    from .timeutil import epoch_day_label
+
+    return epoch_day_label(day)
 
 
 def _daily_date(seed: str | None, game_mode: str) -> str:
@@ -152,6 +145,7 @@ def _load_frame() -> list[tuple]:
                 "deck_size": 1,
                 "relic_count": 1,
                 "submitted_at": 1,
+                "played_at": 1,
                 "username": 1,
                 "was_abandoned": 1,
                 "acts_completed": 1,
@@ -172,7 +166,7 @@ def _load_frame() -> list[tuple]:
                     int(d.get("floors_reached") or 0),
                     int(d.get("deck_size") or 0),
                     int(d.get("relic_count") or 0),
-                    _epoch_day(d.get("submitted_at")),
+                    _epoch_day(d.get("played_at") or d.get("submitted_at")),
                     (d.get("username") or "").lower(),
                     1 if d.get("was_abandoned") else 0,
                     int(d.get("acts_completed") or 0),
@@ -853,7 +847,7 @@ def accumulate(
     is_win: bool,
     character: str,
     player_count: int,
-    submitted: Any = None,
+    played: Any = None,
 ) -> None:
     """Fold one run into the sub-accumulator of every content bracket it belongs
     to (`brackets` always includes 'all')."""
@@ -866,7 +860,7 @@ def accumulate(
                 is_win=is_win,
                 character=character,
                 player_count=player_count,
-                submitted=submitted,
+                played=played,
             )
 
 
@@ -877,13 +871,13 @@ def _accumulate_one(
     is_win: bool,
     character: str,
     player_count: int,
-    submitted: Any = None,
+    played: Any = None,
 ) -> None:
     """Fold one run blob into ONE bracket's accumulator. Defensive like the
     community walk: missing keys skip quietly, never raise."""
     char = _norm_char(character)
     players = min(max(int(player_count or 1), 1), 4)
-    week = _epoch_day(submitted) // 7 if submitted else 0
+    week = _epoch_day(played) // 7 if played else 0
 
     floor_idx = 0
     last_room_type = None
@@ -1500,6 +1494,7 @@ def build_user_blob_stats(username: str) -> dict[str, Any]:
                     "win": 1,
                     "player_count": 1,
                     "submitted_at": 1,
+                    "played_at": 1,
                 },
             )
             .sort("submitted_at", -1)
@@ -1512,6 +1507,7 @@ def build_user_blob_stats(username: str) -> dict[str, Any]:
                 "win": bool(d.get("win")),
                 "player_count": d.get("player_count") or 1,
                 "submitted_at": d.get("submitted_at"),
+                "played_at": d.get("played_at"),
             }
             for d in cursor
         ]
@@ -1555,7 +1551,7 @@ def build_user_blob_stats(username: str) -> dict[str, Any]:
                 is_win=bool(row["win"]),
                 character=row["character"],
                 player_count=row["player_count"],
-                submitted=row.get("submitted_at"),
+                played=row.get("played_at") or row.get("submitted_at"),
             )
         except Exception:
             continue

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -299,7 +299,9 @@ _HISTORY_RETENTION_DAYS = 90
 # Version 22: the official-id filters accept beta-catalog entities (beta-only
 # cards/relics were read as modded and vanished from the tier list); the bump
 # forces the rebuild that restores their walk-time per-act relic data.
-SNAPSHOT_VERSION = 24
+# 25: chart time buckets re-keyed to played-date Pacific days — a full
+# rebuild is required or old runs keep their UTC upload-day keys.
+SNAPSHOT_VERSION = 25
 # Serialized-byte budget per persisted chunk doc. With version-composable
 # brackets a popular entity carries hundreds of per-bracket blocks and
 # entity sizes vary wildly (a card dwarfs an affliction), so chunks are
@@ -1201,6 +1203,11 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=(), preloaded_blob
                 + [_bid]
             )
         try:
+            # Chart time buckets key on when the run was PLAYED; `submitted`
+            # stays the incremental cursor anchor below and must not change.
+            played = row.get("played_at") or row["submitted_at"]
+            if played is not None and hasattr(played, "isoformat"):
+                played = played.isoformat()
             charts_stats.accumulate(
                 charts_acc,
                 blob,
@@ -1208,7 +1215,7 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=(), preloaded_blob
                 is_win=is_win,
                 character=character,
                 player_count=row.get("player_count") or 1,
-                submitted=submitted,
+                submitted=played,
             )
         except Exception:
             logger.warning(
@@ -1779,6 +1786,7 @@ def _build_cache_data(stash: bool = False) -> tuple[dict, dict, dict, dict]:
                     "character": 1,
                     "win": 1,
                     "submitted_at": 1,
+                    "played_at": 1,
                     "player_count": 1,
                     "ascension": 1,
                     "game_mode": 1,
@@ -1799,6 +1807,7 @@ def _build_cache_data(stash: bool = False) -> tuple[dict, dict, dict, dict]:
                 "character": d.get("character") or "",
                 "win": bool(d.get("win")),
                 "submitted_at": d.get("submitted_at"),
+                "played_at": d.get("played_at"),
                 "player_count": d.get("player_count") or 1,
                 "ascension": d.get("ascension") or 0,
                 "game_mode": d.get("game_mode") or "standard",
@@ -2493,6 +2502,7 @@ def _load_rows_after(last_key: tuple) -> list[dict]:
                 "character": 1,
                 "win": 1,
                 "submitted_at": 1,
+                "played_at": 1,
                 "player_count": 1,
                 "ascension": 1,
                 "game_mode": 1,
@@ -2509,6 +2519,7 @@ def _load_rows_after(last_key: tuple) -> list[dict]:
             "character": d.get("character") or "",
             "win": bool(d.get("win")),
             "submitted_at": d.get("submitted_at"),
+            "played_at": d.get("played_at"),
             "player_count": d.get("player_count") or 1,
             "ascension": d.get("ascension") or 0,
             "game_mode": d.get("game_mode") or "standard",

--- a/backend/app/services/timeutil.py
+++ b/backend/app/services/timeutil.py
@@ -1,0 +1,43 @@
+"""Pacific-time calendar handling for user-facing date buckets.
+
+Storage stays UTC; anything that buckets or labels by calendar day or week
+converts to America/Los_Angeles first, so a run played Friday night never
+drifts into Saturday's bar. Buckets are always keyed on when a run was
+PLAYED (played_at), never when it was uploaded — callers pass
+``played_at or submitted_at`` so legacy rows without the field still land
+somewhere sane."""
+
+from datetime import date, datetime, timezone
+from typing import Any
+from zoneinfo import ZoneInfo
+
+PACIFIC = ZoneInfo("America/Los_Angeles")
+_EPOCH_ORDINAL = date(1970, 1, 1).toordinal()
+
+
+def pacific_date(ts: Any) -> date | None:
+    """The Pacific calendar date of a stored timestamp (datetime or ISO-ish
+    string, naive values treated as UTC). None when unparseable."""
+    if ts is None:
+        return None
+    if isinstance(ts, datetime):
+        dt = ts
+    else:
+        try:
+            dt = datetime.fromisoformat(str(ts)[:19].replace("Z", ""))
+        except ValueError:
+            return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(PACIFIC).date()
+
+
+def pacific_epoch_day(ts: Any) -> int:
+    """Days since 1970-01-01 of the Pacific calendar date; 0 when unknown."""
+    d = pacific_date(ts)
+    return (d.toordinal() - _EPOCH_ORDINAL) if d else 0
+
+
+def epoch_day_label(day: int) -> str:
+    """ISO date for a pacific_epoch_day value (pure calendar arithmetic)."""
+    return date.fromordinal(_EPOCH_ORDINAL + day).isoformat()

--- a/backend/app/services/user_insights.py
+++ b/backend/app/services/user_insights.py
@@ -255,19 +255,19 @@ def _run_mode(r: dict) -> str:
 def _activity(rows: list[dict]) -> list[dict]:
     """Weekly run-count buckets split by mode, with the week's win rate,
     oldest first. Weeks with no runs are absent (the chart skips them);
-    capped to the most recent _ACTIVITY_WEEKS buckets."""
+    capped to the most recent _ACTIVITY_WEEKS buckets. Bucketed on when the
+    run was PLAYED, in Pacific time (site policy: never upload date, never
+    UTC calendar boundaries)."""
     from datetime import date
+
+    from .timeutil import pacific_date
 
     buckets: dict[str, dict] = {}
     for r in rows:
-        ts = r.get("submitted_at")
-        if ts is None:
+        d = pacific_date(r.get("played_at") or r.get("submitted_at"))
+        if d is None:
             continue
-        try:
-            d = date.fromisoformat(str(ts)[:10])
-        except ValueError:
-            continue
-        week = d.fromordinal(d.toordinal() - d.weekday()).isoformat()
+        week = date.fromordinal(d.toordinal() - d.weekday()).isoformat()
         b = buckets.setdefault(
             week,
             {
@@ -671,7 +671,16 @@ def _compute_insights(
     except Exception:
         logger.warning("user-insights relic deltas failed", exc_info=True)
         mine["relic_picks"] = {"over_carried": [], "under_carried": []}
-    mine["streaks"] = _streaks(rows)
+    # Streaks are order-sensitive: walk runs in PLAYED order (newest first),
+    # not upload order — a backfilled old loss must not break today's streak.
+    # str() sorts both datetime objects and ISO strings chronologically.
+    mine["streaks"] = _streaks(
+        sorted(
+            rows,
+            key=lambda r: str(r.get("played_at") or r.get("submitted_at") or ""),
+            reverse=True,
+        )
+    )
     mine["elo"] = elo_block
     mine["activity"] = _activity(rows)
     if filtered:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ boto3>=1.34,<2
 redis==5.2.1
 numpy==2.2.6
 scipy==1.14.1
+tzdata==2025.2

--- a/backend/tests/test_timeutil.py
+++ b/backend/tests/test_timeutil.py
@@ -1,0 +1,22 @@
+"""Pacific calendar buckets: late-UTC timestamps belong to the previous
+Pacific day, and labels invert the day numbers exactly."""
+
+from datetime import datetime
+
+from app.services.timeutil import epoch_day_label, pacific_date, pacific_epoch_day
+
+
+def test_late_utc_evening_is_previous_pacific_day():
+    # 05:00 UTC on the 16th is 22:00 PDT on the 15th.
+    assert str(pacific_date("2026-08-16T05:00:00")) == "2026-08-15"
+    assert str(pacific_date(datetime(2026, 8, 16, 12, 0))) == "2026-08-16"
+
+
+def test_epoch_day_roundtrips_through_label():
+    day = pacific_epoch_day("2026-08-16T05:00:00")
+    assert epoch_day_label(day) == "2026-08-15"
+
+
+def test_unparseable_is_none_and_day_zero():
+    assert pacific_date("not a date") is None
+    assert pacific_epoch_day(None) == 0

--- a/backend/tests/test_user_insights.py
+++ b/backend/tests/test_user_insights.py
@@ -17,7 +17,9 @@ def _fake_backend(monkeypatch, rows, blobs, community, table, tallies):
         lambda uid, character=None, **kw: tallies,
     )
     monkeypatch.setattr(user_insights, "get_community_stats", lambda *a, **k: community)
-    monkeypatch.setattr(user_insights, "get_entity_metrics_table", lambda *a, **k: table)
+    monkeypatch.setattr(
+        user_insights, "get_entity_metrics_table", lambda *a, **k: table
+    )
     user_insights._cache.clear()
 
 
@@ -221,6 +223,21 @@ def test_streaks_and_weekly_activity():
     assert newer["solo"] == 1 and newer["coop"] == 1
     assert newer["daily"] == 1 and newer["custom"] == 1
     assert newer["win_rate"] == 75.0
+
+
+def test_activity_buckets_on_played_date_in_pacific():
+    rows = [
+        # Played in June, uploaded in August: the PLAYED week gets the run.
+        {
+            "win": True,
+            "played_at": "2026-06-30T10:00:00",
+            "submitted_at": "2026-08-02T10:00:00",
+        },
+        # Saturday 04:00 UTC is Friday evening Pacific: Friday's week.
+        {"win": False, "submitted_at": "2026-08-08T04:00:00"},
+    ]
+    a = user_insights._activity(rows)
+    assert [w["week"] for w in a] == ["2026-06-29", "2026-08-03"]
 
 
 def test_percentiles_use_qualifying_floor(monkeypatch):


### PR DESCRIPTION
I switched Weekly activity, streak ordering, and every /charts time bucket from upload date to run date, with day and week boundaries in Pacific time instead of UTC, and bumped the snapshot version so history re-buckets cleanly.