### PR TITLE
change to use emerald-200, so dark/light mode takes effect

### DIFF
--- a/frontend/app/components/AlertTicker.tsx
+++ b/frontend/app/components/AlertTicker.tsx
@@ -162,14 +162,14 @@ export default function AlertTicker() {
               href="https://www.patreon.com/cw/SpireCodex"
               target="_blank"
               rel="noopener noreferrer"
-              className="font-medium not-italic text-emerald-100 underline hover:text-white transition-colors"
+              className="font-medium not-italic text-emerald-200 underline hover:text-white transition-colors"
             >
               supporting us on Patreon
             </a>
             . Servants! Fetch tea for{" "}
             <Link
               href="/thank-you"
-              className="font-medium not-italic text-emerald-100 underline hover:text-white transition-colors"
+              className="font-medium not-italic text-emerald-200 underline hover:text-white transition-colors"
             >
               those who&apos;ve supported us
             </Link>


### PR DESCRIPTION
On light mode, the `text-emerald-100`, was not flipping to the correct light mode color, resulting in unreadable text.

<img width="1320" height="147" alt="Screenshot 2026-08-25 at 11 16 39 AM" src="https://github.com/user-attachments/assets/e53a7ddc-189a-4c78-bb88-fa0adb9f48ca" />

`.text-emerald-100` wasn't used anywhere else in the project, or mentioned in `globals.css`, so i figured it was a typo. i updated the alert ticker to use the more frequently used 200 variant.

if we want to keep `.text-emerald-100` as the color for this banner, we'll just need to include it to the CSS rule at line 125 in `globals.css`:

```
:root[data-theme="light"] :is(.text-green-100, .text-green-200, .text-green-300,
  .text-green-400, .text-emerald-200, .text-emerald-300, .text-emerald-400) {
  color: #14532d; /* green-900 */
}
```

i'd be happy to implement that change as well if that's what yall prefer.