### PR TITLE
Deep item tables from the lake

### DIFF
--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -2022,6 +2022,9 @@ def refresh_stats_core() -> int:
 
     coll = _summary_coll()
     written = 0
+    deep: dict[str, dict] = {}
+    if (os.environ.get("LAKE_DEEP_TABLES", "") or "").strip().lower() == "on":
+        deep = deep_tables_by_key()
     for filters, result in _stats_core_results():
         key = _filter_key(**filters_compact(filters))
         if result.get("total_runs"):
@@ -2029,6 +2032,7 @@ def refresh_stats_core() -> int:
             merged = {
                 **existing,
                 **result,
+                **deep.get(key, {}),
                 "_id": key,
                 "updated_at": datetime.now(timezone.utc),
             }
@@ -2061,3 +2065,232 @@ def refresh_stats_core() -> int:
 def filters_compact(filters: dict) -> dict:
     """The sparse combo form the legacy key/cache helpers expect."""
     return {k: v for k, v in filters.items() if v is not None}
+
+
+_DEEP_TABLES_NAME = "deep_tables.json"
+
+
+def _parquet_columns(con, name: str) -> set[str]:
+    res = con.execute(
+        f"SELECT * FROM read_parquet('{LAKE_DIR}/{name}.parquet') LIMIT 0"
+    )
+    return {d[0] for d in res.description}
+
+
+def _fold_deep(rows, char_f, asc_f, official):
+    """Sum grouped (character, ascension, key, *counts) rows into one combo's
+    {key: (counts...)} map. The official filter applies even unfiltered,
+    matching get_stats' _build_match."""
+    out: dict[str, list[int]] = {}
+    for ch, a, key, *counts in rows:
+        if ch not in official:
+            continue
+        if char_f is not None and ch != char_f:
+            continue
+        if asc_f is not None and a != asc_f:
+            continue
+        if key is None:
+            continue
+        rec = out.setdefault(key, [0] * len(counts))
+        for i, c in enumerate(counts):
+            rec[i] += c or 0
+    return out
+
+
+def build_deep_tables() -> int:
+    """Per-combo deep item tables for the materialized stats docs, replacing
+    the retired refresh_stats_summary aggregation (~80 min of Mongo doc
+    scanning per refresh). Five grouped passes over the lake folded across
+    the stats_core combos; refresh_stats_core merges the stored artifact
+    when LAKE_DEEP_TABLES=on. Counting stays per player like the legacy
+    per-player docs (item stats dedupe per run+player+item), except shop
+    potion offers count once per run instead of once per party sibling."""
+    import json as _json
+
+    from .runs_db_mongo import (
+        ASCENSION_FILTER_COMBOS,
+        HOT_FILTER_COMBOS,
+        OFFICIAL_CHARACTERS,
+    )
+
+    if not available():
+        logger.info("deep tables skipped: lake incomplete")
+        return 0
+    runs_p = f"read_parquet('{LAKE_DIR}/runs.parquet')"
+    excl_p = f"read_parquet('{LAKE_DIR}/excluded.parquet')"
+    players_p = f"read_parquet('{LAKE_DIR}/players.parquet')"
+    con = _connect(build=True)
+    try:
+        _ensure_choice_rows(con)
+        deaths = con.execute(
+            f"""
+            SELECT coalesce(upper(r.character), '') AS ch,
+              coalesce(r.ascension, 0)::INT AS a,
+              coalesce(r.killed_by_encounter, r.killed_by_event) AS kb,
+              count(*) AS n
+            FROM {runs_p} r
+            ANTI JOIN {excl_p} x ON r.run_hash = x.run_hash
+            WHERE r.ascension BETWEEN 0 AND 10
+              AND NOT coalesce(r.win, false)
+              AND coalesce(r.killed_by_encounter, r.killed_by_event) IS NOT NULL
+            GROUP BY 1, 2, 3
+            """
+        ).fetchall()
+        picks = con.execute(
+            f"""
+            SELECT p.character AS ch, coalesce(r.ascension, 0)::INT AS a,
+              c.cid, count(*) AS offered, count(*) FILTER (c.picked) AS picked
+            FROM choice_rows c
+            JOIN {players_p} p
+              ON c.run_hash = p.run_hash AND c.pidx = p.player_idx
+            JOIN {runs_p} r ON c.run_hash = r.run_hash
+            GROUP BY 1, 2, 3
+            """
+        ).fetchall()
+
+        def item_rows(table: str, col: str):
+            return con.execute(
+                f"""
+                SELECT ch, a, item, sum(copies)::BIGINT,
+                  coalesce(sum(copies) FILTER (win), 0)::BIGINT,
+                  coalesce(sum(copies) FILTER (NOT win), 0)::BIGINT,
+                  count(*)::BIGINT, count(*) FILTER (win)::BIGINT
+                FROM (
+                  SELECT d.character AS ch, coalesce(r.ascension, 0)::INT AS a,
+                    d.{col} AS item, d.run_hash, d.player_idx,
+                    count(*) AS copies, bool_or(coalesce(r.win, false)) AS win
+                  FROM read_parquet('{LAKE_DIR}/{table}.parquet') d
+                  JOIN {runs_p} r ON d.run_hash = r.run_hash
+                  ANTI JOIN {excl_p} x ON d.run_hash = x.run_hash
+                  WHERE r.ascension BETWEEN 0 AND 10 AND d.{col} IS NOT NULL
+                  GROUP BY 1, 2, 3, d.run_hash, d.player_idx
+                ) GROUP BY 1, 2, 3
+                """
+            ).fetchall()
+
+        cards = item_rows("deck", "card")
+        relics = item_rows("relics", "relic")
+        potions_owned = item_rows("potions", "potion")
+
+        # The potion telemetry columns only exist in lakes built after the
+        # schema gained them; older lakes omit the section and the doc merge
+        # keeps whatever the summary already holds.
+        used = []
+        if "was_used" in _parquet_columns(con, "potions"):
+            used = con.execute(
+                f"""
+                SELECT d.character AS ch, coalesce(r.ascension, 0)::INT AS a,
+                  d.potion AS item, count(*) FILTER (d.was_used)::BIGINT AS used
+                FROM read_parquet('{LAKE_DIR}/potions.parquet') d
+                JOIN {runs_p} r ON d.run_hash = r.run_hash
+                ANTI JOIN {excl_p} x ON d.run_hash = x.run_hash
+                WHERE r.ascension BETWEEN 0 AND 10
+                GROUP BY 1, 2, 3
+                """
+            ).fetchall()
+        shop = []
+        if (LAKE_DIR / "shop_potions.parquet").exists():
+            shop = con.execute(
+                f"""
+                SELECT p.character AS ch, coalesce(r.ascension, 0)::INT AS a,
+                  s.potion AS item, count(*) AS offered,
+                  count(*) FILTER (s.was_picked)::BIGINT AS picked
+                FROM read_parquet('{LAKE_DIR}/shop_potions.parquet') s
+                JOIN {players_p} p
+                  ON s.run_hash = p.run_hash AND s.player_idx = p.player_idx
+                JOIN {runs_p} r ON s.run_hash = r.run_hash
+                ANTI JOIN {excl_p} x ON s.run_hash = x.run_hash
+                WHERE r.ascension BETWEEN 0 AND 10
+                GROUP BY 1, 2, 3
+                """
+            ).fetchall()
+    finally:
+        con.close()
+
+    def pct(a: int, b: int) -> float:
+        return round(a / b * 100, 1) if b > 0 else 0
+
+    official = frozenset(OFFICIAL_CHARACTERS)
+    combos = []
+    for f in [*HOT_FILTER_COMBOS, *ASCENSION_FILTER_COMBOS]:
+        char_f = f.get("character")
+        asc_f = int(f["ascension"]) if "ascension" in f else None
+        d = _fold_deep(deaths, char_f, asc_f, official)
+        pk = _fold_deep(picks, char_f, asc_f, official)
+        cd = _fold_deep(cards, char_f, asc_f, official)
+        rl = _fold_deep(relics, char_f, asc_f, official)
+        tables: dict = {
+            "deadliest": [
+                {"encounter": k, "count": v[0]}
+                for k, v in sorted(d.items(), key=lambda kv: -kv[1][0])[:10]
+            ],
+            "pick_rates": [
+                {
+                    "card_id": k,
+                    "offered": v[0],
+                    "picked": v[1],
+                    "pick_rate": pct(v[1], v[0]),
+                }
+                for k, v in sorted(pk.items(), key=lambda kv: -kv[1][0])
+            ],
+            "top_cards": [
+                {
+                    "card_id": k,
+                    "count": v[0],
+                    "in_wins": v[1],
+                    "in_losses": v[2],
+                    "total_runs_with": v[3],
+                    "win_runs": v[4],
+                }
+                for k, v in sorted(cd.items(), key=lambda kv: -kv[1][0])
+            ],
+            "top_relics": [
+                {
+                    "relic_id": k,
+                    "count": v[0],
+                    "total_runs_with": v[3],
+                    "win_runs": v[4],
+                }
+                for k, v in sorted(rl.items(), key=lambda kv: -kv[1][0])
+            ],
+        }
+        if shop and used:
+            po = _fold_deep(potions_owned, char_f, asc_f, official)
+            us = _fold_deep(used, char_f, asc_f, official)
+            sh = _fold_deep(shop, char_f, asc_f, official)
+            tables["top_potions"] = [
+                {
+                    "potion_id": k,
+                    "offered": v[0],
+                    "picked": v[1],
+                    "used": us.get(k, [0])[0],
+                    "total_runs_with": po.get(k, [0] * 5)[3],
+                    "win_runs": po.get(k, [0] * 5)[4],
+                    "pick_rate": pct(v[1], v[0]),
+                }
+                for k, v in sorted(sh.items(), key=lambda kv: -kv[1][0])
+            ]
+        combos.append({"filters": filters_compact({**f}), "tables": tables})
+
+    doc = {"combos": combos}
+    tmp = LAKE_DIR / (_DEEP_TABLES_NAME + ".tmp")
+    tmp.write_text(_json.dumps(doc, separators=(",", ":")))
+    tmp.replace(LAKE_DIR / _DEEP_TABLES_NAME)
+    logger.info("deep tables stored: %d combos", len(combos))
+    return len(combos)
+
+
+def deep_tables_by_key() -> dict[str, dict]:
+    """{summary-doc key: tables} from the stored artifact; {} when absent."""
+    import json as _json
+
+    from .runs_db_mongo import _filter_key
+
+    try:
+        doc = _json.loads((LAKE_DIR / _DEEP_TABLES_NAME).read_text())
+    except Exception:
+        return {}
+    return {
+        _filter_key(**c.get("filters", {})): c.get("tables", {})
+        for c in doc.get("combos", [])
+    }

