### PR TITLE
Fossil purge, batch 1

### DIFF
--- a/backend/app/routers/charts.py
+++ b/backend/app/routers/charts.py
@@ -312,7 +312,10 @@ def charts_meta(request: Request):
         ],
         "stats": [{"key": k, "label": v["label"]} for k, v in cs.STATS.items()],
         "characters": [{"id": cid, "name": name} for cid, name in chars.items()],
-        "events": cs.event_list(get_charts_blob_stats()),
+        # The blob is bracket-keyed ({all: ..., a10: ...}); event_list wants
+        # one bracket's stats. Passing the outer dict made the event picker
+        # permanently empty.
+        "events": cs.event_list((get_charts_blob_stats() or {}).get("all") or {}),
     }
 
 

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -2977,6 +2977,12 @@ def _maybe_overlay_lake_entities() -> None:
                 _cache[key] = new_entry
                 n += 1
         _type_baselines.update(store.get("baselines") or {})
+        # The store's run totals must ride along: live picks divided by the
+        # frozen snapshot's total_runs skewed every headline pick rate, the
+        # /pulse baseline, and the relic bracket prior (2026-08-29 audit).
+        totals = store.get("totals") or {}
+        if totals.get("total_runs"):
+            _global_totals.update(totals)
         _lake_overlay_mtime = mtime
         logger.info("lake entity overlay applied: %d entities", n)
     except Exception:
@@ -3141,18 +3147,34 @@ def is_valid_stat_bracket(bracket: str | None) -> bool:
     if not bracket:
         return False
     _maybe_rebuild()
-    if bracket in _BRACKET_KEYS or bracket in _recent_stat_versions:
+    versions = set(get_recent_stat_versions())
+    if bracket in _BRACKET_KEYS or bracket in versions:
         return True
     base, sep, ver = bracket.rpartition(":")
-    return bool(sep) and ver in _recent_stat_versions and base in _BRACKET_KEYS
+    return bool(sep) and ver in versions and base in _BRACKET_KEYS
 
 
 def get_recent_stat_versions() -> list[str]:
-    """Game versions (build_ids) the encounter blob carries a per-version slice
-    for, newest first — the options the stats-page version dropdown offers.
-    Empty until a v15+ snapshot is built/loaded."""
+    """Game versions for the version dropdowns, newest first. Lake-first:
+    the cube's versions keep new patches selectable (the snapshot's frozen
+    list silently dropped every patch shipped after the rebuilder retired,
+    2026-08-29 audit), unioned with the snapshot list so any version only
+    the old blob can still slice stays reachable."""
     _maybe_rebuild()
