### PR TITLE
ui-cleanup

### DIFF
--- a/frontend/app/card-revamp.css
+++ b/frontend/app/card-revamp.css
@@ -219,7 +219,7 @@
 .card-rvmp .variant-cap .muted { opacity: .55; }
 
 /* facts table */
-.card-rvmp .facts { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); }
+.card-rvmp .facts { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; }
 .card-rvmp .facts .fh { font-family: var(--mono); font-size: 11px; letter-spacing: .06em; text-transform: uppercase;
   color: var(--text-2); padding: 11px 15px; border-bottom: 1px solid var(--border); background: var(--spine-soft); }
 .card-rvmp .facts dl { margin: 0; padding: 6px 15px 12px; }

--- a/frontend/app/card-revamp.css
+++ b/frontend/app/card-revamp.css
@@ -222,7 +222,7 @@
 .card-rvmp .facts { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; }
 .card-rvmp .facts .fh { font-family: var(--mono); font-size: 11px; letter-spacing: .06em; text-transform: uppercase;
   color: var(--text-2); padding: 11px 15px; border-bottom: 1px solid var(--border); background: var(--spine-soft); }
-.card-rvmp .facts dl { margin: 0; padding: 6px 15px 12px; }
+.card-rvmp .facts dl { margin: 0; padding: 6px 15px 6px; }
 .card-rvmp .frow { display: flex; justify-content: space-between; gap: 12px; padding: 7px 0;
   border-bottom: 1px solid color-mix(in srgb, var(--border) 60%, transparent); font-size: 13.5px; }
 .card-rvmp .frow:last-child { border-bottom: 0; }

--- a/frontend/app/character-extra.css
+++ b/frontend/app/character-extra.css
@@ -66,7 +66,7 @@
   text-align: left;
   color: var(--text);
 }
-.card-rvmp .sec-toggle .sec-count { font-family: var(--mono); font-size: 15px; font-weight: 400; color: var(--text-3); margin-left: 8px; }
+.card-rvmp .sec-toggle .sec-count, .card-rvmp .sec-count { font-family: var(--mono); font-size: 15px; font-weight: 400; color: var(--text-3); margin-left: 8px; }
 .card-rvmp .sec-toggle .chev { color: var(--text-3); font-size: 12px; flex: none; }
 .card-rvmp .rar-group { margin-top: 20px; }
 .card-rvmp .rar-group:first-child { margin-top: 14px; }

--- a/frontend/app/character-extra.css
+++ b/frontend/app/character-extra.css
@@ -66,7 +66,7 @@
   text-align: left;
   color: var(--text);
 }
-.card-rvmp .sec-toggle .sec-count, .card-rvmp .sec-count { font-family: var(--mono); font-size: 15px; font-weight: 400; color: var(--text-3); margin-left: 8px; }
+.card-rvmp .sec-count { font-family: var(--mono); font-size: 15px; font-weight: 400; color: var(--text-3); margin-left: 8px; }
 .card-rvmp .sec-toggle .chev { color: var(--text-3); font-size: 12px; flex: none; }
 .card-rvmp .rar-group { margin-top: 20px; }
 .card-rvmp .rar-group:first-child { margin-top: 14px; }

--- a/frontend/app/characters/[id]/CharacterDetail.tsx
+++ b/frontend/app/characters/[id]/CharacterDetail.tsx
@@ -565,7 +565,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
                       <div className="kit-body">
                         <div className="kit-name">
                           {relic.name}
-                          <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] ${rarityBadgeColors[relic.rarity] ?? "bg-gray-600/30 text-gray-300"}`}>
+                          <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] ${relic?.rarity_key ? rarityBadgeColors[relic.rarity_key] : "bg-gray-600/30 text-gray-300"}`}>
                             {relic.rarity}
                           </span>
                         </div>