--- a/backend/tests/test_deep_tables.py
+++ b/backend/tests/test_deep_tables.py
@@ -1,0 +1,142 @@
+"""Lake-built deep tables: fold semantics and the full builder on a tiny lake."""
+
+import duckdb
+import pytest
+
+from app.services import lake_stats as ls
+
+
+def test_fold_deep_filters_and_sums():
+    rows = [
+        ("IRONCLAD", 10, "STRIKE", 4, 2),
+        ("IRONCLAD", 3, "STRIKE", 2, 1),
+        ("SILENT", 10, "STRIKE", 1, 1),
+        ("MODDED_GUY", 10, "STRIKE", 50, 50),
+        ("IRONCLAD", 10, None, 9, 9),
+    ]
+    official = frozenset({"IRONCLAD", "SILENT"})
+    assert ls._fold_deep(rows, None, None, official) == {"STRIKE": [7, 4]}
+    assert ls._fold_deep(rows, "IRONCLAD", None, official) == {"STRIKE": [6, 3]}
+    assert ls._fold_deep(rows, None, 10, official) == {"STRIKE": [5, 3]}
+    assert ls._fold_deep(rows, "SILENT", 3, official) == {}
+
+
+@pytest.fixture()
+def tiny_lake(tmp_path, monkeypatch):
+    con = duckdb.connect()
+    # r1 IRONCLAD a10 win; r2 SILENT a10 loss (killed); r3 hidden -> excluded.
+    con.execute(
+        f"""COPY (SELECT * FROM (VALUES
+        ('r1', 'IRONCLAD', true, 10, false, NULL::VARCHAR, NULL::VARCHAR),
+        ('r2', 'SILENT', false, 10, false, 'JAW_WORM', NULL::VARCHAR),
+        ('r3', 'IRONCLAD', true, 10, false, NULL::VARCHAR, NULL::VARCHAR))
+        t(run_hash, character, win, ascension, was_abandoned,
+          killed_by_encounter, killed_by_event))
+        TO '{tmp_path}/runs.parquet' (FORMAT parquet)"""
+    )
+    con.execute(
+        f"""COPY (SELECT * FROM (VALUES ('r3'))
+        t(run_hash)) TO '{tmp_path}/excluded.parquet' (FORMAT parquet)"""
+    )
+    con.execute(
+        f"""COPY (SELECT * FROM (VALUES
+        ('r1', 1, 1, 'IRONCLAD', 20), ('r2', 1, 2, 'SILENT', 20))
+        t(run_hash, player_idx, player_id, character, deck_size))
+        TO '{tmp_path}/players.parquet' (FORMAT parquet)"""
+    )
+    con.execute(
+        f"""COPY (SELECT * FROM (VALUES
+        ('r1', 1, 'IRONCLAD', 'STRIKE'), ('r1', 1, 'IRONCLAD', 'STRIKE'),
+        ('r2', 1, 'SILENT', 'STRIKE'), ('r3', 1, 'IRONCLAD', 'STRIKE'))
+        t(run_hash, player_idx, character, card))
+        TO '{tmp_path}/deck.parquet' (FORMAT parquet)"""
+    )
+    con.execute(
+        f"""COPY (SELECT * FROM (VALUES ('r1', 1, 'BURNING_BLOOD', 'IRONCLAD'))
+        t(run_hash, player_idx, relic, character))
+        TO '{tmp_path}/relics.parquet' (FORMAT parquet)"""
+    )
+    con.execute(
+        f"""COPY (SELECT * FROM (VALUES
+        ('r1', 1, 'FIRE_POTION', 'IRONCLAD', true),
+        ('r2', 1, 'FIRE_POTION', 'SILENT', false))
+        t(run_hash, player_idx, potion, character, was_used))
+        TO '{tmp_path}/potions.parquet' (FORMAT parquet)"""
+    )
+    con.execute(
+        f"""COPY (SELECT * FROM (VALUES
+        ('r1', 1, 'FIRE_POTION', true), ('r1', 1, 'BLOCK_POTION', false),
+        ('r2', 1, 'FIRE_POTION', false))
+        t(run_hash, player_idx, potion, was_picked))
+        TO '{tmp_path}/shop_potions.parquet' (FORMAT parquet)"""
+    )
+    # Floors with card_choices so _ensure_choice_rows has something real:
+    # r1's player saw STRIKE (picked) and DEFEND (skipped) on one screen.
+    con.execute(
+        f"""COPY (SELECT 'r1' AS run_hash, 0 AS act, 1 AS floor_idx,
+        [struct_pack(player_id := 1,
+           card_choices := [
+             struct_pack(was_picked := true,
+               card := struct_pack(id := 'CARD.STRIKE')),
+             struct_pack(was_picked := false,
+               card := struct_pack(id := 'CARD.DEFEND'))])] AS players)
+        TO '{tmp_path}/floors.parquet' (FORMAT parquet)"""
+    )
+    con.close()
+    monkeypatch.setattr(ls, "LAKE_DIR", tmp_path)
+    yield tmp_path
+
+
+def _tables(result, filters):
+    for c in result["combos"]:
+        if c["filters"] == filters:
+            return c["tables"]
+    raise AssertionError(f"combo {filters} missing")
+
+
+def test_build_deep_tables_end_to_end(tiny_lake, monkeypatch):
+    import json
+
+    monkeypatch.setattr(ls, "available", lambda *a: True)
+    n = ls.build_deep_tables()
+    assert n > 0
+    doc = json.loads((tiny_lake / "deep_tables.json").read_text())
+
+    t = _tables(doc, {})
+    # r3 is excluded: STRIKE = r1 (2 copies, win) + r2 (1 copy, loss).
+    cards = {r["card_id"]: r for r in t["top_cards"]}
+    assert cards["STRIKE"] == {
+        "card_id": "STRIKE",
+        "count": 3,
+        "in_wins": 2,
+        "in_losses": 1,
+        "total_runs_with": 2,
+        "win_runs": 1,
+    }
+    assert t["deadliest"] == [{"encounter": "JAW_WORM", "count": 1}]
+    assert t["top_relics"][0]["relic_id"] == "BURNING_BLOOD"
+    pots = {r["potion_id"]: r for r in t["top_potions"]}
+    assert pots["FIRE_POTION"]["offered"] == 2
+    assert pots["FIRE_POTION"]["picked"] == 1
+    assert pots["FIRE_POTION"]["used"] == 1
+    assert pots["FIRE_POTION"]["total_runs_with"] == 2
+    assert pots["BLOCK_POTION"]["offered"] == 1
+    assert pots["BLOCK_POTION"]["total_runs_with"] == 0
+    picks = {r["card_id"]: r for r in t["pick_rates"]}
+    assert picks["STRIKE"] == {
+        "card_id": "STRIKE",
+        "offered": 1,
+        "picked": 1,
+        "pick_rate": 100.0,
+    }
+    assert picks["DEFEND"]["picked"] == 0
+
+    t_silent = _tables(doc, {"character": "SILENT"})
+    assert {r["card_id"] for r in t_silent["top_cards"]} == {"STRIKE"}
+    assert t_silent["top_cards"][0]["count"] == 1
+    assert t_silent["deadliest"] == [{"encounter": "JAW_WORM", "count": 1}]
+
+
+def test_deep_tables_by_key_missing_artifact(tmp_path, monkeypatch):
+    monkeypatch.setattr(ls, "LAKE_DIR", tmp_path)
+    assert ls.deep_tables_by_key() == {}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,6 +24,9 @@ x-shared-env: &shared-env
   LAKE_ENTITY_STATS: ${LAKE_ENTITY_STATS:-}
   # off = workers skip the frozen snapshot load (~1.1GB per worker).
   ENTITY_SNAPSHOT_LOAD: ${ENTITY_SNAPSHOT_LOAD:-on}
