### PR TITLE
Stop the duplicate-prefetch request storm

### DIFF
--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -239,7 +239,7 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
             const inner = (<><span className="act-ico">{c.icon}</span><span className="act-t">{c.title}</span><span className="act-d">{c.desc}</span></>);
             return c.ext
               ? (<a key={c.title} href={c.href} target="_blank" rel="noopener noreferrer" className="act">{inner}</a>)
-              : (<Link key={c.title} href={c.href} className="act">{inner}</Link>);
+              : (<Link prefetch={false} key={c.title} href={c.href} className="act">{inner}</Link>);
           })}
         </div>
       </section>
@@ -248,13 +248,13 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
       <section className="hsec">
         <div className="s-head">
           <h2>{t("Characters", lang)}</h2>
-          <Link className="viewmore" href={`${langPrefix}/characters`}>{t("All characters", lang)} {ARROW}</Link>
+          <Link prefetch={false} className="viewmore" href={`${langPrefix}/characters`}>{t("All characters", lang)} {ARROW}</Link>
         </div>
         <div className="charbar">
           {CHARACTERS.map((char, i) => {
             const charName = translations.character_names?.[char.id] ?? char.id.charAt(0).toUpperCase() + char.id.slice(1);
             return (
-              <Link key={char.id} href={`${langPrefix}/characters/${char.id.toLowerCase()}`} className="charp" style={{ ["--cc"]: char.cssColor } as CSSProperties}>
+              <Link prefetch={false} key={char.id} href={`${langPrefix}/characters/${char.id.toLowerCase()}`} className="charp" style={{ ["--cc"]: char.cssColor } as CSSProperties}>
                 <span className="charp-art">
                   {/* The first combat portraits are the page's LCP candidates:
                       hint the browser to fetch them ahead of the below-fold art. */}
@@ -276,7 +276,7 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
         <div className="bgrid">
           {sections.map((s, i) => {
             const tile = (
-              <Link key={s.href} href={`${langPrefix}${s.href}`} className="btile" style={{ ["--cc"]: s.color } as CSSProperties}>
+              <Link prefetch={false} key={s.href} href={`${langPrefix}${s.href}`} className="btile" style={{ ["--cc"]: s.color } as CSSProperties}>
                 <div className="bt-top">
                   <span className="bt-name">{sectionKey(s.key)}</span>
                   {s.count != null && <span className="bt-count">{s.count}</span>}
@@ -289,7 +289,7 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
             if (i === 6) {
               return [
                 tile,
-                <Link key="ow-promo" href={`${langPrefix}/overlay`} className="promo">
+                <Link prefetch={false} key="ow-promo" href={`${langPrefix}/overlay`} className="promo">
                   <img className="promo-img" src="/overwolf-logo.png" alt="Overwolf" loading="lazy" />
                   <div className="promo-body">
                     <span className="promo-kick">{t("New · Overwolf companion", lang)}</span>

--- a/frontend/app/acts/[id]/ActDetail.tsx
+++ b/frontend/app/acts/[id]/ActDetail.tsx
@@ -71,7 +71,7 @@ export default function ActDetail({ initialAct }: { initialAct?: Act | null } = 
     return (
       <div className="max-w-3xl mx-auto px-4 py-12 text-center">
         <p className="text-[var(--text-muted)] mb-4">Act not found.</p>
-        <Link href={`${lp}/reference`} className="text-[var(--accent-gold)] hover:underline">
+        <Link prefetch={false} href={`${lp}/reference`} className="text-[var(--accent-gold)] hover:underline">
           &larr; Back to Reference
         </Link>
       </div>
@@ -135,7 +135,7 @@ export default function ActDetail({ initialAct }: { initialAct?: Act | null } = 
               <h2>Bosses ({act.bosses.length})</h2>
               <div className="chips">
                 {act.bosses.map((b) => (
-                  <Link key={b} href={`${lp}/encounters/${b.toLowerCase()}`} className="chip">
+                  <Link prefetch={false} key={b} href={`${lp}/encounters/${b.toLowerCase()}`} className="chip">
                     <span className="pip" style={{ background: "#b3423a" }} />
                     {titleCase(b).replace(/ Boss$/, "")}
                   </Link>
@@ -150,7 +150,7 @@ export default function ActDetail({ initialAct }: { initialAct?: Act | null } = 
               <h2>Encounters ({act.encounters.length})</h2>
               <div className="chips">
                 {act.encounters.map((e) => (
-                  <Link key={e} href={`${lp}/encounters/${e.toLowerCase()}`} className="chip">
+                  <Link prefetch={false} key={e} href={`${lp}/encounters/${e.toLowerCase()}`} className="chip">
                     <span className="pip" />
                     {titleCase(e).replace(/ (Normal|Weak|Elite|Boss)$/, "")}
                   </Link>
@@ -165,7 +165,7 @@ export default function ActDetail({ initialAct }: { initialAct?: Act | null } = 
               <h2>Events ({act.events.length})</h2>
               <div className="chips">
                 {act.events.map((e) => (
-                  <Link key={e} href={`${lp}/events/${e.toLowerCase()}`} className="chip">
+                  <Link prefetch={false} key={e} href={`${lp}/events/${e.toLowerCase()}`} className="chip">
                     <span className="pip" style={{ background: "#4f7fb3" }} />
                     {titleCase(e)}
                   </Link>

--- a/frontend/app/ancients/AncientsClient.tsx
+++ b/frontend/app/ancients/AncientsClient.tsx
@@ -72,7 +72,7 @@ function RelicPill({
 
   return (
     <div className="anc-relic">
-      <Link href={`${lp}/relics/${relic.id.toLowerCase()}`} className="anc-relic-link">
+      <Link prefetch={false} href={`${lp}/relics/${relic.id.toLowerCase()}`} className="anc-relic-link">
         {info?.image_url && (
           <img src={imageUrl(info.image_url)} alt={name} crossOrigin="anonymous" />
         )}

--- a/frontend/app/archetypes/page.tsx
+++ b/frontend/app/archetypes/page.tsx
@@ -232,6 +232,7 @@ export default async function ArchetypesPage() {
                     <div className="flex flex-wrap gap-1.5">
                       {a.defining_cards.map((e) => (
                         <Link
+                          prefetch={false}
                           key={e.id}
                           href={`/cards/${e.id.toLowerCase()}`}
                           className="text-xs px-2 py-0.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-primary)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50 hover:text-[var(--accent-gold)] transition-colors"
@@ -241,6 +242,7 @@ export default async function ArchetypesPage() {
                       ))}
                       {a.defining_relics.map((e) => (
                         <Link
+                          prefetch={false}
                           key={e.id}
                           href={`/relics/${e.id.toLowerCase()}`}
                           className="text-xs px-2 py-0.5 rounded-md border border-sky-900/50 bg-[var(--bg-primary)] text-sky-300 hover:border-sky-500/60 transition-colors"
@@ -256,6 +258,7 @@ export default async function ArchetypesPage() {
                           <span key={h}>
                             {j > 0 && ", "}
                             <Link
+                              prefetch={false}
                               href={`/runs/${h}`}
                               className="text-[var(--accent-gold)] hover:underline font-mono"
                             >

--- a/frontend/app/badges/page.tsx
+++ b/frontend/app/badges/page.tsx
@@ -103,6 +103,7 @@ export default async function BadgesPage() {
           <div className="flex flex-wrap gap-2">
             {multiplayerOnly.map((b) => (
               <Link
+                prefetch={false}
                 key={b.id}
                 href={`/badges/${b.id.toLowerCase()}`}
                 className="text-sm px-3 py-1 rounded-full border border-[var(--border-subtle)] bg-[var(--bg-card)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50 hover:text-[var(--accent-gold)] transition-colors"
@@ -124,6 +125,7 @@ function BadgeCard({ badge }: { badge: Badge }) {
     "border-[var(--border-subtle)]";
   return (
     <Link
+      prefetch={false}
       href={`/badges/${badge.id.toLowerCase()}`}
       className={`bg-[var(--bg-card)] rounded-lg border ${borderClass} p-4 hover:bg-[var(--bg-card-hover)] hover:border-[var(--border-accent)] transition-all flex gap-4 group`}
     >

--- a/frontend/app/cards/page.tsx
+++ b/frontend/app/cards/page.tsx
@@ -201,6 +201,7 @@ export default async function CardsPage() {
               </h2>
             </div>
             <Link
+              prefetch={false}
               href="/tier-list/cards"
               className="text-xs text-[var(--accent-gold)] hover:underline whitespace-nowrap"
             >
@@ -216,7 +217,7 @@ export default async function CardsPage() {
           <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
             {topByScore.map(({ card, score }) => (
               <li key={card.id}>
-                <Link href={`/cards/${card.id.toLowerCase()}`} className="block group">
+                <Link prefetch={false} href={`/cards/${card.id.toLowerCase()}`} className="block group">
                   <img
                     src={fullCardUrl(card.id.toLowerCase())}
                     alt={`${card.name} - Slay the Spire 2 card`}
@@ -250,6 +251,7 @@ export default async function CardsPage() {
           {cardsByCharacter.map((char) => (
             <li key={char.id}>
               <Link
+                prefetch={false}
                 href={`/cards?color=${char.id}`}
                 className="block p-3 rounded-lg border border-[var(--border-subtle)] hover:border-[var(--accent-gold)] transition-colors"
               >
@@ -269,6 +271,7 @@ export default async function CardsPage() {
         <p className="text-sm text-[var(--text-muted)] mt-4">
           Looking for tier rankings? See the full{" "}
           <Link
+            prefetch={false}
             href="/tier-list/cards"
             className="text-[var(--accent-gold)] hover:underline"
           >
@@ -276,6 +279,7 @@ export default async function CardsPage() {
           </Link>{" "}
           for S-through-F tiers, or check the{" "}
           <Link
+            prefetch={false}
             href="/leaderboards/stats"
             className="text-[var(--accent-gold)] hover:underline"
           >

--- a/frontend/app/characters/[id]/CharacterDetail.tsx
+++ b/frontend/app/characters/[id]/CharacterDetail.tsx
@@ -81,7 +81,7 @@ function TopPicks({
       <ul className="picks">
         {resolved.map(({ it, ent }) => (
           <li key={it.entity_id}>
-            <Link href={`${hrefBase}/${ent.id.toLowerCase()}`} className="pick">
+            <Link prefetch={false} href={`${hrefBase}/${ent.id.toLowerCase()}`} className="pick">
               {ent.image_url && (
                 <img
                   src={imageUrl(ent.image_url)}
@@ -240,7 +240,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
     return (
       <div className="max-w-4xl mx-auto px-4 py-12 text-center">
         <p className="text-[var(--text-muted)] mb-4">Character not found.</p>
-        <Link href="/characters" className="text-[var(--accent-gold)] hover:underline">
+        <Link prefetch={false} href="/characters" className="text-[var(--accent-gold)] hover:underline">
           &larr; Back to Characters
         </Link>
       </div>
@@ -412,6 +412,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
                   if (!cardData) return null;
                   return (
                     <Link
+                      prefetch={false}
                       key={`${cardName}-${i}`}
                       href={`/cards/${cardData.id.toLowerCase()}`}
                       title={cardData.name}
@@ -438,6 +439,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
                   const relicData = relics[toUpperSnake(relicName)];
                   return (
                     <Link
+                      prefetch={false}
                       key={relicName}
                       href={relicData ? `/relics/${relicData.id.toLowerCase()}` : "#"}
                       className="kit-row"
@@ -547,6 +549,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
                 <div className="kit-list">
                   {sortedPoolRelics.map((relic) => (
                     <Link
+                      prefetch={false}
                       key={relic.id}
                       href={`/relics/${relic.id.toLowerCase()}`}
                       className="kit-row"

--- a/frontend/app/components/AlertTicker.tsx
+++ b/frontend/app/components/AlertTicker.tsx
@@ -47,7 +47,7 @@ function renderAnnouncement(message: string): ReactNode[] {
     const [, label, href] = m;
     out.push(
       href.startsWith("/") ? (
-        <Link key={m.index} href={href} className={linkClass}>
+        <Link prefetch={false} key={m.index} href={href} className={linkClass}>
           {label}
         </Link>
       ) : (
@@ -100,6 +100,7 @@ export default function AlertTicker() {
               )}{" "}
             </span>
             <Link
+              prefetch={false}
               href="/overlay"
               className="text-[var(--accent-gold)] hover:underline font-medium whitespace-nowrap"
             >
@@ -168,6 +169,7 @@ export default function AlertTicker() {
             </a>
             . Servants! Fetch tea for{" "}
             <Link
+              prefetch={false}
               href="/thank-you"
               className="font-medium not-italic text-emerald-200 underline hover:text-white transition-colors"
             >

--- a/frontend/app/components/BracketFilter.tsx
+++ b/frontend/app/components/BracketFilter.tsx
@@ -65,6 +65,7 @@ export default function BracketFilter({
     const base = stripVersion(active);
     const renderPill = (b: ContentBracket) => (
       <Link
+        prefetch={false}
         key={b.key}
         href={hrefFor(b.key === "all" ? version || "all" : version ? `${b.key}:${version}` : b.key)}
         className={pillCls(base === b.key || (b.key === "all" && !base))}
@@ -85,6 +86,7 @@ export default function BracketFilter({
       <div className="flex flex-wrap items-center gap-1.5">
         <span className="w-14 text-xs text-[var(--text-muted)]">Mode</span>
         <Link
+          prefetch={false}
           href={hrefFor(
             base && !MODE_BRACKETS.some((m) => m.key === base)
               ? version
@@ -98,6 +100,7 @@ export default function BracketFilter({
         </Link>
         {MODE_BRACKETS.map((m) => (
           <Link
+            prefetch={false}
             key={m.key}
             href={hrefFor(version ? `${m.key}:${version}` : m.key)}
             className={pillCls(base === m.key)}
@@ -129,6 +132,7 @@ export default function BracketFilter({
           const targetSkill = b.key === "all" ? "" : b.key;
           return (
             <Link
+              prefetch={false}
               key={b.key}
               href={hrefFor(combineBracket(player, targetSkill, version, modeComposes ? mode : ""))}
               className={pillCls(skill === targetSkill)}
@@ -142,6 +146,7 @@ export default function BracketFilter({
         <span className="w-14 text-xs text-[var(--text-muted)]">Players</span>
         {playerOpts.map((b) => (
           <Link
+            prefetch={false}
             key={b.key || "all"}
             href={hrefFor(combineBracket(b.key, skill, version, modeComposes ? mode : ""))}
             className={pillCls(player === b.key)}
@@ -157,6 +162,7 @@ export default function BracketFilter({
             {/* Cube-backed page: mode is a real axis, so every mode pill
                 keeps the player + skill selection and vice versa. */}
             <Link
+              prefetch={false}
               href={hrefFor(combineBracket(player, skill, version))}
               className={pillCls(!mode)}
             >
@@ -164,6 +170,7 @@ export default function BracketFilter({
             </Link>
             {MODE_BRACKETS.map((m) => (
               <Link
+                prefetch={false}
                 key={m.key}
                 href={hrefFor(combineBracket(player, skill, version, m.key))}
                 className={pillCls(mode === m.key)}
@@ -175,6 +182,7 @@ export default function BracketFilter({
         ) : (
           <>
             <Link
+              prefetch={false}
               href={hrefFor(
                 base && !MODE_BRACKETS.some((m) => m.key === base)
                   ? version
@@ -188,6 +196,7 @@ export default function BracketFilter({
             </Link>
             {MODE_BRACKETS.map((m) => (
               <Link
+                prefetch={false}
                 key={m.key}
                 href={hrefFor(version ? `${m.key}:${version}` : m.key)}
                 className={pillCls(base === m.key)}

--- a/frontend/app/components/Footer.tsx
+++ b/frontend/app/components/Footer.tsx
@@ -161,6 +161,7 @@ export default function Footer() {
         </a>
         <span className="text-[var(--border-subtle)]" aria-hidden>·</span>
         <Link
+          prefetch={false}
           href="/developers"
           className="hover:text-[var(--accent-gold)] transition-colors"
         >
@@ -202,6 +203,7 @@ export default function Footer() {
         </button>
         <span className="text-[var(--border-subtle)]" aria-hidden>·</span>
         <Link
+          prefetch={false}
           href="/privacy"
           className="hover:text-[var(--accent-gold)] transition-colors"
         >
@@ -223,6 +225,7 @@ export default function Footer() {
         </button>
         <span className="text-[var(--border-subtle)]" aria-hidden>·</span>
         <Link
+          prefetch={false}
           href="/terms"
           className="hover:text-[var(--accent-gold)] transition-colors"
         >
@@ -230,6 +233,7 @@ export default function Footer() {
         </Link>
         <span className="text-[var(--border-subtle)]" aria-hidden>·</span>
         <Link
+          prefetch={false}
           href="/beta"
           className="hover:text-[var(--accent-gold)] transition-colors"
         >

--- a/frontend/app/components/HomeGuidesSection.tsx
+++ b/frontend/app/components/HomeGuidesSection.tsx
@@ -58,7 +58,7 @@ export default async function HomeGuidesSection({
         <div className="hsec">
           <div className="s-head">
             <h2>{t("Guides", lang)}</h2>
-            <Link className="viewmore" href={guidesBase}>
+            <Link prefetch={false} className="viewmore" href={guidesBase}>
               {t("View more", lang)} {ARROW}
             </Link>
           </div>
@@ -67,7 +67,7 @@ export default async function HomeGuidesSection({
             {guides.map((g) => {
               const difficulty = g.difficulty ? DIFFICULTY_LABEL[g.difficulty] ?? g.difficulty : null;
               return (
-                <Link key={g.slug} href={`${guidesBase}/${g.slug}`} className="gcard">
+                <Link prefetch={false} key={g.slug} href={`${guidesBase}/${g.slug}`} className="gcard">
                   <span className="gcard-k">
                     {g.category}
                     {difficulty ? ` · ${difficulty}` : ""}

--- a/frontend/app/components/HomeLeaderboardLive.tsx
+++ b/frontend/app/components/HomeLeaderboardLive.tsx
@@ -147,7 +147,7 @@ export default function HomeLeaderboardLive({
         <div className="hsec">
           <div className="s-head">
             <h2>{t("Leaderboards", lang)}</h2>
-            <Link className="viewmore" href={`${lbBase}/submit`}>
+            <Link prefetch={false} className="viewmore" href={`${lbBase}/submit`}>
               {t("Upload your runs", lang)} {ARROW}
             </Link>
           </div>
@@ -158,7 +158,7 @@ export default function HomeLeaderboardLive({
               <div className="s-head">
                 {ascLabel && <span className="s-kick">{ascLabel}</span>}
                 <h2>{t("Fastest Wins", lang)}</h2>
-                <Link className="viewmore" href={runsBase}>
+                <Link prefetch={false} className="viewmore" href={runsBase}>
                   {t("View more", lang)} {ARROW}
                 </Link>
               </div>
@@ -203,7 +203,7 @@ export default function HomeLeaderboardLive({
               <div className="s-head">
                 <span className="s-kick">{t("resets 00:00 UTC", lang)}</span>
                 <h2>{t("Daily Climb", lang)}</h2>
-                <Link className="viewmore" href={`${runsBase}?win=true&game_mode=daily_today&sort=ascension_desc`}>
+                <Link prefetch={false} className="viewmore" href={`${runsBase}?win=true&game_mode=daily_today&sort=ascension_desc`}>
                   {t("View more", lang)} {ARROW}
                 </Link>
               </div>
@@ -247,7 +247,7 @@ export default function HomeLeaderboardLive({
             <section className="panel">
               <div className="s-head">
                 <h2>{t("Recent Runs", lang)}</h2>
-                <Link className="viewmore" href={runsBase}>
+                <Link prefetch={false} className="viewmore" href={runsBase}>
                   {t("View more", lang)} {ARROW}
                 </Link>
               </div>

--- a/frontend/app/components/HomeMetricsSection.tsx
+++ b/frontend/app/components/HomeMetricsSection.tsx
@@ -114,7 +114,7 @@ export default async function HomeMetricsSection({
           <div className="s-head">
             <span className="s-kick">{t("A10 · by Codex Elo", lang)}</span>
             <h2>{t("Card Metrics", lang)}</h2>
-            <Link className="viewmore" href={href}>
+            <Link prefetch={false} className="viewmore" href={href}>
               {t("View Card metrics", lang)} {ARROW}
             </Link>
           </div>
@@ -134,7 +134,7 @@ export default async function HomeMetricsSection({
                 <tr key={c.id}>
                   <td className="rk">{i + 1}</td>
                   <td className="ent">
-                    <Link href={`${langPrefix}/cards/${c.id.toLowerCase()}`} style={{ color: cardHex(c.color) }}>
+                    <Link prefetch={false} href={`${langPrefix}/cards/${c.id.toLowerCase()}`} style={{ color: cardHex(c.color) }}>
                       {c.name}
                     </Link>
                   </td>

--- a/frontend/app/components/HomeNewsSection.tsx
+++ b/frontend/app/components/HomeNewsSection.tsx
@@ -75,7 +75,7 @@ export default async function HomeNewsSection({
               {t("home_news_heading_prefix", lang)}{" "}
               <span style={{ color: "var(--gold)" }}>Mega Crit</span>
             </h2>
-            <Link className="viewmore" href={newsBase}>
+            <Link prefetch={false} className="viewmore" href={newsBase}>
               {t("View more", lang)} {ARROW}
             </Link>
           </div>
@@ -87,8 +87,8 @@ export default async function HomeNewsSection({
               const date = formatNewsDate(article.date);
               const href = newsSlugForArticle(article.gid, newsBase);
               return (
-                <Link key={article.gid} href={href} className="news">
-                  <img className="news-thumb" src={hero} alt="" loading="lazy" />
+                <Link prefetch={false} key={article.gid} href={href} className="news">
+                  <img className="news-thumb" src={hero} alt="" width={640} height={360} loading="lazy" />
                   <span className="news-src">Mega Crit</span>
                   <span className="news-title">{article.title}</span>
                   {blurb && <span className="news-ex">{blurb}</span>}

--- a/frontend/app/components/HomeShowcaseSection.tsx
+++ b/frontend/app/components/HomeShowcaseSection.tsx
@@ -76,7 +76,7 @@ export default async function HomeShowcaseSection({
         <div className="hsec">
           <div className="s-head">
             <h2>{t("Showcase", lang)}</h2>
-            <Link className="viewmore" href={`${langPrefix}/showcase`}>
+            <Link prefetch={false} className="viewmore" href={`${langPrefix}/showcase`}>
               {t("View more", lang)} {ARROW}
             </Link>
           </div>

--- a/frontend/app/components/HomeStatsLive.tsx
+++ b/frontend/app/components/HomeStatsLive.tsx
@@ -84,7 +84,7 @@ export default function HomeStatsLive({
           <div className="s-head">
             <span className="s-kick">{t("Overview", lang)}</span>
             <h2>{t("Stats", lang)}</h2>
-            <Link className="viewmore" href={`${runsHost}${langPrefix}/leaderboards/stats`}>
+            <Link prefetch={false} className="viewmore" href={`${runsHost}${langPrefix}/leaderboards/stats`}>
               {t("View all stats", lang)} {ARROW}
             </Link>
           </div>

--- a/frontend/app/components/LiveNavButton.tsx
+++ b/frontend/app/components/LiveNavButton.tsx
@@ -59,7 +59,7 @@ export default function LiveNavButton({
 
   if (variant === "mobile") {
     return (
-      <Link href="/live" className="flex items-center gap-2 text-lg font-semibold text-[var(--color-silent)]">
+      <Link prefetch={false} href="/live" className="flex items-center gap-2 text-lg font-semibold text-[var(--color-silent)]">
         <LiveCircle />
         <span className="tabular-nums">{count > 0 ? `(${count}) Live` : "Live"}</span>
       </Link>
@@ -68,6 +68,7 @@ export default function LiveNavButton({
 
   return (
     <Link
+      prefetch={false}
       href="/live"
       title="Watch players live"
       className="inline-flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium text-[var(--color-silent)] hover:bg-[var(--bg-card)] transition-colors shrink-0"

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -324,7 +324,7 @@ export default function Navbar() {
                       </>
                     );
                     return isInternal ? (
-                      <Link key={link.href} href={fullHref} role="menuitem" className={className} onMouseDown={(e) => e.preventDefault()}>{inner}</Link>
+                      <Link prefetch={false} key={link.href} href={fullHref} role="menuitem" className={className} onMouseDown={(e) => e.preventDefault()}>{inner}</Link>
                     ) : (
                       <a key={link.href} href={fullHref} {...(isHttp ? { target: "_blank", rel: "noopener noreferrer" } : {})} role="menuitem" onMouseDown={(e) => e.preventDefault()} className={className}>{inner}</a>
                     );
@@ -342,6 +342,7 @@ export default function Navbar() {
                     const rmeta = DB_META["/" + r.type];
                     return (
                       <Link
+                        prefetch={false}
                         key={`${r.type}-${r.id}`}
                         href={`${langPrefix}/${r.type}/${r.id}`}
                         role="menuitem"
@@ -374,7 +375,7 @@ export default function Navbar() {
         <div className="flex items-center justify-between gap-3 sm:gap-4 h-16">
           {/* Left: logo + nav pushed tight together; the cluster is pushed right */}
           <div className="flex items-center gap-2 sm:gap-6 min-w-0">
-            <Link href={`${langPrefix}/`} className="flex items-center gap-2 shrink-0">
+            <Link prefetch={false} href={`${langPrefix}/`} className="flex items-center gap-2 shrink-0">
               <img
                 src="/spire-codex-white-final.webp"
                 alt="Spire Codex"
@@ -495,6 +496,7 @@ export default function Navbar() {
                     {user.email && <p className="text-xs text-[var(--text-tertiary)] truncate">{user.email}</p>}
                   </div>
                   <Link
+                    prefetch={false}
                     href={`${langPrefix}/profile`}
                     onClick={() => setUserMenuOpen(false)}
                     className="flex items-center gap-2 px-2.5 py-2 text-sm rounded-md hover:bg-[var(--bg-card)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
@@ -502,6 +504,7 @@ export default function Navbar() {
                     {t("Profile", lang)}
                   </Link>
                   <Link
+                    prefetch={false}
                     href={`${langPrefix}/settings`}
                     onClick={() => setUserMenuOpen(false)}
                     className="flex items-center gap-2 px-2.5 py-2 text-sm rounded-md hover:bg-[var(--bg-card)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
@@ -513,6 +516,7 @@ export default function Navbar() {
                       anyone not on the server-side allowlist. */}
                   {user.is_admin && (
                     <Link
+                      prefetch={false}
                       href="/admin"
                       onClick={() => setUserMenuOpen(false)}
                       className="flex items-center gap-2 px-2.5 py-2 text-sm rounded-md hover:bg-[var(--bg-card)] text-[var(--accent-gold)] hover:text-[var(--accent-gold)] transition-colors"
@@ -641,7 +645,7 @@ export default function Navbar() {
                                     </>
                                   );
                                   return isInternal ? (
-                                    <Link key={link.href} href={fullHref} className={cls}>{inner}</Link>
+                                    <Link prefetch={false} key={link.href} href={fullHref} className={cls}>{inner}</Link>
                                   ) : (
                                     <a key={link.href} href={fullHref} {...(isHttp ? { target: "_blank", rel: "noopener noreferrer" } : {})} className={cls}>{inner}</a>
                                   );

--- a/frontend/app/components/ProfileInsights.tsx
+++ b/frontend/app/components/ProfileInsights.tsx
@@ -413,6 +413,7 @@ function CardDeltaList({ rows, cards, lang }: { rows: CardDelta[]; cards: Record
         const info = cards[d.id];
         return (
           <Link
+            prefetch={false}
             key={d.id}
             href={`${lp}/cards/${d.id.toLowerCase()}`}
             className="flex items-center gap-3 py-1.5 hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 transition-colors"
@@ -462,6 +463,7 @@ function RelicDeltaList({ rows, relics, lang }: { rows: RelicDelta[]; relics: Re
         const info = relics[d.id];
         return (
           <Link
+            prefetch={false}
             key={d.id}
             href={`${lp}/relics/${d.id.toLowerCase()}`}
             className="flex items-center gap-3 py-1.5 hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 transition-colors"
@@ -723,7 +725,7 @@ function displayCharacter(id: string): string {
 
 function BestTile({ href, value, label, sub, rank }: { href: string; value: string; label: string; sub?: string; rank?: { rank: number; total: number } | null }) {
   return (
-    <Link href={href} className="bg-[var(--bg-primary)] rounded-lg p-3 text-center hover:bg-[var(--bg-card-hover)] transition-colors">
+    <Link prefetch={false} href={href} className="bg-[var(--bg-primary)] rounded-lg p-3 text-center hover:bg-[var(--bg-card-hover)] transition-colors">
       <p className="text-lg font-bold text-[var(--text-primary)] tabular-nums">{value}</p>
       <p className="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mt-0.5">{label}</p>
       {(sub || rank) && (
@@ -1006,7 +1008,7 @@ export function InsightsPanels({
               <div key={`${d.event_id}-${d.option_id}`} className="space-y-1">
                 <div className="flex items-center justify-between text-sm gap-2">
                   <span className="min-w-0 truncate">
-                    <Link href={`${lp}/events/${d.event_id.toLowerCase()}`} className="text-[var(--text-primary)] hover:text-[var(--accent-gold)] transition-colors">
+                    <Link prefetch={false} href={`${lp}/events/${d.event_id.toLowerCase()}`} className="text-[var(--text-primary)] hover:text-[var(--accent-gold)] transition-colors">
                       {d.event_name || d.event_id.replace(/_/g, " ")}
                     </Link>
                     <span className="text-[var(--text-muted)]"> · {d.option_label || d.option_id.replace(/_/g, " ")}</span>

--- a/frontend/app/components/ProfileStats.tsx
+++ b/frontend/app/components/ProfileStats.tsx
@@ -81,7 +81,7 @@ function displayName(id: string): string {
 
 function EntityRow({ name, imageSrc, stat, href }: { name: string; imageSrc: string | null; stat: string; href: string }) {
   return (
-    <Link href={href} className="flex items-center gap-3 py-1.5 hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 transition-colors">
+    <Link prefetch={false} href={href} className="flex items-center gap-3 py-1.5 hover:bg-[var(--bg-card-hover)] rounded px-2 -mx-2 transition-colors">
       <span className="flex-shrink-0 w-8 h-8 rounded bg-[var(--bg-primary)] border border-[var(--border-subtle)] overflow-hidden flex items-center justify-center">
         {imageSrc ? (
           <img src={imageSrc} alt={name} className="w-full h-full object-contain p-0.5" crossOrigin="anonymous" />
@@ -302,6 +302,7 @@ export default function ProfileStats({
                     </span>
                     <span className="flex-1" />
                     <Link
+                      prefetch={false}
                       href={`/runs/${run.run_hash}`}
                       className="text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors shrink-0"
                     >
@@ -436,6 +437,7 @@ export default function ProfileStats({
         <div>
           <div className="mb-1 flex items-center justify-end">
             <Link
+              prefetch={false}
               href="/tier-list-maker"
               className="text-sm text-sky-400 hover:underline"
             >

--- a/frontend/app/components/RecentlyAdded.tsx
+++ b/frontend/app/components/RecentlyAdded.tsx
@@ -80,6 +80,7 @@ export default async function RecentlyAdded({
             {group.map((item) => (
               <li key={item.id}>
                 <Link
+                  prefetch={false}
                   href={`${pathPrefix}/${item.id.toLowerCase()}`}
                   className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--bg-card)] border border-emerald-800/40 hover:border-emerald-500/60 text-sm text-[var(--text-primary)] hover:text-emerald-300 transition-colors"
                 >

--- a/frontend/app/components/RelatedCards.tsx
+++ b/frontend/app/components/RelatedCards.tsx
@@ -95,6 +95,7 @@ export default function RelatedCards({ currentId, keywords, tags, color }: Relat
               <li key={card.id}>
                 <HoverTooltip title={card.name} content={card.description} image={card.image_url}>
                   <Link
+                    prefetch={false}
                     href={`${lp}/cards/${card.id.toLowerCase()}`}
                     className="text-sm text-[var(--text-secondary)] hover:text-[var(--accent-gold)] transition-colors"
                   >

--- a/frontend/app/enchantments/[id]/EnchantmentDetail.tsx
+++ b/frontend/app/enchantments/[id]/EnchantmentDetail.tsx
@@ -89,7 +89,7 @@ export default function EnchantmentDetail({
     return (
       <div className="max-w-2xl mx-auto px-4 py-12 text-center">
         <p className="text-[var(--text-muted)] mb-4">Enchantment not found.</p>
-        <Link href={`${lp}/enchantments`} className="text-[var(--accent-gold)] hover:underline">
+        <Link prefetch={false} href={`${lp}/enchantments`} className="text-[var(--accent-gold)] hover:underline">
           &larr; {t("Back to", lang)} {t("Enchantments", lang)}
         </Link>
       </div>
@@ -184,7 +184,7 @@ export default function EnchantmentDetail({
                     .replace(/_/g, " ")
                     .replace(/\b\w/g, (c) => c.toUpperCase());
                   return (
-                    <Link key={cid} href={`${lp}/cards/${cid}`} className="ench-cell">
+                    <Link prefetch={false} key={cid} href={`${lp}/cards/${cid}`} className="ench-cell">
                       <img
                         src={enchantedCardUrl(cid, id, false, "stable", lang)}
                         alt={`${cid} with ${enchantment.name} - Slay the Spire 2`}

--- a/frontend/app/encounters/[id]/EncounterDetail.tsx
+++ b/frontend/app/encounters/[id]/EncounterDetail.tsx
@@ -91,7 +91,7 @@ export default function EncounterDetail({ initialEncounter, encounterStat }: { i
     return (
       <div className="max-w-2xl mx-auto px-4 py-12 text-center">
         <p className="text-[var(--text-muted)] mb-4">Encounter not found.</p>
-        <Link href={`${lp}/encounters`} className="text-[var(--accent-gold)] hover:underline">
+        <Link prefetch={false} href={`${lp}/encounters`} className="text-[var(--accent-gold)] hover:underline">
           &larr; {t("Back to", lang)} {t("Encounters", lang)}
         </Link>
       </div>
@@ -187,7 +187,7 @@ export default function EncounterDetail({ initialEncounter, encounterStat }: { i
               <p className="h-note">The enemies you fight in this encounter.</p>
               <div className="chips">
                 {encounter.monsters!.map((m) => (
-                  <Link key={m.id} href={`${lp}/monsters/${m.id}`} className="chip">
+                  <Link prefetch={false} key={m.id} href={`${lp}/monsters/${m.id}`} className="chip">
                     <span className="pip" />
                     <span className="cn">{m.name}</span>
                   </Link>

--- a/frontend/app/keywords/page.tsx
+++ b/frontend/app/keywords/page.tsx
@@ -85,6 +85,7 @@ export default async function KeywordsPage() {
           .filter((k) => k.id !== "PERIOD")
           .map((kw) => (
             <Link
+              prefetch={false}
               key={kw.id}
               href={`/keywords/${kw.id.toLowerCase()}`}
               className="bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] p-5 hover:bg-[var(--bg-card-hover)] hover:border-[var(--border-accent)] transition-all"
@@ -112,6 +113,7 @@ export default async function KeywordsPage() {
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
               {terms.map((term) => (
                 <Link
+                  prefetch={false}
                   key={term.id}
                   href={`/keywords/${term.id.toLowerCase()}`}
                   className="bg-[var(--bg-card)] rounded-lg border border-[var(--border-subtle)] p-4 hover:bg-[var(--bg-card-hover)] hover:border-[var(--border-accent)] transition-all"

--- a/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
+++ b/frontend/app/leaderboards/LeaderboardBrowseClient.tsx
@@ -194,6 +194,9 @@ export default function LeaderboardBrowseClient() {
     if (browseBracket !== "all") params.set("bracket", browseBracket);
     const qs = params.toString();
     const url = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
+    // Next patches replaceState, and every call re-triggers a prefetch of
+    // all visible links -- skip the no-op call the mount run would make.
+    if (url === window.location.pathname + window.location.search) return;
     window.history.replaceState(null, "", url);
   }, [tab, mode, gameMode, lbChar, browseChar, browseWin, browseUser, browseBuildId, browseBracket]);
 
@@ -287,7 +290,7 @@ export default function LeaderboardBrowseClient() {
     <div className="mx-auto max-w-[1400px] px-3 sm:px-5 py-6">
       <div className="flex items-end justify-between mb-4">
         <h1 className="text-3xl font-bold text-[var(--accent-gold)]">{t("Leaderboards", lang)}</h1>
-        <Link href={`${lp}/runs`} className="text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors">
+        <Link prefetch={false} href={`${lp}/runs`} className="text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors">
           {t("Browse Runs", lang)} →
         </Link>
       </div>

--- a/frontend/app/loading.tsx
+++ b/frontend/app/loading.tsx
@@ -1,0 +1,10 @@
+// A route-level loading boundary also changes what a link prefetch costs:
+// with one present, prefetching a dynamic route fetches this cheap shell
+// instead of a full origin render of the target page.
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="w-8 h-8 border-2 border-[var(--text-muted)] border-t-transparent rounded-full animate-spin" />
+    </div>
+  );
+}

--- a/frontend/app/reference/ReferenceClient.tsx
+++ b/frontend/app/reference/ReferenceClient.tsx
@@ -92,7 +92,7 @@ function ReferenceSection<T extends { id: string }>({
             </div>
           );
           return linkPrefix ? (
-            <Link key={item.id} href={`${linkPrefix}/${item.id.toLowerCase()}`} className="block h-full">
+            <Link prefetch={false} key={item.id} href={`${linkPrefix}/${item.id.toLowerCase()}`} className="block h-full">
               {content}
             </Link>
           ) : (

--- a/frontend/app/timeline/[id]/EpochDetail.tsx
+++ b/frontend/app/timeline/[id]/EpochDetail.tsx
@@ -114,7 +114,7 @@ export default function EpochDetail({ initialEpoch }: { initialEpoch?: Epoch | n
   if (notFound || !epoch) {
     return (
       <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <Link href="/timeline" className="text-sm text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors">
+        <Link prefetch={false} href="/timeline" className="text-sm text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors">
           &larr; Back to Timeline
         </Link>
         <div className="text-center py-12">
@@ -216,7 +216,7 @@ export default function EpochDetail({ initialEpoch }: { initialEpoch?: Epoch | n
                       {epoch.unlocks_cards.map((cid) => {
                         const card = cardMap[cid];
                         return (
-                          <Link key={cid} href={`/cards/${cid.toLowerCase()}`} className="chip">
+                          <Link prefetch={false} key={cid} href={`/cards/${cid.toLowerCase()}`} className="chip">
                             <span className="pip" style={{ background: "#4f7fb3" }} />
                             {card?.name || cid.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
                           </Link>
@@ -232,7 +232,7 @@ export default function EpochDetail({ initialEpoch }: { initialEpoch?: Epoch | n
                       {epoch.unlocks_relics.map((rid) => {
                         const relic = relicMap[rid];
                         return (
-                          <Link key={rid} href={`/relics/${rid.toLowerCase()}`} className="chip">
+                          <Link prefetch={false} key={rid} href={`/relics/${rid.toLowerCase()}`} className="chip">
                             <span className="pip" style={{ background: "#c79a3a" }} />
                             {relic?.name || rid.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
                           </Link>
@@ -248,7 +248,7 @@ export default function EpochDetail({ initialEpoch }: { initialEpoch?: Epoch | n
                       {epoch.unlocks_potions.map((pid) => {
                         const potion = potionMap[pid];
                         return (
-                          <Link key={pid} href={`/potions/${pid.toLowerCase()}`} className="chip">
+                          <Link prefetch={false} key={pid} href={`/potions/${pid.toLowerCase()}`} className="chip">
                             <span className="pip" style={{ background: "#3ca47a" }} />
                             {potion?.name || pid.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
                           </Link>
@@ -267,7 +267,7 @@ export default function EpochDetail({ initialEpoch }: { initialEpoch?: Epoch | n
               <h2>Expands timeline</h2>
               <div className="chips">
                 {epoch.expands_timeline.map((eid) => (
-                  <Link key={eid} href={`/timeline/${eid.toLowerCase()}`} className="chip">
+                  <Link prefetch={false} key={eid} href={`/timeline/${eid.toLowerCase()}`} className="chip">
                     <span className="pip" style={{ background: "#8a5cc4" }} />
                     {epochTitleMap[eid] || eid.replace(/_EPOCH$/, "").replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
                   </Link>

--- a/frontend/app/unlocks/UnlocksClient.tsx
+++ b/frontend/app/unlocks/UnlocksClient.tsx
@@ -63,6 +63,7 @@ function EntityCard({ entity, type, lp }: { entity: UnlockEntity; type: string; 
 
   return (
     <Link
+      prefetch={false}
       href={href}
       className="flex items-center gap-3 px-3 py-2.5 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] hover:border-[var(--accent-gold)]/50 transition-colors group"
     >
@@ -226,6 +227,7 @@ export default function UnlocksClient() {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
             {data.characters.map((char) => (
               <Link
+                prefetch={false}
                 key={char.id}
                 href={`${lp}/characters/${char.id.toLowerCase()}`}
                 className="flex items-center gap-3 px-3 py-3 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] hover:border-[var(--accent-gold)]/50 transition-colors group"

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -5,6 +5,13 @@ const LANGS = "deu|esp|fra|ita|jpn|kor|pol|ptb|rus|spa|tha|tur|zhs|zht";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  // Without this, dynamic-route prefetches are stale on arrival
+  // (staleTimes.dynamic defaults to 0), so the router re-issues the same
+  // origin request for every visible link on each ping — measured 8-9
+  // fetches of the same footer link per page view in prod.
+  experimental: {
+    staleTimes: { dynamic: 180, static: 300 },
+  },
   // NitroPay hosts our ads.txt so exchange entries stay current without
   // deploys; the 301 is their recommended setup.
   async redirects() {


### PR DESCRIPTION
Users reported hard refreshes streaming requests for over a minute; every dynamic-route prefetch was stale on arrival and re-issued on each router ping (measured the same footer link fetched 9x per page view), so I set staleTimes, added a root loading boundary so prefetches fetch a cheap shell instead of a full origin render, put prefetch={false} on the ~86 chrome/hub/detail links the first pass missed, and stopped the mount-time replaceState on /leaderboards from re-triggering a prefetch wave.