### PR TITLE
Add the lake query pack for every remaining snapshot surface

### DIFF
--- a/lab/build.sql
+++ b/lab/build.sql
@@ -65,11 +65,12 @@ SELECT r.run_hash, p.i AS player_idx,
   upper(split_part(p.u.character,'.',-1)) AS character,
   upper(split_part(c.u.id,'.',-1)) AS card,
   c.u.floor_added_to_deck AS floor_added,
-  c.u.current_upgrade_level AS upgrade_level
+  c.u.current_upgrade_level AS upgrade_level,
+  upper(split_part(c.u.enchantment.id, '.', -1)) AS enchantment
 FROM read_ndjson('/lake/staging/*.jsonl.gz',
   maximum_object_size=33554432, ignore_errors=true,
   columns={run_hash: 'VARCHAR',
-    players: 'STRUCT("character" VARCHAR, deck STRUCT(floor_added_to_deck BIGINT, id VARCHAR, current_upgrade_level BIGINT)[])[]'}) r,
+    players: 'STRUCT("character" VARCHAR, deck STRUCT(floor_added_to_deck BIGINT, id VARCHAR, current_upgrade_level BIGINT, enchantment STRUCT(id VARCHAR))[])[]'}) r,
   LATERAL (SELECT unnest(players) AS u, generate_subscripts(players,1) AS i) p,
   LATERAL (SELECT unnest(p.u.deck) AS u) c
 ) TO '/lake/deck.parquet' (FORMAT parquet, COMPRESSION zstd);
@@ -85,10 +86,33 @@ SELECT r.run_hash, act.i - 1 AS act, loc.i AS floor_idx,
 FROM read_ndjson('/lake/staging/*.jsonl.gz',
   maximum_object_size=33554432, ignore_errors=true,
   columns={run_hash: 'VARCHAR',
-    map_point_history: 'STRUCT(map_point_type VARCHAR, player_stats STRUCT(player_id BIGINT, current_gold BIGINT, current_hp BIGINT, damage_taken BIGINT, max_hp BIGINT, event_choices STRUCT(title STRUCT("key" VARCHAR, "table" VARCHAR))[], rest_site_choices VARCHAR[], ancient_choice STRUCT(TextKey VARCHAR, title STRUCT("key" VARCHAR, "table" VARCHAR), was_chosen BOOLEAN)[], cards_removed JSON[], card_choices STRUCT(was_picked BOOLEAN)[])[], rooms STRUCT(model_id VARCHAR)[])[][]'}) r,
+    map_point_history: 'STRUCT(map_point_type VARCHAR, player_stats STRUCT(player_id BIGINT, current_gold BIGINT, current_hp BIGINT, damage_taken BIGINT, max_hp BIGINT, event_choices STRUCT(title STRUCT("key" VARCHAR, "table" VARCHAR))[], rest_site_choices VARCHAR[], ancient_choice STRUCT(TextKey VARCHAR, title STRUCT("key" VARCHAR, "table" VARCHAR), was_chosen BOOLEAN)[], cards_removed JSON[], card_choices STRUCT(was_picked BOOLEAN, card STRUCT(id VARCHAR))[])[], rooms STRUCT(model_id VARCHAR)[])[][]'}) r,
   LATERAL (SELECT unnest(map_point_history) AS u, generate_subscripts(map_point_history,1) AS i) act,
   LATERAL (SELECT unnest(act.u) AS u, generate_subscripts(act.u,1) AS i) loc
 ) TO '/lake/floors.parquet' (FORMAT parquet, COMPRESSION zstd);
