### PR TITLE
Ingest memory rework for the pair and charts stages

### DIFF
--- a/backend/app/services/charts_blob_lake.py
+++ b/backend/app/services/charts_blob_lake.py
@@ -109,8 +109,21 @@ def _history_from_nested(floors) -> list[list[dict]]:
     return acts
 
 
+# Hash-bucketed: each pass aggregates the nested lists for 1/N of the
+# runs, bounding the pinned list-aggregate state that OOM'd the 4.5GB cap
+# on the first full-corpus run (2026-09-01) — list aggregation can't
+# spill. Joining chunk_cells inside every CTE also stops the CTEs from
+# building lists for ineligible runs the final join would have dropped.
+_BUCKETS = 8
+
 _NESTED_SQL = """
-    WITH fl AS (
+    WITH chunk_cells AS (
+      SELECT run_hash, character, win, was_abandoned, player_count,
+        played_at, submitted_at, cell
+      FROM cells
+      WHERE hash(run_hash) % {buckets} = {bucket}
+    ),
+    fl AS (
       SELECT f.run_hash,
         list(struct_pack(
           act := f.act, floor_idx := f.floor_idx, room_type := f.room_type,
@@ -124,28 +137,35 @@ _NESTED_SQL = """
           ) FOR p IN f.players]
         ) ORDER BY f.act, f.floor_idx) AS floors
       FROM read_parquet('{lake}/floors.parquet') f
+      JOIN chunk_cells c ON f.run_hash = c.run_hash
       GROUP BY 1
     ),
     dk AS (
-      SELECT run_hash, list(struct_pack(pidx := player_idx, card := card,
-        fa := floor_added, ench := enchantment)) AS deck
-      FROM read_parquet('{lake}/deck.parquet') GROUP BY 1
+      SELECT d.run_hash, list(struct_pack(pidx := d.player_idx,
+        card := d.card, fa := d.floor_added, ench := d.enchantment)) AS deck
+      FROM read_parquet('{lake}/deck.parquet') d
+      JOIN chunk_cells c ON d.run_hash = c.run_hash
+      GROUP BY 1
     ),
     rl AS (
-      SELECT run_hash, list(struct_pack(pidx := player_idx, relic := relic))
-        AS relics
-      FROM read_parquet('{lake}/relics.parquet') GROUP BY 1
+      SELECT r.run_hash, list(struct_pack(pidx := r.player_idx,
+        relic := r.relic)) AS relics
+      FROM read_parquet('{lake}/relics.parquet') r
+      JOIN chunk_cells c ON r.run_hash = c.run_hash
+      GROUP BY 1
     ),
     pt AS (
-      SELECT run_hash, list(struct_pack(pidx := player_idx, potion := potion))
-        AS potions
-      FROM read_parquet('{lake}/potions.parquet') GROUP BY 1
+      SELECT p.run_hash, list(struct_pack(pidx := p.player_idx,
+        potion := p.potion)) AS potions
+      FROM read_parquet('{lake}/potions.parquet') p
+      JOIN chunk_cells c ON p.run_hash = c.run_hash
+      GROUP BY 1
     )
     SELECT c.run_hash, coalesce(c.character, ''), coalesce(c.win, false),
       coalesce(c.was_abandoned, false), coalesce(c.player_count, 1),
       coalesce(c.played_at, c.submitted_at), c.cell,
       fl.floors, dk.deck, rl.relics, pt.potions
-    FROM cells c
+    FROM chunk_cells c
     LEFT JOIN fl USING (run_hash)
     LEFT JOIN dk USING (run_hash)
     LEFT JOIN rl USING (run_hash)
@@ -164,36 +184,41 @@ def build_charts_blob() -> dict | None:
         vset = set(versions)
         acc = charts_stats.new_accumulator(versions)
         bracket_cache: dict[str, list[str]] = {}
-        res = con.execute(_NESTED_SQL.format(lake=LAKE_DIR))
         n = 0
-        while True:
-            rows = res.fetchmany(500)
-            if not rows:
-                break
-            for row in rows:
-                _h, ch, win, ab, pc, played, cellv = row[:7]
-                floors, deck, relics, potions = row[7:]
-                brs = bracket_cache.get(cellv)
-                if brs is None:
-                    brs = _run_brackets(cellv, vset)
-                    bracket_cache[cellv] = brs
-                blob = {
-                    "map_point_history": _history_from_nested(floors or []),
-                    "players": _players_from_nested(
-                        deck or [], relics or [], potions or []
-                    ),
-                    "was_abandoned": bool(ab),
-                }
-                charts_stats.accumulate(
-                    acc,
-                    blob,
-                    brackets=brs,
-                    is_win=bool(win),
-                    character=ch,
-                    player_count=int(pc),
-                    played=played if isinstance(played, datetime) else None,
-                )
-                n += 1
+        for bucket in range(_BUCKETS):
+            res = con.execute(
+                _NESTED_SQL.format(lake=LAKE_DIR, buckets=_BUCKETS, bucket=bucket)
+            )
+            while True:
+                # Each row is one complete nested run (~50 floor structs);
+                # 500 of those in flight was its own memory spike.
+                rows = res.fetchmany(64)
+                if not rows:
+                    break
+                for row in rows:
+                    _h, ch, win, ab, pc, played, cellv = row[:7]
+                    floors, deck, relics, potions = row[7:]
+                    brs = bracket_cache.get(cellv)
+                    if brs is None:
+                        brs = _run_brackets(cellv, vset)
+                        bracket_cache[cellv] = brs
+                    blob = {
+                        "map_point_history": _history_from_nested(floors or []),
+                        "players": _players_from_nested(
+                            deck or [], relics or [], potions or []
+                        ),
+                        "was_abandoned": bool(ab),
+                    }
+                    charts_stats.accumulate(
+                        acc,
+                        blob,
+                        brackets=brs,
+                        is_win=bool(win),
+                        character=ch,
+                        player_count=int(pc),
+                        played=played if isinstance(played, datetime) else None,
+                    )
+                    n += 1
     finally:
         con.close()
     if not n:

--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -236,7 +236,7 @@ GROUP BY 1, 2
 """
 
 _CUBE_MEMBERSHIP_SQL = """
-SELECT c.cell, m.{col}, coalesce(el.character, ''),
+SELECT c.cell, m.{col}, coalesce(c.character, ''),
   count(*), count(*) FILTER (c.win)
 FROM (
   SELECT DISTINCT run_hash, {col}
@@ -244,7 +244,6 @@ FROM (
   WHERE {col} IS NOT NULL AND {col} <> ''
 ) m
 JOIN cells c ON m.run_hash = c.run_hash
-JOIN eligible el ON m.run_hash = el.run_hash
 GROUP BY 1, 2, 3
 """
 
@@ -763,23 +762,12 @@ def reward_pair_counts_by_tier(
     try:
         _ensure_choice_rows(con)
         _ensure_run_tiers(con)
-        # Screen-level lists instead of the 50M-row pairwise self-join (the
-        # cycle's spill heavyweight): one grouped pass builds each screen's
-        # picked/passed card lists, and two lateral unnests expand them to
-        # pairs. A real table in the scratch db, same reasoning as
-        # choice_rows; dropped at the end, and a crash leaves it for the
-        # next cycle's scratch reset.
-        con.execute(
-            """
-            CREATE OR REPLACE TABLE pair_screens AS
-            SELECT t.a10, t.band, t.ver,
-              list(c.cid) FILTER (c.picked) AS picks,
-              list(c.cid) FILTER (NOT c.picked) AS passes
-            FROM choice_rows c JOIN run_tiers t ON t.run_hash = c.run_hash
-            GROUP BY c.run_hash, c.act, c.floor_idx, c.pidx,
-              t.a10, t.band, t.ver
-            """
-        )
+        # Relational form: a pick beats each pass on its own screen, so a
+        # 1-to-K join on the screen key streams straight into a compact
+        # count() hash. The previous per-screen list build (pair_screens)
+        # pinned list-aggregate state for every screen at once and OOM'd
+        # the 4.5GB cap on the first full-corpus run (2026-09-01); plain
+        # count aggregates and hash joins spill, lists don't.
         tiers: dict[tuple[int, int], dict[tuple[str, str], int]] = {}
 
         def cell(a10, band, ver):
@@ -787,33 +775,41 @@ def reward_pair_counts_by_tier(
 
         for a10, band, ver, w, lo, n in con.execute(
             """
-            SELECT s.a10, s.band, s.ver, wp.w, lp.l, count(*)
-            FROM pair_screens s,
-              LATERAL (SELECT unnest(s.picks) AS w) wp,
-              LATERAL (SELECT unnest(s.passes) AS l) lp
-            WHERE wp.w <> lp.l
+            SELECT t.a10, t.band, t.ver, p.cid, q.cid, count(*)
+            FROM choice_rows p
+            JOIN choice_rows q
+              ON q.run_hash = p.run_hash AND q.act = p.act
+             AND q.floor_idx = p.floor_idx AND q.pidx = p.pidx
+            JOIN run_tiers t ON t.run_hash = p.run_hash
+            WHERE p.picked AND NOT q.picked AND p.cid <> q.cid
             GROUP BY 1, 2, 3, 4, 5
             """
         ).fetchall():
             cell(a10, band, ver)[(w, lo)] = n
         for a10, band, ver, cid, n in con.execute(
             """
-            SELECT s.a10, s.band, s.ver, wp.w, count(*)
-            FROM pair_screens s, LATERAL (SELECT unnest(s.picks) AS w) wp
+            SELECT t.a10, t.band, t.ver, c.cid, count(*)
+            FROM choice_rows c JOIN run_tiers t ON t.run_hash = c.run_hash
+            WHERE c.picked
             GROUP BY 1, 2, 3, 4
             """
         ).fetchall():
             cell(a10, band, ver)[(cid, SKIP_ID)] = n
         for a10, band, ver, cid, n in con.execute(
             """
-            SELECT s.a10, s.band, s.ver, lp.l, count(*)
-            FROM pair_screens s, LATERAL (SELECT unnest(s.passes) AS l) lp
-            WHERE len(coalesce(s.picks, [])) = 0
+            SELECT t.a10, t.band, t.ver, c.cid, count(*)
+            FROM choice_rows c
+            JOIN run_tiers t ON t.run_hash = c.run_hash
+            ANTI JOIN (
+              SELECT DISTINCT run_hash, act, floor_idx, pidx
+              FROM choice_rows WHERE picked
+            ) ps ON c.run_hash = ps.run_hash AND c.act = ps.act
+                AND c.floor_idx = ps.floor_idx AND c.pidx = ps.pidx
+            WHERE NOT c.picked
             GROUP BY 1, 2, 3, 4
             """
         ).fetchall():
             cell(a10, band, ver)[(SKIP_ID, cid)] = n
-        con.execute("DROP TABLE IF EXISTS pair_screens")
         return tiers
     finally:
         if own:


### PR DESCRIPTION
Fixes the two OOMs from the first full-corpus cycle: the reward pair extraction streams a pick-to-pass join straight into count aggregates instead of pinning per-screen lists, the charts blob builds in 8 hash-bucket passes that also stop aggregating ineligible runs, and the cube membership query drops a redundant eligible join.