### PR TITLE
Entity detail brackets from the live cube

### DIFF
--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -1484,7 +1484,50 @@ def _entity_cube_with_mtime() -> tuple[float, dict] | None:
         return None
 
 
+_fold_cache: dict[tuple[str, str], tuple[float, dict | None]] = {}
+
+
 def entity_bracket_fold(entity_type: str, bracket: str) -> dict | None:
+    """Cached fold: the entity detail page reads ~20 brackets per request
+    and every entity shares the same folds, so cache per (type, bracket)
+    keyed on the cube file's mtime."""
+    hit = _entity_cube_with_mtime()
+    if hit is None:
+        return None
+    key = (entity_type, bracket)
+    cached = _fold_cache.get(key)
+    if cached is not None and cached[0] == hit[0]:
+        return cached[1]
+    fold = _entity_bracket_fold_uncached(entity_type, bracket)
+    if len(_fold_cache) > 512:
+        _fold_cache.clear()
+    _fold_cache[key] = (hit[0], fold)
+    return fold
+
+
+def cube_versions(min_runs: int = 500, limit: int = 8) -> list[str]:
+    """Game versions present in the entity cube with at least min_runs
+    eligible runs, newest first. The detail page's version picker reads
+    this now that the snapshot's version list is frozen."""
+    hit = _entity_cube_with_mtime()
+    if hit is None:
+        return []
+    counts: dict[str, int] = {}
+    for cell, tw in (hit[1].get("runs") or {}).items():
+        parts = cell.split("|")
+        ver = parts[4] if len(parts) > 4 else ""
+        if ver.startswith("v"):
+            counts[ver] = counts.get(ver, 0) + tw[0]
+    import re as _re
+
+    def _natural(v: str) -> list[int]:
+        return [int(x) for x in _re.findall(r"\d+", v)]
+
+    vs = [v for v, n in counts.items() if n >= min_runs]
+    return sorted(vs, key=_natural, reverse=True)[:limit]
+
+
+def _entity_bracket_fold_uncached(entity_type: str, bracket: str) -> dict | None:
     """Fold the entity cube for one bracket (any mode x players x skill x
     version combination): {"entries": {id: [picks, wins]}, "total_runs",
     "total_wins", "data_through"}. None for unknown brackets or a missing

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -3894,6 +3894,66 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
             "pick_rate": round(cp / ctot * 100, 1) if ctot else 0.0,
             "by_character": _shape_chars(cd.get("by_character") or {}),
         }
+    # Live overlay: every bracket cell the cube can fold replaces the
+    # frozen snapshot's number (the retired rebuilder left agg_brackets
+    # permanently stale — a card page showed a weeks-old 82.1% next to the
+    # live path's 89.5%, 2026-08-29). Character splits ride along from the
+    # fossil where present (the cube has no per-character cells), and the
+    # version keys come from the cube so new patches appear without a
+    # snapshot rebuild. Skill brackets read the store's per-bracket Elo.
+    if _LAKE_ENTITY_SERVE:
+        try:
+            from . import lake_stats
+
+            eid = key[1]
+            lake_versions = lake_stats.cube_versions()
+            lake_keys = [
+                "a10",
+                "wr30",
+                "wr50",
+                "wr75",
+                *_PLAYER_BRACKETS,
+                *_COMPOSITE_BRACKETS,
+                *lake_versions,
+                *(f"a10:{v}" for v in lake_versions),
+            ]
+            for ck in lake_keys:
+                fold = lake_stats.entity_bracket_fold(entity_type, ck)
+                if not fold:
+                    continue
+                pw = (fold.get("entries") or {}).get(eid)
+                if not pw or not pw[0]:
+                    # The live corpus says this entity has no picks in the
+                    # bracket; a lingering fossil cell would resurrect them.
+                    brackets.pop(ck, None)
+                    continue
+                cp, cw = int(pw[0]), int(pw[1])
+                base_p = sum(x[0] for x in fold["entries"].values())
+                base_w = sum(x[1] for x in fold["entries"].values())
+                cbase = (base_w / base_p) if base_p else _baseline_win_rate()
+                ctot = fold["total_runs"]
+                celo = None
+                if entity_type == "cards":
+                    bmap = lake_stats.bracket_elo_for(ck)
+                    celo = bmap.get(eid) if bmap is not None else agg.get("elo")
+                prev = brackets.get(ck) or {}
+                brackets[ck] = {
+                    "picks": cp,
+                    "wins": cw,
+                    "win_rate": round(cw / cp * 100, 1) if cp else 0.0,
+                    "elo": celo,
+                    "score": _compute_score(
+                        cw,
+                        cp,
+                        cbase,
+                        _bracket_prior(ctot) if entity_type == "relics" else None,
+                    ),
+                    "total_runs": ctot,
+                    "pick_rate": round(cp / ctot * 100, 1) if ctot else 0.0,
+                    "by_character": prev.get("by_character") or [],
+                }
+        except Exception:
+            logger.warning("lake bracket overlay failed", exc_info=True)
     return {
         "entity_type": entity_type,
         "entity_id": entity_id.upper(),

--- a/backend/tests/test_lake_stats.py
+++ b/backend/tests/test_lake_stats.py
@@ -309,3 +309,26 @@ def test_bracket_elo_for(monkeypatch, tmp_path):
     assert lake_stats.bracket_elo_for("standard") is None
     assert lake_stats.bracket_elo_for("all") is None
     assert lake_stats.bracket_elo_for("wr75") is None
+
+
+def test_cube_versions_and_fold_cache(monkeypatch):
+    cube = {
+        "runs": {
+            "standard|1|1|0|v0.111.0": [600, 300],
+            "standard|1|0|0|v0.111.0": [700, 200],
+            "standard|1|1|2|v0.110.2": [800, 400],
+            "standard|1|0|0|v0.9.9": [100, 10],
+            "standard|1|0|0|": [900, 100],
+        },
+        "entities": {"cards": {"standard|1|1|0|v0.111.0": {"X": [10, 6]}}},
+        "offers": {},
+    }
+    monkeypatch.setattr(lake_stats, "_entity_cube_with_mtime", lambda: (1.0, cube))
+    monkeypatch.setattr(lake_stats, "_fold_cache", {})
+    # Version floor (500 runs) drops v0.9.9; blank build ids never count.
+    assert lake_stats.cube_versions() == ["v0.111.0", "v0.110.2"]
+    f1 = lake_stats.entity_bracket_fold("cards", "a10")
+    f2 = lake_stats.entity_bracket_fold("cards", "a10")
+    assert f1 is f2, "second fold must come from the mtime-keyed cache"
+    assert f1["entries"]["X"] == [10, 6]
+    assert f1["total_runs"] == 1400


### PR DESCRIPTION
The card page's bracket panel still read the retired snapshot's frozen cells (82.1% next to the live path's 89.5% for the same bracket), so every foldable bracket cell now overlays from the entity cube with the store's per-bracket Elo, folds are mtime-cached since a detail request reads ~20 of them, and the version keys come from the cube so new patches show up without a snapshot rebuild.