### PR TITLE
Build frame.parquet from the lake instead of the 3-hour Mongo walk

### DIFF
--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -86,11 +86,94 @@ def _load_frame_parquet() -> list[tuple] | None:
         return None
 
 
+def _lake_frame_select(runs_p: Path, scalars_p: Path, with_hash: bool = False) -> str:
+    """The frame as one SQL projection over the lake. Mirrors the Mongo row
+    construction exactly: hidden $ne True (from the fresh sidecar, not the
+    stale extract-time flag), ascension 0-10 with missing excluded, Pacific
+    played_day (connection must be SET TimeZone='UTC' so the naive-as-UTC
+    convention matches pacific_epoch_day), daily seed date, fresh username."""
+    hash_col = "r.run_hash AS run_hash, " if with_hash else ""
+    return f"""
+        SELECT {hash_col}
+          upper(split_part(coalesce(r.character, ''), '.', -1)) AS character,
+          (CASE WHEN coalesce(try_cast(r.win AS BOOLEAN), false)
+            THEN 1 ELSE 0 END)::TINYINT AS win,
+          r.ascension::INT AS ascension,
+          lower(coalesce(r.game_mode, 'standard')) AS game_mode,
+          coalesce(r.player_count, 1)::INT AS player_count,
+          coalesce(r.run_time, 0)::BIGINT AS run_time,
+          coalesce(s.floors_reached, 0)::INT AS floors_reached,
+          coalesce(s.deck_size, 0)::INT AS deck_size,
+          coalesce(s.relic_count, 0)::INT AS relic_count,
+          coalesce((timezone('America/Los_Angeles',
+              coalesce(r.played_at, r.submitted_at)::TIMESTAMP::TIMESTAMPTZ))::date
+            - DATE '1970-01-01', 0)::INT AS played_day,
+          lower(coalesce(s.username, '')) AS username,
+          (CASE WHEN coalesce(try_cast(r.was_abandoned AS BOOLEAN), false)
+            THEN 1 ELSE 0 END)::TINYINT AS was_abandoned,
+          coalesce(s.acts_completed, 0)::INT AS acts_completed,
+          CASE WHEN lower(coalesce(r.game_mode, 'standard')) = 'daily'
+                AND regexp_matches(coalesce(r.seed, ''),
+                    '^[0-9]+_[0-9]+_[0-9]{{4}}(_|$)')
+            THEN string_split(r.seed, '_')[3] || '-'
+              || lpad(string_split(r.seed, '_')[2], 2, '0') || '-'
+              || lpad(string_split(r.seed, '_')[1], 2, '0')
+            ELSE '' END AS daily_date,
+          trim(coalesce(r.build_id, '')) AS build_id
+        FROM read_parquet('{runs_p}') r
+        LEFT JOIN read_parquet('{scalars_p}') s USING (run_hash)
+        WHERE coalesce(s.hidden, false) = false
+          AND r.ascension BETWEEN 0 AND 10
+    """
+
+
+def _store_frame_from_lake() -> int | None:
+    """Build frame.parquet as one DuckDB COPY over the lake instead of the
+    doc-by-doc Mongo walk (measured at 3h of the 6.5h store tail). Returns
+    None when the lake inputs aren't present so the caller can fall back."""
+    import duckdb
+
+    lake_dir = Path(os.environ.get("LAKE_DIR", "/lake"))
+    runs_p = lake_dir / "runs.parquet"
+    scalars_p = lake_dir / "run_scalars.parquet"
+    if not (runs_p.exists() and scalars_p.exists()):
+        return None
+    con = duckdb.connect()
+    try:
+        con.execute("SET TimeZone='UTC'")
+        tmp = _FRAME_PARQUET.with_suffix(".parquet.tmp")
+        con.execute(
+            f"COPY ({_lake_frame_select(runs_p, scalars_p)})"
+            f" TO '{tmp}' (FORMAT parquet, COMPRESSION zstd)"
+        )
+        n = int(
+            con.execute(f"SELECT count(*) FROM read_parquet('{tmp}')").fetchone()[0]
+        )
+        tmp.replace(_FRAME_PARQUET)
+    finally:
+        con.close()
+    logger.info(
+        "frame parquet stored from lake: %d rows, %d bytes",
+        n,
+        _FRAME_PARQUET.stat().st_size,
+    )
+    return n
+
+
 def store_frame_parquet() -> int:
     """Ingest-time: run the canonical frame builder once and dump the rows
     to parquet for every worker to load cheaply. Returns the row count."""
     import duckdb
 
