### PR TITLE
Mobile home: get-started carousel and two-block Overwolf tile

### DIFF
--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -316,7 +316,7 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
             );
             // Break the long grid up: drop the full-width Overwolf promo band in
             // the middle so it splits the entities into two groups.
-            if (i === 6) {
+            if (i === 5) {
               return [
                 tile,
                 <Link prefetch={false} key="ow-promo" href={`${langPrefix}/overlay`} className="promo">

--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -60,6 +60,23 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
   const { lang } = useLanguage();
   const { user, loginSteam } = useAuth();
   const initialRender = useRef(true);
+  const gsTrack = useRef<HTMLDivElement>(null);
+  const [gsIndex, setGsIndex] = useState(0);
+  const gsCount = (user ? 0 : 1) + 5;
+
+  const onGsScroll = () => {
+    const el = gsTrack.current;
+    if (!el || !el.firstElementChild) return;
+    const step = (el.firstElementChild as HTMLElement).offsetWidth + 10;
+    setGsIndex(Math.min(gsCount - 1, Math.max(0, Math.round(el.scrollLeft / step))));
+  };
+
+  const gsGoTo = (i: number) => {
+    const el = gsTrack.current;
+    if (!el || !el.firstElementChild) return;
+    const step = (el.firstElementChild as HTMLElement).offsetWidth + 10;
+    el.scrollTo({ left: i * step, behavior: "smooth" });
+  };
   const pathname = usePathname();
   const pathLang = pathname.split("/")[1];
   const langPrefix = LANG_CODES.has(pathLang) ? `/${pathLang}` : lang !== "eng" ? `/${lang}` : "";
@@ -223,7 +240,7 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
           <h2>{t("Get started", lang)}</h2>
           <p>{t("Everything you need to climb the Spire. Track your runs, rank your favorites, and join the community.", lang)}</p>
         </div>
-        <div className="gs-grid">
+        <div className="gs-grid" ref={gsTrack} onScroll={onGsScroll}>
           {!user && (
             <div className="act act-signin">
               <span className="act-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7"><circle cx="12" cy="8" r="4" /><path strokeLinecap="round" strokeLinejoin="round" d="M4 20c0-3.6 3.6-6.5 8-6.5s8 2.9 8 6.5" /></svg></span>
@@ -240,6 +257,20 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
               ? (<a key={c.title} href={c.href} target="_blank" rel="noopener noreferrer" className="act">{inner}</a>)
               : (<Link prefetch={false} key={c.title} href={c.href} className="act">{inner}</Link>);
           })}
+        </div>
+        <div className="gs-dots" role="tablist" aria-label={t("Get started", lang)}>
+          {Array.from({ length: gsCount }, (_, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => gsGoTo(i)}
+              aria-label={`${i + 1} / ${gsCount}`}
+              aria-current={i === gsIndex}
+              className={`h-1.5 rounded-full transition-all ${
+                i === gsIndex ? "w-4 bg-white/80" : "w-1.5 bg-white/30 hover:bg-white/50"
+              }`}
+            />
+          ))}
         </div>
       </section>
 

--- a/frontend/app/home-revamp.css
+++ b/frontend/app/home-revamp.css
@@ -161,7 +161,6 @@
 .rvmp .charp-art img.charp-icon { object-fit: contain; object-position: center; }
 .rvmp .charp::after { display: none; }
 .rvmp .charp-meta { display: none; }
-.rvmp .gs-grid { grid-template-columns: 1fr; }
 }
 .rvmp .btile:hover { background: var(--surface-2); }
 .rvmp .bt-top { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
@@ -177,8 +176,19 @@
 .rvmp .promo-d { font-size: 13px; line-height: 1.5; color: var(--text-2); max-width: 60ch; }
 .rvmp .promo-more { display: inline-block; margin-top: 5px; font-size: 13px; font-weight: 600; color: var(--gold); }
 @media (max-width: 640px) {
-.rvmp .promo { flex-direction: column; align-items: flex-start; }
-.rvmp .promo-img { width: 100%; height: 120px; }
+.rvmp .promo { grid-column: span 2; gap: 12px; padding: 12px; margin-top: 0; }
+.rvmp .promo-img { width: 56px; height: 56px; border-radius: 8px; }
+.rvmp .promo-t { font-size: 15px; margin: 2px 0; }
+.rvmp .promo-d { display: none; }
+.rvmp .promo-more { margin-top: 2px; font-size: 12px; }
+}
+.rvmp .gs-dots { display: none; }
+@media (max-width: 640px) {
+.rvmp .gs-grid { display: flex; overflow-x: auto; scroll-snap-type: x mandatory; gap: 10px;
+    padding-bottom: 4px; scrollbar-width: none; -webkit-overflow-scrolling: touch; }
+.rvmp .gs-grid::-webkit-scrollbar { display: none; }
+.rvmp .gs-grid > .act { flex: 0 0 84%; scroll-snap-align: start; }
+.rvmp .gs-dots { display: flex; justify-content: center; align-items: center; gap: 6px; margin-top: 10px; }
 }
 
 /* sign-in tile in Get started (Steam/Discord login buttons) */

--- a/frontend/app/home-revamp.css
+++ b/frontend/app/home-revamp.css
@@ -179,7 +179,8 @@
 .rvmp .promo { grid-column: span 2; gap: 12px; padding: 12px; margin-top: 0; }
 .rvmp .promo-img { width: 56px; height: 56px; border-radius: 8px; }
 .rvmp .promo-t { font-size: 15px; margin: 2px 0; }
-.rvmp .promo-d { display: none; }
+.rvmp .promo-d { font-size: 12px; line-height: 1.4; display: -webkit-box; -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical; overflow: hidden; }
 .rvmp .promo-more { margin-top: 2px; font-size: 12px; }
 }
 .rvmp .gs-dots { display: none; }


### PR DESCRIPTION
On phones the get-started tiles become a horizontal swipe carousel with the announcement-style dots instead of a six-tile stack, and the Overwolf promo becomes a two-block row with the logo on the left instead of its own tall card.