### PR TITLE
Attribute lake run rows to the document's own character

### DIFF
--- a/lab/build.sql
+++ b/lab/build.sql
@@ -26,12 +26,15 @@ SELECT * FROM read_ndjson('/lake/staging/*.jsonl.gz',
     modifiers: 'VARCHAR[]',
     players: 'STRUCT(id BIGINT, "character" VARCHAR, deck STRUCT(floor_added_to_deck BIGINT, id VARCHAR, current_upgrade_level BIGINT, enchantment STRUCT(id VARCHAR))[], relics STRUCT(id VARCHAR, floor_added_to_deck BIGINT)[], potions STRUCT(id VARCHAR)[])[]',
     map_point_history: 'STRUCT(map_point_type VARCHAR, player_stats STRUCT(player_id BIGINT, current_gold BIGINT, current_hp BIGINT, damage_taken BIGINT, max_hp BIGINT, event_choices STRUCT(title STRUCT("key" VARCHAR, "table" VARCHAR))[], rest_site_choices VARCHAR[], upgraded_cards VARCHAR[], ancient_choice STRUCT(TextKey VARCHAR, title STRUCT("key" VARCHAR, "table" VARCHAR), was_chosen BOOLEAN)[], cards_removed JSON[], card_choices STRUCT(was_picked BOOLEAN, card STRUCT(id VARCHAR))[])[], rooms STRUCT(model_id VARCHAR, room_type VARCHAR, turns_taken BIGINT)[])[][]',
-    _meta: 'STRUCT(username VARCHAR, user_id VARCHAR, hidden BOOLEAN, deleted BOOLEAN, submitted_at TIMESTAMP, played_at TIMESTAMP, player_count BIGINT)'});
+    _meta: 'STRUCT(username VARCHAR, user_id VARCHAR, hidden BOOLEAN, deleted BOOLEAN, submitted_at TIMESTAMP, played_at TIMESTAMP, player_count BIGINT, "character" VARCHAR)'});
 
 
 COPY (
+-- _meta.character is THIS document's player (party siblings share one blob
+-- where players[1] is only right for player 1); the blob fallback covers
+-- pages extracted before the field existed — re-extract to fix history.
 SELECT run_hash,
-  upper(split_part(players[1].character,'.',-1)) AS character,
+  coalesce(upper(_meta."character"), upper(split_part(players[1].character,'.',-1))) AS character,
   win, coalesce(was_abandoned, false) AS was_abandoned,
   ascension, lower(coalesce(game_mode,'standard')) AS game_mode,
   _meta.player_count AS player_count, build_id, seed, start_time, run_time,

--- a/lab/extract.py
+++ b/lab/extract.py
@@ -109,6 +109,7 @@ def main() -> tuple[int, int]:
             "submitted_at": 1,
             "played_at": 1,
             "player_count": 1,
+            "character": 1,
         },
         no_cursor_timeout=True,
     ).sort([("submitted_at", 1), ("_id", 1)])
@@ -146,6 +147,11 @@ def main() -> tuple[int, int]:
                     "submitted_at": _iso(r.get("submitted_at")),
                     "played_at": _iso(r.get("played_at")),
                     "player_count": r.get("player_count") or 1,
+                    # THIS document's character. Party runs fan out to one
+                    # doc per player over the same shared blob, so the
+                    # blob's players[1] is only right for player 1 — every
+                    # sibling was being credited to it.
+                    "character": r.get("character"),
                 }
                 out.write(json.dumps(obj, separators=(",", ":")) + "\n")
                 written += 1


### PR DESCRIPTION
I fixed the party-run character skew in the lake: every sibling document of a multiplayer run was credited to player 1's character because the shared blob's players[1] was the only source, which skewed per-character totals in the stats core. The extract now carries each document's own character in _meta and the build prefers it, with the players[1] fallback covering pages extracted before the field existed — a one-time full re-extract corrects history whenever we schedule it.