### PR TITLE
Treat only a 404 as a missing entity and answer unknown ids with a real 404

### DIFF
--- a/frontend/app/[lang]/badges/[id]/page.tsx
+++ b/frontend/app/[lang]/badges/[id]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import JsonLd from "@/app/components/JsonLd";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import RichDescription from "@/app/components/RichDescription";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { stripTags, stripTagsFlat, clipMetaDescription, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
@@ -51,11 +52,8 @@ const RARITY_BORDER: Record<string, string> = {
 };
 
 async function fetchBadge(id: string, lang: string): Promise<Badge | null> {
-  try {
-    const res = await fetch(`${API_INTERNAL}/api/badges/${id}?lang=${lang}`);
-    if (res.ok) return await res.json();
-  } catch {}
-  return null;
+  const res = await fetchEntityRes(`${API_INTERNAL}/api/badges/${id}?lang=${lang}`);
+  return res.ok ? await res.json() : null;
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -102,9 +100,6 @@ export default async function LangBadgePage({ params }: Props) {
   const langCode = lang as LangCode;
 
   const badge = await fetchBadge(id, lang);
-  // Unknown badge ID → 308 back to the badges hub (locale-prefixed)
-  // instead of serving a hard 404. See `redirectMissingEntity` for the
-  // SEO reasoning.
   if (!badge) redirectMissingEntity("badges", id, lang);
 
   const desc = stripTags(badge.description);

--- a/frontend/app/[lang]/layout.tsx
+++ b/frontend/app/[lang]/layout.tsx
@@ -9,7 +9,7 @@ import {
   LANG_DATABASE,
   type LangCode,
 } from "@/lib/languages";
-import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE } from "@/lib/seo";
+import { SITE_NAME, DEFAULT_OG_IMAGE } from "@/lib/seo";
 import { LanguageProvider } from "@/app/contexts/LanguageContext";
 import HtmlLang from "@/app/components/HtmlLang";
 
@@ -22,6 +22,9 @@ export async function generateStaticParams() {
   return SUPPORTED_LANGS.map((lang) => ({ lang }));
 }
 
+// No `alternates` here on purpose: a layout's canonical is inherited by every
+// child page that doesn't set its own, which pointed list pages at the locale
+// home. The locale home sets its own canonical and hreflang in page.tsx.
 export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
   const { lang } = await params;
   if (!isValidLang(lang)) return {};
@@ -34,14 +37,6 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${dbWord} - Spire Codex (${nativeName})`;
   const description = `Spire Codex, ${gameName} ${dbWord}. ${nativeName}.`;
 
-  // Build hreflang alternates: all other localized versions + English
-  const languages: Record<string, string> = {
-    "en": `${SITE_URL}/`,
-    "x-default": `${SITE_URL}/`,
-  };
-  for (const code of SUPPORTED_LANGS) {
-    languages[LANG_HREFLANG[code]] = `${SITE_URL}/${code}`;
-  }
 
   return {
     title,
@@ -55,10 +50,6 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
       images: [{ url: DEFAULT_OG_IMAGE, width: 3000, height: 3000 }],
     },
     twitter: { card: "summary_large_image", title, description },
-    alternates: {
-      canonical: `/${lang}`,
-      languages,
-    },
   };
 }
 

--- a/frontend/app/[lang]/layout.tsx
+++ b/frontend/app/[lang]/layout.tsx
@@ -37,7 +37,6 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
   const title = `${gameName} ${dbWord} - Spire Codex (${nativeName})`;
   const description = `Spire Codex, ${gameName} ${dbWord}. ${nativeName}.`;
 
-
   return {
     title,
     description,

--- a/frontend/app/[lang]/not-found.tsx
+++ b/frontend/app/[lang]/not-found.tsx
@@ -9,11 +9,9 @@ import { t } from "@/lib/ui-translations";
  *   1. Tell the user what happened in a friendly way and give them a
  *      one-click route home.
  *
- * NOTE: This file only handles routes that don't match any segment at
- * all (`/some-bogus-page`). Entity-detail routes with unknown IDs
- * (`/cards/<unknown>`) now redirect to the entity list via
- * `redirectMissingEntity()` instead of rendering this page, so search
- * engines see a 308 on those URLs and forward the link equity.
+ * NOTE: Entity-detail routes with unknown IDs (`/cards/<unknown>`) also
+ * land here via `redirectMissingEntity()` calling `notFound()`; only a
+ * documented rename gets a 308.
  *
  * Note: this currently can't localise properly because it dosn't have access to the client side localisation contexts etc (and AFAIK is prebaked once for all usages).
  * The simplest way to get a localised version will probably be to utilise i18n-next which (hopefully?) provides server side locales.

--- a/frontend/app/[lang]/not-found.tsx
+++ b/frontend/app/[lang]/not-found.tsx
@@ -13,7 +13,7 @@ import { t } from "@/lib/ui-translations";
  * land here via `redirectMissingEntity()` calling `notFound()`; only a
  * documented rename gets a 308.
  *
- * Note: this currently can't localise properly because it dosn't have access to the client side localisation contexts etc (and AFAIK is prebaked once for all usages).
+ * Note: this currently can't localise properly because it doesn't have access to the client side localisation contexts etc (and AFAIK is prebaked once for all usages).
  * The simplest way to get a localised version will probably be to utilise i18n-next which (hopefully?) provides server side locales.
  * We'll also need [...notfound] catchalls to route unmatched paths to the localised paths so i18n-next can provide locale information.
  * See https://next-intl.dev/docs/environments/error-files and https://github.com/vercel/next.js/discussions/50518

--- a/frontend/app/badges/[id]/page.tsx
+++ b/frontend/app/badges/[id]/page.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from "react";
 import Link from "next/link";
 import JsonLd from "@/app/components/JsonLd";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
+import { fetchEntityRes } from "@/lib/entity-fetch";
 import RichDescription from "@/app/components/RichDescription";
 import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
 import { stripTags, stripTagsFlat, clipMetaDescription, buildLanguageAlternates, SITE_NAME, SITE_URL } from "@/lib/seo";
@@ -46,11 +47,8 @@ const RARITY_COLOR: Record<string, string> = {
 };
 
 async function fetchBadge(id: string): Promise<Badge | null> {
-  try {
-    const res = await fetch(`${API_INTERNAL}/api/badges/${id}`);
-    if (res.ok) return await res.json();
-  } catch {}
-  return null;
+  const res = await fetchEntityRes(`${API_INTERNAL}/api/badges/${id}`);
+  return res.ok ? await res.json() : null;
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -85,11 +83,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function BadgePage({ params }: Props) {
   const { id } = await params;
   const badge = await fetchBadge(id);
-  // Unknown badge ID → 308 back to the badges hub so search engines
-  // forward link equity to the parent page instead of dumping it on a
-  // 404. `fetchBadge` already returns null on both unreachable-backend
-  // *and* 404 responses, but a hot list page is a better landing for
-  // either case than a dead end.
   if (!badge) redirectMissingEntity("badges", id);
 
   const desc = stripTags(badge.description);

--- a/frontend/lib/entity-fetch.test.ts
+++ b/frontend/lib/entity-fetch.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchEntityRes } from "./entity-fetch";
+
+function stub(status: number) {
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(status === 204 ? null : "{}", { status })));
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("fetchEntityRes", () => {
+  it("returns OK responses", async () => {
+    stub(200);
+    expect((await fetchEntityRes("http://api/x")).status).toBe(200);
+  });
+
+  it("returns a 404 so the page can decide the entity is missing", async () => {
+    stub(404);
+    expect((await fetchEntityRes("http://api/x")).status).toBe(404);
+  });
+
+  it.each([429, 401, 403, 500, 502, 503])("throws on %i instead of reading it as missing", async (status) => {
+    stub(status);
+    await expect(fetchEntityRes("http://api/x")).rejects.toThrow(`entity API ${status}`);
+  });
+});

--- a/frontend/lib/entity-fetch.test.ts
+++ b/frontend/lib/entity-fetch.test.ts
@@ -13,9 +13,9 @@ describe("fetchEntityRes", () => {
     expect((await fetchEntityRes("http://api/x")).status).toBe(200);
   });
 
-  it("returns a 404 so the page can decide the entity is missing", async () => {
-    stub(404);
-    expect((await fetchEntityRes("http://api/x")).status).toBe(404);
+  it.each([404, 410])("returns a %i so the page can decide the entity is missing", async (status) => {
+    stub(status);
+    expect((await fetchEntityRes("http://api/x")).status).toBe(status);
   });
 
   it.each([429, 401, 403, 500, 502, 503])("throws on %i instead of reading it as missing", async (status) => {

--- a/frontend/lib/entity-fetch.ts
+++ b/frontend/lib/entity-fetch.ts
@@ -1,5 +1,6 @@
-// fetch() wrapper for entity detail SSR. Only a definitive 404 (or 410) may
-// be read as "this entity doesn't exist"; every other non-OK status (a 429
+// fetch() wrapper for entity detail SSR. Only a definitive 404 or 410 (gone
+// for good, which is the same answer) may be read as "this entity doesn't
+// exist"; every other non-OK status (a 429
 // from the rate limiter, a 5xx, an auth error) throws so the page fails the
 // render instead of redirecting a valid URL to its hub. Google records a
 // hub redirect as a Soft 404 and drops the URL, which is what happened to

--- a/frontend/lib/entity-fetch.ts
+++ b/frontend/lib/entity-fetch.ts
@@ -1,13 +1,16 @@
-// fetch() wrapper for entity detail SSR. Backend 5xx throws (landing in the
-// caller's apiUnreachable catch) so a sick backend is treated as transient,
-// not as "this entity doesn't exist" — only a definitive 404 may 308 the
-// URL back to its hub.
+// fetch() wrapper for entity detail SSR. Only a definitive 404 (or 410) may
+// be read as "this entity doesn't exist"; every other non-OK status (a 429
+// from the rate limiter, a 5xx, an auth error) throws so the page fails the
+// render instead of redirecting a valid URL to its hub. Google records a
+// hub redirect as a Soft 404 and drops the URL, which is what happened to
+// localized entity pages while server-side fetches shared one rate-limit
+// bucket (2026-09).
 export async function fetchEntityRes(
   url: string,
   init?: RequestInit,
 ): Promise<Response> {
   const res = await fetch(url, init);
-  if (res.status >= 500) {
+  if (!res.ok && res.status !== 404 && res.status !== 410) {
     throw new Error(`entity API ${res.status} for ${url}`);
   }
   return res;

--- a/frontend/lib/redirect-helpers.test.ts
+++ b/frontend/lib/redirect-helpers.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+  permanentRedirect: vi.fn((target: string) => {
+    throw new Error(`NEXT_REDIRECT:${target}`);
+  }),
+}));
+
+import { notFound, permanentRedirect } from "next/navigation";
+import { redirectMissingEntity } from "./redirect-helpers";
+
+describe("redirectMissingEntity", () => {
+  it("returns a real 404 for an unknown id instead of redirecting to the hub", () => {
+    expect(() => redirectMissingEntity("cards", "no_such_card")).toThrow("NEXT_NOT_FOUND");
+    expect(notFound).toHaveBeenCalled();
+    expect(permanentRedirect).not.toHaveBeenCalled();
+  });
+
+  it("does the same on a localized route", () => {
+    expect(() => redirectMissingEntity("events", "no_such_event", "fra")).toThrow("NEXT_NOT_FOUND");
+    expect(permanentRedirect).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/lib/redirect-helpers.test.ts
+++ b/frontend/lib/redirect-helpers.test.ts
@@ -19,8 +19,10 @@ describe("redirectMissingEntity", () => {
     expect(permanentRedirect).not.toHaveBeenCalled();
   });
 
-  it("does the same on a localized route", () => {
-    expect(() => redirectMissingEntity("events", "no_such_event", "fra")).toThrow("NEXT_NOT_FOUND");
-    expect(permanentRedirect).not.toHaveBeenCalled();
+  it("308s a documented rename to the new id, keeping the locale prefix", () => {
+    const legacy = { cards: { old_slug: "new_slug" } };
+    expect(() => redirectMissingEntity("cards", "old_slug", "fra", legacy)).toThrow("NEXT_REDIRECT:/fra/cards/new_slug");
+    expect(() => redirectMissingEntity("cards", "old_slug", undefined, legacy)).toThrow("NEXT_REDIRECT:/cards/new_slug");
+    expect(() => redirectMissingEntity("relics", "old_slug", "fra", legacy)).toThrow("NEXT_NOT_FOUND");
   });
 });

--- a/frontend/lib/redirect-helpers.ts
+++ b/frontend/lib/redirect-helpers.ts
@@ -21,7 +21,7 @@
  * to the parent-hub redirect.
  */
 
-import { permanentRedirect } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 
 export type EntityKind =
   | "cards"
@@ -93,37 +93,29 @@ const LEGACY_IDS: Partial<Record<EntityKind, Record<string, string>>> = {
 };
 
 /**
- * Send a request to the entity's parent hub, preserving an optional
- * locale prefix. Server-side `redirect()`, emits a real HTTP 307 by
- * default. We use `permanentRedirect()` (308) for entity-not-found
- * because the old URL is never coming back as a valid entity page,
- * which matches the rules for 308: link equity transfers, search
- * engines re-target their index entry to the destination.
+ * What to do with an entity detail URL whose ID the API does not know.
  *
- * IMPORTANT: must be called from a Server Component / route handler
- *, it throws a special internal error that Next intercepts. Don't
- * try to call it from a Client Component.
+ * A documented rename gets a 308 to the new ID, locale prefix preserved,
+ * so the old URL's authority moves with it. Anything else is a real 404:
+ * redirecting an unknown ID to the category hub was recorded by Google as
+ * a Soft 404 on the original URL, which is worse for the index than an
+ * honest not-found and made transient API failures look like removals.
+ *
+ * Only call this after a definitive 404 from the API; `fetchEntityRes`
+ * throws on every other failure so a sick backend never reaches here.
+ * Server Components / route handlers only: both calls throw an internal
+ * error Next intercepts.
  */
 export function redirectMissingEntity(
   entity: EntityKind,
   id: string,
   lang?: string,
 ): never {
-  // Tier 2: explicit legacy rename → new ID. Preserve the locale
-  // prefix and use a permanent redirect so search engines transfer
-  // the old URL's authority to the new one.
   const renamed = LEGACY_IDS[entity]?.[id];
   if (renamed) {
     const prefix = lang ? `/${lang}` : "";
     permanentRedirect(`${prefix}/${entity}/${renamed}`);
   }
-
-  // Tier 1: unknown ID → parent hub. 308 (permanent) because the
-  // unknown ID is never going to start resolving on its own, better
-  // to hand the equity to the hub than to keep returning 404 every
-  // crawl.
-  const prefix = lang ? `/${lang}` : "";
-  const target = `${prefix}${PARENT_PATH[entity]}`;
-  permanentRedirect(target);
+  notFound();
 }
 

--- a/frontend/lib/redirect-helpers.ts
+++ b/frontend/lib/redirect-helpers.ts
@@ -1,24 +1,11 @@
 /**
- * Entity-detail redirect helpers, used by every `<entity>/[id]/page.tsx`
- * route to send unknown IDs back to a sensible parent hub instead of
- * 404'ing.
+ * What an entity detail route does with an ID the API does not know.
  *
- * Why this exists: Google Search Console reports thousands of 404s for
- * stale crawl URLs (renamed cards, old monster IDs, etc). A 404 dumps
- * link equity on the floor; a 308 hands the equity over to the parent
- * hub page and gives the user something useful to land on. We do this
- * on the *server* via `redirect()` so search engines see a real
- * HTTP-level redirect, not a soft-404.
- *
- * Some entity types don't have a list page of their own, they're
- * surfaced through `/reference` (acts, ascensions, intents, orbs,
- * afflictions, modifiers, achievements). Those redirect there.
- *
- * Tier 2 (renames / legacy paths): the legacy-ID map below is empty
- * for now because we don't have a documented set of historical IDs.
- * When we do an ID rename, add the entry here and unknown-ID requests
- * for the old slug will 308 to the new slug *before* falling through
- * to the parent-hub redirect.
+ * A documented rename (LEGACY_IDS) gets a 308 to the new ID so the old
+ * URL's authority moves with it. Everything else is a real 404: redirecting
+ * unknown IDs to the category hub was recorded by Google as a Soft 404 on
+ * the original URL, which is worse for the index than an honest not-found
+ * and made transient API failures look like removals.
  */
 
 import { notFound, permanentRedirect } from "next/navigation";
@@ -56,29 +43,6 @@ export type EntityKind =
  * page (orbs / afflictions / intents / etc.) send them to `/reference`
  * which is the umbrella hub the navbar links to.
  */
-const PARENT_PATH: Record<EntityKind, string> = {
-  cards: "/cards",
-  relics: "/relics",
-  monsters: "/monsters",
-  potions: "/potions",
-  powers: "/powers",
-  events: "/events",
-  encounters: "/encounters",
-  keywords: "/keywords",
-  characters: "/characters",
-  enchantments: "/enchantments",
-  guides: "/guides",
-  mechanics: "/mechanics",
-  badges: "/badges",
-  timeline: "/timeline",
-  orbs: "/reference",
-  afflictions: "/reference",
-  intents: "/reference",
-  modifiers: "/modifiers",
-  achievements: "/reference",
-  acts: "/reference",
-  ascensions: "/reference",
-};
 
 /**
  * Legacy ID → current ID map. Keyed by entity, then old slug → new
@@ -88,7 +52,9 @@ const PARENT_PATH: Record<EntityKind, string> = {
  * Empty by default, we don't have a documented rename history yet.
  * Wire renames in here when they happen.
  */
-const LEGACY_IDS: Partial<Record<EntityKind, Record<string, string>>> = {
+export type LegacyIdMap = Partial<Record<EntityKind, Record<string, string>>>;
+
+const LEGACY_IDS: LegacyIdMap = {
   // cards: { OLD_ID: "new_id" },
 };
 
@@ -110,8 +76,9 @@ export function redirectMissingEntity(
   entity: EntityKind,
   id: string,
   lang?: string,
+  legacy: LegacyIdMap = LEGACY_IDS,
 ): never {
-  const renamed = LEGACY_IDS[entity]?.[id];
+  const renamed = legacy[entity]?.[id];
   if (renamed) {
     const prefix = lang ? `/${lang}` : "";
     permanentRedirect(`${prefix}/${entity}/${renamed}`);


### PR DESCRIPTION
Stops entity pages from 308-redirecting valid URLs to their hub on a 429 or 5xx (Google recorded those as Soft 404s on localized pages), returns a real 404 for unknown ids, moves the badge pages onto the same fetch path, and removes the localized layout canonical that child pages inherited.