### PR TITLE
Give ingest-time builders a spill-capable connection

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1200,14 +1200,10 @@ def community_stats(request: Request, response: Response, bracket: str | None = 
     # composites, game versions, and any of those composed with a version
     # (solo:wr50:v0.107.1). Shared with the entity endpoints so this route
     # can't drift from what the snapshot actually materializes.
-    if bracket is not None:
-        from ..services.run_entity_stats import is_valid_stat_bracket
-
-        if not is_valid_stat_bracket(bracket):
-            raise HTTPException(status_code=400, detail="bad bracket")
-    # Lake serve mode: the payload comes straight from the parquet lake and
-    # never depends on the snapshot walk. Any miss (flag off, unsupported
-    # bracket, lake not built, error) falls through to the snapshot path.
+    # Lake serve mode first: the cube folds ANY mode x players x skill
+    # combination -- including composites the snapshot never materialized --
+    # so composed brackets must reach the lake before the snapshot-grammar
+    # validation can 400 them. Any miss falls through unchanged.
     from ..services import lake_stats
 
     if lake_stats.SERVE_ENABLED:
@@ -1215,6 +1211,11 @@ def community_stats(request: Request, response: Response, bracket: str | None = 
         if lake_payload is not None:
             response.headers["Cache-Control"] = "public, max-age=300"
             return lake_payload
+    if bracket is not None:
+        from ..services.run_entity_stats import is_valid_stat_bracket
+
+        if not is_valid_stat_bracket(bracket):
+            raise HTTPException(status_code=400, detail="bad bracket")
     # An empty shell during a post-deploy rebuild must not stick in the
     # edge cache for 5 minutes on top of the rebuild itself.
     response.headers["Cache-Control"] = (

--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -770,3 +770,26 @@ def build_entity_store() -> dict | None:
         (LAKE_DIR / _ENTITY_STORE_NAME).stat().st_size,
     )
     return store
+
+
+_entity_store_cache: tuple[float, dict] | None = None
+
+
+def entity_store_with_mtime() -> tuple[float, dict] | None:
+    """Mtime-cached load of the ingest-built entity store, or None."""
+    global _entity_store_cache
+    try:
+        path = LAKE_DIR / _ENTITY_STORE_NAME
+        if not path.exists():
+            return None
+        mtime = path.stat().st_mtime
+        if _entity_store_cache and _entity_store_cache[0] == mtime:
+            return _entity_store_cache
+        import json
+
+        store = json.loads(path.read_text())
+        _entity_store_cache = (mtime, store)
+        return _entity_store_cache
+    except Exception:
+        logger.warning("entity store load failed", exc_info=True)
+        return None

--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -138,10 +138,10 @@ WHERE r.ascension BETWEEN 0 AND 10
 _PFLOORS_SQL = """
 CREATE OR REPLACE TEMP VIEW pfloors AS
 SELECT f.run_hash, f.act, f.floor_idx, ps.u AS p,
-  e.win, lower(e.character) AS run_char,
+  e.win, lower(e.character) AS run_char, e.cell,
   len(list_filter(f.room_models, m -> m LIKE '%THIEVING_HOPPER%')) > 0 AS hopper_floor
 FROM read_parquet('{lake}/floors.parquet') f
-JOIN eligible e ON f.run_hash = e.run_hash,
+JOIN cells e ON f.run_hash = e.run_hash,
 LATERAL (SELECT unnest(f.players) AS u) ps
 """
 
@@ -154,30 +154,120 @@ WHERE player_id IS NOT NULL AND character <> ''
 
 
 _PAYLOAD_PATH_NAME = "community_payload.json"
+_CUBE_PATH_NAME = "community_cube.json.gz"
+
+# Finest-grain bracket cells: game mode x player count x A10 x winrate band.
+# Every eligible run lands in exactly one cell, so any bracket combination
+# folds from cell sums -- the lattice the snapshot could never materialize.
+_CELLS_SQL = """
+CREATE OR REPLACE TEMP VIEW user_wr AS
+SELECT lower(username) AS uname, count(*) FILTER (win) * 1.0 / count(*) AS wr
+FROM read_parquet('{lake}/runs.parquet') r
+ANTI JOIN read_parquet('{lake}/excluded.parquet') x ON r.run_hash = x.run_hash
+WHERE username IS NOT NULL AND username <> ''
+GROUP BY 1 HAVING count(*) >= 5;
+CREATE OR REPLACE TEMP VIEW cells AS
+SELECT e.*,
+  lower(coalesce(e.game_mode, 'standard')) || '|' ||
+  least(coalesce(e.player_count, 1), 4)::VARCHAR || '|' ||
+  (coalesce(e.ascension, 0) = 10)::INT::VARCHAR || '|' ||
+  (CASE WHEN coalesce(e.ascension, 0) = 10 AND u.wr > 0.75 THEN 3
+        WHEN coalesce(e.ascension, 0) = 10 AND u.wr > 0.50 THEN 2
+        WHEN coalesce(e.ascension, 0) = 10 AND u.wr > 0.30 THEN 1
+        ELSE 0 END)::VARCHAR AS cell
+FROM eligible e
+LEFT JOIN user_wr u ON lower(e.username) = u.uname
+"""
+
+
+_MODE_KEYS = frozenset(("standard", "daily", "custom"))
+_PLAYER_KEYS = {"solo": "1", "2p": "2", "3p": "3", "4p": "4"}
+_SKILL_KEYS = {"a10": 0, "wr30": 1, "wr50": 2, "wr75": 3}
+
+_cube_cache: tuple[float, dict, dict] | None = None
+
+
+def _parse_lake_bracket(bracket: str | None):
+    """(mode, player, skill) slots, (None, None, None) for all, or None when
+    any part is outside the cube's axes (versions, unknown keys) -- those
+    fall back to the snapshot path."""
+    if bracket in (None, "", "all"):
+        return (None, None, None)
+    mode = player = skill = None
+    for part in bracket.split(":"):
+        if part == "all" or part == "":
+            continue
+        if part in _MODE_KEYS and mode is None:
+            mode = part
+        elif part in _PLAYER_KEYS and player is None:
+            player = _PLAYER_KEYS[part]
+        elif part in _SKILL_KEYS and skill is None:
+            skill = _SKILL_KEYS[part]
+        else:
+            return None
+    return (mode, player, skill)
 
 
 def community_payload(bracket: str | None = None) -> dict | None:
-    """Community-stats payload PRECOMPUTED by the ingest, or None when this
-    bracket isn't lake-served, no precomputed payload exists, or anything
-    fails -- the caller falls back to the snapshot path. Serving never
-    builds inline: the full-corpus build takes minutes and times out the
-    request."""
+    """Community-stats payload from the ingest-built store: the plain
+    payload file for the all bracket, or any mode x players x skill
+    combination folded from the cube. None (snapshot fallback) for
+    version brackets, unknown keys, missing stores, or any error.
+    Serving never builds from parquet inline."""
     try:
-        if bracket not in (None, "all"):
-            return None
         if not SERVE_ENABLED:
+            return None
+        parsed = _parse_lake_bracket(bracket)
+        if parsed is None:
             return None
         import json
 
-        path = LAKE_DIR / _PAYLOAD_PATH_NAME
+        mode, player, skill = parsed
+        if parsed == (None, None, None):
+            path = LAKE_DIR / _PAYLOAD_PATH_NAME
+            if not path.exists():
+                return None
+            mtime = path.stat().st_mtime
+            hit = _payload_cache.get("all")
+            if hit and hit[0] == mtime:
+                return hit[1]
+            payload = json.loads(path.read_text())
+            _payload_cache["all"] = (mtime, payload)
+            return payload
+
+        import gzip
+
+        global _cube_cache
+        path = LAKE_DIR / _CUBE_PATH_NAME
         if not path.exists():
             return None
         mtime = path.stat().st_mtime
-        hit = _payload_cache.get("all")
-        if hit and hit[0] == mtime:
-            return hit[1]
-        payload = json.loads(path.read_text())
-        _payload_cache["all"] = (mtime, payload)
+        if not _cube_cache or _cube_cache[0] != mtime:
+            with gzip.open(path, "rt", encoding="utf-8") as f:
+                _cube_cache = (mtime, json.load(f), {})
+        _, raw, folded = _cube_cache
+        ckey = f"{mode}|{player}|{skill}"
+        hit = folded.get(ckey)
+        if hit is not None:
+            return hit
+        accs = []
+        for cell_id, acc_raw in (raw.get("cells") or {}).items():
+            m, pc, a10, band = cell_id.split("|")
+            if mode is not None and m != mode:
+                continue
+            if player is not None and pc != player:
+                continue
+            if skill is not None:
+                if a10 != "1":
+                    continue
+                if skill > 0 and int(band) < skill:
+                    continue
+            accs.append(_acc_from_json(acc_raw))
+        from . import community_stats as cs
+
+        payload = cs._finalize_one(_merge_accs(accs))
+        payload["data_through"] = raw.get("data_through")
+        folded[ckey] = payload
         return payload
     except Exception:
         logger.warning(
@@ -187,110 +277,233 @@ def community_payload(bracket: str | None = None) -> dict | None:
 
 
 def build_and_store_payload() -> dict | None:
-    """Build the full community payload from the lake and write it beside
-    the parquet for the serving workers to point-read. Ingest-time only."""
+    """Build the community cube from the lake, store it gzipped beside the
+    parquet, and store the folded all-bracket payload as plain JSON for the
+    fast path. Ingest-time only."""
     if not available(*_SERVE_FILES[1:]):
         logger.info("lake payload build skipped: lake incomplete")
         return None
+    import gzip
     import json
 
-    payload = _build_community_all()
+    from . import community_stats as cs
+
+    cube = _build_community_cube()
+    con = _connect()
+    try:
+        data_through = str(
+            con.execute(
+                f"SELECT max(submitted_at) FROM read_parquet('{LAKE_DIR}/runs.parquet')"
+            ).fetchone()[0]
+        )
+    finally:
+        con.close()
+
+    payload = cs._finalize_one(_merge_accs(list(cube.values())))
+    payload["data_through"] = data_through
     tmp = LAKE_DIR / (_PAYLOAD_PATH_NAME + ".tmp")
     tmp.write_text(json.dumps(payload, separators=(",", ":")))
     tmp.replace(LAKE_DIR / _PAYLOAD_PATH_NAME)
+
+    cube_doc = {
+        "data_through": data_through,
+        "cells": {k: _acc_to_json(a) for k, a in cube.items()},
+    }
+    tmp = LAKE_DIR / (_CUBE_PATH_NAME + ".tmp")
+    with gzip.open(tmp, "wt", encoding="utf-8") as f:
+        json.dump(cube_doc, f, separators=(",", ":"))
+    tmp.replace(LAKE_DIR / _CUBE_PATH_NAME)
     logger.info(
-        "lake community payload stored (%d bytes)",
+        "lake community stores written: payload %d bytes, cube %d cells / %d bytes",
         (LAKE_DIR / _PAYLOAD_PATH_NAME).stat().st_size,
+        len(cube),
+        (LAKE_DIR / _CUBE_PATH_NAME).stat().st_size,
     )
     return payload
 
 
-def _build_community_all() -> dict:
+def _acc_to_json(acc: dict) -> dict:
+    out = dict(acc)
+    out["map_danger"] = {
+        f"{a}|{t}": v for (a, t), v in (acc.get("map_danger") or {}).items()
+    }
+    return out
+
+
+def _acc_from_json(raw: dict) -> dict:
+    acc = dict(raw)
+    acc["map_danger"] = {
+        (int(k.split("|", 1)[0]), k.split("|", 1)[1]): v
+        for k, v in (raw.get("map_danger") or {}).items()
+    }
+    acc["by_ascension"] = {
+        int(k): v for k, v in (raw.get("by_ascension") or {}).items()
+    }
+    acc["floors"] = {int(k): v for k, v in (raw.get("floors") or {}).items()}
+    acc["char_asc"] = {
+        c: {int(a): v for a, v in per.items()}
+        for c, per in (raw.get("char_asc") or {}).items()
+    }
+    return acc
+
+
+def _merge_accs(cells: list[dict]) -> dict:
+    """Fold cell accumulators into one, mirroring how the walk would have
+    accumulated the union of their runs."""
+    from . import community_stats as cs
+
+    out = cs._new_acc_one()
+    for acc in cells:
+        out["total_runs"] += acc["total_runs"]
+        out["total_wins"] += acc["total_wins"]
+        out["reward_screens"] += acc.get("reward_screens") or 0
+        out["reward_skips"] += acc.get("reward_skips") or 0
+        for field in (
+            "by_ascension",
+            "by_character",
+            "rest",
+            "ancient",
+            "map_danger",
+            "floors",
+        ):
+            for k, v in (acc.get(field) or {}).items():
+                rec = out[field].setdefault(k, [0] * len(v))
+                for i, x in enumerate(v):
+                    rec[i] += x
+        for field in (
+            "deaths_encounter",
+            "deaths_event",
+            "removed",
+            "stolen",
+            "char_removes",
+        ):
+            for k, n in (acc.get(field) or {}).items():
+                out[field][k] = out[field].get(k, 0) + n
+        for eid, opts in (acc.get("events") or {}).items():
+            slot = out["events"].setdefault(eid, {})
+            for oid, n in opts.items():
+                slot[oid] = slot.get(oid, 0) + n
+        for c, per in (acc.get("char_asc") or {}).items():
+            slot = out["char_asc"].setdefault(c, {})
+            for a, v in per.items():
+                rec = slot.setdefault(a, [0, 0])
+                rec[0] += v[0]
+                rec[1] += v[1]
+        for c, per in (acc.get("char_rest") or {}).items():
+            slot = out["char_rest"].setdefault(c, {})
+            for ch, n in per.items():
+                slot[ch] = slot.get(ch, 0) + n
+        for key, better in (
+            ("fastest_win", min),
+            ("longest_run", max),
+            ("biggest_deck", max),
+        ):
+            rec = acc.get(key)
+            if rec:
+                cur = out[key]
+                if cur is None or better(cur[0], rec[0]) == rec[0]:
+                    out[key] = tuple(rec)
+    return out
+
+
+def _build_community_cube() -> dict[str, dict]:
+    """One pass over the lake producing a community accumulator per bracket
+    cell (mode x players x A10 x winrate band)."""
     from . import community_stats as cs
 
     lake = str(LAKE_DIR)
     con = _connect(build=True)
+    accs: dict[str, dict] = {}
+
+    def acc_for(cell: str) -> dict:
+        a = accs.get(cell)
+        if a is None:
+            a = accs[cell] = cs._new_acc_one()
+        return a
+
     try:
         con.execute(_ELIGIBLE_SQL.format(lake=lake))
+        con.execute(_CELLS_SQL.format(lake=lake))
         con.execute(_PFLOORS_SQL.format(lake=lake))
         con.execute(_PID_CHAR_SQL.format(lake=lake))
-        acc = cs._new_acc_one()
 
-        for char, asc, runs, wins in con.execute(
-            "SELECT lower(character), coalesce(ascension, 0)::INT, count(*),"
-            " count(*) FILTER (win) FROM eligible GROUP BY 1, 2"
+        for cell, char, asc, runs, wins in con.execute(
+            "SELECT cell, lower(character), coalesce(ascension, 0)::INT, count(*),"
+            " count(*) FILTER (win) FROM cells GROUP BY 1, 2, 3"
         ).fetchall():
+            acc = acc_for(cell)
             acc["total_runs"] += runs
             acc["total_wins"] += wins
-            for store_key, rec in (
-                ("by_ascension", acc["by_ascension"].setdefault(asc, [0, 0])),
-                ("by_character", acc["by_character"].setdefault(char, [0, 0])),
-                (
-                    "char_asc",
-                    acc["char_asc"].setdefault(char, {}).setdefault(asc, [0, 0]),
-                ),
+            for rec in (
+                acc["by_ascension"].setdefault(asc, [0, 0]),
+                acc["by_character"].setdefault(char, [0, 0]),
+                acc["char_asc"].setdefault(char, {}).setdefault(asc, [0, 0]),
             ):
                 rec[0] += runs
                 rec[1] += wins
 
         for col, key in (("encounter", "deaths_encounter"), ("event", "deaths_event")):
-            acc[key] = dict(
-                con.execute(
-                    f"SELECT killed_by_{col}, count(*) FROM eligible"
-                    f" WHERE NOT win AND killed_by_{col} IS NOT NULL"
-                    f" AND killed_by_{col} NOT LIKE 'NONE%' GROUP BY 1"
-                ).fetchall()
-            )
+            for cell, eid, n in con.execute(
+                f"SELECT cell, killed_by_{col}, count(*) FROM cells"
+                f" WHERE NOT win AND killed_by_{col} IS NOT NULL"
+                f" AND killed_by_{col} NOT LIKE 'NONE%' GROUP BY 1, 2"
+            ).fetchall():
+                acc_for(cell)[key][eid] = n
 
-        for floors, runs, wins in con.execute(
+        for cell, floors, runs, wins in con.execute(
             "WITH per_run AS (SELECT f.run_hash, count(*) AS n"
             f" FROM read_parquet('{lake}/floors.parquet') f"
-            " JOIN eligible e ON f.run_hash = e.run_hash GROUP BY 1)"
-            " SELECT n, count(*), count(*) FILTER (e.win) FROM per_run p"
-            " JOIN eligible e ON p.run_hash = e.run_hash GROUP BY 1"
+            " JOIN cells e ON f.run_hash = e.run_hash GROUP BY 1)"
+            " SELECT e.cell, p.n, count(*), count(*) FILTER (e.win) FROM per_run p"
+            " JOIN cells e ON p.run_hash = e.run_hash GROUP BY 1, 2"
         ).fetchall():
-            acc["floors"][int(floors)] = [runs, wins]
+            acc_for(cell)["floors"][int(floors)] = [runs, wins]
 
-        for act, ptype, visits, dmg, deaths in con.execute(
-            f"WITH typed AS (SELECT f.* FROM read_parquet('{lake}/floors.parquet') f"
-            " JOIN eligible e ON f.run_hash = e.run_hash"
+        for cell, act, ptype, visits, dmg, deaths in con.execute(
+            "WITH typed AS (SELECT f.*, e.cell AS cell,"
+            " coalesce(e.killed_by_encounter, '') <> ''"
+            "  OR coalesce(e.killed_by_event, '') <> '' AS died"
+            f" FROM read_parquet('{lake}/floors.parquet') f"
+            " JOIN cells e ON f.run_hash = e.run_hash"
             " WHERE f.map_point_type IS NOT NULL AND f.map_point_type <> '')"
-            ", visits AS (SELECT act, map_point_type, count(*) AS v,"
+            ", visits AS (SELECT cell, act, map_point_type, count(*) AS v,"
             " sum(least(100.0, greatest(0, coalesce(ps.u.damage_taken, 0)) * 100.0"
             " / ps.u.max_hp)) AS dmg FROM typed,"
             " LATERAL (SELECT unnest(players) AS u) ps"
-            " WHERE coalesce(ps.u.max_hp, 0) > 0 GROUP BY 1, 2)"
-            ", lastf AS (SELECT t.run_hash, arg_max(t.act, t.act * 10000 + t.floor_idx)"
-            " AS act, arg_max(t.map_point_type, t.act * 10000 + t.floor_idx) AS mpt"
-            " FROM typed t JOIN eligible e ON t.run_hash = e.run_hash"
-            " WHERE coalesce(e.killed_by_encounter, '') <> ''"
-            "  OR coalesce(e.killed_by_event, '') <> '' GROUP BY 1)"
-            ", deaths AS (SELECT act, mpt, count(*) AS d FROM lastf GROUP BY 1, 2)"
-            " SELECT v.act, v.map_point_type, v.v, v.dmg, coalesce(d.d, 0)"
+            " WHERE coalesce(ps.u.max_hp, 0) > 0 GROUP BY 1, 2, 3)"
+            ", lastf AS (SELECT cell, run_hash, arg_max(act, act * 10000 + floor_idx)"
+            " AS act, arg_max(map_point_type, act * 10000 + floor_idx) AS mpt"
+            " FROM typed WHERE died GROUP BY 1, 2)"
+            ", deaths AS (SELECT cell, act, mpt, count(*) AS d FROM lastf GROUP BY 1, 2, 3)"
+            " SELECT v.cell, v.act, v.map_point_type, v.v, v.dmg, coalesce(d.d, 0)"
             " FROM visits v LEFT JOIN deaths d"
-            " ON v.act = d.act AND v.map_point_type = d.mpt"
+            " ON v.cell = d.cell AND v.act = d.act AND v.map_point_type = d.mpt"
         ).fetchall():
-            acc["map_danger"][(int(act), ptype)] = [visits, float(dmg or 0.0), deaths]
+            acc_for(cell)["map_danger"][(int(act), ptype)] = [
+                visits,
+                float(dmg or 0.0),
+                deaths,
+            ]
 
-        for eid, oid, n in con.execute(
-            "SELECT split_part((ec.u).title.\"key\", '.', 1),"
+        for cell, eid, oid, n in con.execute(
+            "SELECT cell, split_part((ec.u).title.\"key\", '.', 1),"
             " split_part(split_part((ec.u).title.\"key\", '.options.', 2), '.', 1),"
             " count(*) FROM pfloors, LATERAL (SELECT unnest((p).event_choices) AS u) ec"
             " WHERE (ec.u).title.\"table\" = 'events'"
-            " AND (ec.u).title.\"key\" LIKE '%.options.%' GROUP BY 1, 2"
+            " AND (ec.u).title.\"key\" LIKE '%.options.%' GROUP BY 1, 2, 3"
         ).fetchall():
             if eid and oid:
-                acc["events"].setdefault(eid, {})[oid] = n
+                acc_for(cell)["events"].setdefault(eid, {})[oid] = n
 
-        for choice, ps_char, n, wins, low in con.execute(
-            "WITH hp AS (SELECT run_hash, act, floor_idx, p, win, run_char,"
+        for cell, choice, ps_char, n, wins, low in con.execute(
+            "WITH hp AS (SELECT run_hash, cell, act, floor_idx, p, win, run_char,"
             " last_value(CASE WHEN (p).current_hp IS NOT NULL"
             " AND coalesce((p).max_hp, 0) > 0 THEN"
             " struct_pack(hp := (p).current_hp, mx := (p).max_hp) END IGNORE NULLS)"
             " OVER (PARTITION BY run_hash, (p).player_id ORDER BY act, floor_idx"
             " ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS hp_prev"
             " FROM pfloors)"
-            ", choices AS (SELECT rc.u AS choice, h.win,"
+            ", choices AS (SELECT h.cell, rc.u AS choice, h.win,"
             " coalesce(h.hp_prev, struct_pack(hp := (h.p).current_hp,"
             " mx := coalesce((h.p).max_hp, 0))) AS ref,"
             " coalesce(pc.character, h.run_char) AS ps_char FROM hp h"
@@ -298,10 +511,11 @@ def _build_community_all() -> dict:
             " AND (h.p).player_id = pc.player_id,"
             " LATERAL (SELECT unnest((h.p).rest_site_choices) AS u) rc"
             " WHERE rc.u IS NOT NULL AND rc.u <> '')"
-            " SELECT choice, ps_char, count(*), count(*) FILTER (win),"
+            " SELECT cell, choice, ps_char, count(*), count(*) FILTER (win),"
             " count(*) FILTER (ref.mx > 0 AND ref.hp IS NOT NULL"
-            " AND ref.hp * 2 < ref.mx) FROM choices GROUP BY 1, 2"
+            " AND ref.hp * 2 < ref.mx) FROM choices GROUP BY 1, 2, 3"
         ).fetchall():
+            acc = acc_for(cell)
             rec = acc["rest"].setdefault(choice, [0, 0, 0])
             rec[0] += n
             rec[1] += wins
@@ -309,20 +523,20 @@ def _build_community_all() -> dict:
             crest = acc["char_rest"].setdefault(ps_char, {})
             crest[choice] = crest.get(choice, 0) + n
 
-        for rid, chosen, offered in con.execute(
-            "WITH offers AS (SELECT coalesce((ac.u).TextKey,"
+        for cell, rid, chosen, offered in con.execute(
+            "WITH offers AS (SELECT cell, coalesce((ac.u).TextKey,"
             " CASE WHEN (ac.u).title.\"key\" LIKE '%.%' THEN"
             ' substr((ac.u).title."key", strpos((ac.u).title."key", \'.\') + 1)'
             ' ELSE (ac.u).title."key" END) AS rid, (ac.u).was_chosen AS wc'
             " FROM pfloors, LATERAL (SELECT unnest((p).ancient_choice) AS u) ac)"
-            " SELECT rid, count(*) FILTER (coalesce(wc, false)), count(*) FROM offers"
-            " WHERE rid IS NOT NULL AND rid <> '' AND upper(rid) NOT LIKE 'NONE%'"
-            " GROUP BY 1"
+            " SELECT cell, rid, count(*) FILTER (coalesce(wc, false)), count(*)"
+            " FROM offers WHERE rid IS NOT NULL AND rid <> ''"
+            " AND upper(rid) NOT LIKE 'NONE%' GROUP BY 1, 2"
         ).fetchall():
-            acc["ancient"][rid] = [chosen, offered]
+            acc_for(cell)["ancient"][rid] = [chosen, offered]
 
-        for cid, hopper, ps_char, n in con.execute(
-            "WITH rem AS (SELECT hopper_floor,"
+        for cell, cid, hopper, ps_char, n in con.execute(
+            "WITH rem AS (SELECT cell, hopper_floor,"
             " coalesce(pc.character, f.run_char) AS ps_char,"
             " coalesce(json_extract_string(cr.u, '$.card.id'),"
             " json_extract_string(cr.u, '$.id'),"
@@ -330,54 +544,50 @@ def _build_community_all() -> dict:
             " FROM pfloors f LEFT JOIN pid_char pc ON f.run_hash = pc.run_hash"
             " AND (f.p).player_id = pc.player_id,"
             " LATERAL (SELECT unnest((f.p).cards_removed) AS u) cr)"
-            " SELECT CASE WHEN upper(split_part(raw, '.', -1)) LIKE 'STRIKE_%'"
+            " SELECT cell, CASE WHEN upper(split_part(raw, '.', -1)) LIKE 'STRIKE_%'"
             " THEN 'STRIKE' WHEN upper(split_part(raw, '.', -1)) LIKE 'DEFEND_%'"
             " THEN 'DEFEND' ELSE upper(split_part(raw, '.', -1)) END,"
             " hopper_floor, ps_char, count(*) FROM rem"
             " WHERE raw IS NOT NULL AND raw <> ''"
-            " AND upper(split_part(raw, '.', -1)) NOT LIKE 'NONE%' GROUP BY 1, 2, 3"
+            " AND upper(split_part(raw, '.', -1)) NOT LIKE 'NONE%' GROUP BY 1, 2, 3, 4"
         ).fetchall():
+            acc = acc_for(cell)
             if hopper:
                 acc["stolen"][cid] = acc["stolen"].get(cid, 0) + n
             else:
                 acc["removed"][cid] = acc["removed"].get(cid, 0) + n
                 acc["char_removes"][ps_char] = acc["char_removes"].get(ps_char, 0) + n
 
-        screens, skips = con.execute(
-            "SELECT count(*), count(*) FILTER (NOT list_bool_or("
+        for cell, screens, skips in con.execute(
+            "SELECT cell, count(*), count(*) FILTER (NOT list_bool_or("
             "[coalesce(c.was_picked, false) FOR c IN (p).card_choices]))"
-            " FROM pfloors WHERE len((p).card_choices) > 0"
-        ).fetchone()
-        acc["reward_screens"] = screens
-        acc["reward_skips"] = skips
+            " FROM pfloors WHERE len((p).card_choices) > 0 GROUP BY 1"
+        ).fetchall():
+            acc = acc_for(cell)
+            acc["reward_screens"] = screens
+            acc["reward_skips"] = skips
 
-        rec = con.execute(
-            "WITH rr AS (SELECT * FROM eligible WHERE game_mode = 'standard'"
+        for cell, fw, fwh, lr, lrh, bd, bdh in con.execute(
+            "WITH rr AS (SELECT * FROM cells WHERE game_mode = 'standard'"
             " AND NOT has_modifiers)"
-            " SELECT (SELECT min(run_time) FROM rr WHERE win AND run_time > 0),"
-            " (SELECT arg_min(run_hash, run_time) FROM rr WHERE win AND run_time > 0),"
-            " (SELECT max(run_time) FROM rr WHERE run_time > 0),"
-            " (SELECT arg_max(run_hash, run_time) FROM rr WHERE run_time > 0),"
-            f" (SELECT max(p.deck_size) FROM read_parquet('{lake}/players.parquet') p"
-            "  JOIN rr ON p.run_hash = rr.run_hash),"
-            " (SELECT arg_max(p.run_hash, p.deck_size)"
-            f"  FROM read_parquet('{lake}/players.parquet') p"
-            "  JOIN rr ON p.run_hash = rr.run_hash)"
-        ).fetchone()
-        if rec[0] is not None:
-            acc["fastest_win"] = (int(rec[0]), rec[1])
-        if rec[2] is not None:
-            acc["longest_run"] = (int(rec[2]), rec[3])
-        if rec[4]:
-            acc["biggest_deck"] = (int(rec[4]), rec[5])
+            " SELECT cell,"
+            " min(run_time) FILTER (win AND run_time > 0),"
+            " arg_min(rr.run_hash, run_time) FILTER (win AND run_time > 0),"
+            " max(run_time) FILTER (run_time > 0),"
+            " arg_max(rr.run_hash, run_time) FILTER (run_time > 0),"
+            " max(p.deck_size), arg_max(p.run_hash, p.deck_size)"
+            f" FROM rr LEFT JOIN read_parquet('{lake}/players.parquet') p"
+            " ON rr.run_hash = p.run_hash GROUP BY 1"
+        ).fetchall():
+            acc = acc_for(cell)
+            if fw is not None:
+                acc["fastest_win"] = (int(fw), fwh)
+            if lr is not None:
+                acc["longest_run"] = (int(lr), lrh)
+            if bd:
+                acc["biggest_deck"] = (int(bd), bdh)
 
-        payload = cs._finalize_one(acc)
-        payload["data_through"] = str(
-            con.execute(
-                f"SELECT max(submitted_at) FROM read_parquet('{lake}/runs.parquet')"
-            ).fetchone()[0]
-        )
-        return payload
+        return accs
     finally:
         con.close()
 

--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -615,7 +615,7 @@ def build_entity_store() -> dict | None:
                 a = entry(etype, eid)
                 a["picks"] += picks
                 a["wins"] += wins
-                ch = (char or "").lower()
+                ch = char or ""
                 sub = a["by_character"].setdefault(ch, {"picks": 0, "wins": 0})
                 sub["picks"] += picks
                 sub["wins"] += wins

--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -47,11 +47,19 @@ def available(*extra: str) -> bool:
     return True
 
 
-def _connect():
+def _connect(build: bool = False):
+    """Serving reads get a small in-memory connection; ingest-time builds
+    get a bigger cap plus a spill directory, because the full-corpus
+    aggregations run far past 500MB and an in-memory connection can't
+    spill (it errors instead)."""
     import duckdb
 
     con = duckdb.connect()
-    con.execute("SET memory_limit='500MB'")
+    if build:
+        con.execute("SET memory_limit='1500MB'")
+        con.execute(f"SET temp_directory='{LAKE_DIR}/tmp'")
+    else:
+        con.execute("SET memory_limit='500MB'")
     con.execute("SET threads=2")
     return con
 
@@ -201,7 +209,7 @@ def _build_community_all() -> dict:
     from . import community_stats as cs
 
     lake = str(LAKE_DIR)
-    con = _connect()
+    con = _connect(build=True)
     try:
         con.execute(_ELIGIBLE_SQL.format(lake=lake))
         con.execute(_PFLOORS_SQL.format(lake=lake))
@@ -566,7 +574,7 @@ def build_entity_store() -> dict | None:
 
     from . import run_entity_stats as res
 
-    con = _connect()
+    con = _connect(build=True)
     try:
         con.execute(_ELIGIBLE_SQL.format(lake=LAKE_DIR))
         entities: dict[str, dict[str, dict]] = {

--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -56,7 +56,7 @@ def _connect(build: bool = False):
 
     con = duckdb.connect()
     if build:
-        con.execute("SET memory_limit='1500MB'")
+        con.execute("SET memory_limit='3500MB'")
         con.execute(f"SET temp_directory='{LAKE_DIR}/tmp'")
     else:
         con.execute("SET memory_limit='500MB'")

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -1982,6 +1982,9 @@ def _apply_cache(
     _encounter_blob_stats = bracket_meta.get("encounters") or {}
     _recent_stat_versions = bracket_meta.get("recent_versions") or []
     _cache_built_at = time.time()
+    global _lake_overlay_mtime, _lake_overlay_checked
+    _lake_overlay_mtime = 0.0
+    _lake_overlay_checked = 0.0
 
 
 def _build_cache() -> None:
@@ -2938,6 +2941,48 @@ def snapshot_status() -> dict[str, Any]:
     }
 
 
+_LAKE_ENTITY_SERVE = (os.environ.get("LAKE_ENTITY_STATS", "") or "").lower() == "serve"
+_lake_overlay_mtime = 0.0
+_lake_overlay_checked = 0.0
+
+
+def _maybe_overlay_lake_entities() -> None:
+    """Overlay the ingest-built lake aggregates onto the snapshot cache:
+    the all-bracket fields (picks/wins/by_character/reward metrics/Elos/
+    base-upg/act buckets) go lake-fresh while the bracket blocks keep
+    serving from the snapshot until they convert. No-op without
+    LAKE_ENTITY_STATS=serve or without a built store."""
+    global _lake_overlay_mtime, _lake_overlay_checked
+    if not _LAKE_ENTITY_SERVE:
+        return
+    now = time.time()
+    if now - _lake_overlay_checked < 30:
+        return
+    _lake_overlay_checked = now
+    try:
+        from . import lake_stats
+
+        loaded = lake_stats.entity_store_with_mtime()
+        if not loaded or loaded[0] == _lake_overlay_mtime:
+            return
+        mtime, store = loaded
+        n = 0
+        for etype, entries in (store.get("entities") or {}).items():
+            for eid, entry in entries.items():
+                key = (etype, eid)
+                old = _cache.get(key)
+                new_entry = dict(entry)
+                if old and old.get("brackets"):
+                    new_entry["brackets"] = old["brackets"]
+                _cache[key] = new_entry
+                n += 1
+        _type_baselines.update(store.get("baselines") or {})
+        _lake_overlay_mtime = mtime
+        logger.info("lake entity overlay applied: %d entities", n)
+    except Exception:
+        logger.warning("lake entity overlay failed", exc_info=True)
+
+
 def _maybe_rebuild() -> None:
     """Kick a background (re)load of the cache when it's stale. Never blocks:
     the caller reads whatever is in memory right now. The load used to run
@@ -2945,6 +2990,7 @@ def _maybe_rebuild() -> None:
     stats request after a worker boot — and one unlucky request every
     _SNAPSHOT_LOAD_SECONDS per worker, forever — hung for the full multi-
     thousand-doc snapshot read."""
+    _maybe_overlay_lake_entities()
     global _building
     age = time.time() - _cache_built_at
     if age < _SNAPSHOT_LOAD_SECONDS:

--- a/backend/tests/test_lake_stats.py
+++ b/backend/tests/test_lake_stats.py
@@ -38,3 +38,42 @@ def test_community_payload_none_without_lake(monkeypatch, tmp_path):
 def test_community_payload_none_for_unsupported_bracket(monkeypatch):
     monkeypatch.setattr(lake_stats, "SERVE_ENABLED", True)
     assert lake_stats.community_payload("wr50") is None
+
+
+def test_lake_entity_overlay(monkeypatch, tmp_path):
+    import json
+
+    from app.services import run_entity_stats as res
+
+    monkeypatch.setattr(lake_stats, "LAKE_DIR", tmp_path)
+    monkeypatch.setattr(lake_stats, "_entity_store_cache", None)
+    store = {
+        "entities": {
+            "cards": {
+                "ZAP": {
+                    "picks": 100,
+                    "wins": 60,
+                    "by_character": {"DEFECT": {"picks": 100, "wins": 60}},
+                }
+            }
+        },
+        "baselines": {"cards": 0.5},
+    }
+    (tmp_path / "entity_store.json").write_text(json.dumps(store))
+    monkeypatch.setattr(res, "_LAKE_ENTITY_SERVE", True)
+    monkeypatch.setattr(res, "_lake_overlay_checked", 0.0)
+    monkeypatch.setattr(res, "_lake_overlay_mtime", 0.0)
+    res._cache[("cards", "ZAP")] = {
+        "picks": 1,
+        "wins": 0,
+        "brackets": {"a10": {"picks": 5}},
+    }
+    try:
+        res._maybe_overlay_lake_entities()
+        e = res._cache[("cards", "ZAP")]
+        assert e["picks"] == 100
+        assert e["brackets"]["a10"]["picks"] == 5
+        assert res._type_baselines["cards"] == 0.5
+    finally:
+        res._cache.pop(("cards", "ZAP"), None)
+        res._type_baselines.pop("cards", None)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -21,6 +21,7 @@ x-shared-env: &shared-env
   # summary cycle. Set values in the box .env.
   LAKE_COMMUNITY_STATS: ${LAKE_COMMUNITY_STATS:-}
   LAKE_STATS_SHADOW: ${LAKE_STATS_SHADOW:-}
+  LAKE_ENTITY_STATS: ${LAKE_ENTITY_STATS:-}
   # How often the leader may rerun the heavy walk (seconds). Default 7200
   # (2h). With the parallel rebuild on, lower it for fresher public numbers,
   # but keep it well above the observed walk time so the box isn't always

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -229,7 +229,10 @@ services:
     env_file: .env
     environment:
       DATA_DIR: /data
-    mem_limit: 3g
+    # 5g container / 3.5g duckdb: with the rebuilder headed for deletion the
+    # ingest is the box's main computer, so it gets real memory instead of
+    # spilling every heavy aggregate to disk.
+    mem_limit: 5g
     volumes:
       - ./lab:/lab:ro
       - ./data:/data:ro

--- a/frontend/app/community-stats/CommunityStatsBody.tsx
+++ b/frontend/app/community-stats/CommunityStatsBody.tsx
@@ -165,7 +165,7 @@ export async function CommunityStatsBody({ lang, bracket }: { lang: string; brac
       </p>
 
       {/* Content bracket: slice every dataset below by skill and/or player count. */}
-      <BracketFilter basePath={basePath} current={bracket} composite />
+      <BracketFilter basePath={basePath} current={bracket} composite modeComposes />
 
       {/* Headline numbers */}
       <section className="mb-10">

--- a/frontend/app/components/BracketFilter.tsx
+++ b/frontend/app/components/BracketFilter.tsx
@@ -29,14 +29,18 @@ export default function BracketFilter({
   current,
   extraParams,
   composite,
+  modeComposes,
 }: {
   basePath: string;
   current: string;
   extraParams?: Record<string, string | undefined>;
   composite?: boolean;
+  /** The page's data source folds a full bracket cube (lake-served pages),
+   * so the mode row composes with player + skill instead of replacing them. */
+  modeComposes?: boolean;
 }) {
   const active = normalizeBracket(current);
-  const { player, skill, version } = splitBracket(active);
+  const { player, skill, mode, version } = splitBracket(active);
 
   const hrefFor = (bracketValue: string) => {
     const params = new URLSearchParams();
@@ -126,7 +130,7 @@ export default function BracketFilter({
           return (
             <Link
               key={b.key}
-              href={hrefFor(combineBracket(player, targetSkill, version))}
+              href={hrefFor(combineBracket(player, targetSkill, version, modeComposes ? mode : ""))}
               className={pillCls(skill === targetSkill)}
             >
               {b.label}
@@ -139,7 +143,7 @@ export default function BracketFilter({
         {playerOpts.map((b) => (
           <Link
             key={b.key || "all"}
-            href={hrefFor(combineBracket(b.key, skill, version))}
+            href={hrefFor(combineBracket(b.key, skill, version, modeComposes ? mode : ""))}
             className={pillCls(player === b.key)}
           >
             {b.label}
@@ -148,27 +152,51 @@ export default function BracketFilter({
       </div>
       <div className="flex flex-wrap items-center gap-1.5">
         <span className="w-14 text-xs text-[var(--text-muted)]">Mode</span>
-        <Link
-          href={hrefFor(
-            base && !MODE_BRACKETS.some((m) => m.key === base)
-              ? version
-                ? `${base}:${version}`
-                : base
-              : version || "all",
-          )}
-          className={pillCls(!MODE_BRACKETS.some((m) => m.key === base))}
-        >
-          All
-        </Link>
-        {MODE_BRACKETS.map((m) => (
-          <Link
-            key={m.key}
-            href={hrefFor(version ? `${m.key}:${version}` : m.key)}
-            className={pillCls(base === m.key)}
-          >
-            {m.label}
-          </Link>
-        ))}
+        {modeComposes ? (
+          <>
+            {/* Cube-backed page: mode is a real axis, so every mode pill
+                keeps the player + skill selection and vice versa. */}
+            <Link
+              href={hrefFor(combineBracket(player, skill, version))}
+              className={pillCls(!mode)}
+            >
+              All
+            </Link>
+            {MODE_BRACKETS.map((m) => (
+              <Link
+                key={m.key}
+                href={hrefFor(combineBracket(player, skill, version, m.key))}
+                className={pillCls(mode === m.key)}
+              >
+                {m.label}
+              </Link>
+            ))}
+          </>
+        ) : (
+          <>
+            <Link
+              href={hrefFor(
+                base && !MODE_BRACKETS.some((m) => m.key === base)
+                  ? version
+                    ? `${base}:${version}`
+                    : base
+                  : version || "all",
+              )}
+              className={pillCls(!MODE_BRACKETS.some((m) => m.key === base))}
+            >
+              All
+            </Link>
+            {MODE_BRACKETS.map((m) => (
+              <Link
+                key={m.key}
+                href={hrefFor(version ? `${m.key}:${version}` : m.key)}
+                className={pillCls(base === m.key)}
+              >
+                {m.label}
+              </Link>
+            ))}
+          </>
+        )}
       </div>
       {/* Game version is a third axis: it composes with the player and
           skill selections instead of replacing them. */}

--- a/frontend/lib/content-brackets.ts
+++ b/frontend/lib/content-brackets.ts
@@ -75,40 +75,62 @@ function splitVersion(raw: string): { base: string; version: string } {
   return { base: raw, version: "" };
 }
 
+const _MODE_KEYS = new Set(MODE_BRACKETS.map((b) => b.key));
+
 /**
- * A "player:skill" composite (e.g. "solo:wr50") combines a player-count bracket
- * with a content/skill bracket. Only the entity cache (tier list + metrics)
- * materializes these, so BracketFilter offers them only in composite mode.
+ * A composite combines distinct axes with colons: player + skill
+ * ("solo:wr50"), and -- on pages whose data source folds a bracket cube
+ * (community stats) -- game mode as a third axis ("standard:solo:wr50").
+ * Each axis at most once, two or more parts, any order.
  */
 export function isCompositeBracket(raw: string | undefined | null): boolean {
   if (!raw || !raw.includes(":")) return false;
-  const [p, s] = raw.split(":");
-  return _PLAYER_KEYS.has(p) && _SKILL_KEYS.has(s);
+  const parts = raw.split(":");
+  if (parts.length < 2 || parts.length > 3) return false;
+  let player = 0,
+    skill = 0,
+    mode = 0;
+  for (const part of parts) {
+    if (_PLAYER_KEYS.has(part)) player++;
+    else if (_SKILL_KEYS.has(part)) skill++;
+    else if (_MODE_KEYS.has(part)) mode++;
+    else return false;
+  }
+  return player <= 1 && skill <= 1 && mode <= 1;
 }
 
-/** Split a bracket value into its player + skill + version axes. A single
- * bracket maps to whichever axis owns it; "all"/unknown gives all empty. */
+/** Split a bracket value into its player + skill + mode + version axes. A
+ * single bracket maps to whichever axis owns it; "all"/unknown gives all
+ * empty. */
 export function splitBracket(raw: string | undefined | null): {
   player: string;
   skill: string;
+  mode: string;
   version: string;
 } {
   const b = normalizeBracket(raw);
   const { base, version } = splitVersion(b === "all" ? "" : b);
-  if (isCompositeBracket(base)) {
-    const [player, skill] = base.split(":");
-    return { player, skill, version };
+  let player = "",
+    skill = "",
+    mode = "";
+  for (const part of base ? base.split(":") : []) {
+    if (_PLAYER_KEYS.has(part)) player = part;
+    else if (_SKILL_KEYS.has(part)) skill = part;
+    else if (_MODE_KEYS.has(part)) mode = part;
   }
-  if (_PLAYER_KEYS.has(base)) return { player: base, skill: "", version };
-  if (_SKILL_KEYS.has(base)) return { player: "", skill: base, version };
-  return { player: "", skill: "", version };
+  return { player, skill, mode, version };
 }
 
-/** Combine player + skill + version selections into one ?bracket= value.
- * Any subset works: the axes compose in canonical player:skill:version
- * order, and all-empty collapses to "all". */
-export function combineBracket(player: string, skill: string, version = ""): string {
-  const base = [player, skill].filter(Boolean).join(":");
+/** Combine player + skill + mode + version selections into one ?bracket=
+ * value. Any subset works: the axes compose in canonical
+ * player:skill:mode:version order, and all-empty collapses to "all". */
+export function combineBracket(
+  player: string,
+  skill: string,
+  version = "",
+  mode = "",
+): string {
+  const base = [player, skill, mode].filter(Boolean).join(":");
   if (base && version) return `${base}:${version}`;
   return base || version || "all";
 }

--- a/lab/ingest.py
+++ b/lab/ingest.py
@@ -22,7 +22,11 @@ def main() -> None:
     import duckdb
 
     con = duckdb.connect("/lake/build.duckdb")
-    for name in ("build.sql", "shadow_deaths.sql", "shadow_community.sql"):
+    # The shadow SQLs were the migration validation gate; the gate passed,
+    # and the payload builder computes the same sections anyway, so the
+    # nightly run skips them (halves the tail). Run them by hand from
+    # lab/ when a fresh lake-vs-snapshot diff is wanted.
+    for name in ("build.sql",):
         path = pathlib.Path("/lab") / name
         if not path.exists():
             print(f"{name}: not present, skipped", flush=True)


### PR DESCRIPTION
Bundles the lake serving fixes: spill-capable 3.5g build connection, the entity-store overlay behind LAKE_ENTITY_STATS=serve, and a community bracket cube (mode x players x A10 x winrate band) built at ingest so /community-stats folds ANY toggle combination -- including the mode x players composites the snapshot never materialized -- with the frontend mode row now composing instead of resetting the other filters.