### PR TITLE
Fix nonsense Handles-it-best encounter builds

### DIFF
--- a/backend/app/services/run_vectors.py
+++ b/backend/app/services/run_vectors.py
@@ -83,6 +83,7 @@ def build_run_vectors() -> dict:
             "submitted_at": 1,
             "build_id": 1,
             "killed_by": 1,
+            "floors_reached": 1,
             "deck.id": 1,
             "relics.id": 1,
         },
@@ -120,6 +121,7 @@ def build_run_vectors() -> dict:
                 else str(sub or "")[:10],
                 "ver": doc.get("build_id"),
                 "kb": doc.get("killed_by") or "",
+                "floors": int(doc.get("floors_reached") or 0),
             }
         )
 
@@ -159,6 +161,7 @@ def build_run_vectors() -> dict:
             date=np.array([r["date"] for r in m], dtype="S10"),
             ver=np.array([r.get("ver") or "" for r in m], dtype="S16"),
             kb=np.array([r.get("kb") or "" for r in m], dtype="S48"),
+            floors=np.array([r.get("floors") or 0 for r in m], dtype=np.int16),
         )
         total += n
         k = max(4, min(14, n // 3000))
@@ -478,9 +481,22 @@ def _load_labels(character: str):
     return labels
 
 
+# A cluster needs this many runs that actually reached the encounter before
+# its conditioned death rate means anything; thinner clusters drop out.
+_MIN_REACHED = 50
+
+
 def encounter_builds(encounter: str) -> list[dict] | None:
-    """Per-archetype death counts at one encounter, joined from the stored
-    run->cluster labels and the killed_by column of the shard meta."""
+    """Per-archetype death rates at one encounter, joined from the stored
+    run->cluster labels and the killed_by column of the shard meta.
+
+    Death rate is conditioned on runs that actually REACHED the fight: the
+    reachable floor band self-calibrates from where deaths at this encounter
+    occur (5th percentile of their floors_reached), so a build that dies in
+    Act 1 can't top "handles it best" for an Act 3 boss just because it never
+    gets there. Shards built before the floors column fall back to the old
+    whole-cluster rate with a guard that drops builds that neither die here
+    nor win at all."""
     import numpy as np
 
     arch = load_archetypes()
@@ -498,8 +514,24 @@ def encounter_builds(encounter: str) -> list[dict] | None:
             continue
         n = min(len(kb), len(labels))
         lab = np.asarray(labels[:n])
-        sel = (np.asarray(kb[:n]) == enc) & (lab >= 0)
+        kb_arr = np.asarray(kb[:n])
+        death_mask = kb_arr == enc
+        sel = death_mask & (lab >= 0)
         counts = np.bincount(lab[sel].astype(np.int64), minlength=len(clusters))
+
+        reached_counts = None
+        fl = loaded[1].get("floors")
+        if fl is not None:
+            floors_arr = np.asarray(fl[: min(n, len(fl))])
+            m = len(floors_arr)
+            death_floors = floors_arr[death_mask[:m]]
+            if death_floors.size >= 20:
+                threshold = int(np.percentile(death_floors, 5))
+                reached_sel = (floors_arr >= threshold) & (lab[:m] >= 0)
+                reached_counts = np.bincount(
+                    lab[:m][reached_sel].astype(np.int64), minlength=len(clusters)
+                )
+
         total = sum(c["size"] for c in clusters) or 1
         for j, c in enumerate(clusters):
             if not c["defining_cards"] and not c["defining_relics"]:
@@ -507,6 +539,18 @@ def encounter_builds(encounter: str) -> list[dict] | None:
             if c["size"] < 200:
                 continue
             deaths = int(counts[j]) if j < len(counts) else 0
+            if reached_counts is not None:
+                reached = int(reached_counts[j]) if j < len(reached_counts) else 0
+                if reached < _MIN_REACHED:
+                    continue
+                death_rate = round(deaths / reached * 100, 2)
+            else:
+                reached = None
+                # Legacy shards can't tell "survives it" from "never sees
+                # it"; a build with no deaths here and ~no wins is the latter.
+                if deaths == 0 and (c["win_rate"] or 0) < 5:
+                    continue
+                death_rate = round(deaths / c["size"] * 100, 2)
             out.append(
                 {
                     "character": ch,
@@ -517,7 +561,8 @@ def encounter_builds(encounter: str) -> list[dict] | None:
                     "share": round(c["size"] / total * 100, 1),
                     "win_rate": c["win_rate"],
                     "deaths": deaths,
-                    "death_rate": round(deaths / c["size"] * 100, 2),
+                    "reached": reached,
+                    "death_rate": death_rate,
                 }
             )
     return out

--- a/backend/tests/test_encounter_builds.py
+++ b/backend/tests/test_encounter_builds.py
@@ -1,0 +1,67 @@
+"""Encounter build rates must condition on runs that actually reach the
+fight: a build that dies in Act 1 can never rank as "handling" an Act 3 boss
+just because none of its runs live long enough to face it."""
+
+import numpy as np
+
+from app.services import run_vectors
+
+ENC = b"AEONGLASS_BOSS"
+
+
+def _fake(monkeypatch, meta, labels, clusters):
+    monkeypatch.setattr(
+        run_vectors,
+        "load_archetypes",
+        lambda: {"characters": {"IRONCLAD": clusters}},
+    )
+    monkeypatch.setattr(run_vectors, "_load_shard", lambda ch: (None, meta))
+    monkeypatch.setattr(run_vectors, "_load_labels", lambda ch: labels)
+
+
+def _clusters():
+    return [
+        {
+            "defining_cards": ["WHIRLWIND"],
+            "defining_relics": [],
+            "size": 300,
+            "win_rate": 50.0,
+        },
+        {
+            "defining_cards": ["FLEX"],
+            "defining_relics": [],
+            "size": 300,
+            "win_rate": 0.0,
+        },
+    ]
+
+
+def test_conditioned_rate_uses_runs_that_reached(monkeypatch):
+    # Cluster 0: 100 runs reach floor 45+, 10 die to the boss.
+    # Cluster 1: dies in act 1 (floor 10) every time — never reaches.
+    labels = np.array([0] * 100 + [1] * 100)
+    floors = np.array([45] * 100 + [10] * 100, dtype=np.int16)
+    kb = np.array([ENC] * 10 + [b""] * 90 + [b"JAW_WORM"] * 100, dtype="S48")
+    # Death-floor calibration needs >= 20 samples at the encounter.
+    kb[:20] = ENC
+    _fake(monkeypatch, {"kb": kb, "floors": floors}, labels, _clusters())
+
+    rows = run_vectors.encounter_builds("AEONGLASS_BOSS")
+    assert [r["key"] for r in rows] == ["WHIRLWIND"]  # never-reaches drops out
+    row = rows[0]
+    assert row["reached"] == 100
+    assert row["deaths"] == 20
+    assert row["death_rate"] == 20.0  # deaths / reached, not / size
+
+
+def test_legacy_shards_guard_never_sees_it(monkeypatch):
+    # No floors column: the 0%-WR cluster with zero deaths here is "never
+    # sees it", not "handles it", and must not appear at all.
+    labels = np.array([0] * 100 + [1] * 100)
+    kb = np.array([ENC] * 10 + [b""] * 90 + [b"JAW_WORM"] * 100, dtype="S48")
+    _fake(monkeypatch, {"kb": kb}, labels, _clusters())
+
+    rows = run_vectors.encounter_builds("AEONGLASS_BOSS")
+    assert [r["key"] for r in rows] == ["WHIRLWIND"]
+    assert rows[0]["reached"] is None
+    assert rows[0]["death_rate"] == round(10 / 300 * 100, 2)  # legacy semantics

--- a/frontend/app/monsters/[id]/MonsterDetail.tsx
+++ b/frontend/app/monsters/[id]/MonsterDetail.tsx
@@ -305,6 +305,7 @@ interface EncounterBuild {
   size: number;
   win_rate: number;
   deaths: number;
+  reached?: number | null;
   death_rate: number;
 }
 
@@ -498,7 +499,13 @@ export default function MonsterDetail({
   const struggleKeys = new Set(struggles.map((b) => `${b.character}:${b.name}`));
   const handles = [...builds]
     .sort((a, b) => a.death_rate - b.death_rate)
-    .filter((b) => b.size >= 500 && !struggleKeys.has(`${b.character}:${b.name}`))
+    // "Handles it best" needs proof the build actually faces this fight:
+    // enough runs that reached it (or, on legacy data, a big cluster).
+    .filter(
+      (b) =>
+        (b.reached != null ? b.reached >= 50 : b.size >= 500) &&
+        !struggleKeys.has(`${b.character}:${b.name}`),
+    )
     .slice(0, 5);
   const hasBuilds = struggles.length > 0;
 
@@ -664,9 +671,9 @@ export default function MonsterDetail({
             <section id="builds">
               <h2>{t("Builds", lang)}</h2>
               <p className="h-note">
-                Of the community archetypes that face {monster.name}, the share
-                of each build&apos;s runs that end here, next to that
-                build&apos;s overall win rate.
+                Of each community build&apos;s runs that reach {monster.name},
+                the share that die to it, next to that build&apos;s overall
+                win rate.
               </p>
               <div style={{ display: "grid", gap: "1rem", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))" }}>
                 <div>


### PR DESCRIPTION
I conditioned per-build encounter death rates on runs that actually reach the fight (self-calibrated from death floors, with a floors column added to the nightly vector shards), so builds that die in Act 1 can no longer rank as handling an Act 3 boss best.