### PR TITLE
Purge the charts prefix

### DIFF
--- a/lab/edge_purge.py
+++ b/lab/edge_purge.py
@@ -10,6 +10,7 @@ PREFIX_PATHS = (
     "/api/runs/scores/",
     "/api/runs/metrics/",
     "/api/runs/encounter-stats",
+    "/api/charts",
 )
 
 


### PR DESCRIPTION
I added /api/charts to the edge purge prefixes so chart responses refresh at the edge after each pulled generation.