### PR TITLE
Answer replay storage failures with a 503 instead of a bare 500

### DIFF
--- a/backend/app/services/replays_db.py
+++ b/backend/app/services/replays_db.py
@@ -15,12 +15,15 @@ exploder's publication identity (run_hash + sha256) stable.
 import hashlib
 import json
 import os
+import logging
 import zlib
 from datetime import datetime, timezone
 
 from bson import Binary
 from pymongo import ASCENDING, DESCENDING
-from pymongo.errors import DuplicateKeyError
+from pymongo.errors import DuplicateKeyError, PyMongoError
+
+logger = logging.getLogger(__name__)
 
 REPLAY_DB_NAME = os.environ.get("REPLAY_DB_NAME", "spire_replays")
 MAX_GZ_BYTES = int(os.environ.get("REPLAY_MAX_GZ_BYTES", "") or 2 * 1024 * 1024)
@@ -223,7 +226,11 @@ def accept_upload(run_hash: str, gz: bytes, user: dict) -> dict:
     from .runs_db_mongo import get_run_blob
 
     player_idx = check_header(info["header"], run_doc, get_run_blob(run_hash), run_hash)
-    return store_replay(run_hash, gz, info, run_doc, user, player_idx)
+    try:
+        return store_replay(run_hash, gz, info, run_doc, user, player_idx)
+    except PyMongoError as e:
+        logger.error("replay storage failed for %s: %s", run_hash, str(e)[:300])
+        raise ReplayRejected(503, "replay storage is unavailable", "storage")
 
 
 def store_replay(

--- a/backend/tests/test_replays_api.py
+++ b/backend/tests/test_replays_api.py
@@ -402,3 +402,17 @@ def test_if_none_match_parses_entity_tags_not_commas(env):
     assert _etag_matches("*", f'"{sha}"')
     assert not _etag_matches(f'w/"{sha}"', f'"{sha}"')
     assert not _etag_matches(f'"{sha}" garbage', f'"{sha}"')
+
+
+def test_storage_failure_is_a_503_not_a_500(env, monkeypatch):
+    from pymongo.errors import OperationFailure
+
+    class Unauthorized:
+        def insert_one(self, doc):
+            raise OperationFailure("not authorized on spire_replays", 13)
+
+    monkeypatch.setattr(replays_db, "_coll", lambda: Unauthorized())
+    r = _post(_gz())
+    assert r.status_code == 503
+    assert r.json()["detail"]["code"] == "storage"
+    assert "has_replay" not in env[0].docs[RUN_HASH]


### PR DESCRIPTION
When Mongo refuses the replay write (the first prod upload hit a not-authorized error on the new spire_replays database), the upload now returns a 503 with a storage code and logs the cause instead of a bare Internal Server Error.