### PR TITLE
Harden tier-list pages against filter-cube crawls

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,5 +1,7 @@
 """Shared FastAPI dependencies."""
 
+import ipaddress
+
 from fastapi import Query, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
@@ -29,6 +31,40 @@ def client_ip(request: Request) -> str:
     return get_remote_address(request)
 
 
+_PROXY_HEADERS = ("x-real-ip", "cf-connecting-ip", "x-forwarded-for")
+
+
+def is_internal_request(request: Request) -> bool:
+    """True for traffic that reached uvicorn without passing through nginx:
+    the frontend's server-side fetches, ingest jobs, and other containers on
+    the private network. nginx always sets X-Real-IP and the backend port is
+    not published, so no proxy header plus a private peer address can only
+    be one of those."""
+    h = request.headers
+    if any(h.get(name) for name in _PROXY_HEADERS):
+        return False
+    host = request.client.host if request.client else None
+    if not host:
+        return False
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return addr.is_private or addr.is_loopback
+
+
+def limiter_key(request: Request) -> str:
+    """key_func for the shared per-IP limiter: the visitor IP, or an
+    ``internal|<peer>`` bucket for in-network callers so a crawl of the
+    site can't exhaust the frontend container's per-endpoint caps for every
+    page render at once."""
+    from .services.rate_limit_config import INTERNAL_BUCKET_PREFIX
+
+    if is_internal_request(request):
+        return f"{INTERNAL_BUCKET_PREFIX}{get_remote_address(request)}"
+    return client_ip(request)
+
+
 def _make_shared_limiter() -> Limiter:
     # Imported lazily: rate_limit_config itself imports client_ip from this
     # module inside a function, so a top-level import here would be the only
@@ -40,7 +76,7 @@ def _make_shared_limiter() -> Limiter:
     # path its own bucket, so caps on parameterized routes like
     # /shared/{run_hash} were per-hash and never actually bit.
     return Limiter(
-        key_func=client_ip,
+        key_func=limiter_key,
         key_style="endpoint",
         **rate_limit_config.storage_kwargs(),
     )

--- a/backend/app/services/rate_limit_config.py
+++ b/backend/app/services/rate_limit_config.py
@@ -27,6 +27,14 @@ With REDIS_URL set (prod always sets it, the cache lives there) the counters
 live in Redis via ``storage_kwargs`` and are shared across all workers, so a
 cap means exactly what it says. Unset, or with Redis down, slowapi falls back
 to per-worker in-memory counters (~workers x the cap) — the pre-Redis behavior.
+
+Internal callers (the frontend container's server-side fetches, ingest jobs:
+anything that reaches uvicorn without nginx's proxy headers, see
+``dependencies.is_internal_request``) bucket as ``internal|<peer>`` and get
+``INTERNAL_RATE_LIMIT`` (default 6000/minute) on every route, including the
+per-endpoint caps. Before this every page render shared one browse bucket keyed
+on the frontend's bridge IP, so a scraper walking the tier-list filter cube
+429'd the scores fetch for every visitor's render at once.
 """
 
 import logging
@@ -50,6 +58,9 @@ _DEFAULT_TIERS = {
 # Effectively unlimited: what caps become when an operator toggles limiting off
 # (per-endpoint limits still apply).
 _DISABLED_LIMIT = "1000000/minute"
+INTERNAL_BUCKET_PREFIX = "internal|"
+INTERNAL_TIER = "internal"
+_INTERNAL_LIMIT = os.environ.get("INTERNAL_RATE_LIMIT", "").strip() or "6000/minute"
 _CACHE_TTL_SECONDS = 15.0
 _MAX_OVERRIDES = 50
 # Paths an override may never clamp (so an aggressive override can't lock the
@@ -164,9 +175,12 @@ def rate_limit_key(request) -> str:
         if info:
             bucket = f"{info['tier']}|k:{info['key_id']}"
     if bucket is None:
-        from ..dependencies import client_ip
+        from ..dependencies import client_ip, is_internal_request
 
-        bucket = f"browse|{client_ip(request)}"
+        if is_internal_request(request):
+            bucket = f"{INTERNAL_BUCKET_PREFIX}{client_ip(request)}"
+        else:
+            bucket = f"browse|{client_ip(request)}"
     try:
         request.state._rl_bucket = bucket
     except Exception:
@@ -194,6 +208,8 @@ def prepare_request(request) -> None:
 
 
 def _limit_for_tier(tier: str, cfg: dict) -> str:
+    if tier == INTERNAL_TIER:
+        return _INTERNAL_LIMIT
     if tier == "browse" or tier not in _DEFAULT_TIERS:
         return cfg.get("default_limit") or _DEFAULT_LIMIT
     tiers = cfg.get("tiers") or _DEFAULT_TIERS
@@ -229,10 +245,13 @@ def tier_limit_value() -> str:
     cfg = get_config()
     if not cfg.get("enabled", True):
         return _DISABLED_LIMIT
+    tier = _current_tier.get() or "browse"
+    if tier == INTERNAL_TIER:
+        return _INTERNAL_LIMIT
     override = _match_override(_current_path.get(), cfg.get("overrides") or [])
     if override:
         return override
-    return _limit_for_tier(_current_tier.get() or "browse", cfg)
+    return _limit_for_tier(tier, cfg)
 
 
 # Every endpoint-limit knob registered via endpoint_limit(), name -> hardcoded
@@ -244,17 +263,22 @@ _ENDPOINT_DEFAULTS: dict[str, str] = {}
 def endpoint_limit(name: str, default: str):
     """Admin-tunable replacement for a hardcoded ``@limiter.limit("...")``.
 
