### PR TITLE
Pacific time on every displayed date

### DIFF
--- a/frontend/app/admin/AdminClient.tsx
+++ b/frontend/app/admin/AdminClient.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect, useState } from "react";
 import { AdminShell, Card, adminFetch } from "./shared";
+import { fmtDate, fmtTime } from "@/lib/pacific";
 
 interface Overview {
   runs: { total?: number; last_24h?: number; last_submission?: string | null };
@@ -149,8 +150,8 @@ export default function AdminClient() {
             <Card label="Last 24h" value={(r.last_24h ?? 0).toLocaleString()} />
             <Card
               label="Last submission"
-              value={r.last_submission ? new Date(r.last_submission).toLocaleTimeString() : "-"}
-              sub={r.last_submission ? new Date(r.last_submission).toLocaleDateString() : undefined}
+              value={r.last_submission ? fmtTime(r.last_submission) : "-"}
+              sub={r.last_submission ? fmtDate(r.last_submission) : undefined}
             />
             <Card label="Users" value={(data.users.total ?? 0).toLocaleString()} />
           </div>
@@ -244,7 +245,7 @@ export default function AdminClient() {
               value={live?.peak?.value != null ? live.peak.value.toLocaleString() : "-"}
               sub={
                 live?.peak?.at
-                  ? `all-time · ${new Date(live.peak.at).toLocaleDateString()}`
+                  ? `all-time · ${fmtDate(live.peak.at)}`
                   : "all-time"
               }
             />

--- a/frontend/app/admin/banners/BannersClient.tsx
+++ b/frontend/app/admin/banners/BannersClient.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect, useState } from "react";
 import { AdminShell, adminFetch } from "../shared";
+import { fmtDateTime } from "@/lib/pacific";
 
 interface Announcement {
   id: string;
@@ -99,7 +100,7 @@ export default function BannersClient() {
                 >
                   {a.active ? "active" : "off"}
                 </span>
-                {a.created_at && new Date(a.created_at).toLocaleString()}
+                {a.created_at && fmtDateTime(a.created_at)}
               </div>
               <div className="flex gap-2 shrink-0">
                 <button

--- a/frontend/app/admin/elo/EloClient.tsx
+++ b/frontend/app/admin/elo/EloClient.tsx
@@ -10,6 +10,7 @@
 import { Fragment, useEffect, useState } from "react";
 import EloTrajectory, { type EloPoint } from "@/app/components/EloTrajectory";
 import { AdminShell, adminFetch } from "../shared";
+import { fmtTime } from "@/lib/pacific";
 
 interface EloRow {
   user_id: string;
@@ -125,7 +126,7 @@ export default function EloClient() {
             {board.players.length.toLocaleString()} rated players · computed in{" "}
             {board.compute_seconds ?? "?"}s ·{" "}
             {board.computed_at
-              ? new Date(board.computed_at * 1000).toLocaleTimeString()
+              ? fmtTime(board.computed_at * 1000)
               : ""}
           </span>
         )}

--- a/frontend/app/admin/feedback/FeedbackClient.tsx
+++ b/frontend/app/admin/feedback/FeedbackClient.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect, useState } from "react";
 import { AdminShell, adminFetch } from "../shared";
+import { fmtDateTime } from "@/lib/pacific";
 
 interface FeedbackItem {
   id: string;
@@ -71,7 +72,7 @@ export default function FeedbackClient() {
                 </span>
                 {i.type && <span className="mr-2">{i.type}</span>}
                 {i.card_name && <span className="mr-2">{i.card_name}</span>}
-                {i.created_at && new Date(i.created_at).toLocaleString()}
+                {i.created_at && fmtDateTime(i.created_at)}
                 {i.contact && <span className="ml-2">· {i.contact}</span>}
               </div>
               {!i.resolved && (

--- a/frontend/app/admin/guides/GuidesClient.tsx
+++ b/frontend/app/admin/guides/GuidesClient.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect, useState } from "react";
 import { AdminShell, adminFetch } from "../shared";
+import { fmtDateTime } from "@/lib/pacific";
 
 interface GuideSub {
   id: string;
@@ -71,7 +72,7 @@ export default function GuidesClient() {
             <div className="text-xs text-[var(--text-muted)] mb-2">
               {g.author_name} · {g.contact} · {g.category}
               {g.character ? ` · ${g.character}` : ""} · {g.difficulty}
-              {g.created_at ? ` · ${new Date(g.created_at).toLocaleString()}` : ""}
+              {g.created_at ? ` · ${fmtDateTime(g.created_at)}` : ""}
             </div>
             {g.summary && <p className="text-sm text-[var(--text-secondary)] mb-2">{g.summary}</p>}
             {open === g.id && (

--- a/frontend/app/admin/keys/KeysClient.tsx
+++ b/frontend/app/admin/keys/KeysClient.tsx
@@ -6,6 +6,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { AdminShell, adminFetch } from "../shared";
+import { fmtDate } from "@/lib/pacific";
 
 interface AdminKey {
   id: string;
@@ -27,7 +28,7 @@ interface KeysResponse {
 
 function fmt(iso: string | null): string {
   if (!iso) return "never";
-  return new Date(iso).toLocaleDateString();
+  return fmtDate(iso);
 }
 
 const TIER_BADGE: Record<string, string> = {

--- a/frontend/app/admin/runs/RunsClient.tsx
+++ b/frontend/app/admin/runs/RunsClient.tsx
@@ -8,6 +8,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { AdminShell, adminFetch } from "../shared";
+import { fmtDateTime } from "@/lib/pacific";
 
 interface RunRow {
   run_hash?: string;
@@ -334,7 +335,7 @@ export default function RunsClient() {
                   <td className="px-3 py-2 tabular-nums text-xs">{fmtTime(r.run_time)}</td>
                   <td className="px-3 py-2 text-xs">{r.build_id ?? "-"}</td>
                   <td className="px-3 py-2 text-xs">
-                    {r.submitted_at ? new Date(r.submitted_at).toLocaleString() : "-"}
+                    {r.submitted_at ? fmtDateTime(r.submitted_at) : "-"}
                   </td>
                   <td className="px-3 py-2">
                     <div className="flex justify-end gap-1.5">

--- a/frontend/app/admin/users/UsersClient.tsx
+++ b/frontend/app/admin/users/UsersClient.tsx
@@ -7,6 +7,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { AdminShell, adminFetch } from "../shared";
 import GiveawayLookup from "./GiveawayLookup";
+import { fmtDate } from "@/lib/pacific";
 
 interface UserRow {
   _id: string;
@@ -278,7 +279,7 @@ export default function UsersClient() {
                     </td>
                     <td className="px-3 py-2 tabular-nums">{u.run_count}</td>
                     <td className="px-3 py-2 text-xs">
-                      {u.created_at ? new Date(u.created_at).toLocaleDateString() : "-"}
+                      {u.created_at ? fmtDate(u.created_at) : "-"}
                     </td>
                     <td className="px-3 py-2">
                       <div className="flex justify-end gap-1.5">

--- a/frontend/app/components/ApiKeysSection.tsx
+++ b/frontend/app/components/ApiKeysSection.tsx
@@ -9,6 +9,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
+import { fmtDate as fmtPacificDate } from "@/lib/pacific";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -32,7 +33,7 @@ const TIER_LABELS: Record<string, string> = {
 
 function fmtDate(iso: string | null): string {
   if (!iso) return "never";
-  return new Date(iso).toLocaleDateString();
+  return fmtPacificDate(iso);
 }
 
 export default function ApiKeysSection() {

--- a/frontend/app/components/EloTrajectory.tsx
+++ b/frontend/app/components/EloTrajectory.tsx
@@ -15,6 +15,7 @@ import {
   Filler,
 } from "chart.js";
 import { Line } from "react-chartjs-2";
+import { fmtDate } from "@/lib/pacific";
 
 ChartJS.register(LineElement, PointElement, LinearScale, CategoryScale, Tooltip, Filler);
 
@@ -82,7 +83,7 @@ export default function EloTrajectory({
               callbacks: {
                 title: (items) => {
                   const p = points[items[0]?.dataIndex ?? 0];
-                  return `${runLabel} ${p?.n}${p?.t ? ` · ${new Date(p.t).toLocaleDateString()}` : ""}`;
+                  return `${runLabel} ${p?.n}${p?.t ? ` · ${fmtDate(p.t)}` : ""}`;
                 },
                 label: (item) => {
                   const p = points[item.dataIndex];

--- a/frontend/app/runs/[hash]/RunSummary.tsx
+++ b/frontend/app/runs/[hash]/RunSummary.tsx
@@ -5,7 +5,7 @@
  * Renders three act rows of map node icons + relic strip + card grid.
  */
 
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import Link from "next/link";
 import TinyCard from "@/app/components/TinyCard";
 import { useLanguage } from "@/app/contexts/LanguageContext";
@@ -25,7 +25,7 @@ export type { PotionInfo };
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 import { imageUrl } from "@/lib/image-url";
-import { fmtDateTime } from "@/lib/pacific";
+import { fmtDateTime, fmtDateTimePacific } from "@/lib/pacific";
 const ICON_BASE = imageUrl("/static/images/ui/run_history");
 
 interface DeckCard {
@@ -123,15 +123,19 @@ function formatTime(seconds: number): string {
   return `${m}:${s.toString().padStart(2, "0")}`;
 }
 
-function formatDate(epoch?: number): string {
+const DATE_STYLE = {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+} as const;
+
+// Server-rendered pages must emit the same string everywhere, so the first
+// paint is Pacific; after hydration it becomes the viewer's local time.
+function formatDate(epoch: number | undefined, local: boolean): string {
   if (!epoch) return "";
-  return fmtDateTime(epoch * 1000, {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
+  return local ? fmtDateTime(epoch * 1000, DATE_STYLE) : fmtDateTimePacific(epoch * 1000, DATE_STYLE);
 }
 
 /** Decide the tier ("weak"|"normal"|"elite"|"boss") for an encounter. */
@@ -211,6 +215,8 @@ interface Props {
 }
 
 export default function RunSummary({ run, player, cardData, relicData, potionData, charColor, langPrefix: lp }: Props) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
   const { lang } = useLanguage();
   const finalStats = lastPlayerStats(run);
   const totalFloors = (run.map_point_history ?? []).reduce((sum, act) => sum + act.length, 0);
@@ -271,7 +277,7 @@ export default function RunSummary({ run, player, cardData, relicData, potionDat
               </Link>
             </div>
           )}
-          {run.start_time && <div className="truncate">{formatDate(run.start_time)}</div>}
+          {run.start_time && <div className="truncate" suppressHydrationWarning>{formatDate(run.start_time, mounted)}</div>}
           {run.seed && (
             <div className="truncate">
               Seed: <span className="font-mono">{run.seed}</span>

--- a/frontend/app/runs/[hash]/RunSummary.tsx
+++ b/frontend/app/runs/[hash]/RunSummary.tsx
@@ -25,6 +25,7 @@ export type { PotionInfo };
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 import { imageUrl } from "@/lib/image-url";
+import { fmtDateTime } from "@/lib/pacific";
 const ICON_BASE = imageUrl("/static/images/ui/run_history");
 
 interface DeckCard {
@@ -124,8 +125,7 @@ function formatTime(seconds: number): string {
 
 function formatDate(epoch?: number): string {
   if (!epoch) return "";
-  const d = new Date(epoch * 1000);
-  return d.toLocaleString(undefined, {
+  return fmtDateTime(epoch * 1000, {
     year: "numeric",
     month: "long",
     day: "numeric",

--- a/frontend/app/tier-list/TierListBody.tsx
+++ b/frontend/app/tier-list/TierListBody.tsx
@@ -5,6 +5,7 @@ import ScoreBadge from "@/app/components/ScoreBadge";
 import { imageUrl, fullCardUrl } from "@/lib/image-url";
 import { LANG_HREFLANG, type LangCode } from "@/lib/languages";
 import { t } from "@/lib/ui-translations";
+import { fmtDate } from "@/lib/pacific";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -152,11 +153,11 @@ export async function TierListBody({ lang }: { lang: string }) {
   // ISO 8601 date for the visible "updated" line. force-dynamic means
   // this is fresh on every request, Google rewards visible-recent
   // dates on tier-list-style pages.
-  const updatedDate = new Date().toLocaleDateString("en-US", {
+  const updatedDate = fmtDate(new Date(), {
     year: "numeric",
     month: "long",
     day: "numeric",
-  });
+  }, "en-US");
 
   const faqs = buildFaqEntries({ cards: topCards, relics: topRelics, potions: topPotions }, lang);
 

--- a/frontend/app/tier-list/TierListBody.tsx
+++ b/frontend/app/tier-list/TierListBody.tsx
@@ -5,7 +5,7 @@ import ScoreBadge from "@/app/components/ScoreBadge";
 import { imageUrl, fullCardUrl } from "@/lib/image-url";
 import { LANG_HREFLANG, type LangCode } from "@/lib/languages";
 import { t } from "@/lib/ui-translations";
-import { fmtDate } from "@/lib/pacific";
+import { fmtDatePacific } from "@/lib/pacific";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -153,7 +153,7 @@ export async function TierListBody({ lang }: { lang: string }) {
   // ISO 8601 date for the visible "updated" line. force-dynamic means
   // this is fresh on every request, Google rewards visible-recent
   // dates on tier-list-style pages.
-  const updatedDate = fmtDate(new Date(), {
+  const updatedDate = fmtDatePacific(new Date(), {
     year: "numeric",
     month: "long",
     day: "numeric",

--- a/frontend/lib/pacific.ts
+++ b/frontend/lib/pacific.ts
@@ -1,10 +1,12 @@
-// Site policy: every displayed date and time is Pacific (America/Los_Angeles)
-// — never UTC, never the viewer's zone — so two people always read the same
-// number. Backend timestamps are UTC but usually naive ("2026-08-18 18:06:44"
-// or ISO without Z), so they get stamped UTC before converting. Date-only
-// strings ("2026-08-13", week labels, changelog dates) are ALREADY Pacific
-// calendar dates and format as-is — running them through a zone conversion
-// would shift them back a day.
+// Site policy for displayed dates and times: show the VIEWER's local time
+// when we know it (client-side rendering), and Pacific (America/Los_Angeles,
+// the site's home timezone) when we don't (server-rendered content). Never
+// raw UTC. Backend timestamps are UTC but usually naive ("2026-08-18
+// 18:06:44" or ISO without Z), so they get stamped UTC before converting —
+// rendering a naive UTC string as wall-clock time was the original bug.
+// Date-only strings ("2026-08-13", week labels, changelog dates) are ALREADY
+// Pacific calendar dates and format as-is — a zone conversion would shift
+// them back a day.
 
 const TZ = "America/Los_Angeles";
 const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
@@ -23,25 +25,43 @@ function fmt(
   ts: string | number | Date,
   base: Intl.DateTimeFormatOptions,
   opts: Intl.DateTimeFormatOptions,
-  locale?: string,
+  locale: string | undefined,
+  forcePacific: boolean,
 ): string {
   const dateOnly = typeof ts === "string" && DATE_ONLY.test(ts.trim());
   const d = utcDate(ts);
   if (isNaN(d.getTime())) return String(ts);
   // Explicit options replace the defaults wholesale, so a call site keeps
-  // its exact format; the zone pin is the only thing always applied.
+  // its exact format; the zone handling is the only thing always applied.
   const style = Object.keys(opts).length ? opts : base;
-  // Calendar-date strings render as plain dates, no zone math.
-  const zone = dateOnly ? {} : { timeZone: TZ };
+  // Calendar-date strings render as plain dates, no zone math. Otherwise:
+  // the viewer's own zone in the browser, Pacific on the server.
+  const zone = dateOnly
+    ? {}
+    : forcePacific || typeof window === "undefined"
+      ? { timeZone: TZ }
+      : {};
   return d.toLocaleString(locale, { ...style, ...zone });
 }
+
+const DATE_BASE: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+};
+const TIME_BASE: Intl.DateTimeFormatOptions = {
+  hour: "numeric",
+  minute: "2-digit",
+  second: "2-digit",
+};
+const DATETIME_BASE: Intl.DateTimeFormatOptions = { ...DATE_BASE, ...TIME_BASE };
 
 export function fmtDate(
   ts: string | number | Date,
   opts: Intl.DateTimeFormatOptions = {},
   locale?: string,
 ): string {
-  return fmt(ts, { year: "numeric", month: "numeric", day: "numeric" }, opts, locale);
+  return fmt(ts, DATE_BASE, opts, locale, false);
 }
 
 export function fmtTime(
@@ -49,7 +69,7 @@ export function fmtTime(
   opts: Intl.DateTimeFormatOptions = {},
   locale?: string,
 ): string {
-  return fmt(ts, { hour: "numeric", minute: "2-digit", second: "2-digit" }, opts, locale);
+  return fmt(ts, TIME_BASE, opts, locale, false);
 }
 
 export function fmtDateTime(
@@ -57,17 +77,24 @@ export function fmtDateTime(
   opts: Intl.DateTimeFormatOptions = {},
   locale?: string,
 ): string {
-  return fmt(
-    ts,
-    {
-      year: "numeric",
-      month: "numeric",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-      second: "2-digit",
-    },
-    opts,
-    locale,
-  );
+  return fmt(ts, DATETIME_BASE, opts, locale, false);
+}
+
+// Pacific-pinned variants for content that must render identically on the
+// server and every client (SSR'd text where a per-viewer zone would cause a
+// hydration mismatch, or anything meant to read the same for everyone).
+export function fmtDatePacific(
+  ts: string | number | Date,
+  opts: Intl.DateTimeFormatOptions = {},
+  locale?: string,
+): string {
+  return fmt(ts, DATE_BASE, opts, locale, true);
+}
+
+export function fmtDateTimePacific(
+  ts: string | number | Date,
+  opts: Intl.DateTimeFormatOptions = {},
+  locale?: string,
+): string {
+  return fmt(ts, DATETIME_BASE, opts, locale, true);
 }

--- a/frontend/lib/pacific.ts
+++ b/frontend/lib/pacific.ts
@@ -1,0 +1,73 @@
+// Site policy: every displayed date and time is Pacific (America/Los_Angeles)
+// — never UTC, never the viewer's zone — so two people always read the same
+// number. Backend timestamps are UTC but usually naive ("2026-08-18 18:06:44"
+// or ISO without Z), so they get stamped UTC before converting. Date-only
+// strings ("2026-08-13", week labels, changelog dates) are ALREADY Pacific
+// calendar dates and format as-is — running them through a zone conversion
+// would shift them back a day.
+
+const TZ = "America/Los_Angeles";
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+const HAS_ZONE = /(?:[zZ]|[+-]\d{2}:?\d{2})$/;
+
+export function utcDate(ts: string | number | Date): Date {
+  if (ts instanceof Date) return ts;
+  if (typeof ts === "number") return new Date(ts);
+  let s = ts.trim();
+  if (DATE_ONLY.test(s)) return new Date(`${s}T00:00:00`);
+  if (!HAS_ZONE.test(s)) s = `${s.replace(" ", "T")}Z`;
+  return new Date(s);
+}
+
+function fmt(
+  ts: string | number | Date,
+  base: Intl.DateTimeFormatOptions,
+  opts: Intl.DateTimeFormatOptions,
+  locale?: string,
+): string {
+  const dateOnly = typeof ts === "string" && DATE_ONLY.test(ts.trim());
+  const d = utcDate(ts);
+  if (isNaN(d.getTime())) return String(ts);
+  // Explicit options replace the defaults wholesale, so a call site keeps
+  // its exact format; the zone pin is the only thing always applied.
+  const style = Object.keys(opts).length ? opts : base;
+  // Calendar-date strings render as plain dates, no zone math.
+  const zone = dateOnly ? {} : { timeZone: TZ };
+  return d.toLocaleString(locale, { ...style, ...zone });
+}
+
+export function fmtDate(
+  ts: string | number | Date,
+  opts: Intl.DateTimeFormatOptions = {},
+  locale?: string,
+): string {
+  return fmt(ts, { year: "numeric", month: "numeric", day: "numeric" }, opts, locale);
+}
+
+export function fmtTime(
+  ts: string | number | Date,
+  opts: Intl.DateTimeFormatOptions = {},
+  locale?: string,
+): string {
+  return fmt(ts, { hour: "numeric", minute: "2-digit", second: "2-digit" }, opts, locale);
+}
+
+export function fmtDateTime(
+  ts: string | number | Date,
+  opts: Intl.DateTimeFormatOptions = {},
+  locale?: string,
+): string {
+  return fmt(
+    ts,
+    {
+      year: "numeric",
+      month: "numeric",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      second: "2-digit",
+    },
+    opts,
+    locale,
+  );
+}

--- a/frontend/lib/steam-news.ts
+++ b/frontend/lib/steam-news.ts
@@ -10,7 +10,7 @@
  * down to plain text.
  */
 
-import { fmtDate } from "@/lib/pacific";
+import { fmtDatePacific } from "@/lib/pacific";
 
 const STEAM_CLAN_IMAGE_BASE = "https://clan.cloudflare.steamstatic.com/images/";
 
@@ -328,7 +328,7 @@ export function firstNewsImage(raw: string | undefined | null): string | null {
 }
 
 export function formatNewsDate(unixSeconds: number, locale: string = "en"): string {
-  return fmtDate(unixSeconds * 1000, { year: "numeric", month: "long", day: "numeric" }, locale);
+  return fmtDatePacific(unixSeconds * 1000, { year: "numeric", month: "long", day: "numeric" }, locale);
 }
 
 /** Steam exposes the same article under several URL patterns. We canonicalize

--- a/frontend/lib/steam-news.ts
+++ b/frontend/lib/steam-news.ts
@@ -10,6 +10,8 @@
  * down to plain text.
  */
 
+import { fmtDate } from "@/lib/pacific";
+
 const STEAM_CLAN_IMAGE_BASE = "https://clan.cloudflare.steamstatic.com/images/";
 
 /** Convert `{STEAM_CLAN_IMAGE}/path.png` placeholders to absolute Steam CDN URLs. */
@@ -326,8 +328,7 @@ export function firstNewsImage(raw: string | undefined | null): string | null {
 }
 
 export function formatNewsDate(unixSeconds: number, locale: string = "en"): string {
-  const d = new Date(unixSeconds * 1000);
-  return d.toLocaleDateString(locale, { year: "numeric", month: "long", day: "numeric" });
+  return fmtDate(unixSeconds * 1000, { year: "numeric", month: "long", day: "numeric" }, locale);
 }
 
 /** Steam exposes the same article under several URL patterns. We canonicalize


### PR DESCRIPTION
I routed every displayed date and time through a shared formatter that treats naive backend timestamps as UTC and renders in the viewer's local timezone, with Pacific as the default for server-rendered content.