### PR TITLE
Instant profiles after bulk uploads

### DIFF
--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -529,9 +529,10 @@ def submit_run(
 
     if linked_user_id is not None and any(r.get("success") for r in results):
         try:
-            from .user_insights import invalidate_user_insights
+            from .user_insights import invalidate_user_insights, note_profile_activity
 
             invalidate_user_insights(str(linked_user_id))
+            note_profile_activity(str(linked_user_id), linked_username)
         except Exception:
             pass
 
@@ -962,6 +963,14 @@ def backfill_user_runs(
         {"user_id": None, "$or": identity_conds},
         {"$set": update},
     )
+    if result.modified_count:
+        try:
+            from .user_insights import invalidate_user_insights, note_profile_activity
+
+            invalidate_user_insights(user_id)
+            note_profile_activity(user_id, username)
+        except Exception:
+            pass
     return result.modified_count
 
 
@@ -1167,12 +1176,13 @@ def claim_runs(username: str, hashes: list[str]) -> dict:
             {"$set": {"username": username, "username_lower": username.lower()}},
         )
         try:
-            from .user_insights import invalidate_user_insights
+            from .user_insights import invalidate_user_insights, note_profile_activity
             from .users_db import get_user_by_username
 
             owner = get_user_by_username(username)
             if owner:
                 invalidate_user_insights(str(owner["_id"]))
+                note_profile_activity(str(owner["_id"]), username)
         except Exception:
             pass
 
@@ -2784,6 +2794,23 @@ def distinct_build_ids() -> list[str]:
 
 
 @_instrument("get_user_run_rows")
