### PR TITLE
Ingest memory lines and failed-stage visibility

### DIFF
--- a/lab/ingest.py
+++ b/lab/ingest.py
@@ -159,24 +159,65 @@ def main() -> None:
 
     from app.services import lake_stats
 
+    def _mem_line(name: str) -> None:
+        # The cgroup number is what the kernel kills on; the DuckDB cap only
+        # bounds its buffer pool, and a cycle sat at 6.985/7GiB while DuckDB
+        # reported 4.1GiB (2026-09-01).
+        import resource
+
+        peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss // 1024
+        rss = cg = "?"
+        try:
+            for line in open("/proc/self/status"):
+                if line.startswith("VmRSS:"):
+                    rss = int(line.split()[1]) // 1024
+        except OSError:
+            pass
+        try:
+            cg = int(open("/sys/fs/cgroup/memory.current").read()) // (1 << 20)
+        except (OSError, ValueError):
+            pass
+        print(
+            f"mem after {name}: rss={rss}MB peak_rss={peak}MB cgroup={cg}MB",
+            flush=True,
+        )
+
     try:
         session = lake_stats.prepare_build_session()
         session.close()
         print("build session prepared (pfloors materialized)", flush=True)
         _mark("prepare_session")
     except Exception as e:
-        print(f"prepare_session failed: {e}", flush=True)
+        # Every store stage reads the session's pfloors; without it they
+        # would each fail in turn and the cycle would still reach publish.
+        record = {
+            "generation_id": generation_id,
+            "cycle_started_at": _utc(t0),
+            "failed_stage": "prepare_session",
+            "error": str(e)[:500],
+            "complete": False,
+            "published_at": _utc(time.time()),
+        }
+        with open(LAKE / "ingest_metrics.jsonl", "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, separators=(",", ":")) + "\n")
+        print(f"generation {generation_id} FAILED in prepare_session: {e}", flush=True)
+        sys.exit(1)
+    _mem_line("prepare_session")
 
     # Isolated per stage: one store OOMing must not skip the independent
     # stores after it (a charts OOM used to swallow the metric-history
     # append and report itself as "community payload build failed").
+    failed_stages: dict[str, str] = {}
+
     def _stage(name, label, fn):
         try:
             out = fn()
             print(label(out) if callable(label) else label, flush=True)
             _mark(name)
         except Exception as e:
+            failed_stages[name] = str(e)[:200]
             print(f"{name} failed: {e}", flush=True)
+        _mem_line(name)
 
     from app.services import charts_blob_lake
     from app.services.run_entity_stats import (
@@ -296,6 +337,7 @@ def main() -> None:
         "build_sql_seconds": round(t_build - t_extract, 1),
         "stores_seconds": round(published - t_build, 1),
         "stage_seconds": stage_seconds,
+        "failed_stages": failed_stages,
         "total_seconds": round(published - t0, 1),
         "profiles_refreshed": profiles,
         "purge_ok": purge_ok,
@@ -328,7 +370,16 @@ def main() -> None:
         tmp = LAKE / "generation.json.tmp"
         tmp.write_text(json.dumps(manifest, indent=1))
         tmp.replace(LAKE / "generation.json")
-        print(f"generation {generation_id} published", flush=True)
+        if failed_stages:
+            # Non-required stores keep their previous artifact on failure
+            # (the fallback ruling); say so where the log is read.
+            print(
+                f"generation {generation_id} published with FAILED stages: "
+                + ", ".join(failed_stages),
+                flush=True,
+            )
+        else:
+            print(f"generation {generation_id} published", flush=True)
         # A failed publish doesn't void the local cycle; the puller's age
         # warning is the staleness alarm.
         import os

--- a/lab/ingest.py
+++ b/lab/ingest.py
@@ -159,32 +159,78 @@ def main() -> None:
 
     from app.services import lake_stats
 
-    def _mem_line(name: str) -> None:
-        # The cgroup number is what the kernel kills on; the DuckDB cap only
-        # bounds its buffer pool, and a cycle sat at 6.985/7GiB while DuckDB
-        # reported 4.1GiB (2026-09-01).
-        import resource
+    def _stage_memory(name: str, fn):
+        """Run fn while a sampler tracks peak RSS, cgroup usage (what the
+        kernel kills on), DuckDB-tracked memory, and spill. ru_maxrss is
+        process-lifetime, so an early big stage would hide every later
+        stage's own peak; sampling at 0.5s is what makes the per-stage
+        numbers real (a cycle sat at 6.985/7GiB while DuckDB reported
+        4.1GiB, 2026-09-01)."""
+        import os
+        import threading
 
-        peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss // 1024
-        rss = cg = "?"
+        page = os.sysconf("SC_PAGE_SIZE")
+        peak = {"rss": 0, "cgroup": 0, "duckdb": 0, "temp": 0, "err": ""}
+        stop = threading.Event()
+
+        def sample() -> None:
+            try:
+                with open("/proc/self/statm") as f:
+                    peak["rss"] = max(peak["rss"], int(f.read().split()[1]) * page)
+            except OSError:
+                pass
+            try:
+                with open("/sys/fs/cgroup/memory.current") as f:
+                    peak["cgroup"] = max(peak["cgroup"], int(f.read()))
+            except (OSError, ValueError):
+                pass
+
+        def watch() -> None:
+            import duckdb
+
+            mon = None
+            try:
+                mon = duckdb.connect("/lake/build.duckdb")
+                while not stop.wait(0.5):
+                    sample()
+                    mem, temp = mon.execute(
+                        "SELECT coalesce(sum(memory_usage_bytes), 0),"
+                        " coalesce(sum(temporary_storage_bytes), 0)"
+                        " FROM duckdb_memory()"
+                    ).fetchone()
+                    peak["duckdb"] = max(peak["duckdb"], int(mem))
+                    peak["temp"] = max(peak["temp"], int(temp))
+            except Exception as e:
+                peak["err"] = repr(e)[:120]
+                while not stop.wait(0.5):
+                    sample()
+            finally:
+                if mon is not None:
+                    mon.close()
+
+        t = threading.Thread(target=watch, name=f"mem-{name}", daemon=True)
+        t.start()
         try:
-            for line in open("/proc/self/status"):
-                if line.startswith("VmRSS:"):
-                    rss = int(line.split()[1]) // 1024
-        except OSError:
-            pass
-        try:
-            cg = int(open("/sys/fs/cgroup/memory.current").read()) // (1 << 20)
-        except (OSError, ValueError):
-            pass
-        print(
-            f"mem after {name}: rss={rss}MB peak_rss={peak}MB cgroup={cg}MB",
-            flush=True,
-        )
+            return fn()
+        finally:
+            stop.set()
+            t.join()
+            mib = 1 << 20
+            print(
+                f"mem {name}: rss_peak={peak['rss'] // mib}MB"
+                f" duckdb_peak={peak['duckdb'] // mib}MB"
+                f" cgroup_peak={peak['cgroup'] // mib}MB"
+                f" spill_peak={peak['temp'] // mib}MB"
+                + (f" probe_error={peak['err']}" if peak["err"] else ""),
+                flush=True,
+            )
 
     try:
-        session = lake_stats.prepare_build_session()
-        session.close()
+
+        def _prepare() -> None:
+            lake_stats.prepare_build_session().close()
+
+        _stage_memory("prepare_session", _prepare)
         print("build session prepared (pfloors materialized)", flush=True)
         _mark("prepare_session")
     except Exception as e:
@@ -202,7 +248,6 @@ def main() -> None:
             f.write(json.dumps(record, separators=(",", ":")) + "\n")
         print(f"generation {generation_id} FAILED in prepare_session: {e}", flush=True)
         sys.exit(1)
-    _mem_line("prepare_session")
 
     # Isolated per stage: one store OOMing must not skip the independent
     # stores after it (a charts OOM used to swallow the metric-history
@@ -211,18 +256,26 @@ def main() -> None:
 
     def _stage(name, label, fn):
         try:
-            out = fn()
+            out = _stage_memory(name, fn)
             print(label(out) if callable(label) else label, flush=True)
             _mark(name)
         except Exception as e:
             failed_stages[name] = str(e)[:200]
             print(f"{name} failed: {e}", flush=True)
-        _mem_line(name)
 
-    from app.services import charts_blob_lake
-    from app.services.run_entity_stats import (
-        archive_entity_metric_history_from_lake,
-    )
+    # Imported lazily inside their stages: a module import failure here
+    # would skip every stage below it.
+    def _charts_blob():
+        from app.services import charts_blob_lake
+
+        return charts_blob_lake.build_charts_blob()
+
+    def _metric_history():
+        from app.services.run_entity_stats import (
+            archive_entity_metric_history_from_lake,
+        )
+
+        return archive_entity_metric_history_from_lake()
 
     _stage(
         "community_payload",
@@ -239,16 +292,16 @@ def main() -> None:
         lambda n: f"deep tables stored ({n} combos)",
         lake_stats.build_deep_tables,
     )
-    _stage("charts_blob", "charts blob stored", charts_blob_lake.build_charts_blob)
+    _stage("charts_blob", "charts blob stored", _charts_blob)
     _stage(
         "metric_history",
         lambda n: f"metric history archived ({n} rows)",
-        archive_entity_metric_history_from_lake,
+        _metric_history,
     )
     try:
         lake_stats.cleanup_build_session()
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"build session cleanup failed: {e}", flush=True)
     # The rebuilder is retired, so the materialized summaries that fed the
     # home overview and the leaderboards move here: plain Mongo aggregations
     # plus a Redis warm, no snapshot involved.

--- a/lab/ingest.py
+++ b/lab/ingest.py
@@ -373,12 +373,14 @@ def main() -> None:
         purge_ok = False
         print(f"edge purge failed: {e}", flush=True)
 
-    # Cycle record. Stages publish independently (each store is its own
+    # Cycle record. Stages write independently (each store is its own
     # atomic rename), so the generation manifest is the completeness
-    # contract: it only advances when every serving artifact this cycle
-    # owns was rebuilt after the cycle started. /health reports it; a
-    # cycle that lost a stage leaves the previous manifest in place and
-    # shows up in ingest_metrics.jsonl with complete=false.
+    # contract: it only advances when every required artifact was rebuilt
+    # after the cycle started AND no store stage failed — a generation
+    # never ships a stale non-required store under a new id (ruled
+    # 2026-09-01). /health reports it; a cycle that lost a stage leaves the
+    # previous manifest in place, shows up in ingest_metrics.jsonl with
+    # complete=false, and exits non-zero for cron.
     published = time.time()
     manifest: dict = {
         "generation_id": generation_id,
@@ -416,23 +418,16 @@ def main() -> None:
             manifest["artifacts"][name] = None
     # Numeric comparison: the ISO strings are second-truncated, so an old
     # artifact written earlier in the cycle's start second could pass.
-    manifest["complete"] = all(mtimes.get(n, 0.0) >= t0 for n in required)
+    manifest["complete"] = (
+        all(mtimes.get(n, 0.0) >= t0 for n in required) and not failed_stages
+    )
     with open(LAKE / "ingest_metrics.jsonl", "a", encoding="utf-8") as f:
         f.write(json.dumps(manifest, separators=(",", ":")) + "\n")
     if manifest["complete"]:
         tmp = LAKE / "generation.json.tmp"
         tmp.write_text(json.dumps(manifest, indent=1))
         tmp.replace(LAKE / "generation.json")
-        if failed_stages:
-            # Non-required stores keep their previous artifact on failure
-            # (the fallback ruling); say so where the log is read.
-            print(
-                f"generation {generation_id} published with FAILED stages: "
-                + ", ".join(failed_stages),
-                flush=True,
-            )
-        else:
-            print(f"generation {generation_id} published", flush=True)
+        print(f"generation {generation_id} published", flush=True)
         # A failed publish doesn't void the local cycle; the puller's age
         # warning is the staleness alarm.
         import os
@@ -446,12 +441,14 @@ def main() -> None:
                 print(f"lake publish failed: {e}", flush=True)
         print("ingest complete", flush=True)
     else:
-        missing = [n for n in required if mtimes.get(n, 0.0) < t0]
+        reasons = [f"stale {n}" for n in required if mtimes.get(n, 0.0) < t0]
+        reasons += [f"{n} failed: {err}" for n, err in failed_stages.items()]
         print(
-            f"generation {generation_id} INCOMPLETE (stale: {', '.join(missing)}); "
+            f"generation {generation_id} INCOMPLETE ({'; '.join(reasons)}); "
             "manifest not advanced",
             flush=True,
         )
+        sys.exit(1)
         sys.exit(1)
 
 


### PR DESCRIPTION
Prints sampled peak rss/DuckDB/cgroup/spill memory per store stage so the next cycle shows where the container's non-DuckDB memory goes, makes a failed build-session prepare exit non-zero, and holds back the generation publish (manifest not advanced, exit 1) when any store stage failed instead of shipping a stale artifact under a new generation id.