+  # on = stats_core merges the lake-built deep item tables (deep_tables.json)
+  # into the summary docs; off keeps the legacy tables in place.
+  LAKE_DEEP_TABLES: ${LAKE_DEEP_TABLES:-}
   # How often the leader may rerun the heavy walk (seconds). Default 7200
   # (2h). With the parallel rebuild on, lower it for fresher public numbers,
   # but keep it well above the observed walk time so the box isn't always

--- a/lab/build.sql
+++ b/lab/build.sql
@@ -27,8 +27,8 @@ SELECT * FROM read_ndjson('/lake/staging/*.jsonl.gz',
     start_time: 'BIGINT', run_time: 'BIGINT',
     killed_by_encounter: 'VARCHAR', killed_by_event: 'VARCHAR',
     modifiers: 'VARCHAR[]',
-    players: 'STRUCT(id BIGINT, "character" VARCHAR, deck STRUCT(floor_added_to_deck BIGINT, id VARCHAR, current_upgrade_level BIGINT, enchantment STRUCT(id VARCHAR))[], relics STRUCT(id VARCHAR, floor_added_to_deck BIGINT)[], potions STRUCT(id VARCHAR)[])[]',
-    map_point_history: 'STRUCT(map_point_type VARCHAR, player_stats STRUCT(player_id BIGINT, current_gold BIGINT, current_hp BIGINT, damage_taken BIGINT, max_hp BIGINT, event_choices STRUCT(title STRUCT("key" VARCHAR, "table" VARCHAR))[], rest_site_choices VARCHAR[], upgraded_cards VARCHAR[], ancient_choice STRUCT(TextKey VARCHAR, title STRUCT("key" VARCHAR, "table" VARCHAR), was_chosen BOOLEAN)[], cards_removed JSON[], card_choices STRUCT(was_picked BOOLEAN, card STRUCT(id VARCHAR))[])[], rooms STRUCT(model_id VARCHAR, room_type VARCHAR, turns_taken BIGINT)[])[][]',
+    players: 'STRUCT(id BIGINT, "character" VARCHAR, deck STRUCT(floor_added_to_deck BIGINT, id VARCHAR, current_upgrade_level BIGINT, enchantment STRUCT(id VARCHAR))[], relics STRUCT(id VARCHAR, floor_added_to_deck BIGINT)[], potions STRUCT(id VARCHAR, was_used BOOLEAN)[])[]',
+    map_point_history: 'STRUCT(map_point_type VARCHAR, player_stats STRUCT(player_id BIGINT, current_gold BIGINT, current_hp BIGINT, damage_taken BIGINT, max_hp BIGINT, event_choices STRUCT(title STRUCT("key" VARCHAR, "table" VARCHAR))[], rest_site_choices VARCHAR[], upgraded_cards VARCHAR[], ancient_choice STRUCT(TextKey VARCHAR, title STRUCT("key" VARCHAR, "table" VARCHAR), was_chosen BOOLEAN)[], cards_removed JSON[], card_choices STRUCT(was_picked BOOLEAN, card STRUCT(id VARCHAR))[], potion_choices STRUCT(was_picked BOOLEAN, choice VARCHAR)[])[], rooms STRUCT(model_id VARCHAR, room_type VARCHAR, turns_taken BIGINT)[])[][]',
     _meta: 'STRUCT(username VARCHAR, user_id VARCHAR, hidden BOOLEAN, deleted BOOLEAN, submitted_at TIMESTAMP, played_at TIMESTAMP, player_count BIGINT, "character" VARCHAR)'});
 
 
