### PR TITLE
Ingest generation contract: lock, cycle metrics, manifest, frame hot-reload

### DIFF
--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -327,7 +327,14 @@ def frame_loading() -> bool:
 
 
 def _frame_fresh() -> bool:
-    return _FRAME_OK and time.time() - _FRAME_TS < _FRAME_TTL
+    if not (_FRAME_OK and time.time() - _FRAME_TS < _FRAME_TTL):
+        return False
+    # A newly published frame.parquet must be picked up without waiting out
+    # the TTL or restarting workers — the ingest cadence depends on it.
+    try:
+        return _FRAME_PARQUET.stat().st_mtime <= _FRAME_TS
+    except OSError:
+        return True
 
 
 def get_frame(wait: bool = False) -> list[tuple]:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -219,9 +219,13 @@ services:
         max-file: "5"
 
 
-  # Nightly analytics-lake ingest (incremental extract + parquet rebuild).
-  # profiles: never started by `up -d`; host cron runs it, e.g.
-  #   17 9 * * * cd /var/www/spire-codex && docker compose -f docker-compose.prod.yml run --rm lake-ingest >> /var/log/lake-ingest.log 2>&1
+  # Analytics-lake ingest (incremental extract + parquet + store rebuild).
+  # profiles: never started by `up -d`; host cron runs it every 6 hours:
+  #   17 */6 * * * cd /var/www/spire-codex && docker compose -f docker-compose.prod.yml run --rm lake-ingest >> /var/log/lake-ingest.log 2>&1
+  # Overlap-safe: the ingest takes /lake/ingest.lock (flock) and exits if a
+  # prior run still holds it. Keep 6h until three consecutive cycles publish
+  # complete generations (see /lake/ingest_metrics.jsonl) and the max cycle
+  # time sits well under the interval; only then tighten the cadence.
   lake-ingest:
     image: ptrlrd/spire-codex-backend:latest
     profiles: ["ops"]

--- a/lab/extract.py
+++ b/lab/extract.py
@@ -72,11 +72,12 @@ def _refresh_excluded(coll) -> None:
     print(f"excluded sidecar refreshed: {n:,} hidden/deleted runs", flush=True)
 
 
-def main() -> None:
+def main() -> tuple[int, int]:
+    """Returns (written, skipped) so the ingest can record cycle metrics."""
     STAGING.mkdir(parents=True, exist_ok=True)
     if "--bootstrap" in sys.argv:
         _bootstrap()
-        return
+        return (0, 0)
     coll = _get_collection()
     _refresh_excluded(coll)
 
@@ -186,6 +187,7 @@ def main() -> None:
         f"{(time.time() - t0) / 60:.1f} min",
         flush=True,
     )
+    return (written, skipped)
 
 
 if __name__ == "__main__":

