### PR TITLE
Charts blob OOM fix

### DIFF
--- a/backend/app/services/charts_blob_lake.py
+++ b/backend/app/services/charts_blob_lake.py
@@ -183,11 +183,17 @@ def build_charts_blob() -> dict | None:
     acc = charts_stats.new_accumulator(versions)
     bracket_cache: dict[str, list[str]] = {}
 
-    fcon = _connect(build=False)
-    dcon = _connect(build=False)
-    rcon = _connect(build=False)
-    pcon = _connect(build=False)
+    # Cursors on the same shared build instance (4.5GB, spill-enabled).
+    # Build connections set preserve_insertion_order=false, which lets a
+    # parquet scan return blocks out of file order — the merge relies on
+    # each run's rows being contiguous, so restore it for the streams; the
+    # next stage's connect flips it back.
+    fcon = _connect(build=True)
+    dcon = _connect(build=True)
+    rcon = _connect(build=True)
+    pcon = _connect(build=True)
     try:
+        fcon.execute("SET preserve_insertion_order=true")
         floors = _RunStream(
             fcon,
             f"""

--- a/backend/tests/test_charts_blob_lake.py
+++ b/backend/tests/test_charts_blob_lake.py
@@ -133,7 +133,11 @@ def _expected_blob() -> dict:
 
 def test_lake_charts_blob_matches_direct_accumulate(monkeypatch, tmp_path):
     _write_lake(tmp_path)
+    from app.services import lake_stats
+
     monkeypatch.setattr(charts_blob_lake, "LAKE_DIR", tmp_path)
+    # Build-profile connections open the scratch db under lake_stats' dir.
+    monkeypatch.setattr(lake_stats, "LAKE_DIR", tmp_path)
     monkeypatch.setattr(charts_blob_lake, "cube_versions", lambda: [])
     monkeypatch.setattr(charts_blob_lake, "_blob_cache", None)
 


### PR DESCRIPTION
The builder's first production run died at 476.5/476.8 MiB because its serve-profile connections have no spill directory and a 500MB ceiling, so all five cursors now share the scratch database's single 4.5GB spill-enabled instance with preserve_insertion_order restored for the streams whose merge depends on file order.