@@ -131,12 +131,30 @@ ORDER BY 1
 COPY (
 SELECT r.run_hash, p.i AS player_idx,
   upper(split_part(pot.u.id, '.', -1)) AS potion,
-  upper(split_part(p.u.character,'.',-1)) AS character
+  upper(split_part(p.u.character,'.',-1)) AS character,
+  coalesce(pot.u.was_used, false) AS was_used
 FROM raw r,
   LATERAL (SELECT unnest(players) AS u, generate_subscripts(players,1) AS i) p,
   LATERAL (SELECT unnest(p.u.potions) AS u) pot
 ORDER BY 1
 ) TO '/lake/potions.parquet' (FORMAT parquet, COMPRESSION zstd);
+
+-- Shop-shelf potion offers only (a combat-drop "pick rate" measures slot
+-- availability, not potion quality; a purchase is a real decision). One row
+-- per potion seen on a shelf. Counted once per run, not once per party
+-- sibling like the legacy per-player docs did.
+COPY (
+SELECT r.run_hash, ps.i AS player_idx,
+  upper(split_part(pc.u.choice, '.', -1)) AS potion,
+  coalesce(pc.u.was_picked, false) AS was_picked
+FROM raw r,
+  LATERAL (SELECT unnest(map_point_history) AS u) act,
+  LATERAL (SELECT unnest(act.u) AS u) loc,
+  LATERAL (SELECT unnest(loc.u.player_stats) AS u,
+    generate_subscripts(loc.u.player_stats,1) AS i) ps,
+  LATERAL (SELECT unnest(ps.u.potion_choices) AS u) pc
+WHERE list_contains([lower(x.room_type) FOR x IN loc.u.rooms], 'shop')
+) TO '/lake/shop_potions.parquet' (FORMAT parquet, COMPRESSION zstd);
 
 -- Per-player identity + deck size: keys player_id to a character for the
 -- co-op attributions, and carries deck size for the records section.
