### PR TITLE
Edge-cache the sitemap

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -30,6 +30,18 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        // The 4.6MB sitemap regenerates every 30 min (ISR) but shipped
+        // with max-age=0, so every crawler fetch streamed the whole body
+        // from origin. Let the edge hold it between regenerations.
+        source: "/sitemap.xml",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=3600, stale-while-revalidate=86400",
+          },
+        ],
+      },
+      {
         source: "/beta/:path*",
         headers: [{ key: "X-Robots-Tag", value: "noindex, nofollow" }],
       },


### PR DESCRIPTION
Serves the 4.6MB sitemap with max-age=3600 + stale-while-revalidate instead of max-age=0, so crawler fetches hit the edge instead of streaming the whole body from origin every time (verified against a local production build).