### PR TITLE
Charts blob from the lake

### DIFF
--- a/backend/app/services/charts_blob_lake.py
+++ b/backend/app/services/charts_blob_lake.py
@@ -1,0 +1,319 @@
+"""Charts blob built from the lake, replacing the frozen snapshot's copy.
+
+DuckDB does the reading, filtering, eligibility, and bracket assignment;
+the fold is charts_stats.accumulate() itself, so every accumulation
+semantic (floor caps, first-room reads, dedup sets, deck growth) is
+inherited from the proven walk code instead of re-implemented in SQL.
+The streams rely on build.sql writing floors/deck/relics/potions parquet
+ORDER BY run_hash, so each run's rows are contiguous and the builder
+merges four cursors in one pass with constant memory.
+
+Serving follows the fallback ruling (2026-08-29): current generation ->
+previous generation -> empty. Never the snapshot.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+from typing import Any
+
+from . import charts_stats
+from .lake_stats import (
+    _CELLS_SQL,
+    _ELIGIBLE_SQL,
+    LAKE_DIR,
+    _connect,
+    cube_versions,
+)
+
+logger = logging.getLogger(__name__)
+
+_BLOB_NAME = "charts_blob.json.gz"
+_BLOB_PREV_NAME = "charts_blob.prev.json.gz"
+
+_WR_BY_BAND = {1: "wr30", 2: "wr50", 3: "wr75"}
+
+
+def _run_brackets(cell: str, versions: set[str]) -> list[str]:
+    """Bracket keys one run's cell folds into: the skill ladder the walk
+    used, plus version and skill x version composites for cube versions.
+    accumulate() ignores keys the accumulator wasn't seeded with."""
+    parts = cell.split("|")
+    a10 = len(parts) > 2 and parts[2] == "1"
+    band = int(parts[3]) if len(parts) > 3 and parts[3].isdigit() else 0
+    ver = parts[4] if len(parts) > 4 else ""
+    keys = ["all"]
+    if a10:
+        keys.append("a10")
+        for b in range(1, band + 1):
+            keys.append(_WR_BY_BAND[b])
+    if ver in versions:
+        keys.append(ver)
+        for k in list(keys[1:-1]):
+            keys.append(f"{k}:{ver}")
+    return keys
+
+
+class _RunStream:
+    """Cursor over a run_hash-ordered query; take(h) returns that run's
+    rows, silently dropping rows for runs the caller never asks about."""
+
+    def __init__(self, con, sql: str):
+        self._res = con.execute(sql)
+        self._rows: list = []
+        self._i = 0
+        self._done = False
+
+    def _peek(self):
+        while True:
+            if self._i < len(self._rows):
+                return self._rows[self._i]
+            if self._done:
+                return None
+            self._rows = self._res.fetchmany(20_000)
+            self._i = 0
+            if not self._rows:
+                self._done = True
+                return None
+
+    def take(self, run_hash: str) -> list:
+        out = []
+        while True:
+            row = self._peek()
+            if row is None:
+                return out
+            if row[0] < run_hash:
+                self._i += 1
+                continue
+            if row[0] != run_hash:
+                return out
+            out.append(row)
+            self._i += 1
+
+
+def _assemble_players(deck_rows, relic_rows, potion_rows) -> list[dict]:
+    players: dict[int, dict] = {}
+
+    def slot(pidx) -> dict:
+        return players.setdefault(
+            int(pidx or 1), {"deck": [], "relics": [], "potions": []}
+        )
+
+    for _, pidx, card, fa, ench in deck_rows:
+        c: dict[str, Any] = {"id": card, "floor_added_to_deck": fa}
+        if ench:
+            c["enchantment"] = {"id": ench}
+        slot(pidx)["deck"].append(c)
+    for _, pidx, rid in relic_rows:
+        slot(pidx)["relics"].append({"id": rid})
+    for _, pidx, pid in potion_rows:
+        slot(pidx)["potions"].append({"id": pid})
+    return [players[k] for k in sorted(players)]
+
+
+def _assemble_history(floor_rows) -> list[list[dict]]:
+    """floor_rows (sorted by act, floor_idx; one row per floor-player, or a
+    single pidx-NULL row for playerless floors) -> map_point_history."""
+    acts: list[list[dict]] = []
+    cur_act = None
+    cur_floor_key = None
+    floor: dict | None = None
+    for row in floor_rows:
+        (_, act, fidx, rtype, rmodel, rturns, pidx, mhp, chp, gold, dmg, sm, ek) = row
+        if act != cur_act:
+            acts.append([])
+            cur_act = act
+            cur_floor_key = None
+        if (act, fidx) != cur_floor_key:
+            room = {}
+            if rtype or rmodel:
+                room = {
+                    "room_type": rtype,
+                    "model_id": rmodel,
+                    "turns_taken": rturns,
+                }
+            floor = {"rooms": [room] if room else [], "player_stats": []}
+            acts[-1].append(floor)
+            cur_floor_key = (act, fidx)
+        if pidx is None or floor is None:
+            continue
+        floor["player_stats"].append(
+            {
+                "max_hp": mhp,
+                "current_hp": chp,
+                "current_gold": gold,
+                "damage_taken": dmg,
+                "rest_site_choices": ["SMITH"] * int(sm or 0),
+                "event_choices": [
+                    {"title": {"key": k, "table": "events"}} for k in (ek or [])
+                ],
+            }
+        )
+    return acts
+
+
+def build_charts_blob() -> dict | None:
+    """Build and store the finalized charts blob from the lake. Returns the
+    blob or None when the lake is incomplete."""
+    from datetime import datetime
+
+    con = _connect(build=False)
+    try:
+        con.execute(_ELIGIBLE_SQL.format(lake=LAKE_DIR))
+        con.execute(_CELLS_SQL.format(lake=LAKE_DIR))
+        meta: dict[str, tuple] = {}
+        for h, ch, win, ab, pc, played, cell in con.execute(
+            """
+            SELECT run_hash, coalesce(character, ''), coalesce(win, false),
+              coalesce(was_abandoned, false), coalesce(player_count, 1),
+              coalesce(played_at, submitted_at), cell
+            FROM cells
+            """
+        ).fetchall():
+            meta[h] = (ch, bool(win), bool(ab), int(pc), played, cell)
+    finally:
+        con.close()
+    if not meta:
+        return None
+
+    versions = cube_versions()
+    vset = set(versions)
+    acc = charts_stats.new_accumulator(versions)
+    bracket_cache: dict[str, list[str]] = {}
+
+    fcon = _connect(build=False)
+    dcon = _connect(build=False)
+    rcon = _connect(build=False)
+    pcon = _connect(build=False)
+    try:
+        floors = _RunStream(
+            fcon,
+            f"""
+            SELECT f.run_hash, f.act, f.floor_idx, f.room_type, f.room_model,
+              f.room_turns, ps.i,
+              ps.u.max_hp, ps.u.current_hp, ps.u.current_gold,
+              ps.u.damage_taken,
+              len(list_filter(ps.u.rest_site_choices, x -> x = 'SMITH')),
+              [t."key" FOR t IN [e.title FOR e IN ps.u.event_choices]
+               IF t."table" = 'events']
+            FROM read_parquet('{LAKE_DIR}/floors.parquet') f
+            LEFT JOIN LATERAL (
+              SELECT unnest(f.players) AS u,
+                generate_subscripts(f.players, 1) AS i
+            ) ps ON true
+            """,
+        )
+        deck = _RunStream(
+            dcon,
+            f"""
+            SELECT run_hash, player_idx, card, floor_added, enchantment
+            FROM read_parquet('{LAKE_DIR}/deck.parquet')
+            """,
+        )
+        relics = _RunStream(
+            rcon,
+            f"""
+            SELECT run_hash, player_idx, relic
+            FROM read_parquet('{LAKE_DIR}/relics.parquet')
+            """,
+        )
+        potions = _RunStream(
+            pcon,
+            f"""
+            SELECT run_hash, player_idx, potion
+            FROM read_parquet('{LAKE_DIR}/potions.parquet')
+            """,
+        )
+
+        n = 0
+        pending: list = []
+        cur: str | None = None
+
+        def flush() -> None:
+            nonlocal n
+            if cur is None:
+                return
+            m = meta.get(cur)
+            if m is None:
+                return
+            ch, win, ab, pc, played, cell = m
+            brs = bracket_cache.get(cell)
+            if brs is None:
+                brs = _run_brackets(cell, vset)
+                bracket_cache[cell] = brs
+            blob = {
+                "map_point_history": _assemble_history(pending),
+                "players": _assemble_players(
+                    deck.take(cur), relics.take(cur), potions.take(cur)
+                ),
+                "was_abandoned": ab,
+            }
+            charts_stats.accumulate(
+                acc,
+                blob,
+                brackets=brs,
+                is_win=win,
+                character=ch,
+                player_count=pc,
+                played=played if isinstance(played, datetime) else None,
+            )
+            n += 1
+
+        while True:
+            row = floors._peek()
+            if row is None:
+                break
+            if row[0] != cur:
+                flush()
+                cur = row[0]
+                pending = []
+            pending.append(row)
+            floors._i += 1
+        flush()
+    finally:
+        for c in (fcon, dcon, rcon, pcon):
+            try:
+                c.close()
+            except Exception:
+                pass
+
+    blob = charts_stats.finalize(acc)
+    cur_path = LAKE_DIR / _BLOB_NAME
+    tmp = LAKE_DIR / (_BLOB_NAME + ".tmp")
+    with gzip.open(tmp, "wt", encoding="utf-8", compresslevel=6) as f:
+        json.dump(blob, f, separators=(",", ":"))
+    if cur_path.exists():
+        cur_path.replace(LAKE_DIR / _BLOB_PREV_NAME)
+    tmp.replace(cur_path)
+    logger.info(
+        "charts blob stored: %d runs, %d brackets, %d bytes",
+        n,
+        len(blob),
+        cur_path.stat().st_size,
+    )
+    return blob
+
+
+_blob_cache: tuple[float, dict] | None = None
+
+
+def charts_blob_with_mtime() -> tuple[float, dict] | None:
+    """Current generation, else previous, else None — per the fallback
+    ruling the frozen snapshot is never served."""
+    global _blob_cache
+    for name in (_BLOB_NAME, _BLOB_PREV_NAME):
+        path = LAKE_DIR / name
+        try:
+            if not path.exists():
+                continue
+            mtime = path.stat().st_mtime
+            if _blob_cache and _blob_cache[0] == mtime:
+                return _blob_cache
+            with gzip.open(path, "rt", encoding="utf-8") as f:
+                _blob_cache = (mtime, json.load(f))
+            return _blob_cache
+        except Exception:
+            logger.warning("charts blob load failed for %s", name, exc_info=True)
+    return None

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -3139,12 +3139,21 @@ def get_community_stats(bracket: str | None = None) -> dict[str, Any]:
 
 def get_charts_blob_stats() -> dict[str, Any]:
     """Blob-derived chart cells for /api/charts (per-floor damage, encounter
-    damage, death rooms). Same lifecycle as the community stats: built in the
-    walk, carried through the snapshot, O(1) to read."""
-    _maybe_rebuild()
+    damage, death rooms). Lake-built: current generation, else previous,
+    else the empty shape — per the fallback ruling the frozen snapshot copy
+    is never served (it powered charts that visibly ended at the freeze
+    date, 2026-08-29 audit)."""
+    try:
+        from . import charts_blob_lake
+
+        hit = charts_blob_lake.charts_blob_with_mtime()
+        if hit is not None:
+            return hit[1]
+    except Exception:
+        logger.warning("lake charts blob load failed", exc_info=True)
     from . import charts_stats
 
-    return _charts_blob_stats or charts_stats.empty()
+    return charts_stats.empty()
 
 
 def is_valid_stat_bracket(bracket: str | None) -> bool:

--- a/backend/tests/test_charts_blob_lake.py
+++ b/backend/tests/test_charts_blob_lake.py
@@ -1,0 +1,169 @@
+"""Parity: the lake-built charts blob must equal charts_stats.accumulate()
+run directly on the equivalent hand-written run blob — the builder's whole
+design is that the fold IS the walk's accumulator, so any drift here means
+the SQL projection or the assembly lost information."""
+
+import gzip
+import json
+from datetime import datetime
+
+import duckdb
+
+from app.services import charts_blob_lake, charts_stats
+
+
+PLAYED = datetime(2026, 8, 20, 12, 0, 0)
+
+
+def _write_lake(tmp_path):
+    con = duckdb.connect()
+    con.execute(
+        f"""COPY (SELECT * FROM (VALUES
+        ('r1', 10, 'IRONCLAD', NULL::VARCHAR, true, false, 'standard',
+         1, '', TIMESTAMP '2026-08-20 12:00:00', TIMESTAMP '2026-08-20 13:00:00'))
+        t(run_hash, ascension, character, username, win, was_abandoned,
+          game_mode, player_count, build_id, played_at, submitted_at))
+        TO '{tmp_path}/runs.parquet' (FORMAT parquet)"""
+    )
+    con.execute(
+        f"""COPY (SELECT 'x' AS run_hash WHERE false)
+        TO '{tmp_path}/excluded.parquet' (FORMAT parquet)"""
+    )
+    con.execute(
+        f"""COPY (SELECT * FROM (VALUES
+        ('r1', 0, 1, 'monster', 'ENCOUNTER.JAW_WORM', 3,
+         [{{'max_hp': 80, 'current_hp': 70, 'current_gold': 99,
+            'damage_taken': 10, 'rest_site_choices': []::VARCHAR[],
+            'event_choices': []::STRUCT("title" STRUCT("key" VARCHAR,
+              "table" VARCHAR))[]}}]),
+        ('r1', 0, 2, 'event', NULL, NULL,
+         [{{'max_hp': 80, 'current_hp': 60, 'current_gold': 120,
+            'damage_taken': NULL, 'rest_site_choices': ['SMITH', 'REST'],
+            'event_choices': [{{'title': {{'key':
+              'MYSTEVENT.options.OPT_A.x', 'table': 'events'}}}}]}}]))
+        t(run_hash, act, floor_idx, room_type, room_model, room_turns,
+          players))
+        TO '{tmp_path}/floors.parquet' (FORMAT parquet)"""
+    )
+    con.execute(
+        f"""COPY (SELECT * FROM (VALUES
+        ('r1', 1, 'STRIKE', 0, NULL::VARCHAR),
+        ('r1', 1, 'STRIKE', 0, NULL::VARCHAR),
+        ('r1', 1, 'ZAP', 2, 'FIERY'))
+        t(run_hash, player_idx, card, floor_added, enchantment))
+        TO '{tmp_path}/deck.parquet' (FORMAT parquet)"""
+    )
+    con.execute(
+        f"""COPY (SELECT * FROM (VALUES ('r1', 1, 'BURNING_BLOOD'))
+        t(run_hash, player_idx, relic))
+        TO '{tmp_path}/relics.parquet' (FORMAT parquet)"""
+    )
+    con.execute(
+        f"""COPY (SELECT * FROM (VALUES ('r1', 1, 'FIRE_POTION'))
+        t(run_hash, player_idx, potion))
+        TO '{tmp_path}/potions.parquet' (FORMAT parquet)"""
+    )
+    con.close()
+
+
+def _expected_blob() -> dict:
+    """The same run, hand-assembled the way the walk saw blobs."""
+    return {
+        "was_abandoned": False,
+        "map_point_history": [
+            [
+                {
+                    "rooms": [
+                        {
+                            "room_type": "monster",
+                            "model_id": "ENCOUNTER.JAW_WORM",
+                            "turns_taken": 3,
+                        }
+                    ],
+                    "player_stats": [
+                        {
+                            "max_hp": 80,
+                            "current_hp": 70,
+                            "current_gold": 99,
+                            "damage_taken": 10,
+                            "rest_site_choices": [],
+                            "event_choices": [],
+                        }
+                    ],
+                },
+                {
+                    "rooms": [],
+                    "player_stats": [
+                        {
+                            "max_hp": 80,
+                            "current_hp": 60,
+                            "current_gold": 120,
+                            "damage_taken": None,
+                            "rest_site_choices": ["SMITH"],
+                            "event_choices": [
+                                {
+                                    "title": {
+                                        "key": "MYSTEVENT.options.OPT_A.x",
+                                        "table": "events",
+                                    }
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ]
+        ],
+        "players": [
+            {
+                "deck": [
+                    {"id": "STRIKE", "floor_added_to_deck": 0},
+                    {"id": "STRIKE", "floor_added_to_deck": 0},
+                    {
+                        "id": "ZAP",
+                        "floor_added_to_deck": 2,
+                        "enchantment": {"id": "FIERY"},
+                    },
+                ],
+                "relics": [{"id": "BURNING_BLOOD"}],
+                "potions": [{"id": "FIRE_POTION"}],
+            }
+        ],
+    }
+
+
+def test_lake_charts_blob_matches_direct_accumulate(monkeypatch, tmp_path):
+    _write_lake(tmp_path)
+    monkeypatch.setattr(charts_blob_lake, "LAKE_DIR", tmp_path)
+    monkeypatch.setattr(charts_blob_lake, "cube_versions", lambda: [])
+    monkeypatch.setattr(charts_blob_lake, "_blob_cache", None)
+
+    built = charts_blob_lake.build_charts_blob()
+    assert built is not None
+
+    acc = charts_stats.new_accumulator([])
+    charts_stats.accumulate(
+        acc,
+        _expected_blob(),
+        brackets=["all", "a10"],
+        is_win=True,
+        character="CHARACTER.IRONCLAD",
+        player_count=1,
+        played=PLAYED,
+    )
+    expected = charts_stats.finalize(acc)
+
+    def norm(blob):
+        return json.loads(json.dumps(blob, sort_keys=True))
+
+    for bracket in ("all", "a10", "wr30"):
+        assert norm(built[bracket]) == norm(expected[bracket]), bracket
+
+    # The stored artifact round-trips through the loader, and a rebuild
+    # rotates the old generation into the .prev slot.
+    hit = charts_blob_lake.charts_blob_with_mtime()
+    assert hit is not None and norm(hit[1]["all"]) == norm(expected["all"])
+    assert charts_blob_lake.build_charts_blob() is not None
+    assert (tmp_path / "charts_blob.prev.json.gz").exists()
+    with gzip.open(tmp_path / "charts_blob.prev.json.gz", "rt") as f:
+        prev = json.load(f)
+    assert norm(prev["all"]) == norm(expected["all"])

--- a/lab/build.sql
+++ b/lab/build.sql
@@ -94,6 +94,7 @@ SELECT r.run_hash, p.i AS player_idx,
 FROM raw r,
   LATERAL (SELECT unnest(players) AS u, generate_subscripts(players,1) AS i) p,
   LATERAL (SELECT unnest(p.u.deck) AS u) c
+ORDER BY 1
 ) TO '/lake/deck.parquet' (FORMAT parquet, COMPRESSION zstd);
 
 -- Location-level table (one row per visited map point, players kept as a
@@ -103,10 +104,16 @@ COPY (
 SELECT r.run_hash, act.i - 1 AS act, loc.i AS floor_idx,
   lower(loc.u.map_point_type) AS map_point_type,
   loc.u.player_stats AS players,
-  [x.model_id FOR x IN loc.u.rooms] AS room_models
+  [x.model_id FOR x IN loc.u.rooms] AS room_models,
+  -- First-room fields + run_hash ordering: the charts-blob builder streams
+  -- this file in one pass and needs each run's floors contiguous.
+  lower(loc.u.rooms[1].room_type) AS room_type,
+  loc.u.rooms[1].model_id AS room_model,
+  loc.u.rooms[1].turns_taken AS room_turns
 FROM raw r,
   LATERAL (SELECT unnest(map_point_history) AS u, generate_subscripts(map_point_history,1) AS i) act,
   LATERAL (SELECT unnest(act.u) AS u, generate_subscripts(act.u,1) AS i) loc
+ORDER BY 1, 2, 3
 ) TO '/lake/floors.parquet' (FORMAT parquet, COMPRESSION zstd);
 
 COPY (
@@ -116,6 +123,7 @@ SELECT r.run_hash, p.i AS player_idx,
 FROM raw r,
   LATERAL (SELECT unnest(players) AS u, generate_subscripts(players,1) AS i) p,
   LATERAL (SELECT unnest(p.u.relics) AS u) rel
+ORDER BY 1
 ) TO '/lake/relics.parquet' (FORMAT parquet, COMPRESSION zstd);
 
 COPY (
@@ -124,6 +132,7 @@ SELECT r.run_hash, p.i AS player_idx,
 FROM raw r,
   LATERAL (SELECT unnest(players) AS u, generate_subscripts(players,1) AS i) p,
   LATERAL (SELECT unnest(p.u.potions) AS u) pot
+ORDER BY 1
 ) TO '/lake/potions.parquet' (FORMAT parquet, COMPRESSION zstd);
 
 -- Per-player identity + deck size: keys player_id to a character for the

--- a/lab/ingest.py
+++ b/lab/ingest.py
@@ -124,6 +124,11 @@ def main() -> None:
         lake_stats.build_entity_cube()
         print("entity cube stored", flush=True)
         _mark("entity_cube")
+        from app.services import charts_blob_lake
+
+        charts_blob_lake.build_charts_blob()
+        print("charts blob stored", flush=True)
+        _mark("charts_blob")
         lake_stats.cleanup_build_session()
     except Exception as e:
         print(f"community payload build failed: {e}", flush=True)


### PR DESCRIPTION
The 14 blob charts and every detail page's trend panel were the last big frozen surface, so the ingest now builds charts_blob.json.gz by streaming the run-sorted parquet through charts_stats.accumulate itself (DuckDB does reading, eligibility, and bracket assignment; the fold is the proven walk code, with a fixture parity test asserting byte-equality against direct accumulation), serving chains current generation to previous to empty per the fallback ruling with the snapshot branch deleted, and floors.parquet gains first-room fields plus run_hash ordering that the one-pass merge relies on.