-    Returns a no-arg limit callable (same slowapi constraint as
-    tier_limit_value) that reads ``endpoint_limits[name]`` from the config doc
-    and falls back to ``default``. These caps deliberately ignore the global
-    ``enabled`` kill switch, matching the old behavior where per-endpoint
-    limits survived turning blanket limiting off; to effectively disable one,
-    set it to something huge in the dashboard."""
+    Returns a limit callable that reads ``endpoint_limits[name]`` from the
+    config doc and falls back to ``default``. It takes the optional ``key``
+    slowapi passes to decorator limits (the bucket from the limiter's
+    key_func) so internal callers get the internal cap instead; it must stay
+    callable with no arguments for the same reason as tier_limit_value. These
+    caps deliberately ignore the global ``enabled`` kill switch, matching the
+    old behavior where per-endpoint limits survived turning blanket limiting
+    off; to effectively disable one, set it to something huge in the
+    dashboard."""
     if name in _ENDPOINT_DEFAULTS:
         raise ValueError(f"duplicate endpoint limit name '{name}'")
     _ENDPOINT_DEFAULTS[name] = _validate_limit(default, name)
 
-    def _value() -> str:
+    def _value(key: str = "") -> str:
+        if key.startswith(INTERNAL_BUCKET_PREFIX):
+            return _INTERNAL_LIMIT
         cfg = get_config()
         return (cfg.get("endpoint_limits") or {}).get(name) or default
 

--- a/backend/app/services/rate_limit_config.py
+++ b/backend/app/services/rate_limit_config.py
@@ -58,9 +58,8 @@ _DEFAULT_TIERS = {
 # Effectively unlimited: what caps become when an operator toggles limiting off
 # (per-endpoint limits still apply).
 _DISABLED_LIMIT = "1000000/minute"
-INTERNAL_BUCKET_PREFIX = "internal|"
 INTERNAL_TIER = "internal"
-_INTERNAL_LIMIT = os.environ.get("INTERNAL_RATE_LIMIT", "").strip() or "6000/minute"
+INTERNAL_BUCKET_PREFIX = f"{INTERNAL_TIER}|"
 _CACHE_TTL_SECONDS = 15.0
 _MAX_OVERRIDES = 50
 # Paths an override may never clamp (so an aggressive override can't lock the
@@ -245,13 +244,10 @@ def tier_limit_value() -> str:
     cfg = get_config()
     if not cfg.get("enabled", True):
         return _DISABLED_LIMIT
-    tier = _current_tier.get() or "browse"
-    if tier == INTERNAL_TIER:
-        return _INTERNAL_LIMIT
     override = _match_override(_current_path.get(), cfg.get("overrides") or [])
     if override:
         return override
-    return _limit_for_tier(tier, cfg)
+    return _limit_for_tier(_current_tier.get() or "browse", cfg)
 
 
 # Every endpoint-limit knob registered via endpoint_limit(), name -> hardcoded
@@ -277,9 +273,12 @@ def endpoint_limit(name: str, default: str):
     _ENDPOINT_DEFAULTS[name] = _validate_limit(default, name)
 
     def _value(key: str = "") -> str:
+        cfg = get_config()
+        override = _match_override(_current_path.get(), cfg.get("overrides") or [])
+        if override:
+            return override
         if key.startswith(INTERNAL_BUCKET_PREFIX):
             return _INTERNAL_LIMIT
-        cfg = get_config()
         return (cfg.get("endpoint_limits") or {}).get(name) or default
 
     _value.__name__ = f"limit_{name.replace('.', '_')}"
@@ -302,6 +301,15 @@ def _validate_limit(value: str, field: str) -> str:
             f"'{value}' is not a valid {field} limit (try e.g. 300/minute)"
         ) from exc
     return candidate
