### PR TITLE
Serving-side cache tuning

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -226,6 +226,15 @@ def _warm_run_entity_stats() -> None:
             kick_snapshot_load()
         except Exception:
             pass
+        # Pre-parse the lake serving artifacts and keep them warm across
+        # pulls; without this each pull cold-starts every worker's caches
+        # inside a visitor's request.
+        try:
+            from .services import lake_stats
+
+            lake_stats.start_artifact_warmer()
+        except Exception:
+            pass
         return
     import threading
 

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1027,12 +1027,23 @@ _ENTITY_STATS_TYPES = {"relics", "cards", "potions"}
 @limiter.limit(
     rate_limit_config.endpoint_limit("runs.get_entity_run_stats", "120/minute")
 )
-def get_entity_run_stats(request: Request, entity_type: str, entity_id: str):
+def get_entity_run_stats(
+    request: Request, response: Response, entity_type: str, entity_id: str
+):
     if entity_type not in _ENTITY_STATS_TYPES:
         raise HTTPException(
             status_code=400,
             detail=f"entity_type must be one of {sorted(_ENTITY_STATS_TYPES)}",
         )
+    # Changes only when a lake generation applies, and the pull purges the
+    # /api/runs/stats prefix — so serve it long-lived with background
+    # revalidation instead of inheriting the generic 30s /api/runs default
+    # (whose expiry kept the edge permanently EXPIRED on entity pages).
+    response.headers["Cache-Control"] = (
+        "public, max-age=300, stale-while-revalidate=3600"
+        if snapshot_loaded()
+        else "no-store"
+    )
     stats = get_entity_stats(entity_type, entity_id)
     if stats is None:
         # Entity hasn't appeared in any submitted run yet — return a

--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -1494,6 +1494,15 @@ def _entity_cube_with_mtime() -> tuple[float, dict] | None:
 _fold_cache: dict[tuple[str, str], tuple[float, dict | None]] = {}
 
 
+def _fold_cache_put(key, val) -> None:
+    # Evict oldest entries instead of wiping the dict: a wholesale clear
+    # past the cap stampeded every hot bracket back through a full cube
+    # fold at once (2026-09-01 perf survey).
+    while len(_fold_cache) >= 512:
+        _fold_cache.pop(next(iter(_fold_cache)))
+    _fold_cache[key] = val
+
+
 def entity_bracket_fold(entity_type: str, bracket: str) -> dict | None:
     """Cached fold: the entity detail page reads ~20 brackets per request
     and every entity shares the same folds, so cache per (type, bracket)
@@ -1506,9 +1515,7 @@ def entity_bracket_fold(entity_type: str, bracket: str) -> dict | None:
     if cached is not None and cached[0] == hit[0]:
         return cached[1]
     fold = _entity_bracket_fold_uncached(entity_type, bracket)
-    if len(_fold_cache) > 512:
-        _fold_cache.clear()
-    _fold_cache[key] = (hit[0], fold)
+    _fold_cache_put(key, (hit[0], fold))
     return fold
 
 
@@ -1543,9 +1550,7 @@ def entity_character_fold(entity_type: str, bracket: str) -> dict | None:
                         cur[1] += pw[1]
         if not fold:
             fold = None
-    if len(_fold_cache) > 512:
-        _fold_cache.clear()
-    _fold_cache[key] = (hit[0], fold)
+    _fold_cache_put(key, (hit[0], fold))
     return fold
 
 
@@ -2387,3 +2392,54 @@ def deep_tables_by_key() -> dict[str, dict]:
         _filter_key(**c.get("filters", {})): c.get("tables", {})
         for c in doc.get("combos", [])
     }
+
+
+_warmer_started = False
+
+
+def start_artifact_warmer(interval: int = 60) -> None:
+    """Per-worker daemon that re-reads every serving artifact on a timer,
+    so the multi-MB gunzip+parse after a pull happens here instead of in
+    the first visitor's request. Accessors are mtime-cached: an unchanged
+    artifact costs one stat() per tick, and the hot folds only recompute
+    when the cube's mtime moved."""
+    global _warmer_started
+    if _warmer_started:
+        return
+    _warmer_started = True
+    import threading
+    import time
+
+    def _tick() -> None:
+        for load in (
+            lambda: community_payload(None),
+            lambda: community_payload("a10"),
+            _entity_cube_with_mtime,
+            entity_store_with_mtime,
+            encounter_store_with_mtime,
+            deep_tables_by_key,
+        ):
+            try:
+                load()
+            except Exception:
+                pass
+        try:
+            from . import charts_blob_lake
+
+            charts_blob_lake.charts_blob_with_mtime()
+        except Exception:
+            pass
+        try:
+            hot = ["a10", "wr30", "wr50", "wr75", "solo", "2p", *cube_versions()]
+            for etype in ("cards", "relics", "potions"):
+                for bk in hot:
+                    entity_bracket_fold(etype, bk)
+        except Exception:
+            pass
+
+    def _loop() -> None:
+        while True:
+            _tick()
+            time.sleep(interval)
+
+    threading.Thread(target=_loop, daemon=True, name="lake-warmer").start()


### PR DESCRIPTION
Speeds up the stats surfaces: the cube fold cache evicts oldest entries instead of wiping wholesale, a per-worker warmer pre-parses lake artifacts after each pull instead of stalling the first visitor, and entity-stats responses get the purge-backed 300s+SWR edge policy instead of inheriting the generic 30s default.