--- a/frontend/app/characters/[id]/CharacterDetail.tsx
+++ b/frontend/app/characters/[id]/CharacterDetail.tsx
@@ -700,7 +700,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
                 )}
                 {char.unlocks_after && (
                   <div className="frow">
-                    <dt>{t("Unlocks after", lang)}</dt>
+                    <dt>{t("Unlocks After", lang)}</dt>
                     <dd>{char.unlocks_after}</dd>
                   </div>
                 )}

--- a/frontend/app/characters/[id]/CharacterDetail.tsx
+++ b/frontend/app/characters/[id]/CharacterDetail.tsx
@@ -700,7 +700,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
                 )}
                 {char.unlocks_after && (
                   <div className="frow">
-                    <dt>{t("Unlocks After", lang)}</dt>
+                    <dt>{t("Unlocks after", lang)}</dt>
                     <dd>{char.unlocks_after}</dd>
                   </div>
                 )}

--- a/frontend/app/characters/[id]/CharacterDetail.tsx
+++ b/frontend/app/characters/[id]/CharacterDetail.tsx
@@ -303,10 +303,10 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
   });
 
   const rarityBadgeColors: Record<string, string> = {
-    Common: "bg-gray-600/30 text-gray-300",
+    Common: "bg-gray-500/30 text-white",
     Uncommon: "bg-blue-600/30 text-blue-300",
-    Rare: "bg-amber-600/30 text-amber-300",
-    Basic: "bg-gray-700/30 text-gray-400",
+    Rare: "bg-amber-600/30 text-amber-300", 
+    Basic: "bg-gray-700/30 text-white",
     Shop: "bg-green-600/30 text-green-300",
     Event: "bg-purple-600/30 text-purple-300",
     Starter: "bg-yellow-600/30 text-yellow-300",

--- a/frontend/app/components/SearchFilter.tsx
+++ b/frontend/app/components/SearchFilter.tsx
@@ -96,90 +96,90 @@ export default function SearchFilter({
 
   return (
     <div>
-        <div className="flex flex-wrap gap-2 items-end mb-6">
-          <div className="relative flex-1 min-w-[140px]">
-            <input
-              type="text"
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              placeholder={placeholder}
-              className="w-full px-4 py-2.5 bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded-lg text-[var(--text-primary)] placeholder-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-gold)]/50 transition-colors text-sm"
-            />
-          </div>
-          {filters?.map((filter) => (
-            <label key={filter.label} className="flex flex-col gap-1">
-              {filter.name && caption(filter.name)}
-              {filter.options.some((o) => o.icon) ? (
-                <IconSelect
-                  label={t(filter.label, lang)}
-                  value={filter.value}
-                  options={filter.options}
-                  onChange={filter.onChange}
-                />
-              ) : (
-              <select
+      <div className="flex flex-wrap gap-2 items-end mb-6">
+        <div className="relative flex-1 min-w-[140px]">
+          <input
+            type="text"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder={placeholder}
+            className="w-full px-4 py-2.5 bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded-lg text-[var(--text-primary)] placeholder-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-gold)]/50 transition-colors text-sm"
+          />
+        </div>
+        {filters?.map((filter) => (
+          <label key={filter.label} className="flex flex-col gap-1">
+            {filter.name && caption(filter.name)}
+            {filter.options.some((o) => o.icon) ? (
+              <IconSelect
+                label={t(filter.label, lang)}
                 value={filter.value}
-                onChange={(e) => filter.onChange(e.target.value)}
-                aria-label={t(filter.name ?? filter.label, lang)}
-                className={selectClass}
-              >
-                {!filter.noEmptyOption && (
-                  <option className="filter-option" value="">
-                    {t(filter.label, lang)}
-                  </option>
-                )}
-                {groupOptions(filter.options).map((seg, i) =>
-                  seg.group ? (
-                    <optgroup key={`${seg.group}-${i}`} label={seg.group}>
-                      {seg.opts.map((opt) => (
-                        <option className="filter-option" key={opt.value} value={opt.value}>
-                          {opt.label}
-                        </option>
-                      ))}
-                    </optgroup>
-                  ) : (
-                    seg.opts.map((opt) => (
+                options={filter.options}
+                onChange={filter.onChange}
+              />
+            ) : (
+            <select
+              value={filter.value}
+              onChange={(e) => filter.onChange(e.target.value)}
+              aria-label={t(filter.name ?? filter.label, lang)}
+              className={selectClass}
+            >
+              {!filter.noEmptyOption && (
+                <option className="filter-option" value="">
+                  {t(filter.label, lang)}
+                </option>
+              )}
+              {groupOptions(filter.options).map((seg, i) =>
+                seg.group ? (
+                  <optgroup key={`${seg.group}-${i}`} label={seg.group}>
+                    {seg.opts.map((opt) => (
                       <option className="filter-option" key={opt.value} value={opt.value}>
                         {opt.label}
                       </option>
-                    ))
-                  ),
-                )}
-              </select>
+                    ))}
+                  </optgroup>
+                ) : (
+                  seg.opts.map((opt) => (
+                    <option className="filter-option" key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))
+                ),
               )}
-            </label>
-          ))}
-          {sortOptions && onSortChange && (
-            <label className="flex flex-col gap-1">
-              {caption("Sort by")}
-              <select
-                value={sortValue}
-                onChange={(e) => onSortChange(e.target.value)}
-                aria-label={t("Sort by", lang)}
-                className={selectClass}
-              >
-                {sortOptions.map((opt) => (
-                  <option className="filter-option" key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-          )}
-          {resultCount !== undefined && (
-            <span className="text-sm text-[var(--text-muted)] whitespace-nowrap shrink-0 ml-auto text-left w-16">
-              {resultCount} {t("results", lang)}
-            </span>
-          )}
-          {extra && (
-            <div className="flex items-center gap-2 ml-auto">
-              {extra}
-            </div>
-          )}
-        </div>
-        {resultCount === 0 && <div className="text-center py-12 text-[var(--text-muted)]">
-            Nothing was found...
-        </div>}
+            </select>
+            )}
+          </label>
+        ))}
+        {sortOptions && onSortChange && (
+          <label className="flex flex-col gap-1">
+            {caption("Sort by")}
+            <select
+              value={sortValue}
+              onChange={(e) => onSortChange(e.target.value)}
+              aria-label={t("Sort by", lang)}
+              className={selectClass}
+            >
+              {sortOptions.map((opt) => (
+                <option className="filter-option" key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+        {resultCount !== undefined && (
+          <span className="text-sm text-[var(--text-muted)] whitespace-nowrap shrink-0 ml-auto text-left w-16">
+            {resultCount} {t("results", lang)}
+          </span>
+        )}
+        {extra && (
+          <div className="flex items-center gap-2 ml-auto">
+            {extra}
+          </div>
+        )}
+      </div>
+      {resultCount === 0 && <div className="text-center py-12 text-[var(--text-muted)]">
+        {t("No results found for", lang)} &ldquo;{draft}&rdquo;
+      </div>}
     </div>
   );
 }

--- a/frontend/app/components/SearchFilter.tsx
+++ b/frontend/app/components/SearchFilter.tsx
@@ -177,7 +177,7 @@ export default function SearchFilter({
           </div>
         )}
       </div>
-      {resultCount === 0 && <div className="text-center py-12 text-[var(--text-muted)]">
+      {draft !== "" && resultCount === 0 && <div className="text-center py-12 text-[var(--text-muted)]">
         {t("No results found for", lang)} &ldquo;{draft}&rdquo;
       </div>}
     </div>

--- a/frontend/app/components/SearchFilter.tsx
+++ b/frontend/app/components/SearchFilter.tsx
@@ -167,7 +167,7 @@ export default function SearchFilter({
           </label>
         )}
         {resultCount !== undefined && (
-          <span className="text-sm text-[var(--text-muted)] whitespace-nowrap shrink-0 ml-auto text-left w-16">
+          <span className="text-sm text-[var(--text-muted)] whitespace-nowrap">
             {resultCount} {t("results", lang)}
           </span>
         )}

--- a/frontend/app/components/SearchFilter.tsx
+++ b/frontend/app/components/SearchFilter.tsx
@@ -95,86 +95,91 @@ export default function SearchFilter({
   );
 
   return (
-    <div className="flex flex-wrap gap-2 items-end mb-6">
-      <div className="relative flex-1 min-w-[140px]">
-        <input
-          type="text"
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          placeholder={placeholder}
-          className="w-full px-4 py-2.5 bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded-lg text-[var(--text-primary)] placeholder-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-gold)]/50 transition-colors text-sm"
-        />
-      </div>
-      {filters?.map((filter) => (
-        <label key={filter.label} className="flex flex-col gap-1">
-          {filter.name && caption(filter.name)}
-          {filter.options.some((o) => o.icon) ? (
-            <IconSelect
-              label={t(filter.label, lang)}
-              value={filter.value}
-              options={filter.options}
-              onChange={filter.onChange}
+    <div>
+        <div className="flex flex-wrap gap-2 items-end mb-6">
+          <div className="relative flex-1 min-w-[140px]">
+            <input
+              type="text"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder={placeholder}
+              className="w-full px-4 py-2.5 bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded-lg text-[var(--text-primary)] placeholder-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-gold)]/50 transition-colors text-sm"
             />
-          ) : (
-          <select
-            value={filter.value}
-            onChange={(e) => filter.onChange(e.target.value)}
-            aria-label={t(filter.name ?? filter.label, lang)}
-            className={selectClass}
-          >
-            {!filter.noEmptyOption && (
-              <option className="filter-option" value="">
-                {t(filter.label, lang)}
-              </option>
-            )}
-            {groupOptions(filter.options).map((seg, i) =>
-              seg.group ? (
-                <optgroup key={`${seg.group}-${i}`} label={seg.group}>
-                  {seg.opts.map((opt) => (
-                    <option className="filter-option" key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </optgroup>
+          </div>
+          {filters?.map((filter) => (
+            <label key={filter.label} className="flex flex-col gap-1">
+              {filter.name && caption(filter.name)}
+              {filter.options.some((o) => o.icon) ? (
+                <IconSelect
+                  label={t(filter.label, lang)}
+                  value={filter.value}
+                  options={filter.options}
+                  onChange={filter.onChange}
+                />
               ) : (
-                seg.opts.map((opt) => (
+              <select
+                value={filter.value}
+                onChange={(e) => filter.onChange(e.target.value)}
+                aria-label={t(filter.name ?? filter.label, lang)}
+                className={selectClass}
+              >
+                {!filter.noEmptyOption && (
+                  <option className="filter-option" value="">
+                    {t(filter.label, lang)}
+                  </option>
+                )}
+                {groupOptions(filter.options).map((seg, i) =>
+                  seg.group ? (
+                    <optgroup key={`${seg.group}-${i}`} label={seg.group}>
+                      {seg.opts.map((opt) => (
+                        <option className="filter-option" key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </optgroup>
+                  ) : (
+                    seg.opts.map((opt) => (
+                      <option className="filter-option" key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))
+                  ),
+                )}
+              </select>
+              )}
+            </label>
+          ))}
+          {sortOptions && onSortChange && (
+            <label className="flex flex-col gap-1">
+              {caption("Sort by")}
+              <select
+                value={sortValue}
+                onChange={(e) => onSortChange(e.target.value)}
+                aria-label={t("Sort by", lang)}
+                className={selectClass}
+              >
+                {sortOptions.map((opt) => (
                   <option className="filter-option" key={opt.value} value={opt.value}>
                     {opt.label}
                   </option>
-                ))
-              ),
-            )}
-          </select>
+                ))}
+              </select>
+            </label>
           )}
-        </label>
-      ))}
-      {sortOptions && onSortChange && (
-        <label className="flex flex-col gap-1">
-          {caption("Sort by")}
-          <select
-            value={sortValue}
-            onChange={(e) => onSortChange(e.target.value)}
-            aria-label={t("Sort by", lang)}
-            className={selectClass}
-          >
-            {sortOptions.map((opt) => (
-              <option className="filter-option" key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </label>
-      )}
-      {resultCount !== undefined && (
-        <span className="text-sm text-[var(--text-muted)] whitespace-nowrap">
-          {resultCount} {t("results", lang)}
-        </span>
-      )}
-      {extra && (
-        <div className="flex items-center gap-2 ml-auto">
-          {extra}
+          {resultCount !== undefined && (
+            <span className="text-sm text-[var(--text-muted)] whitespace-nowrap shrink-0 ml-auto text-left w-16">
+              {resultCount} {t("results", lang)}
+            </span>
+          )}
+          {extra && (
+            <div className="flex items-center gap-2 ml-auto">
+              {extra}
+            </div>
+          )}
         </div>
-      )}
+        {resultCount === 0 && <div className="text-center py-12 text-[var(--text-muted)]">
+            Nothing was found...
+        </div>}
     </div>
   );
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -131,6 +131,9 @@
 :root[data-theme="light"] :is(.text-red-300, .text-red-400) {
   color: #b91c1c; /* red-700 */
 }
+:root[data-theme="light"] :is(.text-blue-300) {
+  color: #193cb8; /* blue-800 */
+}
 :root[data-theme="light"] :is([class*="bg-green-900/"], [class*="bg-green-950/"],
   [class*="bg-emerald-900/"], [class*="bg-emerald-950/"], [class*="bg-green-500/"],
   [class*="bg-green-600/"], [class*="bg-emerald-500/"], [class*="bg-emerald-600/"]) {


### PR DESCRIPTION
changes by commit:

1. 6192039

This commit fixes two small UI bugs. First fixes an issue related to the headings on characters all using the same styling for the number of items in each path. 
<img width="286" height="75" alt="Screenshot 2026-09-04 at 11 13 08 AM" src="https://github.com/user-attachments/assets/0ff1b45e-6fb5-43cb-8ea2-d4b2d9ddb77c" />
<img width="277" height="69" alt="Screenshot 2026-09-04 at 11 12 22 AM" src="https://github.com/user-attachments/assets/4999c6cb-6bd5-4cc3-9f3b-99356afc3126" />

Second, we fixed an overflow issue with the background of the "at a glance header"
<img width="478" height="261" alt="Screenshot 2026-09-04 at 11 13 43 AM" src="https://github.com/user-attachments/assets/8b7315d5-7192-4c3e-bb98-c5aec2adaed3" />

<img width="522" height="344" alt="Screenshot 2026-09-04 at 11 13 46 AM" src="https://github.com/user-attachments/assets/e84fcda8-fb50-4ce6-b576-b47922d9c929" />

2. 89a297b

the styling was incorrectly using the relic.rarity, which always evaluated to "Starter Relic" instead of "Starter", making the colors never apply, and always styling as the grey fallback option. By using this key, now the colors apply as intended.

<img width="344" height="304" alt="Screenshot 2026-09-04 at 11 15 36 AM" src="https://github.com/user-attachments/assets/a47ba766-bbde-41db-80b0-73a969c518ff" />

3. cfb44e4

This was two small changes to keep capitalization consistent, as well as margin.

4. d21ff6a, 10d3c7b, and fe0bf1e

these three commits add functionality to all users of the `<SearchFilter />` to display a not found message upon finding zero results, similar to the global search.

<img width="1235" height="288" alt="Screenshot 2026-09-04 at 11 19 03 AM" src="https://github.com/user-attachments/assets/ce7deb8a-5f91-4b69-bfa4-949a82e564b3" />

5. 8111be9

fixes colors for light/dark mode for status chips

one example here:
<img width="161" height="55" alt="Screenshot 2026-09-04 at 11 20 27 AM" src="https://github.com/user-attachments/assets/c906bd36-e62c-4ed0-8499-7040d5170268" />
<img width="152" height="59" alt="Screenshot 2026-09-04 at 11 20 39 AM" src="https://github.com/user-attachments/assets/d0588aad-dfe9-4d39-b59e-468561842f8d" />
