### PR TITLE
Backend dependency bumps and request guards

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ import time
 from datetime import datetime, timezone
 
 from fastapi import Depends, FastAPI, Request
+from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -606,9 +607,46 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         return response
 
 
+# Reject oversized bodies by Content-Length before Starlette parses them:
+# the upload route's per-file/file-count checks only run after the whole
+# multipart body has been read. 20 files x 512KB plus form overhead fits
+# comfortably under 16MB; nothing else POSTs anywhere near that.
+_MAX_BODY_BYTES = int(os.environ.get("MAX_REQUEST_BODY_BYTES", "") or 16 * 1024 * 1024)
+
+
+class BodyLimitMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        length = request.headers.get("content-length")
+        if length and length.isdigit() and int(length) > _MAX_BODY_BYTES:
+            return JSONResponse({"detail": "request body too large"}, status_code=413)
+        return await call_next(request)
+
+
+# /metrics is scraped over the public URL. With METRICS_TOKEN set, the
+# scrape must present it (Authorization: Bearer <token>); unset keeps the
+# endpoint open so enabling it is a coordinated change with the scraper.
+_METRICS_TOKEN = os.environ.get("METRICS_TOKEN", "").strip()
+
+
+class MetricsAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if _METRICS_TOKEN and request.url.path == "/metrics":
+            import hmac
+
+            auth = request.headers.get("authorization", "")
+            ok = auth.startswith("Bearer ") and hmac.compare_digest(
+                auth[7:].strip(), _METRICS_TOKEN
+            )
+            if not ok:
+                return JSONResponse({"detail": "unauthorized"}, status_code=401)
+        return await call_next(request)
+
+
 app.add_middleware(VersionMiddleware)
 app.add_middleware(RequestLoggingMiddleware)
 app.add_middleware(CORSStaticMiddleware)
+app.add_middleware(BodyLimitMiddleware)
+app.add_middleware(MetricsAuthMiddleware)
 app.add_middleware(GZipMiddleware, minimum_size=1000)
 _cors_origins = os.environ.get("CORS_ORIGINS", "").strip()
 # Response headers a browser client is allowed to read; wildcard allow_headers

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,9 +6,9 @@ httpx==0.28.1
 python-frontmatter==1.1.0
 sentry-sdk[fastapi]==2.19.2
 prometheus-fastapi-instrumentator==7.0.2
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.13.0
 pymongo==4.10.1
-python-multipart==0.0.20
+python-multipart==0.0.32
 boto3>=1.34,<2
 redis==5.2.1
 numpy==2.2.6

--- a/backend/tests/test_request_guards.py
+++ b/backend/tests/test_request_guards.py
@@ -1,0 +1,33 @@
+"""Body-size and /metrics guards sit in front of parsing and scraping."""
+
+from fastapi.testclient import TestClient
+
+from app import main as m
+
+client = TestClient(m.app, raise_server_exceptions=False)
+
+
+def test_oversized_content_length_is_rejected_before_parsing():
+    r = client.post(
+        "/api/auth/runs/upload",
+        headers={"content-length": str(m._MAX_BODY_BYTES + 1)},
+    )
+    assert r.status_code == 413
+
+
+def test_metrics_requires_token_when_configured(monkeypatch):
+    monkeypatch.setattr(m, "_METRICS_TOKEN", "s3cret")
+    assert client.get("/metrics").status_code == 401
+    assert (
+        client.get("/metrics", headers={"Authorization": "Bearer nope"}).status_code
+        == 401
+    )
+    assert (
+        client.get("/metrics", headers={"Authorization": "Bearer s3cret"}).status_code
+        == 200
+    )
+
+
+def test_metrics_open_when_no_token(monkeypatch):
+    monkeypatch.setattr(m, "_METRICS_TOKEN", "")
+    assert client.get("/metrics").status_code == 200


### PR DESCRIPTION
Bumps python-multipart to 0.0.32 and PyJWT to 2.13.0, rejects requests whose Content-Length exceeds 16MB with a 413 before Starlette parses the body (the upload route's per-file checks only ran after a full multipart parse), and gates /metrics behind a bearer token when METRICS_TOKEN is set so it can be locked down in step with the Prometheus scrape config.