### PR TITLE
Sitemap: fail on API errors, drop synthetic lastmod, list the ancient tier-list variants

### DIFF
--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -184,87 +184,47 @@ const DYNAMIC_ROUTES = [
   { endpoint: "/api/guides", prefix: "/guides", priority: 0.6, localized: true },
 ];
 
+// A failed list fetch throws instead of yielding an empty section: an empty
+// section silently drops hundreds of URLs from the sitemap, and Next keeps
+// serving the last good sitemap when a regeneration fails.
 async function fetchEntities(endpoint: string): Promise<EntityWithImage[]> {
-  // Internal API base like every other server fetch in this file —
-  // imageUrl() resolved these through the public edge. Cached so a
-  // sitemap regen inside the revalidate window is free.
-  try {
-    const res = await fetch(`${API}${endpoint}`, { next: { revalidate: 1800 } });
-    if (!res.ok) return [];
-    return res.json();
-  } catch {
-    return [];
-  }
+  const res = await fetch(`${API}${endpoint}`, { next: { revalidate: 1800 } });
+  if (!res.ok) throw new Error(`sitemap: ${endpoint} returned ${res.status}`);
+  const body: unknown = await res.json();
+  if (!Array.isArray(body)) throw new Error(`sitemap: ${endpoint} did not return a list`);
+  return body as EntityWithImage[];
 }
 