+
+COPY (
+SELECT r.run_hash, p.i AS player_idx,
+  upper(split_part(rel.u.id, '.', -1)) AS relic,
+  rel.u.floor_added_to_deck AS floor_added
+FROM read_ndjson('/lake/staging/*.jsonl.gz',
+  maximum_object_size=33554432, ignore_errors=true,
+  columns={run_hash: 'VARCHAR',
+    players: 'STRUCT(relics STRUCT(id VARCHAR, floor_added_to_deck BIGINT)[])[]'}) r,
+  LATERAL (SELECT unnest(players) AS u, generate_subscripts(players,1) AS i) p,
+  LATERAL (SELECT unnest(p.u.relics) AS u) rel
+) TO '/lake/relics.parquet' (FORMAT parquet, COMPRESSION zstd);
+
+COPY (
+SELECT r.run_hash, p.i AS player_idx,
+  upper(split_part(pot.u.id, '.', -1)) AS potion
+FROM read_ndjson('/lake/staging/*.jsonl.gz',
+  maximum_object_size=33554432, ignore_errors=true,
+  columns={run_hash: 'VARCHAR',
+    players: 'STRUCT(potions STRUCT(id VARCHAR)[])[]'}) r,
+  LATERAL (SELECT unnest(players) AS u, generate_subscripts(players,1) AS i) p,
+  LATERAL (SELECT unnest(p.u.potions) AS u) pot
+) TO '/lake/potions.parquet' (FORMAT parquet, COMPRESSION zstd);
 
 -- Per-player identity + deck size: keys player_id to a character for the
 -- co-op attributions, and carries deck size for the records section.
@@ -108,4 +132,6 @@ UNION ALL SELECT 'excluded', count(*) FROM read_parquet('/lake/excluded.parquet'
 UNION ALL SELECT 'floor_events', count(*) FROM read_parquet('/lake/floor_events.parquet')
 UNION ALL SELECT 'deck', count(*) FROM read_parquet('/lake/deck.parquet')
 UNION ALL SELECT 'floors', count(*) FROM read_parquet('/lake/floors.parquet')
-UNION ALL SELECT 'players', count(*) FROM read_parquet('/lake/players.parquet');
+UNION ALL SELECT 'players', count(*) FROM read_parquet('/lake/players.parquet')
+UNION ALL SELECT 'relics', count(*) FROM read_parquet('/lake/relics.parquet')
+UNION ALL SELECT 'potions', count(*) FROM read_parquet('/lake/potions.parquet');

--- a/lab/build.sql
+++ b/lab/build.sql
@@ -86,7 +86,7 @@ SELECT r.run_hash, act.i - 1 AS act, loc.i AS floor_idx,
 FROM read_ndjson('/lake/staging/*.jsonl.gz',
   maximum_object_size=33554432, ignore_errors=true,
   columns={run_hash: 'VARCHAR',
-    map_point_history: 'STRUCT(map_point_type VARCHAR, player_stats STRUCT(player_id BIGINT, current_gold BIGINT, current_hp BIGINT, damage_taken BIGINT, max_hp BIGINT, event_choices STRUCT(title STRUCT("key" VARCHAR, "table" VARCHAR))[], rest_site_choices VARCHAR[], ancient_choice STRUCT(TextKey VARCHAR, title STRUCT("key" VARCHAR, "table" VARCHAR), was_chosen BOOLEAN)[], cards_removed JSON[], card_choices STRUCT(was_picked BOOLEAN, card STRUCT(id VARCHAR))[])[], rooms STRUCT(model_id VARCHAR)[])[][]'}) r,
+    map_point_history: 'STRUCT(map_point_type VARCHAR, player_stats STRUCT(player_id BIGINT, current_gold BIGINT, current_hp BIGINT, damage_taken BIGINT, max_hp BIGINT, event_choices STRUCT(title STRUCT("key" VARCHAR, "table" VARCHAR))[], rest_site_choices VARCHAR[], upgraded_cards VARCHAR[], ancient_choice STRUCT(TextKey VARCHAR, title STRUCT("key" VARCHAR, "table" VARCHAR), was_chosen BOOLEAN)[], cards_removed JSON[], card_choices STRUCT(was_picked BOOLEAN, card STRUCT(id VARCHAR))[])[], rooms STRUCT(model_id VARCHAR)[])[][]'}) r,
   LATERAL (SELECT unnest(map_point_history) AS u, generate_subscripts(map_point_history,1) AS i) act,
   LATERAL (SELECT unnest(act.u) AS u, generate_subscripts(act.u,1) AS i) loc
 ) TO '/lake/floors.parquet' (FORMAT parquet, COMPRESSION zstd);
