### PR TITLE
Credit co-op uploads to the uploader's own slot

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -639,6 +639,8 @@ def _try_claim_run(run_hash: str, user: dict) -> None:
     submit_run already refuses to reassign for exactly this reason). Scoping
     the update to unowned runs preserves the legitimate "attach my name to a
     run I uploaded anonymously" flow while making cross-user theft impossible.
+    The steam_id guard covers co-op: a teammate's slot is tagged with their
+    SteamID64 at submit, so it only ever links to that account.
     """
     if not os.environ.get("MONGO_URL", "").strip() or not run_hash:
         return
@@ -647,15 +649,17 @@ def _try_claim_run(run_hash: str, user: dict) -> None:
         from bson import ObjectId
 
         coll = _get_collection()
+        user_sid = str(user.get("steam_id") or "") or None
+        owner_set = {
+            "user_id": ObjectId(user["_id"]),
+            "username": user.get("username", ""),
+            "username_lower": (user.get("username") or "").lower() or None,
+        }
+        if user_sid:
+            owner_set["steam_id"] = user_sid
         coll.update_one(
-            {"_id": run_hash, "user_id": None},
-            {
-                "$set": {
-                    "user_id": ObjectId(user["_id"]),
-                    "username": user.get("username", ""),
-                    "username_lower": (user.get("username") or "").lower() or None,
-                }
-            },
+            {"_id": run_hash, "user_id": None, "steam_id": {"$in": [None, user_sid]}},
+            {"$set": owner_set},
         )
     except Exception:
         pass

--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -205,6 +205,7 @@ async def submit_run_endpoint(
                 "success": True,
                 "duplicate": True,
                 "run_hash": result.get("run_hash"),
+                "player_idx": result.get("player_idx", 0),
             }
         else:
             run_submissions.labels(status="error").inc()
@@ -271,7 +272,8 @@ async def submit_run_endpoint(
 
     # Track successful submission metrics
     run_submissions.labels(status="success").inc()
-    player = data.get("players", [{}])[0]
+    players = data.get("players") or [{}]
+    player = players[min(result.get("player_idx", 0), len(players) - 1)]
     char = player.get("character", "").replace("CHARACTER.", "")
     if char:
         run_character.labels(character=char).inc()

--- a/backend/app/services/runs_db.py
+++ b/backend/app/services/runs_db.py
@@ -185,9 +185,10 @@ def submit_run(
 ) -> dict:
     """Parse and store a run. Returns status dict.
 
