### PR TITLE
Load the charts frame from an ingest-built parquet

### DIFF
--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -38,6 +38,66 @@ _DATA_DIR = Path(
 )
 _RUNS_DIR = _DATA_DIR / "runs"
 
+# Ingest-built frame snapshot: the exact per-run tuples below, dumped to
+# parquet once per ingest so workers load the frame in seconds instead of
+# scanning Mongo for 15 minutes per boot (the scan wedged under any
+# concurrent load and took the chart pages down repeatedly on 2026-08-25/26).
+_FRAME_PARQUET = Path(os.environ.get("LAKE_DIR", "/lake")) / "frame.parquet"
+_FRAME_PARQUET_MAX_AGE = 24 * 3600
+_FRAME_COLS = (
+    "character VARCHAR, win TINYINT, ascension INT, game_mode VARCHAR,"
+    " player_count INT, run_time BIGINT, floors_reached INT, deck_size INT,"
+    " relic_count INT, played_day INT, username VARCHAR, was_abandoned TINYINT,"
+    " acts_completed INT, daily_date VARCHAR, build_id VARCHAR"
+)
+
+
+def _load_frame_parquet() -> list[tuple] | None:
+    """The ingest-built frame, or None (missing, stale, or unreadable)."""
+    try:
+        if not _FRAME_PARQUET.exists():
+            return None
+        if time.time() - _FRAME_PARQUET.stat().st_mtime > _FRAME_PARQUET_MAX_AGE:
+            logger.warning("frame parquet is stale; falling back to the DB scan")
+            return None
+        import duckdb
+
+        con = duckdb.connect()
+        try:
+            rows = con.execute(
+                f"SELECT * FROM read_parquet('{_FRAME_PARQUET}')"
+            ).fetchall()
+        finally:
+            con.close()
+        return rows or None
+    except Exception:
+        logger.warning("frame parquet load failed; falling back", exc_info=True)
+        return None
+
+
+def store_frame_parquet() -> int:
+    """Ingest-time: run the canonical frame builder once and dump the rows
+    to parquet for every worker to load cheaply. Returns the row count."""
+    import duckdb
+
+    rows = _load_frame_from_db()
+    con = duckdb.connect()
+    try:
+        con.execute(f"CREATE TABLE f ({_FRAME_COLS})")
+        con.executemany(f"INSERT INTO f VALUES ({', '.join('?' * 15)})", rows)
+        tmp = _FRAME_PARQUET.with_suffix(".parquet.tmp")
+        con.execute(f"COPY f TO '{tmp}' (FORMAT parquet, COMPRESSION zstd)")
+        tmp.replace(_FRAME_PARQUET)
+    finally:
+        con.close()
+    logger.info(
+        "frame parquet stored: %d rows, %d bytes",
+        len(rows),
+        _FRAME_PARQUET.stat().st_size,
+    )
+    return len(rows)
+
+
 # ── Frame: per-run metadata tuples ───────────────────────────────────────────
 
 # Tuple indices (kept positional to stay light at 200k+ rows).
@@ -124,6 +184,13 @@ def _daily_date(seed: str | None, game_mode: str) -> str:
 
 
 def _load_frame() -> list[tuple]:
+    cached = _load_frame_parquet()
+    if cached is not None:
+        return cached
+    return _load_frame_from_db()
+
+
+def _load_frame_from_db() -> list[tuple]:
     rows: list[tuple] = []
     if os.environ.get("MONGO_URL", "").strip():
         from .runs_db_mongo import _get_collection

--- a/backend/tests/test_frame_parquet.py
+++ b/backend/tests/test_frame_parquet.py
@@ -1,0 +1,47 @@
+from app.services import charts_stats as cs
+
+
+def _sample_rows():
+    return [
+        (
+            "IRONCLAD",
+            1,
+            10,
+            "standard",
+            1,
+            3600,
+            45,
+            30,
+            12,
+            20600,
+            "yitsy",
+            0,
+            3,
+            "",
+            "0.111.0",
+        ),
+        ("ALL", 0, 0, "daily", 2, 0, 12, 15, 3, 20601, "", 1, 1, "2026-08-26", ""),
+    ]
+
+
+def test_frame_parquet_roundtrip(monkeypatch, tmp_path):
+    monkeypatch.setattr(cs, "_FRAME_PARQUET", tmp_path / "frame.parquet")
+    monkeypatch.setattr(cs, "_load_frame_from_db", _sample_rows)
+    n = cs.store_frame_parquet()
+    assert n == 2
+    loaded = cs._load_frame_parquet()
+    assert loaded == _sample_rows()
+    # the public loader prefers the parquet over the DB scan
+    assert cs._load_frame() == _sample_rows()
+
+
+def test_frame_parquet_stale_falls_back(monkeypatch, tmp_path):
+    import os
+    import time
+
+    monkeypatch.setattr(cs, "_FRAME_PARQUET", tmp_path / "frame.parquet")
+    monkeypatch.setattr(cs, "_load_frame_from_db", _sample_rows)
+    cs.store_frame_parquet()
+    old = time.time() - cs._FRAME_PARQUET_MAX_AGE - 60
+    os.utime(cs._FRAME_PARQUET, (old, old))
+    assert cs._load_frame_parquet() is None

--- a/lab/ingest.py
+++ b/lab/ingest.py
@@ -57,6 +57,13 @@ def main() -> None:
         print(f"leaderboard summary refreshed ({n} boards)", flush=True)
     except Exception as e:
         print(f"summary refresh failed: {e}", flush=True)
+    try:
+        from app.services.charts_stats import store_frame_parquet
+
+        n = store_frame_parquet()
+        print(f"frame parquet stored ({n} rows)", flush=True)
+    except Exception as e:
+        print(f"frame parquet failed: {e}", flush=True)
     print("ingest complete", flush=True)
 
 


### PR DESCRIPTION
The ingest runs the canonical frame builder once and dumps the rows to frame.parquet, so workers load the frame in seconds with the Mongo scan kept only as a fallback -- the boot-scan wedge that kept taking the chart pages down is gone.