### PR TITLE
Env-driven backend memory cap

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -60,7 +60,9 @@ services:
     # (2026-08-27). 6g gives walks real room; the lasting fix is retiring
     # the per-worker snapshot copies once entity brackets serve from the
     # lake.
-    mem_limit: 6g
+    # With lake-ingest moved to its own box, its 5g budget can go to the
+    # backend: set BACKEND_MEM_LIMIT=8g in the box .env.
+    mem_limit: ${BACKEND_MEM_LIMIT:-6g}
     # Multiple workers so a burst of POST /api/runs (Overwolf launch
     # backfills) doesn't serialise behind a single thread and block
     # everything else (GET /api/runs/stats, /api/runs/list etc.).


### PR DESCRIPTION
I made the backend mem_limit env-driven so the box .env can grant it the 5g the departed lake-ingest freed up.