### PR TITLE
Fix the lab duckdb service: entrypoint and disk-backed build

### DIFF
--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -24,7 +24,9 @@ services:
   duckdb:
     image: duckdb/duckdb:1.5.5
     entrypoint: ["duckdb"]
-    mem_limit: 2g
+    # 3g: DuckDB's internal limit doesn't cover JSON-reader/decompress
+    # buffers; 2g got memcg-killed mid-build on the full corpus.
+    mem_limit: 3g
     working_dir: /lake
     volumes:
       - ./lab:/lake/lab:ro

--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -5,7 +5,7 @@ name: spire-codex-lab
 # targets, memory-capped so they can never starve the site.
 #
 #   docker compose -f docker-compose.lab.yml run --rm extract
-#   docker compose -f docker-compose.lab.yml run --rm duckdb -c ".read /lake/build.sql"
+#   docker compose -f docker-compose.lab.yml run --rm duckdb /lake/build.duckdb -c ".read /lake/lab/build.sql"
 #   docker compose -f docker-compose.lab.yml run --rm duckdb -c "SELECT ... FROM read_parquet('/lake/runs.parquet')"
 
 services:
@@ -23,6 +23,7 @@ services:
 
   duckdb:
     image: duckdb/duckdb:1.5.5
+    entrypoint: ["duckdb"]
     mem_limit: 2g
     working_dir: /lake
     volumes:

--- a/lab/README.md
+++ b/lab/README.md
@@ -30,11 +30,16 @@ the HTTP export doesn't carry. Prints progress per page; capped at 1.5GB RAM.
 ## 2. Build the lake
 
 ```
-docker compose -f docker-compose.lab.yml run --rm duckdb -c ".read /lake/lab/build.sql"
+docker compose -f docker-compose.lab.yml run --rm duckdb /lake/build.duckdb -c ".read /lake/lab/build.sql"
 ```
 
 Produces `lake/runs.parquet`, `excluded.parquet`, `floor_events.parquet`,
-`deck.parquet` and prints row counts. Capped at 2GB RAM (1.5GB inside DuckDB).
+`deck.parquet` and prints row counts. Capped at 2GB RAM (1.5GB inside
+DuckDB). The `/lake/build.duckdb` argument matters: the corpus is far
+larger than the memory cap, so the build needs a disk-backed database to
+spill into. `lake/build.duckdb` and `lake/tmp/` are scratch — delete them
+(and `lake/staging/` if you want the ~4GB back) once the parquet files
+exist.
 
 ## 3. Query
 
