### PR TITLE
Rebuild the Overwolf uninstall survey around Overwolf's guidelines

### DIFF
--- a/backend/app/routers/uninstall.py
+++ b/backend/app/routers/uninstall.py
@@ -1,26 +1,23 @@
 """Uninstall-feedback endpoint.
 
-The Overwolf companion's manifest points its `uninstall_window` at
-https://spire-codex.com/uninstall, which is a hidden one-off page that
-posts here when the user submits the survey. Output is a single plain
-email to the configured inbox — we intentionally avoid Discord for
-this one (unhappy ex-users complaining in a shared channel feels mean)
-and keep the destination off the public feedback surface.
-
-Transport: Resend's HTTP API. One credential (`RESEND_API_KEY`) covers
-auth, no SMTP plumbing. If the API key is missing the endpoint
-returns 503 "not configured" and the form surfaces the error — silent
-swallowing would lose feedback without leaving a trace.
+The Overwolf companion's manifest points its uninstall_window at a stub
+that opens https://spire-codex.com/uninstall in the browser; that page
+posts here when the user submits the survey. Every submission is stored
+in Mongo (uninstall_feedback) so reasons can be counted, and forwarded
+as one plain email through Resend so nothing is missed. Discord is
+avoided on purpose: unhappy ex-users complaining in a shared channel
+feels mean.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+from datetime import datetime, timezone
 
 import httpx
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from ..dependencies import shared_limiter
 from ..services import rate_limit_config
@@ -31,89 +28,210 @@ router = APIRouter(prefix="/api/uninstall-feedback", tags=["Feedback"])
 limiter = shared_limiter
 
 RESEND_ENDPOINT = "https://api.resend.com/emails"
+WOULD_RETURN = {"yes", "maybe", "no"}
+YES_NO = {"yes", "no"}
 
 
 class UninstallFeedback(BaseModel):
-    """Form payload. Everything is optional except that at least one of
-    `reasons`, `other_reason`, or `comment` must be non-empty — keeps
-    auto-blank submissions out of the inbox."""
+    """Survey payload. The Overwolf-guideline shape is primary_reason +
+    issues + rating + improvement + would_return; the older reasons /
+    other_reason / comment fields stay accepted so a cached page keeps
+    working. At least one substantive answer is required."""
 
+    primary_reason: str | None = None
+    reason_detail: str | None = None
+    saves_reimported: str | None = None
+    issues: list[str] = Field(default_factory=list)
+    rating: int | None = None
+    improvement: str | None = None
+    would_return: str | None = None
+    email: str | None = None
+    app_version: str | None = None
+    lang: str | None = None
     reasons: list[str] = Field(default_factory=list)
     other_reason: str | None = None
     comment: str | None = None
-    email: str | None = None
+
+    @field_validator("rating")
+    @classmethod
+    def _rating_range(cls, v):
+        if v is not None and not 1 <= v <= 10:
+            raise ValueError("rating must be between 1 and 10")
+        return v
+
+    @field_validator("saves_reimported")
+    @classmethod
+    def _saves_known(cls, v):
+        if v is not None and v not in YES_NO:
+            raise ValueError("saves_reimported must be yes or no")
+        return v
+
+    @field_validator("would_return")
+    @classmethod
+    def _would_return_known(cls, v):
+        if v is not None and v not in WOULD_RETURN:
+            raise ValueError("would_return must be yes, maybe, or no")
+        return v
 
 
 def _sanitize(value: str | None, limit: int) -> str:
-    """Trim, drop control chars, cap length. Bodies and emails alike."""
     if not value:
         return ""
     cleaned = "".join(c for c in value if c.isprintable() or c in "\n\r\t")
     return cleaned.strip()[:limit]
 
 
-def _build_message(payload: UninstallFeedback) -> tuple[str, str]:
-    """Return (plain_text, html) bodies of the report."""
-    reasons_clean = [_sanitize(r, 100) for r in payload.reasons if isinstance(r, str)]
-    other = _sanitize(payload.other_reason, 500)
-    comment = _sanitize(payload.comment, 2000)
-    email = _sanitize(payload.email, 200)
+def _clean(payload: UninstallFeedback) -> dict:
+    return {
+        "primary_reason": _sanitize(payload.primary_reason, 200) or None,
+        "reason_detail": _sanitize(payload.reason_detail, 1000) or None,
+        "saves_reimported": payload.saves_reimported,
+        "issues": [_sanitize(i, 200) for i in payload.issues if isinstance(i, str)][
+            :20
+        ],
+        "rating": payload.rating,
+        "improvement": _sanitize(payload.improvement, 2000) or None,
+        "would_return": payload.would_return,
+        "email": _sanitize(payload.email, 200) or None,
+        "app_version": _sanitize(payload.app_version, 40) or None,
+        "lang": _sanitize(payload.lang, 8) or None,
+        "reasons": [_sanitize(r, 100) for r in payload.reasons if isinstance(r, str)][
+            :20
+        ],
+        "other_reason": _sanitize(payload.other_reason, 500) or None,
+        "comment": _sanitize(payload.comment, 2000) or None,
+    }
 
-    text_lines = ["Spire Codex — Uninstall feedback", ""]
-    text_lines.append("Reasons:")
-    if reasons_clean:
-        for r in reasons_clean:
-            text_lines.append(f"  - {r}")
-    else:
-        text_lines.append("  (none selected)")
-    if other:
-        text_lines.extend(["", "Other reason:", other])
-    if comment:
-        text_lines.extend(["", "Comment:", comment])
-    text_lines.extend(["", f"Reply-to: {email or '(not provided)'}"])
-    text_body = "\n".join(text_lines)
 
-    # Minimal HTML — Resend rejects empty html/text combos on some
-    # accounts. The plain version stays the source of truth.
+def _has_substance(clean: dict) -> bool:
+    return bool(
+        clean["primary_reason"]
+        or clean["issues"]
+        or clean["improvement"]
+        or clean["reasons"]
+        or clean["other_reason"]
+        or clean["comment"]
+    )
+
+
+def _build_message(clean: dict) -> tuple[str, str]:
+    lines = ["Spire Codex — Uninstall feedback", ""]
+    if clean["primary_reason"]:
+        lines += ["Primary reason:", f"  {clean['primary_reason']}", ""]
+    if clean["reason_detail"]:
+        lines += ["Reason detail:", clean["reason_detail"], ""]
+    if clean["saves_reimported"]:
+        lines += [f"Read the FAQ and re-imported save: {clean['saves_reimported']}", ""]
+    if clean["issues"]:
+        lines.append("What went wrong:")
+        lines += [f"  - {i}" for i in clean["issues"]]
+        lines.append("")
+    if clean["rating"] is not None:
+        lines += [f"Experience rating: {clean['rating']}/10", ""]
+    if clean["improvement"]:
+        lines += ["One thing to do better:", clean["improvement"], ""]
+    if clean["would_return"]:
+        lines += [f"Would try again: {clean['would_return']}", ""]
+    if clean["reasons"]:
+        lines.append("Reasons (legacy form):")
+        lines += [f"  - {r}" for r in clean["reasons"]]
+        lines.append("")
+    if clean["other_reason"]:
+        lines += ["Other reason:", clean["other_reason"], ""]
+    if clean["comment"]:
+        lines += ["Comment:", clean["comment"], ""]
+    meta = []
+    if clean["app_version"]:
+        meta.append(f"app {clean['app_version']}")
+    if clean["lang"]:
+        meta.append(f"lang {clean['lang']}")
+    if meta:
+        lines += [" · ".join(meta), ""]
+    lines.append(f"Reply-to: {clean['email'] or '(not provided)'}")
+    text_body = "\n".join(lines)
+
     def esc(s: str) -> str:
         return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
-    reason_html = (
-        "".join(f"<li>{esc(r)}</li>" for r in reasons_clean)
-        or "<li><em>(none selected)</em></li>"
-    )
-    html_parts = [
-        "<h2>Spire Codex — Uninstall feedback</h2>",
-        "<h3>Reasons</h3>",
-        f"<ul>{reason_html}</ul>",
-    ]
-    if other:
-        html_parts.append(
-            f"<h3>Other reason</h3><p>{esc(other).replace(chr(10), '<br>')}</p>"
+    html = ["<h2>Spire Codex — Uninstall feedback</h2>"]
+    if clean["primary_reason"]:
+        html.append(
+            f"<p><strong>Primary reason:</strong> {esc(clean['primary_reason'])}</p>"
         )
-    if comment:
-        html_parts.append(
-            f"<h3>Comment</h3><p>{esc(comment).replace(chr(10), '<br>')}</p>"
+    if clean["reason_detail"]:
+        html.append(
+            f"<h3>Reason detail</h3><p>{esc(clean['reason_detail']).replace(chr(10), '<br>')}</p>"
         )
-    html_parts.append(
-        f"<p><strong>Reply-to:</strong> {esc(email) if email else '<em>(not provided)</em>'}</p>"
+    if clean["saves_reimported"]:
+        html.append(
+            f"<p><strong>Read the FAQ and re-imported save:</strong> {esc(clean['saves_reimported'])}</p>"
+        )
+    if clean["issues"]:
+        html.append(
+            "<h3>What went wrong</h3><ul>"
+            + "".join(f"<li>{esc(i)}</li>" for i in clean["issues"])
+            + "</ul>"
+        )
+    if clean["rating"] is not None:
+        html.append(f"<p><strong>Experience rating:</strong> {clean['rating']}/10</p>")
+    if clean["improvement"]:
+        html.append(
+            f"<h3>One thing to do better</h3><p>{esc(clean['improvement']).replace(chr(10), '<br>')}</p>"
+        )
+    if clean["would_return"]:
+        html.append(
+            f"<p><strong>Would try again:</strong> {esc(clean['would_return'])}</p>"
+        )
+    if clean["reasons"]:
+        html.append(
+            "<h3>Reasons (legacy form)</h3><ul>"
+            + "".join(f"<li>{esc(r)}</li>" for r in clean["reasons"])
+            + "</ul>"
+        )
+    if clean["other_reason"]:
+        html.append(
+            f"<h3>Other reason</h3><p>{esc(clean['other_reason']).replace(chr(10), '<br>')}</p>"
+        )
+    if clean["comment"]:
+        html.append(
+            f"<h3>Comment</h3><p>{esc(clean['comment']).replace(chr(10), '<br>')}</p>"
+        )
+    if meta:
+        html.append(f"<p><em>{esc(' · '.join(meta))}</em></p>")
+    html.append(
+        f"<p><strong>Reply-to:</strong> {esc(clean['email']) if clean['email'] else '<em>(not provided)</em>'}</p>"
     )
-    return text_body, "".join(html_parts)
+    return text_body, "".join(html)
+
+
+def _store(clean: dict, request: Request) -> None:
+    """Persist the answers so they can be counted; best effort, never
+    blocks the email."""
+    if not os.environ.get("MONGO_URL", "").strip():
+        return
+    try:
+        from ..services.runs_db_mongo import get_database
+
+        doc = {
+            **clean,
+            "submitted_at": datetime.now(timezone.utc),
+            "user_agent": (request.headers.get("user-agent") or "")[:300],
+        }
+        get_database()["uninstall_feedback"].insert_one(doc)
+    except Exception as e:
+        logger.warning("uninstall feedback not stored: %s", e)
 
 
 async def _send_via_resend(
     text_body: str, html_body: str, reply_to: str | None
 ) -> None:
-    """POST the message to Resend. Raises on any failure."""
     api_key = os.environ.get("RESEND_API_KEY")
     if not api_key:
         raise RuntimeError("RESEND_API_KEY not set")
-
     sender = os.environ.get(
         "UNINSTALL_FORWARD_FROM", "Spire Codex <onboarding@resend.dev>"
     )
     recipient = os.environ.get("UNINSTALL_FORWARD_TO", "feedback@spire-codex.com")
-
     payload: dict = {
         "from": sender,
         "to": [recipient],
@@ -123,7 +241,6 @@ async def _send_via_resend(
     }
     if reply_to:
         payload["reply_to"] = reply_to
-
     async with httpx.AsyncClient(timeout=15) as client:
         resp = await client.post(
             RESEND_ENDPOINT,
@@ -141,29 +258,24 @@ async def _send_via_resend(
     rate_limit_config.endpoint_limit("uninstall.submit_uninstall_feedback", "5/minute")
 )
 async def submit_uninstall_feedback(request: Request, body: UninstallFeedback):
-    # Drop completely-empty submissions — Overwolf can flash the window
-    # past a user and we don't want auto-blank rows piling up.
-    if not (body.reasons or body.other_reason or body.comment):
+    clean = _clean(body)
+    if not _has_substance(clean):
         raise HTTPException(
-            status_code=422, detail="Please select a reason or leave a comment."
+            status_code=422,
+            detail="Please pick a reason or tell us one thing to improve.",
         )
-
-    reply_to = _sanitize(body.email, 200) or None
-    text_body, html_body = _build_message(body)
-
+    _store(clean, request)
+    text_body, html_body = _build_message(clean)
     try:
-        await _send_via_resend(text_body, html_body, reply_to)
+        await _send_via_resend(text_body, html_body, clean["email"])
     except RuntimeError as cfg_err:
-        # Distinguish "no API key" (operator problem → 503) from a
-        # Resend-side rejection (transient or quota → 502).
         msg = str(cfg_err)
         if "not set" in msg:
-            logger.error("uninstall feedback dropped: %s", msg)
+            logger.error("uninstall feedback email dropped: %s", msg)
             raise HTTPException(status_code=503, detail="Feedback not configured.")
         logger.error("uninstall feedback send failed: %s", msg)
         raise HTTPException(status_code=502, detail="Failed to send feedback.")
     except Exception as send_err:
         logger.exception("uninstall feedback send failed: %s", send_err)
         raise HTTPException(status_code=502, detail="Failed to send feedback.")
-
     return {"ok": True}

--- a/backend/tests/test_uninstall_feedback.py
+++ b/backend/tests/test_uninstall_feedback.py
@@ -1,0 +1,130 @@
+"""The uninstall survey accepts the Overwolf-guideline shape and the legacy
+shape, rejects empty and out-of-range answers, stores every submission,
+and still emails it."""
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.routers import uninstall
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def _arm(monkeypatch):
+    sent = []
+    stored = []
+
+    async def fake_send(text, html, reply_to):
+        sent.append((text, html, reply_to))
+
+    monkeypatch.setattr(uninstall, "_send_via_resend", fake_send)
+    monkeypatch.setattr(
+        uninstall, "_store", lambda clean, request: stored.append(clean)
+    )
+    from app.dependencies import shared_limiter
+
+    monkeypatch.setattr(shared_limiter, "enabled", False)
+    return sent, stored
+
+
+def test_guideline_payload_is_stored_and_emailed(monkeypatch):
+    sent, stored = _arm(monkeypatch)
+    r = client.post(
+        "/api/uninstall-feedback",
+        json={
+            "primary_reason": "It hurt my game's performance",
+            "reason_detail": "Stutter every time the overlay opened",
+            "issues": ["FPS drops or stutter", "It crashed or froze"],
+            "rating": 4,
+            "improvement": "Make the overlay lighter",
+            "would_return": "maybe",
+            "email": "me@example.com",
+            "app_version": "1.0.0.13",
+            "lang": "eng",
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert stored[0]["primary_reason"] == "It hurt my game's performance"
+    assert stored[0]["issues"] == ["FPS drops or stutter", "It crashed or froze"]
+    assert stored[0]["rating"] == 4 and stored[0]["would_return"] == "maybe"
+    text, html, reply_to = sent[0]
+    assert "Experience rating: 4/10" in text and "Would try again: maybe" in text
+    assert "Make the overlay lighter" in text and reply_to == "me@example.com"
+    assert "Stutter every time the overlay opened" in text
+    assert stored[0]["reason_detail"] == "Stutter every time the overlay opened"
+    assert "app 1.0.0.13" in text and "<li>It crashed or froze</li>" in html
+
+
+def test_legacy_payload_still_accepted(monkeypatch):
+    sent, stored = _arm(monkeypatch)
+    r = client.post(
+        "/api/uninstall-feedback",
+        json={"reasons": ["I no longer need it"], "comment": "bye"},
+    )
+    assert r.status_code == 200
+    assert "Reasons (legacy form)" in sent[0][0] and "bye" in sent[0][0]
+
+
+def test_empty_and_invalid_submissions_are_rejected(monkeypatch):
+    sent, stored = _arm(monkeypatch)
+    assert client.post("/api/uninstall-feedback", json={}).status_code == 422
+    assert client.post("/api/uninstall-feedback", json={"rating": 7}).status_code == 422
+    assert (
+        client.post("/api/uninstall-feedback", json={"email": "x@y.z"}).status_code
+        == 422
+    )
+    r = client.post(
+        "/api/uninstall-feedback", json={"primary_reason": "x", "rating": 11}
+    )
+    assert r.status_code == 422
+    r = client.post(
+        "/api/uninstall-feedback", json={"primary_reason": "x", "would_return": "later"}
+    )
+    assert r.status_code == 422
+    r = client.post(
+        "/api/uninstall-feedback",
+        json={"primary_reason": "x", "saves_reimported": "kinda"},
+    )
+    assert r.status_code == 422
+    assert not sent and not stored
+
+
+def test_control_characters_and_lengths_are_sanitised(monkeypatch):
+    sent, stored = _arm(monkeypatch)
+    r = client.post(
+        "/api/uninstall-feedback",
+        json={
+            "primary_reason": "ok\x00\x07",
+            "improvement": "x" * 5000,
+            "issues": ["a"] * 40,
+        },
+    )
+    assert r.status_code == 200
+    assert stored[0]["primary_reason"] == "ok"
+    assert len(stored[0]["improvement"]) == 2000 and len(stored[0]["issues"]) == 20
+
+
+def test_missing_resend_key_is_a_503_after_storing(monkeypatch):
+    sent, stored = _arm(monkeypatch)
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+
+    async def real_send(text, html, reply_to):
+        raise RuntimeError("RESEND_API_KEY not set")
+
+    monkeypatch.setattr(uninstall, "_send_via_resend", real_send)
+    r = client.post("/api/uninstall-feedback", json={"primary_reason": "x"})
+    assert r.status_code == 503 and len(stored) == 1
+
+
+def test_missing_saves_answer_is_recorded(monkeypatch):
+    sent, stored = _arm(monkeypatch)
+    r = client.post(
+        "/api/uninstall-feedback",
+        json={
+            "primary_reason": "My saves or runs went missing after installing the mod",
+            "saves_reimported": "no",
+        },
+    )
+    assert r.status_code == 200
+    assert stored[0]["saves_reimported"] == "no"
+    assert "Read the FAQ and re-imported save: no" in sent[0][0]

--- a/frontend/app/[lang]/uninstall/page.tsx
+++ b/frontend/app/[lang]/uninstall/page.tsx
@@ -29,12 +29,6 @@ export default async function LangUninstallFeedbackPage({
   return (
     <main className="min-h-[calc(100vh-6rem)] bg-[var(--bg-primary)] py-10 px-4">
       <div className="max-w-xl mx-auto bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded-xl p-6 md:p-8 shadow-lg">
-        <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-1">
-          Help us improve.
-        </h1>
-        <p className="text-sm text-[var(--text-muted)] mb-6">
-          We&apos;re sorry to see you go. Two minutes of feedback helps shape what we build next.
-        </p>
         <UninstallFormClient />
       </div>
     </main>

--- a/frontend/app/uninstall/UninstallFormClient.tsx
+++ b/frontend/app/uninstall/UninstallFormClient.tsx
@@ -5,55 +5,111 @@ import { useLanguage } from "@/app/contexts/LanguageContext";
 import { t } from "@/lib/ui-translations";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+const SAVE_IMPORTER_URL = "https://steamcommunity.com/sharedfiles/filedetails/?id=3747503308";
+const MOD_FAQ_URL = "https://steamcommunity.com/sharedfiles/filedetails/?id=3747536911";
+const DISCORD_URL = "https://discord.gg/xMsTBeh";
+const SAVE_DIR = "%APPDATA%\\SlayTheSpire2\\steam";
 
-// Each reason is shown as a checkbox. The labels are also the values sent
-// up to the backend, keeps the wire format human-readable when it lands
-// in the email body so no decoding step is needed when reading reports.
-const REASONS = [
-  "I no longer need it",
-  "It was slowing my computer down",
-  "I found a better alternative",
-  "It wasn't working as expected",
-  "It lacked the features I needed",
+const REASON_BUGS = "Technical issues: crashes, bugs, or the app wouldn't open";
+const REASON_FEATURES = "It's missing features I want";
+const REASON_SAVES = "My saves or runs went missing after installing the mod";
+const PRIMARY_REASONS = [
+  "I'm just reinstalling, or I'll reinstall later",
+  REASON_BUGS,
+  "It hurt my game's performance",
+  "It wasn't useful for me",
+  "It was confusing or hard to use",
+  REASON_FEATURES,
+  "I don't play Slay the Spire 2 anymore",
+  "I couldn't get it working",
+  REASON_SAVES,
+];
+
+const FOLLOW_UP: Record<string, string> = {
+  [REASON_BUGS]: "What was bugged?",
+  [REASON_FEATURES]: "What features would make your experience better?",
+};
+
+
+const RETURN_OPTIONS: [string, string][] = [
+  ["yes", "Yes"],
+  ["maybe", "Maybe"],
+  ["no", "No"],
 ];
 
 type Status = "idle" | "submitting" | "success" | "error";
 
+const field =
+  "w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]";
+const choice =
+  "flex items-start gap-2.5 text-sm text-[var(--text-secondary)] cursor-pointer hover:text-[var(--text-primary)]";
+const heading = "block text-sm font-semibold text-[var(--text-primary)] mb-2";
+
+function SavesNotice({ lang }: { lang: string }) {
+  return (
+    <aside className="mb-6 rounded-lg border border-[var(--accent-gold)] bg-[color-mix(in_srgb,var(--accent-gold)_10%,transparent)] p-4">
+      <h2 className="text-sm font-semibold text-[var(--accent-gold)] mb-1.5">
+        {t("Lost your characters, runs, or unlocks?", lang)}
+      </h2>
+      <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
+        {t("Slay the Spire 2 keeps modded and unmodded play in separate save folders, so the first launch with a mod starts you on a fresh profile. Nothing is deleted: your original save is still where it always was, in", lang)}{" "}
+        <code className="text-xs text-[var(--text-primary)] bg-[var(--bg-primary)] px-1 py-0.5 rounded">{SAVE_DIR}</code>.
+      </p>
+      <p className="text-sm text-[var(--text-secondary)] leading-relaxed mt-2">
+        {t("To bring your progress across, use the import save menu under F5 in the mod menu, or use the community save importer and it does the move for you. Back up both folders first, and copy rather than move.", lang)}
+      </p>
+      <div className="flex flex-wrap gap-2 mt-3">
+        <a href={SAVE_IMPORTER_URL} target="_blank" rel="noopener noreferrer" className="rounded-md bg-[var(--accent-gold)] text-[var(--bg-primary)] font-semibold px-3 py-1.5 text-xs hover:opacity-90">
+          {t("Open the save importer", lang)}
+        </a>
+      </div>
+    </aside>
+  );
+}
+
 export default function UninstallFormClient() {
   const { lang } = useLanguage();
-  const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [otherReason, setOtherReason] = useState("");
-  const [comment, setComment] = useState("");
+  const [primary, setPrimary] = useState<string>("");
+  const [reasonDetail, setReasonDetail] = useState("");
+  const [savesReimported, setSavesReimported] = useState<string>("");
+  const [rating, setRating] = useState<number | null>(null);
+  const [improvement, setImprovement] = useState("");
+  const [wouldReturn, setWouldReturn] = useState<string>("");
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<Status>("idle");
-  const [errMessage, setErrMessage] = useState<string>("");
-
-  const toggle = (reason: string) =>
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(reason)) next.delete(reason);
-      else next.add(reason);
-      return next;
-    });
+  const [errMessage, setErrMessage] = useState("");
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setStatus("submitting");
     setErrMessage("");
+    let appVersion: string | null = null;
+    try {
+      const q = new URLSearchParams(window.location.search);
+      appVersion = q.get("version") || q.get("v");
+    } catch {
+      appVersion = null;
+    }
     try {
       const res = await fetch(`${API}/api/uninstall-feedback`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          reasons: Array.from(selected),
-          other_reason: otherReason.trim() || null,
-          comment: comment.trim() || null,
+          primary_reason: primary || null,
+          reason_detail: FOLLOW_UP[primary] ? reasonDetail.trim() || null : null,
+          saves_reimported: primary === REASON_SAVES ? savesReimported || null : null,
+          rating,
+          improvement: improvement.trim() || null,
+          would_return: wouldReturn || null,
           email: email.trim() || null,
+          app_version: appVersion,
+          lang,
         }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        throw new Error(data?.detail || `HTTP ${res.status}`);
+        const detail = data?.detail;
+        throw new Error(typeof detail === "string" ? detail : `HTTP ${res.status}`);
       }
       setStatus("success");
     } catch (err) {
@@ -64,104 +120,182 @@ export default function UninstallFormClient() {
 
   if (status === "success") {
     return (
-      <div className="text-center py-8">
+      <div className="text-center py-6">
         <h2 className="text-xl font-semibold text-[var(--accent-gold)] mb-3">
-          {t("Thanks for using spire-codex.com.", lang)}
+          {t("Thanks for using Spire Codex.", lang)}
         </h2>
-        <p className="text-sm text-[var(--text-secondary)]">
-          {t("We appreciate you trying us out, and we've recorded your feedback.", lang)}
+        <p className="text-sm text-[var(--text-secondary)] mb-5">
+          {t("Your answers go straight into what we fix and build next.", lang)}
         </p>
+        <div className="flex flex-wrap justify-center gap-2">
+          <a href={DISCORD_URL} target="_blank" rel="noopener noreferrer" className="rounded-md border border-[var(--border-subtle)] px-3 py-1.5 text-xs font-semibold text-[var(--text-primary)] hover:border-[var(--accent-gold)]">
+            {t("Join the Discord", lang)}
+          </a>
+          <a href={MOD_FAQ_URL} target="_blank" rel="noopener noreferrer" className="rounded-md border border-[var(--border-subtle)] px-3 py-1.5 text-xs font-semibold text-[var(--text-primary)] hover:border-[var(--accent-gold)]">
+            {t("Read the FAQ", lang)}
+          </a>
+        </div>
       </div>
     );
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-6">
-      <fieldset>
-        <legend className="text-sm font-semibold text-[var(--text-primary)] mb-2">
-          {t("Why did you uninstall our extension? Please select all that apply.", lang)}
-        </legend>
-        <div className="space-y-2">
-          {REASONS.map((reason) => (
-            <label
-              key={reason}
-              className="flex items-start gap-2.5 text-sm text-[var(--text-secondary)] cursor-pointer hover:text-[var(--text-primary)]"
-            >
-              <input
-                type="checkbox"
-                checked={selected.has(reason)}
-                onChange={() => toggle(reason)}
-                className="mt-0.5 accent-[var(--accent-gold)]"
-              />
-              <span>{t(reason, lang)}</span>
-            </label>
-          ))}
-          <label className="flex items-start gap-2.5 text-sm text-[var(--text-secondary)] cursor-pointer hover:text-[var(--text-primary)]">
-            <input
-              type="checkbox"
-              checked={selected.has("Other")}
-              onChange={() => toggle("Other")}
-              className="mt-0.5 accent-[var(--accent-gold)]"
-            />
-            <span>{t("Other", lang)}</span>
+    <>
+      <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-1">{t("Help us improve.", lang)}</h1>
+      <p className="text-sm text-[var(--text-muted)] mb-5">
+        {t("Sorry to see you go. Thirty seconds of answers shape what we fix next. If you need support we are always available via", lang)}{" "}
+        <a href={DISCORD_URL} target="_blank" rel="noopener noreferrer" className="text-[var(--accent-gold)] hover:underline">Discord</a>.
+      </p>
+      <SavesNotice lang={lang} />
+      <form onSubmit={onSubmit} className="space-y-6">
+        <fieldset>
+          <legend className={heading}>{t("What's the main reason you uninstalled?", lang)}</legend>
+          <div className="space-y-1.5">
+            {PRIMARY_REASONS.map((reason) => (
+              <div key={reason}>
+                <label className={choice}>
+                  <input
+                    type="radio"
+                    name="primary_reason"
+                    value={reason}
+                    checked={primary === reason}
+                    onChange={() => setPrimary(reason)}
+                    className="mt-0.5 accent-[var(--accent-gold)]"
+                  />
+                  <span>{t(reason, lang)}</span>
+                </label>
+                {primary === reason && reason === REASON_SAVES && (
+                  <div className="mt-2 pl-6">
+                    <p className="text-sm text-[var(--text-primary)] mb-1.5">
+                      {t("Did you read the FAQ and re-import your save?", lang)}
+                    </p>
+                    <div className="flex gap-4 mb-1.5">
+                      {(["yes", "no"] as const).map((value) => (
+                        <label key={value} className={choice}>
+                          <input
+                            type="radio"
+                            name="saves_reimported"
+                            value={value}
+                            checked={savesReimported === value}
+                            onChange={() => setSavesReimported(value)}
+                            className="mt-0.5 accent-[var(--accent-gold)]"
+                          />
+                          <span>{t(value === "yes" ? "Yes" : "No", lang)}</span>
+                        </label>
+                      ))}
+                    </div>
+                    {savesReimported === "no" && (
+                      <p className="text-xs text-[var(--text-muted)]">
+                        {t("Your save is still there. The notice above shows where it lives and how to bring it across.", lang)}
+                      </p>
+                    )}
+                  </div>
+                )}
+                {primary === reason && FOLLOW_UP[reason] && (
+                  <div className="mt-1.5 pl-6">
+                    <textarea
+                      value={reasonDetail}
+                      onChange={(e) => setReasonDetail(e.target.value)}
+                      rows={2}
+                      maxLength={1000}
+                      placeholder={t(FOLLOW_UP[reason], lang)}
+                      aria-label={t(FOLLOW_UP[reason], lang)}
+                      className={field}
+                    />
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend className={heading}>{t("How was your overall experience?", lang)}</legend>
+          <div className="flex gap-1.5" role="radiogroup" aria-label={t("How was your overall experience?", lang)}>
+            {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
+              <button
+                key={n}
+                type="button"
+                role="radio"
+                aria-checked={rating === n}
+                onClick={() => setRating(rating === n ? null : n)}
+                className={`flex-1 min-w-0 max-w-12 h-9 rounded-md border text-sm font-semibold transition-colors ${
+                  rating === n
+                    ? "border-[var(--accent-gold)] bg-[var(--accent-gold)] text-[var(--bg-primary)]"
+                    : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)] hover:text-[var(--text-primary)]"
+                }`}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-[var(--text-muted)] mt-1.5">{t("1 is awful, 10 is great.", lang)}</p>
+        </fieldset>
+
+        <div>
+          <label htmlFor="uninstall-improvement" className={heading}>
+            {t("What's one thing we could do better?", lang)}
           </label>
-          {selected.has("Other") && (
-            <textarea
-              value={otherReason}
-              onChange={(e) => setOtherReason(e.target.value)}
-              rows={2}
-              maxLength={500}
-              placeholder={t("Tell us more...", lang)}
-              className="w-full mt-1 rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]"
-            />
-          )}
+          <textarea
+            id="uninstall-improvement"
+            value={improvement}
+            onChange={(e) => setImprovement(e.target.value)}
+            rows={3}
+            maxLength={2000}
+            placeholder={t("Optional, but this is the answer we read most closely.", lang)}
+            className={field}
+          />
         </div>
-      </fieldset>
 
-      <div>
-        <label htmlFor="uninstall-comment" className="block text-sm font-semibold text-[var(--text-primary)] mb-2">
-          {t("Leave a comment", lang)}
-        </label>
-        <textarea
-          id="uninstall-comment"
-          value={comment}
-          onChange={(e) => setComment(e.target.value)}
-          rows={4}
-          maxLength={2000}
-          placeholder={t("Any feedback you want to share...", lang)}
-          className="w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]"
-        />
-      </div>
+        <fieldset>
+          <legend className={heading}>{t("Would you try it again if that were fixed?", lang)}</legend>
+          <div className="flex gap-4">
+            {RETURN_OPTIONS.map(([value, label]) => (
+              <label key={value} className={choice}>
+                <input
+                  type="radio"
+                  name="would_return"
+                  value={value}
+                  checked={wouldReturn === value}
+                  onChange={() => setWouldReturn(value)}
+                  className="mt-0.5 accent-[var(--accent-gold)]"
+                />
+                <span>{t(label, lang)}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
 
-      <div>
-        <label htmlFor="uninstall-email" className="block text-sm font-semibold text-[var(--text-primary)] mb-1">
-          {t("Can we reach out to you for further questions?", lang)}
-        </label>
-        <p className="text-xs text-[var(--text-muted)] mb-2">{t("Optional. We won't add you to anything.", lang)}</p>
-        <input
-          id="uninstall-email"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          maxLength={200}
-          placeholder="you@example.com"
-          className="w-full rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)]"
-        />
-      </div>
-
-      {status === "error" && (
-        <div className="text-sm text-red-400 bg-red-950/30 border border-red-900/50 rounded px-3 py-2">
-          {t("Couldn't submit.", lang)} {errMessage}
+        <div>
+          <label htmlFor="uninstall-email" className={heading}>
+            {t("Can we email you if we have a question?", lang)}
+          </label>
+          <p className="text-xs text-[var(--text-muted)] mb-2">{t("Optional. We won't add you to anything.", lang)}</p>
+          <input
+            id="uninstall-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            maxLength={200}
+            placeholder="you@example.com"
+            className={field}
+          />
         </div>
-      )}
 
-      <button
-        type="submit"
-        disabled={status === "submitting"}
-        className="w-full rounded-md bg-[var(--accent-gold)] text-[var(--bg-primary)] font-semibold px-4 py-2.5 text-sm hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
-      >
-        {status === "submitting" ? t("Sending...", lang) : t("Send feedback", lang)}
-      </button>
-    </form>
+        {status === "error" && (
+          <div className="text-sm text-[var(--accent-red)] border border-[var(--accent-red)] rounded px-3 py-2">
+            {t("Couldn't submit.", lang)} {errMessage}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={status === "submitting" || (!primary && !improvement.trim())}
+          className="w-full rounded-md bg-[var(--accent-gold)] text-[var(--bg-primary)] font-semibold px-4 py-2.5 text-sm hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+        >
+          {status === "submitting" ? t("Sending...", lang) : t("Send feedback", lang)}
+        </button>
+      </form>
+    </>
   );
 }

--- a/frontend/app/uninstall/page.tsx
+++ b/frontend/app/uninstall/page.tsx
@@ -24,12 +24,6 @@ export default function UninstallFeedbackPage() {
   return (
     <main className="min-h-[calc(100vh-6rem)] bg-[var(--bg-primary)] py-10 px-4">
       <div className="max-w-xl mx-auto bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded-xl p-6 md:p-8 shadow-lg">
-        <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-1">
-          Help us improve.
-        </h1>
-        <p className="text-sm text-[var(--text-muted)] mb-6">
-          We&apos;re sorry to see you go. Two minutes of feedback helps shape what we build next.
-        </p>
         <UninstallFormClient />
       </div>
     </main>


### PR DESCRIPTION
The uninstall survey now opens with a notice about saves moving into the modded folder and how to restore them, asks Overwolf's recommended question set adapted to the companion (one primary reason with follow-up prompts, a 1 to 10 rating, one open question, would-you-return, optional email), and I store every submission in Mongo alongside the email so the reasons can actually be counted.