### PR TITLE
Canonical counting: official-only totals, abandons explicit

### DIFF
--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -1067,6 +1067,11 @@ def _stats_core_results() -> list[tuple[dict, dict]]:
         return round(w / n * 100, 1) if n > 0 else 0
 
     out: list[tuple[dict, dict]] = []
+    # Canonical counting (ruling 2026-08-27): totals cover OFFICIAL
+    # characters only, so every headline equals the sum of its character
+    # table; abandons stay their own visible number, never folded into
+    # losses; win_rate remains wins over total attempts.
+    cells = [c for c in cells if c[0] in OFFICIAL_CHARACTERS]
     for f in [*HOT_FILTER_COMBOS, *ASCENSION_FILTER_COMBOS]:
         char_f = f.get("character")
         asc_f = int(f["ascension"]) if "ascension" in f else None
@@ -1092,14 +1097,16 @@ def _stats_core_results() -> list[tuple[dict, dict]]:
         no_char = [c for c in cells if asc_f is None or c[1] == asc_f]
         char_totals: dict[str, list[int]] = {}
         for c in no_char:
-            rec = char_totals.setdefault(c[0], [0, 0])
+            rec = char_totals.setdefault(c[0], [0, 0, 0])
             rec[0] += c[2]
             rec[1] += c[3]
+            rec[2] += c[4]
         asc_totals: dict[int, list[int]] = {}
         for c in rows:
-            rec = asc_totals.setdefault(c[1], [0, 0])
+            rec = asc_totals.setdefault(c[1], [0, 0, 0])
             rec[0] += c[2]
             rec[1] += c[3]
+            rec[2] += c[4]
         out.append(
             (
                 f,
@@ -1114,21 +1121,22 @@ def _stats_core_results() -> list[tuple[dict, dict]]:
                             "character": ch,
                             "total": t,
                             "wins": w,
+                            "abandoned": ab,
                             "win_rate": pct(w, t),
                         }
-                        for ch, (t, w) in sorted(
+                        for ch, (t, w, ab) in sorted(
                             char_totals.items(), key=lambda kv: -kv[1][0]
                         )
-                        if ch in OFFICIAL_CHARACTERS
                     ],
                     "ascensions": [
                         {
                             "level": a,
                             "total": t,
                             "wins": w,
+                            "abandoned": ab,
                             "win_rate": pct(w, t),
                         }
-                        for a, (t, w) in sorted(asc_totals.items())
+                        for a, (t, w, ab) in sorted(asc_totals.items())
                     ],
                 },
             )

--- a/backend/tests/test_lake_stats.py
+++ b/backend/tests/test_lake_stats.py
@@ -83,3 +83,33 @@ def test_lake_entity_overlay(monkeypatch, tmp_path):
     finally:
         res._cache.pop(("cards", "ZAP"), None)
         res._type_baselines.pop("cards", None)
+
+
+def test_stats_core_excludes_modded_characters(monkeypatch):
+    cells = [
+        ("IRONCLAD", 0, 100, 30, 5),
+        ("SILENT", 10, 50, 20, 2),
+        ("THE_MODDED_ONE", 0, 40, 39, 0),
+    ]
+    monkeypatch.setattr(lake_stats, "_connect", lambda build=False: None)
+
+    class FakeCon:
+        def execute(self, *a):
+            return self
+
+        def fetchall(self):
+            return cells
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(lake_stats, "_connect", lambda build=False: FakeCon())
+    results = dict(
+        (tuple(sorted(lake_stats.filters_compact(f).items())), r)
+        for f, r in lake_stats._stats_core_results()
+    )
+    g = results[()]
+    assert g["total_runs"] == 150, "modded character runs must not count"
+    assert g["total_wins"] == 50
+    assert sum(c["total"] for c in g["characters"]) == g["total_runs"]
+    assert all("abandoned" in c for c in g["characters"])

