### PR TITLE
Sign in with Steam only; Discord and Twitch become connectors

### DIFF
--- a/backend/app/routers/auth_discord.py
+++ b/backend/app/routers/auth_discord.py
@@ -154,7 +154,7 @@ async def callback(request: Request):
     try:
         from ..services.auth_jwt import get_current_user, create_token, set_auth_cookie
         from ..services.users_db import (
-            find_or_create_by_discord,
+            get_user_by_discord_id,
             link_discord,
             update_email as _update_email,
         )
@@ -170,7 +170,14 @@ async def callback(request: Request):
             user = existing_user
             user["discord_id"] = discord_id
         else:
-            user = find_or_create_by_discord(discord_id, discord_username, email)
+            # Steam is the only way to create an account; Discord is a
+            # connector. An account that already carries this Discord id
+            # still signs in with it, a new visitor is sent to Steam.
+            user = get_user_by_discord_id(discord_id)
+            if not user:
+                response = RedirectResponse(f"{base}/?auth=steam_required")
+                clear_oauth_state_cookie(response)
+                return response
 
         token = create_token(
             user_id=user["_id"],

--- a/backend/app/routers/auth_twitch.py
+++ b/backend/app/routers/auth_twitch.py
@@ -178,7 +178,7 @@ async def callback(request: Request):
     try:
         from ..services.auth_jwt import create_token, get_current_user, set_auth_cookie
         from ..services.users_db import (
-            find_or_create_by_twitch,
+            get_user_by_twitch_id,
             link_twitch,
             update_email as _update_email,
         )
@@ -196,9 +196,12 @@ async def callback(request: Request):
             user = existing_user
             user["twitch_id"] = twitch_id
         else:
-            user = find_or_create_by_twitch(
-                twitch_id, twitch_login, twitch_display, email
-            )
+            # Same rule as Discord: connector only, no account creation.
+            user = get_user_by_twitch_id(twitch_id)
+            if not user:
+                response = RedirectResponse(f"{base}/?auth=steam_required")
+                clear_oauth_state_cookie(response)
+                return response
 
         token = create_token(
             user_id=user["_id"],

--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -58,7 +58,7 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
   const [stats, setStats] = useState<Stats | null>(initialStats);
   const [translations, setTranslations] = useState<Translations>(initialTranslations);
   const { lang } = useLanguage();
-  const { user, loginSteam, loginDiscord } = useAuth();
+  const { user, loginSteam } = useAuth();
   const initialRender = useRef(true);
   const pathname = usePathname();
   const pathLang = pathname.split("/")[1];
@@ -231,7 +231,6 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
               <span className="act-d">{t("Spire Codex keeps track of your runs and tier lists, all while not tracking you.", lang)}</span>
               <div className="act-logins">
                 <button onClick={loginSteam} className="act-login act-steam">{t("Steam", lang)}</button>
-                <button onClick={loginDiscord} className="act-login act-discord">{t("Discord", lang)}</button>
               </div>
             </div>
           )}

