### PR TITLE
Bestiary encounter stats with bracket and version charts

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -786,6 +786,7 @@ def get_encounter_stats_endpoint(
     limit: int = 50,
     bracket: str | None = None,
     build_id: str | None = None,
+    encounter: str | None = None,
 ):
     """Per-encounter combat stats over submitted runs.
 
@@ -807,6 +808,8 @@ def get_encounter_stats_endpoint(
         applied after grouping, sorted by sample size descending.
       * `bracket` — content bracket: `a10`, `wr30`, `wr50`, `wr75`
         (A10-gated win-rate tiers). Omit for all runs.
+      * `encounter` — comma-separated encounter ids to keep (a monster
+        page asks for just its own fights). Omit for all.
 
     Each row contains the encounter's total appearances, fatal count,
     avg damage taken, avg turns, plus a `characters` array with the
@@ -842,6 +845,11 @@ def get_encounter_stats_endpoint(
         if room_type
         else None
     )
+    encounters = (
+        [e.strip().upper() for e in encounter.split(",") if e.strip()][:50]
+        if encounter
+        else None
+    )
     result = _get_encounter_stats(
         acts=acts,
         room_types=room_types,
@@ -850,11 +858,35 @@ def get_encounter_stats_endpoint(
         limit=limit,
         bracket=bracket,
         build_id=build_id,
+        encounters=encounters,
     )
     # A not-yet-built snapshot answers empty; don't let the edge cache that
     # for an hour and keep serving zeros after the data lands.
     if not result.get("encounters"):
         response.headers["Cache-Control"] = "no-store"
+    return result
+
+
+@router.get("/encounter-series", tags=["Runs"])
+@limiter.limit(
+    rate_limit_config.endpoint_limit("runs.get_encounter_series_endpoint", "60/minute")
+)
+def get_encounter_series_endpoint(request: Request, response: Response, encounter: str):
+    """The given encounters (comma-separated ids, max 20) rolled up per
+    bracket and per recent game version in one response, for the bestiary
+    charts. Rows carry the same fields as /encounter-stats."""
+    ids = [e.strip().upper() for e in encounter.split(",") if e.strip()][:20]
+    if not ids:
+        raise HTTPException(status_code=400, detail="encounter required")
+    from ..services.run_entity_stats import get_encounter_series
+
+    result = get_encounter_series(ids)
+    if not any(result["brackets"].values()):
+        response.headers["Cache-Control"] = "no-store"
+    else:
+        response.headers["Cache-Control"] = (
+            "public, max-age=300, stale-while-revalidate=3600"
+        )
     return result
 
 

--- a/backend/app/services/encounter_stats.py
+++ b/backend/app/services/encounter_stats.py
@@ -278,6 +278,7 @@ def rollup(
     multiplayer: str | None = None,
     page: int = 1,
     limit: int = 50,
+    encounters: list[str] | None = None,
 ) -> dict[str, Any]:
     """Slice the precomputed encounter cells into the API response shape.
 
