### PR TITLE
Add on-box DuckDB lab: extract runs from Mongo, build a Parquet lake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ backend/static/images/cards/composite/
 # at runtime by bin/op-ansible. Origin IPs are CF-shielded; keep them
 # out of git.
 infrastructure/ansible/inventory.yml
+
+# on-box analytics lab output
+lake/

--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -1,0 +1,34 @@
+name: spire-codex-lab
+
+# The analytics lab: extraction + DuckDB, fully separate from the prod stack.
+# Nothing here runs continuously — both services are one-shot `compose run`
+# targets, memory-capped so they can never starve the site.
+#
+#   docker compose -f docker-compose.lab.yml run --rm extract
+#   docker compose -f docker-compose.lab.yml run --rm duckdb -c ".read /lake/build.sql"
+#   docker compose -f docker-compose.lab.yml run --rm duckdb -c "SELECT ... FROM read_parquet('/lake/runs.parquet')"
+
+services:
+  extract:
+    image: ptrlrd/spire-codex-backend:latest
+    entrypoint: ["python", "/lab/extract.py"]
+    env_file: .env
+    mem_limit: 1500m
+    volumes:
+      - ./lab:/lab:ro
+      - ./data:/data:ro
+      - ./lake:/lake
+    networks:
+      - nginx_web-network
+
+  duckdb:
+    image: duckdb/duckdb:1.5.5
+    mem_limit: 2g
+    working_dir: /lake
+    volumes:
+      - ./lab:/lake/lab:ro
+      - ./lake:/lake
+
+networks:
+  nginx_web-network:
+    external: true

--- a/lab/README.md
+++ b/lab/README.md
@@ -1,0 +1,57 @@
+# On-box analytics lab (DuckDB 1.5.5)
+
+One-shot tooling to build a Parquet lake from prod Mongo, on the box itself.
+Nothing here touches the running services: `extract` is a throwaway container
+using the existing backend image, `duckdb` is the official `duckdb/duckdb`
+image pinned to 1.5.5. Output lands in `./lake/` (gitignored, local to the box).
+
+## One-time setup (on the box, from the repo root)
+
+```
+git fetch origin lab/on-box-lake
+git checkout origin/lab/on-box-lake -- lab docker-compose.lab.yml
+mkdir -p lake
+```
+
+This only copies the lab files into the working tree; the checked-out branch
+stays `main` and the deploy script is unaffected.
+
+## 1. Extract (wait for any full walk to finish first — it reads the same blobs)
+
+```
+docker compose -f docker-compose.lab.yml run --rm extract
+```
+
+Streams every run (Mongo blobs first, file fallback) into
+`lake/staging/*.jsonl.gz` pages of 50k, each line tagged with `_meta`
+(username, hidden, deleted, submitted_at, played_at, player_count) — fields
+the HTTP export doesn't carry. Prints progress per page; capped at 1.5GB RAM.
+
+## 2. Build the lake
+
+```
+docker compose -f docker-compose.lab.yml run --rm duckdb -c ".read /lake/lab/build.sql"
+```
+
+Produces `lake/runs.parquet`, `excluded.parquet`, `floor_events.parquet`,
+`deck.parquet` and prints row counts. Capped at 2GB RAM (1.5GB inside DuckDB).
+
+## 3. Query
+
+```
+docker compose -f docker-compose.lab.yml run --rm duckdb -c "
+SELECT killed_by_encounter, count(*) AS deaths
+FROM read_parquet('/lake/runs.parquet') r
+ANTI JOIN read_parquet('/lake/excluded.parquet') x USING (run_hash)
+WHERE NOT win AND killed_by_encounter IS NOT NULL
+GROUP BY 1 ORDER BY 2 DESC LIMIT 15"
+```
+
+Interactive shell: `docker compose -f docker-compose.lab.yml run --rm duckdb`
+(`.quit` to exit). Always anti-join `excluded.parquet` so hidden/deleted runs
+stay out, same as the site.
+
+## Refresh
+
+Re-run steps 1-2. The extract is a full re-pull (staging pages are
+overwritten); incremental append is a later problem, this is a lab.

