### PR TITLE
Precompute profile insights into the durable store

### DIFF
--- a/backend/app/routers/auth_steam.py
+++ b/backend/app/routers/auth_steam.py
@@ -1,6 +1,6 @@
 """Steam OpenID 2.0 sign-in — server-mediated for Overwolf clients.
 
-Compendium (the Tauri desktop app) does OpenID directly: it binds a one-shot
+Compendium (the Tauri desktop app) does OpenID directly: it binds a single-use
 local listener and uses that as the OpenID return_to URL. Overwolf
 extensions can't bind sockets, so the overlay needs a backend to act as
 the relying party. The flow:

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1526,7 +1526,7 @@ def start_stats_refresher() -> None:
         # Stats aggregations run after the tick: its finalize pins the GIL and
         # pegs Mongo for minutes, so anything kicked before it just races it.
         _kick_side_job("home_stats", refresh_home_stats)
-        # One-shot files -> run_blobs backfill, first leader cycle only.
+        # Startup files -> run_blobs backfill, first leader cycle only.
         _maybe_kick_blob_backfill()
 
         if (

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -161,7 +161,7 @@ def _ensure_indexes(coll) -> None:
     # hundreds of thousands of index keys or walks the date index — measured
     # at 12.8s per cache miss on 1.4M docs (2026-08-27). With them a miss is
     # an index seek. Pre-build on the box before deploying (create_index
-    # blocks the caller): see the PR body for the one-shot.
+    # blocks the caller): see the PR body for the pre-build command.
     coll.create_index([("character", ASCENDING), ("submitted_at", DESCENDING)])
     coll.create_index([("ascension", ASCENDING), ("submitted_at", DESCENDING)])
     coll.create_index([("game_mode", ASCENDING), ("submitted_at", DESCENDING)])
@@ -966,7 +966,7 @@ def backfill_user_runs(
 
 
 def backfill_played_at() -> int:
-    """One-shot: stamp played_at on existing docs from the stored blob's
+    """Backfill: stamp played_at on existing docs from the stored blob's
     start_time (raw.start_time, epoch seconds). Same bounds as ingest —
     [2020, now+1d] — with submitted_at as the fallback, so every doc ends up
     sortable. Server-side pipeline update, idempotent (only touches docs

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,7 +27,7 @@ x-shared-env: &shared-env
   # but keep it well above the observed walk time so the box isn't always
   # mid-rebuild. Floored at 300s in code.
   ENTITY_STATS_REBUILD_INTERVAL_SECONDS: ${ENTITY_STATS_REBUILD_INTERVAL_SECONDS:-7200}
-  # One-shot files -> run_blobs backfill on the first lease cycle after
+  # Startup files -> run_blobs backfill on the first lease cycle after
   # boot; only the refresh-lease holder runs it. Set to off to skip (e.g.
   # while diagnosing Mongo load).
   RUN_BLOBS_STARTUP_BACKFILL: "${RUN_BLOBS_STARTUP_BACKFILL:-on}"
@@ -49,7 +49,7 @@ services:
     container_name: spire-codex-backend
     restart: unless-stopped
     # Memory budget, 15.6G box: mongo 5G + backend 6G + lake-ingest 5G
-    # (one-shot, not resident) + redis 2.5G + frontend 1G. Caps, not
+    # (runs to completion, not resident) + redis 2.5G + frontend 1G. Caps, not
     # reservations — real steady usage is well under total, and redis
     # never approaches its cap. Each of the 4 web workers holds its own copy
     # of the entity-stats snapshot (~4.5G total), which left a 5g cap with

--- a/lab/ingest.py
+++ b/lab/ingest.py
@@ -1,6 +1,6 @@
 """Nightly lake ingest: incremental extract, then rebuild the parquet lake.
 
-One-shot for host cron, using the backend image (pymongo for the extract,
+Runs to completion for host cron, using the backend image (pymongo for the extract,
 the pinned duckdb for the build). The shadow SQL files run too when
 present, so the nightly log carries fresh comparison inputs for free.
 

--- a/lab/precompute_insights.py
+++ b/lab/precompute_insights.py
@@ -1,0 +1,73 @@
+"""Compute and durably store profile insights for EVERY account
+with claimed runs, most recently active first.
+
+Runs in its own container (the backend image, same env the ingest uses), so
+the walk gets a whole process instead of a thread inside a serving worker —
+the in-worker walk died to deploys, memory pressure, and worker churn all
+day on 2026-08-27; this environment completed the same walk in minutes.
+Results land in the durable user_insights store, where serving already
+reads them (Redis re-warms from the store on view, submit/claim
+invalidation keeps them fresh). Does NOT take the ingest lock: it only
+reads Mongo and writes the store, so it can run beside a cycle.
+
+    docker compose -f docker-compose.prod.yml run -T --rm --entrypoint python lake-ingest /lab/precompute_insights.py
+"""
+
+import sys
+import time
+
+sys.path.insert(0, "/app")
+
+
+def main() -> None:
+    from fastapi.encoders import jsonable_encoder
+
+    from app.services import user_insights as ui
+    from app.services.runs_db_mongo import _get_collection
+
+    coll = _get_collection()
+    users = list(
+        coll.aggregate(
+            [
+                {"$match": {"user_id": {"$ne": None}}},
+                {
+                    "$group": {
+                        "_id": "$user_id",
+                        "last": {"$max": "$submitted_at"},
+                        "n": {"$sum": 1},
+                        "username": {"$max": "$username"},
+                    }
+                },
+                {"$sort": {"last": -1}},
+            ],
+            allowDiskUse=True,
+        )
+    )
+    print(f"{len(users)} accounts with claimed runs", flush=True)
+    done = failed = 0
+    t0 = time.time()
+    for u in users:
+        uid = str(u["_id"])
+        try:
+            t = time.time()
+            slices = ui._compute_insights_all_slices(uid, u.get("username"))
+            for suffix, payload in slices.items():
+                ui._store_payload(f"{uid}{suffix}", jsonable_encoder(payload))
+            done += 1
+            print(
+                f"stored {u.get('username') or uid} runs={u['n']} "
+                f"slices={len(slices)} in {time.time() - t:.0f}s "
+                f"[{done + failed}/{len(users)}]",
+                flush=True,
+            )
+        except Exception as e:
+            failed += 1
+            print(f"FAILED {uid}: {type(e).__name__}: {e}", flush=True)
+    print(
+        f"done: {done} stored, {failed} failed in {(time.time() - t0) / 60:.1f} min",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I added a lab script that walks every account with claimed runs, in its own container run to completion, and stores the results in the durable user_insights store — the in-worker walk died all day to deploys, memory pressure, and worker churn, while this exact environment completed the same walk in minutes. Serving already reads the store, so profiles come back site-wide as the script progresses; it needs no image rebuild (lab/ is bind-mounted) and doesn't take the ingest lock. Also sweeps a banned term from comments repo-wide.