### PR TITLE
Fix ascension stats 504s (issue #868)

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -7,6 +7,7 @@ import time
 from functools import lru_cache
 from pathlib import Path
 from fastapi import APIRouter, HTTPException, Query, Request, Response
+from pymongo.errors import ExecutionTimeout
 from starlette.concurrency import run_in_threadpool
 from ..dependencies import shared_limiter
 from ..services import rate_limit_config
@@ -1656,14 +1657,29 @@ def get_community_stats(
                 return winner
 
     try:
-        result = get_stats(
-            character=character,
-            win=win,
-            ascension=ascension,
-            game_mode=game_mode,
-            players=players,
-            username=username,
-        )
+        # Bounded so an aggregation that outgrew the data can never hold the
+        # request past the gateway timeout (issue #868): it either finishes
+        # inside the cap or aborts into a clear 503, and combos the refresher
+        # owns get materialized within minutes regardless.
+        try:
+            result = get_stats(
+                character=character,
+                win=win,
+                ascension=ascension,
+                game_mode=game_mode,
+                players=players,
+                username=username,
+                max_time_ms=20_000,
+            )
+        except ExecutionTimeout:
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "Stats for this filter combination are being computed "
+                    "in the background; retry in a few minutes."
+                ),
+                headers={"Retry-After": "120"},
+            )
         _stats_fallback_cache[cache_key] = (time.monotonic(), result)
         app_cache.set_json(redis_key, result, ttl_seconds=60)
 

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1303,6 +1303,8 @@ def get_stats(
         coll.find_one({"username_lower": username.lower()}, {"_id": 1}) is None
     ):
         total = 0
+    elif max_time_ms:
+        total = coll.count_documents(match, maxTimeMS=max_time_ms)
     else:
         total = coll.count_documents(match)
     if total == 0:
@@ -1693,10 +1695,15 @@ def read_stats_summary(
         doc = _summary_coll().find_one({"_id": key})
         if not doc:
             return None
-        # Hot combos (no filter, or character only) are kept fresh by the
-        # refresher and always served. Every other combo is write-through only,
-        # so honor its age and fall through to a recompute past the TTL.
-        non_hot = bool(win or ascension or game_mode or players or username)
+        # Combos the refresher owns (hot + the ascension rotation) are always
+        # served whatever their age — minutes-stale beats an inline
+        # multi-aggregation that can no longer finish inside the gateway
+        # timeout (issue #868). Every other combo is write-through only, so
+        # honor its age and fall through to a recompute past the TTL.
+        non_hot = (
+            bool(win or ascension or game_mode or players or username)
+            and key not in MATERIALIZED_STATS_KEYS
+        )
         if non_hot:
             updated = doc.get("updated_at")
             if not isinstance(updated, datetime):
@@ -1725,6 +1732,24 @@ HOT_FILTER_COMBOS: list[dict] = [
     {"character": "NECROBINDER"},
     {"character": "REGENT"},
 ]
+
+# Second tier: every ascension slice (A0-A10, alone and per character). Their
+# live aggregation outgrew the gateway timeout at ~1.2M runs (issue #868), so
+# they must never compute on the request path — but 66 combos are too many to
+# recompute every cycle, so the refresher rotates through the stalest K per
+# cycle. Full coverage lands within ~11 cycles (~11 minutes).
+ASCENSION_FILTER_COMBOS: list[dict] = [
+    {**({"character": c} if c else {}), "ascension": str(a)}
+    for a in range(0, 11)
+    for c in (None, "IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT")
+]
+_ASCENSION_COMBOS_PER_CYCLE = 6
+
+# Every combo the refresher owns. Reads serve these regardless of age — a
+# minutes-stale doc beats recomputing a multi-aggregation inline.
+MATERIALIZED_STATS_KEYS = frozenset(
+    _filter_key(**f) for f in (*HOT_FILTER_COMBOS, *ASCENSION_FILTER_COMBOS)
+)
 
 
 # Hot leaderboard combos to materialize into leaderboard_summary.
@@ -1782,13 +1807,28 @@ def try_acquire_refresh_lease() -> bool:
         return False
 
 
+def _pick_stalest_keys(ages: dict[str, datetime | None], k: int) -> list[str]:
+    """The k keys most in need of a refresh: never-materialized first, then
+    oldest updated_at (naive values treated as UTC)."""
+    floor = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+    def _age(key: str) -> datetime:
+        u = ages.get(key)
+        if not isinstance(u, datetime):
+            return floor
+        return u if u.tzinfo else u.replace(tzinfo=timezone.utc)
+
+    return sorted(ages, key=_age)[:k]
+
+
 @_instrument("refresh_stats_summary", collection="stats_summary")
 def refresh_stats_summary() -> int:
-    """Compute every hot filter combo and write to stats_summary.
-    Returns count of docs written. Called by the leader-only loop."""
+    """Compute the hot filter combos plus a rotating slice of the ascension
+    tier and write them to stats_summary. Returns count of docs written.
+    Called by the leader-only loop."""
     summary = _summary_coll()
-    written = 0
-    for filters in HOT_FILTER_COMBOS:
+
+    def _refresh_one(filters: dict) -> int:
         try:
             result = get_stats(**filters, max_time_ms=120_000)
             key = _filter_key(**filters)
@@ -1804,10 +1844,27 @@ def refresh_stats_summary() -> int:
                 result,
                 ttl_seconds=app_cache.WARM_TTL_SECONDS,
             )
