### PR TITLE
Fix batch run uploads: body cap above the route maximum

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -614,9 +614,10 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
 
 # Reject oversized bodies by Content-Length before Starlette parses them:
 # the upload route's per-file/file-count checks only run after the whole
-# multipart body has been read. 20 files x 512KB plus form overhead fits
-# comfortably under 16MB; nothing else POSTs anywhere near that.
-_MAX_BODY_BYTES = int(os.environ.get("MAX_REQUEST_BODY_BYTES", "") or 16 * 1024 * 1024)
+# multipart body has been read. The cap must clear the route's own maximum
+# (100 files x 512KB) plus multipart overhead — a 16MB cap shipped on
+# 2026-09-02 and 413'd every batch upload over ~30 runs.
+_MAX_BODY_BYTES = int(os.environ.get("MAX_REQUEST_BODY_BYTES", "") or 64 * 1024 * 1024)
 
 
 class BodyLimitMiddleware(BaseHTTPMiddleware):

--- a/backend/tests/test_request_guards.py
+++ b/backend/tests/test_request_guards.py
@@ -31,3 +31,9 @@ def test_metrics_requires_token_when_configured(monkeypatch):
 def test_metrics_open_when_no_token(monkeypatch):
     monkeypatch.setattr(m, "_METRICS_TOKEN", "")
     assert client.get("/metrics").status_code == 200
+
+
+def test_body_cap_clears_the_upload_routes_own_maximum():
+    from app.routers.auth import _MAX_UPLOAD_FILES, _MAX_UPLOAD_SIZE
+
+    assert m._MAX_BODY_BYTES > _MAX_UPLOAD_FILES * _MAX_UPLOAD_SIZE * 1.1


### PR DESCRIPTION
Fixes batch run uploads over ~30 files, which #1010's 16MB body cap rejected with a 413 even though the upload route allows 100 files x 512KB; the cap is now 64MB and a test pins it above the route's own maximum.