### PR TITLE
Upgrade-aware card prose

### DIFF
--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -438,7 +438,7 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
             </div>
             {/* Overview prose as the hero lead (replaces the old token-stripped
                 description lede, which rendered blanks like "Gain ."). */}
-            <EntityProse kind="card" card={card} lead />
+            <EntityProse kind="card" card={card} upgraded={upgraded} lead />
           </div>
 
           {/* Sticky ToC */}

--- a/frontend/app/components/EntityProse.tsx
+++ b/frontend/app/components/EntityProse.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Fragment, type ReactNode } from "react";
+import { getCardDisplayModel } from "@/lib/card-display";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import type {
   Relic,
@@ -50,7 +52,7 @@ interface RelicProseProps { kind: "relic"; relic: Relic; }
 interface PotionProseProps { kind: "potion"; potion: Potion; }
 interface PowerProseProps { kind: "power"; power: Power; appliedByCount: number; }
 interface MonsterProseProps { kind: "monster"; monster: Monster; deadliest?: { name: string; killRate: number } | null; }
-interface CardProseProps { kind: "card"; card: Card; }
+interface CardProseProps { kind: "card"; card: Card; upgraded?: boolean; }
 interface EnchantmentProseProps { kind: "enchantment"; enchantment: Enchantment; }
 interface CharacterProseProps { kind: "character"; character: Character; }
 interface OrbProseProps { kind: "orb"; orb: Orb; }
@@ -104,6 +106,16 @@ function listWords(items: string[]): string {
   if (items.length <= 1) return items[0] ?? "";
   if (items.length === 2) return `${items[0]} and ${items[1]}`;
   return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
+function listNodes(items: ReactNode[]): ReactNode {
+  if (items.length <= 1) return items[0] ?? "";
+  return items.map((item, i) => (
+    <Fragment key={i}>
+      {i > 0 && (i === items.length - 1 ? (items.length === 2 ? " and " : ", and ") : ", ")}
+      {item}
+    </Fragment>
+  ));
 }
 
 export default function EntityProse(props: Props) {
@@ -170,19 +182,56 @@ export default function EntityProse(props: Props) {
       return <Prose lead={props.lead} sentences={[`${name} · ${c.rarity} · ${c.type}`]} />;
     }
     const who = pools[c.color] ? ` for the ${pools[c.color]}` : "";
-    const cost = c.is_x_cost ? "X" : `${c.cost}`;
-    const sentences: string[] = [];
-    sentences.push(`${name} is a ${c.rarity} ${c.type} card${who} in Slay the Spire 2, costing ${cost} energy.`);
-    const eff: string[] = [];
-    if (c.damage != null) eff.push(`deals ${c.damage} damage${c.hit_count && c.hit_count > 1 ? ` across ${c.hit_count} hits` : ""}`);
-    if (c.block != null) eff.push(`grants ${c.block} Block`);
+    // The prose tracks the page's upgrade toggle through the same display
+    // model as the card render; upgraded values that differ render in the
+    // render's green.
+    const display = getCardDisplayModel(c, !!props.upgraded);
+    const baseModel = getCardDisplayModel(c, false);
+    const up = display.isUpgraded;
+    const green = (v: ReactNode, changed: boolean) =>
+      up && changed ? <span className="text-emerald-400">{v}</span> : v;
+    const cost = c.is_x_cost ? "X" : `${display.cost ?? c.cost}`;
+    const activeDesc = (up && c.upgrade_description) || c.description || "";
+    const xTimes = !!c.is_x_cost && /\bX times/i.test(activeDesc);
+    const sentences: ReactNode[] = [];
+    sentences.push(
+      <>
+        {green(`${name}${up ? "+" : ""}`, true)} is a {c.rarity} {c.type} card{who} in Slay
+        the Spire 2, costing {green(cost, display.cost !== baseModel.cost)} energy.
+      </>,
+    );
+    const eff: ReactNode[] = [];
+    if (display.damage != null)
+      eff.push(
+        <>
+          deals {green(display.damage, display.damage !== baseModel.damage)} damage
+          {display.hitCount && display.hitCount > 1 ? (
+            <> across {green(display.hitCount, display.hitCount !== baseModel.hitCount)} hits</>
+          ) : xTimes ? (
+            " X times"
+          ) : (
+            ""
+          )}
+        </>,
+      );
+    if (display.block != null)
+      eff.push(<>grants {green(display.block, display.block !== baseModel.block)} Block</>);
     if (c.cards_draw != null) eff.push(`draws ${c.cards_draw} card${c.cards_draw === 1 ? "" : "s"}`);
     if (c.energy_gain != null) eff.push(`gains ${c.energy_gain} energy`);
     const powerParts = (c.powers_applied || []).map((p) => `${p.amount} ${p.power}`);
     if (powerParts.length) eff.push(`applies ${listWords(powerParts)}`);
-    if (eff.length) sentences.push(`It ${listWords(eff)}.`);
-    if (c.keywords && c.keywords.length) {
-      sentences.push(`It carries the ${listWords(c.keywords)} keyword${c.keywords.length > 1 ? "s" : ""}.`);
+    if (eff.length) sentences.push(<>It {listNodes(eff)}.</>);
+    const kws = [
+      ...display.visibleKeywords.map((k) => ({ k, added: false })),
+      ...display.addedKeywords.map((k) => ({ k, added: true })),
+    ];
+    if (kws.length) {
+      sentences.push(
+        <>
+          It carries the {listNodes(kws.map(({ k, added }) => green(k, added)))} keyword
+          {kws.length > 1 ? "s" : ""}.
+        </>,
+      );
     }
     return <Prose lead={props.lead} sentences={sentences} />;
   }
@@ -495,7 +544,7 @@ export default function EntityProse(props: Props) {
   return <Prose lead={props.lead} sentences={sentences} />;
 }
 
-function Prose({ sentences, lead }: { sentences: string[]; lead?: boolean }) {
+function Prose({ sentences, lead }: { sentences: ReactNode[]; lead?: boolean }) {
   // lead: rendered as an intro right under a page hero (no top border/rule).
   if (lead) {
     return (

--- a/frontend/app/components/EntityProse.tsx
+++ b/frontend/app/components/EntityProse.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Fragment, type ReactNode } from "react";
-import { getCardDisplayModel } from "@/lib/card-display";
+import { getCardProseFacts } from "@/lib/card-display";
 import { useLanguage } from "@/app/contexts/LanguageContext";
 import type {
   Relic,
@@ -185,51 +185,41 @@ export default function EntityProse(props: Props) {
     // The prose tracks the page's upgrade toggle through the same display
     // model as the card render; upgraded values that differ render in the
     // render's green.
-    const display = getCardDisplayModel(c, !!props.upgraded);
-    const baseModel = getCardDisplayModel(c, false);
-    const up = display.isUpgraded;
+    const f = getCardProseFacts(c, !!props.upgraded);
     const green = (v: ReactNode, changed: boolean) =>
-      up && changed ? <span className="text-emerald-400">{v}</span> : v;
-    const cost = c.is_x_cost ? "X" : `${display.cost ?? c.cost}`;
-    const activeDesc = (up && c.upgrade_description) || c.description || "";
-    const xTimes = !!c.is_x_cost && /\bX times/i.test(activeDesc);
+      f.isUpgraded && changed ? <span className="text-emerald-400">{v}</span> : v;
     const sentences: ReactNode[] = [];
     sentences.push(
       <>
-        {green(`${name}${up ? "+" : ""}`, true)} is a {c.rarity} {c.type} card{who} in Slay
-        the Spire 2, costing {green(cost, display.cost !== baseModel.cost)} energy.
+        {green(f.displayName, true)} is a {c.rarity} {c.type} card{who} in Slay the Spire
+        2, costing {green(f.cost, f.costChanged)} energy.
       </>,
     );
     const eff: ReactNode[] = [];
-    if (display.damage != null)
+    if (f.damage != null)
       eff.push(
         <>
-          deals {green(display.damage, display.damage !== baseModel.damage)} damage
-          {display.hitCount && display.hitCount > 1 ? (
-            <> across {green(display.hitCount, display.hitCount !== baseModel.hitCount)} hits</>
-          ) : xTimes ? (
+          deals {green(f.damage, f.damageChanged)} damage
+          {f.hitCount && f.hitCount > 1 ? (
+            <> across {green(f.hitCount, f.hitCountChanged)} hits</>
+          ) : f.xTimes ? (
             " X times"
           ) : (
             ""
           )}
         </>,
       );
-    if (display.block != null)
-      eff.push(<>grants {green(display.block, display.block !== baseModel.block)} Block</>);
+    if (f.block != null) eff.push(<>grants {green(f.block, f.blockChanged)} Block</>);
     if (c.cards_draw != null) eff.push(`draws ${c.cards_draw} card${c.cards_draw === 1 ? "" : "s"}`);
     if (c.energy_gain != null) eff.push(`gains ${c.energy_gain} energy`);
     const powerParts = (c.powers_applied || []).map((p) => `${p.amount} ${p.power}`);
     if (powerParts.length) eff.push(`applies ${listWords(powerParts)}`);
     if (eff.length) sentences.push(<>It {listNodes(eff)}.</>);
-    const kws = [
-      ...display.visibleKeywords.map((k) => ({ k, added: false })),
-      ...display.addedKeywords.map((k) => ({ k, added: true })),
-    ];
-    if (kws.length) {
+    if (f.keywords.length) {
       sentences.push(
         <>
-          It carries the {listNodes(kws.map(({ k, added }) => green(k, added)))} keyword
-          {kws.length > 1 ? "s" : ""}.
+          It carries the {listNodes(f.keywords.map(({ keyword, added }) => green(keyword, added)))} keyword
+          {f.keywords.length > 1 ? "s" : ""}.
         </>,
       );
     }

--- a/frontend/lib/card-display.ts
+++ b/frontend/lib/card-display.ts
@@ -242,3 +242,46 @@ export function getCardDisplayModel(card: Card, upgraded: boolean): CardDisplayM
     removedKeywords: keywordDisplay.removedKeywords,
   };
 }
+
+export interface CardProseFacts {
+  displayName: string;
+  isUpgraded: boolean;
+  cost: string;
+  costChanged: boolean;
+  damage: number | null | undefined;
+  damageChanged: boolean;
+  hitCount: number | null | undefined;
+  hitCountChanged: boolean;
+  block: number | null | undefined;
+  blockChanged: boolean;
+  xTimes: boolean;
+  keywords: { keyword: string; added: boolean }[];
+}
+
+/** The prose summary's inputs for one card + toggle state, derived from the
+ * same display model as the card render so the two can never disagree. */
+export function getCardProseFacts(card: Card, upgraded: boolean): CardProseFacts {
+  const display = getCardDisplayModel(card, upgraded);
+  const base = getCardDisplayModel(card, false);
+  const up = display.isUpgraded;
+  const activeDesc = (up && card.upgrade_description) || card.description || "";
+  return {
+    displayName: up ? `${card.name}+` : card.name,
+    isUpgraded: up,
+    cost: card.is_x_cost ? "X" : `${display.cost ?? card.cost}`,
+    costChanged: up && display.cost !== base.cost,
+    damage: display.damage,
+    damageChanged: up && display.damage !== base.damage,
+    hitCount: display.hitCount,
+    hitCountChanged: up && display.hitCount !== base.hitCount,
+    block: display.block,
+    blockChanged: up && display.block !== base.block,
+    // Description-driven, not is_x_cost-gated: Stardust deals damage X
+    // times with X from a resource, not energy.
+    xTimes: /damage(?: to [a-z ]+?)? X(?:\+\d+)? times/i.test(activeDesc),
+    keywords: [
+      ...display.visibleKeywords.map((keyword) => ({ keyword, added: false })),
+      ...display.addedKeywords.map((keyword) => ({ keyword, added: true })),
+    ],
+  };
+}

--- a/frontend/lib/card-prose.test.ts
+++ b/frontend/lib/card-prose.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { getCardDisplayModel, getCardProseFacts } from "./card-display";
+import type { Card } from "./api";
+
+const cards: Card[] = JSON.parse(
+  readFileSync(join(__dirname, "../../data/eng/cards.json"), "utf8"),
+);
+const upgradable = cards.filter((c) => c.upgrade || c.upgrade_description);
+
+describe("upgrade toggle across the whole catalog", () => {
+  it("every upgradable card visibly changes when toggled", () => {
+    const inert: string[] = [];
+    for (const c of upgradable) {
+      const base = getCardDisplayModel(c, false);
+      const up = getCardDisplayModel(c, true);
+      const changed =
+        base.descriptionText !== up.descriptionText ||
+        base.damage !== up.damage ||
+        base.block !== up.block ||
+        base.cost !== up.cost ||
+        base.hitCount !== up.hitCount ||
+        JSON.stringify([base.visibleKeywords, base.addedKeywords]) !==
+          JSON.stringify([up.visibleKeywords, up.addedKeywords]);
+      if (!changed) inert.push(c.id);
+    }
+    expect(inert).toEqual([]);
+  });
+
+  it("prose facts follow the toggle for every upgradable card", () => {
+    for (const c of upgradable) {
+      const base = getCardProseFacts(c, false);
+      const up = getCardProseFacts(c, true);
+      expect(up.isUpgraded).toBe(true);
+      expect(up.displayName).toBe(`${c.name}+`);
+      expect(base.displayName).toBe(c.name);
+      if (up.damageChanged) expect(up.damage).not.toBe(base.damage);
+      if (up.blockChanged) expect(up.block).not.toBe(base.block);
+    }
+  });
+
+  it("X-cost multi-hit cards say X times", () => {
+    const xTimes = cards.filter((c) =>
+      /damage(?: to [a-z ]+?)? X(?:\+\d+)? times/i.test(c.description || ""),
+    );
+    expect(xTimes.length).toBeGreaterThanOrEqual(5);
+    for (const c of xTimes) {
+      expect(getCardProseFacts(c, false).xTimes).toBe(true);
+      if (c.upgrade_description) {
+        expect(getCardProseFacts(c, true).xTimes).toBe(true);
+      }
+    }
+  });
+
+  it("no damage clause hides a multiplicity stated in the description", () => {
+    const hidden: string[] = [];
+    for (const c of cards) {
+      const f = getCardProseFacts(c, false);
+      if (f.damage == null) continue;
+      const desc = c.description || "";
+      // Damage-adjacent multiplicity only: "twice as effective" or a
+      // conditional "hits twice" elsewhere in the text is not a damage claim.
+      const multi = /damage(?: to [a-z ]+?)? (?:twice|\d+ times|X(?:\+\d+)? times)\b/i.test(desc);
+      const covered = (f.hitCount && f.hitCount > 1) || f.xTimes;
+      if (multi && !covered) hidden.push(c.id);
+    }
+    expect(hidden).toEqual([]);
+  });
+});


### PR DESCRIPTION
I made the card page's prose summary track the upgrade toggle through the same display model as the render (name+ and changed values in the upgrade green, added keywords highlighted) and taught its damage sentence about X-cost multi-hit cards like Eradicate.