### PR TITLE
Cap ingest CPU so serving always wins the box

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -237,6 +237,11 @@ services:
     # ingest is the box's main computer, so it gets real memory instead of
     # spilling every heavy aggregate to disk.
     mem_limit: 5g
+    # Serving always wins the box: 3 of 4 cores at most, and an eighth of
+    # the default CPU weight so under contention the kernel hands cycles to
+    # the backend/Mongo first. An idle box still runs the ingest full speed.
+    cpus: 3
+    cpu_shares: 128
     volumes:
       - ./lab:/lab:ro
       - ./data:/data:ro


### PR DESCRIPTION
I capped the lake-ingest container at 3 of 4 cores with an eighth of the default CPU weight: an idle box still runs it full speed, but under contention the kernel hands cycles to the backend and Mongo first, so a cycle can never starve serving.