### PR TITLE
Fix community-stats 500

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1295,11 +1295,10 @@ def community_stats(request: Request, response: Response, bracket: str | None = 
     # validation can 400 them. Any miss falls through unchanged.
     from ..services import lake_stats
 
-    if lake_stats.SERVE_ENABLED:
-        lake_payload = lake_stats.community_payload(bracket)
-        if lake_payload is not None:
-            response.headers["Cache-Control"] = "public, max-age=300"
-            return lake_payload
+    lake_payload = lake_stats.community_payload(bracket)
+    if lake_payload is not None:
+        response.headers["Cache-Control"] = "public, max-age=300"
+        return lake_payload
     if bracket is not None:
         from ..services.run_entity_stats import is_valid_stat_bracket
 

--- a/backend/tests/test_route_smoke.py
+++ b/backend/tests/test_route_smoke.py
@@ -1,0 +1,28 @@
+"""HTTP-level smoke: the stats routes must never 500 on a bare request.
+
+Service-level tests missed a route referencing a deleted module attribute
+(lake_stats.SERVE_ENABLED, 2026-09-01) — every request 500'd in prod while
+224 tests stayed green. TestClient is used without its context manager on
+purpose: no lifespan/startup, so no Mongo/Redis needed."""
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def test_stats_routes_never_500():
+    for path in (
+        "/api/runs/community-stats",
+        "/api/runs/community-stats?bracket=a10",
+        "/api/runs/community-stats?bracket=solo:a10:standard",
+        "/api/runs/stats/cards/STRIKE",
+        "/api/runs/scores/cards",
+        "/api/runs/metrics/cards",
+        "/api/runs/metrics/cards?bracket=a10",
+        "/api/runs/encounter-stats",
+        "/api/runs/stats/cards/STRIKE/history",
+    ):
+        r = client.get(path)
+        assert r.status_code < 500, f"{path} -> {r.status_code}"


### PR DESCRIPTION
Fixes /api/runs/community-stats returning 500 on every request since the demolition merge: the route still gated on the deleted lake_stats.SERVE_ENABLED flag, and a new HTTP-level smoke test now covers the stats routes so a dead symbol in a route can't pass the suite again.