+def count_user_runs(user_id: str) -> int:
+    """How many visible runs an account has claimed; the profile's building
+    placeholder shows it so a fresh bulk upload isn't a dead spinner."""
+    from bson import ObjectId
+
+    try:
+        return _get_collection().count_documents(
+            {
+                "user_id": ObjectId(user_id),
+                "deleted_at": None,
+                "hidden": {"$ne": True},
+            }
+        )
+    except Exception:
+        return 0
+
+
 def get_user_run_rows(user_id: str, limit: int = 2000) -> list[dict]:
     """One account's claimed run rows (newest first) for the profile insights
     walk: just the fields the community-stats accumulator needs per run.

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -466,6 +466,21 @@ def submit_run(
         except Exception:
             # Linking is best-effort; a lookup failure must not drop the run.
             pass
+    if linked_user_id is None and username:
+        # Username-only uploads (Compendium ?username=, mismatched Steam ids)
+        # used to stay invisible on the profile until the next sign-in
+        # backfill hoovered them (Dobo, 2026-08-30: 304 runs, 0 linked).
+        # The sign-in backfill already links by username, so linking the
+        # same way at submit changes when, not whether.
+        try:
+            from .users_db import get_user_by_username
+
+            owner = get_user_by_username(username)
+            if owner:
+                linked_user_id = owner["_id"]
+                linked_username = owner.get("username")
+        except Exception:
+            pass
 
     missing: list[str] = []
     if not data.get("players"):
@@ -1181,6 +1196,15 @@ def claim_runs(username: str, hashes: list[str]) -> dict:
 
             owner = get_user_by_username(username)
             if owner:
+                from bson import ObjectId
+
+                # The profile walk matches user_id, not username, so a claim
+                # must link both or the runs stay profile-invisible until
+                # the next sign-in backfill.
+                coll.update_many(
+                    {"_id": {"$in": unclaimed}, "user_id": None},
+                    {"$set": {"user_id": ObjectId(str(owner["_id"]))}},
+                )
                 invalidate_user_insights(str(owner["_id"]))
                 note_profile_activity(str(owner["_id"]), username)
         except Exception:

--- a/backend/app/services/user_insights.py
+++ b/backend/app/services/user_insights.py
@@ -514,6 +514,9 @@ def _store_payload(cache_key: str, payload: dict) -> None:
     if _is_hollow(payload):
         logger.warning("refusing to durably store a hollow profile: %s", cache_key)
         return
+    if payload.get("partial"):
+        logger.warning("not durably storing a partial profile: %s", cache_key)
+        return
     try:
         from datetime import datetime, timezone
 
@@ -576,7 +579,14 @@ def get_user_insights(
     _kick_refresh(cache_key, user_id, username, character, ascension, version, players)
     if payload is not None:
         return payload
-    return {"building": True}
+    building: dict[str, Any] = {"building": True}
+    try:
+        from .runs_db_mongo import count_user_runs
+
+        building["claimed_runs"] = count_user_runs(user_id)
+    except Exception:
+        pass
+    return building
 
 
 def _prewarm_slices() -> list[tuple]:
@@ -603,6 +613,70 @@ def invalidate_user_insights(user_id: str) -> None:
             app_cache.delete(_fresh_key(key))
         except Exception:
             return
+
+
+# Accounts that gained runs recently, per worker: uid -> (last activity,
+# username). A bulk upload notes activity per submit; the sweeper rebuilds
+# once the burst goes quiet instead of once per run. Cross-worker dedup is
+# _kick_refresh's Redis lock.
+_pending_lock = threading.Lock()
+_pending: dict[str, tuple[float, str | None]] = {}
+_pending_checked: set[str] = set()
+_sweeper_started = False
+_PENDING_IDLE_SECONDS = 45.0
+_SWEEP_INTERVAL_SECONDS = 20.0
+
+
+def _due_pending(
+    pending: dict[str, tuple[float, str | None]],
+    now: float,
+    idle: float = _PENDING_IDLE_SECONDS,
+) -> list[str]:
+    return [uid for uid, (ts, _) in pending.items() if now - ts >= idle]
+
+
+def note_profile_activity(user_id: str, username: str | None = None) -> None:
+    """Called when an account gains runs (submit, claim, sign-in backfill).
+    An account with no profile yet starts building immediately, so a new
+    player's page exists while their backlog is still uploading; the burst
+    then gets one final rebuild after it goes quiet."""
+    global _sweeper_started
+    with _pending_lock:
+        first_sight = user_id not in _pending_checked
+        _pending_checked.add(user_id)
+        _pending[user_id] = (time.time(), username)
+        if not _sweeper_started:
+            _sweeper_started = True
+            threading.Thread(
+                target=_sweep_pending, daemon=True, name="insights-sweeper"
+            ).start()
+    if not first_sight:
+        return
+    from . import cache as app_cache
+
+    cache_key = f"{user_id}:"
+    has_payload = (
+        _cache_get(cache_key) is not None
+        or app_cache.get_json(_payload_key(cache_key)) is not None
+        or _load_stored_payload(cache_key) is not None
+    )
+    if not has_payload:
+        _kick_refresh(cache_key, user_id, username, None, None, None, None)
+
+
+def _sweep_pending() -> None:
+    while True:
+        time.sleep(_SWEEP_INTERVAL_SECONDS)
+        try:
+            now = time.time()
+            with _pending_lock:
+                due = _due_pending(_pending, now)
+                items = [(uid, _pending.pop(uid)[1]) for uid in due]
+                _pending_checked.difference_update(due)
+            for uid, username in items:
+                _kick_refresh(f"{uid}:", uid, username, None, None, None, None)
+        except Exception:
+            logger.warning("insights sweeper pass failed", exc_info=True)
 
 
 def prewarm_user_insights(user_id: str, username: str | None = None) -> None:
@@ -689,7 +763,10 @@ def _kick_refresh(
                     enc = jsonable_encoder(slice_payload)
                     key = f"{user_id}{suffix}"
                     app_cache.set_json(_payload_key(key), enc, _STALE_REDIS_TTL)
-                    app_cache.set_json(_fresh_key(key), 1, int(_CACHE_TTL))
+                    # Partial payloads (blob fetch under pressure) serve now
+                    # but go stale fast so the walk retries toward complete.
+                    fresh_ttl = 60 if enc.get("partial") else int(_CACHE_TTL)
+                    app_cache.set_json(_fresh_key(key), 1, fresh_ttl)
                     _cache_put(key, enc)
                     _store_payload(key, enc)
                 return
@@ -704,7 +781,8 @@ def _kick_refresh(
                 )
             )
             app_cache.set_json(_payload_key(cache_key), payload, _STALE_REDIS_TTL)
-            app_cache.set_json(_fresh_key(cache_key), 1, int(_CACHE_TTL))
+            fresh_ttl = 60 if payload.get("partial") else int(_CACHE_TTL)
+            app_cache.set_json(_fresh_key(cache_key), 1, fresh_ttl)
             _cache_put(cache_key, payload)
             # Durable standing is reserved for the prewarmed slices; an
             # ad-hoc tuple (arbitrary version/ascension spellings on the
@@ -761,7 +839,7 @@ def _compute_insights(
     rows = _apply_row_filters(rows, character, ascension, version, players)
     t1 = time.time()
     blobs = _fetch_blobs(rows)
-    _require_blob_coverage(rows, blobs)
+    cov_ok = _require_blob_coverage(rows, blobs)
     t2 = time.time()
     acc = community_stats._new_acc_one()
     walked = _accumulate_rows(rows, blobs, acc)
@@ -777,6 +855,8 @@ def _compute_insights(
         version,
         players,
     )
+    if not cov_ok:
+        payload["partial"] = True
     logger.info(
         "user-insights walk uid=%s slice=%s rows=%d fetch_ms=%d walk_ms=%d total_ms=%d",
         user_id,
@@ -792,20 +872,21 @@ def _compute_insights(
 _PREWARM_CHARACTERS = ("IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT")
 
 
-def _require_blob_coverage(rows: list[dict], blobs: dict[str, dict]) -> None:
-    """get_run_blobs degrades quietly under Mongo pressure (other callers
-    have a per-file fallback; this walk doesn't), so a hollow or heavily
-    partial fetch means Mongo was unavailable — not that the runs vanished.
-    Refuse to build the payload rather than durably store an empty profile
-    over a real one. The slack covers the few known-corrupt blobless runs."""
+def _require_blob_coverage(rows: list[dict], blobs: dict[str, dict]) -> bool:
+    """True when the fetch covered enough of the account to store durably.
+    Zero coverage on a nonempty account raises (Mongo was unavailable);
+    anything between builds a payload that serves flagged partial but is
+    never durably stored, instead of the old hard refusal that left bulk
+    uploads with missing blobs stuck on "building" forever."""
     if not rows:
-        return
+        return True
     have = sum(1 for r in rows if r["run_hash"] in blobs)
+    if not have:
+        raise RuntimeError(f"insights blob fetch returned 0/{len(rows)} runs")
     if have < len(rows) * 0.9:
-        raise RuntimeError(
-            f"insights blob fetch returned {have}/{len(rows)} runs; "
-            "refusing to build a hollow profile"
-        )
+        logger.warning("insights blob fetch partial: %d/%d runs", have, len(rows))
+        return False
+    return True
 
 
 def _fetch_blobs(rows: list[dict]) -> dict[str, dict]:
@@ -876,7 +957,7 @@ def _compute_insights_all_slices(user_id: str, username: str | None) -> dict[str
         elo_block = None
     t1 = time.time()
     blobs = _fetch_blobs(rows)
-    _require_blob_coverage(rows, blobs)
+    cov_ok = _require_blob_coverage(rows, blobs)
     t2 = time.time()
 
     slices: list[tuple[tuple, list[dict]]] = [((None, None, None, None), rows)]
@@ -905,6 +986,9 @@ def _compute_insights_all_slices(user_id: str, username: str | None) -> dict[str
             )
         except Exception:
             logger.warning("insights slice assemble failed for %s", f, exc_info=True)
+    if not cov_ok:
+        for p in out.values():
+            p["partial"] = True
     logger.info(
         "user-insights prewarm uid=%s rows=%d slices=%d rows_ms=%d fetch_ms=%d walk_ms=%d total_ms=%d",
         user_id,

--- a/backend/tests/test_instant_profiles.py
+++ b/backend/tests/test_instant_profiles.py
@@ -1,0 +1,87 @@
+"""Build-on-upload kicks, partial blob coverage, and the building count."""
+
+import time
+
+import pytest
+
+from app.services import cache as app_cache
+from app.services import user_insights as ui
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    with ui._pending_lock:
+        ui._pending.clear()
+        ui._pending_checked.clear()
+    with ui._cache_lock:
+        ui._cache.clear()
+    monkeypatch.setattr(ui, "_sweeper_started", True)
+    yield
+    with ui._pending_lock:
+        ui._pending.clear()
+        ui._pending_checked.clear()
+
+
+def test_first_activity_kicks_build_when_no_profile_exists(monkeypatch):
+    kicks = []
+    monkeypatch.setattr(ui, "_kick_refresh", lambda *a: kicks.append(a))
+    monkeypatch.setattr(ui, "_load_stored_payload", lambda k: None)
+    monkeypatch.setattr(app_cache, "get_json", lambda k: None)
+
+    ui.note_profile_activity("u1", "Dobo")
+    assert len(kicks) == 1
+    assert kicks[0][0] == "u1:"
+
+    ui.note_profile_activity("u1", "Dobo")
+    assert len(kicks) == 1
+    assert "u1" in ui._pending
+
+
+def test_activity_with_existing_profile_only_records_pending(monkeypatch):
+    kicks = []
+    monkeypatch.setattr(ui, "_kick_refresh", lambda *a: kicks.append(a))
+    monkeypatch.setattr(ui, "_load_stored_payload", lambda k: {"runs_walked": 5})
+    monkeypatch.setattr(app_cache, "get_json", lambda k: None)
+
+    ui.note_profile_activity("u2", None)
+    assert kicks == []
+    assert "u2" in ui._pending
+
+
+def test_due_pending_waits_for_the_burst_to_quiet():
+    now = time.time()
+    pending = {
+        "old": (now - 60.0, "a"),
+        "hot": (now - 5.0, "b"),
+    }
+    assert ui._due_pending(pending, now) == ["old"]
+
+
+def test_coverage_full_partial_and_zero():
+    rows = [{"run_hash": f"h{i}"} for i in range(10)]
+    full = {f"h{i}": {} for i in range(10)}
+    half = {f"h{i}": {} for i in range(5)}
+    assert ui._require_blob_coverage(rows, full) is True
+    assert ui._require_blob_coverage(rows, half) is False
+    with pytest.raises(RuntimeError):
+        ui._require_blob_coverage(rows, {})
+    assert ui._require_blob_coverage([], {}) is True
+
+
+def test_partial_payload_never_stored_durably(monkeypatch):
+    touched = []
+    monkeypatch.setattr(ui, "_insights_coll", lambda: touched.append(1))
+    ui._store_payload("k", {"partial": True, "claimed_runs": 9, "runs_walked": 5})
+    assert touched == []
+
+
+def test_building_response_carries_claimed_count(monkeypatch):
+    import app.services.runs_db_mongo as rdm
+
+    monkeypatch.setattr(ui, "_kick_refresh", lambda *a: None)
+    monkeypatch.setattr(ui, "_load_stored_payload", lambda k: None)
+    monkeypatch.setattr(app_cache, "get_json", lambda k: None)
+    monkeypatch.setattr(rdm, "count_user_runs", lambda uid: 42)
+
+    out = ui.get_user_insights("u3")
+    assert out == {"building": True, "claimed_runs": 42}

--- a/backend/tests/test_user_insights.py
+++ b/backend/tests/test_user_insights.py
@@ -116,7 +116,7 @@ def test_insights_build_then_cache(monkeypatch):
     # The walk never runs on the request path: the first call kicks the
     # refresh (inline here) and reports building; the next serves the result.
     first = user_insights.get_user_insights("u1")
-    assert first == {"building": True}
+    assert first.get("building") is True
     second = user_insights.get_user_insights("u1")
     assert second.get("building") is None
     assert second["runs_walked"] == 0

--- a/backend/tests/test_user_insights_store.py
+++ b/backend/tests/test_user_insights_store.py
@@ -36,7 +36,8 @@ def test_never_computed_still_builds(monkeypatch):
     monkeypatch.setattr(ui, "_cache_get", lambda k: None)
     monkeypatch.setattr("app.services.cache.get_json", lambda k: None)
     monkeypatch.setattr(ui, "_kick_refresh", lambda *a: None)
-    assert ui.get_user_insights("nobody") == {"building": True}
+    out = ui.get_user_insights("nobody")
+    assert out.get("building") is True
 
 
 def test_store_write_failure_is_soft(monkeypatch):
@@ -57,8 +58,8 @@ def test_hollow_blob_fetch_refuses_to_build():
 
     with pytest.raises(RuntimeError):
         ui._require_blob_coverage(rows, {})
-    with pytest.raises(RuntimeError):
-        ui._require_blob_coverage(rows, {f"h{i}": {} for i in range(85)})
+    # Heavy-but-nonzero misses build a partial payload now instead of raising.
+    assert ui._require_blob_coverage(rows, {f"h{i}": {} for i in range(85)}) is False
 
 
 def test_invalidate_clears_prewarmed_fresh_markers(monkeypatch):

--- a/frontend/app/components/ProfileInsights.tsx
+++ b/frontend/app/components/ProfileInsights.tsx
@@ -1081,6 +1081,7 @@ export default function ProfileInsights({
   const [data, setData] = useState<Insights | null>(null);
   const [loading, setLoading] = useState(true);
   const [building, setBuilding] = useState(false);
+  const [claimedRuns, setClaimedRuns] = useState<number | null>(null);
   const [filters, setFilters] = useState<InsightFilters>(EMPTY_INSIGHT_FILTERS);
   const filtered =
     !!filters.character || !!filters.ascension || !!filters.players || !!filters.version;
@@ -1101,6 +1102,7 @@ export default function ProfileInsights({
           if (!alive) return;
           if (d && d.building) {
             setBuilding(true);
+            if (typeof d.claimed_runs === "number") setClaimedRuns(d.claimed_runs);
             timer = setTimeout(load, 5000);
             return;
           }
@@ -1127,6 +1129,7 @@ export default function ProfileInsights({
         {building && (
           <p className="text-sm text-[var(--text-secondary)]">
             {t("Crunching your runs. The first load can take a minute or two.", lang)}
+            {claimedRuns ? ` · ${claimedRuns.toLocaleString()} ${t("runs", lang)}` : ""}
           </p>
         )}
         {[...Array(4)].map((_, i) => (

--- a/frontend/app/players/[username]/PlayerProfileClient.tsx
+++ b/frontend/app/players/[username]/PlayerProfileClient.tsx
@@ -14,6 +14,7 @@ export default function PlayerProfileClient({ username }: { username: string }) 
   const [data, setData] = useState<PlayerInsights | null>(null);
   const [status, setStatus] = useState<"loading" | "ok" | "missing">("loading");
   const [building, setBuilding] = useState(false);
+  const [claimedRuns, setClaimedRuns] = useState<number | null>(null);
   const [filters, setFilters] = useState<InsightFilters>(EMPTY_INSIGHT_FILTERS);
   const cards = useCardMap();
   const relics = useRelicMap();
@@ -31,6 +32,7 @@ export default function PlayerProfileClient({ username }: { username: string }) 
           if (!alive) return;
           if (d && d.building) {
             setBuilding(true);
+            if (typeof d.claimed_runs === "number") setClaimedRuns(d.claimed_runs);
             timer = setTimeout(load, 5000);
             return;
           }
@@ -54,6 +56,7 @@ export default function PlayerProfileClient({ username }: { username: string }) 
         {building && (
           <p className="text-sm text-[var(--text-secondary)]">
             {t("Crunching your runs. The first load can take a minute or two.", lang)}
+            {claimedRuns ? ` · ${claimedRuns.toLocaleString()} ${t("runs", lang)}` : ""}
           </p>
         )}
         {[...Array(4)].map((_, i) => (


### PR DESCRIPTION
I made linked submits, claims, and sign-in backfills kick the profile build (debounced per upload burst), partial blob coverage now serves a fast-refreshing partial profile instead of spinning forever, and the building placeholder shows the claimed run count.