@@ -48,7 +53,8 @@ GROUP BY 1 ORDER BY 2 DESC LIMIT 15"
 ```
 
 Interactive shell: `docker compose -f docker-compose.lab.yml run --rm duckdb`
-(`.quit` to exit). Always anti-join `excluded.parquet` so hidden/deleted runs
+(`.quit` to exit). Queries read the parquet files directly — no database
+file argument needed. Always anti-join `excluded.parquet` so hidden/deleted runs
 stay out, same as the site.
 
 ## Refresh

--- a/lab/build.sql
+++ b/lab/build.sql
@@ -3,6 +3,7 @@
 -- corpus is far larger than the memory cap):
 --   docker compose -f docker-compose.lab.yml run --rm duckdb /lake/build.duckdb -c ".read /lake/lab/build.sql"
 SET memory_limit='1500MB';
+SET threads=2;
 SET temp_directory='/lake/tmp';
 SET preserve_insertion_order=false;
 

--- a/lab/build.sql
+++ b/lab/build.sql
@@ -1,34 +1,34 @@
 -- Build the analytical lake from /lake/staging/*.jsonl.gz.
--- Must run against a disk-backed database file (spills to disk; the full
--- corpus is far larger than the memory cap):
+-- Fully streaming: no intermediate table, each parquet file is written
+-- straight off a pass over the staging files, so memory stays bounded
+-- regardless of corpus size (materializing the corpus first blew a 3g
+-- container cap). Three JSON passes; excluded derives from runs.parquet.
 --   docker compose -f docker-compose.lab.yml run --rm duckdb /lake/build.duckdb -c ".read /lake/lab/build.sql"
-SET memory_limit='1500MB';
+SET memory_limit='800MB';
 SET threads=2;
 SET temp_directory='/lake/tmp';
 SET preserve_insertion_order=false;
 
-CREATE OR REPLACE TABLE raw AS SELECT * FROM read_ndjson_auto(
-  '/lake/staging/*.jsonl.gz',
-  maximum_object_size=104857600, sample_size=30000,
-  ignore_errors=true, union_by_name=true);
-
-CREATE OR REPLACE TABLE runs AS SELECT run_hash,
+COPY (
+SELECT run_hash,
   upper(split_part(players[1].character,'.',-1)) AS character,
   win, coalesce(was_abandoned, false) AS was_abandoned,
   ascension, lower(coalesce(game_mode,'standard')) AS game_mode,
   _meta.player_count AS player_count, build_id, seed, start_time, run_time,
   upper(split_part(killed_by_encounter,'.',-1)) AS killed_by_encounter,
   upper(split_part(killed_by_event,'.',-1)) AS killed_by_event,
-  _meta.username AS username,
+  _meta.username AS username, _meta.hidden AS hidden, _meta.deleted AS deleted,
   _meta.submitted_at AS submitted_at, _meta.played_at AS played_at
-FROM raw;
+FROM read_ndjson_auto('/lake/staging/*.jsonl.gz',
+  maximum_object_size=104857600, sample_size=30000,
+  ignore_errors=true, union_by_name=true)
+) TO '/lake/runs.parquet' (FORMAT parquet, COMPRESSION zstd);
 
--- Sidecar: exclusions. Queries anti-join this so hidden/deleted runs never
--- surface, mirroring the site's own filters.
-CREATE OR REPLACE TABLE excluded AS
-SELECT run_hash FROM raw WHERE _meta.hidden OR _meta.deleted;
+COPY (
+SELECT run_hash FROM read_parquet('/lake/runs.parquet') WHERE hidden OR deleted
+) TO '/lake/excluded.parquet' (FORMAT parquet, COMPRESSION zstd);
 
-CREATE OR REPLACE TABLE floor_events AS
+COPY (
 SELECT r.run_hash, act.i AS act, loc.i AS floor_idx,
   lower(loc.u.map_point_type) AS map_point_type,
   lower(room.u.room_type) AS room_type,
@@ -38,27 +38,28 @@ SELECT r.run_hash, act.i AS act, loc.i AS floor_idx,
   loc.u.player_stats[1].current_hp AS p1_hp,
   loc.u.player_stats[1].max_hp AS p1_max_hp,
   loc.u.player_stats[1].current_gold AS p1_gold
-FROM raw r,
+FROM read_ndjson_auto('/lake/staging/*.jsonl.gz',
+  maximum_object_size=104857600, sample_size=30000,
+  ignore_errors=true, union_by_name=true) r,
   LATERAL (SELECT unnest(map_point_history) AS u, generate_subscripts(map_point_history,1) AS i) act,
   LATERAL (SELECT unnest(act.u) AS u, generate_subscripts(act.u,1) AS i) loc,
-  LATERAL (SELECT unnest(loc.u.rooms) AS u) room;
+  LATERAL (SELECT unnest(loc.u.rooms) AS u) room
+) TO '/lake/floor_events.parquet' (FORMAT parquet, COMPRESSION zstd);
 
-CREATE OR REPLACE TABLE deck AS
+COPY (
 SELECT r.run_hash, p.i AS player_idx,
   upper(split_part(p.u.character,'.',-1)) AS character,
   upper(split_part(c.u.id,'.',-1)) AS card,
   c.u.floor_added_to_deck AS floor_added,
   c.u.current_upgrade_level AS upgrade_level
-FROM raw r,
+FROM read_ndjson_auto('/lake/staging/*.jsonl.gz',
+  maximum_object_size=104857600, sample_size=30000,
+  ignore_errors=true, union_by_name=true) r,
   LATERAL (SELECT unnest(players) AS u, generate_subscripts(players,1) AS i) p,
-  LATERAL (SELECT unnest(p.u.deck) AS u) c;
+  LATERAL (SELECT unnest(p.u.deck) AS u) c
+) TO '/lake/deck.parquet' (FORMAT parquet, COMPRESSION zstd);
 
-COPY runs TO '/lake/runs.parquet' (FORMAT parquet, COMPRESSION zstd);
-COPY excluded TO '/lake/excluded.parquet' (FORMAT parquet, COMPRESSION zstd);
-COPY floor_events TO '/lake/floor_events.parquet' (FORMAT parquet, COMPRESSION zstd);
-COPY deck TO '/lake/deck.parquet' (FORMAT parquet, COMPRESSION zstd);
-
-SELECT 'runs' AS t, count(*) AS n FROM runs
-UNION ALL SELECT 'excluded', count(*) FROM excluded
-UNION ALL SELECT 'floor_events', count(*) FROM floor_events
-UNION ALL SELECT 'deck', count(*) FROM deck;
+SELECT 'runs' AS t, count(*) AS n FROM read_parquet('/lake/runs.parquet')
+UNION ALL SELECT 'excluded', count(*) FROM read_parquet('/lake/excluded.parquet')
+UNION ALL SELECT 'floor_events', count(*) FROM read_parquet('/lake/floor_events.parquet')
+UNION ALL SELECT 'deck', count(*) FROM read_parquet('/lake/deck.parquet');

--- a/lab/build.sql
+++ b/lab/build.sql
@@ -1,10 +1,11 @@
 -- Build the analytical lake from /lake/staging/*.jsonl.gz.
--- Fully streaming: no intermediate table, each parquet file is written
--- straight off a pass over the staging files, so memory stays bounded
--- regardless of corpus size (materializing the corpus first blew a 3g
--- container cap). Three JSON passes; excluded derives from runs.parquet.
+-- Fully streaming with explicit per-pass schemas: no sniffing pass, and the
+-- reader only parses the declared fields, so memory stays low and bounded
+-- (auto-inference held ~30k sample lines and blew both a 2g and 3g cap).
+-- Missing fields in old runs become NULL; a line that can't convert is
+-- dropped (ignore_errors) -- the final counts surface any aggregate loss.
 --   docker compose -f docker-compose.lab.yml run --rm duckdb /lake/build.duckdb -c ".read /lake/lab/build.sql"
-SET memory_limit='800MB';
+SET memory_limit='1800MB';
 SET threads=2;
 SET temp_directory='/lake/tmp';
 SET preserve_insertion_order=false;
@@ -19,9 +20,15 @@ SELECT run_hash,
   upper(split_part(killed_by_event,'.',-1)) AS killed_by_event,
   _meta.username AS username, _meta.hidden AS hidden, _meta.deleted AS deleted,
   _meta.submitted_at AS submitted_at, _meta.played_at AS played_at
-FROM read_ndjson_auto('/lake/staging/*.jsonl.gz',
-  maximum_object_size=104857600, sample_size=30000,
-  ignore_errors=true, union_by_name=true)
+FROM read_ndjson('/lake/staging/*.jsonl.gz',
+  maximum_object_size=33554432, ignore_errors=true,
+  columns={run_hash: 'VARCHAR',
+    players: 'STRUCT("character" VARCHAR)[]',
+    win: 'BOOLEAN', was_abandoned: 'BOOLEAN', ascension: 'BIGINT',
+    game_mode: 'VARCHAR', build_id: 'VARCHAR', seed: 'VARCHAR',
+    start_time: 'BIGINT', run_time: 'BIGINT',
+    killed_by_encounter: 'VARCHAR', killed_by_event: 'VARCHAR',
+    _meta: 'STRUCT(username VARCHAR, hidden BOOLEAN, deleted BOOLEAN, submitted_at TIMESTAMP, played_at TIMESTAMP, player_count BIGINT)'})
 ) TO '/lake/runs.parquet' (FORMAT parquet, COMPRESSION zstd);
 
 COPY (
@@ -38,9 +45,10 @@ SELECT r.run_hash, act.i AS act, loc.i AS floor_idx,
   loc.u.player_stats[1].current_hp AS p1_hp,
   loc.u.player_stats[1].max_hp AS p1_max_hp,
   loc.u.player_stats[1].current_gold AS p1_gold
-FROM read_ndjson_auto('/lake/staging/*.jsonl.gz',
-  maximum_object_size=104857600, sample_size=30000,
-  ignore_errors=true, union_by_name=true) r,
+FROM read_ndjson('/lake/staging/*.jsonl.gz',
+  maximum_object_size=33554432, ignore_errors=true,
+  columns={run_hash: 'VARCHAR',
+    map_point_history: 'STRUCT(map_point_type VARCHAR, player_stats STRUCT(current_gold BIGINT, current_hp BIGINT, damage_taken BIGINT, max_hp BIGINT)[], rooms STRUCT(model_id VARCHAR, room_type VARCHAR, turns_taken BIGINT)[])[][]'}) r,
   LATERAL (SELECT unnest(map_point_history) AS u, generate_subscripts(map_point_history,1) AS i) act,
   LATERAL (SELECT unnest(act.u) AS u, generate_subscripts(act.u,1) AS i) loc,
   LATERAL (SELECT unnest(loc.u.rooms) AS u) room
@@ -52,9 +60,10 @@ SELECT r.run_hash, p.i AS player_idx,
   upper(split_part(c.u.id,'.',-1)) AS card,
   c.u.floor_added_to_deck AS floor_added,
   c.u.current_upgrade_level AS upgrade_level
-FROM read_ndjson_auto('/lake/staging/*.jsonl.gz',
-  maximum_object_size=104857600, sample_size=30000,
-  ignore_errors=true, union_by_name=true) r,
+FROM read_ndjson('/lake/staging/*.jsonl.gz',
+  maximum_object_size=33554432, ignore_errors=true,
+  columns={run_hash: 'VARCHAR',
+    players: 'STRUCT("character" VARCHAR, deck STRUCT(floor_added_to_deck BIGINT, id VARCHAR, current_upgrade_level BIGINT)[])[]'}) r,
   LATERAL (SELECT unnest(players) AS u, generate_subscripts(players,1) AS i) p,
   LATERAL (SELECT unnest(p.u.deck) AS u) c
 ) TO '/lake/deck.parquet' (FORMAT parquet, COMPRESSION zstd);

--- a/lab/build.sql
+++ b/lab/build.sql
@@ -1,10 +1,14 @@
 -- Build the analytical lake from /lake/staging/*.jsonl.gz.
---   docker compose -f docker-compose.lab.yml run --rm duckdb -c ".read /lake/lab/build.sql"
+-- Must run against a disk-backed database file (spills to disk; the full
+-- corpus is far larger than the memory cap):
+--   docker compose -f docker-compose.lab.yml run --rm duckdb /lake/build.duckdb -c ".read /lake/lab/build.sql"
 SET memory_limit='1500MB';
+SET temp_directory='/lake/tmp';
+SET preserve_insertion_order=false;
 
 CREATE OR REPLACE TABLE raw AS SELECT * FROM read_ndjson_auto(
   '/lake/staging/*.jsonl.gz',
-  maximum_object_size=104857600, sample_size=5000,
+  maximum_object_size=104857600, sample_size=30000,
   ignore_errors=true, union_by_name=true);
 
 CREATE OR REPLACE TABLE runs AS SELECT run_hash,


### PR DESCRIPTION
The official duckdb image has no entrypoint (so compose run treated -c as the binary), and the full corpus is far larger than the memory cap, so the build now runs against a disk-backed database file that can spill to /lake/tmp.