### PR TITLE
Entity store speed: numpy Elo, one choice extraction

### DIFF
--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -1065,22 +1065,15 @@ def build_entity_store() -> dict | None:
                     a["last_submitted_at"] = ts
                     a["last_run_hash"] = last_hash
 
-        # Card-reward offer/pick counts with 3 act buckets (A1/A2/A3+).
-        _ids_temp_table(con, "excluded_cards", res._excluded_card_ids())
+        # Card-reward offer/pick counts with 3 act buckets (A1/A2/A3+),
+        # read off the shared choice_rows materialization -- the pair fits
+        # reuse the same scratch table later on their own connection, so
+        # the floors unnest happens once per cycle instead of twice.
+        _ensure_choice_rows(con)
         for eid, bucket, offered, picked in con.execute(
-            f"""
-            SELECT upper(split_part(cc.u.card.id, '.', -1)),
-              least(f.act, 2), count(*),
-              count(*) FILTER (coalesce(cc.u.was_picked, false))
-            FROM read_parquet('{LAKE_DIR}/floors.parquet') f
-            JOIN eligible e ON f.run_hash = e.run_hash,
-            LATERAL (SELECT unnest(f.players) AS u) ps,
-            LATERAL (SELECT unnest(ps.u.card_choices) AS u) cc
-            WHERE cc.u.card.id IS NOT NULL
-              AND upper(split_part(cc.u.card.id, '.', 1)) = 'CARD'
-              AND upper(split_part(cc.u.card.id, '.', -1))
-                  NOT IN (SELECT cid FROM excluded_cards)
-            GROUP BY 1, 2
+            """
+            SELECT cid, least(act, 2), count(*), count(*) FILTER (picked)
+            FROM choice_rows GROUP BY 1, 2
             """
         ).fetchall():
             a = entry("cards", eid)

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -907,6 +907,56 @@ def _compute_codex_elo(
     if not nodes:
         return {}, {}
 
+    # Vectorized MM when numpy is available: the interpreted loop was ~50M
+    # float ops per fit and the store now runs five fits per cycle. Same
+    # update, same normalization, same stopping rule -- float summation
+    # order can move a rating by at most the display rounding.
+    try:
+        import numpy as _np
+    except Exception:
+        _np = None
+    if _np is not None:
+        idx = {n: k for k, n in enumerate(nodes)}
+        edges = [(idx[i], idx[j], c) for (i, j), c in pair_wins.items() if c > 0]
+        ei = _np.fromiter((e[0] for e in edges), dtype=_np.int64, count=len(edges))
+        ej = _np.fromiter((e[1] for e in edges), dtype=_np.int64, count=len(edges))
+        en = _np.fromiter(
+            (float(e[2]) for e in edges), dtype=_np.float64, count=len(edges)
+        )
+        p_arr = _np.ones(len(nodes), dtype=_np.float64)
+        if warm:
+            for n, k in idx.items():
+                v = warm.get(n)
+                if v is not None and v > 0:
+                    p_arr[k] = v
+        w_arr = _np.fromiter(
+            (wins.get(n, 0.0) + 1e-3 for n in nodes),
+            dtype=_np.float64,
+            count=len(nodes),
+        )
+        for _ in range(_ELO_MAX_ITERS):
+            contrib = en / (p_arr[ei] + p_arr[ej])
+            denom = _np.zeros(len(nodes), dtype=_np.float64)
+            _np.add.at(denom, ei, contrib)
+            _np.add.at(denom, ej, contrib)
+            new_p = _np.where(denom > 0, w_arr / denom, p_arr)
+            gmean = float(_np.exp(_np.mean(_np.log(_np.maximum(new_p, 1e-300)))))
+            if gmean > 0:
+                new_p = new_p / gmean
+            delta = float(_np.max(_np.abs(new_p - p_arr)))
+            p_arr = new_p
+            if delta < _ELO_TOL:
+                break
+        out_np: dict[str, float] = {}
+        strengths_np: dict[str, float] = {}
+        for n, k in idx.items():
+            strength = float(p_arr[k])
+            strengths_np[n] = strength
+            if total_games.get(n, 0.0) < _ELO_MIN_GAMES or strength <= 0:
+                continue
+            out_np[n] = round(_ELO_ANCHOR + _ELO_SPREAD * math.log10(strength), 1)
+        return out_np, strengths_np
+
     # MM needs strictly-positive wins to be identifiable. A card that was
     # never once preferred (W_i == 0) would collapse to strength 0 and
     # stall the update; seed every card with a tiny pseudo-win so the

--- a/backend/tests/test_lake_stats.py
+++ b/backend/tests/test_lake_stats.py
@@ -455,3 +455,26 @@ def test_lake_metric_history_appends(monkeypatch):
     ids = sorted(op._filter["_id"] for op in captured["ops"])
     assert ids[0].startswith("cards:X:all:")
     assert ids[1].startswith("cards:X:wr75:")
+
+
+def test_elo_numpy_path_matches_python_path(monkeypatch):
+    import sys
+
+    from app.services.run_entity_stats import _compute_codex_elo
+
+    pairs = {
+        ("A", "B"): 30,
+        ("B", "C"): 25,
+        ("A", "C"): 10,
+        ("C", "A"): 8,
+        ("A", "SKIP"): 40,
+        ("SKIP", "B"): 22,
+    }
+    elo_np, p_np = _compute_codex_elo(pairs)
+    monkeypatch.setitem(sys.modules, "numpy", None)
+    elo_py, p_py = _compute_codex_elo(pairs)
+    assert set(elo_np) == set(elo_py)
+    for k in elo_np:
+        assert abs(elo_np[k] - elo_py[k]) <= 0.1, k
+    for k in p_np:
+        assert abs(p_np[k] - p_py[k]) < 1e-6, k


### PR DESCRIPTION
The store's five Bradley-Terry fits ran a ~50M-op interpreted loop each so the MM update is vectorized with a parity test pinning numpy and pure-python outputs together (the python path stays as fallback), and the offers query now reads the shared choice_rows table so the floors unnest happens once per cycle instead of twice; merge after #976 validates.