### PR TITLE
Make hollow profiles unstorable and unservable at every layer

### DIFF
--- a/backend/app/routers/players.py
+++ b/backend/app/routers/players.py
@@ -77,9 +77,11 @@ def player_insights(
         version=version,
         players=players,
     )
-    # Never let the edge cache a building placeholder: CF would pin it for
-    # 5 minutes and every viewer's poll loop would spin against it.
+    # Never let the edge cache a building placeholder OR an empty profile:
+    # CF would pin it for 5 minutes — poll loops would spin against a
+    # placeholder, and a just-claimed account would look empty long after
+    # its walk landed.
     response.headers["Cache-Control"] = (
-        "no-store" if data.get("building") else "public, max-age=300"
+        "public, max-age=300" if data.get("runs_walked") else "no-store"
     )
     return {"username": user.get("username"), **data}

--- a/backend/app/services/user_insights.py
+++ b/backend/app/services/user_insights.py
@@ -496,7 +496,21 @@ def _insights_coll():
     return _get_collection().database["user_insights"]
 
 
+def _is_hollow(payload: dict | None) -> bool:
+    """A payload claiming runs but walking none means the blob fetch failed
+    underneath the walk — an artifact of database pressure, not a real
+    profile. Such payloads must never be stored, cached, or served: treat
+    them as absent everywhere so the next view rebuilds instead. (A user
+    with zero claimed runs walking zero is a REAL empty profile.)"""
+    return bool(
+        payload and payload.get("claimed_runs") and not payload.get("runs_walked")
+    )
+
+
 def _store_payload(cache_key: str, payload: dict) -> None:
+    if _is_hollow(payload):
+        logger.warning("refusing to durably store a hollow profile: %s", cache_key)
+        return
     try:
         from datetime import datetime, timezone
 
@@ -540,9 +554,11 @@ def get_user_insights(
     version = (version or "").strip() or None
     cache_key = f"{user_id}{_filters_suffix(character, ascension, version, players)}"
     local = _cache_get(cache_key)
-    if local is not None:
+    if local is not None and not _is_hollow(local):
         return local
     payload = app_cache.get_json(_payload_key(cache_key))
+    if _is_hollow(payload):
+        payload = None
     if payload is not None and app_cache.get_json(_fresh_key(cache_key)) is not None:
         _cache_put(cache_key, payload)
         return payload
@@ -550,6 +566,8 @@ def get_user_insights(
         # Redis miss: the database is the store of record. Serve the stored
         # copy immediately and let the background refresh recompute it.
         payload = _load_stored_payload(cache_key)
+        if _is_hollow(payload):
+            payload = None
         if payload is not None:
             app_cache.set_json(_payload_key(cache_key), payload, _STALE_REDIS_TTL)
     _kick_refresh(cache_key, user_id, username, character, ascension, version, players)
@@ -956,5 +974,6 @@ def _assemble_payload(
     mine["version"] = version
     mine["players"] = players
     mine["runs_walked"] = walked
+    mine["claimed_runs"] = len(rows)
     mine["runs_capped"] = len(rows) >= _MAX_RUNS
     return mine

--- a/backend/tests/test_user_insights_store.py
+++ b/backend/tests/test_user_insights_store.py
@@ -77,3 +77,20 @@ def test_invalidate_clears_prewarmed_fresh_markers(monkeypatch):
         f"user_insights:fresh:u1{ui._filters_suffix(None, None, None, None)}" in deleted
     )
     assert len(deleted) == 8
+
+
+def test_hollow_payloads_are_never_stored_or_served(monkeypatch):
+    hollow = {"claimed_runs": 162, "runs_walked": 0}
+    legit_empty = {"claimed_runs": 0, "runs_walked": 0}
+    real = {"claimed_runs": 162, "runs_walked": 160}
+    assert ui._is_hollow(hollow)
+    assert not ui._is_hollow(legit_empty)
+    assert not ui._is_hollow(real)
+    assert not ui._is_hollow(None)
+
+    fake = FakeColl()
+    monkeypatch.setattr(ui, "_insights_coll", lambda: fake)
+    ui._store_payload("u9:", hollow)
+    assert "u9:" not in fake.docs
+    ui._store_payload("u9:", real)
+    assert fake.docs["u9:"]["payload"] == real


### PR DESCRIPTION
I finished killing the empty-profile class: payloads now record how many runs the account had at walk time, and any payload claiming runs but walking none is refused by the durable store, treated as absent by the local cache, Redis, and the store read (forcing a rebuild instead of serving it), and the public insights endpoint only lets the edge cache responses that actually contain data. With the walk-time coverage guard from before, emptiness can no longer be created, stored, cached, or served over a rebuild.