### PR TITLE
Load relief for the ascension refresher and insight walks

### DIFF
--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1743,7 +1743,11 @@ ASCENSION_FILTER_COMBOS: list[dict] = [
     for a in range(0, 11)
     for c in (None, "IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT")
 ]
-_ASCENSION_COMBOS_PER_CYCLE = 6
+# Throttled after the 2026-08-20 load incident: 6 per cycle kept Mongo in a
+# continuous disk-spilling aggregation storm. 2 per cycle = full coverage in
+# ~33 min, still minutes-fresh for readers who serve any age. Set
+# STATS_ASCENSION_TIER=off to disable the tier entirely under duress.
+_ASCENSION_COMBOS_PER_CYCLE = 2
 
 # Every combo the refresher owns. Reads serve these regardless of age — a
 # minutes-stale doc beats recomputing a multi-aggregation inline.
@@ -1856,6 +1860,12 @@ def refresh_stats_summary() -> int:
     # Ascension tier: refresh the stalest K this cycle (issue #868 — these
     # can never compute on the request path, so the rotation is their only
     # source of freshness).
+    if os.environ.get("STATS_ASCENSION_TIER", "on").strip().lower() in (
+        "off",
+        "0",
+        "false",
+    ):
+        return written
     keyed = {_filter_key(**f): f for f in ASCENSION_FILTER_COMBOS}
     ages: dict[str, datetime | None] = dict.fromkeys(keyed)
     try:

--- a/backend/app/services/user_insights.py
+++ b/backend/app/services/user_insights.py
@@ -43,6 +43,7 @@ _MIN_RUNS_FOR_UNDER = 10
 _RELIC_RARITIES_SKIPPED = frozenset({"starter", "ancient"})
 
 _CACHE_TTL = 120.0
+_walk_gate = threading.BoundedSemaphore(1)
 _CACHE_MAX = 500
 _cache: dict[str, tuple[float, dict]] = {}
 _cache_lock = threading.Lock()
@@ -555,6 +556,13 @@ def _kick_refresh(
         return
 
     def _run() -> None:
+        # One walk at a time per worker: each holds every blob for the
+        # account in memory, and unbounded stacking swapped the box on
+        # 2026-08-20.
+        with _walk_gate:
+            _run_locked()
+
+    def _run_locked() -> None:
         from fastapi.encoders import jsonable_encoder
 
         try:
@@ -683,7 +691,9 @@ def _fetch_blobs(rows: list[dict]) -> dict[str, dict]:
     if len(batches) == 1:
         return get_run_blobs([r["run_hash"] for r in batches[0]])
     out: dict[str, dict] = {}
-    with ThreadPoolExecutor(max_workers=min(4, len(batches))) as pool:
+    # 2 workers, not 4: the 2026-08-20 load incident showed stacked walks x
+    # wide fetches swapping the box; latency still roughly halves vs serial.
+    with ThreadPoolExecutor(max_workers=min(2, len(batches))) as pool:
         for blobs in pool.map(
             lambda b: get_run_blobs([r["run_hash"] for r in b]), batches
         ):


### PR DESCRIPTION
I throttled the ascension stats rotation to 2 combos per cycle with a STATS_ASCENSION_TIER=off kill switch, halved the insights blob-fetch parallelism, and serialized insight walks per worker after the load incident.