--- a/lab/build.sql
+++ b/lab/build.sql
@@ -1,0 +1,59 @@
+-- Build the analytical lake from /lake/staging/*.jsonl.gz.
+--   docker compose -f docker-compose.lab.yml run --rm duckdb -c ".read /lake/lab/build.sql"
+SET memory_limit='1500MB';
+
+CREATE OR REPLACE TABLE raw AS SELECT * FROM read_ndjson_auto(
+  '/lake/staging/*.jsonl.gz',
+  maximum_object_size=104857600, sample_size=5000,
+  ignore_errors=true, union_by_name=true);
+
+CREATE OR REPLACE TABLE runs AS SELECT run_hash,
+  upper(split_part(players[1].character,'.',-1)) AS character,
+  win, coalesce(was_abandoned, false) AS was_abandoned,
+  ascension, lower(coalesce(game_mode,'standard')) AS game_mode,
+  _meta.player_count AS player_count, build_id, seed, start_time, run_time,
+  upper(split_part(killed_by_encounter,'.',-1)) AS killed_by_encounter,
+  upper(split_part(killed_by_event,'.',-1)) AS killed_by_event,
+  _meta.username AS username,
+  _meta.submitted_at AS submitted_at, _meta.played_at AS played_at
+FROM raw;
+
+-- Sidecar: exclusions. Queries anti-join this so hidden/deleted runs never
+-- surface, mirroring the site's own filters.
+CREATE OR REPLACE TABLE excluded AS
+SELECT run_hash FROM raw WHERE _meta.hidden OR _meta.deleted;
+
+CREATE OR REPLACE TABLE floor_events AS
+SELECT r.run_hash, act.i AS act, loc.i AS floor_idx,
+  lower(loc.u.map_point_type) AS map_point_type,
+  lower(room.u.room_type) AS room_type,
+  upper(split_part(room.u.model_id,'.',-1)) AS encounter,
+  room.u.turns_taken AS turns,
+  (SELECT sum(ps.u.damage_taken) FROM (SELECT unnest(loc.u.player_stats) AS u) ps) AS damage_taken,
+  loc.u.player_stats[1].current_hp AS p1_hp,
+  loc.u.player_stats[1].max_hp AS p1_max_hp,
+  loc.u.player_stats[1].current_gold AS p1_gold
+FROM raw r,
+  LATERAL (SELECT unnest(map_point_history) AS u, generate_subscripts(map_point_history,1) AS i) act,
+  LATERAL (SELECT unnest(act.u) AS u, generate_subscripts(act.u,1) AS i) loc,
+  LATERAL (SELECT unnest(loc.u.rooms) AS u) room;
+
+CREATE OR REPLACE TABLE deck AS
+SELECT r.run_hash, p.i AS player_idx,
+  upper(split_part(p.u.character,'.',-1)) AS character,
+  upper(split_part(c.u.id,'.',-1)) AS card,
+  c.u.floor_added_to_deck AS floor_added,
+  c.u.current_upgrade_level AS upgrade_level
+FROM raw r,
+  LATERAL (SELECT unnest(players) AS u, generate_subscripts(players,1) AS i) p,
+  LATERAL (SELECT unnest(p.u.deck) AS u) c;
+
+COPY runs TO '/lake/runs.parquet' (FORMAT parquet, COMPRESSION zstd);
+COPY excluded TO '/lake/excluded.parquet' (FORMAT parquet, COMPRESSION zstd);
+COPY floor_events TO '/lake/floor_events.parquet' (FORMAT parquet, COMPRESSION zstd);
+COPY deck TO '/lake/deck.parquet' (FORMAT parquet, COMPRESSION zstd);
+
+SELECT 'runs' AS t, count(*) AS n FROM runs
+UNION ALL SELECT 'excluded', count(*) FROM excluded
+UNION ALL SELECT 'floor_events', count(*) FROM floor_events
+UNION ALL SELECT 'deck', count(*) FROM deck;

--- a/lab/extract.py
+++ b/lab/extract.py
@@ -1,0 +1,120 @@
+"""On-box lake extraction: every run -> gzipped JSONL pages in /lake/staging.
+
+Runs inside the backend image (has pymongo + the app's Mongo config), so it
+reads blobs Mongo-first with per-run file fallback -- the same source of
+truth the site serves from, including the ~7% of runs the HTTP export's
+file-only path silently skipped. Each line is the raw run blob plus a _meta
+envelope carrying the server-side fields the blob itself lacks (username,
+hidden, timestamps), which later become the lake's sidecar tables.
+
+    docker compose -f docker-compose.lab.yml run --rm extract
+"""
+
+import gzip
+import json
+import pathlib
+import sys
+import time
+
+sys.path.insert(0, "/app")
+
+from app.services.runs_db_mongo import _get_collection, get_run_blobs 
+
+STAGING = pathlib.Path("/lake/staging")
+RUNS_DIR = pathlib.Path("/data/runs")
+PAGE_SIZE = 50_000
+BATCH = 300
+
+
+def _iso(v):
+    return v.isoformat() if hasattr(v, "isoformat") else v
+
+
+def main() -> None:
+    STAGING.mkdir(parents=True, exist_ok=True)
+    coll = _get_collection()
+    cursor = coll.find(
+        {},
+        {
+            "_id": 1,
+            "username": 1,
+            "hidden": 1,
+            "deleted_at": 1,
+            "submitted_at": 1,
+            "played_at": 1,
+            "player_count": 1,
+        },
+        no_cursor_timeout=True,
+    ).sort([("submitted_at", 1), ("_id", 1)])
+
+    t0 = time.time()
+    page = written = skipped = 0
+    out = gzip.open(STAGING / f"{page:05d}.jsonl.gz", "wt", encoding="utf-8")
+    batch: list[dict] = []
+
+    def flush(rows: list[dict]) -> None:
+        nonlocal written, skipped, page, out
+        blobs = {}
+        try:
+            blobs = get_run_blobs([r["_id"] for r in rows])
+        except Exception:
+            blobs = {}
+        for r in rows:
+            h = r["_id"]
+            obj = blobs.get(h)
+            if obj is None:
+                try:
+                    obj = json.loads(
+                        (RUNS_DIR / f"{h}.json").read_text(encoding="utf-8")
+                    )
+                except Exception:
+                    skipped += 1
+                    continue
+            try:
+                obj["run_hash"] = h
+                obj["_meta"] = {
+                    "username": r.get("username"),
+                    "hidden": bool(r.get("hidden")),
+                    "deleted": r.get("deleted_at") is not None,
+                    "submitted_at": _iso(r.get("submitted_at")),
+                    "played_at": _iso(r.get("played_at")),
+                    "player_count": r.get("player_count") or 1,
+                }
+                out.write(json.dumps(obj, separators=(",", ":")) + "\n")
+                written += 1
+            except Exception:
+                skipped += 1
+                continue
+            if written % PAGE_SIZE == 0:
+                out.close()
+                page += 1
+                out = gzip.open(
+                    STAGING / f"{page:05d}.jsonl.gz", "wt", encoding="utf-8"
+                )
+                rate = written / max(1.0, time.time() - t0)
+                print(
+                    f"page {page}: {written:,} written, {skipped:,} skipped, "
+                    f"{rate:.0f} runs/s",
+                    flush=True,
+                )
+
+    try:
+        for row in cursor:
+            batch.append(row)
+            if len(batch) >= BATCH:
+                flush(batch)
+                batch = []
+        if batch:
+            flush(batch)
+    finally:
+        cursor.close()
+        out.close()
+    print(
+        f"DONE: {written:,} written, {skipped:,} skipped in "
+        f"{(time.time() - t0) / 60:.1f} min",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a standalone compose file plus extract/build scripts that pull every run out of Mongo (with file fallback and hidden/deleted sidecar metadata) and build a Parquet lake with DuckDB 1.5.5 on the box, without touching the running services.