@@ -300,6 +301,7 @@ def rollup(
     # Modded-id scrub: drop encounter ids not in the official (main + beta)
     # catalog, like charts_stats.encounter_ranking. Empty set -> don't filter.
     official = _official_encounter_ids()
+    wanted = {e.upper() for e in encounters} if encounters else None
 
     # (encounter, act, room_type) -> aggregate with a nested per-character map.
     grouped: dict[tuple[str, int, str], dict[str, Any]] = {}
@@ -309,6 +311,8 @@ def rollup(
         # fight isn't split into two half-sized entries.
         enc_id = ENCOUNTER_ID_RENAMES.get(enc_id, enc_id)
         if official and enc_id not in official:
+            continue
+        if wanted is not None and enc_id not in wanted:
             continue
         if mp not in mp_keep:
             continue

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -2311,6 +2311,34 @@ def is_valid_stat_bracket(bracket: str | None) -> bool:
     return bool(sep) and ver in versions and base in _BRACKET_KEYS
 
 
+_SERIES_BRACKETS = ("all", "a10", "wr30", "wr50", "wr75", "solo", "2p", "3p", "4p")
+
+
+def get_encounter_series(encounters: list[str]) -> dict[str, Any]:
+    """One call for a monster page: the requested encounters rolled up per
+    skill/player bracket and per recent game version, so the page can draw
+    its charts without a request per slice."""
+    from . import encounter_stats, lake_stats
+
+    hit = lake_stats.encounter_store_with_mtime()
+    store = hit[1] if hit else {}
+
+    def slice_for(key: str) -> list[dict]:
+        sub = store.get(key)
+        if sub is None:
+            return []
+        return encounter_stats.rollup(sub, limit=50, encounters=encounters)[
+            "encounters"
+        ]
+
+    versions = get_recent_stat_versions()
+    return {
+        "brackets": {k: slice_for(k) for k in _SERIES_BRACKETS},
+        "versions": {v: slice_for(f"ver:{v}") for v in versions},
+        "version_order": versions,
+    }
+
+
 def get_recent_stat_versions() -> list[str]:
     """Game versions for the version dropdowns, newest first. Lake-first:
     the cube's versions keep new patches selectable (the snapshot's frozen
@@ -2342,6 +2370,7 @@ def get_encounter_stats(
     limit: int = 50,
     bracket: str | None = None,
     build_id: str | None = None,
+    encounters: list[str] | None = None,
 ) -> dict[str, Any]:
     """Per-encounter combat stats for /api/runs/encounter-stats, rolled up
     from the precomputed snapshot cells for one content bracket. Same lifecycle
@@ -2382,6 +2411,7 @@ def get_encounter_stats(
                         multiplayer=multiplayer,
                         page=page,
                         limit=limit,
+                        encounters=encounters,
                     )
         except Exception:
             logger.warning(
@@ -2398,6 +2428,7 @@ def get_encounter_stats(
         room_types=room_types,
         multiplayer=multiplayer,
         page=page,
+        encounters=encounters,
         limit=limit,
     )
 

--- a/backend/tests/test_encounter_filter.py
+++ b/backend/tests/test_encounter_filter.py
@@ -1,0 +1,52 @@
+from app.services import encounter_stats
+
+
+def _blob():
+    return {
+        "version": encounter_stats.ENCOUNTER_VERSION,
+        "cells": [
+            [
+                "AXEBOTS_NORMAL",
+                3,
+                "monster",
+                "IRONCLAD",
+                "solo",
+                100,
+                10,
+                1200.0,
+                500.0,
+            ],
+            ["AXEBOTS_NORMAL", 3, "monster", "SILENT", "multi", 40, 2, 300.0, 180.0],
+            ["AEONGLASS_BOSS", 3, "boss", "IRONCLAD", "solo", 80, 30, 2400.0, 640.0],
+        ],
+    }
+
+
+def test_rollup_keeps_only_requested_encounters():
+    out = encounter_stats.rollup(_blob(), encounters=["axebots_normal"])
+    assert [r["encounter_id"] for r in out["encounters"]] == ["AXEBOTS_NORMAL"]
+    row = out["encounters"][0]
+    assert row["total"] == 140 and row["fatal"] == 12
+    assert {c["character"] for c in row["characters"]} == {"IRONCLAD", "SILENT"}
+
+
+def test_rollup_without_filter_keeps_everything():
+    out = encounter_stats.rollup(_blob())
+    assert {r["encounter_id"] for r in out["encounters"]} == {
+        "AXEBOTS_NORMAL",
+        "AEONGLASS_BOSS",
+    }
+
+
+def test_series_rolls_up_per_bracket_and_version(monkeypatch):
+    from app.services import lake_stats, run_entity_stats as res
+
+    blob = _blob()
+    store = {"all": blob, "a10": blob, "ver:v0.111.0": blob}
+    monkeypatch.setattr(lake_stats, "encounter_store_with_mtime", lambda: (1.0, store))
+    monkeypatch.setattr(res, "get_recent_stat_versions", lambda: ["v0.111.0"])
+    out = res.get_encounter_series(["AXEBOTS_NORMAL"])
+    assert [r["encounter_id"] for r in out["brackets"]["all"]] == ["AXEBOTS_NORMAL"]
+    assert out["brackets"]["wr30"] == []
+    assert out["versions"]["v0.111.0"][0]["total"] == 140
+    assert out["version_order"] == ["v0.111.0"]

--- a/backend/tests/test_route_smoke.py
+++ b/backend/tests/test_route_smoke.py
@@ -22,6 +22,7 @@ def test_stats_routes_never_500():
         "/api/runs/metrics/cards",
         "/api/runs/metrics/cards?bracket=a10",
         "/api/runs/encounter-stats",
+        "/api/runs/encounter-series?encounter=AXEBOTS_NORMAL",
         "/api/runs/stats/cards/STRIKE/history",
         "/api/auth/steam/callback?session=nope",
     ):

--- a/frontend/app/monsters/[id]/MonsterDetail.tsx
+++ b/frontend/app/monsters/[id]/MonsterDetail.tsx
@@ -16,6 +16,7 @@ import EntityProse from "@/app/components/EntityProse";
 import { imageUrl } from "@/lib/image-url";
 import "../../card-revamp.css";
 import "../../monster-encounter-extra.css";
+import MonsterEncounterStats from "./MonsterEncounterStats";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -746,7 +747,14 @@ export default function MonsterDetail({
                   })}
                 </div>
               )}
