### PR TITLE
Composable tier-list brackets via a lake entity cube

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1159,8 +1159,18 @@ def get_entity_scores(
     if stat_filter:
         bracket = _STAT_FILTER_TO_BRACKET.get(stat_filter.strip().lower(), bracket)
     # Unknown bracket -> None so it grades against all runs (and shares that
-    # cache slot) rather than 400ing.
+    # cache slot) rather than 400ing. Lake-foldable brackets (mode axes and
+    # composites like solo:standard) pass through even though the snapshot's
+    # validator doesn't know them — the entity cube folds them.
     brk = bracket if is_valid_stat_bracket(bracket) else None
+    if brk is None and bracket:
+        try:
+            from ..services.lake_stats import _parse_lake_bracket
+
+            if _parse_lake_bracket(bracket) is not None:
+                brk = bracket
+        except Exception:
+            pass
     # Redis layer (5min TTL): hit constantly by tier-list pages and detail
     # sort columns. Key carries every response-shaping param.
     cache_key = app_cache.entity_scores_key(

--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -1177,6 +1177,27 @@ def build_entity_cube(con=None) -> dict:
             ).fetchall():
                 per.setdefault(cell, {})[eid] = [p, w]
             types[etype] = per
+        # Card-reward offer/pick counts per cell with the store's 3 act
+        # buckets (floors.parquet acts are 0-based; least(act,2) = A1/A2/A3+),
+        # so the metrics table's Pick% and per-act splits fold per bracket.
+        offers: dict[str, dict] = {}
+        for cell, eid, bucket, offered, picked in con.execute(
+            f"""
+            SELECT e.cell, upper(split_part(cc.u.card.id, '.', -1)),
+              least(f.act, 2), count(*),
+              count(*) FILTER (coalesce(cc.u.was_picked, false))
+            FROM read_parquet('{LAKE_DIR}/floors.parquet') f
+            JOIN cells e ON f.run_hash = e.run_hash,
+            LATERAL (SELECT unnest(f.players) AS u) ps,
+            LATERAL (SELECT unnest(ps.u.card_choices) AS u) cc
+            WHERE cc.u.card.id IS NOT NULL AND cc.u.card.id <> ''
+            GROUP BY 1, 2, 3
+            """
+        ).fetchall():
+            offers.setdefault(cell, {}).setdefault(eid, {})[str(bucket)] = [
+                offered,
+                picked,
+            ]
         data_through = str(
             con.execute(
                 f"SELECT max(submitted_at) FROM read_parquet('{LAKE_DIR}/runs.parquet')"
@@ -1185,7 +1206,12 @@ def build_entity_cube(con=None) -> dict:
     finally:
         if own:
             con.close()
-    cube = {"runs": runs_cells, "entities": types, "data_through": data_through}
+    cube = {
+        "runs": runs_cells,
+        "entities": types,
+        "offers": offers,
+        "data_through": data_through,
+    }
     import gzip as _gzip
     import json as _json
 
@@ -1259,10 +1285,36 @@ def entity_bracket_fold(entity_type: str, bracket: str) -> dict | None:
             else:
                 cur[0] += pw[0]
                 cur[1] += pw[1]
+    # Card-reward metrics (cards only): offered/picked totals plus the
+    # 3-bucket per-act splits, folded from the same matching cells.
+    offers: dict[str, dict] = {}
+    if entity_type == "cards":
+        for cell, ids in (cube.get("offers") or {}).items():
+            if not _cell_matches(cell, mode, player, skill, version):
+                continue
+            for eid, buckets in ids.items():
+                agg = offers.setdefault(
+                    eid,
+                    {
+                        "offered": 0,
+                        "picked": 0,
+                        "off_act": [0, 0, 0],
+                        "pick_act": [0, 0, 0],
+                    },
+                )
+                for b, op in buckets.items():
+                    i = int(b)
+                    if 0 <= i <= 2:
+                        agg["offered"] += op[0]
+                        agg["picked"] += op[1]
+                        agg["off_act"][i] += op[0]
+                        agg["pick_act"][i] += op[1]
     return {
         "entries": entries,
+        "offers": offers,
         "total_runs": total,
         "total_wins": wins,
+        "parsed": (mode, player, skill, version),
         "data_through": cube.get("data_through"),
     }
 

--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -1108,6 +1108,165 @@ def build_entity_store() -> dict | None:
 _entity_store_cache: tuple[float, dict] | None = None
 
 
+_ENTITY_CUBE_NAME = "entity_cube.json.gz"
+
+
+def _cell_matches(
+    cell: str,
+    mode: str | None,
+    player: str | None,
+    skill: int | None,
+    version: str | None,
+) -> bool:
+    """Whether one cube cell (mode|pc|a10|band|build_id) belongs to a parsed
+    bracket — the community cube's fold conditions, shared so the entity
+    cube folds identically."""
+    parts = (cell or "").split("|")
+    if len(parts) != 5:
+        return False
+    cmode, pc, a10, band, ver = parts
+    if mode is not None and cmode != mode:
+        return False
+    if player is not None and pc != player:
+        return False
+    if skill is not None:
+        if a10 != "1":
+            return False
+        try:
+            if skill > 0 and int(band) < skill:
+                return False
+        except ValueError:
+            return False
+    if version is not None and ver != version:
+        return False
+    return True
+
+
+def build_entity_cube(con=None) -> dict:
+    """Per-cell entity pick/win counts for every type, plus per-cell run
+    totals — the tier-list analogue of the community cube. Any mode x
+    players x skill x version bracket folds from these cells at request
+    time, which is what lets the tier pages compose mode with the other
+    axes instead of one replacing the rest."""
+    own = con is None
+    if own:
+        con = _connect(build=True)
+    try:
+        _prepare_sources(con, str(LAKE_DIR))
+        runs_cells = {
+            cell: [t, w]
+            for cell, t, w in con.execute(
+                "SELECT cell, count(*), count(*) FILTER (win) FROM cells GROUP BY 1"
+            ).fetchall()
+        }
+        types: dict[str, dict] = {}
+        for etype, table, col in (
+            ("cards", "deck", "card"),
+            ("relics", "relics", "relic"),
+            ("potions", "potions", "potion"),
+        ):
+            per: dict[str, dict] = {}
+            for cell, eid, p, w in con.execute(
+                f"""
+                SELECT e.cell, m.{col}, count(*), count(*) FILTER (e.win)
+                FROM read_parquet('{LAKE_DIR}/{table}.parquet') m
+                JOIN cells e ON m.run_hash = e.run_hash
+                WHERE m.{col} IS NOT NULL AND m.{col} <> ''
+                GROUP BY 1, 2
+                """
+            ).fetchall():
+                per.setdefault(cell, {})[eid] = [p, w]
+            types[etype] = per
+        data_through = str(
+            con.execute(
+                f"SELECT max(submitted_at) FROM read_parquet('{LAKE_DIR}/runs.parquet')"
+            ).fetchone()[0]
+        )
+    finally:
+        if own:
+            con.close()
+    cube = {"runs": runs_cells, "entities": types, "data_through": data_through}
+    import gzip as _gzip
+    import json as _json
+
+    tmp = LAKE_DIR / (_ENTITY_CUBE_NAME + ".tmp")
+    with _gzip.open(tmp, "wt", encoding="utf-8") as f:
+        f.write(_json.dumps(cube, separators=(",", ":")))
+    tmp.replace(LAKE_DIR / _ENTITY_CUBE_NAME)
+    logger.info(
+        "lake entity cube: %d run cells, %d bytes gz",
+        len(runs_cells),
+        (LAKE_DIR / _ENTITY_CUBE_NAME).stat().st_size,
+    )
+    return cube
+
+
+_entity_cube_cache: tuple[float, dict] | None = None
+
+
+def _entity_cube_with_mtime() -> tuple[float, dict] | None:
+    global _entity_cube_cache
+    try:
+        path = LAKE_DIR / _ENTITY_CUBE_NAME
+        if not path.exists():
+            return None
+        mtime = path.stat().st_mtime
+        if _entity_cube_cache and _entity_cube_cache[0] == mtime:
+            return _entity_cube_cache
+        import gzip as _gzip
+        import json as _json
+
+        with _gzip.open(path, "rt", encoding="utf-8") as f:
+            cube = _json.loads(f.read())
+        _entity_cube_cache = (mtime, cube)
+        return _entity_cube_cache
+    except Exception:
+        logger.warning("entity cube load failed", exc_info=True)
+        return None
+
+
+def entity_bracket_fold(entity_type: str, bracket: str) -> dict | None:
+    """Fold the entity cube for one bracket (any mode x players x skill x
+    version combination): {"entries": {id: [picks, wins]}, "total_runs",
+    "total_wins", "data_through"}. None for unknown brackets or a missing
+    cube (callers fall back to the snapshot's fixed buckets)."""
+    parsed = _parse_lake_bracket(bracket)
+    if parsed is None:
+        return None
+    mode, player, skill, version = parsed
+    hit = _entity_cube_with_mtime()
+    if hit is None:
+        return None
+    cube = hit[1]
+    per = (cube.get("entities") or {}).get(entity_type)
+    if per is None:
+        return None
+    total = wins = 0
+    for cell, tw in (cube.get("runs") or {}).items():
+        if _cell_matches(cell, mode, player, skill, version):
+            total += tw[0]
+            wins += tw[1]
+    if total == 0:
+        return None
+    entries: dict[str, list] = {}
+    for cell, ids in per.items():
+        if not _cell_matches(cell, mode, player, skill, version):
+            continue
+        for eid, pw in ids.items():
+            cur = entries.get(eid)
+            if cur is None:
+                entries[eid] = [pw[0], pw[1]]
+            else:
+                cur[0] += pw[0]
+                cur[1] += pw[1]
+    return {
+        "entries": entries,
+        "total_runs": total,
+        "total_wins": wins,
+        "data_through": cube.get("data_through"),
+    }
+
+
 _ENCOUNTER_STORE_NAME = "encounter_store.json"
 
 

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -3273,6 +3273,40 @@ def get_all_entity_scores(
     # only gates ascension + character, not per-entity content. Drop them for
     # every type; the per-act relic view already does this via _official_relic_ids.
     official = _official_entity_ids(entity_type)
+    # Lake path first: the entity cube folds ANY mode x players x skill x
+    # version bracket (composable, like community stats), not just the
+    # snapshot's fixed buckets — this is what lets the tier pages combine
+    # mode with the other axes. Elo comes from the all-runs store (it isn't
+    # refit per bracket in the lake). Unknown brackets or a missing cube
+    # fall through to the snapshot buckets below.
+    if bracket and _LAKE_ENTITY_SERVE:
+        try:
+            from . import lake_stats
+
+            fold = lake_stats.entity_bracket_fold(entity_type, bracket)
+        except Exception:
+            fold = None
+            logger.warning("lake entity cube fold failed", exc_info=True)
+        if fold:
+            entries = fold["entries"]
+            btot = fold["total_runs"]
+            base_p = sum(pw[0] for pw in entries.values())
+            base_w = sum(pw[1] for pw in entries.values())
+            c_baseline = (base_w / base_p) if base_p else _baseline_win_rate()
+            prior = _bracket_prior(btot) if entity_type == "relics" else None
+            cube_out: dict[str, dict[str, Any]] = {}
+            for eid, (cpicks, cwins) in entries.items():
+                if eid in excluded or (official and eid not in official):
+                    continue
+                cube_out[eid] = {
+                    "score": _compute_score(cwins, cpicks, c_baseline, prior),
+                    "elo": (_cache.get((entity_type, eid)) or {}).get("elo"),
+                    "picks": cpicks,
+                    "wins": cwins,
+                    "win_rate": round(cwins / cpicks * 100, 1) if cpicks else 0.0,
+                    "pick_rate": round(cpicks / btot * 100, 1) if btot else 0.0,
+                }
+            return cube_out
     # Bracket view (the content brackets: a10 / wr30 / wr50 / wr75 etc.): grade
     # each entity against that bracket's baseline using its nested per-bracket
     # counts, mirroring get_entity_metrics_table. character scoping isn't tracked

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -3441,6 +3441,84 @@ def get_entity_metrics_table(
     """
     _maybe_rebuild()
     character = (character or "").strip().upper() or None
+    # Lake path first: the entity cube folds ANY mode x players x skill x
+    # version bracket — including mode composites (solo:standard) the
+    # snapshot never had, and the player:skill composites its frozen copy
+    # never materialized for current versions. Character views keep the
+    # snapshot path (the cube doesn't track per-character splits yet), and
+    # a missing cube or unknown bracket falls through unchanged.
+    if bracket != "all" and character is None and _LAKE_ENTITY_SERVE:
+        try:
+            from . import lake_stats
+
+            fold = lake_stats.entity_bracket_fold(entity_type, bracket)
+        except Exception:
+            fold = None
+            logger.warning("lake metrics fold failed", exc_info=True)
+        if fold:
+            entries = fold["entries"]
+            offers = fold.get("offers") or {}
+            btot = fold["total_runs"]
+            base_p = sum(pw[0] for pw in entries.values())
+            base_w = sum(pw[1] for pw in entries.values())
+            baseline = (base_w / base_p) if base_p else _baseline_win_rate()
+            prior = _bracket_prior(btot) if entity_type == "relics" else None
+            excluded_cards = (
+                _excluded_card_ids() if entity_type == "cards" else frozenset()
+            )
+            solo_cards = (
+                _multiplayer_card_ids()
+                if entity_type == "cards" and fold["parsed"][1] == "1"
+                else frozenset()
+            )
+            official = _official_entity_ids(entity_type)
+            z3 = [0] * _ACT_BUCKETS
+            rows = []
+            for eid, (picks, wins) in entries.items():
+                if eid in excluded_cards or eid in solo_cards:
+                    continue
+                if official and eid not in official:
+                    continue
+                off = offers.get(eid) or {}
+                offered = off.get("offered", 0)
+                picked = off.get("picked", 0)
+                off_act = off.get("off_act") or z3
+                pick_act = off.get("pick_act") or z3
+                score = _compute_score(wins, picks, baseline, prior)
+                rows.append(
+                    {
+                        "id": eid,
+                        "upgraded": False,
+                        "score": score,
+                        "tier": _score_to_tier(score),
+                        "elo": (_cache.get((entity_type, eid)) or {}).get("elo"),
+                        "win_rate": round(wins / picks * 100, 1) if picks else None,
+                        "pick_rate": round(picked / offered * 100, 1)
+                        if offered
+                        else None,
+                        "picks": picks,
+                        "wins": wins,
+                        "losses": picks - wins,
+                        "offered": offered,
+                        "picked": picked,
+                        "pick_rate_by_act": [
+                            round(pick_act[i] / off_act[i] * 100, 1)
+                            if off_act[i]
+                            else None
+                            for i in range(_ACT_BUCKETS)
+                        ],
+                    }
+                )
+            return {
+                "entity_type": entity_type,
+                "bracket": bracket,
+                "character": None,
+                "baseline_win_rate": round(baseline * 100, 1),
+                "total_runs": btot,
+                "character_runs": None,
+                "character_wins": None,
+                "rows": rows,
+            }
     use_bracket = is_valid_stat_bracket(bracket)
     if use_bracket:
         baseline = _bracket_baselines.get(bracket, {}).get(

--- a/backend/tests/test_lake_stats.py
+++ b/backend/tests/test_lake_stats.py
@@ -134,3 +134,20 @@ def test_encounter_blob_keys_fold():
     }
     assert _encounter_blob_keys("custom|4|0|0|v9", recent) == ["all", "4p"]
     assert _encounter_blob_keys("garbage", recent) == []
+
+
+def test_entity_cube_cell_matching_and_fold_parity():
+    from app.services.lake_stats import _cell_matches, _parse_lake_bracket
+
+    cell = "standard|1|1|2|v0.111.0"
+    assert _parse_lake_bracket("standard") is not None
+    assert _parse_lake_bracket("solo:standard") is not None
+    m, p, s, v = _parse_lake_bracket("solo:standard")
+    assert _cell_matches(cell, m, p, s, v)
+    assert not _cell_matches("custom|1|1|2|v0.111.0", m, p, s, v)
+    m, p, s, v = _parse_lake_bracket("wr50")
+    assert _cell_matches(cell, m, p, s, v)
+    assert not _cell_matches("standard|1|1|1|v0.111.0", m, p, s, v)
+    m, p, s, v = _parse_lake_bracket("2p:a10:standard")
+    assert not _cell_matches(cell, m, p, s, v)
+    assert _cell_matches("standard|2|1|0|v9", m, p, s, v)

--- a/frontend/app/leaderboards/metrics/MetricsClient.tsx
+++ b/frontend/app/leaderboards/metrics/MetricsClient.tsx
@@ -54,9 +54,10 @@ const COLOR_FILTERS = [
 ];
 
 
-// The run-bracket filter has two combinable axes (player count x skill tier),
-// served as a "player:skill" composite (solo:wr50), plus a mutually-exclusive
-// game-mode axis. Keep keys in sync with _BRACKET_KEYS in run_entity_stats.py.
+// The run-bracket filter has four combinable axes (player count x skill tier
+// x game mode x version), served as a colon-joined composite (solo:a10:standard)
+// the lake entity cube folds server-side. Keep keys in sync with the lake's
+// bracket parser (lake_stats._parse_lake_bracket).
 const PLAYER_AXIS = [
   { key: "", label: "All" },
   { key: "solo", label: "Solo" },
@@ -73,6 +74,7 @@ const SKILL_AXIS = [
 ];
 const MODE_AXIS = [
   { key: "", label: "All" },
+  { key: "standard", label: "Standard" },
   { key: "daily", label: "Daily" },
   { key: "custom", label: "Custom" },
 ];
@@ -90,30 +92,22 @@ function parseBracket(b: string): {
   mode: string;
   version: string;
 } {
-  let version = "";
-  const i = b.lastIndexOf(":");
-  if (i > 0 && /^v\d/.test(b.slice(i + 1))) {
-    version = b.slice(i + 1);
-    b = b.slice(0, i);
-  } else if (/^v\d/.test(b)) {
-    return { player: "", skill: "", mode: "", version: b };
+  // Token scan: axes join with ":" in any order, matching the lake parser.
+  const out = { player: "", skill: "", mode: "", version: "" };
+  for (const part of b.split(":")) {
+    if (/^v\d/.test(part)) out.version = part;
+    else if (PLAYER_KEYS.includes(part)) out.player = part;
+    else if (SKILL_KEYS.includes(part)) out.skill = part;
+    else if (MODE_KEYS.includes(part)) out.mode = part;
   }
-  if (b.includes(":")) {
-    const [p, s] = b.split(":");
-    return { player: p, skill: s, mode: "", version };
-  }
-  if (PLAYER_KEYS.includes(b)) return { player: b, skill: "", mode: "", version };
-  if (SKILL_KEYS.includes(b)) return { player: "", skill: b, mode: "", version };
-  if (MODE_KEYS.includes(b)) return { player: "", skill: "", mode: b, version };
-  return { player: "", skill: "", mode: "", version };
+  return out;
 }
 
-// Mode is exclusive with player/skill (there are no daily/custom player
-// composites), but the version composes with any of them.
+// Every axis composes: player, skill, mode, and version join freely — the
+// lake entity cube folds any combination server-side.
 function combineBracket(player: string, skill: string, mode: string, version = ""): string {
-  const base = mode || [player, skill].filter(Boolean).join(":");
-  if (base && version) return `${base}:${version}`;
-  return base || version || "all";
+  const base = [player, skill, mode, version].filter(Boolean).join(":");
+  return base || "all";
 }
 
 function bracketLabel(b: string, lang: string): string {
@@ -227,9 +221,9 @@ export default function MetricsClient({
   };
   // Player and skill combine; picking either clears the exclusive mode axis.
   // Every pill keeps the version selection.
-  const pickPlayer = (p: string) => nav(combineBracket(p, sel.skill, "", sel.version));
-  const pickSkill = (s: string) => nav(combineBracket(sel.player, s, "", sel.version));
-  const pickMode = (m: string) => nav(combineBracket("", "", m, sel.version));
+  const pickPlayer = (p: string) => nav(combineBracket(p, sel.skill, sel.mode, sel.version));
+  const pickSkill = (s: string) => nav(combineBracket(sel.player, s, sel.mode, sel.version));
+  const pickMode = (m: string) => nav(combineBracket(sel.player, sel.skill, m, sel.version));
   const pickVersion = (v: string) =>
     nav(combineBracket(sel.player, sel.skill, sel.mode, v));
   // "Played by": server-side character re-scope (that character's runs), on top

--- a/frontend/app/tier-list/cards/page.tsx
+++ b/frontend/app/tier-list/cards/page.tsx
@@ -304,6 +304,7 @@ export default async function CardsTierListPage({ searchParams }: PageProps) {
         current={bracket}
         extraParams={{ color, sort: sort === "elo" ? "elo" : undefined }}
         composite
+        modeComposes
       />
 
       <TierList route="cards" entities={entities} valueLabel={sort === "elo" ? "Elo" : "Score"} />

--- a/frontend/app/tier-list/potions/page.tsx
+++ b/frontend/app/tier-list/potions/page.tsx
@@ -117,7 +117,7 @@ export default async function PotionsTierListPage({ searchParams }: PageProps) {
       </p>
 
       {/* Content bracket: grade against all runs, A10, or win-rate skill tiers. */}
-      <BracketFilter basePath="/tier-list/potions" current={bracket} composite />
+      <BracketFilter basePath="/tier-list/potions" current={bracket} composite modeComposes />
 
       <TierList route="potions" entities={entities} />
     </div>

--- a/frontend/app/tier-list/relics/page.tsx
+++ b/frontend/app/tier-list/relics/page.tsx
@@ -367,6 +367,7 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
         current={bracket}
         extraParams={{ pool, rarity, act, ancient }}
         composite
+        modeComposes
       />
 
       <TierList route="relics" entities={entities} />

--- a/lab/ingest.py
+++ b/lab/ingest.py
@@ -107,6 +107,8 @@ def main() -> None:
         print("entity store stored", flush=True)
         lake_stats.build_encounter_store()
         print("encounter store stored", flush=True)
+        lake_stats.build_entity_cube()
+        print("entity cube stored", flush=True)
         lake_stats.cleanup_build_session()
     except Exception as e:
         print(f"community payload build failed: {e}", flush=True)


### PR DESCRIPTION
I gave the tier lists AND the metrics tables the same composable brackets community stats has. The ingest builds an entity cube (per-cell pick/win counts for cards/relics/potions, card-reward offer/pick counts with per-act buckets, and per-cell run totals); entity scores and the metrics table fold any mode x players x skill x version combination from it at request time with the existing score formula; the scores endpoint accepts mode and composite brackets instead of silently grading them against all runs; and the metrics page gains Standard in its mode axis with all four axes composing instead of clearing each other. Character-scoped metrics views keep the snapshot path for now, and a missing cube falls back to today's behavior.