### PR TITLE
Add the lake shadow-diff: incremental extract and deaths comparison

### DIFF
--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -21,6 +21,17 @@ services:
     networks:
       - nginx_web-network
 
+  shadow:
+    image: ptrlrd/spire-codex-backend:latest
+    entrypoint: ["python", "/lab/shadow_diff.py"]
+    env_file: .env
+    mem_limit: 512m
+    volumes:
+      - ./lab:/lab:ro
+      - ./lake:/lake:ro
+    networks:
+      - nginx_web-network
+
   duckdb:
     image: duckdb/duckdb:1.5.5
     entrypoint: ["duckdb"]

--- a/lab/README.md
+++ b/lab/README.md
@@ -27,6 +27,16 @@ Streams every run (Mongo blobs first, file fallback) into
 (username, hidden, deleted, submitted_at, played_at, player_count) — fields
 the HTTP export doesn't carry. Prints progress per page; capped at 1.5GB RAM.
 
+Incremental: `lake/staging/state.json` records the cursor, so re-running
+only appends runs submitted since the last pull (minutes, not hours). Every
+run also refreshes `lake/excluded_current.jsonl.gz`, the full current
+hidden/deleted id set, since those flags mutate after a run's page is
+written. If your staging predates state.json, bootstrap the cursor once:
+
+```
+docker compose -f docker-compose.lab.yml run --rm extract --bootstrap
+```
+
 ## 2. Build the lake
 
 ```
@@ -62,3 +72,23 @@ the site.
 
 Re-run steps 1-2. The extract is a full re-pull (staging pages are
 overwritten); incremental append is a later problem, this is a lab.
+
+## Shadow-diff: lake vs the live site
+
+The migration gate: prove the lake reproduces the live community-stats
+deaths numbers before anything serves from it. Run an incremental extract
+first so the lake is minutes behind the live snapshot, then:
+
+```
+docker compose -f docker-compose.lab.yml run --rm extract
+docker compose -f docker-compose.lab.yml run --rm duckdb /lake/build.duckdb -c ".read /lake/lab/build.sql"
+docker compose -f docker-compose.lab.yml run --rm duckdb /lake/build.duckdb -c ".read /lake/lab/shadow_deaths.sql"
+docker compose -f docker-compose.lab.yml run --rm shadow
+```
+
+`shadow_deaths.sql` replicates the walk's filters (hidden/deleted out via
+the sidecar, A0-A10 only, official characters only, losses only, NONE
+sentinels dropped); `shadow` fetches the live payload (backend-direct, so
+no edge cache) and prints a per-id drift table for both top-15 lists. The
+verdict passes under 1% worst drift — the residual is fold lag between the
+extract and the live snapshot's incremental updates.

--- a/lab/build.sql
+++ b/lab/build.sql
@@ -31,8 +31,11 @@ FROM read_ndjson('/lake/staging/*.jsonl.gz',
     _meta: 'STRUCT(username VARCHAR, hidden BOOLEAN, deleted BOOLEAN, submitted_at TIMESTAMP, played_at TIMESTAMP, player_count BIGINT)'})
 ) TO '/lake/runs.parquet' (FORMAT parquet, COMPRESSION zstd);
 
+-- Sidecar from the extractor's fresh scan, NOT the per-page _meta: hidden
+-- and deleted flags mutate after a run's page is written.
 COPY (
-SELECT run_hash FROM read_parquet('/lake/runs.parquet') WHERE hidden OR deleted
+SELECT run_hash FROM read_ndjson('/lake/excluded_current.jsonl.gz',
+  columns={run_hash: 'VARCHAR'})
 ) TO '/lake/excluded.parquet' (FORMAT parquet, COMPRESSION zstd);
 
 COPY (

--- a/lab/extract.py
+++ b/lab/extract.py
@@ -2,12 +2,20 @@
 
 Runs inside the backend image (has pymongo + the app's Mongo config), so it
 reads blobs Mongo-first with per-run file fallback -- the same source of
-truth the site serves from, including the ~7% of runs the HTTP export's
-file-only path silently skipped. Each line is the raw run blob plus a _meta
-envelope carrying the server-side fields the blob itself lacks (username,
-hidden, timestamps), which later become the lake's sidecar tables.
+truth the site serves from. Each line is the raw run blob plus a _meta
+envelope carrying server-side fields the blob lacks (username, hidden,
+timestamps).
+
+Incremental: /lake/staging/state.json records the (submitted_at, _id)
+cursor; when present, only newer runs are pulled and appended as new pages.
+Every run also refreshes /lake/excluded_current.jsonl.gz (outside the
+pages glob) -- the
+full current hidden/deleted id set -- because runs mutate (hide/unhide,
+deletes) after their page was written.
 
     docker compose -f docker-compose.lab.yml run --rm extract
+    docker compose -f docker-compose.lab.yml run --rm extract --bootstrap
+      (one-time: derive state.json from existing pages that predate it)
 """
 
 import gzip
@@ -18,9 +26,10 @@ import time
 
 sys.path.insert(0, "/app")
 
-from app.services.runs_db_mongo import _get_collection, get_run_blobs 
+from app.services.runs_db_mongo import _get_collection, get_run_blobs
 
 STAGING = pathlib.Path("/lake/staging")
+STATE = STAGING / "state.json"
 RUNS_DIR = pathlib.Path("/data/runs")
 PAGE_SIZE = 50_000
 BATCH = 300
@@ -30,11 +39,66 @@ def _iso(v):
     return v.isoformat() if hasattr(v, "isoformat") else v
 
 
+def _bootstrap() -> None:
+    """Write state.json from the newest existing page (pre-state extracts)."""
+    pages = sorted(STAGING.glob("[0-9]*.jsonl.gz"))
+    if not pages:
+        print("no pages found; nothing to bootstrap")
+        return
+    last = None
+    with gzip.open(pages[-1], "rt", encoding="utf-8") as f:
+        for line in f:
+            last = line
+    obj = json.loads(last)
+    state = {
+        "submitted_at": obj["_meta"]["submitted_at"],
+        "run_hash": obj["run_hash"],
+        "page_next": int(pages[-1].stem) + 1,
+    }
+    STATE.write_text(json.dumps(state))
+    print(f"state bootstrapped from {pages[-1].name}: {state}")
+
+
+def _refresh_excluded(coll) -> None:
+    n = 0
+    tmp = pathlib.Path("/lake/excluded_current.jsonl.gz.tmp")
+    with gzip.open(tmp, "wt", encoding="utf-8") as out:
+        for doc in coll.find(
+            {"$or": [{"hidden": True}, {"deleted_at": {"$ne": None}}]}, {"_id": 1}
+        ):
+            out.write(json.dumps({"run_hash": doc["_id"]}) + "\n")
+            n += 1
+    tmp.replace(pathlib.Path("/lake/excluded_current.jsonl.gz"))
+    print(f"excluded sidecar refreshed: {n:,} hidden/deleted runs", flush=True)
+
+
 def main() -> None:
     STAGING.mkdir(parents=True, exist_ok=True)
+    if "--bootstrap" in sys.argv:
+        _bootstrap()
+        return
     coll = _get_collection()
+    _refresh_excluded(coll)
+
+    query: dict = {}
+    page = 0
+    if STATE.exists():
+        st = json.loads(STATE.read_text())
+        page = st["page_next"]
+        ts, last_id = st["submitted_at"], st["run_hash"]
+        from datetime import datetime
+
+        cutoff = datetime.fromisoformat(ts)
+        query = {
+            "$or": [
+                {"submitted_at": {"$gt": cutoff}},
+                {"submitted_at": cutoff, "_id": {"$gt": last_id}},
+            ]
+        }
+        print(f"incremental from ({ts}, {last_id}), next page {page}", flush=True)
+
     cursor = coll.find(
-        {},
+        query,
         {
             "_id": 1,
             "username": 1,
@@ -48,13 +112,13 @@ def main() -> None:
     ).sort([("submitted_at", 1), ("_id", 1)])
 
     t0 = time.time()
-    page = written = skipped = 0
+    written = skipped = 0
+    last_meta: dict = {}
     out = gzip.open(STAGING / f"{page:05d}.jsonl.gz", "wt", encoding="utf-8")
     batch: list[dict] = []
 
     def flush(rows: list[dict]) -> None:
-        nonlocal written, skipped, page, out
-        blobs = {}
+        nonlocal written, skipped, page, out, last_meta
         try:
             blobs = get_run_blobs([r["_id"] for r in rows])
         except Exception:
@@ -82,6 +146,10 @@ def main() -> None:
                 }
                 out.write(json.dumps(obj, separators=(",", ":")) + "\n")
                 written += 1
+                last_meta = {
+                    "submitted_at": obj["_meta"]["submitted_at"],
+                    "run_hash": h,
+                }
             except Exception:
                 skipped += 1
                 continue
@@ -109,6 +177,8 @@ def main() -> None:
     finally:
         cursor.close()
         out.close()
+    if last_meta:
+        STATE.write_text(json.dumps({**last_meta, "page_next": page + 1}))
     print(
         f"DONE: {written:,} written, {skipped:,} skipped in "
         f"{(time.time() - t0) / 60:.1f} min",

--- a/lab/shadow_deaths.sql
+++ b/lab/shadow_deaths.sql
@@ -1,0 +1,38 @@
+-- Lake-side community-stats deaths, replicating the walk's filters for the
+-- "all" bracket: hidden/deleted out (excluded sidecar), A0-A10 only,
+-- official characters only, losses only, NONE sentinels dropped. Catalog
+-- (modded-id) filtering happens in shadow_diff.py by comparing against the
+-- live payload's ids.
+--   docker compose -f docker-compose.lab.yml run --rm duckdb /lake/build.duckdb -c ".read /lake/lab/shadow_deaths.sql"
+SET memory_limit='1500MB';
+SET threads=2;
+
+CREATE OR REPLACE TEMP VIEW eligible AS
+SELECT killed_by_encounter, killed_by_event
+FROM read_parquet('/lake/runs.parquet') r
+ANTI JOIN read_parquet('/lake/excluded.parquet') x ON r.run_hash = x.run_hash
+WHERE NOT r.win
+  AND r.ascension BETWEEN 0 AND 10
+  AND r.character IN ('IRONCLAD','SILENT','DEFECT','NECROBINDER','REGENT');
+
+COPY (
+SELECT killed_by_encounter AS id, count(*) AS count
+FROM eligible
+WHERE killed_by_encounter IS NOT NULL AND killed_by_encounter NOT LIKE 'NONE%'
+GROUP BY 1 ORDER BY 2 DESC
+) TO '/lake/shadow_deaths_encounters.json' (FORMAT json, ARRAY true);
+
+COPY (
+SELECT killed_by_event AS id, count(*) AS count
+FROM eligible
+WHERE killed_by_event IS NOT NULL AND killed_by_event NOT LIKE 'NONE%'
+GROUP BY 1 ORDER BY 2 DESC
+) TO '/lake/shadow_deaths_events.json' (FORMAT json, ARRAY true);
+
+SELECT 'encounter ids' AS t, count(*) AS n FROM read_json('/lake/shadow_deaths_encounters.json')
+UNION ALL SELECT 'event ids', count(*) FROM read_json('/lake/shadow_deaths_events.json');
+
+COPY (
+SELECT (SELECT count(*) FROM read_parquet('/lake/runs.parquet')) AS lake_runs,
+       (SELECT count(*) FROM eligible) AS eligible_losses
+) TO '/lake/shadow_meta.json' (FORMAT json, ARRAY true);

--- a/lab/shadow_diff.py
+++ b/lab/shadow_diff.py
@@ -1,0 +1,96 @@
+"""Shadow-diff: lake-computed deaths vs the live community-stats payload.
+
+Reads the JSON files shadow_deaths.sql wrote and compares every id in the
+live top-15 lists (already catalog-filtered by the site) against the lake's
+counts. Exact agreement is only expected right after an incremental extract
+-- the live snapshot folds new runs every cycle -- so each row reports its
+drift and the verdict line the worst one, with the Mongo-vs-lake run delta
+as freshness context.
+
+    docker compose -f docker-compose.lab.yml run --rm shadow
+"""
+
+import json
+import pathlib
+import sys
+import urllib.request
+
+sys.path.insert(0, "/app")
+
+LAKE = pathlib.Path("/lake")
+LIVE_URLS = [
+    "http://spire-codex-backend:8000/api/runs/community-stats",
+    "https://spire-codex.com/api/runs/community-stats",
+]
+
+
+def _fetch_live() -> dict:
+    for url in LIVE_URLS:
+        try:
+            req = urllib.request.Request(
+                url, headers={"User-Agent": "spire-codex-lab-shadow-diff/1"}
+            )
+            with urllib.request.urlopen(req, timeout=30) as r:
+                data = json.load(r)
+                print(f"live payload from {url}")
+                return data
+        except Exception as e:
+            print(f"fetch {url}: {e}")
+    raise SystemExit("could not fetch live community-stats")
+
+
+def _freshness(lake_runs: int) -> None:
+    try:
+        from app.services.runs_db_mongo import _get_collection
+
+        n = _get_collection().count_documents({})
+        print(
+            f"freshness: mongo {n:,} runs vs lake {lake_runs:,} "
+            f"({n - lake_runs:+,} not yet extracted)"
+        )
+    except Exception as e:
+        print(f"freshness check unavailable: {e}")
+
+
+def _diff_section(name: str, live_rows: list[dict], lake_file: str) -> float:
+    lake = {r["id"]: r["count"] for r in json.loads((LAKE / lake_file).read_text())}
+    total = sum(lake.values())
+    print(f"\n== deaths.{name} (live top-{len(live_rows)} vs lake) ==")
+    print(f"{'id':<34} {'live':>9} {'lake':>9} {'diff':>7} {'drift%':>7}")
+    worst = 0.0
+    for row in live_rows:
+        lv, lk = row["count"], lake.get(row["id"], 0)
+        drift = abs(lk - lv) * 100.0 / max(lv, 1)
+        worst = max(worst, drift)
+        print(f"{row['id']:<34} {lv:>9,} {lk:>9,} {lk - lv:>+7,} {drift:>6.2f}%")
+    missing = [i for i in lake if i not in {r["id"] for r in live_rows}]
+    print(
+        f"lake-only ids (below live top-{len(live_rows)} or catalog-filtered): "
+        f"{len(missing)}; lake {name} total: {total:,}"
+    )
+    return worst
+
+
+def main() -> None:
+    live = _fetch_live()
+    meta = json.loads((LAKE / "shadow_meta.json").read_text())[0]
+    _freshness(meta["lake_runs"])
+    print(
+        f"lake eligible losses (A0-A10, official, not hidden): {meta['eligible_losses']:,}"
+    )
+    worst = max(
+        _diff_section(
+            "encounters",
+            live["deaths"]["encounters"],
+            "shadow_deaths_encounters.json",
+        ),
+        _diff_section("events", live["deaths"]["events"], "shadow_deaths_events.json"),
+    )
+    print(
+        f"\nVERDICT: worst per-id drift {worst:.2f}% "
+        f"({'PASS - within fold lag' if worst < 1.0 else 'INVESTIGATE'})"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
First DuckDB migration gate: the extractor becomes incremental with a hidden/deleted sidecar refresh, shadow_deaths.sql recomputes community-stats deaths from the lake with the walk's exact filters, and a shadow service diffs it per-id against the live payload.