### PR TITLE
Clamp encounter acts and prune ghost rows

### DIFF
--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -1356,6 +1356,29 @@ def _encounter_blob_keys(cell: str, recent: frozenset[str]) -> list[str]:
     return keys
 
 
+# A (encounter, act, room_type) row needs this many appearances in the ALL
+# bracket to exist at all. Structurally weird runs (custom games starting at
+# a later act put that act's boss in their first act array) created ghost
+# rows like a 16-sample act-1 Aeonglass next to its 111k-sample act-3 row;
+# a triple that's noise globally is a ghost everywhere, so it's dropped
+# from every bracket, while legitimately small rows in niche brackets
+# survive (ruling 2026-08-28).
+_ENCOUNTER_ROW_MIN_ALL = 50
+
+
+def _prune_ghost_rows(accs: dict[str, dict]) -> None:
+    all_totals: dict[tuple, int] = {}
+    for (enc, act, rt, _ch, _mp), vals in (accs.get("all") or {}).items():
+        k = (enc, act, rt)
+        all_totals[k] = all_totals.get(k, 0) + vals[0]
+    ghosts = {k for k, t in all_totals.items() if t < _ENCOUNTER_ROW_MIN_ALL}
+    if not ghosts:
+        return
+    for cells in accs.values():
+        for ck in [k for k in cells if (k[0], k[1], k[2]) in ghosts]:
+            del cells[ck]
+
+
 def build_encounter_store(con=None) -> dict:
     """Per-bracket encounter-stats blob from the lake, in encounter_stats'
     finalized snapshot shape ({key: {"version": N, "cells": [[enc, act,
@@ -1396,6 +1419,7 @@ def build_encounter_store(con=None) -> dict:
             JOIN cells e ON f.run_hash = e.run_hash
             WHERE f.room_type IN ('monster', 'elite', 'boss')
               AND f.encounter IS NOT NULL AND f.encounter <> ''
+              AND f.act BETWEEN 1 AND 3
             GROUP BY 1, 2, 3, 4, 5, 6
             """
         ).fetchall()
@@ -1421,6 +1445,7 @@ def build_encounter_store(con=None) -> dict:
                 cur[1] += fa
                 cur[2] += float(d or 0)
                 cur[3] += float(tu or 0)
+    _prune_ghost_rows(accs)
     store: dict = {
         key: {
             "version": es.ENCOUNTER_VERSION,

--- a/backend/tests/test_lake_stats.py
+++ b/backend/tests/test_lake_stats.py
@@ -151,3 +151,21 @@ def test_entity_cube_cell_matching_and_fold_parity():
     m, p, s, v = _parse_lake_bracket("2p:a10:standard")
     assert not _cell_matches(cell, m, p, s, v)
     assert _cell_matches("standard|2|1|0|v9", m, p, s, v)
+
+
+def test_encounter_ghost_rows_pruned_from_every_bracket():
+    from app.services.lake_stats import _prune_ghost_rows
+
+    big = ("AEONGLASS_BOSS", 3, "boss", "IRONCLAD", "solo")
+    ghost = ("AEONGLASS_BOSS", 1, "boss", "IRONCLAD", "solo")
+    accs = {
+        "all": {big: [111398, 28121, 1.0, 1.0], ghost: [16, 13, 1.0, 1.0]},
+        "solo": {big: [90000, 20000, 1.0, 1.0], ghost: [10, 8, 1.0, 1.0]},
+        "wr75": {big: [40, 5, 1.0, 1.0]},
+    }
+    _prune_ghost_rows(accs)
+    assert ghost not in accs["all"] and ghost not in accs["solo"]
+    assert big in accs["all"] and big in accs["solo"]
+    # A legitimately small row in a niche bracket survives: the floor is
+    # judged on the ALL bracket, not per bracket.
+    assert big in accs["wr75"]


### PR DESCRIPTION
I cleaned the encounter table's phantom rows: acts beyond 3 (endless-style histories) are clamped at build, and any encounter-act-room row with under 50 appearances in the all bracket is dropped from every bracket — custom games starting at a later act were creating rows like a 16-sample act-1 Aeonglass beside its 111k-sample act-3 row. The floor is judged globally so legitimately small rows in niche brackets survive.