### PR TITLE
Productionize the lake: duckdb dependency and nightly ingest one-shot

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,5 @@ redis==5.2.1
 numpy==2.2.6
 scipy==1.14.1
 tzdata==2025.2
+# Analytics lake (pinned exactly; see lab/README.md)
+duckdb==1.5.5

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -211,6 +211,22 @@ services:
         max-file: "5"
 
 
+  # Nightly analytics-lake ingest (incremental extract + parquet rebuild).
+  # profiles: never started by `up -d`; host cron runs it, e.g.
+  #   17 9 * * * cd /var/www/spire-codex && docker compose -f docker-compose.prod.yml run --rm lake-ingest >> /var/log/lake-ingest.log 2>&1
+  lake-ingest:
+    image: ptrlrd/spire-codex-backend:latest
+    profiles: ["ops"]
+    entrypoint: ["python", "/lab/ingest.py"]
+    env_file: .env
+    mem_limit: 3g
+    volumes:
+      - ./lab:/lab:ro
+      - ./data:/data:ro
+      - ./lake:/lake
+    networks:
+      - nginx_web-network
+
   redis:
     image: redis:7-alpine
     # Must stay ABOVE redis's own --maxmemory so it evicts by LRU (its

--- a/lab/ingest.py
+++ b/lab/ingest.py
@@ -1,0 +1,36 @@
+"""Nightly lake ingest: incremental extract, then rebuild the parquet lake.
+
+One-shot for host cron, using the backend image (pymongo for the extract,
+the pinned duckdb for the build). The shadow SQL files run too when
+present, so the nightly log carries fresh comparison inputs for free.
+
+    docker compose -f docker-compose.prod.yml run --rm lake-ingest
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, "/lab")
+sys.path.insert(0, "/app")
+
+import extract
+
+
+def main() -> None:
+    extract.main()
+
+    import duckdb
+
+    con = duckdb.connect("/lake/build.duckdb")
+    for name in ("build.sql", "shadow_deaths.sql", "shadow_community.sql"):
+        path = pathlib.Path("/lab") / name
+        if not path.exists():
+            print(f"{name}: not present, skipped", flush=True)
+            continue
+        con.execute(path.read_text())
+        print(f"{name}: done", flush=True)
+    print("ingest complete", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Pins duckdb 1.5.5 into the backend image and adds a cron-run lake-ingest compose service (profiles: ops, never started by up -d) that does the incremental extract and parquet rebuild in one shot.