### PR TITLE
Never store a hollow profile; invalidate insights on submit and claim

### DIFF
--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -527,6 +527,14 @@ def submit_run(
                 # The upsert inside makes the duplicate-submission case cheap.
                 save_run_blob(run_hash, data)
 
+    if linked_user_id is not None and any(r.get("success") for r in results):
+        try:
+            from .user_insights import invalidate_user_insights
+
+            invalidate_user_insights(str(linked_user_id))
+        except Exception:
+            pass
+
     return results[0]
 
 
@@ -1158,6 +1166,15 @@ def claim_runs(username: str, hashes: list[str]) -> dict:
             {"_id": {"$in": unclaimed}, "$or": [{"username": None}, {"username": ""}]},
             {"$set": {"username": username, "username_lower": username.lower()}},
         )
+        try:
+            from .user_insights import invalidate_user_insights
+            from .users_db import get_user_by_username
+
+            owner = get_user_by_username(username)
+            if owner:
+                invalidate_user_insights(str(owner["_id"]))
+        except Exception:
+            pass
 
     return {
         "claimed": len(unclaimed),

--- a/backend/app/services/user_insights.py
+++ b/backend/app/services/user_insights.py
@@ -558,6 +558,26 @@ def get_user_insights(
     return {"building": True}
 
 
+def invalidate_user_insights(user_id: str) -> None:
+    """Mark an account's insight slices stale after it gains runs (submit
+    or claim). The stored payload keeps serving instantly; the next profile
+    view sees the missing fresh marker and kicks a background re-walk, so
+    the profile looks current right after your own upload without paying a
+    walk per submission. Only the prewarmed slices need clearing — ad-hoc
+    slices' fresh markers expire on their own short TTL."""
+    from . import cache as app_cache
+
+    slices: list[tuple] = [(None, None, None, None)]
+    slices += [(c, None, None, None) for c in _PREWARM_CHARACTERS]
+    slices += [(None, 10, None, None), (None, None, None, 1)]
+    for c, a, v, p in slices:
+        key = f"{user_id}{_filters_suffix(c, a, v, p)}"
+        try:
+            app_cache.delete(_fresh_key(key))
+        except Exception:
+            return
+
+
 def prewarm_user_insights(user_id: str, username: str | None = None) -> None:
     """Fill a cold cache before the user ever opens their profile (called from
     /me, which fires on every page load). Kicks the background walk only when
@@ -572,7 +592,11 @@ def prewarm_user_insights(user_id: str, username: str | None = None) -> None:
         return
     if app_cache.get_json(_payload_key(cache_key)) is not None:
         return
-    if _load_stored_payload(cache_key) is not None:
+    stored = _load_stored_payload(cache_key)
+    if stored is not None:
+        # Re-warm Redis (not marked fresh) so the next /me hits Redis
+        # instead of repeating this Mongo read on every page load.
+        app_cache.set_json(_payload_key(cache_key), stored, _STALE_REDIS_TTL)
         return
     _kick_refresh(cache_key, user_id, username, None, None, None, None)
 
@@ -696,6 +720,7 @@ def _compute_insights(
     rows = _apply_row_filters(rows, character, ascension, version, players)
     t1 = time.time()
     blobs = _fetch_blobs(rows)
+    _require_blob_coverage(rows, blobs)
     t2 = time.time()
     acc = community_stats._new_acc_one()
     walked = _accumulate_rows(rows, blobs, acc)
@@ -724,6 +749,22 @@ def _compute_insights(
 
 
 _PREWARM_CHARACTERS = ("IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT")
+
+
+def _require_blob_coverage(rows: list[dict], blobs: dict[str, dict]) -> None:
+    """get_run_blobs degrades quietly under Mongo pressure (other callers
+    have a per-file fallback; this walk doesn't), so a hollow or heavily
+    partial fetch means Mongo was unavailable — not that the runs vanished.
+    Refuse to build the payload rather than durably store an empty profile
+    over a real one. The slack covers the few known-corrupt blobless runs."""
+    if not rows:
+        return
+    have = sum(1 for r in rows if r["run_hash"] in blobs)
+    if have < len(rows) * 0.9:
+        raise RuntimeError(
+            f"insights blob fetch returned {have}/{len(rows)} runs; "
+            "refusing to build a hollow profile"
+        )
 
 
 def _fetch_blobs(rows: list[dict]) -> dict[str, dict]:
@@ -794,6 +835,7 @@ def _compute_insights_all_slices(user_id: str, username: str | None) -> dict[str
         elo_block = None
     t1 = time.time()
     blobs = _fetch_blobs(rows)
+    _require_blob_coverage(rows, blobs)
     t2 = time.time()
 
     slices: list[tuple[tuple, list[dict]]] = [((None, None, None, None), rows)]

--- a/backend/tests/test_user_insights_store.py
+++ b/backend/tests/test_user_insights_store.py
@@ -46,3 +46,34 @@ def test_store_write_failure_is_soft(monkeypatch):
 
     monkeypatch.setattr(ui, "_insights_coll", lambda: Boom())
     ui._store_payload("k", {"x": 1})  # must not raise
+
+
+def test_hollow_blob_fetch_refuses_to_build():
+    rows = [{"run_hash": f"h{i}"} for i in range(100)]
+    ui._require_blob_coverage([], {})
+    ui._require_blob_coverage(rows, {f"h{i}": {} for i in range(100)})
+    ui._require_blob_coverage(rows, {f"h{i}": {} for i in range(95)})
+    import pytest
+
+    with pytest.raises(RuntimeError):
+        ui._require_blob_coverage(rows, {})
+    with pytest.raises(RuntimeError):
+        ui._require_blob_coverage(rows, {f"h{i}": {} for i in range(85)})
+
+
+def test_invalidate_clears_prewarmed_fresh_markers(monkeypatch):
+    deleted = []
+
+    class FakeCache:
+        @staticmethod
+        def delete(key):
+            deleted.append(key)
+
+    import app.services.cache as app_cache
+
+    monkeypatch.setattr(app_cache, "delete", FakeCache.delete)
+    ui.invalidate_user_insights("u1")
+    assert (
+        f"user_insights:fresh:u1{ui._filters_suffix(None, None, None, None)}" in deleted
+    )
+    assert len(deleted) == 8


### PR DESCRIPTION
I fixed the empty-profile bug: the insights walk now refuses to build (and durably store) a payload when the blob fetch came back hollow or heavily partial, which is what happened to profiles during tonight's Mongo contention. Submitting or claiming runs now clears the account's fresh markers so the profile re-walks on next view and always looks current after your own upload, and the prewarm re-warms Redis from the durable store instead of re-reading Mongo on every /me.