-            written += 1
+            return 1
         except Exception:
             # Best-effort; if one filter combo fails, keep going.
-            pass
+            return 0
+
+    written = 0
+    for filters in HOT_FILTER_COMBOS:
+        written += _refresh_one(filters)
+
+    # Ascension tier: refresh the stalest K this cycle (issue #868 — these
+    # can never compute on the request path, so the rotation is their only
+    # source of freshness).
+    keyed = {_filter_key(**f): f for f in ASCENSION_FILTER_COMBOS}
+    ages: dict[str, datetime | None] = dict.fromkeys(keyed)
+    try:
+        for doc in summary.find({"_id": {"$in": list(keyed)}}, {"updated_at": 1}):
+            ages[doc["_id"]] = doc.get("updated_at")
+    except Exception:
+        pass
+    for key in _pick_stalest_keys(ages, _ASCENSION_COMBOS_PER_CYCLE):
+        written += _refresh_one(keyed[key])
     return written
 
 

--- a/backend/tests/test_stats_ascension_combos.py
+++ b/backend/tests/test_stats_ascension_combos.py
@@ -1,0 +1,57 @@
+"""Ascension stat slices must never compute on the request path (their live
+aggregation outgrew the gateway timeout — issue #868): the refresher owns
+them via a rotation, and reads serve the materialized doc whatever its age."""
+
+from datetime import datetime, timedelta, timezone
+
+from app.services import runs_db_mongo
+from app.services.runs_db_mongo import (
+    ASCENSION_FILTER_COMBOS,
+    MATERIALIZED_STATS_KEYS,
+    _filter_key,
+    _pick_stalest_keys,
+)
+
+
+def test_every_ascension_slice_is_materialized():
+    assert len(ASCENSION_FILTER_COMBOS) == 66  # 11 ascensions x (5 chars + alone)
+    for c in (None, "IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"):
+        for a in range(11):
+            assert _filter_key(character=c, ascension=str(a)) in MATERIALIZED_STATS_KEYS
+
+
+def test_rotation_prefers_missing_then_oldest():
+    now = datetime.now(timezone.utc)
+    ages = {
+        "fresh": now,
+        "older": now - timedelta(minutes=30),
+        "oldest": now - timedelta(hours=2),
+        "never": None,
+        "naive": (now - timedelta(hours=1)).replace(tzinfo=None),
+    }
+    assert _pick_stalest_keys(ages, 3) == ["never", "oldest", "naive"]
+
+
+class _FakeSummaryColl:
+    def __init__(self, doc):
+        self.doc = doc
+
+    def find_one(self, q):
+        return dict(self.doc) if q.get("_id") == self.doc["_id"] else None
+
+
+def test_reader_serves_stale_materialized_ascension_doc(monkeypatch):
+    old = datetime.now(timezone.utc) - timedelta(hours=6)
+    key = _filter_key(character="IRONCLAD", ascension="10")
+    fake = _FakeSummaryColl({"_id": key, "updated_at": old, "total_runs": 123})
+    monkeypatch.setattr(runs_db_mongo, "_summary_coll", lambda: fake)
+    out = runs_db_mongo.read_stats_summary(character="IRONCLAD", ascension="10")
+    assert out is not None and out["total_runs"] == 123
+
+
+def test_reader_still_expires_non_materialized_combos(monkeypatch):
+    old = datetime.now(timezone.utc) - timedelta(hours=6)
+    key = _filter_key(username="yitsy")
+    fake = _FakeSummaryColl({"_id": key, "updated_at": old, "total_runs": 5})
+    monkeypatch.setattr(runs_db_mongo, "_summary_coll", lambda: fake)
+    assert runs_db_mongo.read_stats_summary(username="yitsy") is None


### PR DESCRIPTION
I made the stats refresher rotate through every ascension slice so those combos always serve a materialized doc, and bounded the inline aggregation fallback to 20s with a clear 503 instead of a gateway 504. Fixes #868.