--- a/frontend/app/components/HomeStatsLive.tsx
+++ b/frontend/app/components/HomeStatsLive.tsx
@@ -133,7 +133,7 @@ export default function HomeStatsLive({
                       <span className="wr-fill" style={{ width: `${relPct}%`, background: charColor }} />
                     </span>
                     <span className="wr-wl">
-                      {c.wins}W / {c.total - c.wins}L
+                      {c.wins}W / {c.total - c.wins - (c.abandoned || 0)}L
                     </span>
                     <span className="wr-num" style={{ color: winRateColor(c.win_rate) }}>
                       {c.win_rate}%

--- a/frontend/app/components/HomeStatsSection.tsx
+++ b/frontend/app/components/HomeStatsSection.tsx
@@ -13,7 +13,7 @@ export interface CommunityStats {
   total_wins: number;
   total_abandoned: number;
   win_rate: number;
-  characters: { character: string; total: number; wins: number; win_rate: number }[];
+  characters: { character: string; total: number; wins: number; abandoned?: number; win_rate: number }[];
 }
 
 async function loadStats(): Promise<CommunityStats | null> {

--- a/frontend/app/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/leaderboards/stats/StatsClient.tsx
@@ -107,8 +107,8 @@ export interface CommunityStats {
     game_mode: string | null;
     players: string | null;
   };
-  characters: { character: string; total: number; wins: number; win_rate: number }[];
-  ascensions: { level: number; total: number; wins: number; win_rate: number }[];
+  characters: { character: string; total: number; wins: number; abandoned?: number; win_rate: number }[];
+  ascensions: { level: number; total: number; wins: number; abandoned?: number; win_rate: number }[];
   top_cards: {
     card_id: string;
     count: number;
@@ -1140,7 +1140,7 @@ function OverviewTab({
   return (
     <div className="space-y-4">
       <div className="bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] p-5">
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-center">
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 text-center">
           <div className="bg-[var(--bg-primary)] rounded-lg p-3">
             <div className="text-2xl font-bold text-[var(--text-primary)]">
               {stats.total_runs}
@@ -1154,6 +1154,12 @@ function OverviewTab({
           <div className="bg-[var(--bg-primary)] rounded-lg p-3">
             <div className="text-2xl font-bold text-red-400">{losses}</div>
             <div className="text-xs text-[var(--text-muted)]">{t("Losses", lang)}</div>
+          </div>
+          <div className="bg-[var(--bg-primary)] rounded-lg p-3">
+            <div className="text-2xl font-bold text-[var(--text-secondary)]">
+              {stats.total_abandoned || 0}
+            </div>
+            <div className="text-xs text-[var(--text-muted)]">{t("Abandoned", lang)}</div>
           </div>
           <div className="bg-[var(--bg-primary)] rounded-lg p-3">
             <div className="text-2xl font-bold text-[var(--accent-gold)]">
@@ -1195,7 +1201,8 @@ function OverviewTab({
                     </span>
                     <div className="flex items-center gap-3 text-xs">
                       <span className="text-[var(--text-muted)]">
-                        {c.wins}W / {c.total - c.wins}L
+                        {c.wins}W / {c.total - c.wins - (c.abandoned || 0)}L
+                        {c.abandoned ? ` / ${c.abandoned}A` : ""}
                       </span>
                       <span
                         className="font-semibold tabular-nums"
@@ -1252,7 +1259,7 @@ function OverviewTab({
                   </td>
                   <td className="py-2 text-right text-emerald-400 tabular-nums">{a.wins}</td>
                   <td className="py-2 text-right text-red-400 tabular-nums">
-                    {a.total - a.wins}
+                    {a.total - a.wins - (a.abandoned || 0)}
                   </td>
                   <td
                     className="py-2 text-right font-semibold tabular-nums"


### PR DESCRIPTION
Per the ruling, stats totals cover official characters only so every headline equals the sum of its character table, abandons become an explicit number everywhere (per-character and per-ascension rows carry them, losses exclude them consistently), the stats page gains an Abandoned card, and a modded-character fixture now guards the rule.