### PR TITLE
Character axis in the entity cube

### DIFF
--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -1393,23 +1393,34 @@ def build_entity_cube(con=None) -> dict:
             ).fetchall()
         }
         types: dict[str, dict] = {}
+        by_char: dict[str, dict] = {}
         for etype, table, col in (
             ("cards", "deck", "card"),
             ("relics", "relics", "relic"),
             ("potions", "potions", "potion"),
         ):
             per: dict[str, dict] = {}
-            for cell, eid, p, w in con.execute(
+            per_char: dict[str, dict] = {}
+            # One scan grouped by character yields both sections: the
+            # entity cells (summed over characters) and the character axis
+            # that gives bracketed by-character views a live source.
+            for cell, eid, ch, p, w in con.execute(
                 f"""
-                SELECT e.cell, m.{col}, count(*), count(*) FILTER (e.win)
+                SELECT e.cell, m.{col}, coalesce(m.character, ''),
+                  count(*), count(*) FILTER (e.win)
                 FROM read_parquet('{LAKE_DIR}/{table}.parquet') m
                 JOIN cells e ON m.run_hash = e.run_hash
                 WHERE m.{col} IS NOT NULL AND m.{col} <> ''
-                GROUP BY 1, 2
+                GROUP BY 1, 2, 3
                 """
             ).fetchall():
-                per.setdefault(cell, {})[eid] = [p, w]
+                cur = per.setdefault(cell, {}).setdefault(eid, [0, 0])
+                cur[0] += p
+                cur[1] += w
+                if ch:
+                    per_char.setdefault(cell, {}).setdefault(eid, {})[ch] = [p, w]
             types[etype] = per
+            by_char[etype] = per_char
         # Card-reward offer/pick counts per cell with the store's 3 act
         # buckets (floors.parquet acts are 0-based; least(act,2) = A1/A2/A3+),
         # so the metrics table's Pick% and per-act splits fold per bracket.
@@ -1442,6 +1453,7 @@ def build_entity_cube(con=None) -> dict:
     cube = {
         "runs": runs_cells,
         "entities": types,
+        "by_character": by_char,
         "offers": offers,
         "data_through": data_through,
     }
@@ -1499,6 +1511,43 @@ def entity_bracket_fold(entity_type: str, bracket: str) -> dict | None:
     if cached is not None and cached[0] == hit[0]:
         return cached[1]
     fold = _entity_bracket_fold_uncached(entity_type, bracket)
+    if len(_fold_cache) > 512:
+        _fold_cache.clear()
+    _fold_cache[key] = (hit[0], fold)
+    return fold
+
+
+def entity_character_fold(entity_type: str, bracket: str) -> dict | None:
+    """{eid: {CHARACTER: [picks, wins]}} folded from the cube's character
+    axis for one bracket, fold-cached like entity_bracket_fold. None until
+    a cube with the axis is published or for unfoldable brackets."""
+    hit = _entity_cube_with_mtime()
+    if hit is None:
+        return None
+    key = (f"char:{entity_type}", bracket)
+    cached = _fold_cache.get(key)
+    if cached is not None and cached[0] == hit[0]:
+        return cached[1]
+    parsed = _parse_lake_bracket(bracket)
+    per = ((hit[1].get("by_character") or {}).get(entity_type)) or None
+    fold: dict | None = None
+    if parsed is not None and per is not None:
+        mode, player, skill, version = parsed
+        fold = {}
+        for cell, ids in per.items():
+            if not _cell_matches(cell, mode, player, skill, version):
+                continue
+            for eid, chars in ids.items():
+                slot = fold.setdefault(eid, {})
+                for ch, pw in chars.items():
+                    cur = slot.get(ch)
+                    if cur is None:
+                        slot[ch] = [pw[0], pw[1]]
+                    else:
+                        cur[0] += pw[0]
+                        cur[1] += pw[1]
+        if not fold:
+            fold = None
     if len(_fold_cache) > 512:
         _fold_cache.clear()
     _fold_cache[key] = (hit[0], fold)

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -3625,6 +3625,14 @@ def get_entity_metrics_table(
             _skill_bmap = _ls.bracket_elo_for(bracket)
         except Exception:
             _skill_bmap = None
+    _char_fold: dict | None = None
+    if character and use_bracket:
+        try:
+            from . import lake_stats as _ls
+
+            _char_fold = _ls.entity_character_fold(entity_type, bracket)
+        except Exception:
+            _char_fold = None
 
     def _live_elo(agg: dict, eid: str, fallback) -> float | None:
         if _skill_bmap is not None:
@@ -3676,12 +3684,17 @@ def get_entity_metrics_table(
         # the zhs metrics page).
         if eid in solo_excluded_cards:
             continue
-        # Character view: one merged row per entity from the bracket's (or the
-        # top-level) by_character split. Score + Win% only — Elo/Pick%/per-act
+        # Character view: one merged row per entity. Bracketed views fold
+        # from the cube's character axis (the fossil bracket cells are gone
+        # per the fallback ruling); the all-runs view reads the live
+        # store-overlaid split. Score + Win% only — Elo/Pick%/per-act
         # aren't tracked per character — and no base/upg split either.
         if character:
-            src = (agg.get("brackets") or {}).get(bracket) if use_bracket else agg
-            cb = ((src or {}).get("by_character") or {}).get(character)
+            if use_bracket:
+                cb_pw = ((_char_fold or {}).get(eid) or {}).get(character)
+                cb = {"picks": cb_pw[0], "wins": cb_pw[1]} if cb_pw else None
+            else:
+                cb = (agg.get("by_character") or {}).get(character)
             if not cb or not cb.get("picks"):
                 continue
             rows.append(
@@ -3976,7 +3989,22 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
                 if entity_type == "cards":
                     bmap = lake_stats.bracket_elo_for(ck)
                     celo = bmap.get(eid) if bmap is not None else agg.get("elo")
-                prev = brackets.get(ck) or {}
+                try:
+                    cfold = lake_stats.entity_character_fold(entity_type, ck)
+                except Exception:
+                    cfold = None
+                chars = (cfold or {}).get(eid) or {}
+                by_char_rows = [
+                    {
+                        "character": ch2,
+                        "picks": pw2[0],
+                        "wins": pw2[1],
+                        "win_rate": round(pw2[1] / pw2[0] * 100, 1) if pw2[0] else 0.0,
+                    }
+                    for ch2, pw2 in sorted(
+                        chars.items(), key=lambda kv: kv[1][0], reverse=True
+                    )
+                ]
                 brackets[ck] = {
                     "picks": cp,
                     "wins": cw,
@@ -3990,7 +4018,7 @@ def get_entity_stats(entity_type: str, entity_id: str) -> dict[str, Any] | None:
                     ),
                     "total_runs": ctot,
                     "pick_rate": round(cp / ctot * 100, 1) if ctot else 0.0,
-                    "by_character": prev.get("by_character") or [],
+                    "by_character": by_char_rows,
                 }
         except Exception:
             logger.warning("lake bracket overlay failed", exc_info=True)

--- a/backend/tests/test_lake_stats.py
+++ b/backend/tests/test_lake_stats.py
@@ -391,3 +391,32 @@ def test_get_community_stats_is_lake_first(monkeypatch):
     monkeypatch.setattr(res, "_maybe_rebuild", lambda: None)
     out = res.get_community_stats("solo")
     assert isinstance(out, dict) and out is not live
+
+
+def test_entity_character_fold(monkeypatch):
+    cube = {
+        "runs": {"standard|1|1|0|v1": [100, 50], "standard|2|1|0|v1": [40, 10]},
+        "entities": {},
+        "by_character": {
+            "cards": {
+                "standard|1|1|0|v1": {"X": {"IRONCLAD": [10, 6], "SILENT": [4, 1]}},
+                "standard|2|1|0|v1": {"X": {"IRONCLAD": [3, 2]}},
+            }
+        },
+        "offers": {},
+    }
+    monkeypatch.setattr(lake_stats, "_entity_cube_with_mtime", lambda: (2.0, cube))
+    monkeypatch.setattr(lake_stats, "_fold_cache", {})
+    fold = lake_stats.entity_character_fold("cards", "a10")
+    assert fold["X"]["IRONCLAD"] == [13, 8]
+    assert fold["X"]["SILENT"] == [4, 1]
+    solo = lake_stats.entity_character_fold("cards", "solo")
+    assert solo["X"]["IRONCLAD"] == [10, 6]
+    # Cube without the axis (pre-upgrade store) -> None, callers go empty.
+    monkeypatch.setattr(
+        lake_stats,
+        "_entity_cube_with_mtime",
+        lambda: (3.0, {"runs": {}, "entities": {}, "offers": {}}),
+    )
+    monkeypatch.setattr(lake_stats, "_fold_cache", {})
+    assert lake_stats.entity_character_fold("cards", "a10") is None

--- a/lab/build.sql
+++ b/lab/build.sql
@@ -119,7 +119,8 @@ ORDER BY 1, 2, 3
 COPY (
 SELECT r.run_hash, p.i AS player_idx,
   upper(split_part(rel.u.id, '.', -1)) AS relic,
-  rel.u.floor_added_to_deck AS floor_added
+  rel.u.floor_added_to_deck AS floor_added,
+  upper(split_part(p.u.character,'.',-1)) AS character
 FROM raw r,
   LATERAL (SELECT unnest(players) AS u, generate_subscripts(players,1) AS i) p,
   LATERAL (SELECT unnest(p.u.relics) AS u) rel
@@ -128,7 +129,8 @@ ORDER BY 1
 
 COPY (
 SELECT r.run_hash, p.i AS player_idx,
-  upper(split_part(pot.u.id, '.', -1)) AS potion
+  upper(split_part(pot.u.id, '.', -1)) AS potion,
+  upper(split_part(p.u.character,'.',-1)) AS character
 FROM raw r,
   LATERAL (SELECT unnest(players) AS u, generate_subscripts(players,1) AS i) p,
   LATERAL (SELECT unnest(p.u.potions) AS u) pot


### PR DESCRIPTION
Bracketed by-character views (metrics with a character selected, the character tables under bracket views on detail pages) were the last cells still reading the frozen snapshot, so the cube's per-type scan now groups by character too (one scan still yields both sections), a cached entity_character_fold serves any composable bracket, and both consumers read it with the fossil branches removed per the fallback ruling; relics and potions parquet gain the character column and a cube built by the previous code simply returns None so callers go empty until the next cycle.