### PR TITLE
Flag to boot workers without the frozen entity-stats snapshot

### DIFF
--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -2406,10 +2406,18 @@ def _persist_snapshot(
     )
 
 
+def _snapshot_boot_disabled() -> bool:
+    """ENTITY_SNAPSHOT_LOAD=off skips the ~1.1GB-per-worker snapshot load;
+    only lake-served surfaces keep data."""
+    return os.environ.get("ENTITY_SNAPSHOT_LOAD", "on").strip().lower() == "off"
+
+
 def _load_snapshot() -> bool:
     """Load the shared snapshot from Mongo into module globals. Returns
     False if no snapshot exists yet (caller falls back to local build)."""
     global _cache_snapshot_version
+    if _snapshot_boot_disabled():
+        return False
     coll = _snapshot_coll()
     started = time.monotonic()
     meta = coll.find_one({"_id": "__meta__"})
@@ -3045,6 +3053,8 @@ def _maybe_rebuild() -> None:
     _SNAPSHOT_LOAD_SECONDS per worker, forever — hung for the full multi-
     thousand-doc snapshot read."""
     _maybe_overlay_lake_entities()
+    if _USING_MONGO and _snapshot_boot_disabled():
+        return
     global _building
     age = time.time() - _cache_built_at
     if age < _SNAPSHOT_LOAD_SECONDS:

--- a/backend/tests/test_snapshot_flag.py
+++ b/backend/tests/test_snapshot_flag.py
@@ -1,0 +1,34 @@
+"""ENTITY_SNAPSHOT_LOAD=off must keep the frozen snapshot out of memory."""
+
+from app.services import run_entity_stats as res
+
+
+def test_off_returns_false_without_touching_mongo(monkeypatch):
+    monkeypatch.setenv("ENTITY_SNAPSHOT_LOAD", "off")
+
+    def boom():
+        raise AssertionError("snapshot collection touched with loads disabled")
+
+    monkeypatch.setattr(res, "_snapshot_coll", boom)
+    assert res._load_snapshot() is False
+
+
+def test_default_still_reads_the_snapshot(monkeypatch):
+    monkeypatch.delenv("ENTITY_SNAPSHOT_LOAD", raising=False)
+    calls = {}
+
+    class _Coll:
+        def find_one(self, q):
+            calls["hit"] = True
+            return None
+
+    monkeypatch.setattr(res, "_snapshot_coll", lambda: _Coll())
+    assert res._load_snapshot() is False
+    assert calls.get("hit")
+
+
+def test_flag_reads_env_per_call(monkeypatch):
+    monkeypatch.setenv("ENTITY_SNAPSHOT_LOAD", "off")
+    assert res._snapshot_boot_disabled()
+    monkeypatch.setenv("ENTITY_SNAPSHOT_LOAD", "on")
+    assert not res._snapshot_boot_disabled()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,8 @@ x-shared-env: &shared-env
   LAKE_COMMUNITY_STATS: ${LAKE_COMMUNITY_STATS:-}
   LAKE_STATS_SHADOW: ${LAKE_STATS_SHADOW:-}
   LAKE_ENTITY_STATS: ${LAKE_ENTITY_STATS:-}
+  # off = workers skip the frozen snapshot load (~1.1GB per worker).
+  ENTITY_SNAPSHOT_LOAD: ${ENTITY_SNAPSHOT_LOAD:-on}
   # How often the leader may rerun the heavy walk (seconds). Default 7200
   # (2h). With the parallel rebuild on, lower it for fresher public numbers,
   # but keep it well above the observed walk time so the box isn't always


### PR DESCRIPTION
I added ENTITY_SNAPSHOT_LOAD=off so workers skip the ~1.1GB-per-worker snapshot load; default stays on, flip on beta first.