+
+
+# Validated at import so a typo in the env fails the process at startup, not
+# on the first rate-limited request. Path overrides from the admin page still
+# clamp internal traffic: an emergency clamp has to clamp everyone.
+_INTERNAL_LIMIT = _validate_limit(
+    os.environ.get("INTERNAL_RATE_LIMIT", "").strip() or "6000/minute",
+    "INTERNAL_RATE_LIMIT",
+)
 
 
 def set_config(

--- a/backend/tests/test_rate_limit_internal.py
+++ b/backend/tests/test_rate_limit_internal.py
@@ -1,0 +1,89 @@
+"""In-network callers (the frontend's server-side fetches, ingest jobs) get
+their own generous rate-limit bucket instead of sharing one browse bucket
+keyed on the frontend container's bridge IP."""
+
+from starlette.requests import Request
+
+from app import dependencies
+from app.services import rate_limit_config
+
+
+def _request(
+    host: str, headers: dict | None = None, path: str = "/api/runs/scores/relics"
+) -> Request:
+    raw = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "path": path,
+            "query_string": b"",
+            "headers": raw,
+            "client": (host, 1234),
+        }
+    )
+
+
+def test_container_peer_without_proxy_headers_is_internal():
+    assert dependencies.limiter_key(_request("172.18.0.5")) == "internal|172.18.0.5"
+    assert dependencies.limiter_key(_request("10.120.0.3")) == "internal|10.120.0.3"
+    assert dependencies.limiter_key(_request("127.0.0.1")) == "internal|127.0.0.1"
+
+
+def test_proxied_visitor_keeps_its_ip():
+    req = _request("172.18.0.6", {"X-Real-IP": "203.0.113.9"})
+    assert dependencies.limiter_key(req) == "203.0.113.9"
+    req = _request("172.18.0.6", {"X-Forwarded-For": "203.0.113.9, 172.18.0.6"})
+    assert dependencies.limiter_key(req) == "203.0.113.9"
+
+
+def test_public_or_unparseable_peer_is_not_internal():
+    assert dependencies.limiter_key(_request("93.184.216.34")) == "93.184.216.34"
+    assert dependencies.limiter_key(_request("testclient")) == "testclient"
+
+
+def test_shared_limiter_uses_internal_aware_key():
+    assert dependencies.shared_limiter._key_func is dependencies.limiter_key
+
+
+def test_default_limit_for_internal_bucket():
+    rate_limit_config.prepare_request(_request("172.18.0.5"))
+    assert rate_limit_config.tier_limit_value() == rate_limit_config._INTERNAL_LIMIT
+
+    rate_limit_config.prepare_request(
+        _request("172.18.0.6", {"X-Real-IP": "203.0.113.9"})
+    )
+    assert (
+        rate_limit_config.rate_limit_key(
+            _request("172.18.0.6", {"X-Real-IP": "203.0.113.9"})
+        )
+        == "browse|203.0.113.9"
+    )
+    assert rate_limit_config.tier_limit_value() == rate_limit_config._DEFAULT_LIMIT
+
+
+def test_internal_bucket_skips_path_overrides(monkeypatch):
+    cfg = rate_limit_config._fallback()
+    cfg["overrides"] = [{"path": "/api/runs", "limit": "5/minute"}]
+    monkeypatch.setattr(rate_limit_config, "get_config", lambda: cfg)
+
+    rate_limit_config.prepare_request(_request("172.18.0.5"))
+    assert rate_limit_config.tier_limit_value() == rate_limit_config._INTERNAL_LIMIT
+
+    rate_limit_config.prepare_request(
+        _request("172.18.0.6", {"X-Real-IP": "203.0.113.9"})
+    )
+    assert rate_limit_config.tier_limit_value() == "5/minute"
+
+
+def test_endpoint_limit_honours_internal_bucket():
+    name = "test.internal_probe"
+    limit = rate_limit_config.endpoint_limit(name, "60/minute")
+    try:
+        assert limit("internal|172.18.0.5") == rate_limit_config._INTERNAL_LIMIT
+        assert limit("203.0.113.9") == "60/minute"
+        assert limit() == "60/minute"
+    finally:
+        rate_limit_config._ENDPOINT_DEFAULTS.pop(name, None)

