### PR TITLE
Canonicalize public stats filters; stop durable-document minting

### DIFF
--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -22,9 +22,11 @@ def _validate_insight_filters(
 
     from fastapi import HTTPException
 
-    if ascension is not None and not (0 <= ascension <= 20):
+    if ascension is not None and not (0 <= ascension <= 10):
         raise HTTPException(status_code=400, detail="ascension out of range")
-    if version is not None and not re.fullmatch(r"v\d+(\.\d+){0,3}", version):
+    if version is not None and (
+        len(version) > 16 or not re.fullmatch(r"v\d{1,2}(\.\d{1,4}){0,3}", version)
+    ):
         raise HTTPException(status_code=400, detail="bad version")
     if players is not None and players not in (1, 2, 3, 4):
         raise HTTPException(status_code=400, detail="players must be 1-4")

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import re
 import time
 from functools import lru_cache
 from pathlib import Path
@@ -564,6 +565,21 @@ def get_leaderboard(
     Single-player and multiplayer runs aren't directly comparable, so the
     frontend reads them as disjoint pools.
     """
+    # Same canonicalize-before-keys rule as /stats: reject unknown spellings
+    # instead of minting per-spelling cache keys (an invalid category used to
+    # silently get fastest semantics under its own key).
+    if category not in ("fastest", "highest_ascension"):
+        raise HTTPException(status_code=400, detail="bad category")
+    if players not in (None, "", "single", "multi", "1", "2", "3", "4"):
+        raise HTTPException(status_code=400, detail="bad players")
+    if game_mode not in (None, "", "standard", "daily", "custom"):
+        raise HTTPException(status_code=400, detail="bad game_mode")
+    if character:
+        character = character.strip().upper()
+        if not re.fullmatch(r"[A-Z0-9_]{1,40}", character):
+            raise HTTPException(status_code=400, detail="bad character")
+    if build_id is not None and not re.fullmatch(r"v[0-9.]{1,15}", build_id):
+        raise HTTPException(status_code=400, detail="bad build_id")
     # Edge/browser caching: 30s of ladder staleness is invisible and lets
     # Cloudflare absorb repeat hits now that the frontend stopped cache-busting.
     response.headers["Cache-Control"] = "public, max-age=30"
@@ -1627,16 +1643,33 @@ def get_community_stats(
          materialized yet, fall through to a process-local TTL cache.
       3. On cache miss, run the live aggregation (slow, ~5-10s).
     """
-    # Normalize once so the Redis key, the materialized-summary key, and the DB
-    # filter all key off the same case-insensitive value (the per-user docs are
-    # keyed and matched on the lowercased name).
+    # Canonicalize every filter BEFORE any key is built from it. Each raw
+    # spelling otherwise mints its own Redis key, lock, TTL-cache entry, and
+    # permanent stats_summary document — an unauthenticated amplification
+    # vector (e.g. every out-of-range ascension aliased to the same official
+    # query under a distinct durable key).
     if username:
         username = username.strip().lower()
+        if not re.fullmatch(r"[a-z0-9_\- ]{1,32}", username):
+            raise HTTPException(status_code=400, detail="bad username")
+    if character:
+        character = character.strip().upper()
+        if not re.fullmatch(r"[A-Z0-9_]{1,40}", character):
+            raise HTTPException(status_code=400, detail="bad character")
+    if win not in (None, "", "true", "false", "abandoned"):
+        raise HTTPException(status_code=400, detail="bad win filter")
+    if game_mode not in (None, "", "standard", "daily", "custom"):
+        raise HTTPException(status_code=400, detail="bad game_mode")
+    if players not in (None, "", "single", "multi", "1", "2", "3", "4"):
+        raise HTTPException(status_code=400, detail="bad players")
     if ascension is not None and ascension.strip():
         try:
-            int(ascension)
+            asc = int(ascension)
         except ValueError:
             raise HTTPException(status_code=400, detail="ascension must be an integer")
+        if not 0 <= asc <= 10:
+            raise HTTPException(status_code=400, detail="ascension must be 0-10")
+        ascension = str(asc)
     # 0. Redis layer: one cluster-wide copy per filter combo, refreshed on
     # the same cadence as the refresher cycle. Misses fall through to the
     # existing chain unchanged.
@@ -1735,15 +1768,18 @@ def get_community_stats(
         try:
             from ..services.runs_db_mongo import write_stats_summary
 
-            write_stats_summary(
-                result,
-                character=character,
-                win=win,
-                ascension=ascension,
-                game_mode=game_mode,
-                players=players,
-                username=username,
-            )
+            # Empty results (junk username, no matching runs) aren't worth a
+            # permanent summary document; Redis's 60s copy absorbs repeats.
+            if result.get("total_runs"):
+                write_stats_summary(
+                    result,
+                    character=character,
+                    win=win,
+                    ascension=ascension,
+                    game_mode=game_mode,
+                    players=players,
+                    username=username,
+                )
         except Exception:
             pass
     finally:

--- a/backend/app/services/user_insights.py
+++ b/backend/app/services/user_insights.py
@@ -558,6 +558,15 @@ def get_user_insights(
     return {"building": True}
 
 
+def _prewarm_slices() -> list[tuple]:
+    """The filter slices with durable standing: the unfiltered profile plus
+    the dropdown picks the prewarmer builds (each character, A10, Solo)."""
+    slices: list[tuple] = [(None, None, None, None)]
+    slices += [(c, None, None, None) for c in _PREWARM_CHARACTERS]
+    slices += [(None, 10, None, None), (None, None, None, 1)]
+    return slices
+
+
 def invalidate_user_insights(user_id: str) -> None:
     """Mark an account's insight slices stale after it gains runs (submit
     or claim). The stored payload keeps serving instantly; the next profile
@@ -567,10 +576,7 @@ def invalidate_user_insights(user_id: str) -> None:
     slices' fresh markers expire on their own short TTL."""
     from . import cache as app_cache
 
-    slices: list[tuple] = [(None, None, None, None)]
-    slices += [(c, None, None, None) for c in _PREWARM_CHARACTERS]
-    slices += [(None, 10, None, None), (None, None, None, 1)]
-    for c, a, v, p in slices:
+    for c, a, v, p in _prewarm_slices():
         key = f"{user_id}{_filters_suffix(c, a, v, p)}"
         try:
             app_cache.delete(_fresh_key(key))
@@ -670,7 +676,12 @@ def _kick_refresh(
             app_cache.set_json(_payload_key(cache_key), payload, _STALE_REDIS_TTL)
             app_cache.set_json(_fresh_key(cache_key), 1, int(_CACHE_TTL))
             _cache_put(cache_key, payload)
-            _store_payload(cache_key, payload)
+            # Durable standing is reserved for the prewarmed slices; an
+            # ad-hoc tuple (arbitrary version/ascension spellings on the
+            # public endpoint) lives in Redis only, so unauthenticated
+            # requests can't mint permanent user_insights documents.
+            if (character, ascension, version, players) in set(_prewarm_slices()):
+                _store_payload(cache_key, payload)
         except Exception:
             logger.warning("user-insights refresh failed", exc_info=True)
         finally:


### PR DESCRIPTION
I closed the keyspace-amplification findings: /api/runs/stats and /api/runs/leaderboard now reject unknown filter spellings with 400 before any cache key, lock, or summary identity is built (out-of-range ascensions and invalid categories used to alias real queries under unlimited distinct durable keys), empty results are no longer persisted to stats_summary, player insights caps ascension at A10 and bounds versions, and durable user_insights documents are reserved for the prewarmed slices so ad-hoc public tuples live only in Redis.