### PR TITLE
Handles it best: highest win rate first

### DIFF
--- a/frontend/app/monsters/[id]/MonsterDetail.tsx
+++ b/frontend/app/monsters/[id]/MonsterDetail.tsx
@@ -499,11 +499,14 @@ export default function MonsterDetail({
   const struggleKeys = new Set(struggles.map((b) => `${b.character}:${b.name}`));
   const handles = [...builds]
     .sort((a, b) => a.death_rate - b.death_rate)
-    // "Handles it best" needs proof the build actually faces this fight:
-    // enough runs that reached it (or, on legacy data, a big cluster).
+    // "Handles it best" needs proof the build actually faces this fight
+    // (enough runs that reached it; on legacy data, a big cluster) AND that
+    // it is a build worth copying — dodging deaths here at a near-zero
+    // overall win rate is trivia, not handling.
     .filter(
       (b) =>
         (b.reached != null ? b.reached >= 50 : b.size >= 500) &&
+        b.win_rate >= 20 &&
         !struggleKeys.has(`${b.character}:${b.name}`),
     )
     .slice(0, 5);

--- a/frontend/app/monsters/[id]/MonsterDetail.tsx
+++ b/frontend/app/monsters/[id]/MonsterDetail.tsx
@@ -497,16 +497,14 @@ export default function MonsterDetail({
 
   const struggles = builds.filter((b) => b.deaths >= 5).slice(0, 5);
   const struggleKeys = new Set(struggles.map((b) => `${b.character}:${b.name}`));
+  // "Handles it best" = the highest-win-rate builds among those with proof
+  // they actually face this fight (enough runs that reached it; on legacy
+  // data, a big cluster), with their death share here alongside.
   const handles = [...builds]
-    .sort((a, b) => a.death_rate - b.death_rate)
-    // "Handles it best" needs proof the build actually faces this fight
-    // (enough runs that reached it; on legacy data, a big cluster) AND that
-    // it is a build worth copying — dodging deaths here at a near-zero
-    // overall win rate is trivia, not handling.
+    .sort((a, b) => b.win_rate - a.win_rate)
     .filter(
       (b) =>
         (b.reached != null ? b.reached >= 50 : b.size >= 500) &&
-        b.win_rate >= 20 &&
         !struggleKeys.has(`${b.character}:${b.name}`),
     )
     .slice(0, 5);
@@ -713,7 +711,7 @@ export default function MonsterDetail({
                         />
                         <span className="cn" style={{ flexGrow: 1 }}>{b.name}</span>
                         <span style={{ color: "var(--text-muted)", fontVariantNumeric: "tabular-nums" }}>
-                          {b.death_rate}% {t("die here", lang)} · {b.win_rate}% WR
+                          {b.win_rate}% WR · {b.death_rate}% {t("die here", lang)}
                         </span>
                       </div>
                     ))}


### PR DESCRIPTION
I made Handles-it-best rank by highest overall win rate among builds with enough runs reaching the fight, leading each row with the win rate and showing the die-here share alongside, while Dies-here-most keeps its death-share ranking.