--- a/backend/tests/test_rate_limit_internal.py
+++ b/backend/tests/test_rate_limit_internal.py
@@ -64,12 +64,20 @@ def test_default_limit_for_internal_bucket():
     assert rate_limit_config.tier_limit_value() == rate_limit_config._DEFAULT_LIMIT
 
 
-def test_internal_bucket_skips_path_overrides(monkeypatch):
+def test_path_overrides_clamp_internal_traffic_too(monkeypatch):
     cfg = rate_limit_config._fallback()
     cfg["overrides"] = [{"path": "/api/runs", "limit": "5/minute"}]
     monkeypatch.setattr(rate_limit_config, "get_config", lambda: cfg)
 
     rate_limit_config.prepare_request(_request("172.18.0.5"))
+    assert rate_limit_config.tier_limit_value() == "5/minute"
+    limit = rate_limit_config.endpoint_limit("test.override_probe", "60/minute")
+    try:
+        assert limit("internal|172.18.0.5") == "5/minute"
+    finally:
+        rate_limit_config._ENDPOINT_DEFAULTS.pop("test.override_probe", None)
+
+    rate_limit_config.prepare_request(_request("172.18.0.5", path="/api/cards"))
     assert rate_limit_config.tier_limit_value() == rate_limit_config._INTERNAL_LIMIT
 
     rate_limit_config.prepare_request(

--- a/backend/tests/test_rate_limit_internal_integration.py
+++ b/backend/tests/test_rate_limit_internal_integration.py
@@ -1,0 +1,78 @@
+"""The internal bucket through real slowapi: a decorated route with a small
+per-endpoint cap lets an in-network peer through while a proxied visitor
+still hits 429 at the cap. Peers are set by a tiny ASGI wrapper so the test
+client can play every role; each test uses its own address because the
+shared limiter's counters live for the process."""
+
+import importlib
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import PlainTextResponse
+from fastapi.testclient import TestClient
+from slowapi.errors import RateLimitExceeded
+
+from app.dependencies import shared_limiter
+from app.services import rate_limit_config
+
+_PROBE_LIMIT = rate_limit_config.endpoint_limit("test.slowapi_probe", "2/minute")
+
+
+def _build():
+    app = FastAPI()
+    app.state.limiter = shared_limiter
+
+    @app.exception_handler(RateLimitExceeded)
+    async def _too_many(request: Request, exc: RateLimitExceeded):
+        return PlainTextResponse("slow down", status_code=429)
+
+    @app.get("/probe")
+    @shared_limiter.limit(_PROBE_LIMIT)
+    def probe(request: Request):
+        return {"ok": True}
+
+    async def with_peer(scope, receive, send):
+        if scope["type"] == "http":
+            headers = dict(scope.get("headers") or [])
+            peer = headers.get(b"x-test-peer", b"").decode() or "8.8.8.8"
+            scope = {**scope, "client": (peer, 1234)}
+        await app(scope, receive, send)
+
+    return TestClient(with_peer, raise_server_exceptions=True)
+
+
+@pytest.fixture(scope="module")
+def client():
+    return _build()
+
+
+def test_slowapi_applies_internal_endpoint_limit_to_private_peer(client):
+    statuses = [
+        client.get("/probe", headers={"x-test-peer": "172.18.0.5"}).status_code
+        for _ in range(8)
+    ]
+    assert statuses == [200] * 8
+
+
+def test_slowapi_keeps_the_public_cap_for_a_proxied_visitor(client):
+    headers = {"x-test-peer": "172.18.0.6", "x-real-ip": "8.8.4.4"}
+    statuses = [client.get("/probe", headers=headers).status_code for _ in range(4)]
+    assert statuses == [200, 200, 429, 429]
+
+
+def test_slowapi_keeps_the_public_cap_for_a_public_peer(client):
+    statuses = [
+        client.get("/probe", headers={"x-test-peer": "1.1.1.1"}).status_code
+        for _ in range(4)
+    ]
+    assert statuses == [200, 200, 429, 429]
+
+
+def test_invalid_internal_rate_limit_fails_fast(monkeypatch):
+    monkeypatch.setenv("INTERNAL_RATE_LIMIT", "lots")
+    try:
+        with pytest.raises(ValueError, match="INTERNAL_RATE_LIMIT"):
+            importlib.reload(rate_limit_config)
+    finally:
+        monkeypatch.delenv("INTERNAL_RATE_LIMIT")
+        importlib.reload(rate_limit_config)

--- a/frontend/app/components/BracketFilter.tsx
+++ b/frontend/app/components/BracketFilter.tsx
@@ -16,9 +16,12 @@ import { imageUrl } from "@/lib/image-url";
 /**
  * Bracket pill rows (All / Asc 10 / win-rate tiers, plus player count) for
  * tier-list and other run-derived pages. Server component: each bracket is its
- * own indexable URL. `extraParams` carries the page's other filters
- * (color/pool/sort/act) so switching bracket preserves them; "all" omits the
- * param to keep the canonical URL clean.
+ * own URL, but the pills are rel="nofollow" and the pages canonicalize to
+ * the unfiltered path: the player x skill x mode x character x version cube
+ * is thousands of URLs per page, each a full server render, and a crawler
+ * walking it took the frontend down (2026-09-06). `extraParams` carries the
+ * page's other filters (color/pool/sort/act) so switching bracket preserves
+ * them; "all" omits the param to keep the canonical URL clean.
  *
  * `composite`: when the page's data source materializes player x skill
  * composites (the entity cache behind the tier list / metrics), the two rows
@@ -68,6 +71,7 @@ export default function BracketFilter({
     const renderPill = (b: ContentBracket) => (
       <Link
         prefetch={false}
+        rel="nofollow"
         key={b.key}
         href={hrefFor(b.key === "all" ? version || "all" : version ? `${b.key}:${version}` : b.key)}
         className={pillCls(base === b.key || (b.key === "all" && !base))}
@@ -89,6 +93,7 @@ export default function BracketFilter({
         <span className="w-14 text-xs text-[var(--text-muted)]">Mode</span>
         <Link
           prefetch={false}
+          rel="nofollow"
           href={hrefFor(
             base && !MODE_BRACKETS.some((m) => m.key === base)
               ? version
@@ -103,6 +108,7 @@ export default function BracketFilter({
         {MODE_BRACKETS.map((m) => (
           <Link
             prefetch={false}
+            rel="nofollow"
             key={m.key}
             href={hrefFor(version ? `${m.key}:${version}` : m.key)}
             className={pillCls(base === m.key)}
@@ -135,6 +141,7 @@ export default function BracketFilter({
           return (
             <Link
               prefetch={false}
+              rel="nofollow"
               key={b.key}
               href={hrefFor(combineBracket(player, targetSkill, version, modeComposes ? mode : "", modeComposes ? character : ""))}
               className={pillCls(skill === targetSkill)}
@@ -149,6 +156,7 @@ export default function BracketFilter({
         {playerOpts.map((b) => (
           <Link
             prefetch={false}
+            rel="nofollow"
             key={b.key || "all"}
             href={hrefFor(combineBracket(b.key, skill, version, modeComposes ? mode : "", modeComposes ? character : ""))}
             className={pillCls(player === b.key)}
@@ -165,6 +173,7 @@ export default function BracketFilter({
                 keeps the player + skill selection and vice versa. */}
             <Link
               prefetch={false}
