### PR TITLE
Durable profile insights: database store of record, Redis in front

### DIFF
--- a/backend/app/services/user_insights.py
+++ b/backend/app/services/user_insights.py
@@ -487,6 +487,41 @@ def _fresh_key(cache_key: str) -> str:
     return f"user_insights:fresh:{cache_key}"
 
 
+def _insights_coll():
+    """Durable store for computed insight payloads: database first, Redis
+    in front. Redis expiry or eviction can never empty a profile again --
+    only a user who has never been computed shows the building state."""
+    from .runs_db_mongo import _get_collection
+
+    return _get_collection().database["user_insights"]
+
+
+def _store_payload(cache_key: str, payload: dict) -> None:
+    try:
+        from datetime import datetime, timezone
+
+        _insights_coll().replace_one(
+            {"_id": cache_key},
+            {
+                "_id": cache_key,
+                "payload": payload,
+                "updated_at": datetime.now(timezone.utc),
+            },
+            upsert=True,
+        )
+    except Exception:
+        logger.warning("insights durable store write failed", exc_info=True)
+
+
+def _load_stored_payload(cache_key: str) -> dict | None:
+    try:
+        doc = _insights_coll().find_one({"_id": cache_key})
+        return doc.get("payload") if doc else None
+    except Exception:
+        logger.warning("insights durable store read failed", exc_info=True)
+        return None
+
+
 def get_user_insights(
     user_id: str,
     username: str | None = None,
@@ -511,6 +546,12 @@ def get_user_insights(
     if payload is not None and app_cache.get_json(_fresh_key(cache_key)) is not None:
         _cache_put(cache_key, payload)
         return payload
+    if payload is None:
+        # Redis miss: the database is the store of record. Serve the stored
+        # copy immediately and let the background refresh recompute it.
+        payload = _load_stored_payload(cache_key)
+        if payload is not None:
+            app_cache.set_json(_payload_key(cache_key), payload, _STALE_REDIS_TTL)
     _kick_refresh(cache_key, user_id, username, character, ascension, version, players)
     if payload is not None:
         return payload
@@ -530,6 +571,8 @@ def prewarm_user_insights(user_id: str, username: str | None = None) -> None:
     if _cache_get(cache_key) is not None:
         return
     if app_cache.get_json(_payload_key(cache_key)) is not None:
+        return
+    if _load_stored_payload(cache_key) is not None:
         return
     _kick_refresh(cache_key, user_id, username, None, None, None, None)
 
@@ -588,6 +631,7 @@ def _kick_refresh(
                     app_cache.set_json(_payload_key(key), enc, _STALE_REDIS_TTL)
                     app_cache.set_json(_fresh_key(key), 1, int(_CACHE_TTL))
                     _cache_put(key, enc)
+                    _store_payload(key, enc)
                 return
             payload = jsonable_encoder(
                 _compute_insights(
@@ -602,6 +646,7 @@ def _kick_refresh(
             app_cache.set_json(_payload_key(cache_key), payload, _STALE_REDIS_TTL)
             app_cache.set_json(_fresh_key(cache_key), 1, int(_CACHE_TTL))
             _cache_put(cache_key, payload)
+            _store_payload(cache_key, payload)
         except Exception:
             logger.warning("user-insights refresh failed", exc_info=True)
         finally:

--- a/backend/app/services/user_insights.py
+++ b/backend/app/services/user_insights.py
@@ -414,7 +414,11 @@ def _bare_character(raw: str | None) -> str:
 # live in Redis so all workers share them; a fresh marker with the old 120s
 # TTL decides when to re-walk, and stale copies keep serving instantly while
 # the refresh runs behind them.
-_STALE_REDIS_TTL = 24 * 3600
+# 7 days, not 24h: the payload is stale-while-revalidate, so serving an old
+# profile instantly beats an empty one in every case -- 24h TTLs let a
+# two-day incident window (2026-08-25/26) empty every profile on the site
+# into the building placeholder at once.
+_STALE_REDIS_TTL = 7 * 24 * 3600
 _LOCK_TTL = 15 * 60
 
 _inflight: set[str] = set()

--- a/backend/tests/test_user_insights_store.py
+++ b/backend/tests/test_user_insights_store.py
@@ -1,0 +1,48 @@
+from app.services import user_insights as ui
+
+
+class FakeColl:
+    def __init__(self):
+        self.docs = {}
+
+    def replace_one(self, flt, doc, upsert=False):
+        self.docs[flt["_id"]] = doc
+
+    def find_one(self, flt):
+        return self.docs.get(flt["_id"])
+
+
+def test_redis_miss_serves_durable_store(monkeypatch):
+    fake = FakeColl()
+    fake.docs["u1:"] = {"_id": "u1:", "payload": {"total_runs": 42}}
+    monkeypatch.setattr(ui, "_insights_coll", lambda: fake)
+    monkeypatch.setattr(ui, "_cache_get", lambda k: None)
+    stored_redis = {}
+    monkeypatch.setattr("app.services.cache.get_json", lambda k: None)
+    monkeypatch.setattr(
+        "app.services.cache.set_json",
+        lambda k, v, ttl_seconds=None: stored_redis.__setitem__(k, v),
+    )
+    kicked = []
+    monkeypatch.setattr(ui, "_kick_refresh", lambda *a: kicked.append(a))
+    out = ui.get_user_insights("u1")
+    assert out == {"total_runs": 42}
+    assert stored_redis, "redis should be re-warmed from the store"
+    assert kicked, "a background refresh should still be kicked"
+
+
+def test_never_computed_still_builds(monkeypatch):
+    monkeypatch.setattr(ui, "_insights_coll", lambda: FakeColl())
+    monkeypatch.setattr(ui, "_cache_get", lambda k: None)
+    monkeypatch.setattr("app.services.cache.get_json", lambda k: None)
+    monkeypatch.setattr(ui, "_kick_refresh", lambda *a: None)
+    assert ui.get_user_insights("nobody") == {"building": True}
+
+
+def test_store_write_failure_is_soft(monkeypatch):
+    class Boom:
+        def replace_one(self, *a, **k):
+            raise RuntimeError("db down")
+
+    monkeypatch.setattr(ui, "_insights_coll", lambda: Boom())
+    ui._store_payload("k", {"x": 1})  # must not raise


### PR DESCRIPTION
Profile payloads now persist in a user_insights collection with Redis as the read-through cache (redis miss -> database -> re-warm redis -> background refresh), so cache expiry or incident windows can never empty profiles into the building placeholder again; the placeholder now only appears for users never computed, and the Redis TTL rises to 7 days as belt on top.