### PR TITLE
Show abandons everywhere per canon; fix the party dedupe key

### DIFF
--- a/frontend/app/components/HomeLeaderboardLive.tsx
+++ b/frontend/app/components/HomeLeaderboardLive.tsx
@@ -105,7 +105,7 @@ export default function HomeLeaderboardLive({
           if (runs.length) setFastest({ runs, ascension: TARGET_ASCENSION });
         }
       });
-      grab(`${pollBase}/api/runs/leaderboard?category=highest_ascension&game_mode=daily&today=true&limit=15`).then((d) => {
+      grab(`${pollBase}/api/runs/leaderboard?category=highest_ascension&game_mode=daily&today=true&limit=20`).then((d) => {
         if (active && d?.runs) setDaily(dedupePartyRows(d.runs as RunRow[]).slice(0, 5));
       });
       grab(`${pollBase}/api/runs/list?limit=5&sort=newest`).then((d) => {

--- a/frontend/app/components/HomeLeaderboardSection.tsx
+++ b/frontend/app/components/HomeLeaderboardSection.tsx
@@ -66,7 +66,7 @@ async function loadRecentRuns(): Promise<RunRow[]> {
 async function loadDailyClimb(): Promise<RunRow[]> {
   try {
     const res = await fetch(
-      `${RUNS_API}/api/runs/leaderboard?category=highest_ascension&game_mode=daily&today=true&limit=15`,
+      `${RUNS_API}/api/runs/leaderboard?category=highest_ascension&game_mode=daily&today=true&limit=20`,
       { next: { revalidate: REVALIDATE } },
     );
     if (!res.ok) return [];

--- a/frontend/app/components/HomeStatsLive.tsx
+++ b/frontend/app/components/HomeStatsLive.tsx
@@ -89,7 +89,7 @@ export default function HomeStatsLive({
             </Link>
           </div>
 
-          <div className="statgrid five">
+          <div className="statgrid six">
             <div className="stat">
               <span className="stat-v">{stats.total_runs}</span>
               <span className="stat-k">{t("Runs", lang)}</span>
@@ -101,6 +101,10 @@ export default function HomeStatsLive({
             <div className="stat">
               <span className="stat-v" style={{ color: "var(--warn)" }}>{losses}</span>
               <span className="stat-k">{t("Losses", lang)}</span>
+            </div>
+            <div className="stat">
+              <span className="stat-v" style={{ color: "var(--text-3)" }}>{stats.total_abandoned || 0}</span>
+              <span className="stat-k">{t("Abandoned", lang)}</span>
             </div>
             <div className="stat">
               <span className="stat-v">{stats.win_rate}%</span>
@@ -134,6 +138,7 @@ export default function HomeStatsLive({
                     </span>
                     <span className="wr-wl">
                       {c.wins}W / {c.total - c.wins - (c.abandoned || 0)}L
+                      {c.abandoned ? ` / ${c.abandoned}A` : ""}
                     </span>
                     <span className="wr-num" style={{ color: winRateColor(c.win_rate) }}>
                       {c.win_rate}%

--- a/frontend/app/home-sections.css
+++ b/frontend/app/home-sections.css
@@ -24,8 +24,9 @@
 .rvmp .lb-sub { font-size: 11px; color: var(--text-3); font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .rvmp .lb-empty { padding: 14px 4px 6px; font-size: 13px; color: var(--text-3); }
 
-/* Stats: 5-tile strip + character win-rate rows with a W/L column. */
+/* Stats: 6-tile strip + character win-rate rows with a W/L/A column. */
 .rvmp .statgrid.five { grid-template-columns: repeat(5, 1fr); }
+.rvmp .statgrid.six { grid-template-columns: repeat(6, 1fr); }
 .rvmp .wr-row.wr-stat { grid-template-columns: 92px 1fr auto auto; }
 .rvmp .wr-wl { font-size: 11.5px; color: var(--text-3); font-variant-numeric: tabular-nums; text-align: right; }
 
@@ -43,4 +44,5 @@
   .rvmp .hb { padding: 0 15px; }
   .rvmp .lbgrid { grid-template-columns: minmax(0, 1fr); }
   .rvmp .statgrid.five { grid-template-columns: repeat(2, 1fr); }
+  .rvmp .statgrid.six { grid-template-columns: repeat(2, 1fr); }
 }

--- a/frontend/app/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/leaderboards/stats/StatsClient.tsx
@@ -1244,6 +1244,7 @@ function OverviewTab({
                 <th className="text-right py-2 font-medium">{t("Runs", lang)}</th>
                 <th className="text-right py-2 font-medium">{t("Wins", lang)}</th>
                 <th className="text-right py-2 font-medium">{t("Losses", lang)}</th>
+                <th className="text-right py-2 font-medium">{t("Abandoned", lang)}</th>
                 <th className="text-right py-2 font-medium">{t("Win Rate", lang)}</th>
               </tr>
             </thead>
@@ -1260,6 +1261,9 @@ function OverviewTab({
                   <td className="py-2 text-right text-emerald-400 tabular-nums">{a.wins}</td>
                   <td className="py-2 text-right text-red-400 tabular-nums">
                     {a.total - a.wins - (a.abandoned || 0)}
+                  </td>
+                  <td className="py-2 text-right text-[var(--text-secondary)] tabular-nums">
+                    {a.abandoned || 0}
                   </td>
                   <td
                     className="py-2 text-right font-semibold tabular-nums"

--- a/frontend/lib/party-dedupe.ts
+++ b/frontend/lib/party-dedupe.ts
@@ -1,12 +1,14 @@
 // Party runs fan out to one leaderboard row per player, so boards that
 // don't filter to players=single show the same run once per member.
-// Collapse by (run_time, submitted_at), which party members share.
+// Collapse by (run_time, submitted_at truncated to the second): siblings
+// are written milliseconds apart in one submit, so exact timestamps
+// differ but the second doesn't.
 export function dedupePartyRows<
   T extends { run_time: number; submitted_at: string },
 >(rows: T[]): T[] {
   const seen = new Set<string>();
   return rows.filter((r) => {
-    const key = `${r.run_time}|${r.submitted_at}`;
+    const key = `${r.run_time}|${(r.submitted_at || "").slice(0, 19)}`;
     if (seen.has(key)) return false;
     seen.add(key);
     return true;


### PR DESCRIPTION
I finished the counting-canon display work: the homepage overview gains an Abandoned tile and character rows show W/L/A, the stats-page ascension table gets an Abandoned column, and the daily-board party dedupe now keys on second-truncated timestamps (siblings are written milliseconds apart so the exact-timestamp key never matched) with the fetch raised to 20 rows so five unique parties always survive. Bracket views still lack abandon counts in the payload — that lands with the cube conversion.