+              rel="nofollow"
               href={hrefFor(combineBracket(player, skill, version, "", character))}
               className={pillCls(!mode)}
             >
@@ -173,6 +182,7 @@ export default function BracketFilter({
             {MODE_BRACKETS.map((m) => (
               <Link
                 prefetch={false}
+                rel="nofollow"
                 key={m.key}
                 href={hrefFor(combineBracket(player, skill, version, m.key, character))}
                 className={pillCls(mode === m.key)}
@@ -185,6 +195,7 @@ export default function BracketFilter({
           <>
             <Link
               prefetch={false}
+              rel="nofollow"
               href={hrefFor(
                 base && !MODE_BRACKETS.some((m) => m.key === base)
                   ? version
@@ -199,6 +210,7 @@ export default function BracketFilter({
             {MODE_BRACKETS.map((m) => (
               <Link
                 prefetch={false}
+                rel="nofollow"
                 key={m.key}
                 href={hrefFor(version ? `${m.key}:${version}` : m.key)}
                 className={pillCls(base === m.key)}
@@ -214,6 +226,7 @@ export default function BracketFilter({
           <span className="w-14 text-xs text-[var(--text-muted)]">Character</span>
           <Link
             prefetch={false}
+            rel="nofollow"
             href={hrefFor(combineBracket(player, skill, version, mode))}
             className={pillCls(!character)}
           >
@@ -222,6 +235,7 @@ export default function BracketFilter({
           {CHARACTER_BRACKETS.map((c) => (
             <Link
               prefetch={false}
+              rel="nofollow"
               key={c.key}
               href={hrefFor(combineBracket(player, skill, version, mode, c.key))}
               className={`${pillCls(character === c.key)} inline-flex items-center gap-1.5`}

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -21,6 +21,15 @@ export default function robots(): MetadataRoute.Robots {
           "/api/",       // backend JSON + download endpoints
           "/static/",    // static asset trees (CDN-served)
           "/uninstall",  // Overwolf post-uninstall survey, entered only by the OW client
+          // Tier-list filter variants canonicalize to the unfiltered page and
+          // each one is a full server render; the bracket cube alone is
+          // thousands of URLs per list. Keep crawlers on the canonical pages.
+          "/tier-list/*bracket=",
+          "/tier-list/*rarity=",
+          "/tier-list/*sort=",
+          "/*/tier-list/*bracket=",
+          "/*/tier-list/*rarity=",
+          "/*/tier-list/*sort=",
         ],
       },
     ],

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -24,12 +24,12 @@ export default function robots(): MetadataRoute.Robots {
           // Tier-list filter variants canonicalize to the unfiltered page and
           // each one is a full server render; the bracket cube alone is
           // thousands of URLs per list. Keep crawlers on the canonical pages.
-          "/tier-list/*bracket=",
-          "/tier-list/*rarity=",
-          "/tier-list/*sort=",
-          "/*/tier-list/*bracket=",
-          "/*/tier-list/*rarity=",
-          "/*/tier-list/*sort=",
+          "/tier-list*bracket=",
+          "/tier-list*rarity=",
+          "/tier-list*sort=",
+          "/*/tier-list*bracket=",
+          "/*/tier-list*rarity=",
+          "/*/tier-list*sort=",
         ],
       },
     ],

--- a/frontend/app/tier-list/cards/page.tsx
+++ b/frontend/app/tier-list/cards/page.tsx
@@ -257,6 +257,7 @@ export default async function CardsTierListPage({ searchParams }: PageProps) {
           return (
             <Link
               key={opt.value}
+              rel="nofollow"
               href={sortHref(opt.value)}
               className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
                 isActive

--- a/frontend/app/tier-list/relics/page.tsx
+++ b/frontend/app/tier-list/relics/page.tsx
@@ -307,6 +307,7 @@ export default async function RelicsTierListPage({ searchParams }: PageProps) {
           return (
             <Link
               key={opt.value || "all-rarities"}
+              rel="nofollow"
               href={relicHref(pool, opt.value || undefined, act, bracket, ancient)}
               className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
                 isActive

--- a/infrastructure/ansible/templates/nginx.conf.j2
+++ b/infrastructure/ansible/templates/nginx.conf.j2
@@ -15,6 +15,9 @@ http {
     types_hash_max_size 2048;
     server_tokens off;
 
+    # HTML cache for the tier-list pages (see the location block below).
+    proxy_cache_path /var/cache/nginx/pages levels=1:2 keys_zone=pages:10m max_size=256m inactive=10m use_temp_path=off;
+
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
@@ -248,6 +251,34 @@ http {
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto $scheme;
+      }
+
+      # Tier-list pages render on every request (they read search params), so
+      # a crawl of the filter cube costs one full Next render per URL and a
+      # scraper walking it pegged the frontend (2026-09-06). Cache the HTML
+      # here for a few minutes, collapse concurrent misses onto one render,
+      # and serve stale while refreshing. Next's Vary (RSC, Next-Router-*)
+      # keeps client navigations and full loads as separate variants; the key
+      # carries the two headers that matter in case Vary is ever dropped.
+      # Set-Cookie responses are never cached (nginx default), so nothing
+      # user-specific can leak between visitors.
+      location ~ ^/(?:[a-z]{3}/)?tier-list(?:/|$) {
+          proxy_pass $codex_frontend;
+          proxy_http_version 1.1;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_cache pages;
+          proxy_cache_key "$scheme$host$request_uri|$http_rsc|$http_next_router_prefetch";
+          proxy_cache_valid 200 5m;
+          proxy_cache_valid 404 1m;
+          proxy_cache_lock on;
+          proxy_cache_lock_timeout 15s;
+          proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+          proxy_cache_background_update on;
+          proxy_ignore_headers Cache-Control Expires;
+          add_header X-Cache-Status $upstream_cache_status always;
       }
 
       # Everything else -> frontend container

--- a/infrastructure/ansible/templates/nginx.conf.j2
+++ b/infrastructure/ansible/templates/nginx.conf.j2
@@ -257,11 +257,13 @@ http {
       # a crawl of the filter cube costs one full Next render per URL and a
       # scraper walking it pegged the frontend (2026-09-06). Cache the HTML
       # here for a few minutes, collapse concurrent misses onto one render,
-      # and serve stale while refreshing. Next's Vary (RSC, Next-Router-*)
-      # keeps client navigations and full loads as separate variants; the key
-      # carries the two headers that matter in case Vary is ever dropped.
-      # Set-Cookie responses are never cached (nginx default), so nothing
-      # user-specific can leak between visitors.
+      # and serve stale while refreshing. This only absorbs repeated URLs;
+      # a crawl of distinct URLs is bounded by the Cloudflare rules, not here.
+      # Next's Vary (RSC, Next-Router-*) keeps client navigations and full
+      # loads as separate variants; the key carries the two headers that
+      # matter in case Vary is ever dropped. Signed-in visitors bypass the
+      # cache entirely and Set-Cookie responses are never stored, so nothing
+      # user-specific can be served to someone else.
       location ~ ^/(?:[a-z]{3}/)?tier-list(?:/|$) {
           proxy_pass $codex_frontend;
           proxy_http_version 1.1;
@@ -278,6 +280,8 @@ http {
           proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
           proxy_cache_background_update on;
           proxy_ignore_headers Cache-Control Expires;
+          proxy_no_cache $cookie_spire_session;
+          proxy_cache_bypass $cookie_spire_session;
           add_header X-Cache-Status $upstream_cache_status always;
       }
 


### PR DESCRIPTION
Hardens the tier-list pages after tonight's scraper pegged the frontend: nginx caches the rendered tier-list HTML for five minutes, the bracket, rarity and sort pills are nofollow and disallowed in robots.txt, and in-network callers like the frontend's server-side fetches get their own rate-limit bucket instead of sharing the browse cap keyed on the container IP.