### PR TITLE
Shadow the community-stats sections against the lake

### DIFF
--- a/lab/build.sql
+++ b/lab/build.sql
@@ -71,7 +71,23 @@ FROM read_ndjson('/lake/staging/*.jsonl.gz',
   LATERAL (SELECT unnest(p.u.deck) AS u) c
 ) TO '/lake/deck.parquet' (FORMAT parquet, COMPRESSION zstd);
 
+-- Location-level table (one row per visited map point, players kept as a
+-- nested list): floor_events drops roomless locations via its rooms
+-- unnest, so survival and map-danger need this shape.
+COPY (
+SELECT r.run_hash, act.i - 1 AS act, loc.i AS floor_idx,
+  lower(loc.u.map_point_type) AS map_point_type,
+  loc.u.player_stats AS players
+FROM read_ndjson('/lake/staging/*.jsonl.gz',
+  maximum_object_size=33554432, ignore_errors=true,
+  columns={run_hash: 'VARCHAR',
+    map_point_history: 'STRUCT(map_point_type VARCHAR, player_stats STRUCT(current_gold BIGINT, current_hp BIGINT, damage_taken BIGINT, max_hp BIGINT)[])[][]'}) r,
+  LATERAL (SELECT unnest(map_point_history) AS u, generate_subscripts(map_point_history,1) AS i) act,
+  LATERAL (SELECT unnest(act.u) AS u, generate_subscripts(act.u,1) AS i) loc
+) TO '/lake/floors.parquet' (FORMAT parquet, COMPRESSION zstd);
+
 SELECT 'runs' AS t, count(*) AS n FROM read_parquet('/lake/runs.parquet')
 UNION ALL SELECT 'excluded', count(*) FROM read_parquet('/lake/excluded.parquet')
 UNION ALL SELECT 'floor_events', count(*) FROM read_parquet('/lake/floor_events.parquet')
-UNION ALL SELECT 'deck', count(*) FROM read_parquet('/lake/deck.parquet');
+UNION ALL SELECT 'deck', count(*) FROM read_parquet('/lake/deck.parquet')
+UNION ALL SELECT 'floors', count(*) FROM read_parquet('/lake/floors.parquet');

--- a/lab/build.sql
+++ b/lab/build.sql
@@ -19,6 +19,7 @@ SELECT run_hash,
   upper(split_part(killed_by_encounter,'.',-1)) AS killed_by_encounter,
   upper(split_part(killed_by_event,'.',-1)) AS killed_by_event,
   _meta.username AS username, _meta.hidden AS hidden, _meta.deleted AS deleted,
+  coalesce(len(modifiers), 0) > 0 AS has_modifiers,
   _meta.submitted_at AS submitted_at, _meta.played_at AS played_at
 FROM read_ndjson('/lake/staging/*.jsonl.gz',
   maximum_object_size=33554432, ignore_errors=true,
@@ -28,6 +29,7 @@ FROM read_ndjson('/lake/staging/*.jsonl.gz',
     game_mode: 'VARCHAR', build_id: 'VARCHAR', seed: 'VARCHAR',
     start_time: 'BIGINT', run_time: 'BIGINT',
     killed_by_encounter: 'VARCHAR', killed_by_event: 'VARCHAR',
+    modifiers: 'VARCHAR[]',
     _meta: 'STRUCT(username VARCHAR, hidden BOOLEAN, deleted BOOLEAN, submitted_at TIMESTAMP, played_at TIMESTAMP, player_count BIGINT)'})
 ) TO '/lake/runs.parquet' (FORMAT parquet, COMPRESSION zstd);
 
@@ -77,17 +79,32 @@ FROM read_ndjson('/lake/staging/*.jsonl.gz',
 COPY (
 SELECT r.run_hash, act.i - 1 AS act, loc.i AS floor_idx,
   lower(loc.u.map_point_type) AS map_point_type,
-  loc.u.player_stats AS players
+  loc.u.player_stats AS players,
+  [x.model_id FOR x IN loc.u.rooms] AS room_models
 FROM read_ndjson('/lake/staging/*.jsonl.gz',
   maximum_object_size=33554432, ignore_errors=true,
   columns={run_hash: 'VARCHAR',
-    map_point_history: 'STRUCT(map_point_type VARCHAR, player_stats STRUCT(current_gold BIGINT, current_hp BIGINT, damage_taken BIGINT, max_hp BIGINT)[])[][]'}) r,
+    map_point_history: 'STRUCT(map_point_type VARCHAR, player_stats STRUCT(player_id BIGINT, current_gold BIGINT, current_hp BIGINT, damage_taken BIGINT, max_hp BIGINT, event_choices STRUCT(title STRUCT("key" VARCHAR, "table" VARCHAR))[], rest_site_choices VARCHAR[], ancient_choice STRUCT(TextKey VARCHAR, title STRUCT("key" VARCHAR, "table" VARCHAR), was_chosen BOOLEAN)[], cards_removed JSON[], card_choices STRUCT(was_picked BOOLEAN)[])[], rooms STRUCT(model_id VARCHAR)[])[][]'}) r,
   LATERAL (SELECT unnest(map_point_history) AS u, generate_subscripts(map_point_history,1) AS i) act,
   LATERAL (SELECT unnest(act.u) AS u, generate_subscripts(act.u,1) AS i) loc
 ) TO '/lake/floors.parquet' (FORMAT parquet, COMPRESSION zstd);