@@ -117,14 +117,14 @@ FROM read_ndjson('/lake/staging/*.jsonl.gz',
 -- Per-player identity + deck size: keys player_id to a character for the
 -- co-op attributions, and carries deck size for the records section.
 COPY (
-SELECT r.run_hash, p.u.id AS player_id,
+SELECT r.run_hash, p.i AS player_idx, p.u.id AS player_id,
   upper(split_part(p.u.character,'.',-1)) AS character,
   coalesce(len(p.u.deck), 0) AS deck_size
 FROM read_ndjson('/lake/staging/*.jsonl.gz',
   maximum_object_size=33554432, ignore_errors=true,
   columns={run_hash: 'VARCHAR',
     players: 'STRUCT(id BIGINT, "character" VARCHAR, deck STRUCT(id VARCHAR)[])[]'}) r,
-  LATERAL (SELECT unnest(players) AS u) p
+  LATERAL (SELECT unnest(players) AS u, generate_subscripts(players,1) AS i) p
 ) TO '/lake/players.parquet' (FORMAT parquet, COMPRESSION zstd);
 
 SELECT 'runs' AS t, count(*) AS n FROM read_parquet('/lake/runs.parquet')

--- a/lab/queries/README.md
+++ b/lab/queries/README.md
@@ -1,0 +1,23 @@
+# Lake query pack
+
+Replicas of every remaining snapshot-served surface, straight off the
+parquet lake. Run any of them with:
+
+```
+docker compose -f docker-compose.lab.yml run --rm duckdb /lake/build.duckdb -c ".read /lake/lab/queries/<file>.sql"
+```
+
+Every query starts from the same `eligible` filter the walk uses
+(hidden/deleted out, A0-A10, official characters). Files:
+
+- `tierlist_cards.sql` — per-card picks / wins / win rate / base-vs-upgraded,
+  the Codex Score inputs ("all" bracket plus an A10 and a solo slice).
+- `card_rewards.sql` — offered / picked / pick rate per card, with per-act
+  splits: the reward-screen metrics.
+- `elo_pairs.sql` — per-screen picked-beats-skipped pairs, the Elo input.
+- `winrate_brackets.sql` — per-user winrate classification (5-run floor,
+  abandons = losses) and a wr50 tier-list slice built from it.
+- `charts_frame.sql` — the frame-chart family: winrate by floor, runs and
+  winrate over time (Pacific-bucketed), time-to-win histogram.
+- `charts_blob.sql` — the blob-chart family: HP trajectory, gold curve,
+  deck growth, encounter damage/turns rankings, deaths by room type.

--- a/lab/queries/card_rewards.sql
+++ b/lab/queries/card_rewards.sql
@@ -1,0 +1,25 @@
+SET memory_limit='1500MB';
+SET threads=2;
+CREATE OR REPLACE TEMP VIEW eligible AS
+SELECT r.* FROM read_parquet('/lake/runs.parquet') r
+ANTI JOIN read_parquet('/lake/excluded.parquet') x ON r.run_hash = x.run_hash
+WHERE r.ascension BETWEEN 0 AND 10
+  AND r.character IN ('IRONCLAD','SILENT','DEFECT','NECROBINDER','REGENT');
+
+WITH offers AS (
+  SELECT f.act, upper(split_part(cc.u.card.id, '.', -1)) AS card,
+    coalesce(cc.u.was_picked, false) AS picked
+  FROM read_parquet('/lake/floors.parquet') f
+  JOIN eligible e ON f.run_hash = e.run_hash,
+  LATERAL (SELECT unnest(f.players) AS u) ps,
+  LATERAL (SELECT unnest(ps.u.card_choices) AS u) cc
+  WHERE cc.u.card.id IS NOT NULL
+)
+SELECT card,
+  count(*) AS offered,
+  count(*) FILTER (picked) AS picked,
+  round(count(*) FILTER (picked) * 100.0 / count(*), 1) AS pick_rate,
+  round(count(*) FILTER (picked AND act = 0) * 100.0
+    / greatest(count(*) FILTER (act = 0), 1), 1) AS pick_rate_act1
+FROM offers GROUP BY 1 HAVING count(*) >= 200
+ORDER BY pick_rate DESC LIMIT 25;

--- a/lab/queries/charts_blob.sql
+++ b/lab/queries/charts_blob.sql
@@ -1,0 +1,53 @@
+SET memory_limit='1500MB';
+SET threads=2;
+CREATE OR REPLACE TEMP VIEW eligible AS
+SELECT r.* FROM read_parquet('/lake/runs.parquet') r
+ANTI JOIN read_parquet('/lake/excluded.parquet') x ON r.run_hash = x.run_hash
+WHERE r.ascension BETWEEN 0 AND 10
+  AND r.character IN ('IRONCLAD','SILENT','DEFECT','NECROBINDER','REGENT');
+
+-- hp-trajectory: avg % of max HP per floor, wins vs losses (player 1).
+SELECT fe.floor_idx AS floor, e.win,
+  round(avg(fe.p1_hp * 100.0 / nullif(fe.p1_max_hp, 0)), 1) AS avg_hp_pct,
+  count(*) AS n
+FROM read_parquet('/lake/floor_events.parquet') fe
+JOIN eligible e ON fe.run_hash = e.run_hash
+WHERE fe.floor_idx <= 16 AND fe.p1_max_hp > 0
+GROUP BY 1, 2 ORDER BY 1, 2 LIMIT 32;
+
+-- gold-curve: avg gold per floor.
+SELECT fe.floor_idx AS floor, round(avg(fe.p1_gold), 0) AS avg_gold, count(*) AS n
+FROM read_parquet('/lake/floor_events.parquet') fe
+JOIN eligible e ON fe.run_hash = e.run_hash
+WHERE fe.floor_idx <= 16 GROUP BY 1 ORDER BY 1 LIMIT 16;
+
+-- deck-growth: avg cards added by floor (cumulative), from deck membership.
+WITH adds AS (
+  SELECT d.run_hash, d.floor_added, count(*) AS added
+  FROM read_parquet('/lake/deck.parquet') d
+  JOIN eligible e ON d.run_hash = e.run_hash
+  WHERE d.floor_added IS NOT NULL AND d.floor_added BETWEEN 0 AND 48
+  GROUP BY 1, 2
+)
+SELECT floor_added AS floor, round(avg(added), 2) AS avg_cards_added, count(*) AS runs
+FROM adds GROUP BY 1 ORDER BY 1 LIMIT 16;
+
+-- encounter-damage + turns rankings.
+SELECT fe.encounter,
+  round(avg(fe.damage_taken), 1) AS avg_damage,
+  round(avg(fe.turns), 1) AS avg_turns, count(*) AS fights
+FROM read_parquet('/lake/floor_events.parquet') fe
+JOIN eligible e ON fe.run_hash = e.run_hash
+WHERE fe.encounter IS NOT NULL AND fe.room_type = 'monster'
+GROUP BY 1 HAVING count(*) >= 100 ORDER BY avg_damage DESC LIMIT 15;
+
+-- deaths-by-room: the room type each dead run ended in.
+WITH last_room AS (
+  SELECT fe.run_hash,
+    arg_max(fe.room_type, fe.act * 10000 + fe.floor_idx) AS room_type
+  FROM read_parquet('/lake/floor_events.parquet') fe
+  JOIN eligible e ON fe.run_hash = e.run_hash
+  WHERE coalesce(e.killed_by_encounter, '') <> '' OR coalesce(e.killed_by_event, '') <> ''
+  GROUP BY 1
+)
+SELECT room_type, count(*) AS deaths FROM last_room GROUP BY 1 ORDER BY 2 DESC;

--- a/lab/queries/charts_frame.sql
+++ b/lab/queries/charts_frame.sql
@@ -1,0 +1,33 @@
+SET memory_limit='1500MB';
+SET threads=2;
+SET TimeZone='America/Los_Angeles';
+CREATE OR REPLACE TEMP VIEW eligible AS
+SELECT r.* FROM read_parquet('/lake/runs.parquet') r
+ANTI JOIN read_parquet('/lake/excluded.parquet') x ON r.run_hash = x.run_hash
+WHERE r.ascension BETWEEN 0 AND 10
+  AND r.character IN ('IRONCLAD','SILENT','DEFECT','NECROBINDER','REGENT');
+
+-- winrate-by-floor: of runs that reached floor f, how many won.
+WITH per_run AS (
+  SELECT f.run_hash, least(count(*), 48) AS floors, bool_or(e.win) AS win
+  FROM read_parquet('/lake/floors.parquet') f
+  JOIN eligible e ON f.run_hash = e.run_hash
+  GROUP BY 1
+)
+SELECT fl.f AS floor,
+  count(*) AS reached, count(*) FILTER (win) AS wins,
+  round(count(*) FILTER (win) * 100.0 / count(*), 1) AS win_rate
+FROM per_run, LATERAL (SELECT unnest(generate_series(1, floors)) AS f) fl
+GROUP BY 1 ORDER BY 1 LIMIT 48;
+
+-- runs-over-time + winrate-over-time (Pacific run-date buckets).
+SELECT date_trunc('day', played_at AT TIME ZONE 'UTC') AS day,
+  count(*) AS runs,
+  round(count(*) FILTER (win) * 100.0 / count(*), 1) AS win_rate
+FROM eligible WHERE played_at IS NOT NULL
+GROUP BY 1 ORDER BY 1 DESC LIMIT 14;
+
+-- time-to-win histogram (10-minute buckets, standard wins).
+SELECT (run_time // 600) * 10 AS minutes_bucket, count(*) AS wins
+FROM eligible WHERE win AND game_mode = 'standard' AND run_time > 0
+GROUP BY 1 ORDER BY 1 LIMIT 20;

--- a/lab/queries/elo_pairs.sql
+++ b/lab/queries/elo_pairs.sql
@@ -1,0 +1,21 @@
+SET memory_limit='1500MB';
+SET threads=2;
+CREATE OR REPLACE TEMP VIEW eligible AS
+SELECT r.* FROM read_parquet('/lake/runs.parquet') r
+ANTI JOIN read_parquet('/lake/excluded.parquet') x ON r.run_hash = x.run_hash
+WHERE r.ascension BETWEEN 0 AND 10
+  AND r.character IN ('IRONCLAD','SILENT','DEFECT','NECROBINDER','REGENT');
+
+-- One row per (winner, loser) per reward screen: the Elo fit's raw input.
+WITH screens AS (
+  SELECT f.run_hash, f.act, f.floor_idx, ps.i AS player_idx,
+    [upper(split_part(c.card.id, '.', -1)) FOR c IN ps.u.card_choices IF coalesce(c.was_picked, false) AND c.card.id IS NOT NULL] AS picked,
+    [upper(split_part(c.card.id, '.', -1)) FOR c IN ps.u.card_choices IF NOT coalesce(c.was_picked, false) AND c.card.id IS NOT NULL] AS skipped
+  FROM read_parquet('/lake/floors.parquet') f
+  JOIN eligible e ON f.run_hash = e.run_hash,
+  LATERAL (SELECT unnest(f.players) AS u, generate_subscripts(f.players, 1) AS i) ps
+  WHERE len(ps.u.card_choices) > 0
+)
+SELECT w.u AS winner, l.u AS loser, count(*) AS n
+FROM screens, LATERAL (SELECT unnest(picked) AS u) w, LATERAL (SELECT unnest(skipped) AS u) l
+GROUP BY 1, 2 ORDER BY n DESC LIMIT 20;

--- a/lab/queries/tierlist_cards.sql
+++ b/lab/queries/tierlist_cards.sql
@@ -1,0 +1,34 @@
+SET memory_limit='1500MB';
+SET threads=2;
+CREATE OR REPLACE TEMP VIEW eligible AS
+SELECT r.* FROM read_parquet('/lake/runs.parquet') r
+ANTI JOIN read_parquet('/lake/excluded.parquet') x ON r.run_hash = x.run_hash
+WHERE r.ascension BETWEEN 0 AND 10
+  AND r.character IN ('IRONCLAD','SILENT','DEFECT','NECROBINDER','REGENT');
+
+-- "all" bracket: per-instance deck membership, like the walk counts picks.
+SELECT d.card,
+  count(*) AS picks,
+  count(*) FILTER (e.win) AS wins,
+  round(count(*) FILTER (e.win) * 100.0 / count(*), 1) AS win_rate,
+  count(*) FILTER (coalesce(d.upgrade_level, 0) = 0) AS base_copies,
+  count(*) FILTER (coalesce(d.upgrade_level, 0) > 0) AS upgraded_copies
+FROM read_parquet('/lake/deck.parquet') d
+JOIN eligible e ON d.run_hash = e.run_hash
+GROUP BY 1 HAVING count(*) >= 50 ORDER BY win_rate DESC LIMIT 25;
+
+-- A10 slice: same thing, one WHERE clause.
+SELECT d.card, count(*) AS picks,
+  round(count(*) FILTER (e.win) * 100.0 / count(*), 1) AS win_rate
+FROM read_parquet('/lake/deck.parquet') d
+JOIN eligible e ON d.run_hash = e.run_hash
+WHERE e.ascension = 10
+GROUP BY 1 HAVING count(*) >= 50 ORDER BY win_rate DESC LIMIT 10;
+
+-- Solo slice.
+SELECT d.card, count(*) AS picks,
+  round(count(*) FILTER (e.win) * 100.0 / count(*), 1) AS win_rate
+FROM read_parquet('/lake/deck.parquet') d
+JOIN eligible e ON d.run_hash = e.run_hash
+WHERE e.player_count = 1
+GROUP BY 1 HAVING count(*) >= 50 ORDER BY win_rate DESC LIMIT 10;

--- a/lab/queries/winrate_brackets.sql
+++ b/lab/queries/winrate_brackets.sql
@@ -1,0 +1,33 @@
+SET memory_limit='1500MB';
+SET threads=2;
+CREATE OR REPLACE TEMP VIEW eligible AS
+SELECT r.* FROM read_parquet('/lake/runs.parquet') r
+ANTI JOIN read_parquet('/lake/excluded.parquet') x ON r.run_hash = x.run_hash
+WHERE r.ascension BETWEEN 0 AND 10
+  AND r.character IN ('IRONCLAD','SILENT','DEFECT','NECROBINDER','REGENT');
+
+-- Per-user winrate exactly like the walk: every run counted, abandons are
+-- losses, 5-run floor. (Same username-stamped-per-doc caveat as the walk.)
+CREATE OR REPLACE TEMP VIEW user_wr AS
+SELECT lower(username) AS uname,
+  count(*) AS runs, count(*) FILTER (win) AS wins,
+  count(*) FILTER (win) * 1.0 / count(*) AS wr
+FROM read_parquet('/lake/runs.parquet')
+WHERE username IS NOT NULL AND username <> ''
+GROUP BY 1 HAVING count(*) >= 5;
+
+SELECT count(*) AS qualified_users,
+  count(*) FILTER (wr > 0.30) AS wr30,
+  count(*) FILTER (wr > 0.50) AS wr50,
+  count(*) FILTER (wr > 0.75) AS wr75
+FROM user_wr;
+
+-- wr50 tier-list slice: A10 runs by >50% winrate players, like the snapshot
+-- bracket, but one WHERE clause instead of 980 accumulators.
+SELECT d.card, count(*) AS picks,
+  round(count(*) FILTER (e.win) * 100.0 / count(*), 1) AS win_rate
+FROM read_parquet('/lake/deck.parquet') d
+JOIN eligible e ON d.run_hash = e.run_hash
+JOIN user_wr u ON lower(e.username) = u.uname AND u.wr > 0.50
+WHERE e.ascension = 10
+GROUP BY 1 HAVING count(*) >= 25 ORDER BY win_rate DESC LIMIT 15;


### PR DESCRIPTION
Extends the lake with relics, potions, deck enchantments, and reward-screen card ids, and adds six query files proving the remaining snapshot-served surfaces (tier lists with brackets, card-reward metrics, Elo pairs, winrate brackets, and both chart families) answer straight from parquet.