### PR TITLE
Write a start record per ingest cycle and mark killed cycles

### DIFF
--- a/backend/tests/test_ingest_cycle_markers.py
+++ b/backend/tests/test_ingest_cycle_markers.py
@@ -1,0 +1,88 @@
+"""A cycle writes a start record before doing anything, and the next start
+closes out a predecessor that vanished without a completion record (an OOM
+kill writes nothing of its own)."""
+
+import importlib.util
+import json
+import pathlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def ingest(tmp_path, monkeypatch):
+    monkeypatch.setitem(sys.modules, "extract", types.ModuleType("extract"))
+    spec = importlib.util.spec_from_file_location(
+        "ingest_under_test",
+        pathlib.Path(__file__).resolve().parents[2] / "lab" / "ingest.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    monkeypatch.setattr(mod, "LAKE", tmp_path)
+    return mod
+
+
+def _records(path):
+    return [
+        json.loads(ln)
+        for ln in (path / "ingest_metrics.jsonl").read_text().splitlines()
+        if ln.strip()
+    ]
+
+
+def test_start_record_is_written_first(ingest, tmp_path):
+    ingest.mark_cycle_started("20260907T001702Z", 1_788_999_000.0)
+    recs = _records(tmp_path)
+    assert recs == [
+        {
+            "generation_id": "20260907T001702Z",
+            "cycle_started_at": ingest._utc(1_788_999_000.0),
+            "started": True,
+            "complete": False,
+        }
+    ]
+
+
+def test_unfinished_predecessor_is_marked_killed(ingest, tmp_path):
+    ingest.mark_cycle_started("A", 100.0)
+    ingest.mark_cycle_started("B", 200.0)
+    recs = _records(tmp_path)
+    assert [r["generation_id"] for r in recs] == ["A", "A", "B"]
+    killed = recs[1]
+    assert killed["failed_stage"] == "killed"
+    assert killed["complete"] is False
+    assert killed["cycle_started_at"] == ingest._utc(100.0)
+    assert killed["published_at"] == ingest._utc(200.0)
+    assert recs[2]["started"] is True
+
+
+def test_completed_predecessor_is_left_alone(ingest, tmp_path):
+    ingest.mark_cycle_started("A", 100.0)
+    ingest._append_metric(
+        {"generation_id": "A", "complete": True, "published_at": ingest._utc(150.0)}
+    )
+    ingest.mark_cycle_started("B", 200.0)
+    recs = _records(tmp_path)
+    assert [r["generation_id"] for r in recs] == ["A", "A", "B"]
+    assert "failed_stage" not in recs[1]
+
+
+def test_skipped_and_failed_predecessors_are_left_alone(ingest, tmp_path):
+    ingest._append_metric(
+        {"generation_id": "A", "skipped": "no source change", "complete": True}
+    )
+    ingest.mark_cycle_started("B", 200.0)
+    ingest._append_metric(
+        {"generation_id": "B", "failed_stage": "extract/build", "complete": False}
+    )
+    ingest.mark_cycle_started("C", 300.0)
+    recs = _records(tmp_path)
+    assert [r.get("failed_stage") for r in recs] == [None, None, "extract/build", None]
+
+
+def test_missing_metrics_file_is_fine(ingest, tmp_path):
+    assert ingest._last_metric() is None
+    ingest.mark_cycle_started("A", 100.0)
+    assert len(_records(tmp_path)) == 1

--- a/backend/tests/test_ingest_cycle_markers.py
+++ b/backend/tests/test_ingest_cycle_markers.py
@@ -45,13 +45,13 @@ def test_start_record_is_written_first(ingest, tmp_path):
     ]
 
 
-def test_unfinished_predecessor_is_marked_killed(ingest, tmp_path):
+def test_unfinished_predecessor_is_marked_interrupted(ingest, tmp_path):
     ingest.mark_cycle_started("A", 100.0)
     ingest.mark_cycle_started("B", 200.0)
     recs = _records(tmp_path)
     assert [r["generation_id"] for r in recs] == ["A", "A", "B"]
     killed = recs[1]
-    assert killed["failed_stage"] == "killed"
+    assert killed["failed_stage"] == "interrupted"
     assert killed["complete"] is False
     assert killed["cycle_started_at"] == ingest._utc(100.0)
     assert killed["published_at"] == ingest._utc(200.0)
