### PR TITLE
Cheat signal: co-op-only cards in solo decks

### DIFF
--- a/backend/app/services/cheat_detect.py
+++ b/backend/app/services/cheat_detect.py
@@ -1,11 +1,14 @@
 """Submit-time cheated-run detection.
 
-Three high-confidence signals, all from real cheated submissions:
+Four high-confidence signals, all from real cheated submissions:
 stacked copies of one relic (a savegame editor artifact; 21x Infused Core),
 boss-teleport wins where an act's visited path is a floor or two instead
-of the ~16 a real act takes, and boss fights cleared in a single turn.
-Flagged runs are stored hidden with a reason so they never enter
-leaderboards or stats but stay inspectable in the admin console."""
+of the ~16 a real act takes, boss fights cleared in a single turn, and
+co-op-only cards in a single-player deck (the pools never offer them solo,
+so their presence is console tampering — found via a co-op card posting a
+"solo win rate" from 8 tampered runs, 2026-08-28). Flagged runs are stored
+hidden with a reason so they never enter leaderboards or stats but stay
+inspectable in the admin console."""
 
 from __future__ import annotations
 
@@ -55,6 +58,31 @@ def one_turn_bosses(data: dict) -> list[str]:
     return reasons
 
 
+def coop_cards_in_solo(data: dict, coop_ids=None) -> list[str]:
+    """Co-op-only cards in a single-player run's deck — impossible without
+    console tampering. The catalog set can be injected (tests, the rehide
+    backfill); submit-time loads it lazily and fails open when the catalog
+    can't be read, since a missed flag must never block a submission."""
+    players = data.get("players") or []
+    if len(players) != 1:
+        return []
+    if coop_ids is None:
+        try:
+            from .run_entity_stats import _multiplayer_card_ids
+
+            coop_ids = _multiplayer_card_ids()
+        except Exception:
+            return []
+    if not coop_ids:
+        return []
+    found: set[str] = set()
+    for c in players[0].get("deck") or []:
+        cid = _bare((c or {}).get("id", "")).upper()
+        if cid in coop_ids:
+            found.add(cid)
+    return [f"coop_card_solo:{cid}" for cid in sorted(found)]
+
+
 def detect_cheats(data: dict) -> list[str]:
     """Reasons this submission looks cheated; empty list = clean."""
     reasons: list[str] = []
@@ -96,4 +124,5 @@ def detect_cheats(data: dict) -> list[str]:
         ):
             reasons.append(f"missing_acts:{boss_acts}of3bosses")
     reasons.extend(one_turn_bosses(data))
+    reasons.extend(coop_cards_in_solo(data))
     return reasons

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -2440,6 +2440,49 @@ def rehide_one_turn_boss_runs(dry_run: bool = False) -> dict:
     return {"candidates": checked, "hidden": len(hidden_runs), "hashes": hidden_runs}
 
 
+def rehide_coop_card_solo_runs(dry_run: bool = False) -> dict:
+    """Backfill for the co-op-card-in-solo cheat signal: sweep stored solo
+    runs whose decks contain a co-op-only card (submit-time detection only
+    covers new uploads). The Mongo prefilter matches deck ids against the
+    catalog's co-op set case-insensitively; the shared detector then
+    re-checks per doc off the blob's own player list. Returns counts;
+    dry_run only reports."""
+    import re as _re
+
+    from .cheat_detect import coop_cards_in_solo
+    from .run_entity_stats import _multiplayer_card_ids
+
+    coop_ids = _multiplayer_card_ids()
+    if not coop_ids:
+        return {"candidates": 0, "hidden": 0, "hashes": []}
+    patterns = [
+        _re.compile(rf"^CARD\.{_re.escape(cid)}$", _re.IGNORECASE)
+        for cid in sorted(coop_ids)
+    ]
+    coll = _get_collection()
+    cursor = coll.find(
+        {
+            "hidden": {"$ne": True},
+            "player_count": 1,
+            "players.deck.id": {"$in": patterns},
+        },
+        {"players.deck.id": 1, "run_hash": 1},
+    )
+    checked = 0
+    hidden_runs: list[str] = []
+    for doc in cursor:
+        checked += 1
+        run_hash = doc.get("run_hash") or doc["_id"]
+        reasons = coop_cards_in_solo({"players": doc.get("players")}, coop_ids)
+        if not reasons:
+            continue
+        hidden_runs.append(run_hash)
+        if not dry_run:
+            set_run_hidden(run_hash, True, reason="auto:" + ",".join(reasons[:4]))
+            logger.info("auto-hid coop-card-solo run %s: %s", run_hash, reasons[:4])
+    return {"candidates": checked, "hidden": len(hidden_runs), "hashes": hidden_runs}
+
+
 def leaderboard(
     category: str = "fastest",
     character: str | None = None,

--- a/backend/tests/test_cheat_detect.py
+++ b/backend/tests/test_cheat_detect.py
@@ -59,3 +59,39 @@ def test_normal_turn_counts_and_non_boss_rooms_are_clean():
         ],
     }
     assert one_turn_bosses(data) == []
+
+
+def test_coop_card_in_solo_deck_flags():
+    from app.services.cheat_detect import coop_cards_in_solo
+
+    data = {"players": [{"deck": [{"id": "CARD.MIDNIGHT"}, {"id": "CARD.STRIKE"}]}]}
+    assert coop_cards_in_solo(data, coop_ids=frozenset({"MIDNIGHT"})) == [
+        "coop_card_solo:MIDNIGHT"
+    ]
+
+
+def test_coop_card_in_actual_coop_run_is_clean():
+    from app.services.cheat_detect import coop_cards_in_solo
+
+    data = {
+        "players": [
+            {"deck": [{"id": "CARD.MIDNIGHT"}]},
+            {"deck": [{"id": "CARD.STRIKE"}]},
+        ]
+    }
+    assert coop_cards_in_solo(data, coop_ids=frozenset({"MIDNIGHT"})) == []
+
+
+def test_solo_run_without_coop_cards_is_clean():
+    from app.services.cheat_detect import coop_cards_in_solo
+
+    data = {"players": [{"deck": [{"id": "CARD.STRIKE"}]}]}
+    assert coop_cards_in_solo(data, coop_ids=frozenset({"MIDNIGHT"})) == []
+
+
+def test_detect_cheats_carries_the_coop_solo_signal(monkeypatch):
+    from app.services import run_entity_stats as res
+
+    monkeypatch.setattr(res, "_multiplayer_card_ids", lambda: frozenset({"MIDNIGHT"}))
+    data = {"players": [{"deck": [{"id": "card.midnight"}]}]}
+    assert "coop_card_solo:MIDNIGHT" in detect_cheats(data)


### PR DESCRIPTION
A co-op-only card posted a solo win rate off 8 console-tampered runs, so detect_cheats gains a fourth deterministic signal (co-op card in a single-player deck, catalog set from both channels) and rehide_coop_card_solo_runs sweeps the stored corpus the same way the one-turn-boss backfill does.