+    if (os.environ.get("FRAME_FROM_LAKE", "") or "").strip().lower() in (
+        "1",
+        "on",
+        "true",
+    ):
+        n = _store_frame_from_lake()
+        if n is not None:
+            return n
+        logger.warning("lake frame inputs missing; falling back to the db walk")
     rows = _load_frame_from_db()
     con = duckdb.connect()
     try:

--- a/backend/tests/test_frame_parquet.py
+++ b/backend/tests/test_frame_parquet.py
@@ -45,3 +45,83 @@ def test_frame_parquet_stale_falls_back(monkeypatch, tmp_path):
     old = time.time() - cs._FRAME_PARQUET_MAX_AGE - 60
     os.utime(cs._FRAME_PARQUET, (old, old))
     assert cs._load_frame_parquet() is None
+
+
+def _write_lake_frame_fixtures(tmp_path):
+    import duckdb
+
+    con = duckdb.connect()
+    # r1: normal win, played 05:30 UTC -> previous Pacific day (22:30 PDT).
+    # r2: daily seed date, played 08:30 UTC -> same Pacific day.
+    # r3: hidden -> excluded. r4: ascension NULL -> excluded (mirrors Mongo
+    # $gte on a missing field). r5: no sidecar row -> zero-filled scalars.
+    con.execute(
+        f"""COPY (SELECT * FROM (VALUES
+        ('r1', 'IRONCLAD', true, 10, 'standard', 1, 3600,
+         TIMESTAMP '2026-08-28 05:30:00', TIMESTAMP '2026-08-28 06:00:00',
+         false, NULL, '0.111.0'),
+        ('r2', 'SILENT', false, 0, 'daily', 2, 0,
+         TIMESTAMP '2026-08-28 08:30:00', TIMESTAMP '2026-08-28 09:00:00',
+         true, '26_08_2026_abc', ''),
+        ('r3', 'DEFECT', true, 5, 'standard', 1, 100,
+         TIMESTAMP '2026-08-28 05:30:00', TIMESTAMP '2026-08-28 06:00:00',
+         false, NULL, ''),
+        ('r4', 'REGENT', true, NULL, 'standard', 1, 100,
+         TIMESTAMP '2026-08-28 05:30:00', TIMESTAMP '2026-08-28 06:00:00',
+         false, NULL, ''),
+        ('r5', 'NECROBINDER', false, 3, 'standard', 1, 50,
+         TIMESTAMP '2026-08-28 05:30:00', TIMESTAMP '2026-08-28 06:00:00',
+         false, NULL, ''))
+        t(run_hash, character, win, ascension, game_mode, player_count,
+          run_time, played_at, submitted_at, was_abandoned, seed, build_id))
+        TO '{tmp_path}/runs.parquet' (FORMAT parquet)"""
+    )
+    con.execute(
+        f"""COPY (SELECT * FROM (VALUES
+        ('r1', 45, 30, 12, 3, 'Yitsy', false),
+        ('r2', 12, 15, 3, 1, NULL, false),
+        ('r3', 1, 1, 1, 1, 'cheat', true),
+        ('r4', 1, 1, 1, 1, 'x', false))
+        t(run_hash, floors_reached, deck_size, relic_count, acts_completed,
+          username, hidden))
+        TO '{tmp_path}/run_scalars.parquet' (FORMAT parquet)"""
+    )
+    con.close()
+
+
+def test_store_frame_from_lake(monkeypatch, tmp_path):
+    import duckdb
+
+    _write_lake_frame_fixtures(tmp_path)
+    monkeypatch.setenv("LAKE_DIR", str(tmp_path))
+    monkeypatch.setattr(cs, "_FRAME_PARQUET", tmp_path / "frame.parquet")
+    n = cs._store_frame_from_lake()
+    assert n == 3
+    con = duckdb.connect()
+    rows = {
+        r[-1]: r
+        for r in con.execute(
+            "SELECT character, win, ascension, game_mode, player_count,"
+            " run_time, floors_reached, deck_size, relic_count, played_day,"
+            " username, was_abandoned, acts_completed, daily_date, build_id,"
+            " character FROM read_parquet(?)",
+            [str(tmp_path / "frame.parquet")],
+        ).fetchall()
+    }
+    con.close()
+    r1 = rows["IRONCLAD"]
+    # 2026-08-28 05:30 UTC is 22:30 Pacific on the 27th; epoch day of 08-27.
+    from datetime import date
+
+    assert r1[:15] == (
+        "IRONCLAD", 1, 10, "standard", 1, 3600, 45, 30, 12,
+        date(2026, 8, 27).toordinal() - date(1970, 1, 1).toordinal(),
+        "yitsy", 0, 3, "", "0.111.0",
+    )
+    r2 = rows["SILENT"]
+    assert r2[3] == "daily" and r2[13] == "2026-08-26"
+    assert r2[9] == date(2026, 8, 28).toordinal() - date(1970, 1, 1).toordinal()
+    assert r2[10] == "" and r2[11] == 1
+    r5 = rows["NECROBINDER"]
+    assert r5[6:9] == (0, 0, 0) and r5[12] == 0
+    assert "DEFECT" not in rows and "REGENT" not in rows

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -192,6 +192,9 @@ services:
     env_file: .env
     environment:
       DATA_DIR: /data