+
+-- Per-player identity + deck size: keys player_id to a character for the
+-- co-op attributions, and carries deck size for the records section.
+COPY (
+SELECT r.run_hash, p.u.id AS player_id,
+  upper(split_part(p.u.character,'.',-1)) AS character,
+  coalesce(len(p.u.deck), 0) AS deck_size
+FROM read_ndjson('/lake/staging/*.jsonl.gz',
+  maximum_object_size=33554432, ignore_errors=true,
+  columns={run_hash: 'VARCHAR',
+    players: 'STRUCT(id BIGINT, "character" VARCHAR, deck STRUCT(id VARCHAR)[])[]'}) r,
+  LATERAL (SELECT unnest(players) AS u) p
+) TO '/lake/players.parquet' (FORMAT parquet, COMPRESSION zstd);
 
 SELECT 'runs' AS t, count(*) AS n FROM read_parquet('/lake/runs.parquet')
 UNION ALL SELECT 'excluded', count(*) FROM read_parquet('/lake/excluded.parquet')
 UNION ALL SELECT 'floor_events', count(*) FROM read_parquet('/lake/floor_events.parquet')
 UNION ALL SELECT 'deck', count(*) FROM read_parquet('/lake/deck.parquet')
-UNION ALL SELECT 'floors', count(*) FROM read_parquet('/lake/floors.parquet');
+UNION ALL SELECT 'floors', count(*) FROM read_parquet('/lake/floors.parquet')
+UNION ALL SELECT 'players', count(*) FROM read_parquet('/lake/players.parquet');

--- a/lab/build.sql
+++ b/lab/build.sql
@@ -18,7 +18,8 @@ SELECT run_hash,
   _meta.player_count AS player_count, build_id, seed, start_time, run_time,
   upper(split_part(killed_by_encounter,'.',-1)) AS killed_by_encounter,
   upper(split_part(killed_by_event,'.',-1)) AS killed_by_event,
-  _meta.username AS username, _meta.hidden AS hidden, _meta.deleted AS deleted,
+  _meta.username AS username, _meta.user_id AS user_id,
+  _meta.hidden AS hidden, _meta.deleted AS deleted,
   coalesce(len(modifiers), 0) > 0 AS has_modifiers,
   _meta.submitted_at AS submitted_at, _meta.played_at AS played_at
 FROM read_ndjson('/lake/staging/*.jsonl.gz',
@@ -30,7 +31,7 @@ FROM read_ndjson('/lake/staging/*.jsonl.gz',
     start_time: 'BIGINT', run_time: 'BIGINT',
     killed_by_encounter: 'VARCHAR', killed_by_event: 'VARCHAR',
     modifiers: 'VARCHAR[]',
-    _meta: 'STRUCT(username VARCHAR, hidden BOOLEAN, deleted BOOLEAN, submitted_at TIMESTAMP, played_at TIMESTAMP, player_count BIGINT)'})
+    _meta: 'STRUCT(username VARCHAR, user_id VARCHAR, hidden BOOLEAN, deleted BOOLEAN, submitted_at TIMESTAMP, played_at TIMESTAMP, player_count BIGINT)'})
 ) TO '/lake/runs.parquet' (FORMAT parquet, COMPRESSION zstd);
 
 -- Sidecar from the extractor's fresh scan, NOT the per-page _meta: hidden