@@ -86,3 +86,32 @@ def test_missing_metrics_file_is_fine(ingest, tmp_path):
     assert ingest._last_metric() is None
     ingest.mark_cycle_started("A", 100.0)
     assert len(_records(tmp_path)) == 1
+
+
+def test_torn_tail_is_repaired_and_predecessor_closed(ingest, tmp_path):
+    ingest.mark_cycle_started("A", 100.0)
+    with open(tmp_path / "ingest_metrics.jsonl", "ab") as f:
+        f.write(b'{"generation_id":"A","complete":tr')
+    ingest.mark_cycle_started("B", 200.0)
+    raw = (tmp_path / "ingest_metrics.jsonl").read_text().splitlines()
+    assert raw[1].startswith('{"generation_id":"A","complete":tr')
+    recs = [json.loads(ln) for ln in raw if ln.startswith("{") and ln.endswith("}")]
+    assert [r["generation_id"] for r in recs] == ["A", "A", "B"]
+    assert recs[1]["failed_stage"] == "interrupted"
+
+
+def test_start_record_is_written_before_extract_runs(ingest, tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_extract():
+        seen["at_extract"] = _records(tmp_path)
+        raise RuntimeError("boom")
+
+    ingest.extract.main = fake_extract
+    with pytest.raises(SystemExit):
+        ingest.main()
+    assert [r.get("started") for r in seen["at_extract"]] == [True]
+    recs = _records(tmp_path)
+    assert recs[0]["started"] is True
+    assert recs[-1]["failed_stage"] == "extract/build"
+    assert recs[-1]["complete"] is False

--- a/lab/ingest.py
+++ b/lab/ingest.py
@@ -24,6 +24,49 @@ def _utc(ts: float) -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts))
 
 
+def _append_metric(record: dict) -> None:
+    with open(LAKE / "ingest_metrics.jsonl", "a", encoding="utf-8") as f:
+        f.write(json.dumps(record, separators=(",", ":")) + "\n")
+
+
+def _last_metric() -> dict | None:
+    try:
+        with open(LAKE / "ingest_metrics.jsonl", "rb") as f:
+            f.seek(0, 2)
+            f.seek(max(0, f.tell() - 65536))
+            lines = [ln for ln in f.read().splitlines() if ln.strip()]
+        return json.loads(lines[-1]) if lines else None
+    except (OSError, ValueError):
+        return None
+
+
+def mark_cycle_started(generation_id: str, t0: float) -> None:
+    """Append a start record, and first close out a previous cycle that
+    started but never wrote a completion, failure, or skip record: the
+    kernel's OOM killer leaves no trace of its own, so the only evidence
+    of a killed cycle is a start record with nothing after it."""
+    prev = _last_metric()
+    if prev and prev.get("started") and not prev.get("complete"):
+        _append_metric(
+            {
+                "generation_id": prev.get("generation_id"),
+                "cycle_started_at": prev.get("cycle_started_at"),
+                "failed_stage": "killed",
+                "error": "no completion record; the process was killed or the box restarted",
+                "complete": False,
+                "published_at": _utc(t0),
+            }
+        )
+    _append_metric(
+        {
+            "generation_id": generation_id,
+            "cycle_started_at": _utc(t0),
+            "started": True,
+            "complete": False,
+        }
+    )
+
+
 def _sidecar_digest() -> str:
     """Content hash of the two mutable sidecars, ignoring gzip headers
     (they embed a timestamp, so identical content still differs on bytes)."""
@@ -85,6 +128,7 @@ def main() -> None:
     t0 = time.time()
     generation_id = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(t0))
     print(f"generation {generation_id} starting", flush=True)
+    mark_cycle_started(generation_id, t0)
 
     # Fresh scratch every cycle: a DuckDB file never returns freed pages to
     # the OS, so a persistent scratch keeps last cycle's high-water mark on

