### PR TITLE
Frame attribution fix, the missing files

### DIFF
--- a/backend/app/services/charts_stats.py
+++ b/backend/app/services/charts_stats.py
@@ -95,7 +95,12 @@ def _lake_frame_select(runs_p: Path, scalars_p: Path, with_hash: bool = False) -
     hash_col = "r.run_hash AS run_hash, " if with_hash else ""
     return f"""
         SELECT {hash_col}
-          upper(split_part(coalesce(r.character, ''), '.', -1)) AS character,
+          -- Doc-truth character/build_id via the fresh sidecar: pages
+          -- extracted before _meta.character existed fall back to players[1]
+          -- and misattribute co-op party members (369/2000 in the 2026-08-29
+          -- validation).
+          upper(split_part(coalesce(s.character, r.character, ''), '.', -1))
+            AS character,
           (CASE WHEN coalesce(try_cast(r.win AS BOOLEAN), false)
             THEN 1 ELSE 0 END)::TINYINT AS win,
           r.ascension::INT AS ascension,
@@ -119,7 +124,7 @@ def _lake_frame_select(runs_p: Path, scalars_p: Path, with_hash: bool = False) -
               || lpad(string_split(r.seed, '_')[2], 2, '0') || '-'
               || lpad(string_split(r.seed, '_')[1], 2, '0')
             ELSE '' END AS daily_date,
-          trim(coalesce(r.build_id, '')) AS build_id
+          trim(coalesce(s.build_id, r.build_id, '')) AS build_id
         FROM read_parquet('{runs_p}') r
         LEFT JOIN read_parquet('{scalars_p}') s USING (run_hash)
         WHERE coalesce(s.hidden, false) = false

--- a/lab/build.sql
+++ b/lab/build.sql
@@ -61,11 +61,12 @@ SELECT run_hash FROM read_ndjson('/lake/excluded_current.jsonl.gz',
 -- mutable username/hidden, so frame.parquet builds from the lake.
 COPY (
 SELECT run_hash, floors_reached, deck_size, relic_count, acts_completed,
-  username, hidden
+  username, hidden, character, build_id
 FROM read_ndjson('/lake/run_scalars_current.jsonl.gz',
   columns={run_hash: 'VARCHAR', floors_reached: 'INTEGER',
            deck_size: 'INTEGER', relic_count: 'INTEGER',
-           acts_completed: 'INTEGER', username: 'VARCHAR', hidden: 'BOOLEAN'})
+           acts_completed: 'INTEGER', username: 'VARCHAR', hidden: 'BOOLEAN',
+           character: 'VARCHAR', build_id: 'VARCHAR'})
 ) TO '/lake/run_scalars.parquet' (FORMAT parquet, COMPRESSION zstd);
 
 COPY (

--- a/lab/extract.py
+++ b/lab/extract.py
@@ -90,6 +90,8 @@ def _refresh_scalars(coll) -> None:
                 "acts_completed": 1,
                 "username": 1,
                 "hidden": 1,
+                "character": 1,
+                "build_id": 1,
             },
         ):
             out.write(
@@ -102,6 +104,8 @@ def _refresh_scalars(coll) -> None:
                         "acts_completed": doc.get("acts_completed"),
                         "username": doc.get("username"),
                         "hidden": bool(doc.get("hidden")),
+                        "character": doc.get("character"),
+                        "build_id": doc.get("build_id"),
                     }
                 )
                 + "\n"


### PR DESCRIPTION
PR #973 accidentally shipped only the test file because a broken command chain never staged the code, so here are the three files that do the work: the run-scalars sidecar gains doc-truth character and build_id, build.sql carries them into run_scalars.parquet, and the lake frame select prefers them over the stale page attribution.