### PR TITLE
Make the whole account tile the Steam sign-in button

### DIFF
--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -242,14 +242,11 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
         </div>
         <div className="gs-grid" ref={gsTrack} onScroll={onGsScroll}>
           {!user && (
-            <div className="act act-signin">
-              <span className="act-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7"><circle cx="12" cy="8" r="4" /><path strokeLinecap="round" strokeLinejoin="round" d="M4 20c0-3.6 3.6-6.5 8-6.5s8 2.9 8 6.5" /></svg></span>
-              <span className="act-t">{t("Create an account", lang)}</span>
+            <button type="button" onClick={loginSteam} className="act act-signin">
+              <span className="act-ico"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M11.979 0C5.678 0 .511 4.86.022 11.037l6.432 2.658a3.387 3.387 0 0 1 1.912-.593c.064 0 .127.003.19.007l2.862-4.146v-.058a4.533 4.533 0 0 1 4.53-4.53 4.533 4.533 0 0 1 4.53 4.53 4.533 4.533 0 0 1-4.53 4.53h-.106l-4.08 2.91c0 .053.003.107.003.161a3.4 3.4 0 0 1-3.4 3.4 3.404 3.404 0 0 1-3.367-2.936L.256 15.21C1.542 20.2 6.218 24 11.979 24 18.627 24 24 18.627 24 11.979 24 5.373 18.627 0 11.979 0z" /></svg></span>
+              <span className="act-t">{t("Sign in with Steam", lang)}</span>
               <span className="act-d">{t("Spire Codex keeps track of your runs and tier lists, all while not tracking you.", lang)}</span>
-              <div className="act-logins">
-                <button onClick={loginSteam} className="act-login act-steam">{t("Steam", lang)}</button>
-              </div>
-            </div>
+            </button>
           )}
           {startTiles.map((c) => {
             const inner = (<><span className="act-ico">{c.icon}</span><span className="act-t">{c.title}</span><span className="act-d">{c.desc}</span></>);

--- a/frontend/app/home-revamp.css
+++ b/frontend/app/home-revamp.css
@@ -192,12 +192,5 @@
 .rvmp .gs-dots { display: flex; justify-content: center; align-items: center; gap: 6px; margin-top: 10px; }
 }
 
-/* sign-in tile in Get started (Steam/Discord login buttons) */
-.rvmp .act-signin { gap: 7px; }
-.rvmp .act-logins { display: flex; gap: 8px; width: 100%; margin-top: auto; padding-top: 8px; }
-.rvmp .act-login { flex: 1; display: inline-flex; align-items: center; justify-content: center; padding: 8px 6px;
-  border: 0; border-radius: 8px; font-family: var(--sans); font-size: 12.5px; font-weight: 600; color: #fff; cursor: pointer; }
-.rvmp .act-steam { background: #1b2838; }
-.rvmp .act-steam:hover { background: #2a475e; }
-.rvmp .act-discord { background: #5865f2; }
-.rvmp .act-discord:hover { background: #4752c4; }
+/* sign-in tile in Get started: a button styled exactly like the link tiles */
+.rvmp .act-signin { appearance: none; width: 100%; text-align: left; font: inherit; color: inherit; cursor: pointer; }


### PR DESCRIPTION
The get-started account tile was a static box with only a small Steam button inside while every other tile is clickable across its whole area; I made the whole tile the Steam sign-in button, matching the siblings, and dropped the hard-coded Steam and Discord button colors.