-              <div className="enc-list">
+              <MonsterEncounterStats
+                encounters={monster.encounters!.map((e) => ({
+                  encounter_id: e.encounter_id,
+                  encounter_name: e.encounter_name,
+                }))}
+                lp={lp}
+              />
+              <div className="enc-list mt-4">
                 {monster.encounters!.map((enc) => (
                   <Link
                     key={enc.encounter_id}

--- a/frontend/app/monsters/[id]/MonsterEncounterStats.tsx
+++ b/frontend/app/monsters/[id]/MonsterEncounterStats.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  Tooltip,
+} from "chart.js";
+import { Bar } from "react-chartjs-2";
+import { useLanguage } from "@/app/contexts/LanguageContext";
+import { t } from "@/lib/ui-translations";
+
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend);
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+function cssVar(name: string): string {
+  if (typeof window === "undefined") return "";
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+function withAlpha(color: string, alpha: number): string {
+  const m = color.match(/^#([0-9a-f]{6})$/i);
+  if (!m) return color;
+  const n = parseInt(m[1], 16);
+  return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${alpha})`;
+}
+
+interface Theme {
+  gold: string;
+  goldDim: string;
+  text: string;
+  grid: string;
+  tipBg: string;
+  tipBorder: string;
+  tipText: string;
+}
+
+function readTheme(): Theme {
+  const gold = cssVar("--accent-gold");
+  return {
+    gold,
+    goldDim: withAlpha(gold, 0.45),
+    text: cssVar("--text-muted"),
+    grid: withAlpha(cssVar("--text-primary"), 0.06),
+    tipBg: cssVar("--bg-card"),
+    tipBorder: cssVar("--border-subtle"),
+    tipText: cssVar("--text-primary"),
+  };
+}
+const SKILL = ["all", "a10", "wr30", "wr50", "wr75"] as const;
+const PLAYERS = ["solo", "2p", "3p", "4p"] as const;
+const LABEL: Record<string, string> = {
+  all: "All",
+  a10: "A10",
+  wr30: ">30% WR",
+  wr50: ">50% WR",
+  wr75: ">75% WR",
+  solo: "Solo",
+  "2p": "2P",
+  "3p": "3P",
+  "4p": "4P",
+};
+
+interface CharacterStat {
+  character: string;
+  total: number;
+  fatal: number;
+  avg_damage: number;
+  avg_turns: number;
+}
+
+interface Row {
+  encounter_id: string;
+  act: number;
+  room_type: string;
+  total: number;
+  fatal: number;
+  avg_damage: number;
+  avg_turns: number;
+  characters: CharacterStat[];
+}
+
+interface Series {
+  brackets: Record<string, Row[]>;
+  versions: Record<string, Row[]>;
+  version_order: string[];
+}
+
+export interface MonsterEncounterRef {
+  encounter_id: string;
+  encounter_name: string;
+}
+
+function charColor(id: string, fallback: string): string {
+  return cssVar(`--color-${id.toLowerCase()}`) || fallback;
+}
+
+function pick(rows: Row[] | undefined, id: string): Row | null {
+  const hits = (rows || []).filter((r) => r.encounter_id === id);
+  if (!hits.length) return null;
+  return hits.reduce((a, b) => (b.total > a.total ? b : a));
+}
+
+function fatalPct(r: Row | CharacterStat | null): number | null {
+  if (!r || !r.total) return null;
+  return Math.round((r.fatal / r.total) * 1000) / 10;
+}
+
+async function fetchSeries(ids: string): Promise<Series | null> {
+  const res = await fetch(`${API}/api/runs/encounter-series?encounter=${ids}`);
+  if (res.ok) return res.json();
+  if (res.status !== 404) return null;
+  const one = async (params: Record<string, string>) => {
+    const q = new URLSearchParams({ encounter: ids, limit: "200", ...params });
+    const r = await fetch(`${API}/api/runs/encounter-stats?${q}`);
+    const d = r.ok ? await r.json() : null;
+    return ((d?.encounters as Row[]) || []).filter((x) => ids.split(",").includes(x.encounter_id));
+  };
+  const vr = await fetch(`${API}/api/runs/versions`).then((r) => (r.ok ? r.json() : null)).catch(() => null);
+  const versions: string[] = vr?.stat_versions || [];
+  const brackets: Record<string, Row[]> = {};
+  for (const k of [...SKILL, ...PLAYERS]) brackets[k] = await one(k === "all" ? {} : { bracket: k });
+  const byVersion: Record<string, Row[]> = {};
+  for (const v of versions) byVersion[v] = await one({ build_id: v });
+  return { brackets, versions: byVersion, version_order: versions };
+}
+
+const axisOpts = (th: Theme, suffix: string, max?: number) => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      backgroundColor: th.tipBg,
+      borderColor: th.tipBorder,
+      borderWidth: 1,
+      cornerRadius: 6,
+      padding: 8,
+      titleColor: th.tipText,
+      bodyColor: th.tipText,
+      callbacks: { label: (c: { parsed: { y: number | null } }) => ` ${c.parsed.y ?? 0}${suffix}` },
+    },
+  },
+  scales: {
+    x: { ticks: { color: th.text, font: { size: 11 } }, grid: { display: false } },
+    y: {
+      beginAtZero: true,
+      max,
+      ticks: { color: th.text, font: { size: 11 }, callback: (v: number | string) => `${v}${suffix}` },
+      grid: { color: th.grid },
+    },
+  },
+});
+
+export default function MonsterEncounterStats({
+  encounters,
+}: {
+  encounters: MonsterEncounterRef[];
+  lp: string;
+}) {
+  const { lang } = useLanguage();
+  const ids = encounters.map((e) => e.encounter_id).join(",");
+  const [series, setSeries] = useState<Series | null | undefined>(undefined);
+  const [enc, setEnc] = useState<string>("");
+  const [bracket, setBracket] = useState("all");
+  const [version, setVersion] = useState("");
+  const [th, setTh] = useState<Theme | null>(null);
+
+  useEffect(() => {
+    setTh(readTheme());
+  }, []);
+
+  useEffect(() => {
+    if (!ids) return;
+    fetchSeries(ids).then(setSeries).catch(() => setSeries(null));
+  }, [ids]);
+
+  useEffect(() => {
+    if (!series || enc) return;
+    const all = series.brackets.all || [];
+    const best = all.reduce<Row | null>((a, b) => (!a || b.total > a.total ? b : a), null);
+    setEnc(best?.encounter_id || encounters[0]?.encounter_id || "");
+  }, [series, enc, encounters]);
+
+  const names = useMemo(() => new Map(encounters.map((e) => [e.encounter_id, e.encounter_name])), [encounters]);
+  const withData = useMemo(
+    () => encounters.filter((e) => pick(series?.brackets.all, e.encounter_id)),
+    [encounters, series],
+  );
+
+  if (!ids || series === null) return null;
+  if (series === undefined || !th) {
+    return <div className="text-sm text-[var(--text-muted)] py-4">{t("Loading", lang)}…</div>;
+  }
+  if (!withData.length) return null;
+
+  const current = version ? pick(series.versions[version], enc) : pick(series.brackets[bracket], enc);
+  const skillData = SKILL.map((k) => fatalPct(pick(series.brackets[k], enc)));
+  const playerData = PLAYERS.map((k) => fatalPct(pick(series.brackets[k], enc)));
+  const versionOrder = [...series.version_order].reverse();
+  const versionData = versionOrder.map((v) => fatalPct(pick(series.versions[v], enc)));
+  const chars = (current?.characters || []).filter((c) => c.total >= 20);
+  const charLabels = chars.map((c) => c.character.charAt(0) + c.character.slice(1).toLowerCase());
+  const yMax = Math.max(1, ...[...skillData, ...playerData, ...versionData].filter((x): x is number => x !== null)) * 1.3;
+
+  const tile = (label: string, value: string) => (
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] px-3 py-2">
+      <div className="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">{label}</div>
+      <div className="text-lg font-semibold tabular-nums text-[var(--text-primary)]">{value}</div>
+    </div>
+  );
+
+  const pill = (on: boolean) =>
+    `px-2.5 py-1 rounded-md text-xs border transition-colors ${
+      on
+        ? "border-[var(--accent-gold)] text-[var(--accent-gold)] bg-[var(--accent-gold)]/10"
+        : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50"
+    }`;
+
+  return (
+    <div className="mt-4 space-y-4">
+      {withData.length > 1 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {withData.map((e) => (
+            <button key={e.encounter_id} type="button" onClick={() => setEnc(e.encounter_id)} className={pill(enc === e.encounter_id)}>
+              {e.encounter_name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-xs text-[var(--text-muted)] w-16">{t("Bracket", lang)}</span>
+          {[...SKILL, ...PLAYERS].map((k) => (
+            <button key={k} type="button" onClick={() => { setBracket(k); setVersion(""); }} className={pill(!version && bracket === k)}>
+              {LABEL[k]}
+            </button>
+          ))}
+        </div>
+        {series.version_order.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-xs text-[var(--text-muted)] w-16">{t("Version", lang)}</span>
+            <select
+              value={version}
+              onChange={(e) => setVersion(e.target.value)}
+              className="rounded-md border border-[var(--border-subtle)] bg-[var(--bg-card)] px-2 py-1 text-xs text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent-gold)]"
+              aria-label={t("Game version", lang)}
+            >
+              <option value="">{t("All versions", lang)}</option>
+              {series.version_order.map((v) => (
+                <option key={v} value={v}>{v}</option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      {current ? (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+          {tile(t("Runs", lang), current.total.toLocaleString())}
+          {tile(t("Fatal", lang), `${fatalPct(current)}%`)}
+          {tile(t("Avg damage", lang), current.avg_damage.toFixed(1))}
+          {tile(t("Avg turns", lang), current.avg_turns.toFixed(1))}
+        </div>
+      ) : (
+        <div className="text-sm text-[var(--text-muted)]">{t("No community data for this selection yet.", lang)}</div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-3">
+          <div className="text-xs text-[var(--text-muted)] mb-2">{t("Fatal rate by skill tier", lang)}</div>
+          <div className="h-44">
+            <Bar
+              data={{ labels: SKILL.map((k) => LABEL[k]), datasets: [{ data: skillData, backgroundColor: SKILL.map((k) => (!version && k === bracket ? th.gold : th.goldDim)), borderRadius: 4 }] }}
+              options={axisOpts(th, "%", yMax)}
+            />
+          </div>
+        </div>
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-3">
+          <div className="text-xs text-[var(--text-muted)] mb-2">{t("Fatal rate by party size", lang)}</div>
+          <div className="h-44">
+            <Bar
+              data={{ labels: PLAYERS.map((k) => LABEL[k]), datasets: [{ data: playerData, backgroundColor: PLAYERS.map((k) => (!version && k === bracket ? th.gold : th.goldDim)), borderRadius: 4 }] }}
+              options={axisOpts(th, "%", yMax)}
+            />
+          </div>
+        </div>
+        {versionOrder.length > 1 && (
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-3">
+            <div className="text-xs text-[var(--text-muted)] mb-2">{t("Fatal rate by game version", lang)}</div>
+            <div className="h-44">
+              <Bar
+                data={{ labels: versionOrder, datasets: [{ data: versionData, backgroundColor: versionOrder.map((v) => (v === version ? th.gold : th.goldDim)), borderRadius: 4 }] }}
+                options={axisOpts(th, "%", yMax)}
+              />
+            </div>
+          </div>
+        )}
+        {chars.length > 0 && chars.every((c) => c.fatal === 0) && (
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-3">
+            <div className="text-xs text-[var(--text-muted)] mb-2">{t("Fatal rate by character", lang)}</div>
+            <div className="text-sm text-[var(--text-secondary)]">
+              {t("No deaths recorded in this selection", lang)} ({chars.reduce((n, c) => n + c.total, 0).toLocaleString()} {t("runs", lang)}).
+            </div>
+          </div>
+        )}
+        {chars.length > 0 && chars.some((c) => c.fatal > 0) && (
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-3">
+            <div className="text-xs text-[var(--text-muted)] mb-2">{t("Fatal rate by character", lang)}</div>
+            <div className="h-44">
+              <Bar
+                data={{ labels: charLabels, datasets: [{ data: chars.map((c) => fatalPct(c)), backgroundColor: chars.map((c) => charColor(c.character, th.gold)), borderRadius: 4 }] }}
+                options={{
+                  ...axisOpts(th, "%"),
+                  indexAxis: "y" as const,
+                  scales: {
+                    x: { beginAtZero: true, ticks: { color: th.text, font: { size: 11 }, callback: (v: number | string) => `${v}%` }, grid: { color: th.grid } },
+                    y: { ticks: { color: th.text, font: { size: 11 } }, grid: { display: false } },
+                  },
+                  plugins: {
+                    ...axisOpts(th, "%").plugins,
+                    tooltip: {
+                      ...axisOpts(th, "%").plugins.tooltip,
+                      callbacks: {
+                        label: (c: { dataIndex: number }) => {
+                          const ch = chars[c.dataIndex];
+                          return ` ${fatalPct(ch)}% fatal · ${ch.total.toLocaleString()} runs · ${ch.avg_damage.toFixed(1)} dmg`;
+                        },
+                      },
+                    },
+                  },
+                }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Each monster page now carries its encounters' community stats as stat tiles plus fatal-rate charts by skill tier, party size, game version and character, driven by a new /api/runs/encounter-series endpoint (and an encounter= filter on /encounter-stats) so a page loads its own fights in one request.