@@ -176,6 +194,7 @@ UNION ALL SELECT 'deck', count(*) FROM read_parquet('/lake/deck.parquet')
 UNION ALL SELECT 'floors', count(*) FROM read_parquet('/lake/floors.parquet')
 UNION ALL SELECT 'players', count(*) FROM read_parquet('/lake/players.parquet')
 UNION ALL SELECT 'relics', count(*) FROM read_parquet('/lake/relics.parquet')
-UNION ALL SELECT 'potions', count(*) FROM read_parquet('/lake/potions.parquet');
+UNION ALL SELECT 'potions', count(*) FROM read_parquet('/lake/potions.parquet')
+UNION ALL SELECT 'shop_potions', count(*) FROM read_parquet('/lake/shop_potions.parquet');
 
 DROP TABLE raw;

--- a/lab/ingest.py
+++ b/lab/ingest.py
@@ -124,6 +124,9 @@ def main() -> None:
         lake_stats.build_entity_cube()
         print("entity cube stored", flush=True)
         _mark("entity_cube")
+        n_deep = lake_stats.build_deep_tables()
+        print(f"deep tables stored ({n_deep} combos)", flush=True)
+        _mark("deep_tables")
         from app.services import charts_blob_lake
 
         charts_blob_lake.build_charts_blob()

