### PR TITLE
Game mode composes with the other filters

### DIFF
--- a/backend/app/services/community_stats.py
+++ b/backend/app/services/community_stats.py
@@ -79,16 +79,19 @@ COMMUNITY_VERSION = 1
 # _COMPOSITE_BRACKETS in run_entity_stats.py.
 _PLAYER_BRACKETS = ("solo", "2p", "3p", "4p")
 _SKILL_BRACKETS = ("a10", "wr30", "wr50", "wr75")
-# Game-mode keys share the single ?bracket= slot (a mode replaces the
-# player/skill selection, like daily/custom always did on the entity side).
+# Game-mode keys are a third composing axis (v27): a mode narrows the
+# player/skill selection instead of replacing it.
 _MODE_BRACKETS = ("standard", "daily", "custom")
-_BLOB_BRACKETS = (
-    ["all"]
-    + list(_PLAYER_BRACKETS)
-    + list(_SKILL_BRACKETS)
-    + list(_MODE_BRACKETS)
-    + [f"{p}:{c}" for p in _PLAYER_BRACKETS for c in _SKILL_BRACKETS]
-)
+# Every combination of the three axes, canonical player:skill:mode order.
+# Kept identical to _ALL_BRACKET_COMBOS in run_entity_stats.py (a test pins
+# them together) so a filter the UI can express always has a slice.
+_BLOB_BRACKETS = ["all"] + [
+    ":".join(x for x in (p, s, m) if x)
+    for p in ("",) + _PLAYER_BRACKETS
+    for s in ("",) + _SKILL_BRACKETS
+    for m in ("",) + _MODE_BRACKETS
+    if (p or s or m)
+]
 
 
 def _new_acc_one() -> dict[str, Any]:

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -109,13 +109,46 @@ _ACT_MIN_PICKS = 200
 # encounter / charts blobs filter to their own key sets and skip them.
 _PLAYER_BRACKETS = ("solo", "2p", "3p", "4p")
 _SKILL_BRACKETS = ("a10", "wr30", "wr50", "wr75")
+_MODE_BRACKET_KEYS = ("standard", "daily", "custom")
 _COMPOSITE_BRACKETS = [f"{p}:{c}" for p in _PLAYER_BRACKETS for c in _SKILL_BRACKETS]
+
+# Every combination of the three run axes, in canonical player:skill:mode
+# order (the same order the frontend's combineBracket builds). A filter the
+# UI can express must have a materialized slice behind it, so picking Solo,
+# then A10, then Standard narrows instead of resetting.
+_ALL_BRACKET_COMBOS = [
+    ":".join(x for x in (p, s, m) if x)
+    for p in ("",) + _PLAYER_BRACKETS
+    for s in ("",) + _SKILL_BRACKETS
+    for m in ("",) + _MODE_BRACKET_KEYS
+    if (p or s or m)
+]
+
+
+def axis_combos(players: list[str], skills: list[str], modes: list[str]) -> list[str]:
+    """Every canonical key a run matching these axes belongs to, singles
+    included. Shared by the entity cache and the community blob so the two
+    can never disagree about what a combination is called."""
+    out: list[str] = []
+    for p in [""] + list(players):
+        for s in [""] + list(skills):
+            for m in [""] + list(modes):
+                key = ":".join(x for x in (p, s, m) if x)
+                if key:
+                    out.append(key)
+    return out
+
+
 # Fast membership test in the hot per-run walk. Composites carry the full
 # reward-pairwise / Codex Elo + Pick% build like every other bracket (v16); it's
 # the heaviest part of the walk, so this build leans on the parallel rebuild.
 # Cards below the per-bracket head-to-head floor still get no Elo in that slice.
 _COMPOSITE_BRACKETS_SET = frozenset(_COMPOSITE_BRACKETS)
 
