### PR TITLE
Archetypes must be card-driven

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1832,10 +1832,12 @@ def get_archetypes(request: Request, response: Response, lang: str = "eng"):
         for c in clusters:
             if c["size"] < 50:
                 continue
-            # No draftable identity after the starter filter = not a build
-            # (the starter-deck early-exit clusters); real archetypes' share
-            # stays computed against ALL runs so the numbers remain honest.
-            if not c["defining_cards"] and not c["defining_relics"]:
+            # Archetypes are card-driven: a cluster with no distinctive
+            # cards is a character's catch-all deck, not a build, even when
+            # a couple of relics cleared the lift bar. Real archetypes'
+            # share stays computed against ALL runs so the numbers remain
+            # honest.
+            if not c["defining_cards"]:
                 continue
             trend = None
             if len(recent) == 2:

--- a/backend/app/services/run_vectors.py
+++ b/backend/app/services/run_vectors.py
@@ -534,7 +534,8 @@ def encounter_builds(encounter: str) -> list[dict] | None:
 
         total = sum(c["size"] for c in clusters) or 1
         for j, c in enumerate(clusters):
-            if not c["defining_cards"] and not c["defining_relics"]:
+            # Card-driven only: relic-only catch-all clusters aren't builds.
+            if not c["defining_cards"]:
                 continue
             if c["size"] < 200:
                 continue
@@ -609,7 +610,12 @@ def match_archetype(character: str, deck: list, relics: list) -> dict | None:
         return None
     q = built[0]
     sims = centers.dot(q)
-    j = int(np.argmax(sims))
+    # Archetypes are card-driven: never name a run after a relic-only
+    # catch-all cluster.
+    eligible = [i for i, c in enumerate(clusters) if c["defining_cards"]]
+    if not eligible:
+        return None
+    j = max(eligible, key=lambda i: float(sims[i]))
     total = sum(c["size"] for c in clusters) or 1
     c = clusters[j]
     return {
@@ -705,7 +711,7 @@ def pick_coach(
                 "similarity": round(float(sims[i]) * 100, 1),
             }
             for i, c in enumerate(clusters)
-            if c["defining_cards"] or c["defining_relics"]
+            if c["defining_cards"]
         ),
         key=lambda c: -c["similarity"],
     )[:5]

--- a/backend/tests/test_encounter_builds.py
+++ b/backend/tests/test_encounter_builds.py
@@ -33,6 +33,14 @@ def _clusters():
             "size": 300,
             "win_rate": 0.0,
         },
+        # Relic-only catch-all: not a build, must never appear (archetypes
+        # are card-driven).
+        {
+            "defining_cards": [],
+            "defining_relics": ["BLOOD_VIAL"],
+            "size": 300,
+            "win_rate": 40.0,
+        },
     ]
 
 


### PR DESCRIPTION
I excluded relic-only catch-all clusters from every archetype surface (/archetypes, encounter builds, run archetype naming, deck advisor), so bare character-name entries with no defining cards no longer appear.