-    return list(_recent_stat_versions)
+    merged = list(_recent_stat_versions)
+    if _LAKE_ENTITY_SERVE:
+        try:
+            from . import lake_stats
+
+            for v in lake_stats.cube_versions():
+                if v not in merged:
+                    merged.append(v)
+        except Exception:
+            logger.warning("cube version list failed", exc_info=True)
+    import re as _re
+
+    merged.sort(key=lambda v: [int(x) for x in _re.findall(r"\d+", v)], reverse=True)
+    return merged
 
 
 def get_encounter_stats(
@@ -3569,27 +3591,25 @@ def get_entity_metrics_table(
                 character_wins = ch.get("wins")
                 break
 
-    # Player=All rows blend the per-player Elos (equal weight) instead of the
-    # pooled fit, so a card's "All players" rating reflects every mode rather
-    # than being dominated by solo volume. Maps the requested bracket to the
-    # player brackets to average; None for player-specific / composite brackets,
-    # which keep their own stored Elo.
-    avg_siblings = {
-        "all": list(_PLAYER_BRACKETS),
-        "a10": [f"{p}:a10" for p in _PLAYER_BRACKETS],
-        "wr30": [f"{p}:wr30" for p in _PLAYER_BRACKETS],
-        "wr50": [f"{p}:wr50" for p in _PLAYER_BRACKETS],
-        "wr75": [f"{p}:wr75" for p in _PLAYER_BRACKETS],
-    }.get(bracket)
+    # The old "average the per-player-bracket Elos" blend is retired: it
+    # read the frozen snapshot's bracket cells, so the default metrics view
+    # disagreed with the tier list's live rating for the same card
+    # (2026-08-29 audit). Rows now carry the live store rating — the
+    # per-bracket fit when the view has a skill component, all-runs
+    # otherwise — matching /scores exactly.
+    _skill_bmap: dict | None = None
+    if bracket in _SKILL_BRACKETS:
+        try:
+            from . import lake_stats as _ls
 
-    def _avg_player_elo(agg: dict) -> float | None:
-        brackets = agg.get("brackets") or {}
-        vals = [
-            brackets[b]["elo"]
-            for b in avg_siblings or []
-            if brackets.get(b) and brackets[b].get("elo") is not None
-        ]
-        return round(sum(vals) / len(vals), 1) if vals else None
+            _skill_bmap = _ls.bracket_elo_for(bracket)
+        except Exception:
+            _skill_bmap = None
+
+    def _live_elo(agg: dict, eid: str, fallback) -> float | None:
+        if _skill_bmap is not None:
+            return _skill_bmap.get(eid)
+        return fallback
 
     z3 = [0] * _ACT_BUCKETS
 
@@ -3668,7 +3688,7 @@ def get_entity_metrics_table(
                     eid,
                     data.get("picks", 0),
                     data.get("wins", 0),
-                    elo=_avg_player_elo(agg) if avg_siblings else data.get("elo"),
+                    elo=_live_elo(agg, eid, data.get("elo")),
                     offered=data.get("offered", 0),
                     picked=data.get("picked", 0),
                     off_act=data.get("off_act") or z3,
@@ -3688,7 +3708,7 @@ def get_entity_metrics_table(
                     eid,
                     base["picks"],
                     base["wins"],
-                    elo=_avg_player_elo(agg) if avg_siblings else agg.get("elo"),
+                    elo=_live_elo(agg, eid, agg.get("elo")),
                     offered=agg.get("offered", 0),
                     picked=agg.get("picked", 0),
                     off_act=agg.get("off_act") or z3,
@@ -3720,7 +3740,7 @@ def get_entity_metrics_table(
                     eid,
                     agg.get("picks", 0),
                     agg.get("wins", 0),
-                    elo=_avg_player_elo(agg) if avg_siblings else agg.get("elo"),
+                    elo=_live_elo(agg, eid, agg.get("elo")),
                     offered=agg.get("offered", 0),
                     picked=agg.get("picked", 0),
                     off_act=agg.get("off_act") or z3,

--- a/backend/tests/test_lake_stats.py
+++ b/backend/tests/test_lake_stats.py
@@ -332,3 +332,49 @@ def test_cube_versions_and_fold_cache(monkeypatch):
     assert f1 is f2, "second fold must come from the mtime-keyed cache"
     assert f1["entries"]["X"] == [10, 6]
     assert f1["total_runs"] == 1400
+
+
+def test_overlay_carries_store_totals(monkeypatch, tmp_path):
+    import json
+
+    from app.services import run_entity_stats as res
+
+    monkeypatch.setattr(lake_stats, "LAKE_DIR", tmp_path)
+    monkeypatch.setattr(lake_stats, "_entity_store_cache", None)
+    (tmp_path / "entity_store.json").write_text(
+        json.dumps(
+            {
+                "entities": {"cards": {}},
+                "baselines": {},
+                "totals": {"total_runs": 123456, "total_wins": 45678},
+            }
+        )
+    )
+    monkeypatch.setattr(res, "_LAKE_ENTITY_SERVE", True)
+    monkeypatch.setattr(res, "_lake_overlay_checked", 0.0)
+    monkeypatch.setattr(res, "_lake_overlay_mtime", 0.0)
+    old = dict(res._global_totals)
+    try:
+        res._maybe_overlay_lake_entities()
+        assert res._global_totals["total_runs"] == 123456
+        assert res._global_totals["total_wins"] == 45678
+    finally:
+        res._global_totals.clear()
+        res._global_totals.update(old)
+
+
+def test_recent_versions_include_cube_and_validate(monkeypatch):
+    from app.services import run_entity_stats as res
+
+    cube = {
+        "runs": {"standard|1|0|0|v0.112.0": [600, 1]},
+        "entities": {},
+        "offers": {},
+    }
+    monkeypatch.setattr(lake_stats, "_entity_cube_with_mtime", lambda: (1.0, cube))
+    monkeypatch.setattr(res, "_LAKE_ENTITY_SERVE", True)
+    monkeypatch.setattr(res, "_recent_stat_versions", ["v0.110.2"])
+    monkeypatch.setattr(res, "_maybe_rebuild", lambda: None)
+    assert res.get_recent_stat_versions() == ["v0.112.0", "v0.110.2"]
+    assert res.is_valid_stat_bracket("v0.112.0")
+    assert res.is_valid_stat_bracket("a10:v0.112.0")

--- a/backend/tests/test_lake_stats.py
+++ b/backend/tests/test_lake_stats.py
@@ -378,25 +378,3 @@ def test_recent_versions_include_cube_and_validate(monkeypatch):
     assert res.get_recent_stat_versions() == ["v0.112.0", "v0.110.2"]
     assert res.is_valid_stat_bracket("v0.112.0")
     assert res.is_valid_stat_bracket("a10:v0.112.0")
-
-def test_cube_versions_and_fold_cache(monkeypatch):
-    cube = {
-        "runs": {
-            "standard|1|1|0|v0.111.0": [600, 300],
-            "standard|1|0|0|v0.111.0": [700, 200],
-            "standard|1|1|2|v0.110.2": [800, 400],
-            "standard|1|0|0|v0.9.9": [100, 10],
-            "standard|1|0|0|": [900, 100],
-        },
-        "entities": {"cards": {"standard|1|1|0|v0.111.0": {"X": [10, 6]}}},
-        "offers": {},
-    }
-    monkeypatch.setattr(lake_stats, "_entity_cube_with_mtime", lambda: (1.0, cube))
-    monkeypatch.setattr(lake_stats, "_fold_cache", {})
-    # Version floor (500 runs) drops v0.9.9; blank build ids never count.
-    assert lake_stats.cube_versions() == ["v0.111.0", "v0.110.2"]
-    f1 = lake_stats.entity_bracket_fold("cards", "a10")
-    f2 = lake_stats.entity_bracket_fold("cards", "a10")
-    assert f1 is f2, "second fold must come from the mtime-keyed cache"
-    assert f1["entries"]["X"] == [10, 6]
-    assert f1["total_runs"] == 1400

--- a/backend/tests/test_lake_stats.py
+++ b/backend/tests/test_lake_stats.py
@@ -378,3 +378,25 @@ def test_recent_versions_include_cube_and_validate(monkeypatch):
     assert res.get_recent_stat_versions() == ["v0.112.0", "v0.110.2"]
     assert res.is_valid_stat_bracket("v0.112.0")
     assert res.is_valid_stat_bracket("a10:v0.112.0")
+
+def test_cube_versions_and_fold_cache(monkeypatch):
+    cube = {
+        "runs": {
+            "standard|1|1|0|v0.111.0": [600, 300],
+            "standard|1|0|0|v0.111.0": [700, 200],
+            "standard|1|1|2|v0.110.2": [800, 400],
+            "standard|1|0|0|v0.9.9": [100, 10],
+            "standard|1|0|0|": [900, 100],
+        },
+        "entities": {"cards": {"standard|1|1|0|v0.111.0": {"X": [10, 6]}}},
+        "offers": {},
+    }
+    monkeypatch.setattr(lake_stats, "_entity_cube_with_mtime", lambda: (1.0, cube))
+    monkeypatch.setattr(lake_stats, "_fold_cache", {})
+    # Version floor (500 runs) drops v0.9.9; blank build ids never count.
+    assert lake_stats.cube_versions() == ["v0.111.0", "v0.110.2"]
+    f1 = lake_stats.entity_bracket_fold("cards", "a10")
+    f2 = lake_stats.entity_bracket_fold("cards", "a10")
+    assert f1 is f2, "second fold must come from the mtime-keyed cache"
+    assert f1["entries"]["X"] == [10, 6]
+    assert f1["total_runs"] == 1400


### PR DESCRIPTION
First batch from the frozen-snapshot audit: the entity-store totals now overlay the global counters (fixing detail pick rates, the pulse baseline, and the relic prior in one move), the metrics table's Elo column reads the live store per-bracket instead of averaging frozen cells, the version dropdowns and encounter version gate merge in the cube's versions so new patches are selectable again, and the charts event picker gets the missing .get('all') that left it permanently empty. Includes the #967 commit; merge #967 first and this diff shrinks to just batch 1.