--- a/lab/extract.py
+++ b/lab/extract.py
@@ -102,6 +102,7 @@ def main() -> None:
         {
             "_id": 1,
             "username": 1,
+            "user_id": 1,
             "hidden": 1,
             "deleted_at": 1,
             "submitted_at": 1,
@@ -138,6 +139,7 @@ def main() -> None:
                 obj["run_hash"] = h
                 obj["_meta"] = {
                     "username": r.get("username"),
+                    "user_id": str(r["user_id"]) if r.get("user_id") else None,
                     "hidden": bool(r.get("hidden")),
                     "deleted": r.get("deleted_at") is not None,
                     "submitted_at": _iso(r.get("submitted_at")),

--- a/lab/shadow_community.sql
+++ b/lab/shadow_community.sql
@@ -1,0 +1,70 @@
+-- Raw aggregates for the community-stats shadow diff, "all" bracket.
+-- Eligibility mirrors the walk's row filter: hidden/deleted out, A0-A10,
+-- official characters. Finalization (sorting, percentages, gates) happens
+-- in shadow_diff.py, replicating community_stats.py exactly.
+--   docker compose -f docker-compose.lab.yml run --rm duckdb /lake/build.duckdb -c ".read /lake/lab/shadow_community.sql"
+SET memory_limit='1500MB';
+SET threads=2;
+
+CREATE OR REPLACE TEMP VIEW eligible AS
+SELECT r.*
+FROM read_parquet('/lake/runs.parquet') r
+ANTI JOIN read_parquet('/lake/excluded.parquet') x ON r.run_hash = x.run_hash
+WHERE r.ascension BETWEEN 0 AND 10
+  AND r.character IN ('IRONCLAD','SILENT','DEFECT','NECROBINDER','REGENT');
+
+COPY (
+SELECT lower(character) AS character, coalesce(ascension, 0) AS ascension,
+  count(*) AS runs, count(*) FILTER (win) AS wins
+FROM eligible GROUP BY 1, 2
+) TO '/lake/shadow_char_asc.json' (FORMAT json, ARRAY true);
+
+-- floors_reached histogram (runs with at least one visited location).
+COPY (
+WITH per_run AS (
+  SELECT f.run_hash, count(*) AS floors_reached
+  FROM read_parquet('/lake/floors.parquet') f
+  JOIN eligible e ON f.run_hash = e.run_hash
+  GROUP BY 1
+)
+SELECT floors_reached, count(*) AS runs, count(*) FILTER (e.win) AS wins
+FROM per_run p JOIN eligible e ON p.run_hash = e.run_hash
+GROUP BY 1
+) TO '/lake/shadow_floors_hist.json' (FORMAT json, ARRAY true);
+
+-- Map danger raw: per (act, node type) player-visits, damage%-of-max-hp sum,
+-- and deaths attributed to the run's final visited typed location. The died
+-- flag is raw truthiness like the walk's: NONE sentinels count.
+COPY (
+WITH typed AS (
+  SELECT f.* FROM read_parquet('/lake/floors.parquet') f
+  JOIN eligible e ON f.run_hash = e.run_hash
+  WHERE f.map_point_type IS NOT NULL AND f.map_point_type <> ''
+),
+visits AS (
+  SELECT act, map_point_type,
+    count(*) AS visits,
+    sum(least(100.0, greatest(0, coalesce(ps.u.damage_taken, 0)) * 100.0 / ps.u.max_hp)) AS dmg_sum
+  FROM typed, LATERAL (SELECT unnest(players) AS u) ps
+  WHERE coalesce(ps.u.max_hp, 0) > 0
+  GROUP BY 1, 2
+),
+last_floor AS (
+  SELECT t.run_hash,
+    arg_max(t.act, t.act * 10000 + t.floor_idx) AS act,
+    arg_max(t.map_point_type, t.act * 10000 + t.floor_idx) AS map_point_type
+  FROM typed t
+  JOIN eligible e ON t.run_hash = e.run_hash
+  WHERE coalesce(e.killed_by_encounter, '') <> '' OR coalesce(e.killed_by_event, '') <> ''
+  GROUP BY 1
+),
+deaths AS (
+  SELECT act, map_point_type, count(*) AS deaths FROM last_floor GROUP BY 1, 2
+)
+SELECT v.act, v.map_point_type, v.visits, v.dmg_sum, coalesce(d.deaths, 0) AS deaths
+FROM visits v LEFT JOIN deaths d USING (act, map_point_type)
+) TO '/lake/shadow_map_danger.json' (FORMAT json, ARRAY true);
+
+SELECT 'char_asc rows' AS t, count(*) AS n FROM read_json('/lake/shadow_char_asc.json')
+UNION ALL SELECT 'floors hist rows', count(*) FROM read_json('/lake/shadow_floors_hist.json')
+UNION ALL SELECT 'map danger rows', count(*) FROM read_json('/lake/shadow_map_danger.json');

--- a/lab/shadow_community.sql
+++ b/lab/shadow_community.sql
@@ -65,6 +65,114 @@ SELECT v.act, v.map_point_type, v.visits, v.dmg_sum, coalesce(d.deaths, 0) AS de
 FROM visits v LEFT JOIN deaths d USING (act, map_point_type)
 ) TO '/lake/shadow_map_danger.json' (FORMAT json, ARRAY true);
 
+-- Per-player floor rows for the choice-driven sections, with the walk's
+-- carried-forward HP for campfire banding and the hopper-floor flag.
+CREATE OR REPLACE TEMP VIEW pfloors AS
+SELECT f.run_hash, f.act, f.floor_idx, ps.u AS p,
+  e.win, lower(e.character) AS run_char,
+  len(list_filter(f.room_models, m -> m LIKE '%THIEVING_HOPPER%')) > 0 AS hopper_floor,
+  last_value(CASE WHEN ps.u.current_hp IS NOT NULL AND coalesce(ps.u.max_hp, 0) > 0
+    THEN struct_pack(hp := ps.u.current_hp, mx := ps.u.max_hp) END IGNORE NULLS)
+    OVER (PARTITION BY f.run_hash, ps.u.player_id ORDER BY f.act, f.floor_idx
+          ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS hp_prev
+FROM read_parquet('/lake/floors.parquet') f
+JOIN eligible e ON f.run_hash = e.run_hash,
+LATERAL (SELECT unnest(f.players) AS u) ps;
+
+CREATE OR REPLACE TEMP VIEW pid_char AS
+SELECT run_hash, player_id, lower(character) AS character
+FROM read_parquet('/lake/players.parquet') WHERE player_id IS NOT NULL AND character <> '';
+
+-- Event option counts (official-option filtering happens in the diff).
+COPY (
+SELECT split_part(ec.u.title."key", '.', 1) AS event_id,
+  split_part(split_part(ec.u.title."key", '.options.', 2), '.', 1) AS option_id,
+  count(*) AS n
+FROM pfloors, LATERAL (SELECT unnest(p.event_choices) AS u) ec
+WHERE ec.u.title."table" = 'events' AND ec.u.title."key" LIKE '%.options.%'
+  AND split_part(ec.u.title."key", '.', 1) <> ''
+  AND split_part(split_part(ec.u.title."key", '.options.', 2), '.', 1) <> ''
+GROUP BY 1, 2
+) TO '/lake/shadow_events.json' (FORMAT json, ARRAY true);
+
+-- Campfire choices: count / wins / made-at-low-HP, plus per-character counts.
+COPY (
+WITH choices AS (
+  SELECT rc.u AS choice, f.win,
+    coalesce(f.hp_prev, struct_pack(hp := f.p.current_hp, mx := coalesce(f.p.max_hp, 0))) AS ref,
+    coalesce(pc.character, f.run_char) AS ps_char
+  FROM pfloors f
+  LEFT JOIN pid_char pc ON f.run_hash = pc.run_hash AND f.p.player_id = pc.player_id,
+  LATERAL (SELECT unnest(f.p.rest_site_choices) AS u) rc
+  WHERE rc.u IS NOT NULL AND rc.u <> ''
+)
+SELECT choice, ps_char, count(*) AS n, count(*) FILTER (win) AS wins,
+  count(*) FILTER (ref.mx > 0 AND ref.hp IS NOT NULL AND ref.hp * 2 < ref.mx) AS low
+FROM choices GROUP BY 1, 2
+) TO '/lake/shadow_rest.json' (FORMAT json, ARRAY true);
+
+-- Ancient offers: chosen and offered per relic id.
+COPY (
+WITH offers AS (
+  SELECT coalesce(ac.u.TextKey,
+    CASE WHEN ac.u.title."key" LIKE '%.%'
+         THEN substr(ac.u.title."key", strpos(ac.u.title."key", '.') + 1)
+         ELSE ac.u.title."key" END) AS rid,
+    ac.u.was_chosen AS was_chosen
+  FROM pfloors, LATERAL (SELECT unnest(p.ancient_choice) AS u) ac
+)
+SELECT rid, count(*) FILTER (coalesce(was_chosen, false)) AS chosen, count(*) AS offered
+FROM offers WHERE rid IS NOT NULL AND rid <> '' AND upper(rid) NOT LIKE 'NONE%'
+GROUP BY 1
+) TO '/lake/shadow_ancient.json' (FORMAT json, ARRAY true);
+
+-- Removed vs hopper-stolen cards (starter variants merged), + per-char removes.
+COPY (
+WITH rem AS (
+  SELECT f.hopper_floor, coalesce(pc.character, f.run_char) AS ps_char,
+    coalesce(json_extract_string(cr.u, '$.card.id'),
+             json_extract_string(cr.u, '$.id'),
+             CASE WHEN json_type(cr.u) = 'VARCHAR' THEN cr.u::VARCHAR END) AS raw_id
+  FROM pfloors f
+  LEFT JOIN pid_char pc ON f.run_hash = pc.run_hash AND f.p.player_id = pc.player_id,
+  LATERAL (SELECT unnest(f.p.cards_removed) AS u) cr
+),
+named AS (
+  SELECT hopper_floor, ps_char,
+    CASE WHEN upper(split_part(raw_id, '.', -1)) LIKE 'STRIKE_%' THEN 'STRIKE'
+         WHEN upper(split_part(raw_id, '.', -1)) LIKE 'DEFEND_%' THEN 'DEFEND'
+         ELSE upper(split_part(raw_id, '.', -1)) END AS cid
+  FROM rem WHERE raw_id IS NOT NULL AND raw_id <> ''
+    AND upper(split_part(raw_id, '.', -1)) NOT LIKE 'NONE%'
+)
+SELECT cid, hopper_floor, ps_char, count(*) AS n FROM named GROUP BY 1, 2, 3
+) TO '/lake/shadow_removed.json' (FORMAT json, ARRAY true);
+
+-- Card-reward screens and skips.
+COPY (
+SELECT count(*) AS screens,
+  count(*) FILTER (NOT list_bool_or([coalesce(c.was_picked, false) FOR c IN p.card_choices])) AS skips
+FROM pfloors WHERE len(p.card_choices) > 0
+) TO '/lake/shadow_reward.json' (FORMAT json, ARRAY true);
+
+-- Records: standard modifier-free eligible runs only.
+COPY (
+WITH rec_runs AS (
+  SELECT * FROM eligible
+  WHERE game_mode = 'standard' AND NOT has_modifiers
+)
+SELECT
+  (SELECT min(run_time) FROM rec_runs WHERE win AND run_time > 0) AS fastest_win,
+  (SELECT arg_min(run_hash, run_time) FROM rec_runs WHERE win AND run_time > 0) AS fastest_win_hash,
+  (SELECT max(run_time) FROM rec_runs WHERE run_time > 0) AS longest_run,
+  (SELECT arg_max(run_hash, run_time) FROM rec_runs WHERE run_time > 0) AS longest_run_hash,
+  (SELECT max(p.deck_size) FROM read_parquet('/lake/players.parquet') p JOIN rec_runs r ON p.run_hash = r.run_hash) AS biggest_deck
+) TO '/lake/shadow_records.json' (FORMAT json, ARRAY true);
+
 SELECT 'char_asc rows' AS t, count(*) AS n FROM read_json('/lake/shadow_char_asc.json')
 UNION ALL SELECT 'floors hist rows', count(*) FROM read_json('/lake/shadow_floors_hist.json')
-UNION ALL SELECT 'map danger rows', count(*) FROM read_json('/lake/shadow_map_danger.json');
+UNION ALL SELECT 'map danger rows', count(*) FROM read_json('/lake/shadow_map_danger.json')
+UNION ALL SELECT 'event option rows', count(*) FROM read_json('/lake/shadow_events.json')
+UNION ALL SELECT 'rest rows', count(*) FROM read_json('/lake/shadow_rest.json')
+UNION ALL SELECT 'ancient rows', count(*) FROM read_json('/lake/shadow_ancient.json')
+UNION ALL SELECT 'removed rows', count(*) FROM read_json('/lake/shadow_removed.json');

--- a/lab/shadow_diff.py
+++ b/lab/shadow_diff.py
@@ -1,11 +1,11 @@
-"""Shadow-diff: lake-computed deaths vs the live community-stats payload.
+"""Shadow-diff: lake-computed community-stats vs the live payload.
 
-Reads the JSON files shadow_deaths.sql wrote and compares every id in the
-live top-15 lists (already catalog-filtered by the site) against the lake's
-counts. Exact agreement is only expected right after an incremental extract
--- the live snapshot folds new runs every cycle -- so each row reports its
-drift and the verdict line the worst one, with the Mongo-vs-lake run delta
-as freshness context.
+Reads the raw aggregates shadow_deaths.sql and shadow_community.sql wrote,
+finalizes them with the same arithmetic community_stats.py uses, and diffs
+each section against the live response. Exact agreement is only expected
+right after an incremental extract; each section reports its worst drift
+and the verdict line the overall worst. Count drift is relative (%), rate
+drift is in percentage points (pp).
 
     docker compose -f docker-compose.lab.yml run --rm shadow
 """
@@ -22,6 +22,12 @@ LIVE_URLS = [
     "http://spire-codex-backend:8000/api/runs/community-stats",
     "https://spire-codex.com/api/runs/community-stats",
 ]
+MAX_REAL_FLOOR = 48
+WORST_SHOWN = 5
+
+
+def _pct(part, whole):
+    return round(part / whole * 100, 1) if whole else 0.0
 
 
 def _fetch_live() -> dict:
@@ -39,55 +45,173 @@ def _fetch_live() -> dict:
     raise SystemExit("could not fetch live community-stats")
 
 
-def _freshness(lake_runs: int) -> None:
+def _load(name: str):
+    return json.loads((LAKE / name).read_text())
+
+
+class Section:
+    def __init__(self, name: str):
+        self.name = name
+        self.rows: list[tuple[float, str]] = []
+
+    def count(self, label: str, live, lake) -> None:
+        drift = abs((lake or 0) - (live or 0)) * 100.0 / max(live or 0, 1)
+        self.rows.append(
+            (drift, f"{label}: live {live:,} lake {lake:,} ({drift:.2f}%)")
+        )
+
+    def rate(self, label: str, live, lake) -> None:
+        drift = abs((lake or 0.0) - (live or 0.0))
+        self.rows.append((drift, f"{label}: live {live} lake {lake} ({drift:.2f}pp)"))
+
+    def report(self) -> float:
+        worst = max((d for d, _ in self.rows), default=0.0)
+        print(f"\n== {self.name}: {len(self.rows)} values, worst drift {worst:.2f} ==")
+        for d, line in sorted(self.rows, reverse=True)[:WORST_SHOWN]:
+            print("  " + line)
+        return worst
+
+
+def diff_deaths(live: dict) -> float:
+    worst = 0.0
+    for section, fname in (
+        ("encounters", "shadow_deaths_encounters.json"),
+        ("events", "shadow_deaths_events.json"),
+    ):
+        lake = {r["id"]: r["count"] for r in _load(fname)}
+        s = Section(f"deaths.{section}")
+        for row in live["deaths"][section]:
+            s.count(row["id"], row["count"], lake.get(row["id"], 0))
+        worst = max(worst, s.report())
+    return worst
+
+
+def diff_char_asc(live: dict) -> float:
+    rows = _load("shadow_char_asc.json")
+    total_runs = sum(r["runs"] for r in rows)
+    total_wins = sum(r["wins"] for r in rows)
+
+    s = Section("totals")
+    s.count("total_runs", live["total_runs"], total_runs)
+    s.count("total_wins", live["total_wins"], total_wins)
+    s.count("total_losses", live["total_losses"], total_runs - total_wins)
+    s.rate("win_rate", live["win_rate"], _pct(total_wins, total_runs))
+    worst = s.report()
+
+    by_asc: dict[int, list[int]] = {}
+    by_char: dict[str, list[int]] = {}
+    matrix: dict[tuple[str, int], list[int]] = {}
+    for r in rows:
+        for key, store in (
+            (int(r["ascension"]), by_asc),
+            (r["character"], by_char),
+            ((r["character"], int(r["ascension"])), matrix),
+        ):
+            rec = store.setdefault(key, [0, 0])
+            rec[0] += r["runs"]
+            rec[1] += r["wins"]
+
+    s = Section("by_ascension")
+    for row in live["by_ascension"]:
+        rec = by_asc.get(int(row["ascension"]), [0, 0])
+        s.count(f"A{row['ascension']} runs", row["runs"], rec[0])
+        s.count(f"A{row['ascension']} wins", row["wins"], rec[1])
+    worst = max(worst, s.report())
+
+    s = Section("by_character")
+    for row in live["by_character"]:
+        rec = by_char.get(row["id"], [0, 0])
+        s.count(f"{row['id']} runs", row["runs"], rec[0])
+        s.count(f"{row['id']} wins", row["wins"], rec[1])
+        s.rate(f"{row['id']} share", row["share"], _pct(rec[0], total_runs))
+    worst = max(worst, s.report())
+
+    s = Section("ascension_matrix")
+    for cid, per_asc in (live.get("ascension_matrix") or {}).items():
+        for asc, cell in per_asc.items():
+            rec = matrix.get((cid, int(asc)), [0, 0])
+            s.count(f"{cid} A{asc} runs", cell["runs"], rec[0])
+            s.count(f"{cid} A{asc} wins", cell["wins"], rec[1])
+    return max(worst, s.report())
+
+
+def diff_survival(live: dict) -> float:
+    hist: dict[int, int] = {}
+    for r in _load("shadow_floors_hist.json"):
+        f = min(int(r["floors_reached"]), MAX_REAL_FLOOR)
+        hist[f] = hist.get(f, 0) + r["runs"]
+    total = sum(hist.values())
+    lake_curve = {}
+    remaining = total
+    for f in range(1, max(hist, default=0) + 1):
+        lake_curve[f] = _pct(remaining, total)
+        remaining -= hist.get(f, 0)
+    s = Section("survival")
+    for row in live.get("survival") or []:
+        s.rate(f"floor {row['floor']}", row["alive_pct"], lake_curve.get(row["floor"]))
+    return s.report()
+
+
+def diff_map_danger(live: dict) -> float:
+    lake: dict[tuple[int, str], dict] = {}
+    for r in _load("shadow_map_danger.json"):
+        if r["visits"] < 50:
+            continue
+        lake[(int(r["act"]), r["map_point_type"])] = {
+            "visits": r["visits"],
+            "avg_dmg_pct": round(r["dmg_sum"] / r["visits"], 1),
+            "death_rate": round(r["deaths"] * 100.0 / r["visits"], 2),
+        }
+    s = Section("map_danger")
+    for act_row in live.get("map_danger") or []:
+        for ptype, cell in (act_row.get("types") or {}).items():
+            lk = lake.get((int(act_row["act"]), ptype))
+            if lk is None:
+                s.rows.append(
+                    (100.0, f"act {act_row['act']} {ptype}: missing from lake")
+                )
+                continue
+            s.count(
+                f"act {act_row['act']} {ptype} visits", cell["visits"], lk["visits"]
+            )
+            s.rate(
+                f"act {act_row['act']} {ptype} dmg%",
+                cell["avg_dmg_pct"],
+                lk["avg_dmg_pct"],
+            )
+            s.rate(
+                f"act {act_row['act']} {ptype} deaths%",
+                cell["death_rate"],
+                lk["death_rate"],
+            )
+    return s.report()
+
+
+def _freshness() -> None:
+    meta = _load("shadow_meta.json")[0]
     try:
         from app.services.runs_db_mongo import _get_collection
 
         n = _get_collection().count_documents({})
         print(
-            f"freshness: mongo {n:,} runs vs lake {lake_runs:,} "
-            f"({n - lake_runs:+,} not yet extracted)"
+            f"freshness: mongo {n:,} runs vs lake {meta['lake_runs']:,} "
+            f"({n - meta['lake_runs']:+,} not yet extracted)"
         )
     except Exception as e:
         print(f"freshness check unavailable: {e}")
 
 
-def _diff_section(name: str, live_rows: list[dict], lake_file: str) -> float:
-    lake = {r["id"]: r["count"] for r in json.loads((LAKE / lake_file).read_text())}
-    total = sum(lake.values())
-    print(f"\n== deaths.{name} (live top-{len(live_rows)} vs lake) ==")
-    print(f"{'id':<34} {'live':>9} {'lake':>9} {'diff':>7} {'drift%':>7}")
-    worst = 0.0
-    for row in live_rows:
-        lv, lk = row["count"], lake.get(row["id"], 0)
-        drift = abs(lk - lv) * 100.0 / max(lv, 1)
-        worst = max(worst, drift)
-        print(f"{row['id']:<34} {lv:>9,} {lk:>9,} {lk - lv:>+7,} {drift:>6.2f}%")
-    missing = [i for i in lake if i not in {r["id"] for r in live_rows}]
-    print(
-        f"lake-only ids (below live top-{len(live_rows)} or catalog-filtered): "
-        f"{len(missing)}; lake {name} total: {total:,}"
-    )
-    return worst
-
-
 def main() -> None:
     live = _fetch_live()
-    meta = json.loads((LAKE / "shadow_meta.json").read_text())[0]
-    _freshness(meta["lake_runs"])
-    print(
-        f"lake eligible losses (A0-A10, official, not hidden): {meta['eligible_losses']:,}"
-    )
+    _freshness()
     worst = max(
-        _diff_section(
-            "encounters",
-            live["deaths"]["encounters"],
-            "shadow_deaths_encounters.json",
-        ),
-        _diff_section("events", live["deaths"]["events"], "shadow_deaths_events.json"),
+        diff_deaths(live),
+        diff_char_asc(live),
+        diff_survival(live),
+        diff_map_danger(live),
     )
     print(
-        f"\nVERDICT: worst per-id drift {worst:.2f}% "
+        f"\nVERDICT: worst drift {worst:.2f} "
         f"({'PASS - within fold lag' if worst < 1.0 else 'INVESTIGATE'})"
     )
 

--- a/lab/shadow_diff.py
+++ b/lab/shadow_diff.py
@@ -24,6 +24,17 @@ LIVE_URLS = [
 ]
 MAX_REAL_FLOOR = 48
 WORST_SHOWN = 5
+OFFICIAL_REST = {
+    "SMITH",
+    "HEAL",
+    "MEND",
+    "DIG",
+    "CLONE",
+    "COOK",
+    "LIFT",
+    "HATCH",
+    "KINDLE",
+}
 
 
 def _pct(part, whole):
@@ -187,6 +198,126 @@ def diff_map_danger(live: dict) -> float:
     return s.report()
 
 
+def diff_events(live: dict) -> float:
+    lake: dict[tuple[str, str], int] = {}
+    for r in _load("shadow_events.json"):
+        lake[(r["event_id"], r["option_id"])] = r["n"]
+    s = Section("events")
+    for ev in (live.get("events") or [])[:12]:
+        opts = ev.get("options") or []
+        total = sum(lake.get((ev["id"], o["id"]), 0) for o in opts)
+        s.count(f"{ev['id']} total", ev["total"], total)
+        for o in opts[:3]:
+            s.count(
+                f"{ev['id']}.{o['id']}", o["count"], lake.get((ev["id"], o["id"]), 0)
+            )
+    return s.report()
+
+
+def diff_rest(live: dict) -> float:
+    agg: dict[str, list[int]] = {}
+    for r in _load("shadow_rest.json"):
+        if r["choice"].upper() not in OFFICIAL_REST:
+            continue
+        rec = agg.setdefault(r["choice"], [0, 0, 0])
+        rec[0] += r["n"]
+        rec[1] += r["wins"]
+        rec[2] += r["low"]
+    total = sum(rec[0] for rec in agg.values())
+    low_total = sum(rec[2] for rec in agg.values())
+    high_total = total - low_total
+    s = Section("rest_sites")
+    for row in live.get("rest_sites") or []:
+        count, wins, low = agg.get(row["id"], [0, 0, 0])
+        s.count(f"{row['id']} count", row["count"], count)
+        s.rate(f"{row['id']} win_rate", row["win_rate"], _pct(wins, count))
+        s.rate(f"{row['id']} pct_low_hp", row["pct_low_hp"], _pct(low, low_total))
+        s.rate(
+            f"{row['id']} pct_high_hp",
+            row["pct_high_hp"],
+            _pct(count - low, high_total),
+        )
+    return s.report()
+
+
+def diff_ancients(live: dict) -> float:
+    lake = {r["rid"]: r for r in _load("shadow_ancient.json")}
+    s = Section("ancient_picks")
+    for row in live.get("ancient_picks") or []:
+        rec = lake.get(row["id"]) or {"chosen": 0, "offered": 0}
+        s.count(f"{row['id']} count", row["count"], rec["chosen"])
+        if row.get("offered"):
+            s.count(f"{row['id']} offered", row["offered"], rec["offered"])
+            s.rate(
+                f"{row['id']} take_rate",
+                row.get("take_rate"),
+                _pct(rec["chosen"], rec["offered"]),
+            )
+    return s.report()
+
+
+def diff_removed(live: dict) -> float:
+    removed: dict[str, int] = {}
+    stolen: dict[str, int] = {}
+    char_removes: dict[str, int] = {}
+    for r in _load("shadow_removed.json"):
+        if r["hopper_floor"]:
+            stolen[r["cid"]] = stolen.get(r["cid"], 0) + r["n"]
+        else:
+            removed[r["cid"]] = removed.get(r["cid"], 0) + r["n"]
+            char_removes[r["ps_char"]] = char_removes.get(r["ps_char"], 0) + r["n"]
+    worst = 0.0
+    s = Section("most_removed")
+    for row in live.get("most_removed") or []:
+        s.count(row["id"], row["count"], removed.get(row["id"], 0))
+    worst = s.report()
+    s = Section("hopper_stolen")
+    for row in live.get("hopper_stolen") or []:
+        s.count(row["id"], row["count"], stolen.get(row["id"], 0))
+    worst = max(worst, s.report())
+
+    reward = _load("shadow_reward.json")[0]
+    s = Section("reward_skip_rate")
+    s.rate(
+        "reward_skip_rate",
+        live.get("reward_skip_rate"),
+        _pct(reward["skips"], reward["screens"]),
+    )
+    worst = max(worst, s.report())
+
+    rests: dict[str, dict[str, int]] = {}
+    for r in _load("shadow_rest.json"):
+        rests.setdefault(r["ps_char"], {})
+        rests[r["ps_char"]][r["choice"]] = (
+            rests[r["ps_char"]].get(r["choice"], 0) + r["n"]
+        )
+    s = Section("character_behavior")
+    for row in live.get("character_behavior") or []:
+        s.count(f"{row['id']} removes", row["removes"], char_removes.get(row["id"], 0))
+        crest = rests.get(row["id"]) or {}
+        rest_total = sum(crest.values())
+        for choice, pct in (row.get("rest") or {}).items():
+            s.rate(
+                f"{row['id']} rest.{choice}",
+                pct,
+                _pct(crest.get(choice, 0), rest_total),
+            )
+    return max(worst, s.report())
+
+
+def diff_records(live: dict) -> float:
+    rec = _load("shadow_records.json")[0]
+    lr = live.get("records") or {}
+    s = Section("records")
+    if lr.get("fastest_win"):
+        s.count("fastest_win", lr["fastest_win"]["run_time"], rec["fastest_win"])
+    if lr.get("longest_run"):
+        s.count("longest_run", lr["longest_run"]["run_time"], rec["longest_run"])
+    if lr.get("biggest_deck"):
+        s.count("biggest_deck", lr["biggest_deck"]["size"], rec["biggest_deck"])
+    return s.report()
+
+
 def _freshness() -> None:
     meta = _load("shadow_meta.json")[0]
     try:
@@ -209,6 +340,11 @@ def main() -> None:
         diff_char_asc(live),
         diff_survival(live),
         diff_map_danger(live),
+        diff_events(live),
+        diff_rest(live),
+        diff_ancients(live),
+        diff_removed(live),
+        diff_records(live),
     )
     print(
         f"\nVERDICT: worst drift {worst:.2f} "


### PR DESCRIPTION
Extends the shadow harness beyond deaths: a location-level floors table joins the lake, shadow_community.sql emits raw aggregates for totals, by-character, by-ascension, the ascension matrix, survival, and map danger, and shadow_diff.py finalizes them with the same arithmetic the walk uses and diffs every section against the live payload.