### PR TITLE
Harden the run export stream

### DIFF
--- a/backend/app/routers/exports.py
+++ b/backend/app/routers/exports.py
@@ -1,5 +1,6 @@
 import base64
 import gzip
+import logging
 import io
 import json
 import os
@@ -15,6 +16,8 @@ from ..dependencies import VALID_LANGUAGES, shared_limiter
 from ..services import rate_limit_config
 from ..metrics import data_exports, run_export_pages, run_exports
 from ..services.data_service import DATA_DIR
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/exports", tags=["Exports"])
 
@@ -200,31 +203,61 @@ def _export_cost(request: Request) -> int:
     return 1 if request.query_params.get("limit") else 60
 
 
+def _read_file_blob(run_hash: str) -> dict | None:
+    run_file = _RUNS_DIR / f"{run_hash}.json"
+    try:
+        return json.loads(run_file.read_text(encoding="utf-8").strip())
+    except Exception:
+        # Missing file, bad bytes, bad JSON — the caller skips this run.
+        return None
+
+
 def _stream_runs_jsonl(hashes):
+    """Gzipped JSONL of the requested runs: Mongo blobs first (the canonical
+    store, batched like _BlobProvider), per-run file fallback for anything
+    not there. Every per-run failure SKIPS instead of raising: an exception
+    mid-generator used to kill the stream after the 200 was already sent,
+    handing clients a silently truncated file (found 2026-08-25 when a
+    poison run aborted a 50k-page export 236 lines in)."""
     buf = io.BytesIO()
     gz = gzip.GzipFile(fileobj=buf, mode="wb")
+    written = skipped = 0
 
-    for run_hash in hashes:
-        run_file = _RUNS_DIR / f"{run_hash}.json"
-        if not run_file.exists():
-            continue
+    for i in range(0, len(hashes), 300):
+        batch = hashes[i : i + 300]
+        fetched: dict = {}
         try:
-            raw = run_file.read_text(encoding="utf-8").strip()
-            obj = json.loads(raw)
-        except (json.JSONDecodeError, OSError):
-            continue
-        # The blob has no identifier of its own (the hash is derived), so
-        # stamp it in — consumers link back to /runs/<run_hash> with it.
-        obj["run_hash"] = run_hash
-        gz.write(json.dumps(obj, separators=(",", ":")).encode("utf-8"))
-        gz.write(b"\n")
-        if buf.tell() > 65536:
-            gz.flush()
-            yield buf.getvalue()
-            buf.seek(0)
-            buf.truncate()
+            from ..services.runs_db_mongo import get_run_blobs
+
+            fetched = get_run_blobs(batch)
+        except Exception:
+            # SQLite dev mode or a Mongo hiccup: files still serve below.
+            fetched = {}
+        for run_hash in batch:
+            try:
+                obj = fetched.get(run_hash) or _read_file_blob(run_hash)
+                if obj is None:
+                    skipped += 1
+                    continue
+                # The blob has no identifier of its own (the hash is
+                # derived), so stamp it in — consumers link back to
+                # /runs/<run_hash> with it.
+                obj["run_hash"] = run_hash
+                gz.write(json.dumps(obj, separators=(",", ":")).encode("utf-8"))
+                gz.write(b"\n")
+                written += 1
+            except Exception:
+                skipped += 1
+                continue
+            if buf.tell() > 65536:
+                gz.flush()
+                yield buf.getvalue()
+                buf.seek(0)
+                buf.truncate()
 
     gz.close()
+    if skipped:
+        logger.warning("run export: wrote %d, skipped %d", written, skipped)
     tail = buf.getvalue()
     if tail:
         yield tail

--- a/backend/tests/test_export_helpers.py
+++ b/backend/tests/test_export_helpers.py
@@ -178,3 +178,27 @@ def test_export_cost_paged_is_cheap():
 
 def test_export_cost_full_dump_is_expensive():
     assert _export_cost(_FakeRequest({})) == 60
+
+
+def test_stream_survives_poison_runs(tmp_path, monkeypatch):
+    # A run that raises mid-stream must be SKIPPED, not kill the generator —
+    # a dead generator hands clients a 200 with a truncated gzip.
+    import gzip as _gzip
+    import io as _io
+
+    from app.routers import exports
+
+    good = tmp_path / "good.json"
+    good.write_text('{"win": true}', encoding="utf-8")
+    poison = tmp_path / "poison.json"
+    poison.write_bytes(b"\xff\xfe not utf8 at all")
+    monkeypatch.setattr(exports, "_RUNS_DIR", tmp_path)
+
+    chunks = b"".join(exports._stream_runs_jsonl(["good", "poison", "good"]))
+    lines = (
+        _gzip.GzipFile(fileobj=_io.BytesIO(chunks)).read().decode().strip().split("\n")
+    )
+    assert len(lines) == 2  # both good copies, poison skipped
+    assert all(
+        '"run_hash": "good"'.replace(" ", "") in l.replace(" ", "") for l in lines
+    )


### PR DESCRIPTION
I made the run export read Mongo blobs first with per-run file fallback and skip any run that fails instead of letting one poison run kill the stream mid-gzip, which was silently truncating large exports after the 200 was already sent.