--- a/frontend/app/components/AuthNotice.tsx
+++ b/frontend/app/components/AuthNotice.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+import { useToast } from "./Toast";
+
+const MESSAGES: Record<string, [string, "error" | "success"]> = {
+  steam_required: [
+    "Sign in with Steam first, then connect Discord or Twitch from Settings.",
+    "error",
+  ],
+  steam_in_use: ["That Steam account is already linked to another account.", "error"],
+};
+
+/** Reads the auth query params the backend redirects with and shows them
+ * as a toast. window.location on purpose: useSearchParams in a component
+ * mounted on every page forces a Suspense boundary around the app. */
+export default function AuthNotice() {
+  const { toast } = useToast();
+  useEffect(() => {
+    let params: URLSearchParams;
+    try {
+      params = new URLSearchParams(window.location.search);
+    } catch {
+      return;
+    }
+    const key = params.get("auth") || params.get("error");
+    if (!key) return;
+    const hit = MESSAGES[key];
+    if (hit) toast(hit[0], hit[1]);
+    params.delete("auth");
+    params.delete("error");
+    const qs = params.toString();
+    window.history.replaceState(
+      window.history.state,
+      "",
+      window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash
+    );
+  }, [toast]);
+  return null;
+}

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -193,7 +193,7 @@ export default function Navbar() {
   const langPrefix = currentLang ? `/${currentLang}` : "";
   const strippedPath = currentLang ? pathname.replace(`/${currentLang}`, "") || "/" : pathname;
   const isHome = strippedPath === "/";
-  const { user, loading: authLoading, loginSteam, loginDiscord, logout } = useAuth();
+  const { user, loading: authLoading, loginSteam, logout } = useAuth();
   const [open, setOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const { unread: newsUnread } = useAnnouncementUnread();
@@ -474,13 +474,6 @@ export default function Navbar() {
                   >
                     <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="currentColor"><path d="M11.979 0C5.678 0 .511 4.86.022 11.037l6.432 2.658a3.387 3.387 0 0 1 1.912-.593c.064 0 .127.003.19.007l2.862-4.146v-.058a4.533 4.533 0 0 1 4.53-4.53 4.533 4.533 0 0 1 4.53 4.53 4.533 4.533 0 0 1-4.53 4.53h-.106l-4.08 2.91c0 .053.003.107.003.161a3.4 3.4 0 0 1-3.4 3.4 3.404 3.404 0 0 1-3.367-2.936L.256 15.21C1.542 20.2 6.218 24 11.979 24 18.627 24 24 18.627 24 11.979 24 5.373 18.627 0 11.979 0z"/></svg>
                     Steam
-                  </button>
-                  <button
-                    onClick={() => { setUserMenuOpen(false); loginDiscord(); }}
-                    className="w-full flex items-center gap-2 px-2.5 py-2 text-sm rounded-md hover:bg-[var(--bg-card)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
-                  >
-                    <DiscordIcon className="w-4 h-4 shrink-0" />
-                    Discord
                   </button>
                 </div>
               )}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -14,6 +14,7 @@ import { LanguageProvider } from "./contexts/LanguageContext";
 import { BetaVersionProvider } from "./contexts/BetaVersionContext";
 import { AuthProvider } from "./contexts/AuthContext";
 import { ToastProvider } from "./components/Toast";
+import AuthNotice from "./components/AuthNotice";
 import { SITE_NAME, SITE_URL, DEFAULT_OG_IMAGE } from "@/lib/seo";
 
 // Self-hosted Umami analytics. Both values are public-by-design, the
@@ -154,6 +155,7 @@ export default function RootLayout({
             <BetaVersionProvider>
               <AuthProvider>
               <ToastProvider>
+              <AuthNotice />
               <Navbar />
               <div className="pt-16">
                 <AlertTicker />

--- a/frontend/app/leaderboards/submit/SubmitRunClient.tsx
+++ b/frontend/app/leaderboards/submit/SubmitRunClient.tsx
@@ -8,7 +8,6 @@ import { useLanguage } from "@/app/contexts/LanguageContext";
 import { useAuth } from "@/app/contexts/AuthContext";
 import { t } from "@/lib/ui-translations";
 import RunDropZone from "@/app/components/RunDropZone";
-import DiscordIcon from "@/app/components/DiscordIcon";
 import { characterHex } from "@/lib/character-colors";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -41,7 +40,7 @@ export default function SubmitRunClient() {
   const router = useRouter();
   const lp = useLangPrefix();
   const { lang } = useLanguage();
-  const { user, loading: authLoading, loginSteam, loginDiscord } = useAuth();
+  const { user, loading: authLoading, loginSteam } = useAuth();
   const [error, setError] = useState("");
   const [username, setUsername] = useState("");
   const [runs, setRuns] = useState<Run[]>([]);
@@ -267,13 +266,6 @@ export default function SubmitRunClient() {
             >
               <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="currentColor"><path d="M11.979 0C5.678 0 .511 4.86.022 11.037l6.432 2.658a3.387 3.387 0 0 1 1.912-.593c.064 0 .127.003.19.007l2.862-4.146v-.058a4.533 4.533 0 0 1 4.53-4.53 4.533 4.533 0 0 1 4.53 4.53 4.533 4.533 0 0 1-4.53 4.53h-.106l-4.08 2.91c0 .053.003.107.003.161a3.4 3.4 0 0 1-3.4 3.4 3.404 3.404 0 0 1-3.367-2.936L.256 15.21C1.542 20.2 6.218 24 11.979 24 18.627 24 24 18.627 24 11.979 24 5.373 18.627 0 11.979 0z"/></svg>
               Steam
-            </button>
-            <button
-              onClick={loginDiscord}
-              className="inline-flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-card-hover)] transition-colors"
-            >
-              <DiscordIcon className="w-4 h-4 shrink-0" />
-              Discord
             </button>
           </div>
         </div>


### PR DESCRIPTION
Steam is now the only way to create an account: the Discord and Twitch callbacks no longer create users (an account that already carries that Discord or Twitch id still signs in with it), their sign-in buttons are gone from the home tile, navbar and submit page while the Connect buttons in Settings stay, and a visitor who tries Discord or Twitch without an account lands on the home page with a toast telling them to sign in with Steam first.