-    ``steam_id`` / ``discord_id`` are accepted for signature parity with the
-    Mongo implementation (the production path). The SQLite fallback doesn't
-    track per-account run ownership, so they're ignored here."""
+    ``steam_id`` picks the uploader's slot in a co-op file; ``discord_id`` is
+    accepted for signature parity with the Mongo implementation (the
+    production path). The SQLite fallback doesn't track per-account run
+    ownership beyond the username."""
     # Validate structure. Errors call out the specific field so failed
     # batch uploads (issue #151) can be triaged without re-running with
     # a debugger — previously every rejection collapsed to the same
@@ -217,7 +218,9 @@ def submit_run(
     )
     player_count = len(data.get("players", []))
 
-    # Process each player as a separate run entry (multiplayer support)
+    from .runs_db_mongo import uploader_player_index
+
+    uploader_idx = uploader_player_index(data["players"], steam_id)
     results = []
     for player_idx, player in enumerate(data["players"]):
         result = _submit_player_run(
@@ -228,7 +231,7 @@ def submit_run(
             total_floors,
             killed_by,
             player_count,
-            username,
+            username if player_idx == uploader_idx else None,
         )
         results.append(result)
 
@@ -247,8 +250,10 @@ def submit_run(
                     except Exception as e:
                         print(f"Warning: failed to save run {run_hash}: {e}")
 
-    # Return first player's result (for hash/sharing)
-    return results[0]
+    primary = uploader_idx if uploader_idx is not None else 0
+    out = dict(results[primary])
+    out["player_idx"] = primary
+    return out
 
 
 def _submit_player_run(

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -429,6 +429,49 @@ def init_db():
 
 
 # ── public surface ──────────────────────────────────────────────────────
+_STEAMID64_LEN = 17
+
+
+def _steamid64(value) -> str | None:
+    sid = str(value or "")
+    return sid if len(sid) == _STEAMID64_LEN and sid.isdigit() else None
+
+
+def uploader_player_index(players: list, steam_id: str | None) -> int | None:
+    """Which slot of a submitted run is the uploader's: the player whose
+    SteamID64 (players[i].id in the run file) matches. Slot 0 for solo runs
+    and files without player ids. None when a multiplayer file carries ids
+    and the uploader is unknown or matches none of them: crediting the
+    host's slot to whoever holds the file is the bug."""
+    if steam_id:
+        for idx, player in enumerate(players):
+            if str((player or {}).get("id") or "") == steam_id:
+                return idx
+    has_ids = any(_steamid64((p or {}).get("id")) for p in players)
+    if len(players) > 1 and has_ids:
+        return None
+    return 0
+
+
+def _teammate_identity(player: dict) -> tuple[str | None, str | None, str | None]:
+    """(username, steam_id, user_id) for a co-op slot the uploader doesn't
+    own. Tagged with that player's own SteamID64 and linked to their account
+    when one exists, so the run lands on their profile instead of the
+    uploader's; unlinked slots get claimed by backfill_user_runs on sign-in."""
+    own_sid = _steamid64(player.get("id"))
+    if not own_sid:
+        return (None, None, None)
+    try:
+        from .users_db import get_user_by_steam_id
+
+        owner = get_user_by_steam_id(own_sid)
+    except Exception:
+        owner = None
+    if owner:
+        return (owner.get("username"), own_sid, owner["_id"])
+    return (None, own_sid, None)
+
+
 @_instrument("submit_run")
 def submit_run(
     data: dict,
@@ -436,8 +479,10 @@ def submit_run(
     steam_id: str | None = None,
     discord_id: str | None = None,
 ) -> dict:
-    """Parse a run and store one document per player. Returns status dict
-    matching the SQLite implementation.
+    """Parse a run and store one document per player. Returns the uploader's
+    slot's status dict (plus ``player_idx``), matching the SQLite
+    implementation. In co-op only the uploader's slot carries their
+    identity; teammates' slots are tagged with their own SteamID64s.
 
     When ``steam_id`` / ``discord_id`` is provided (the overlay / Compendium
     pass the signed-in player's SteamID64), the run is tagged with it and,
@@ -451,6 +496,7 @@ def submit_run(
     # parity so any client that knows it links the same way.
     linked_user_id = None
     linked_username = None
+    owner = None
     if steam_id or discord_id:
         try:
             from .users_db import get_user_by_steam_id, get_user_by_discord_id
@@ -482,6 +528,9 @@ def submit_run(
         except Exception:
             pass
 
+    if not steam_id and linked_user_id is not None:
+        steam_id = _steamid64((owner or {}).get("steam_id"))
+
     missing: list[str] = []
     if not data.get("players"):
         missing.append("players")
@@ -502,10 +551,20 @@ def submit_run(
         if killed_by_raw and killed_by_raw != "NONE.NONE"
         else None
     )
-    player_count = len(data.get("players", []))
+    players = data["players"]
+    player_count = len(players)
+    uploader_idx = uploader_player_index(players, steam_id)
 
     results = []
-    for player_idx, player in enumerate(data["players"]):
+    owners: list[tuple[str | None, str | None]] = []
+    for player_idx, player in enumerate(players):
+        if player_idx == uploader_idx:
+            p_username = linked_username or username
+            p_steam_id, p_discord_id, p_user_id = steam_id, discord_id, linked_user_id
+        else:
+            p_username, p_steam_id, p_user_id = _teammate_identity(player)
+            p_discord_id = None
+        owners.append((p_user_id, p_username))
         result = _submit_player_run(
             data,
             player,
@@ -514,10 +573,11 @@ def submit_run(
             total_floors,
             killed_by,
             player_count,
-            linked_username or username,
-            steam_id,
-            discord_id,
-            linked_user_id,
+            p_username,
+            p_steam_id,
+            p_discord_id,
+            p_user_id,
+            is_uploader=player_idx == uploader_idx,
         )
         results.append(result)
 
@@ -530,7 +590,8 @@ def submit_run(
             run_hash = result.get("run_hash", "")
             if run_hash:
                 run_file = runs_dir / f"{run_hash}.json"
-                if not run_file.exists():
+                fresh = bool(result.get("success"))
+                if fresh and not run_file.exists():
                     try:
                         with open(run_file, "w", encoding="utf-8") as f:
                             json.dump(data, f, ensure_ascii=False)
@@ -539,36 +600,66 @@ def submit_run(
                 # Outside the exists-gate on purpose: blob write failures are
                 # swallowed, so gating on the file would make one transient
                 # Mongo hiccup permanent (resubmission would skip the repair).
-                # The upsert inside makes the duplicate-submission case cheap.
-                save_run_blob(run_hash, data)
+                save_run_blob(
+                    run_hash,
+                    data,
+                    replace=fresh,
+                    seed_path=None if fresh else run_file,
+                )
 
-    if linked_user_id is not None and any(r.get("success") for r in results):
-        try:
-            from .user_insights import invalidate_user_insights, note_profile_activity
+    for result, (owner_id, owner_name) in zip(results, owners):
+        if owner_id is not None and result.get("success"):
+            try:
+                from .user_insights import (
+                    invalidate_user_insights,
+                    note_profile_activity,
+                )
 
-            invalidate_user_insights(str(linked_user_id))
-            note_profile_activity(str(linked_user_id), linked_username)
-        except Exception:
-            pass
+                invalidate_user_insights(str(owner_id))
+                note_profile_activity(str(owner_id), owner_name)
+            except Exception:
+                pass
 
-    return results[0]
+    primary = uploader_idx if uploader_idx is not None else 0
+    out = dict(results[primary])
+    out["player_idx"] = primary
+    return out
 
 
 def _blob_collection():
     return _get_collection().database["run_blobs"]
 
 
-def save_run_blob(run_hash: str, data: dict) -> None:
+def save_run_blob(
+    run_hash: str, data: dict, replace: bool = True, seed_path=None
+) -> None:
+    """Store the submitted JSON. A duplicate submission (replace=False) never
+    overwrites: an existing blob wins, then the run file already on disk,
+    then the submitted JSON, which is stored flagged untrusted. The blob is
+    the ownership evidence for each co-op slot and player ids aren't part
+    of the hash, so an edited re-upload must not become evidence."""
+    now = datetime.now(timezone.utc)
     try:
-        _blob_collection().replace_one(
-            {"_id": run_hash},
-            {
-                "_id": run_hash,
-                "blob": data,
-                "updated_at": datetime.now(timezone.utc),
-            },
-            upsert=True,
-        )
+        coll = _blob_collection()
+        if replace:
+            coll.replace_one(
+                {"_id": run_hash},
+                {"_id": run_hash, "blob": data, "updated_at": now},
+                upsert=True,
+            )
+            return
+        if coll.count_documents({"_id": run_hash}, limit=1):
+            return
+        fields: dict = {"blob": data, "updated_at": now, "untrusted": True}
+        if seed_path is not None and seed_path.exists():
+            try:
+                fields = {
+                    "blob": json.loads(seed_path.read_text(encoding="utf-8")),
+                    "updated_at": now,
+                }
+            except Exception:
+                pass
+        coll.update_one({"_id": run_hash}, {"$setOnInsert": fields}, upsert=True)
     except Exception as e:
         logger.warning("failed to save run blob %s: %s", run_hash, e)
 
@@ -751,9 +842,16 @@ def _submit_player_run(
     steam_id: str | None = None,
     discord_id: str | None = None,
     linked_user_id: str | None = None,
+    is_uploader: bool = True,
 ) -> dict:
     """One Mongo insert per player. The full nested structure goes into
-    a single document — no joins required at query time."""
+    a single document — no joins required at query time. The mod's damage
+    summary is the uploader's own, so only their slot carries it.
+
+    A duplicate fills identity fields that are still null, and only on a
+    slot whose steam_id and user_id are null or the caller's own: every
+    run's JSON is public and player ids aren't in the hash, so re-posting
+    an edited blob must not reassign or touch another player's slot."""
     from bson import ObjectId
 
     seed = data.get("seed", "")
@@ -872,10 +970,7 @@ def _submit_player_run(
         "map_point_history": data.get("map_point_history", []),
     }
 
-    # DPS tracking: `_spirecodex_damage` is the whole-run total from the local
-    # player's mod, so attach it only to player 0 (avoids co-op double-counting
-    # in the per-character damage aggregates). Absent / invalid -> no field.
-    if player_idx == 0:
+    if is_uploader:
         dmg = clean_damage(data.get("_spirecodex_damage"))
         if dmg:
             doc["damage"] = dmg
@@ -894,24 +989,27 @@ def _submit_player_run(
         if not doc.get("hidden"):
             bump_stats_counters(doc)
     except DuplicateKeyError:
-        # Re-uploading the exact run file restores a soft-deleted run:
-        # holding the file is ownership proof, and delete only ever meant
-        # "hide from my profile" — without this, a delete-then-reupload
-        # leaves the list empty while every upload reports "duplicate".
-        _undelete_on_reupload(coll, run_hash)
-        # The run already exists (commonly: it was submitted anonymously
-        # before the client started sending an identity). Re-submitting with
-        # a steam_id / discord_id becomes a migration path — tag the existing
-        # doc so a later sign-in can link it. Each $set is guarded on the
-        # field being null so we never reassign a run another account owns.
+        steam_ok: dict = (
+            {"$or": [{"steam_id": None}, {"steam_id": steam_id}]}
+            if steam_id
+            else {"steam_id": None}
+        )
+        user_ok: dict = {
+            "user_id": (
+                {"$in": [None, ObjectId(linked_user_id)]} if linked_user_id else None
+            )
+        }
+        own_slot = {**steam_ok, **user_ok}
+        if is_uploader:
+            _undelete_on_reupload(coll, run_hash, own_slot)
         if steam_id:
             coll.update_one(
-                {"_id": run_hash, "steam_id": None},
+                {"_id": run_hash, "steam_id": None, **user_ok},
                 {"$set": {"steam_id": steam_id}},
             )
         if discord_id:
             coll.update_one(
-                {"_id": run_hash, "discord_id": None},
+                {"_id": run_hash, "discord_id": None, **own_slot},
                 {"$set": {"discord_id": discord_id}},
             )
         if linked_user_id:
@@ -920,8 +1018,13 @@ def _submit_player_run(
                 owner_set["username"] = username
                 owner_set["username_lower"] = username.lower()
             coll.update_one(
-                {"_id": run_hash, "user_id": None},
+                {"_id": run_hash, "user_id": None, **steam_ok},
                 {"$set": owner_set},
+            )
+        if is_uploader and doc.get("damage"):
+            coll.update_one(
+                {"_id": run_hash, "damage": {"$exists": False}, **own_slot},
+                {"$set": {"damage": doc["damage"]}},
             )
         return {
             "error": "This run has already been submitted",
@@ -1171,44 +1274,67 @@ def backfill_bought() -> int:
 
 @_instrument("claim_runs")
 def claim_runs(username: str, hashes: list[str]) -> dict:
-    """Attach `username` to any runs whose _id matches and whose current
-    username is null/empty. Matches the SQLite implementation: never
-    overwrites an existing claim."""
+    """Attach `username` to runs whose _id matches and that nobody owns yet:
+    username and user_id null, steam_id null or the claimant account's own.
+    A co-op teammate's slot carries their SteamID64, so another player can't
+    claim it by hash."""
     if not hashes:
         return {"claimed": 0, "already_claimed": 0, "unknown": 0}
 
-    coll = _get_collection()
-    existing = list(coll.find({"_id": {"$in": hashes}}, {"_id": 1, "username": 1}))
-    by_hash = {d["_id"]: d.get("username") for d in existing}
+    owner = None
+    try:
+        from .users_db import get_user_by_username
 
-    unclaimed = [h for h, u in by_hash.items() if not u]
-    already_claimed = len(by_hash) - len(unclaimed)
-    unknown = len(hashes) - len(by_hash)
+        owner = get_user_by_username(username)
+    except Exception:
+        owner = None
+    owner_sid = str((owner or {}).get("steam_id") or "") or None
+
+    coll = _get_collection()
+    existing = list(
+        coll.find(
+            {"_id": {"$in": hashes}},
+            {"_id": 1, "username": 1, "user_id": 1, "steam_id": 1},
+        )
+    )
+    unclaimed = [
+        d["_id"]
+        for d in existing
+        if not d.get("username")
+        and not d.get("user_id")
+        and d.get("steam_id") in (None, owner_sid)
+    ]
+    already_claimed = len(existing) - len(unclaimed)
+    unknown = len(hashes) - len(existing)
 
     if unclaimed:
+        update: dict = {"username": username, "username_lower": username.lower()}
+        if owner:
+            from bson import ObjectId
+
+            update["user_id"] = ObjectId(str(owner["_id"]))
+        if owner_sid:
+            update["steam_id"] = owner_sid
         coll.update_many(
-            {"_id": {"$in": unclaimed}, "$or": [{"username": None}, {"username": ""}]},
-            {"$set": {"username": username, "username_lower": username.lower()}},
+            {
+                "_id": {"$in": unclaimed},
+                "user_id": None,
+                "steam_id": {"$in": [None, owner_sid]},
+                "$or": [{"username": None}, {"username": ""}],
+            },
+            {"$set": update},
         )
-        try:
-            from .user_insights import invalidate_user_insights, note_profile_activity
-            from .users_db import get_user_by_username
-
-            owner = get_user_by_username(username)
-            if owner:
-                from bson import ObjectId
-
-                # The profile walk matches user_id, not username, so a claim
-                # must link both or the runs stay profile-invisible until
-                # the next sign-in backfill.
-                coll.update_many(
-                    {"_id": {"$in": unclaimed}, "user_id": None},
-                    {"$set": {"user_id": ObjectId(str(owner["_id"]))}},
+        if owner:
+            try:
+                from .user_insights import (
+                    invalidate_user_insights,
+                    note_profile_activity,
                 )
+
                 invalidate_user_insights(str(owner["_id"]))
                 note_profile_activity(str(owner["_id"]), username)
-        except Exception:
-            pass
+            except Exception:
+                pass
 
     return {
         "claimed": len(unclaimed),
@@ -3304,12 +3430,12 @@ def get_user_runs(
     return {"runs": runs, "total": total, "page": page, "limit": limit}
 
 
-def _undelete_on_reupload(coll, run_hash: str) -> None:
-    """Clear a soft delete when the same run file comes back in. Guarded on
-    deleted_at being set so the common duplicate (never-deleted) is a no-op
-    matching zero docs."""
+def _undelete_on_reupload(coll, run_hash: str, extra: dict | None = None) -> None:
+    """Clear a soft delete when the owner re-uploads the same run file.
+    Guarded on deleted_at being set so the common duplicate (never-deleted)
+    is a no-op matching zero docs."""
     coll.update_one(
-        {"_id": run_hash, "deleted_at": {"$ne": None}},
+        {"_id": run_hash, "deleted_at": {"$ne": None}, **(extra or {})},
         {"$unset": {"deleted_at": ""}},
     )
 

--- a/backend/scripts/repair_coop_attribution.py
+++ b/backend/scripts/repair_coop_attribution.py
@@ -1,0 +1,255 @@
+"""Re-own co-op run docs that were credited to whoever uploaded them.
+
+Every slot of a multiplayer run used to be tagged with the uploader's
+identity, so teammates' runs sat on the uploader's profile and the
+uploader's damage summary sat on the host's slot. Each slot's owner is
+recoverable from the stored blob (players[i].id is that player's
+SteamID64): walk the multiplayer docs, compare, and re-tag.
+
+Per doc: the slot owner's SteamID64 must agree with the doc's steam_id (or,
+when that is null, with the steam_id of the account in user_id). A
+disagreement re-tags the doc to the owner (linked to their account when one
+exists, null otherwise, stale discord_id cleared) and moves any damage
+summary to the uploader's own slot. An agreeing doc still gets a null
+steam_id filled and an unlinked owner linked. Docs with no blob, a blob
+seeded by a duplicate re-upload (flagged untrusted), no slot ids, or
+nothing to compare against are left alone. Dry run by default.
+
+    python -m scripts.repair_coop_attribution
+    python -m scripts.repair_coop_attribution --apply
+"""
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+from collections import Counter
+
+STEAMID64_LEN = 17
+
+
+def _sid(value) -> str | None:
+    sid = str(value or "")
+    return sid if len(sid) == STEAMID64_LEN and sid.isdigit() else None
+
+
+def _slot_hash(blob: dict, idx: int) -> str:
+    player = blob["players"][idx]
+    key = (
+        f"{blob.get('seed', '')}:{player['character']}:{blob.get('start_time', '')}:"
+        f"{blob.get('run_time', 0)}:{len(player.get('deck', []))}:{idx}"
+    )
+    return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+def _slot_of_sid(blob: dict, sid: str) -> int | None:
+    for idx, player in enumerate(blob.get("players") or []):
+        if _sid((player or {}).get("id")) == sid:
+            return idx
+    return None
+
+
+def _slot_owner(
+    blob: dict, run_hash: str, player_index_for_hash
+) -> tuple[int | None, str | None]:
+    idx = player_index_for_hash(blob, run_hash)
+    if idx is None:
+        return None, None
+    try:
+        return idx, _sid((blob["players"][idx] or {}).get("id"))
+    except (IndexError, KeyError, TypeError):
+        return None, None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--batch", type=int, default=300)
+    ap.add_argument("--limit", type=int, default=0)
+    args = ap.parse_args()
+    if not os.environ.get("MONGO_URL", "").strip():
+        print("MONGO_URL unset; nothing to do")
+        return 1
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    from bson import ObjectId
+    from pymongo import UpdateOne
+
+    from app.services.runs_db_mongo import (
+        _blob_collection,
+        _data_dir,
+        _get_collection,
+        player_index_for_hash,
+    )
+    from app.services.users_db import get_user, get_user_by_steam_id
+
+    coll = _get_collection()
+    counts: Counter = Counter()
+    touched_users: set[str] = set()
+    accounts: dict[str, dict | None] = {}
+    users: dict[str, dict | None] = {}
+
+    def account_for(sid: str) -> dict | None:
+        if sid not in accounts:
+            accounts[sid] = get_user_by_steam_id(sid)
+        return accounts[sid]
+
+    def user_by_id(uid) -> dict | None:
+        key = str(uid)
+        if key not in users:
+            users[key] = get_user(key)
+        return users[key]
+
+    def load_blobs(hashes: list[str]) -> dict[str, dict | None]:
+        blobs: dict[str, dict | None] = {}
+        for doc in _blob_collection().find(
+            {"_id": {"$in": hashes}}, {"blob": 1, "untrusted": 1}
+        ):
+            blobs[doc["_id"]] = None if doc.get("untrusted") else doc.get("blob")
+        for h in hashes:
+            if h in blobs:
+                continue
+            path = _data_dir / "runs" / f"{h}.json"
+            if path.exists():
+                try:
+                    blobs[h] = json.loads(path.read_text(encoding="utf-8"))
+                except Exception:
+                    pass
+        return blobs
+
+    def owner_fields(owner_sid: str) -> tuple[dict, dict | None]:
+        acct = account_for(owner_sid)
+        name = (acct or {}).get("username") or None
+        fields = {
+            "steam_id": owner_sid,
+            "user_id": ObjectId(acct["_id"]) if acct else None,
+            "username": name,
+            "username_lower": name.lower() if name else None,
+            "discord_id": None,
+        }
+        return fields, acct
+
+    def flush(docs: list[dict]) -> None:
+        blobs = load_blobs([d["_id"] for d in docs])
+        writes: list[UpdateOne] = []
+        for doc in docs:
+            counts["scanned"] += 1
+            if doc["_id"] in blobs and blobs[doc["_id"]] is None:
+                counts["untrusted_blob"] += 1
+                continue
+            blob = blobs.get(doc["_id"])
+            if not blob:
+                counts["no_blob"] += 1
+                continue
+            idx, owner_sid = _slot_owner(blob, doc["_id"], player_index_for_hash)
+            if idx is None or not owner_sid:
+                counts["no_slot_id"] += 1
+                continue
+
+            doc_sid = str(doc.get("steam_id") or "") or None
+            acct = user_by_id(doc["user_id"]) if doc.get("user_id") else None
+            acct_sid = str((acct or {}).get("steam_id") or "") or None
+            if doc_sid is None and acct_sid is None:
+                counts["unverifiable"] += 1
+                continue
+            wrong = (doc_sid is not None and doc_sid != owner_sid) or (
+                acct_sid is not None and acct_sid != owner_sid
+            )
+
+            if wrong:
+                counts["mismatched"] += 1
+                update, new_acct = owner_fields(owner_sid)
+                counts["relinked" if new_acct else "unlinked"] += 1
+                if doc.get("user_id"):
+                    touched_users.add(str(doc["user_id"]))
+                if new_acct:
+                    touched_users.add(str(new_acct["_id"]))
+                ops: dict = {"$set": update}
+                damage = doc.get("damage")
+                uploader_sid = doc_sid or acct_sid
+                uploader_slot = (
+                    _slot_of_sid(blob, uploader_sid) if uploader_sid else None
+                )
+                if damage and uploader_slot is not None and uploader_slot != idx:
+                    dest = coll.find_one(
+                        {"_id": _slot_hash(blob, uploader_slot)}, {"damage": 1}
+                    )
+                    if dest is None:
+                        counts["damage_orphaned"] += 1
+                    else:
+                        if not dest.get("damage"):
+                            writes.append(
+                                UpdateOne(
+                                    {"_id": dest["_id"], "damage": {"$exists": False}},
+                                    {"$set": {"damage": damage}},
+                                )
+                            )
+                        ops["$unset"] = {"damage": ""}
+                        counts["damage_moved"] += 1
+                writes.append(UpdateOne({"_id": doc["_id"]}, ops))
+                logging.info(
+                    "%s: %s -> %s (%s)",
+                    doc["_id"],
+                    doc_sid or acct_sid,
+                    owner_sid,
+                    update["username"] or "unlinked",
+                )
+                continue
+
+            fill: dict = {}
+            if doc_sid is None:
+                fill["steam_id"] = owner_sid
+            if doc.get("user_id") is None:
+                owner_acct = account_for(owner_sid)
+                if owner_acct:
+                    name = owner_acct.get("username") or None
+                    fill.update(
+                        {
+                            "user_id": ObjectId(owner_acct["_id"]),
+                            "username": name,
+                            "username_lower": name.lower() if name else None,
+                        }
+                    )
+                    touched_users.add(str(owner_acct["_id"]))
+            if fill:
+                counts["filled"] += 1
+                writes.append(UpdateOne({"_id": doc["_id"]}, {"$set": fill}))
+            else:
+                counts["ok"] += 1
+        if writes and args.apply:
+            coll.bulk_write(writes, ordered=False)
+            counts["written"] += len(writes)
+
+    cursor = coll.find(
+        {"player_count": {"$gt": 1}},
+        {"steam_id": 1, "user_id": 1, "username": 1, "damage": 1},
+        sort=[("_id", 1)],
+    )
+    if args.limit:
+        cursor = cursor.limit(args.limit)
+
+    pending: list[dict] = []
+    for doc in cursor:
+        pending.append(doc)
+        if len(pending) >= args.batch:
+            flush(pending)
+            pending = []
+    if pending:
+        flush(pending)
+
+    if args.apply and touched_users:
+        from app.services.user_insights import invalidate_user_insights
+
+        for uid in touched_users:
+            try:
+                invalidate_user_insights(uid)
+            except Exception:
+                pass
+
+    print(dict(counts), "apply" if args.apply else "dry-run", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_coop_attribution.py
+++ b/backend/tests/test_coop_attribution.py
@@ -1,0 +1,683 @@
+"""A co-op upload must credit the uploader with THEIR slot, not the host's.
+The mod uploads the shared .run file; every slot used to be tagged with the
+uploader's identity and the response carried player 0's hash, so a Regent
+in slot 1 got the host's Ironclad run on their profile (Workshop report,
+2026-09-04). Every run's JSON is public and player ids aren't in the hash,
+so the duplicate and claim paths must never hand a tagged slot to someone
+else."""
+
+import hashlib
+import sys
+
+import pytest
+from bson import ObjectId
+from pymongo import UpdateOne
+from pymongo.errors import DuplicateKeyError
+
+from app.routers import auth as auth_router
+from app.services import cheat_detect, runs_db_mongo, user_insights, users_db
+from app.services.runs_db_mongo import claim_runs, submit_run, uploader_player_index
+from scripts import repair_coop_attribution as repair
+
+REAL_SAVE_RUN_BLOB = runs_db_mongo.save_run_blob
+
+HOST_SID = "76561198000000001"
+ME_SID = "76561198000000002"
+GUEST_SID = "76561198000000003"
+STRANGER_SID = "76561198000000009"
+ME_ID = "6" * 24
+GUEST_ID = "7" * 24
+HOST_ID = "8" * 24
+STRANGER_ID = "9" * 24
+
+
+def _blob(with_ids=True, damage=True):
+    def player(sid, char):
+        p = {"character": char, "deck": [], "relics": []}
+        if with_ids:
+            p["id"] = int(sid)
+        return p
+
+    blob = {
+        "seed": "ABC",
+        "start_time": 1756684800,
+        "run_time": 1000,
+        "win": True,
+        "acts": [1, 2, 3],
+        "map_point_history": [[{"room_type": "MONSTER", "player_stats": []}]],
+        "players": [
+            player(HOST_SID, "CHARACTER.IRONCLAD"),
+            player(ME_SID, "CHARACTER.REGENT"),
+            player(GUEST_SID, "CHARACTER.DEFECT"),
+        ],
+    }
+    if damage:
+        blob["_spirecodex_damage"] = {"damage_dealt": 10, "damage_taken": 2}
+    return blob
+
+
+def _hash(blob, idx):
+    p = blob["players"][idx]
+    key = (
+        f"{blob['seed']}:{p['character']}:{blob['start_time']}:"
+        f"{blob['run_time']}:{len(p['deck'])}:{idx}"
+    )
+    return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+def _match(doc, cond):
+    for key, want in cond.items():
+        if key == "$or":
+            if not any(_match(doc, c) for c in want):
+                return False
+            continue
+        have = doc.get(key)
+        if isinstance(want, dict):
+            if "$in" in want and have not in want["$in"]:
+                return False
+            if "$ne" in want and have == want["$ne"]:
+                return False
+            if "$gt" in want and not (have is not None and have > want["$gt"]):
+                return False
+            if "$exists" in want and (key in doc) != want["$exists"]:
+                return False
+        elif have != want:
+            return False
+    return True
+
+
+class FakeCursor:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def limit(self, n):
+        self.docs = self.docs[:n] if n else self.docs
+        return self
+
+    def __iter__(self):
+        return iter(self.docs)
+
+
+class FakeColl:
+    def __init__(self):
+        self.docs = {}
+
+    def insert_one(self, doc):
+        if doc["_id"] in self.docs:
+            raise DuplicateKeyError("dup")
+        self.docs[doc["_id"]] = dict(doc)
+
+    def _project(self, doc, proj):
+        if not proj:
+            return dict(doc)
+        return {k: v for k, v in doc.items() if k == "_id" or proj.get(k)}
+
+    def find_one(self, flt, proj=None):
+        for d in self.docs.values():
+            if _match(d, flt):
+                return self._project(d, proj)
+        return None
+
+    def find(self, flt, proj=None, sort=None):
+        return FakeCursor(
+            [self._project(d, proj) for d in self.docs.values() if _match(d, flt)]
+        )
+
+    def _apply(self, doc, update):
+        for k, v in update.get("$set", {}).items():
+            doc[k] = v
+        for k in update.get("$unset", {}):
+            doc.pop(k, None)
+
+    def update_one(self, flt, update):
+        for d in self.docs.values():
+            if _match(d, flt):
+                self._apply(d, update)
+                return
+
+    def update_many(self, flt, update):
+        n = 0
+        for d in self.docs.values():
+            if _match(d, flt):
+                self._apply(d, update)
+                n += 1
+        return type("R", (), {"modified_count": n})()
+
+    def bulk_write(self, writes, ordered=False):
+        for w in writes:
+            assert isinstance(w, UpdateOne)
+            self.update_one(w._filter, w._doc)
+
+    def by_char(self):
+        return {d["character"]: d for d in self.docs.values()}
+
+
+USERS = {
+    ME_SID: {"_id": ME_ID, "username": "PC-Reviver", "steam_id": ME_SID},
+    GUEST_SID: {"_id": GUEST_ID, "username": "Guest", "steam_id": GUEST_SID},
+    HOST_SID: {"_id": HOST_ID, "username": "Host", "steam_id": HOST_SID},
+}
+
+
+@pytest.fixture
+def coll(monkeypatch, tmp_path):
+    coll = FakeColl()
+    monkeypatch.setattr(runs_db_mongo, "_get_collection", lambda: coll)
+    monkeypatch.setattr(runs_db_mongo, "_data_dir", tmp_path)
+    monkeypatch.setattr(runs_db_mongo, "save_run_blob", lambda *a, **k: None)
+    monkeypatch.setattr(runs_db_mongo, "bump_stats_counters", lambda doc: None)
+    monkeypatch.setattr(cheat_detect, "detect_cheats", lambda data: [])
+    monkeypatch.setattr(users_db, "get_user_by_steam_id", lambda sid: USERS.get(sid))
+    monkeypatch.setattr(
+        users_db,
+        "get_user_by_username",
+        lambda name: next(
+            (u for u in USERS.values() if u["username"].lower() == name.lower()), None
+        ),
+    )
+    monkeypatch.setattr(
+        users_db,
+        "get_user",
+        lambda uid: next((u for u in USERS.values() if u["_id"] == str(uid)), None),
+    )
+    monkeypatch.setattr(user_insights, "invalidate_user_insights", lambda uid: None)
+    monkeypatch.setattr(user_insights, "note_profile_activity", lambda *a: None)
+    return coll
+
+
+def test_uploader_slot_is_matched_by_steam_id():
+    players = _blob()["players"]
+    assert uploader_player_index(players, ME_SID) == 1
+    assert uploader_player_index(players, GUEST_SID) == 2
+    assert uploader_player_index(players, None) is None
+    assert uploader_player_index(players, STRANGER_SID) is None
+    assert uploader_player_index(_blob(with_ids=False)["players"], ME_SID) == 0
+    assert uploader_player_index(_blob(with_ids=False)["players"], None) == 0
+    assert uploader_player_index(players[:1], STRANGER_SID) == 0
+    assert uploader_player_index(players[:1], None) == 0
+
+
+def test_coop_upload_credits_only_the_uploaders_slot(coll):
+    result = submit_run(_blob(), username="PC-Reviver", steam_id=ME_SID)
+    by = coll.by_char()
+
+    me = by["REGENT"]
+    assert result["player_idx"] == 1
+    assert result["run_hash"] == me["_id"]
+    assert me["steam_id"] == ME_SID
+    assert me["user_id"] == ObjectId(ME_ID)
+    assert me["username"] == "PC-Reviver"
+    assert "damage" in me
+
+    host = by["IRONCLAD"]
+    assert host["steam_id"] == HOST_SID
+    assert host["user_id"] == ObjectId(HOST_ID)
+    assert host["username"] == "Host"
+    assert "damage" not in host
+
+    guest = by["DEFECT"]
+    assert guest["steam_id"] == GUEST_SID
+    assert guest["user_id"] == ObjectId(GUEST_ID)
+
+
+def test_teammate_without_account_is_tagged_but_unlinked(coll, monkeypatch):
+    monkeypatch.setattr(users_db, "get_user_by_steam_id", lambda sid: None)
+    submit_run(_blob(), username="PC-Reviver", steam_id=ME_SID)
+    host = coll.by_char()["IRONCLAD"]
+    assert host["steam_id"] == HOST_SID
+    assert host["user_id"] is None
+    assert host["username"] is None
+    assert host["username_lower"] is None
+
+
+def test_stranger_upload_of_a_coop_file_credits_nobody(coll):
+    result = submit_run(_blob(), username="Stranger", steam_id=STRANGER_SID)
+    assert result["player_idx"] == 0
+    for d in coll.docs.values():
+        assert d["username"] != "Stranger"
+        assert d["steam_id"] != STRANGER_SID
+        assert "damage" not in d
+
+
+def test_anonymous_coop_upload_with_ids_tags_every_slot_and_credits_nobody(coll):
+    result = submit_run(_blob(), username="Nobody")
+    assert result["player_idx"] == 0
+    by = coll.by_char()
+    assert by["IRONCLAD"]["steam_id"] == HOST_SID
+    assert by["IRONCLAD"]["user_id"] == ObjectId(HOST_ID)
+    assert by["REGENT"]["steam_id"] == ME_SID
+    for d in coll.docs.values():
+        assert d["username"] != "Nobody"
+        assert "damage" not in d
+
+
+def test_username_only_upload_uses_the_accounts_steam_id_for_the_slot(coll):
+    result = submit_run(_blob(), username="PC-Reviver")
+    assert result["player_idx"] == 1
+    by = coll.by_char()
+    assert by["REGENT"]["user_id"] == ObjectId(ME_ID)
+    assert by["REGENT"]["steam_id"] == ME_SID
+    assert by["IRONCLAD"]["user_id"] == ObjectId(HOST_ID)
+
+
+def test_anonymous_coop_upload_names_only_slot_zero(coll):
+    result = submit_run(_blob(with_ids=False), username="Nobody")
+    assert result["player_idx"] == 0
+    docs = list(coll.docs.values())
+    assert docs[0]["username"] == "Nobody"
+    assert [d["username"] for d in docs[1:]] == [None, None]
+    assert [d["steam_id"] for d in docs] == [None, None, None]
+
+
+def test_solo_upload_is_unchanged(coll):
+    blob = _blob()
+    blob["players"] = blob["players"][1:2]
+    result = submit_run(blob, username="PC-Reviver", steam_id=ME_SID)
+    doc = list(coll.docs.values())[0]
+    assert result["player_idx"] == 0
+    assert result["run_hash"] == doc["_id"]
+    assert doc["user_id"] == ObjectId(ME_ID)
+    assert "damage" in doc
+
+
+def test_second_participant_gets_their_damage_and_link_on_duplicate(coll, monkeypatch):
+    monkeypatch.setattr(users_db, "get_user_by_steam_id", lambda sid: None)
+    submit_run(_blob(), username="Host", steam_id=HOST_SID)
+    assert "damage" not in coll.by_char()["REGENT"]
+
+    monkeypatch.setattr(users_db, "get_user_by_steam_id", lambda sid: USERS.get(sid))
+    mine = _blob()
+    mine["_spirecodex_damage"] = {"damage_dealt": 99, "damage_taken": 1}
+    result = submit_run(mine, username="PC-Reviver", steam_id=ME_SID)
+    me = coll.by_char()["REGENT"]
+    assert result["duplicate"] is True
+    assert result["player_idx"] == 1
+    assert result["run_hash"] == me["_id"]
+    assert me["damage"]["damage_dealt"] == 99
+    assert me["user_id"] == ObjectId(ME_ID)
+    assert "damage" not in coll.by_char()["IRONCLAD"] or (
+        coll.by_char()["IRONCLAD"]["damage"]["damage_dealt"] == 10
+    )
+
+
+def test_edited_player_id_cannot_take_a_tagged_slot_on_duplicate(coll, monkeypatch):
+    monkeypatch.setattr(users_db, "get_user_by_steam_id", lambda sid: None)
+    submit_run(_blob(), username="Host", steam_id=HOST_SID)
+    me_before = coll.by_char()["REGENT"]
+    assert me_before["user_id"] is None
+
+    forged = _blob()
+    forged["players"][1]["id"] = int(STRANGER_SID)
+    USERS_WITH_STRANGER = dict(USERS)
+    USERS_WITH_STRANGER[STRANGER_SID] = {
+        "_id": STRANGER_ID,
+        "username": "Thief",
+        "steam_id": STRANGER_SID,
+    }
+    monkeypatch.setattr(
+        users_db, "get_user_by_steam_id", lambda sid: USERS_WITH_STRANGER.get(sid)
+    )
+    result = submit_run(forged, username="Thief", steam_id=STRANGER_SID)
+    me = coll.by_char()["REGENT"]
+    assert result["duplicate"] is True
+    assert me["steam_id"] == ME_SID
+    assert me["user_id"] is None
+    assert me["username"] is None
+    assert "damage" not in me
+
+
+def _owned_solo(coll, blob, user_id, **extra):
+    h = _hash(blob, 0)
+    coll.docs[h] = {
+        "_id": h,
+        "character": "IRONCLAD",
+        "player_count": 1,
+        "user_id": ObjectId(user_id) if user_id else None,
+        "username": "Victim" if user_id else None,
+        "deleted_at": "2026-09-01",
+        **extra,
+    }
+    return h
+
+
+def test_anonymous_duplicate_cannot_touch_an_owned_run_missing_steam_id(coll):
+    blob = _blob()
+    blob["players"] = blob["players"][:1]
+    h = _owned_solo(coll, blob, HOST_ID)
+    before = dict(coll.docs[h])
+    result = submit_run(blob)
+    assert result["duplicate"] is True
+    assert coll.docs[h] == before
+
+
+def test_authenticated_duplicate_cannot_tag_someone_elses_owned_run(coll):
+    blob = _blob()
+    blob["players"] = blob["players"][:1]
+    h = _owned_solo(coll, blob, HOST_ID)
+    before = dict(coll.docs[h])
+    submit_run(blob, username="PC-Reviver", steam_id=ME_SID)
+    assert coll.docs[h] == before
+
+
+def test_owner_reupload_fills_steam_id_and_restores_their_own_run(coll):
+    blob = _blob()
+    blob["players"] = blob["players"][:1]
+    h = _owned_solo(coll, blob, HOST_ID)
+    submit_run(blob, username="Host", steam_id=HOST_SID)
+    doc = coll.docs[h]
+    assert doc["steam_id"] == HOST_SID
+    assert "deleted_at" not in doc
+    assert doc["damage"]["damage_dealt"] == 10
+
+
+def test_anonymous_legacy_run_is_claimed_by_a_signed_in_reupload(coll):
+    blob = _blob()
+    blob["players"] = blob["players"][:1]
+    h = _owned_solo(coll, blob, None)
+    coll.docs[h].pop("deleted_at")
+    submit_run(blob, username="Host", steam_id=HOST_SID)
+    doc = coll.docs[h]
+    assert doc["steam_id"] == HOST_SID
+    assert doc["user_id"] == ObjectId(HOST_ID)
+    assert doc["username"] == "Host"
+
+
+def test_reupload_only_undeletes_the_uploaders_own_slot(coll):
+    submit_run(_blob(), username="Host", steam_id=HOST_SID)
+    for d in coll.docs.values():
+        d["deleted_at"] = "2026-09-01"
+    submit_run(_blob(), username="PC-Reviver", steam_id=ME_SID)
+    by = coll.by_char()
+    assert "deleted_at" not in by["REGENT"]
+    assert by["IRONCLAD"]["deleted_at"] == "2026-09-01"
+    assert by["DEFECT"]["deleted_at"] == "2026-09-01"
+
+
+def test_claim_runs_cannot_take_a_teammates_tagged_slot(coll, monkeypatch):
+    monkeypatch.setattr(users_db, "get_user_by_steam_id", lambda sid: None)
+    submit_run(_blob(), username="Host", steam_id=HOST_SID)
+    guest = coll.by_char()["DEFECT"]
+    assert guest["steam_id"] == GUEST_SID and guest["user_id"] is None
+
+    out = claim_runs("PC-Reviver", [guest["_id"]])
+    assert out == {"claimed": 0, "already_claimed": 1, "unknown": 0}
+    assert coll.by_char()["DEFECT"]["username"] is None
+
+    out = claim_runs("Guest", [guest["_id"]])
+    assert out["claimed"] == 1
+    guest = coll.by_char()["DEFECT"]
+    assert guest["username"] == "Guest"
+    assert guest["user_id"] == ObjectId(GUEST_ID)
+    assert guest["steam_id"] == GUEST_SID
+
+
+def test_claim_runs_still_claims_untagged_anonymous_runs(coll):
+    submit_run(_blob(with_ids=False))
+    hashes = list(coll.docs)
+    out = claim_runs("PC-Reviver", hashes)
+    assert out["claimed"] == 3
+    assert all(d["steam_id"] == ME_SID for d in coll.docs.values())
+    assert all(d["user_id"] == ObjectId(ME_ID) for d in coll.docs.values())
+
+
+def test_website_claim_respects_the_slots_steam_id(coll, monkeypatch):
+    monkeypatch.setenv("MONGO_URL", "mongodb://x")
+    monkeypatch.setattr(users_db, "get_user_by_steam_id", lambda sid: None)
+    submit_run(_blob(), username="Host", steam_id=HOST_SID)
+    guest_hash = coll.by_char()["DEFECT"]["_id"]
+
+    auth_router._try_claim_run(guest_hash, USERS[ME_SID])
+    assert coll.by_char()["DEFECT"]["user_id"] is None
+
+    auth_router._try_claim_run(guest_hash, {"_id": STRANGER_ID, "username": "Legacy"})
+    assert coll.by_char()["DEFECT"]["user_id"] is None
+
+    auth_router._try_claim_run(guest_hash, USERS[GUEST_SID])
+    guest = coll.by_char()["DEFECT"]
+    assert guest["user_id"] == ObjectId(GUEST_ID)
+    assert guest["steam_id"] == GUEST_SID
+
+
+class FakeBlobs:
+    def __init__(self, blobs=None):
+        self.docs = {h: {"_id": h, "blob": b} for h, b in (blobs or {}).items()}
+
+    @property
+    def blobs(self):
+        return {h: d["blob"] for h, d in self.docs.items()}
+
+    def count_documents(self, flt, limit=0):
+        return int(flt["_id"] in self.docs)
+
+    def replace_one(self, flt, doc, upsert=False):
+        self.docs[flt["_id"]] = dict(doc)
+
+    def update_one(self, flt, update, upsert=False):
+        assert "$setOnInsert" in update and upsert
+        self.docs.setdefault(flt["_id"], {"_id": flt["_id"], **update["$setOnInsert"]})
+
+    def find(self, flt, proj=None):
+        return [dict(d) for h, d in self.docs.items() if h in flt["_id"]["$in"]]
+
+
+def test_duplicate_blob_save_never_overwrites_evidence(monkeypatch, tmp_path):
+    import json
+
+    blobs = FakeBlobs()
+    monkeypatch.setattr(runs_db_mongo, "_blob_collection", lambda: blobs)
+    on_disk = tmp_path / "h.json"
+    on_disk.write_text(json.dumps({"source": "disk"}))
+
+    REAL_SAVE_RUN_BLOB("h", {"source": "edited"}, replace=False, seed_path=on_disk)
+    assert blobs.blobs["h"] == {"source": "disk"}
+    assert "untrusted" not in blobs.docs["h"]
+    REAL_SAVE_RUN_BLOB("h", {"source": "edited"}, replace=False)
+    assert blobs.blobs["h"] == {"source": "disk"}
+    REAL_SAVE_RUN_BLOB("h", {"source": "fresh"})
+    assert blobs.blobs["h"] == {"source": "fresh"}
+    assert "untrusted" not in blobs.docs["h"]
+    REAL_SAVE_RUN_BLOB(
+        "g", {"source": "only-copy"}, replace=False, seed_path=tmp_path / "missing.json"
+    )
+    assert blobs.blobs["g"] == {"source": "only-copy"}
+    assert blobs.docs["g"]["untrusted"] is True
+
+
+def test_forged_duplicate_cannot_become_ownership_evidence(coll, monkeypatch, tmp_path):
+    blobs = FakeBlobs()
+    monkeypatch.setattr(runs_db_mongo, "_blob_collection", lambda: blobs)
+    monkeypatch.setattr(runs_db_mongo, "save_run_blob", REAL_SAVE_RUN_BLOB)
+    original = _blob()
+    host_hash = _hash(original, 0)
+    coll.docs[host_hash] = {
+        "_id": host_hash,
+        "character": "IRONCLAD",
+        "player_count": 3,
+        "steam_id": HOST_SID,
+        "user_id": ObjectId(HOST_ID),
+        "username": "Host",
+    }
+
+    forged = _blob()
+    forged["players"][0]["id"] = int(ME_SID)
+    forged["players"][1]["id"] = int(HOST_SID)
+    result = submit_run(forged, username="PC-Reviver", steam_id=ME_SID)
+    assert result["duplicate"] is True
+    assert blobs.docs[host_hash]["untrusted"] is True
+    assert not (tmp_path / "runs" / f"{host_hash}.json").exists()
+
+    _run_repair(monkeypatch, coll, blobs)
+    assert coll.docs[host_hash]["steam_id"] == HOST_SID
+    assert coll.docs[host_hash]["user_id"] == ObjectId(HOST_ID)
+
+
+def _legacy_docs(coll, blob, uploader_sid, uploader_id, uploader_name):
+    for idx, p in enumerate(blob["players"]):
+        doc = {
+            "_id": _hash(blob, idx),
+            "character": p["character"].split(".")[-1],
+            "player_count": len(blob["players"]),
+            "steam_id": uploader_sid,
+            "discord_id": "1234",
+            "user_id": ObjectId(uploader_id) if uploader_id else None,
+            "username": uploader_name,
+            "username_lower": uploader_name.lower() if uploader_name else None,
+        }
+        if idx == 0:
+            doc["damage"] = {"damage_dealt": 42}
+        coll.docs[doc["_id"]] = doc
+
+
+def _run_repair(monkeypatch, coll, blobs, apply=True):
+    monkeypatch.setenv("MONGO_URL", "mongodb://x")
+    monkeypatch.setattr(sys, "argv", ["repair"] + (["--apply"] if apply else []))
+    store = blobs if isinstance(blobs, FakeBlobs) else FakeBlobs(blobs)
+    monkeypatch.setattr(runs_db_mongo, "_blob_collection", lambda: store)
+    assert repair.main() == 0
+
+
+def test_repair_reowns_legacy_slots_and_moves_damage(coll, monkeypatch):
+    blob = _blob()
+    _legacy_docs(coll, blob, ME_SID, ME_ID, "PC-Reviver")
+    blobs = {_hash(blob, i): blob for i in range(3)}
+
+    _run_repair(monkeypatch, coll, blobs, apply=False)
+    assert coll.by_char()["IRONCLAD"]["username"] == "PC-Reviver"
+
+    _run_repair(monkeypatch, coll, blobs)
+    by = coll.by_char()
+    host = by["IRONCLAD"]
+    assert host["steam_id"] == HOST_SID
+    assert host["user_id"] == ObjectId(HOST_ID)
+    assert host["username"] == "Host"
+    assert host["discord_id"] is None
+    assert "damage" not in host
+
+    me = by["REGENT"]
+    assert me["steam_id"] == ME_SID
+    assert me["user_id"] == ObjectId(ME_ID)
+    assert me["damage"] == {"damage_dealt": 42}
+    assert me["discord_id"] == "1234"
+
+    guest = by["DEFECT"]
+    assert guest["steam_id"] == GUEST_SID
+    assert guest["user_id"] == ObjectId(GUEST_ID)
+
+
+def test_repair_moves_damage_when_the_legacy_doc_only_has_a_user_id(coll, monkeypatch):
+    blob = _blob()
+    _legacy_docs(coll, blob, None, ME_ID, "PC-Reviver")
+    _run_repair(monkeypatch, coll, {_hash(blob, i): blob for i in range(3)})
+    by = coll.by_char()
+    assert "damage" not in by["IRONCLAD"]
+    assert by["REGENT"]["damage"] == {"damage_dealt": 42}
+    assert by["REGENT"]["steam_id"] == ME_SID
+    assert by["IRONCLAD"]["user_id"] == ObjectId(HOST_ID)
+
+
+def test_repair_keeps_damage_when_the_uploaders_slot_doc_is_missing(coll, monkeypatch):
+    blob = _blob()
+    _legacy_docs(coll, blob, ME_SID, ME_ID, "PC-Reviver")
+    del coll.docs[_hash(blob, 1)]
+    _run_repair(monkeypatch, coll, {_hash(blob, i): blob for i in (0, 2)})
+    host = coll.by_char()["IRONCLAD"]
+    assert host["damage"] == {"damage_dealt": 42}
+    assert host["user_id"] == ObjectId(HOST_ID)
+
+
+def test_repair_unlinks_when_the_owner_has_no_account(coll, monkeypatch):
+    blob = _blob()
+    _legacy_docs(coll, blob, ME_SID, ME_ID, "PC-Reviver")
+    monkeypatch.setattr(users_db, "get_user_by_steam_id", lambda sid: None)
+    _run_repair(monkeypatch, coll, {_hash(blob, i): blob for i in range(3)})
+    host = coll.by_char()["IRONCLAD"]
+    assert host["steam_id"] == HOST_SID
+    assert host["user_id"] is None
+    assert host["username"] is None
+
+
+def test_repair_fills_null_steam_id_and_links_unlinked_owner(coll, monkeypatch):
+    blob = _blob()
+    h1 = _hash(blob, 1)
+    coll.docs[h1] = {
+        "_id": h1,
+        "character": "REGENT",
+        "player_count": 3,
+        "steam_id": None,
+        "user_id": ObjectId(ME_ID),
+        "username": "PC-Reviver",
+    }
+    h2 = _hash(blob, 2)
+    coll.docs[h2] = {
+        "_id": h2,
+        "character": "DEFECT",
+        "player_count": 3,
+        "steam_id": GUEST_SID,
+        "user_id": None,
+        "username": None,
+    }
+    _run_repair(monkeypatch, coll, {h1: blob, h2: blob})
+    assert coll.docs[h1]["steam_id"] == ME_SID
+    assert coll.docs[h1]["user_id"] == ObjectId(ME_ID)
+    assert coll.docs[h2]["user_id"] == ObjectId(GUEST_ID)
+    assert coll.docs[h2]["username"] == "Guest"
+
+
+def test_repair_reassigns_user_id_of_the_wrong_account(coll, monkeypatch):
+    blob = _blob()
+    h1 = _hash(blob, 1)
+    coll.docs[h1] = {
+        "_id": h1,
+        "character": "REGENT",
+        "player_count": 3,
+        "steam_id": ME_SID,
+        "user_id": ObjectId(HOST_ID),
+        "username": "Host",
+    }
+    _run_repair(monkeypatch, coll, {h1: blob})
+    assert coll.docs[h1]["user_id"] == ObjectId(ME_ID)
+    assert coll.docs[h1]["username"] == "PC-Reviver"
+
+
+def test_repair_leaves_unverifiable_and_blobless_docs_alone(coll, monkeypatch):
+    blob = _blob()
+    h0, h1 = _hash(blob, 0), _hash(blob, 1)
+    coll.docs[h0] = {
+        "_id": h0,
+        "character": "IRONCLAD",
+        "player_count": 3,
+        "steam_id": None,
+        "user_id": None,
+        "username": "Someone",
+    }
+    coll.docs[h1] = {
+        "_id": h1,
+        "character": "REGENT",
+        "player_count": 3,
+        "steam_id": HOST_SID,
+        "user_id": None,
+        "username": None,
+    }
+    _run_repair(monkeypatch, coll, {h0: blob})
+    assert coll.docs[h0]["username"] == "Someone"
+    assert coll.docs[h1]["steam_id"] == HOST_SID
+
+
+def test_repair_reads_blob_files_when_mongo_has_none(coll, monkeypatch, tmp_path):
+    import json
+
+    blob = _blob()
+    h1 = _hash(blob, 1)
+    coll.docs[h1] = {
+        "_id": h1,
+        "character": "REGENT",
+        "player_count": 3,
+        "steam_id": HOST_SID,
+        "user_id": ObjectId(HOST_ID),
+        "username": "Host",
+    }
+    (tmp_path / "runs").mkdir()
+    (tmp_path / "runs" / f"{h1}.json").write_text(json.dumps(blob))
+    _run_repair(monkeypatch, coll, {})
+    assert coll.docs[h1]["steam_id"] == ME_SID
+    assert coll.docs[h1]["user_id"] == ObjectId(ME_ID)


### PR DESCRIPTION
Fixes co-op uploads being credited to the host's slot: I match the uploader's steam id to their player slot, tag teammates' slots with their own ids, guard the duplicate and claim paths on the slot's owner, and add a repair script for the runs already mis-credited.