### PR TITLE
Defer the ad loader past page load

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -103,21 +103,28 @@ export default function RootLayout({
           RTTs that's a few hundred ms off every art-heavy page. */}
       <link rel="preconnect" href="https://cdn.spire-codex.com" crossOrigin="anonymous" />
       <link rel="dns-prefetch" href="https://cdn.spire-codex.com" />
-      {/* NitroPay: the queue stub must exist before any createAd call, and
-          the loader wants <head> placement so the auction starts early.
-          beforeInteractive injects both into <head>. Production builds only —
-          Nitro authorizes spire-codex.com, so dev would just log errors. */}
+      {/* NitroPay: the queue stub must exist before any createAd call, so it
+          stays beforeInteractive (it's one statement). The loader itself is
+          deferred to lazyOnload: its stack owned every top main-thread
+          blocking task in the field (INP 221ms p75 on mobile, the one
+          failing Core Web Vital), so the auction now starts after load
+          instead of before hydration. The preconnects keep the deferred
+          path fast once it fires. Production builds only — Nitro authorizes
+          spire-codex.com, so dev would just log errors. */}
       {process.env.NODE_ENV === "production" && (
         <>
+          <link rel="preconnect" href="https://s.nitropay.com" crossOrigin="anonymous" />
+          <link rel="dns-prefetch" href="https://consent.nitrocnct.com" />
+          <link rel="dns-prefetch" href="https://p.cpx.to" />
+          <link rel="dns-prefetch" href="https://prebid.cwi.re" />
           <Script id="nitro-stub" strategy="beforeInteractive">
             {`window.nitroAds=window.nitroAds||{createAd:function(){return new Promise(e=>{window.nitroAds.queue.push(["createAd",arguments,e])})},addUserToken:function(){window.nitroAds.queue.push(["addUserToken",arguments])},queue:[]};`}
           </Script>
           <Script
             src="https://s.nitropay.com/ads-2467.js"
-            strategy="beforeInteractive"
+            strategy="lazyOnload"
             data-cfasync="false"
             data-spa="auto"
-            async
           />
         </>
       )}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,5 +37,11 @@
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^3.2.4"
-  }
+  },
+  "browserslist": [
+    "chrome >= 100",
+    "edge >= 100",
+    "firefox >= 100",
+    "safari >= 15.6"
+  ]
 }


### PR DESCRIPTION
Every top main-thread blocking task in the Lighthouse trace was the ad stack and mobile fails Core Web Vitals only on INP, so the Nitro loader moves from beforeInteractive to lazyOnload (the queue stub stays early so createAd calls keep working), its hosts get preconnect/dns-prefetch hints so the deferred auction still starts fast, and an explicit modern browserslist drops the legacy transforms Lighthouse flagged.