### PR TITLE
Survive a read-only data mount in the SQLite fallback init

### DIFF
--- a/backend/app/services/runs_db.py
+++ b/backend/app/services/runs_db.py
@@ -759,8 +759,17 @@ def get_stats(
         }
 
 
-# Initialize on import
-init_db()
+# Initialize on import. Best-effort: on Mongo deployments this SQLite
+# fallback is never read, and containers that mount the data dir read-only
+# (the lake ingest) can't open it at all -- that must not poison imports.
+try:
+    init_db()
+except sqlite3.OperationalError as e:
+    import logging
+
+    logging.getLogger(__name__).warning(
+        "sqlite runs db unavailable (%s); local fallback disabled", e
+    )
 
 
 # ── MongoDB dispatch ──────────────────────────────────────────────────────


### PR DESCRIPTION
run_entity_stats imports the SQLite fallback whose import-time init opens the database read-write, which crashed the entity-store build in the lake-ingest container where /data is mounted read-only.