-/**
- * Per-section freshness signal. Different content updates at different
- * cadences, slamming every URL with the same `now` timestamp on every
- * sitemap fetch defeats `lastmod`'s purpose (Google deprioritizes URLs
- * whose timestamp never changes). We bucket lastmod by content type
- * and pull a real signal from `/api/changelogs` for entity content.
- */
-async function getLastModBuckets(now: Date): Promise<{
-  content: Date; // entity data, last game patch / data parse
-  community: Date; // runs, leaderboards, refresh roughly hourly
-  static: Date; // hub pages, dev docs, week-stable
-}> {
-  // Default fallbacks if the backend is unreachable (frontend build under
-  // network-isolated CI shouldn't hard-fail the sitemap).
-  let contentDate = new Date(now);
-  contentDate.setUTCHours(0, 0, 0, 0);
-  const staticDate = new Date(contentDate);
-
+// The only truthful lastmod we have is the latest game-data changelog date,
+// which is when entity pages last changed. Hub and community pages carry no
+// lastmod: a synthetic "today" or "this hour" on every fetch tells Google
+// the page changed when it didn't, and it stops trusting the field.
+async function contentLastMod(): Promise<Date | undefined> {
   try {
     const res = await fetch(`${API}/api/changelogs`, { next: { revalidate: 1800 } });
-    if (res.ok) {
-      const log = (await res.json()) as Array<{ date?: string }>;
-      // Most recent entry first per /api/changelogs ordering.
-      const latest = log.find((e) => e.date);
-      if (latest?.date) {
-        const parsed = new Date(latest.date);
-        if (!Number.isNaN(parsed.getTime())) {
-          contentDate = parsed;
-        }
-      }
-    }
+    if (!res.ok) return undefined;
+    const log = (await res.json()) as Array<{ date?: string }>;
+    const latest = log.find((e) => e.date);
+    if (!latest?.date) return undefined;
+    const parsed = new Date(latest.date);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
   } catch {
-    // keep fallback
+    return undefined;
   }
-
-  // Community pages tick more often, bucket to the hour so we get a
-  // moving lastmod without burning crawl budget on every-minute changes.
-  const community = new Date(now);
-  community.setUTCMinutes(0, 0, 0);
-
-  return { content: contentDate, community, static: staticDate };
 }
 
+// Ancient offer pools on the relic tier list, mirrored from ANCIENT_FILTERS in
+// app/tier-list/relics/page.tsx. Each is its own canonical page and several
+// rank on page one, so they are listed explicitly instead of left to crawl
+// discovery; every other filter combination canonicalizes to one of these.
+const TIER_RELIC_ANCIENTS = ["neow", "tezcatara", "pael", "orobas", "darv", "nonupeipe", "tanx", "vakuu"];
+const TIER_RELIC_ACTS = ["1", "2", "3"];
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const now = new Date();
-  const lastMod = await getLastModBuckets(now);
-
-  const COMMUNITY_PATHS = new Set([
-    "/leaderboards",
-    "/leaderboards/submit",
-    "/leaderboards/stats",
-    "/community-stats",
-    "/leaderboards/scoring",
-    "/tier-list",
-    "/tier-list/cards",
-    "/tier-list/relics",
-    "/tier-list/potions",
-    "/news",
-  ]);
-
-  const pickLastMod = (path: string): Date => {
-    if (COMMUNITY_PATHS.has(path)) return lastMod.community;
-    return lastMod.static;
-  };
+  const contentDate = await contentLastMod();
 
   const staticEntries: MetadataRoute.Sitemap = STATIC_PAGES.map((p) => ({
     url: `${SITE_URL}${p.path}`,
-    lastModified: pickLastMod(p.path),
     changeFrequency: p.changeFrequency,
     priority: p.priority,
   }));
@@ -284,7 +244,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     route.entities.map((entity) => {
       const entry: MetadataRoute.Sitemap[number] = {
         url: `${SITE_URL}${route.prefix}/${entity.id.toLowerCase()}`,
-        lastModified: lastMod.content,
+        lastModified: contentDate,
         changeFrequency: "weekly",
         priority: route.priority,
       };
@@ -309,7 +269,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     : [];
   const mechanicsEntries: MetadataRoute.Sitemap = mechanicSections.map((s) => ({
     url: `${SITE_URL}/mechanics/${s.slug}`,
-    lastModified: lastMod.static,
     changeFrequency: "monthly" as const,
     priority: 0.6,
   }));
@@ -328,22 +287,37 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const tierListVariants: MetadataRoute.Sitemap = [
     ...TIER_CARD_COLORS.map((c) => ({
       url: `${SITE_URL}/tier-list/cards?color=${c}`,
-      lastModified: lastMod.community,
       changeFrequency: "daily" as const,
       priority: 0.8,
     })),
     ...TIER_RELIC_POOLS.map((p) => ({
       url: `${SITE_URL}/tier-list/relics?pool=${p}`,
-      lastModified: lastMod.community,
       changeFrequency: "daily" as const,
       priority: 0.8,
     })),
+    ...TIER_RELIC_ACTS.map((a) => ({
+      url: `${SITE_URL}/tier-list/relics?act=${a}`,
+      changeFrequency: "daily" as const,
+      priority: 0.7,
+    })),
+    ...TIER_RELIC_ANCIENTS.map((a) => ({
+      url: `${SITE_URL}/tier-list/relics?ancient=${a}`,
+      changeFrequency: "daily" as const,
+      priority: 0.8,
+    })),
+    ...TIER_RELIC_ACTS.flatMap((act) =>
+      TIER_RELIC_ANCIENTS.map((a) => ({
+        url: `${SITE_URL}/tier-list/relics?act=${act}&ancient=${a}`,
+        changeFrequency: "daily" as const,
+        priority: 0.6,
+      })),
+    ),
   ];
 
   // Card browse pages (programmatic SEO)
   const browseEntries: MetadataRoute.Sitemap = ALL_BROWSE_SLUGS.map((slug) => ({
     url: `${SITE_URL}/cards/browse/${slug}`,
-    lastModified: lastMod.content,
+    lastModified: contentDate,
     changeFrequency: "weekly" as const,
     priority: 0.7,
   }));
@@ -356,13 +330,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const langListEntries: MetadataRoute.Sitemap = SUPPORTED_LANGS.flatMap((lang) => [
     {
       url: `${SITE_URL}/${lang}`,
-      lastModified: lastMod.static,
       changeFrequency: "weekly" as const,
       priority: 0.6,
     },
     ...LANG_LIST_ROUTES.map((route) => ({
       url: `${SITE_URL}/${lang}/${route}`,
-      lastModified: lastMod.static,
       changeFrequency: "weekly" as const,
       priority: 0.5,
     })),
@@ -374,7 +346,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const langMechanicsEntries: MetadataRoute.Sitemap = SUPPORTED_LANGS.flatMap((lang) =>
     mechanicSections.map((s) => ({
       url: `${SITE_URL}/${lang}/mechanics/${s.slug}`,
-      lastModified: lastMod.static,
       changeFrequency: "monthly" as const,
       priority: 0.4,
     }))
@@ -391,13 +362,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     localizedDynamicRoutes.flatMap((route) =>
       route.entities.map((entity) => ({
         url: `${SITE_URL}/${lang}${route.prefix}/${entity.id.toLowerCase()}`,
-        lastModified: lastMod.content,
+        lastModified: contentDate,
         changeFrequency: "weekly" as const,
         priority: 0.4,
       }))
     )
   );
 
+  const seen = new Set<string>();
   return [
     ...staticEntries,
     ...mechanicsEntries,
@@ -407,5 +379,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...langMechanicsEntries,
     ...langDetailEntries,
     ...englishDetailEntries,
-  ];
+  ].filter((entry) => {
+    if (seen.has(entry.url)) return false;
+    seen.add(entry.url);
+    return true;
+  });
 }

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from "next";
 import { ALL_BROWSE_SLUGS } from "./cards/browse/slug-map";
 import { SUPPORTED_LANGS } from "@/lib/languages";
 import { imageUrl } from "@/lib/image-url";
+import { TIER_CARD_COLORS, TIER_RELIC_ACTS, TIER_RELIC_ANCIENTS, TIER_RELIC_POOLS } from "@/lib/tier-list-filters";
 
 // Regenerate at most every 30 minutes: crawler fetches between ticks are
 // served from cache instead of re-running ~21 API list fetches each hit.
@@ -184,16 +185,22 @@ const DYNAMIC_ROUTES = [
   { endpoint: "/api/guides", prefix: "/guides", priority: 0.6, localized: true },
 ];
 
-// A failed list fetch throws instead of yielding an empty section: an empty
-// section silently drops hundreds of URLs from the sitemap, and Next keeps
+function isEntity(x: unknown): x is EntityWithImage {
+  return !!x && typeof x === "object" && typeof (x as { id?: unknown }).id === "string";
+}
+
+// A failed or malformed list fetch throws instead of yielding an empty
+// section: an empty section silently drops hundreds of URLs, and Next keeps
 // serving the last good sitemap when a regeneration fails.
-async function fetchEntities(endpoint: string): Promise<EntityWithImage[]> {
-  const res = await fetch(`${API}${endpoint}`, { next: { revalidate: 1800 } });
+async function fetchList<T>(endpoint: string, guard: (x: unknown) => x is T, revalidate = 1800): Promise<T[]> {
+  const res = await fetch(`${API}${endpoint}`, { next: { revalidate } });
   if (!res.ok) throw new Error(`sitemap: ${endpoint} returned ${res.status}`);
   const body: unknown = await res.json();
-  if (!Array.isArray(body)) throw new Error(`sitemap: ${endpoint} did not return a list`);
-  return body as EntityWithImage[];
+  if (!Array.isArray(body) || !body.every(guard)) throw new Error(`sitemap: ${endpoint} returned a malformed list`);
+  return body;
 }
+
+const fetchEntities = (endpoint: string) => fetchList(endpoint, isEntity);
 
 // The only truthful lastmod we have is the latest game-data changelog date,
 // which is when entity pages last changed. Hub and community pages carry no
@@ -213,12 +220,9 @@ async function contentLastMod(): Promise<Date | undefined> {
   }
 }
 
-// Ancient offer pools on the relic tier list, mirrored from ANCIENT_FILTERS in
-// app/tier-list/relics/page.tsx. Each is its own canonical page and several
-// rank on page one, so they are listed explicitly instead of left to crawl
-// discovery; every other filter combination canonicalizes to one of these.
-const TIER_RELIC_ANCIENTS = ["neow", "tezcatara", "pael", "orobas", "darv", "nonupeipe", "tanx", "vakuu"];
-const TIER_RELIC_ACTS = ["1", "2", "3"];
+// Routes whose pages change with the game data and so carry the changelog
+// date; everything else (guides are edited on their own schedule) is undated.
+const GAME_DATA_PREFIXES = new Set(DYNAMIC_ROUTES.map((r) => r.prefix).filter((p) => p !== "/guides"));
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const contentDate = await contentLastMod();
@@ -244,7 +248,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     route.entities.map((entity) => {
       const entry: MetadataRoute.Sitemap[number] = {
         url: `${SITE_URL}${route.prefix}/${entity.id.toLowerCase()}`,
-        lastModified: contentDate,
+        lastModified: GAME_DATA_PREFIXES.has(route.prefix) ? contentDate : undefined,
         changeFrequency: "weekly",
         priority: route.priority,
       };
@@ -261,12 +265,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // adding/removing a slug only requires a markdown file in
   // data/mechanics_pages/, no sitemap edit.
   type MechanicSectionMeta = { slug: string };
-  const mechanicsRes = await fetch(`${API}/api/mechanics/sections`, {
-    next: { revalidate: 300 },
-  }).catch(() => null);
-  const mechanicSections: MechanicSectionMeta[] = mechanicsRes && mechanicsRes.ok
-    ? ((await mechanicsRes.json()) as MechanicSectionMeta[])
-    : [];
+  const mechanicSections = await fetchList(
+    "/api/mechanics/sections",
+    (x): x is MechanicSectionMeta => !!x && typeof x === "object" && typeof (x as { slug?: unknown }).slug === "string",
+    300,
+  );
   const mechanicsEntries: MetadataRoute.Sitemap = mechanicSections.map((s) => ({
     url: `${SITE_URL}/mechanics/${s.slug}`,
     changeFrequency: "monthly" as const,
@@ -282,8 +285,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // its own generateMetadata title + canonical, so they need their
   // own sitemap entries to surface in search. Targets long-tail
   // queries like "ironclad tier list", "necrobinder relic tier list".
-  const TIER_CARD_COLORS = ["ironclad", "silent", "defect", "necrobinder", "regent", "colorless"];
-  const TIER_RELIC_POOLS = ["shared", "ironclad", "silent", "defect", "necrobinder", "regent"];
   const tierListVariants: MetadataRoute.Sitemap = [
     ...TIER_CARD_COLORS.map((c) => ({
       url: `${SITE_URL}/tier-list/cards?color=${c}`,
@@ -362,7 +363,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     localizedDynamicRoutes.flatMap((route) =>
       route.entities.map((entity) => ({
         url: `${SITE_URL}/${lang}${route.prefix}/${entity.id.toLowerCase()}`,
-        lastModified: contentDate,
+        lastModified: GAME_DATA_PREFIXES.has(route.prefix) ? contentDate : undefined,
         changeFrequency: "weekly" as const,
         priority: 0.4,
       }))

--- a/frontend/app/tier-list/relics/page.tsx
+++ b/frontend/app/tier-list/relics/page.tsx
@@ -6,6 +6,7 @@ import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd } from "@/lib/jsonld";
 import TierList, { type TierEntity } from "@/app/components/TierList";
 import BracketFilter from "@/app/components/BracketFilter";
 import { bracketParam, normalizeBracket } from "@/lib/content-brackets";
+import { TIER_RELIC_ANCIENTS } from "@/lib/tier-list-filters";
 
 const API_INTERNAL = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -60,15 +61,8 @@ const ACT_FILTERS = [
 // relics one ancient can offer, so "which Neow relic should I take" gets
 // a direct answer.
 const ANCIENT_FILTERS = [
-  { value: "",          label: "All" },
-  { value: "neow",      label: "Neow" },
-  { value: "tezcatara", label: "Tezcatara" },
-  { value: "pael",      label: "Pael" },
-  { value: "orobas",    label: "Orobas" },
-  { value: "darv",      label: "Darv" },
-  { value: "nonupeipe", label: "Nonupeipe" },
-  { value: "tanx",      label: "Tanx" },
-  { value: "vakuu",     label: "Vakuu" },
+  { value: "", label: "All" },
+  ...TIER_RELIC_ANCIENTS.map((a) => ({ value: a, label: a.charAt(0).toUpperCase() + a.slice(1) })),
 ];
 
 function relicHref(

--- a/frontend/lib/sitemap.test.ts
+++ b/frontend/lib/sitemap.test.ts
@@ -1,5 +1,14 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import sitemap from "@/app/sitemap";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { TIER_RELIC_ACTS, TIER_RELIC_ANCIENTS } from "./tier-list-filters";
+
+const SITE = "https://sitemap.test";
+let sitemap: () => Promise<{ url: string; lastModified?: Date | string }[]>;
+
+beforeAll(async () => {
+  vi.stubEnv("NEXT_PUBLIC_SITE_URL", SITE);
+  vi.resetModules();
+  sitemap = (await import("@/app/sitemap")).default;
+});
 
 type Handler = (url: string) => Response | Promise<Response>;
 
@@ -15,30 +24,37 @@ function healthyApi(url: string): Response {
   if (url.endsWith("/api/mechanics/sections")) return ok([{ slug: "score-formula" }]);
   if (url.endsWith("/api/glossary")) return ok([entity("STRENGTH")]);
   if (url.endsWith("/api/keywords")) return ok([entity("STRENGTH"), entity("BLOCK")]);
+  if (url.endsWith("/api/guides")) return ok([entity("first-guide")]);
   return ok([entity("ALPHA")]);
 }
 
 afterEach(() => vi.unstubAllGlobals());
 
 describe("sitemap", () => {
-  it("lists the ancient and act tier-list variants once each", async () => {
+  it("lists every ancient and act relic tier-list variant exactly once", async () => {
     stubApi(healthyApi);
     const urls = (await sitemap()).map((e) => e.url);
-    expect(urls).toContain("https://spire-codex.com/tier-list/relics?ancient=pael");
-    expect(urls).toContain("https://spire-codex.com/tier-list/relics?act=3&ancient=vakuu");
-    expect(urls).toContain("https://spire-codex.com/tier-list/relics?act=2");
+    const expected = new Set<string>([
+      ...TIER_RELIC_ACTS.map((a) => `${SITE}/tier-list/relics?act=${a}`),
+      ...TIER_RELIC_ANCIENTS.map((a) => `${SITE}/tier-list/relics?ancient=${a}`),
+      ...TIER_RELIC_ACTS.flatMap((act) => TIER_RELIC_ANCIENTS.map((a) => `${SITE}/tier-list/relics?act=${act}&ancient=${a}`)),
+    ]);
+    const variants = urls.filter((u) => u.includes("/tier-list/relics?") && (u.includes("ancient=") || u.includes("act=")));
+    expect(new Set(variants)).toEqual(expected);
+    expect(variants).toHaveLength(expected.size);
     expect(new Set(urls).size).toBe(urls.length);
   });
 
-  it("dates entity pages by the changelog and leaves hub pages undated", async () => {
+  it("dates game-data pages by the changelog and leaves hubs and guides undated", async () => {
     stubApi(healthyApi);
     const entries = await sitemap();
-    const home = entries.find((e) => e.url === "https://spire-codex.com/")!;
-    const card = entries.find((e) => e.url === "https://spire-codex.com/cards/alpha")!;
-    const tier = entries.find((e) => e.url === "https://spire-codex.com/tier-list/relics")!;
-    expect(home.lastModified).toBeUndefined();
-    expect(tier.lastModified).toBeUndefined();
-    expect(card.lastModified).toEqual(new Date("2026-08-14"));
+    const byUrl = new Map(entries.map((e) => [e.url, e]));
+    expect(byUrl.get(`${SITE}/`)?.lastModified).toBeUndefined();
+    expect(byUrl.get(`${SITE}/tier-list/relics`)?.lastModified).toBeUndefined();
+    expect(byUrl.get(`${SITE}/guides/first-guide`)?.lastModified).toBeUndefined();
+    expect(byUrl.get(`${SITE}/fra/guides/first-guide`)?.lastModified).toBeUndefined();
+    expect(byUrl.get(`${SITE}/cards/alpha`)?.lastModified).toEqual(new Date("2026-08-14"));
+    expect(byUrl.get(`${SITE}/fra/cards/alpha`)?.lastModified).toEqual(new Date("2026-08-14"));
   });
 
   it("fails the build when a list endpoint errors instead of dropping the section", async () => {
@@ -46,9 +62,19 @@ describe("sitemap", () => {
     await expect(sitemap()).rejects.toThrow("/api/monsters returned 429");
   });
 
+  it("fails the build when the mechanics inventory errors", async () => {
+    stubApi((url) => (url.endsWith("/api/mechanics/sections") ? new Response("", { status: 500 }) : healthyApi(url)));
+    await expect(sitemap()).rejects.toThrow("/api/mechanics/sections returned 500");
+  });
+
+  it("rejects entity rows without a string id", async () => {
+    stubApi((url) => (url.endsWith("/api/relics") ? ok([{ id: 7 }]) : healthyApi(url)));
+    await expect(sitemap()).rejects.toThrow("/api/relics returned a malformed list");
+  });
+
   it("keeps keyword ids that appear in both keyword sources to one URL", async () => {
     stubApi(healthyApi);
     const urls = (await sitemap()).map((e) => e.url);
-    expect(urls.filter((u) => u === "https://spire-codex.com/keywords/strength")).toHaveLength(1);
+    expect(urls.filter((u) => u === `${SITE}/keywords/strength`)).toHaveLength(1);
   });
 });

--- a/frontend/lib/sitemap.test.ts
+++ b/frontend/lib/sitemap.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import sitemap from "@/app/sitemap";
+
+type Handler = (url: string) => Response | Promise<Response>;
+
+function stubApi(handler: Handler) {
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => handler(String(input))));
+}
+
+const ok = (body: unknown) => new Response(JSON.stringify(body), { status: 200 });
+const entity = (id: string) => ({ id, name: id, image_url: null });
+
+function healthyApi(url: string): Response {
+  if (url.endsWith("/api/changelogs")) return ok([{ date: "2026-08-14" }]);
+  if (url.endsWith("/api/mechanics/sections")) return ok([{ slug: "score-formula" }]);
+  if (url.endsWith("/api/glossary")) return ok([entity("STRENGTH")]);
+  if (url.endsWith("/api/keywords")) return ok([entity("STRENGTH"), entity("BLOCK")]);
+  return ok([entity("ALPHA")]);
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("sitemap", () => {
+  it("lists the ancient and act tier-list variants once each", async () => {
+    stubApi(healthyApi);
+    const urls = (await sitemap()).map((e) => e.url);
+    expect(urls).toContain("https://spire-codex.com/tier-list/relics?ancient=pael");
+    expect(urls).toContain("https://spire-codex.com/tier-list/relics?act=3&ancient=vakuu");
+    expect(urls).toContain("https://spire-codex.com/tier-list/relics?act=2");
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+
+  it("dates entity pages by the changelog and leaves hub pages undated", async () => {
+    stubApi(healthyApi);
+    const entries = await sitemap();
+    const home = entries.find((e) => e.url === "https://spire-codex.com/")!;
+    const card = entries.find((e) => e.url === "https://spire-codex.com/cards/alpha")!;
+    const tier = entries.find((e) => e.url === "https://spire-codex.com/tier-list/relics")!;
+    expect(home.lastModified).toBeUndefined();
+    expect(tier.lastModified).toBeUndefined();
+    expect(card.lastModified).toEqual(new Date("2026-08-14"));
+  });
+
+  it("fails the build when a list endpoint errors instead of dropping the section", async () => {
+    stubApi((url) => (url.endsWith("/api/monsters") ? new Response("", { status: 429 }) : healthyApi(url)));
+    await expect(sitemap()).rejects.toThrow("/api/monsters returned 429");
+  });
+
+  it("keeps keyword ids that appear in both keyword sources to one URL", async () => {
+    stubApi(healthyApi);
+    const urls = (await sitemap()).map((e) => e.url);
+    expect(urls.filter((u) => u === "https://spire-codex.com/keywords/strength")).toHaveLength(1);
+  });
+});

--- a/frontend/lib/tier-list-filters.ts
+++ b/frontend/lib/tier-list-filters.ts
@@ -1,0 +1,7 @@
+// Filter values that are their own canonical tier-list pages. The pages
+// render the pills from these lists and the sitemap lists the same URLs, so
+// adding a value here is the whole change.
+export const TIER_CARD_COLORS = ["ironclad", "silent", "defect", "necrobinder", "regent", "colorless"] as const;
+export const TIER_RELIC_POOLS = ["shared", "ironclad", "silent", "defect", "necrobinder", "regent"] as const;
+export const TIER_RELIC_ANCIENTS = ["neow", "tezcatara", "pael", "orobas", "darv", "nonupeipe", "tanx", "vakuu"] as const;
+export const TIER_RELIC_ACTS = ["1", "2", "3"] as const;

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,9 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: { "@": fileURLToPath(new URL(".", import.meta.url)).replace(/\/$/, "") },
+  },
+  test: { environment: "node" },
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,9 +1,13 @@
+import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
-    alias: { "@": fileURLToPath(new URL(".", import.meta.url)).replace(/\/$/, "") },
+    alias: { "@": dirname(fileURLToPath(import.meta.url)) },
   },
-  test: { environment: "node" },
+  test: {
+    environment: "node",
+    exclude: ["**/node_modules/**", "**/.next/**"],
+  },
 });


### PR DESCRIPTION
Makes the sitemap fail a regeneration instead of silently emitting empty sections when a list endpoint errors, removes the synthetic today/this-hour lastmod on hub and community pages so only entity pages carry the real changelog date, lists the relic tier list's ancient and act variants explicitly, and dedupes URLs; adds a vitest config with the @ alias so the sitemap can be tested.