### PR TITLE
Deep-tables validator follow-ups

### DIFF
--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -2133,6 +2133,10 @@ def build_deep_tables() -> int:
             WHERE r.ascension BETWEEN 0 AND 10
               AND NOT coalesce(r.win, false)
               AND coalesce(r.killed_by_encounter, r.killed_by_event) IS NOT NULL
+              -- The game stamps ENCOUNTER.NONE on deaths with no killer;
+              -- counting it crowned "NONE" the deadliest encounter.
+              AND coalesce(r.killed_by_encounter, r.killed_by_event)
+                  NOT IN ('NONE', '')
             GROUP BY 1, 2, 3
             """
         ).fetchall()

--- a/lab/validate_deep_tables.py
+++ b/lab/validate_deep_tables.py
@@ -48,7 +48,17 @@ def main() -> None:
             ("deadliest", "encounter"),
         ):
             lake_ids = _ids(tables.get(section), id_key)
-            doc_ids = _ids(doc.get(section), id_key)
+            doc_rows = doc.get(section) or []
+            if section == "top_potions":
+                # The legacy potion list was never sorted and is full of
+                # mod-namespaced ids (MARTHCHARACTERMOD-..., KNOWLEDGEDEMON-...)
+                # the frontend filtered; sort by offers and drop them so the
+                # comparison judges the lake, not the legacy junk.
+                doc_rows = sorted(
+                    (r for r in doc_rows if "-" not in (r.get(id_key) or "")),
+                    key=lambda r: -(r.get("offered") or 0),
+                )
+            doc_ids = _ids(doc_rows, id_key)
             if not lake_ids:
                 print(f"  {section}: lake EMPTY ({len(doc_ids)} legacy rows)")
                 if section != "top_potions":  # absent until the new columns build


### PR DESCRIPTION
I excluded the ENCOUNTER.NONE placeholder from the deadliest table and made the validator sort and de-mod the legacy potion list before comparing, per the first live validation run.