### PR TITLE
Fix empty blob charts (accumulator keyword mismatch)

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -102,7 +102,18 @@ def _snapshot_info() -> dict:
                 "age_seconds": age,
                 "version": meta.get("snapshot_version"),
                 "total_runs": (meta.get("global_totals") or {}).get("total_runs"),
-                "has_charts": bool(meta.get("charts")),
+                # The blobs were moved out of __meta__ into their own
+                # sharded docs (charts / charts:<bracket>), so the old
+                # meta.get("charts") probe reported "building" forever.
+                "has_charts": bool(
+                    (
+                        db[SNAPSHOT_COLLECTION_NAME].find_one(
+                            {"_id": "charts"}, {"keys": 1}
+                        )
+                        or {}
+                    ).get("keys")
+                    or meta.get("charts")
+                ),
             }
         from ..services import run_entity_stats as res
 

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -1234,7 +1234,7 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=(), preloaded_blob
                 is_win=is_win,
                 character=character,
                 player_count=row.get("player_count") or 1,
-                submitted=played,
+                played=played,
             )
         except Exception:
             logger.warning(

--- a/backend/tests/test_walk_accumulator_contract.py
+++ b/backend/tests/test_walk_accumulator_contract.py
@@ -1,0 +1,88 @@
+"""The snapshot walk wraps every accumulate() call in try/except, so a
+signature drift fails SILENTLY and empties that blob for a whole rebuild.
+
+That happened for real: PR #867 renamed charts_stats.accumulate's `submitted`
+keyword to `played` but left the walk passing `submitted=`, so every run threw
+TypeError, the walk logged a warning per run, and all 14 blob-backed charts
+served empty series for days.
+
+Rather than restate the walk's keywords here (which would drift with it),
+these tests read the ACTUAL call sites out of run_entity_stats.py and bind
+them against each accumulator's real signature."""
+
+import ast
+import inspect
+from pathlib import Path
+
+from app.services import charts_stats, community_stats, encounter_stats
+from app.services import run_entity_stats
+
+ACCUMULATORS = {
+    "charts_stats": charts_stats,
+    "community_stats": community_stats,
+    "encounter_stats": encounter_stats,
+}
+
+
+def _call_sites(source: str, module_name: str) -> list[tuple[int, list[str]]]:
+    """(positional count, keyword names) for each `<module>.accumulate(...)`."""
+    tree = ast.parse(source)
+    found = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "accumulate"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == module_name
+        ):
+            found.append((len(node.args), [kw.arg for kw in node.keywords if kw.arg]))
+    return found
+
+
+def test_walk_call_sites_bind_to_accumulator_signatures():
+    source = Path(inspect.getfile(run_entity_stats)).read_text(encoding="utf-8")
+    for module_name, module in ACCUMULATORS.items():
+        sites = _call_sites(source, module_name)
+        assert sites, f"no {module_name}.accumulate call found in the walk"
+        sig = inspect.signature(module.accumulate)
+        for n_positional, keywords in sites:
+            # Raises TypeError on a renamed, removed, or missing keyword.
+            sig.bind(*([{}] * n_positional), **dict.fromkeys(keywords))
+
+
+def test_charts_accumulate_actually_folds_a_run():
+    blob = {
+        "game_mode": "standard",
+        "run_time": 900,
+        "players": [{"deck": [{"id": "CARD.STRIKE"}] * 12, "relics": []}],
+        "map_point_history": [
+            [
+                {
+                    "rooms": [
+                        {
+                            "room_type": "monster",
+                            "model_id": "ENCOUNTER.JAW_WORM",
+                            "turns_taken": 4,
+                        }
+                    ],
+                    "player_stats": [
+                        {"damage_taken": 7, "current_hp": 60, "max_hp": 80}
+                    ],
+                }
+            ]
+        ],
+    }
+    acc = charts_stats.new_accumulator()
+    charts_stats.accumulate(
+        acc,
+        blob,
+        brackets=["all"],
+        is_win=True,
+        character="IRONCLAD",
+        player_count=1,
+        played="2026-08-20T10:00:00",
+    )
+    out = charts_stats.finalize(acc)["all"]
+    # Something must land: an empty result here is the silent-failure mode.
+    assert any(out.get(k) for k in out), "charts accumulator produced nothing"


### PR DESCRIPTION
I fixed the walk passing a renamed keyword to the charts accumulator, which made every run throw and left all 14 blob-backed charts serving empty series since the v25 rebuild, and added a contract test that binds the walk's real call sites against each accumulator signature.