+      # Build frame.parquet from the lake (one COPY) instead of the 3h Mongo
+      # doc walk. Flip in .env after lab/validate_frame_lake.py passes.
+      FRAME_FROM_LAKE: ${FRAME_FROM_LAKE:-}
     # 5g container / 3.5g duckdb: with the rebuilder headed for deletion the
     # ingest is the box's main computer, so it gets real memory instead of
     # spilling every heavy aggregate to disk.

--- a/lab/build.sql
+++ b/lab/build.sql
@@ -57,6 +57,17 @@ SELECT run_hash FROM read_ndjson('/lake/excluded_current.jsonl.gz',
   columns={run_hash: 'VARCHAR'})
 ) TO '/lake/excluded.parquet' (FORMAT parquet, COMPRESSION zstd);
 
+-- Same fresh-scan sidecar pattern: the frame's doc-scalar columns plus the
+-- mutable username/hidden, so frame.parquet builds from the lake.
+COPY (
+SELECT run_hash, floors_reached, deck_size, relic_count, acts_completed,
+  username, hidden
+FROM read_ndjson('/lake/run_scalars_current.jsonl.gz',
+  columns={run_hash: 'VARCHAR', floors_reached: 'INTEGER',
+           deck_size: 'INTEGER', relic_count: 'INTEGER',
+           acts_completed: 'INTEGER', username: 'VARCHAR', hidden: 'BOOLEAN'})
+) TO '/lake/run_scalars.parquet' (FORMAT parquet, COMPRESSION zstd);
+
 COPY (
 SELECT r.run_hash, act.i AS act, loc.i AS floor_idx,
   lower(loc.u.map_point_type) AS map_point_type,

--- a/lab/extract.py
+++ b/lab/extract.py
@@ -72,6 +72,45 @@ def _refresh_excluded(coll) -> None:
     print(f"excluded sidecar refreshed: {n:,} hidden/deleted runs", flush=True)
 
 
+def _refresh_scalars(coll) -> None:
+    """Frame inputs that exist only as doc scalars, plus the two mutable
+    fields (username, hidden) the frame needs fresh. Full projection scan
+    like the excluded sidecar, so frame.parquet can build from the lake
+    instead of walking every Mongo doc through Python."""
+    n = 0
+    tmp = pathlib.Path("/lake/run_scalars_current.jsonl.gz.tmp")
+    with gzip.open(tmp, "wt", encoding="utf-8") as out:
+        for doc in coll.find(
+            {},
+            {
+                "_id": 1,
+                "floors_reached": 1,
+                "deck_size": 1,
+                "relic_count": 1,
+                "acts_completed": 1,
+                "username": 1,
+                "hidden": 1,
+            },
+        ):
+            out.write(
+                json.dumps(
+                    {
+                        "run_hash": doc["_id"],
+                        "floors_reached": doc.get("floors_reached"),
+                        "deck_size": doc.get("deck_size"),
+                        "relic_count": doc.get("relic_count"),
+                        "acts_completed": doc.get("acts_completed"),
+                        "username": doc.get("username"),
+                        "hidden": bool(doc.get("hidden")),
+                    }
+                )
+                + "\n"
+            )
+            n += 1
+    tmp.replace(pathlib.Path("/lake/run_scalars_current.jsonl.gz"))
+    print(f"run-scalars sidecar refreshed: {n:,} runs", flush=True)
+
+
 def main() -> tuple[int, int]:
     """Returns (written, skipped) so the ingest can record cycle metrics."""
     STAGING.mkdir(parents=True, exist_ok=True)
@@ -80,6 +119,7 @@ def main() -> tuple[int, int]:
         return (0, 0)
     coll = _get_collection()
     _refresh_excluded(coll)
+    _refresh_scalars(coll)
 
     query: dict = {}
     page = 0

--- a/lab/validate_frame_lake.py
+++ b/lab/validate_frame_lake.py
@@ -1,0 +1,126 @@
+"""Shadow-validate the lake-built frame against the Mongo row construction.
+
+Builds the lake frame (with run_hash) to a scratch parquet, samples rows,
+fetches the same docs from Mongo, runs them through the exact Python row
+construction the DB walk uses, and diffs column by column. Sampling makes it
+exact on transformation semantics without paying the 3h full walk.
+
+    docker compose -f docker-compose.prod.yml run -T --rm --entrypoint python lake-ingest /lab/validate_frame_lake.py
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, "/app")
+
+SAMPLE = 2000
+COLS = (
+    "character",
+    "win",
+    "ascension",
+    "game_mode",
+    "player_count",
+    "run_time",
+    "floors_reached",
+    "deck_size",
+    "relic_count",
+    "played_day",
+    "username",
+    "was_abandoned",
+    "acts_completed",
+    "daily_date",
+    "build_id",
+)
+
+
+def main() -> None:
+    import duckdb
+
+    from app.services import charts_stats as cs
+    from app.services.runs_db_mongo import _get_collection
+
+    lake = pathlib.Path("/lake")
+    runs_p = lake / "runs.parquet"
+    scalars_p = lake / "run_scalars.parquet"
+    if not (runs_p.exists() and scalars_p.exists()):
+        print("lake inputs missing (runs.parquet / run_scalars.parquet)")
+        sys.exit(1)
+
+    out = lake / "frame_lake_validate.parquet"
+    con = duckdb.connect()
+    con.execute("SET TimeZone='UTC'")
+    con.execute(
+        f"COPY ({cs._lake_frame_select(runs_p, scalars_p, with_hash=True)})"
+        f" TO '{out}' (FORMAT parquet, COMPRESSION zstd)"
+    )
+    total = con.execute(f"SELECT count(*) FROM read_parquet('{out}')").fetchone()[0]
+    print(f"lake frame: {total:,} rows")
+
+    hashes = [
+        r[0]
+        for r in con.execute(
+            f"SELECT run_hash FROM read_parquet('{out}') USING SAMPLE {SAMPLE}"
+        ).fetchall()
+    ]
+    lake_rows = {
+        r[0]: r[1:]
+        for r in con.execute(
+            f"SELECT run_hash, {', '.join(COLS)} FROM read_parquet('{out}')"
+            " WHERE run_hash IN (SELECT unnest(?))",
+            [hashes],
+        ).fetchall()
+    }
+
+    coll = _get_collection()
+    docs = {d["_id"]: d for d in coll.find({"_id": {"$in": hashes}})}
+    mismatches = 0
+    missing = 0
+    by_col: dict[str, int] = {}
+    for h in hashes:
+        d = docs.get(h)
+        if d is None:
+            missing += 1
+            continue
+        mode = (d.get("game_mode") or "standard").lower()
+        expected = (
+            cs._norm_char(d.get("character")),
+            1 if d.get("win") else 0,
+            int(d.get("ascension") or 0),
+            mode,
+            int(d.get("player_count") or 1),
+            int(d.get("run_time") or 0),
+            int(d.get("floors_reached") or 0),
+            int(d.get("deck_size") or 0),
+            int(d.get("relic_count") or 0),
+            cs._epoch_day(d.get("played_at") or d.get("submitted_at")),
+            (d.get("username") or "").lower(),
+            1 if d.get("was_abandoned") else 0,
+            int(d.get("acts_completed") or 0),
+            cs._daily_date(d.get("seed"), mode),
+            (d.get("build_id") or "").strip(),
+        )
+        got = lake_rows.get(h)
+        if got != expected:
+            mismatches += 1
+            for name, e, g in zip(COLS, expected, got or ()):
+                if e != g:
+                    by_col[name] = by_col.get(name, 0) + 1
+                    if by_col[name] <= 3:
+                        print(f"  {h} {name}: mongo={e!r} lake={g!r}")
+    print(
+        f"sampled {len(hashes)}: {mismatches} mismatched rows, "
+        f"{missing} not in mongo, per-column: {by_col or 'clean'}"
+    )
+    # Coverage: how much newer is Mongo than the lake (explains count deltas).
+    newer = coll.count_documents(
+        {
+            "hidden": {"$ne": True},
+            "ascension": {"$gte": 0, "$lte": 10},
+        }
+    )
+    print(f"mongo eligible now: {newer:,} vs lake frame {total:,}")
+    sys.exit(1 if mismatches else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
stage_seconds showed the frame stage at 3 of the 6.5 store-tail hours, so the extractor now refreshes a run-scalars sidecar (the excluded.parquet pattern, carrying the doc-only columns plus fresh username/hidden) and frame.parquet becomes a single DuckDB COPY over the lake, gated behind FRAME_FROM_LAKE with lab/validate_frame_lake.py to shadow-diff sampled rows against the Mongo construction before flipping it.