--- a/lab/ingest.py
+++ b/lab/ingest.py
@@ -8,6 +8,7 @@ present, so the nightly log carries fresh comparison inputs for free.
 """
 
 import json
+import os
 import pathlib
 import sys
 import time
@@ -24,34 +25,61 @@ def _utc(ts: float) -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts))
 
 
+_METRICS = "ingest_metrics.jsonl"
+
+
 def _append_metric(record: dict) -> None:
-    with open(LAKE / "ingest_metrics.jsonl", "a", encoding="utf-8") as f:
-        f.write(json.dumps(record, separators=(",", ":")) + "\n")
+    """The one writer for the metrics file. A process killed mid-write can
+    leave a torn last line with no newline; the next record starts on a
+    fresh line so one torn record never corrupts the ones after it."""
+    path = LAKE / _METRICS
+    prefix = b""
+    try:
+        if path.stat().st_size > 0:
+            with open(path, "rb") as f:
+                f.seek(-1, 2)
+                if f.read(1) != b"\n":
+                    prefix = b"\n"
+    except OSError:
+        pass
+    with open(path, "ab") as f:
+        f.write(
+            prefix + json.dumps(record, separators=(",", ":")).encode("utf-8") + b"\n"
+        )
+        f.flush()
+        os.fsync(f.fileno())
 
 
 def _last_metric() -> dict | None:
+    """The newest record that parses; a torn tail is skipped."""
     try:
-        with open(LAKE / "ingest_metrics.jsonl", "rb") as f:
+        with open(LAKE / _METRICS, "rb") as f:
             f.seek(0, 2)
             f.seek(max(0, f.tell() - 65536))
             lines = [ln for ln in f.read().splitlines() if ln.strip()]
-        return json.loads(lines[-1]) if lines else None
-    except (OSError, ValueError):
+    except OSError:
         return None
+    for raw in reversed(lines):
+        try:
+            return json.loads(raw)
+        except ValueError:
+            continue
+    return None
 
 
 def mark_cycle_started(generation_id: str, t0: float) -> None:
     """Append a start record, and first close out a previous cycle that
-    started but never wrote a completion, failure, or skip record: the
-    kernel's OOM killer leaves no trace of its own, so the only evidence
-    of a killed cycle is a start record with nothing after it."""
+    started but never wrote a completion, failure, or skip record. The
+    kernel's OOM killer, a host restart, and a crash outside the guarded
+    stages all leave the same evidence (a start record with nothing after
+    it), so the marker says "interrupted" rather than guessing the cause."""
     prev = _last_metric()
     if prev and prev.get("started") and not prev.get("complete"):
         _append_metric(
             {
                 "generation_id": prev.get("generation_id"),
                 "cycle_started_at": prev.get("cycle_started_at"),
-                "failed_stage": "killed",
+                "failed_stage": "interrupted",
                 "error": "no completion record; the process was killed or the box restarted",
                 "complete": False,
                 "published_at": _utc(t0),
@@ -107,8 +135,7 @@ def _no_source_change(rows_added: int, generation_id: str, t0: float) -> bool:
         "complete": True,
         "published_at": _utc(time.time()),
     }
-    with open(LAKE / "ingest_metrics.jsonl", "a", encoding="utf-8") as f:
-        f.write(json.dumps(record, separators=(",", ":")) + "\n")
+    _append_metric(record)
     return True
 
 
@@ -186,8 +213,7 @@ def main() -> None:
             "complete": False,
             "published_at": _utc(time.time()),
         }
-        with open(LAKE / "ingest_metrics.jsonl", "a", encoding="utf-8") as f:
-            f.write(json.dumps(record, separators=(",", ":")) + "\n")
+        _append_metric(record)
         print(f"generation {generation_id} FAILED in extract/build: {e}", flush=True)
         sys.exit(1)
     t_build = time.time()
@@ -288,8 +314,7 @@ def main() -> None:
             "complete": False,
             "published_at": _utc(time.time()),
         }
-        with open(LAKE / "ingest_metrics.jsonl", "a", encoding="utf-8") as f:
-            f.write(json.dumps(record, separators=(",", ":")) + "\n")
+        _append_metric(record)
         print(f"generation {generation_id} FAILED in prepare_session: {e}", flush=True)
         sys.exit(1)
 
@@ -465,8 +490,7 @@ def main() -> None:
     manifest["complete"] = (
         all(mtimes.get(n, 0.0) >= t0 for n in required) and not failed_stages
     )
-    with open(LAKE / "ingest_metrics.jsonl", "a", encoding="utf-8") as f:
-        f.write(json.dumps(manifest, separators=(",", ":")) + "\n")
+    _append_metric(manifest)
     if manifest["complete"]:
         tmp = LAKE / "generation.json.tmp"
         tmp.write_text(json.dumps(manifest, indent=1))


### PR DESCRIPTION
Every ingest cycle now writes a start record to ingest_metrics.jsonl before doing anything, and the next start marks a predecessor that never finished as killed, so an OOM-killed cycle shows up in the metrics file instead of leaving no trace.