--- a/lab/run_stage.py
+++ b/lab/run_stage.py
@@ -49,6 +49,7 @@ def _stages():
         "entity_store": lake_stats.build_entity_store,
         "encounter_store": lake_stats.build_encounter_store,
         "entity_cube": lake_stats.build_entity_cube,
+        "deep_tables": lake_stats.build_deep_tables,
         "charts_blob": charts_blob_lake.build_charts_blob,
         "stats_core": lake_stats.refresh_stats_core,
         "leaderboard_summary": leaderboard_summary,

--- a/lab/validate_deep_tables.py
+++ b/lab/validate_deep_tables.py
@@ -1,0 +1,78 @@
+"""Compare the lake-built deep tables against the legacy summary docs.
+
+The legacy tables froze when refresh_stats_summary left the cycle, so
+counts have drifted; what this validates is STRUCTURE: the section keys,
+the id namespaces (the likeliest silent breakage — bare-upper lake ids vs
+whatever the Mongo docs carried), and whether the same entities rank near
+the top. Run after a cycle has stored /lake/deep_tables.json:
+
+    docker compose -f docker-compose.prod.yml run --rm --entrypoint python \
+        lake-ingest /lab/validate_deep_tables.py
+"""
+
+import sys
+
+sys.path.insert(0, "/lab")
+sys.path.insert(0, "/app")
+
+
+def _ids(rows, key):
+    return [r.get(key) for r in rows or [] if r.get(key)]
+
+
+def main() -> None:
+    from app.services.lake_stats import deep_tables_by_key
+    from app.services.runs_db_mongo import _filter_key, _summary_coll
+
+    deep = deep_tables_by_key()
+    if not deep:
+        print("no /lake/deep_tables.json; run a cycle (or run_stage.py deep_tables)")
+        sys.exit(1)
+    coll = _summary_coll()
+    failures = 0
+    checked = 0
+    for combo in ({}, {"character": "IRONCLAD"}, {"ascension": "10"}):
+        key = _filter_key(**combo)
+        tables = deep.get(key)
+        doc = coll.find_one({"_id": key})
+        if not tables or not doc:
+            print(f"{key or 'all'}: missing (lake={bool(tables)} doc={bool(doc)})")
+            continue
+        checked += 1
+        print(f"== {key or 'all'} ==")
+        for section, id_key in (
+            ("top_cards", "card_id"),
+            ("pick_rates", "card_id"),
+            ("top_relics", "relic_id"),
+            ("top_potions", "potion_id"),
+            ("deadliest", "encounter"),
+        ):
+            lake_ids = _ids(tables.get(section), id_key)
+            doc_ids = _ids(doc.get(section), id_key)
+            if not lake_ids:
+                print(f"  {section}: lake EMPTY ({len(doc_ids)} legacy rows)")
+                if section != "top_potions":  # absent until the new columns build
+                    failures += 1
+                continue
+            if not doc_ids:
+                print(f"  {section}: no legacy rows to compare ({len(lake_ids)} lake)")
+                continue
+            top = set(doc_ids[:20])
+            overlap = len(top & set(lake_ids[:40])) / max(1, len(top))
+            print(
+                f"  {section}: lake {len(lake_ids)} rows, legacy {len(doc_ids)}; "
+                f"top-20 overlap {overlap:.0%}; "
+                f"sample lake={lake_ids[0]!r} legacy={doc_ids[0]!r}"
+            )
+            if overlap < 0.5:
+                failures += 1
+                print("    ^ LOW OVERLAP - check id namespaces above")
+    if not checked:
+        print("no combos comparable")
+        sys.exit(1)
+    print(f"done: {failures} failing sections")
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I converted the last legacy analytics surface: the per-item deep tables (cards, pick rates, relics, potions offered/picked/used, deadliest) now build from the lake each cycle into deep_tables.json and merge into the summary docs behind LAKE_DEEP_TABLES=on, with shop-only potion semantics preserved and a validator for the id namespaces.