+# The chart prewarm's warm-up grid. Deliberately the pre-composition set:
+# the charts page filters players and mode query-time off the metadata frame
+# rather than the blob, so its bracket space is its own and warming the full
+# 99-key grid would just burn cycles.
 _BRACKET_KEYS = [
     "solo",
     "2p",
@@ -131,25 +164,9 @@ _BRACKET_KEYS = [
     "wr75",
 ] + _COMPOSITE_BRACKETS
 
-
-_MODE_BRACKET_KEYS = ("standard", "daily", "custom")
-
-
-def _community_blob_brackets(
-    mp_blob_brackets: list[str], extra_brackets: list[str]
-) -> list[str]:
-    """Blob brackets the community accumulator slices by: the player-count set,
-    the player x skill composites (solo:wr50, ...) so the page can combine both
-    axes like the tier list, and the run's game mode. Modes occupy the whole
-    base slot (they never compose with players or skill), but they DO compose
-    with versions via the caller's version step. The mode keys were silently
-    dropped by allowlists until snapshot v26 — the mode pills served blobs
-    nothing had ever accumulated into."""
-    return (
-        mp_blob_brackets
-        + [c for c in extra_brackets if c in _COMPOSITE_BRACKETS_SET]
-        + [c for c in extra_brackets if c in _MODE_BRACKET_KEYS]
-    )
+# What the entity cache materializes: every expressible combination.
+_ENTITY_BRACKET_KEYS = _ALL_BRACKET_COMBOS
+_ALL_BRACKET_COMBOS_SET = frozenset(_ALL_BRACKET_COMBOS)
 
 
 def _run_extra_brackets(player_count: int, ascension: int, game_mode: str) -> list[str]:
@@ -323,7 +340,9 @@ _HISTORY_RETENTION_DAYS = 90
 # rebuild is required or old runs keep their UTC upload-day keys.
 # 26: mode brackets actually accumulate (they were allowlist-dropped since
 # v24, so Standard/Daily/Custom community blobs sat empty).
-SNAPSHOT_VERSION = 26
+# 27: game mode became a composing axis (player x skill x mode), so picking
+# Standard on top of Solo + A10 narrows instead of replacing the selection.
+SNAPSHOT_VERSION = 27
 # Serialized-byte budget per persisted chunk doc. With version-composable
 # brackets a popular entity carries hundreds of per-bracket blocks and
 # entity sizes vary wildly (a card dwarfs an affliction), so chunks are
@@ -1092,11 +1111,11 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=(), preloaded_blob
     # mid-walk - which is exactly how the un-seeded version keys killed
     # every v18-v20 rebuild the first time one actually ran to this point.
     bracket_accs: dict[str, dict[str, Any]] = {
-        k: _new_bracket_acc() for k in _BRACKET_KEYS
+        k: _new_bracket_acc() for k in _ENTITY_BRACKET_KEYS
     }
     for _v in recent_versions:
         bracket_accs[_v] = _new_bracket_acc()
-        for _b in _BRACKET_KEYS:
+        for _b in _ENTITY_BRACKET_KEYS:
             bracket_accs[f"{_b}:{_v}"] = _new_bracket_acc()
 
     if preloaded_blobs is not None:
@@ -1138,8 +1157,8 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=(), preloaded_blob
         # their own keys and skip composites.
         _pc = [b for b in extra_brackets if b in _PLAYER_BRACKETS]
         _sk = [b for b in extra_brackets if b in _SKILL_BRACKETS]
-        if _pc and _sk:
-            extra_brackets = extra_brackets + [f"{p}:{c}" for p in _pc for c in _sk]
+        _md = [b for b in extra_brackets if b in _MODE_BRACKET_KEYS]
+        extra_brackets = axis_combos(_pc, _sk, _md)
         # Version brackets: a run's build_id becomes one more bracket key AND
         # composes with every bracket key the run already matched (player,
         # skill, mode, player:skill), so any filter combo the UI can express
@@ -1180,9 +1199,11 @@ def _accumulate(rows, official_chars, wr_map, recent_versions=(), preloaded_blob
         mp_blob_brackets = blob_brackets + [
             c for c in extra_brackets if c in ("solo", "2p", "3p", "4p")
         ]
-        community_blob_brackets = _community_blob_brackets(
-            mp_blob_brackets, extra_brackets
-        )
+        # The community blob carries every combination too, so its page can
+        # narrow by player AND skill AND mode the way the tier list does.
+        community_blob_brackets = ["all"] + [
+            b for b in extra_brackets if b in _ALL_BRACKET_COMBOS_SET
+        ]
         # Version slices: one accumulator per game version, plus the version
         # composed onto every other blob bracket ("all:version" collapses to
         # the bare version key), so /community-stats combines version with

--- a/backend/tests/test_bracket_composition.py
+++ b/backend/tests/test_bracket_composition.py
@@ -1,0 +1,63 @@
+"""Filters compose: player x skill x mode all narrow together, so picking
+Standard on top of Solo + A10 keeps Solo + A10 (it used to replace them).
+
+Everything the UI can express must have a materialized slice, and the entity
+cache and the community blob have to agree on what each combination is
+called, or one surface silently serves an empty bracket."""
+
+from app.services.community_stats import _BLOB_BRACKETS
+from app.services.run_entity_stats import (
+    _ALL_BRACKET_COMBOS,
+    _MODE_BRACKET_KEYS,
+    _PLAYER_BRACKETS,
+    _SKILL_BRACKETS,
+    axis_combos,
+)
+
+
+def test_entity_and_community_key_sets_match():
+    assert sorted(_ALL_BRACKET_COMBOS) == sorted(
+        k for k in _BLOB_BRACKETS if k != "all"
+    )
+    assert "all" in _BLOB_BRACKETS
+
+
+def test_every_expressible_combination_exists():
+    combos = set(_ALL_BRACKET_COMBOS)
+    for p in ("",) + _PLAYER_BRACKETS:
+        for s in ("",) + _SKILL_BRACKETS:
+            for m in ("",) + _MODE_BRACKET_KEYS:
+                key = ":".join(x for x in (p, s, m) if x)
+                if key:
+                    assert key in combos, key
+    # 5 player slots x 5 skill slots x 4 mode slots, minus the empty one.
+    assert len(combos) == 99
+
+
+def test_a_run_lands_in_every_slice_that_contains_it():
+    keys = set(axis_combos(["solo"], ["a10", "wr30"], ["standard"]))
+    # Singles, pairs, and the full triple all get the run.
+    for expected in (
+        "solo",
+        "a10",
+        "standard",
+        "solo:a10",
+        "solo:standard",
+        "a10:standard",
+        "solo:a10:standard",
+        "solo:wr30:standard",
+    ):
+        assert expected in keys, expected
+    # It must NOT land in a slice it doesn't belong to.
+    for unexpected in ("2p", "daily", "wr75", "solo:daily", "2p:a10:standard"):
+        assert unexpected not in keys, unexpected
+
+
+def test_canonical_order_is_player_skill_mode():
+    for key in _ALL_BRACKET_COMBOS:
+        parts = key.split(":")
+        axes = [
+            0 if p in _PLAYER_BRACKETS else 1 if p in _SKILL_BRACKETS else 2
+            for p in parts
+        ]
+        assert axes == sorted(axes), key

--- a/backend/tests/test_mode_brackets.py
+++ b/backend/tests/test_mode_brackets.py
@@ -1,30 +1,25 @@
 """Game-mode brackets must actually receive runs: every run carries exactly
-one mode key, and the community blob bracket list keeps it (the allowlists
-silently dropped modes from v24 to v25, leaving the Standard/Daily/Custom
-pills with blobs nothing had ever accumulated into)."""
+one mode key, and that key survives into the composed bracket set (the
+allowlists silently dropped modes from v24 to v25, leaving the
+Standard/Daily/Custom pills with blobs nothing had ever accumulated into)."""
 
-from app.services.run_entity_stats import (
-    _community_blob_brackets,
-    _run_extra_brackets,
-)
+from app.services.run_entity_stats import _run_extra_brackets, axis_combos
+
+MODES = {"standard", "daily", "custom"}
 
 
 def test_every_run_carries_exactly_one_mode_key():
-    modes = {"standard", "daily", "custom"}
-    assert modes & set(_run_extra_brackets(1, 10, "standard")) == {"standard"}
-    assert modes & set(_run_extra_brackets(2, 0, "daily")) == {"daily"}
-    assert modes & set(_run_extra_brackets(4, 5, "CUSTOM")) == {"custom"}
-    assert modes & set(_run_extra_brackets(1, 0, None)) == {"standard"}
+    assert MODES & set(_run_extra_brackets(1, 10, "standard")) == {"standard"}
+    assert MODES & set(_run_extra_brackets(2, 0, "daily")) == {"daily"}
+    assert MODES & set(_run_extra_brackets(4, 5, "CUSTOM")) == {"custom"}
+    assert MODES & set(_run_extra_brackets(1, 0, None)) == {"standard"}
 
 
-def test_community_brackets_keep_the_mode():
+def test_the_mode_survives_into_the_composed_keys():
     extra = _run_extra_brackets(1, 10, "standard")
-    out = _community_blob_brackets(["all", "a10", "solo"], extra)
-    assert "standard" in out
-    assert out[:3] == ["all", "a10", "solo"]  # shared brackets unchanged
-
-    extra = _run_extra_brackets(2, 0, "daily")
-    assert "daily" in _community_blob_brackets(["all", "2p"], extra)
-
-    extra = _run_extra_brackets(3, 0, "custom")
-    assert "custom" in _community_blob_brackets(["all", "3p"], extra)
+    players = [b for b in extra if b in ("solo", "2p", "3p", "4p")]
+    skills = [b for b in extra if b in ("a10", "wr30", "wr50", "wr75")]
+    modes = [b for b in extra if b in MODES]
+    keys = set(axis_combos(players, skills, modes))
+    assert "standard" in keys
+    assert "solo:a10:standard" in keys

--- a/frontend/app/community-stats/CommunityStatsBody.tsx
+++ b/frontend/app/community-stats/CommunityStatsBody.tsx
@@ -111,7 +111,7 @@ function Empty({ jsonLd, current, lang, basePath }: { jsonLd: object[]; current:
     <div className="mx-auto max-w-[1400px] px-3 sm:px-5 py-6">
       <JsonLd data={jsonLd} />
       <h1 className="text-3xl font-bold mb-2"><span className="text-[var(--accent-gold)]">{t("Community Stats", lang)}</span></h1>
-      <BracketFilter basePath={basePath} current={current} composite />
+      <BracketFilter basePath={basePath} current={current} />
       <p className="text-sm text-[var(--text-muted)]">
         {t("No data for this bracket yet. Stats build from community-submitted runs,", lang)} <Link href="/leaderboards/submit" className="text-[var(--accent-gold)] hover:underline">{t("submit a run", lang)}</Link> {t("to seed them.", lang)}
       </p>
@@ -165,7 +165,7 @@ export async function CommunityStatsBody({ lang, bracket }: { lang: string; brac
       </p>
 
       {/* Content bracket: slice every dataset below by skill and/or player count. */}
-      <BracketFilter basePath={basePath} current={bracket} composite />
+      <BracketFilter basePath={basePath} current={bracket} />
 
       {/* Headline numbers */}
       <section className="mb-10">

--- a/frontend/app/components/BracketFilter.tsx
+++ b/frontend/app/components/BracketFilter.tsx
@@ -18,25 +18,22 @@ import VersionSelectNav from "@/app/components/VersionSelectNav";
  * (color/pool/sort/act) so switching bracket preserves them; "all" omits the
  * param to keep the canonical URL clean.
  *
- * `composite`: when the page's data source materializes player x skill
- * composites (the entity cache behind the tier list / metrics), the two rows
- * COMBINE — e.g. Solo + A10 together. Otherwise the two rows share the single
- * ?bracket= slot and are mutually exclusive (blob-backed pages like community
- * stats, which have no composites).
+ * All three content axes compose (snapshot v27 materializes every
+ * player x skill x mode combination, and the version composes onto those), so
+ * picking Standard on top of Solo + A10 narrows the slice instead of
+ * replacing it.
  */
 export default function BracketFilter({
   basePath,
   current,
   extraParams,
-  composite,
 }: {
   basePath: string;
   current: string;
   extraParams?: Record<string, string | undefined>;
-  composite?: boolean;
 }) {
   const active = normalizeBracket(current);
-  const { player, skill, version } = splitBracket(active);
+  const { player, skill, mode, version } = splitBracket(active);
 
   const hrefFor = (bracketValue: string) => {
     const params = new URLSearchParams();
@@ -55,68 +52,9 @@ export default function BracketFilter({
         : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
     }`;
 
-  if (!composite) {
-    // Mutually-exclusive pills (each sets the base bracket), but the version
-    // axis still composes: picking a pill keeps the version and vice versa.
-    const base = stripVersion(active);
-    const renderPill = (b: ContentBracket) => (
-      <Link
-        key={b.key}
-        href={hrefFor(b.key === "all" ? version || "all" : version ? `${b.key}:${version}` : b.key)}
-        className={pillCls(base === b.key || (b.key === "all" && !base))}
-      >
-        {b.label}
-      </Link>
-    );
-    return (
-      <div className="mb-5 space-y-1.5">
-        <div className="flex flex-wrap items-center gap-1.5">
-          <span className="text-xs text-[var(--text-muted)] mr-1">Bracket</span>
-          {CONTENT_BRACKETS.map(renderPill)}
-          {/* Player count shares the ?bracket= slot, so picking one clears the
-              content bracket and vice versa. */}
-          <span className="text-xs text-[var(--text-muted)] mx-1">Players</span>
-          {PLAYER_BRACKETS.map(renderPill)}
-        </div>
-      <div className="flex flex-wrap items-center gap-1.5">
-        <span className="w-14 text-xs text-[var(--text-muted)]">Mode</span>
-        <Link
-          href={hrefFor(
-            base && !MODE_BRACKETS.some((m) => m.key === base)
-              ? version
-                ? `${base}:${version}`
-                : base
-              : version || "all",
-          )}
-          className={pillCls(!MODE_BRACKETS.some((m) => m.key === base))}
-        >
-          All
-        </Link>
-        {MODE_BRACKETS.map((m) => (
-          <Link
-            key={m.key}
-            href={hrefFor(version ? `${m.key}:${version}` : m.key)}
-            className={pillCls(base === m.key)}
-          >
-            {m.label}
-          </Link>
-        ))}
-      </div>
-        <VersionSelectNav
-          basePath={basePath}
-          current={active}
-          extraParams={extraParams}
-          base={base}
-        />
-      </div>
-    );
-  }
-
-  // Composite: each skill pill keeps the current player and vice versa, so the
-  // two axes combine into a player:skill bracket. Modes occupy the whole base
-  // slot instead (they don't compose with player/skill).
   const base = stripVersion(active);
   const playerOpts = [{ key: "", label: "All" }, ...PLAYER_BRACKETS];
+  const modeOpts = [{ key: "", label: "All" }, ...MODE_BRACKETS];
   return (
     <div className="mb-5 space-y-1.5">
       <div className="flex flex-wrap items-center gap-1.5">
@@ -126,7 +64,7 @@ export default function BracketFilter({
           return (
             <Link
               key={b.key}
-              href={hrefFor(combineBracket(player, targetSkill, version))}
+              href={hrefFor(combineBracket(player, targetSkill, mode, version))}
               className={pillCls(skill === targetSkill)}
             >
               {b.label}
@@ -139,7 +77,7 @@ export default function BracketFilter({
         {playerOpts.map((b) => (
           <Link
             key={b.key || "all"}
-            href={hrefFor(combineBracket(b.key, skill, version))}
+            href={hrefFor(combineBracket(b.key, skill, mode, version))}
             className={pillCls(player === b.key)}
           >
             {b.label}
@@ -148,23 +86,11 @@ export default function BracketFilter({
       </div>
       <div className="flex flex-wrap items-center gap-1.5">
         <span className="w-14 text-xs text-[var(--text-muted)]">Mode</span>
-        <Link
-          href={hrefFor(
-            base && !MODE_BRACKETS.some((m) => m.key === base)
-              ? version
-                ? `${base}:${version}`
-                : base
-              : version || "all",
-          )}
-          className={pillCls(!MODE_BRACKETS.some((m) => m.key === base))}
-        >
-          All
-        </Link>
-        {MODE_BRACKETS.map((m) => (
+        {modeOpts.map((m) => (
           <Link
-            key={m.key}
-            href={hrefFor(version ? `${m.key}:${version}` : m.key)}
-            className={pillCls(base === m.key)}
+            key={m.key || "all"}
+            href={hrefFor(combineBracket(player, skill, m.key, version))}
+            className={pillCls(mode === m.key)}
           >
             {m.label}
           </Link>

--- a/frontend/app/components/EntityRunStats.tsx
+++ b/frontend/app/components/EntityRunStats.tsx
@@ -263,12 +263,15 @@ export default function EntityRunStats({ entityType, entityId, entityName, varia
   const {
     player: selPlayer,
     skill: selSkill,
+    mode: selMode,
     version: selVersion,
   } = splitBracket(selectedBracket);
   const pickPlayer = (p: string) =>
-    setSelectedBracket(combineBracket(p, selSkill, selVersion));
+    setSelectedBracket(combineBracket(p, selSkill, selMode, selVersion));
   const pickSkill = (sk: string) =>
-    setSelectedBracket(combineBracket(selPlayer, sk === "all" ? "" : sk, selVersion));
+    setSelectedBracket(
+      combineBracket(selPlayer, sk === "all" ? "" : sk, selMode, selVersion),
+    );
   const sel = brackets[selectedBracket] ?? brackets["all"];
   // Everything below scopes to the selected bracket, with a fall back to the
   // global figures for a pre-update API response that lacks the per-bracket data.

--- a/frontend/app/components/EntityVersionSelect.tsx
+++ b/frontend/app/components/EntityVersionSelect.tsx
@@ -42,8 +42,10 @@ export default function EntityVersionSelect({
 
   async function pick(v: string) {
     setSelected(v);
-    const { player, skill } = splitBracket(bracket);
-    onBracketChange(combineBracket(player, skill, statVersions.has(v) ? v : ""));
+    const { player, skill, mode } = splitBracket(bracket);
+    onBracketChange(
+      combineBracket(player, skill, mode, statVersions.has(v) ? v : ""),
+    );
     if (!onEntityData) return;
     const qs = `lang=${lang}${v ? `&version=${v}` : ""}`;
     try {

--- a/frontend/app/tier-list/cards/page.tsx
+++ b/frontend/app/tier-list/cards/page.tsx
@@ -303,7 +303,6 @@ export default async function CardsTierListPage({ searchParams }: PageProps) {
         basePath="/tier-list/cards"
         current={bracket}
         extraParams={{ color, sort: sort === "elo" ? "elo" : undefined }}
-        composite
       />
 
       <TierList route="cards" entities={entities} valueLabel={sort === "elo" ? "Elo" : "Score"} />

--- a/frontend/app/tier-list/potions/page.tsx
+++ b/frontend/app/tier-list/potions/page.tsx
@@ -117,7 +117,7 @@ export default async function PotionsTierListPage({ searchParams }: PageProps) {
       </p>
 
       {/* Content bracket: grade against all runs, A10, or win-rate skill tiers. */}
-      <BracketFilter basePath="/tier-list/potions" current={bracket} composite />
+      <BracketFilter basePath="/tier-list/potions" current={bracket} />
 
       <TierList route="potions" entities={entities} />
     </div>

--- a/frontend/app/tier-list/relics/page.tsx
+++ b/frontend/app/tier-list/relics/page.tsx
@@ -366,7 +366,6 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
         basePath="/tier-list/relics"
         current={bracket}
         extraParams={{ pool, rarity, act, ancient }}
-        composite
       />
 
       <TierList route="relics" entities={entities} />

--- a/frontend/lib/content-brackets.ts
+++ b/frontend/lib/content-brackets.ts
@@ -28,9 +28,9 @@ export const PLAYER_BRACKETS: ContentBracket[] = [
   { key: "4p", param: "4p", label: "4P" },
 ];
 
-// Game-mode brackets. Like the player axis they share the single ?bracket=
-// slot: picking a mode replaces the player/skill selection (only the version
-// composes on top). "All" is the absence of a mode key.
+// Game-mode brackets: a third composing axis (snapshot v27). Picking a mode
+// narrows the player/skill selection rather than replacing it. "All" is the
+// absence of a mode key.
 export const MODE_BRACKETS: ContentBracket[] = [
   { key: "standard", param: "standard", label: "Standard" },
   { key: "daily", param: "daily", label: "Daily" },
@@ -46,6 +46,29 @@ const _PLAYER_KEYS = new Set(PLAYER_BRACKETS.map((b) => b.key));
 const _SKILL_KEYS = new Set(
   CONTENT_BRACKETS.filter((b) => b.key !== "all").map((b) => b.key),
 );
+const _MODE_KEYS = new Set(MODE_BRACKETS.map((b) => b.key));
+
+export interface BracketAxes {
+  player: string;
+  skill: string;
+  mode: string;
+  version: string;
+}
+
+/** Classify each colon-separated segment onto its axis. Unknown segments
+ * make the whole value invalid (callers fall back to "all"). Order-tolerant
+ * on the way in; canonical on the way out. */
+function parseAxes(raw: string): BracketAxes | null {
+  const axes: BracketAxes = { player: "", skill: "", mode: "", version: "" };
+  for (const part of raw.split(":")) {
+    if (_PLAYER_KEYS.has(part)) axes.player = part;
+    else if (_SKILL_KEYS.has(part)) axes.skill = part;
+    else if (_MODE_KEYS.has(part)) axes.mode = part;
+    else if (isVersionBracket(part)) axes.version = part;
+    else if (part !== "all") return null;
+  }
+  return axes;
+}
 
 /**
  * A game-version bracket ("v0.107.1"): the snapshot keeps a per-version
@@ -60,19 +83,9 @@ export function isVersionBracket(raw: string | undefined | null): boolean {
 /** The bracket value minus any trailing version segment ("" for a bare
  * version or "all"). */
 export function stripVersion(raw: string | undefined | null): string {
-  if (!raw || raw === "all") return "";
-  const { base } = splitVersion(raw);
+  const { player, skill, mode } = splitBracket(raw);
+  const base = combineBracket(player, skill, mode);
   return base === "all" ? "" : base;
-}
-
-/** Split a trailing ":vX.Y.Z" version segment off a bracket value. */
-function splitVersion(raw: string): { base: string; version: string } {
-  const i = raw.lastIndexOf(":");
-  if (i > 0 && isVersionBracket(raw.slice(i + 1))) {
-    return { base: raw.slice(0, i), version: raw.slice(i + 1) };
-  }
-  if (isVersionBracket(raw)) return { base: "", version: raw };
-  return { base: raw, version: "" };
 }
 
 /**
@@ -82,35 +95,30 @@ function splitVersion(raw: string): { base: string; version: string } {
  */
 export function isCompositeBracket(raw: string | undefined | null): boolean {
   if (!raw || !raw.includes(":")) return false;
-  const [p, s] = raw.split(":");
-  return _PLAYER_KEYS.has(p) && _SKILL_KEYS.has(s);
+  const axes = parseAxes(raw);
+  if (!axes) return false;
+  // Two or more content axes selected (version alone doesn't count).
+  return [axes.player, axes.skill, axes.mode].filter(Boolean).length >= 2;
 }
 
 /** Split a bracket value into its player + skill + version axes. A single
  * bracket maps to whichever axis owns it; "all"/unknown gives all empty. */
-export function splitBracket(raw: string | undefined | null): {
-  player: string;
-  skill: string;
-  version: string;
-} {
+export function splitBracket(raw: string | undefined | null): BracketAxes {
   const b = normalizeBracket(raw);
-  const { base, version } = splitVersion(b === "all" ? "" : b);
-  if (isCompositeBracket(base)) {
-    const [player, skill] = base.split(":");
-    return { player, skill, version };
-  }
-  if (_PLAYER_KEYS.has(base)) return { player: base, skill: "", version };
-  if (_SKILL_KEYS.has(base)) return { player: "", skill: base, version };
-  return { player: "", skill: "", version };
+  if (b === "all") return { player: "", skill: "", mode: "", version: "" };
+  return parseAxes(b) ?? { player: "", skill: "", mode: "", version: "" };
 }
 
 /** Combine player + skill + version selections into one ?bracket= value.
  * Any subset works: the axes compose in canonical player:skill:version
  * order, and all-empty collapses to "all". */
-export function combineBracket(player: string, skill: string, version = ""): string {
-  const base = [player, skill].filter(Boolean).join(":");
-  if (base && version) return `${base}:${version}`;
-  return base || version || "all";
+export function combineBracket(
+  player: string,
+  skill: string,
+  mode = "",
+  version = "",
+): string {
+  return [player, skill, mode, version].filter(Boolean).join(":") || "all";
 }
 
 /** Normalize a raw ?bracket= value to a known bracket key, a player:skill
@@ -118,26 +126,17 @@ export function combineBracket(player: string, skill: string, version = ""): str
  * ("all" if unknown). */
 export function normalizeBracket(raw: string | undefined | null): string {
   if (!raw) return "all";
-  if (_BY_KEY.has(raw)) return raw;
-  if (isCompositeBracket(raw)) return raw;
-  if (isVersionBracket(raw)) return raw;
-  const { base, version } = splitVersion(raw);
-  if (version && base && (_BY_KEY.has(base) || isCompositeBracket(base))) return raw;
-  return "all";
+  const axes = parseAxes(raw);
+  if (!axes) return "all";
+  return combineBracket(axes.player, axes.skill, axes.mode, axes.version);
 }
 
 /** The ?bracket= API value for a bracket key (null = all runs, no param). A
  * composite passes through unchanged (its API value is the composite itself). */
 export function bracketParam(key: string | undefined | null): string | null {
+  // The normalized key IS the API value for everything except "all".
   const n = normalizeBracket(key);
-  if (n === "all") return null;
-  if (isCompositeBracket(n) || isVersionBracket(n)) return n;
-  // base+version combos ("wr50:v0.111.0", "solo:wr50:v0.111.0") are already
-  // the API value; the map lookup below only resolves plain single-axis keys
-  // (and used to swallow these into null = all runs).
-  const { base, version } = splitVersion(n);
-  if (version) return base === "all" ? version : n;
-  return _BY_KEY.get(n)?.param ?? null;
+  return n === "all" ? null : n;
 }
 
 /**


### PR DESCRIPTION
I made game mode a third composing bracket axis so picking Standard on top of Solo and A10 narrows the slice instead of resetting it, materializing every player x skill x mode combination in both the entity cache and the community blob under snapshot v27.