--- a/lab/ingest.py
+++ b/lab/ingest.py
@@ -7,17 +7,41 @@ present, so the nightly log carries fresh comparison inputs for free.
     docker compose -f docker-compose.prod.yml run --rm lake-ingest
 """
 
+import json
 import pathlib
 import sys
+import time
 
 sys.path.insert(0, "/lab")
 sys.path.insert(0, "/app")
 
 import extract
 
+LAKE = pathlib.Path("/lake")
+
+
+def _utc(ts: float) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts))
+
 
 def main() -> None:
-    extract.main()
+    # One ingest at a time: an overlapping cron start would race the shared
+    # scratch DB and double the box's memory pressure. The lock lives for
+    # the process; a crashed run releases it automatically.
+    import fcntl
+
+    lock = open(LAKE / "ingest.lock", "w")
+    try:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        print("another ingest holds /lake/ingest.lock; exiting", flush=True)
+        sys.exit(1)
+
+    t0 = time.time()
+    generation_id = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(t0))
+    print(f"generation {generation_id} starting", flush=True)
+    extracted = extract.main() or (0, 0)
+    t_extract = time.time()
 
     import duckdb
 
@@ -33,6 +57,7 @@ def main() -> None:
             continue
         con.execute(path.read_text())
         print(f"{name}: done", flush=True)
+    t_build = time.time()
     try:
         from app.services import lake_stats
 
@@ -75,6 +100,7 @@ def main() -> None:
     # The edge is the last stale layer: origin freshness means nothing while
     # Cloudflare serves yesterday's JSON. Purge exactly the URLs this run
     # refreshed (CF_TOKEN/CF_ZONE come from the same .env the admin tab uses).
+    purge_ok = None
     try:
         import os
 
@@ -106,12 +132,74 @@ def main() -> None:
                 json={"files": files},
                 timeout=15,
             )
-            ok = resp.status_code == 200 and resp.json().get("success") is True
-            print(f"edge purge: ok={ok} ({len(files)} urls)", flush=True)
+            purge_ok = resp.status_code == 200 and resp.json().get("success") is True
+            print(f"edge purge: ok={purge_ok} ({len(files)} urls)", flush=True)
         else:
             print("edge purge skipped: CF_TOKEN/CF_ZONE not set", flush=True)
     except Exception as e:
+        purge_ok = False
         print(f"edge purge failed: {e}", flush=True)
+
+    # Cycle record. Stages publish independently (each store is its own
+    # atomic rename), so the generation manifest is the completeness
+    # contract: it only advances when every serving artifact this cycle
+    # owns was rebuilt after the cycle started. /health reports it; a
+    # cycle that lost a stage leaves the previous manifest in place and
+    # shows up in ingest_metrics.jsonl with complete=false.
+    published = time.time()
+    manifest: dict = {
+        "generation_id": generation_id,
+        "cycle_started_at": _utc(t0),
+        "source_watermark": None,
+        "rows_added": extracted[0],
+        "rows_skipped": extracted[1],
+        "extract_seconds": round(t_extract - t0, 1),
+        "build_sql_seconds": round(t_build - t_extract, 1),
+        "stores_seconds": round(published - t_build, 1),
+        "total_seconds": round(published - t0, 1),
+        "purge_ok": purge_ok,
+        "published_at": _utc(published),
+        "artifacts": {},
+    }
+    try:
+        st = json.loads((LAKE / "staging" / "state.json").read_text())
+        manifest["source_watermark"] = st.get("submitted_at")
+    except Exception:
+        pass
+    required = ("community_payload.json", "entity_store.json", "frame.parquet")
+    for name in required + ("community_cube.json.gz",):
+        try:
+            s = (LAKE / name).stat()
+            manifest["artifacts"][name] = {
+                "bytes": s.st_size,
+                "modified_at": _utc(s.st_mtime),
+            }
+        except OSError:
+            manifest["artifacts"][name] = None
+    manifest["complete"] = all(
+        (a := manifest["artifacts"].get(n)) and a["modified_at"] >= _utc(t0)
+        for n in required
+    )
+    with open(LAKE / "ingest_metrics.jsonl", "a", encoding="utf-8") as f:
+        f.write(json.dumps(manifest, separators=(",", ":")) + "\n")
+    if manifest["complete"]:
+        tmp = LAKE / "generation.json.tmp"
+        tmp.write_text(json.dumps(manifest, indent=1))
+        tmp.replace(LAKE / "generation.json")
+        print(f"generation {generation_id} published", flush=True)
+    else:
+        missing = [
+            n
+            for n in required
+            if not (
+                (a := manifest["artifacts"].get(n)) and a["modified_at"] >= _utc(t0)
+            )
+        ]
+        print(
+            f"generation {generation_id} INCOMPLETE (stale: {', '.join(missing)}); "
+            "manifest not advanced",
+            flush=True,
+        )
     print("ingest complete", flush=True)
 
 


### PR DESCRIPTION
I added the cadence-safety contract to the ingest: a flock so overlapping runs exit instead of racing, per-cycle metrics in /lake/ingest_metrics.jsonl (stage timings, rows, artifact sizes, purge result, watermark), a /lake/generation.json manifest that only advances when every serving artifact of the cycle rebuilt (surfaced by /health after #930), and mtime-based frame.parquet pickup so charts refresh without a backend restart.