### PR TITLE
Fix audit P0s: compact home stats, home board filters, ascension 400, health identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,8 @@ jobs:
         with:
           context: ./backend
           push: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           tags: |
             ptrlrd/spire-codex-backend:latest
             ptrlrd/spire-codex-backend:${{ github.sha }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,6 +19,11 @@ COPY app/ app/
 # without copying files into a running container.
 COPY scripts/ scripts/
 
+# Deploy identity: CI passes the commit SHA so /health can report exactly
+# which build is running (last layer, so it never busts the cache above).
+ARG GIT_SHA=""
+ENV GIT_SHA=$GIT_SHA
+
 EXPOSE 8000
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -780,6 +780,14 @@ def health(request: Request):
         data_through = state.get("submitted_at")
     except Exception:
         pass
+    # The ingest publishes this manifest last, after every artifact of a
+    # cycle landed, so it names the newest COMPLETE generation; individual
+    # store mtimes above can run ahead of it mid-cycle.
+    generation = None
+    try:
+        generation = json.loads((lake_dir / "generation.json").read_text())
+    except Exception:
+        pass
 
     return {
         "status": "ok" if data_ok else "degraded",
@@ -787,6 +795,7 @@ def health(request: Request):
         "git_sha": os.environ.get("GIT_SHA") or None,
         "lake": lake,
         "data_through": data_through,
+        "generation": generation,
     }
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,11 @@
 """Spire Codex API - FastAPI Application."""
 
+import json
 import logging
 import os
 import re
 import time
+from datetime import datetime, timezone
 
 from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -748,15 +750,43 @@ def stats(request: Request, lang: str = Depends(get_lang)):
 
 @app.get("/health", tags=["Health"])
 def health(request: Request):
-    """Health check — verifies the API is running and data is accessible."""
+    """Health check — verifies the API is running and data is accessible.
+
+    Also reports deploy + data identity: the git SHA the image was built
+    from and the lake stores' freshness, so "is the box actually running
+    the merged code / fresh data" is one curl instead of docker inspect.
+    """
     data_dir = Path(
         os.environ.get("DATA_DIR", Path(__file__).resolve().parents[1] / "data")
     )
     eng_dir = data_dir / "eng"
     data_ok = eng_dir.exists() and any(eng_dir.glob("*.json"))
+
+    lake_dir = Path(os.environ.get("LAKE_DIR", "/lake"))
+    lake: dict[str, str | None] = {}
+    for label, name in (
+        ("community_payload", "community_payload.json"),
+        ("entity_store", "entity_store.json"),
+        ("frame_parquet", "frame.parquet"),
+    ):
+        try:
+            ts = (lake_dir / name).stat().st_mtime
+            lake[label] = datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+        except OSError:
+            lake[label] = None
+    data_through = None
+    try:
+        state = json.loads((lake_dir / "staging" / "state.json").read_text())
+        data_through = state.get("submitted_at")
+    except Exception:
+        pass
+
     return {
         "status": "ok" if data_ok else "degraded",
         "data_available": data_ok,
+        "git_sha": os.environ.get("GIT_SHA") or None,
+        "lake": lake,
+        "data_through": data_through,
     }
 
 

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -758,6 +758,7 @@ def get_run_rank(request: Request, run_hash: str, category: str = "fastest"):
 )
 def get_encounter_stats_endpoint(
     request: Request,
+    response: Response,
     act: str | None = None,
     room_type: str | None = None,
     multiplayer: str | None = None,
@@ -821,7 +822,7 @@ def get_encounter_stats_endpoint(
         if room_type
         else None
     )
-    return _get_encounter_stats(
+    result = _get_encounter_stats(
         acts=acts,
         room_types=room_types,
         multiplayer=multiplayer,
@@ -830,6 +831,11 @@ def get_encounter_stats_endpoint(
         bracket=bracket,
         build_id=build_id,
     )
+    # A not-yet-built snapshot answers empty; don't let the edge cache that
+    # for an hour and keep serving zeros after the data lands.
+    if not result.get("encounters"):
+        response.headers["Cache-Control"] = "no-store"
+    return result
 
 
 @router.get("/versions", tags=["Runs"])
@@ -1588,6 +1594,15 @@ def start_stats_refresher() -> None:
     threading.Thread(target=_loop, daemon=True, name="stats-refresher").start()
 
 
+# The homepage needs only the headline numbers + character table; these four
+# arrays are ~4.2MB of the ~4.3MB payload and only the stats page reads them.
+_HEAVY_STATS_KEYS = ("top_cards", "pick_rates", "top_relics", "top_potions")
+
+
+def _compact_stats(doc: dict) -> dict:
+    return {k: v for k, v in doc.items() if k not in _HEAVY_STATS_KEYS}
+
+
 @router.get("/stats", tags=["Runs"])
 @limiter.limit(
     rate_limit_config.endpoint_limit("runs.get_community_stats", "120/minute")
@@ -1600,6 +1615,7 @@ def get_community_stats(
     game_mode: str | None = None,
     players: str | None = None,
     username: str | None = None,
+    compact: bool = False,
 ):
     """Get aggregated run stats. Community-wide by default; pass
     `username` to narrow to a single uploader.
@@ -1616,6 +1632,11 @@ def get_community_stats(
     # keyed and matched on the lowercased name).
     if username:
         username = username.strip().lower()
+    if ascension is not None and ascension.strip():
+        try:
+            int(ascension)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="ascension must be an integer")
     # 0. Redis layer: one cluster-wide copy per filter combo, refreshed on
     # the same cadence as the refresher cycle. Misses fall through to the
     # existing chain unchanged.
@@ -1629,7 +1650,7 @@ def get_community_stats(
     )
     redis_cached = app_cache.get_json(redis_key)
     if redis_cached is not None:
-        return redis_cached
+        return _compact_stats(redis_cached) if compact else redis_cached
 
     # 1. Materialized view path
     try:
@@ -1645,7 +1666,7 @@ def get_community_stats(
         )
         if materialized is not None:
             app_cache.set_json(redis_key, materialized, ttl_seconds=60)
-            return materialized
+            return _compact_stats(materialized) if compact else materialized
     except Exception:
         # Not on the Mongo path (SQLite fallback) — keep going.
         pass
@@ -1655,7 +1676,7 @@ def get_community_stats(
     now = time.monotonic()
     hit = _stats_fallback_cache.get(cache_key)
     if hit and now - hit[0] < _STATS_FALLBACK_TTL_SECONDS:
-        return hit[1]
+        return _compact_stats(hit[1]) if compact else hit[1]
     for k in [
         k
         for k, (t, _) in _stats_fallback_cache.items()
@@ -1677,7 +1698,7 @@ def get_community_stats(
             time.sleep(0.25)
             winner = app_cache.get_json(redis_key)
             if winner is not None:
-                return winner
+                return _compact_stats(winner) if compact else winner
 
     try:
         # Bounded so an aggregation that outgrew the data can never hold the
@@ -1729,7 +1750,7 @@ def get_community_stats(
         if lock_acquired:
             app_cache.delete(lock_key)
 
-    return result
+    return _compact_stats(result) if compact else result
 
 
 @router.get("/{run_hash}/similar", tags=["Runs"])

--- a/frontend/app/components/HomeLeaderboardLive.tsx
+++ b/frontend/app/components/HomeLeaderboardLive.tsx
@@ -6,6 +6,7 @@ import { t } from "@/lib/ui-translations";
 import { imageUrl } from "@/lib/image-url";
 import { characterHex } from "@/lib/character-colors";
 import type { FastestBlock, RunRow } from "./HomeLeaderboardSection";
+import { dedupePartyRows } from "@/lib/party-dedupe";
 
 const TARGET_ASCENSION = 10;
 const POLL_MS = 20_000;
@@ -98,14 +99,14 @@ export default function HomeLeaderboardLive({
       fetch(url).then((r) => (r.ok ? r.json() : null)).catch(() => null);
     const load = () => {
       if (document.hidden) return;
-      grab(`${pollBase}/api/runs/leaderboard?category=fastest&ascension_min=${TARGET_ASCENSION}&limit=5`).then((d) => {
+      grab(`${pollBase}/api/runs/leaderboard?category=fastest&ascension_min=${TARGET_ASCENSION}&players=single&game_mode=standard&limit=5`).then((d) => {
         if (active && d?.runs) {
           const runs = (d.runs as RunRow[]).filter((r) => r.win === 1).slice(0, 5);
           if (runs.length) setFastest({ runs, ascension: TARGET_ASCENSION });
         }
       });
-      grab(`${pollBase}/api/runs/leaderboard?category=highest_ascension&game_mode=daily&today=true&limit=5`).then((d) => {
-        if (active && d?.runs) setDaily((d.runs as RunRow[]).slice(0, 5));
+      grab(`${pollBase}/api/runs/leaderboard?category=highest_ascension&game_mode=daily&today=true&limit=15`).then((d) => {
+        if (active && d?.runs) setDaily(dedupePartyRows(d.runs as RunRow[]).slice(0, 5));
       });
       grab(`${pollBase}/api/runs/list?limit=5&sort=newest`).then((d) => {
         if (active && d?.runs) setRecent(d.runs as RunRow[]);

--- a/frontend/app/components/HomeLeaderboardSection.tsx
+++ b/frontend/app/components/HomeLeaderboardSection.tsx
@@ -1,4 +1,5 @@
 import HomeLeaderboardLive from "./HomeLeaderboardLive";
+import { dedupePartyRows } from "@/lib/party-dedupe";
 
 const API = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 const RUNS_HOST = "";
@@ -37,7 +38,7 @@ interface RunListResponse {
 async function loadFastestWins(): Promise<FastestBlock> {
   try {
     const res = await fetch(
-      `${RUNS_API}/api/runs/leaderboard?category=fastest&ascension_min=${TARGET_ASCENSION}&limit=5`,
+      `${RUNS_API}/api/runs/leaderboard?category=fastest&ascension_min=${TARGET_ASCENSION}&players=single&game_mode=standard&limit=5`,
       { next: { revalidate: REVALIDATE } },
     );
     if (!res.ok) return { runs: [], ascension: null };
@@ -65,12 +66,12 @@ async function loadRecentRuns(): Promise<RunRow[]> {
 async function loadDailyClimb(): Promise<RunRow[]> {
   try {
     const res = await fetch(
-      `${RUNS_API}/api/runs/leaderboard?category=highest_ascension&game_mode=daily&today=true&limit=5`,
+      `${RUNS_API}/api/runs/leaderboard?category=highest_ascension&game_mode=daily&today=true&limit=15`,
       { next: { revalidate: REVALIDATE } },
     );
     if (!res.ok) return [];
     const data = (await res.json()) as { runs: RunRow[] };
-    return (data.runs ?? []).slice(0, 5);
+    return dedupePartyRows(data.runs ?? []).slice(0, 5);
   } catch {
     return [];
   }

--- a/frontend/app/components/HomeStatsLive.tsx
+++ b/frontend/app/components/HomeStatsLive.tsx
@@ -52,7 +52,7 @@ export default function HomeStatsLive({
     let active = true;
     const load = () => {
       if (document.hidden) return;
-      fetch(`${pollBase}/api/runs/stats`)
+      fetch(`${pollBase}/api/runs/stats?compact=1`)
         .then((r) => (r.ok ? r.json() : null))
         .then((d) => {
           if (active && d?.total_runs) setStats(d as CommunityStats);

--- a/frontend/app/components/HomeStatsSection.tsx
+++ b/frontend/app/components/HomeStatsSection.tsx
@@ -18,7 +18,7 @@ export interface CommunityStats {
 
 async function loadStats(): Promise<CommunityStats | null> {
   try {
-    const res = await fetch(`${RUNS_API}/api/runs/stats`, { next: { revalidate: REVALIDATE } });
+    const res = await fetch(`${RUNS_API}/api/runs/stats?compact=1`, { next: { revalidate: REVALIDATE } });
     if (!res.ok) return null;
     return (await res.json()) as CommunityStats;
   } catch {

--- a/frontend/lib/party-dedupe.ts
+++ b/frontend/lib/party-dedupe.ts
@@ -1,0 +1,14 @@
+// Party runs fan out to one leaderboard row per player, so boards that
+// don't filter to players=single show the same run once per member.
+// Collapse by (run_time, submitted_at), which party members share.
+export function dedupePartyRows<
+  T extends { run_time: number; submitted_at: string },
+>(rows: T[]): T[] {
+  const seen = new Set<string>();
+  return rows.filter((r) => {
+    const key = `${r.run_time}|${r.submitted_at}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}


### PR DESCRIPTION
I fixed the surviving P0s from the production audit: the homepage now requests a compact stats payload (drops the ~4.2MB of arrays it never reads, server render and browser polls both), the home fastest board pins single/standard and daily rows dedupe party members, bad ascension values return 400 instead of 500, /health reports the running image's git SHA plus lake store freshness, and empty encounter-stats responses are no-store so the edge can't cache zeros.