### PR TITLE
Baseline security headers and disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report privately through GitHub's private vulnerability reporting:
+https://github.com/ptrlrd/spire-codex/security/advisories/new
+
+Please don't open a public issue for security problems. I'll acknowledge a
+report within 7 days and keep you updated while it's being fixed.
+
+## Scope
+
+- spire-codex.com and its API (`/api/*`)
+- cdn.spire-codex.com
+- this repository
+
+## Rules for testing
+
+- Don't test against production destructively: no denial of service, no
+  mass scraping, no spam submissions, no attempts to access other users'
+  accounts or data.
+- If you find a way to read or change someone else's data, stop there and
+  report it. Don't dig further to prove impact.
+- Reports that follow these rules are welcome and won't be pursued as
+  hostile.
+
+## Supported versions
+
+Only what runs on spire-codex.com (the `main` branch) receives security
+fixes.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -357,6 +357,11 @@ class CORSStaticMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         response = await call_next(request)
         response.headers["Access-Control-Allow-Origin"] = "*"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Strict-Transport-Security"] = (
+            "max-age=31536000; includeSubDomains"
+        )
         if request.method != "GET" or response.status_code >= 400:
             return response
         # A handler that declared its own Cache-Control knows better than

--- a/frontend/app/components/JsonLd.tsx
+++ b/frontend/app/components/JsonLd.tsx
@@ -6,7 +6,10 @@ export default function JsonLd({ data }: { data: unknown | unknown[] }) {
         <script
           key={i}
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(item) }}
+          dangerouslySetInnerHTML={{
+            // "<" can't be allowed to close the script element.
+            __html: JSON.stringify(item).replace(/</g, "\\u003c"),
+          }}
         />
       ))}
     </>

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -5,6 +5,7 @@ const LANGS = "deu|esp|fra|ita|jpn|kor|pol|ptb|rus|spa|tha|tur|zhs|zht";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  poweredByHeader: false,
   // Without this, dynamic-route prefetches are stale on arrival
   // (staleTimes.dynamic defaults to 0), so the router re-issues the same
   // origin request for every visible link on each ping — measured 8-9
@@ -29,6 +30,32 @@ const nextConfig: NextConfig = {
   // header-level noindex without touching the shared pages.
   async headers() {
     return [
+      {
+        // Baseline browser hardening on every response. HSTS is a year
+        // without preload (preload is irreversible); the frame lockdown
+        // lives on the widget-excluded rule below because /widget/* is
+        // meant to be embedded by other sites.
+        source: "/:path*",
+        headers: [
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000; includeSubDomains",
+          },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=(), payment=()",
+          },
+        ],
+      },
+      {
+        source: "/((?!widget/).*)",
+        headers: [
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          { key: "Content-Security-Policy", value: "frame-ancestors 'self'" },
+        ],
+      },
       {
         // The 4.6MB sitemap regenerates every 30 min (ISR) but shipped
         // with max-age=0, so every crawler fetch streamed the whole body

--- a/frontend/public/.well-known/security.txt
+++ b/frontend/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: https://github.com/ptrlrd/spire-codex/security/advisories/new
+Expires: 2027-09-01T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://spire-codex.com/.well-known/security.txt
+Policy: https://github.com/ptrlrd/spire-codex/blob/main/SECURITY.md


### PR DESCRIPTION
Adds HSTS, nosniff, Referrer-Policy, Permissions-Policy and a frame lockdown (widget routes excluded so embeds keep working) on both the site and the API, drops the X-Powered-By header, escapes < in JSON-LD output, and publishes SECURITY.md plus /.well-known/security.txt pointing at GitHub private vulnerability reporting.