### PR TITLE
Render community stats on localized card and event pages, drop their English FAQ schema

### DIFF
--- a/frontend/app/[lang]/cards/[id]/page.tsx
+++ b/frontend/app/[lang]/cards/[id]/page.tsx
@@ -69,6 +69,7 @@ export default async function Page({ params, searchParams }: Props) {
   const qs = await channelQS(searchParams);
   if (!isValidLang(lang)) return null;
   const langCode = lang as LangCode;
+  const statsPromise: Promise<EntityStats | null> = fetchEntityStats("cards", id);
   let jsonLd = null;
   let card = null;
   let apiUnreachable = false;
@@ -91,7 +92,7 @@ export default async function Page({ params, searchParams }: Props) {
   // Fail the render (500) instead of ISR-caching a contentless shell.
   if (apiUnreachable) throw new Error("entity API unreachable");
   if (!card) redirectMissingEntity("cards", id, lang);
-  const initialStats: EntityStats | null = await fetchEntityStats("cards", id);
+  const initialStats = await statsPromise;
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/cards/[id]/page.tsx
+++ b/frontend/app/[lang]/cards/[id]/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import CardDetail from "@/app/cards/[id]/CardDetail";
 import { stripTags, stripTagsFlat, clipMetaDescription, SITE_NAME, SITE_URL, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
-import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
+import { buildDetailPageJsonLd } from "@/lib/jsonld";
+import type { EntityStats } from "@/app/components/EntityRunStats";
+import { fetchEntityStats } from "@/lib/entity-stats";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { fetchEntityRes } from "@/lib/entity-fetch";
@@ -81,12 +83,7 @@ export default async function Page({ params, searchParams }: Props) {
         breadcrumbs: [{ name: "Home", href: `/${lang}` }, { name: "Cards", href: `/${lang}/cards` }, { name: card.name, href: `/${lang}/cards/${id}` }],
         inLanguage: LANG_HREFLANG[langCode],
       });
-      const costText = card.is_x_cost ? "X" : card.star_cost ? `${card.star_cost}★` : `${card.cost}`;
-      jsonLd = [...detailJsonLd, buildFAQPageJsonLd([
-        { question: `What does ${card.name} do in Slay the Spire 2?`, answer: desc || card.name },
-        { question: `How much does ${card.name} cost?`, answer: `${card.name} costs ${costText} energy.` },
-        { question: `What type of card is ${card.name}?`, answer: `${card.name} is a ${card.rarity} ${card.type} card for ${card.color}.` },
-      ])];
+      jsonLd = detailJsonLd;
     }
   } catch {
     apiUnreachable = true;
@@ -94,10 +91,11 @@ export default async function Page({ params, searchParams }: Props) {
   // Fail the render (500) instead of ISR-caching a contentless shell.
   if (apiUnreachable) throw new Error("entity API unreachable");
   if (!card) redirectMissingEntity("cards", id, lang);
+  const initialStats: EntityStats | null = await fetchEntityStats("cards", id);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <CardDetail initialCard={card} initialEnchantments={enchantmentsForCard(id)} />
+      <CardDetail initialCard={card} initialEnchantments={enchantmentsForCard(id)} initialStats={initialStats} />
     </>
   );
 }

--- a/frontend/app/[lang]/events/[id]/page.tsx
+++ b/frontend/app/[lang]/events/[id]/page.tsx
@@ -51,6 +51,7 @@ export default async function Page({ params }: Props) {
   const { lang, id } = await params;
   if (!isValidLang(lang)) return null;
   const langCode = lang as LangCode;
+  const votesPromise = fetchEventVotes(id);
   let jsonLd = null;
   let data = null;
   let apiUnreachable = false;
@@ -74,7 +75,7 @@ export default async function Page({ params }: Props) {
   // Fail the render (500) instead of ISR-caching a contentless shell.
   if (apiUnreachable) throw new Error("entity API unreachable");
   if (!data) redirectMissingEntity("events", id, lang);
-  const voteStats = await fetchEventVotes(id);
+  const voteStats = await votesPromise;
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}

--- a/frontend/app/[lang]/events/[id]/page.tsx
+++ b/frontend/app/[lang]/events/[id]/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next";
 import EventDetail from "@/app/events/[id]/EventDetail";
 import { stripTags, SITE_NAME, SITE_URL, stripTagsFlat, clipMetaDescription, buildLanguageAlternates } from "@/lib/seo";
 import JsonLd from "@/app/components/JsonLd";
-import { buildDetailPageJsonLd, buildFAQPageJsonLd } from "@/lib/jsonld";
+import { buildDetailPageJsonLd } from "@/lib/jsonld";
+import { fetchEventVotes } from "@/lib/event-votes";
 import { isValidLang, LANG_HREFLANG, LANG_NAMES, LANG_GAME_NAME, type LangCode } from "@/lib/languages";
 import { redirectMissingEntity } from "@/lib/redirect-helpers";
 import { fetchEntityRes } from "@/lib/entity-fetch";
@@ -65,10 +66,7 @@ export default async function Page({ params }: Props) {
         breadcrumbs: [{ name: "Home", href: `/${lang}` }, { name: "Events", href: `/${lang}/events` }, { name, href: `/${lang}/events/${id}` }],
         inLanguage: LANG_HREFLANG[langCode],
       });
-      jsonLd = [...detailJsonLd, buildFAQPageJsonLd([
-        { question: `What happens at the ${name} event in Slay the Spire 2?`, answer: desc || name },
-        { question: `Where does the ${name} event appear in Slay the Spire 2?`, answer: `${name} is a random event encounter in Slay the Spire 2.` },
-      ])];
+      jsonLd = detailJsonLd;
     }
   } catch {
     apiUnreachable = true;
@@ -76,10 +74,11 @@ export default async function Page({ params }: Props) {
   // Fail the render (500) instead of ISR-caching a contentless shell.
   if (apiUnreachable) throw new Error("entity API unreachable");
   if (!data) redirectMissingEntity("events", id, lang);
+  const voteStats = await fetchEventVotes(id);
   return (
     <>
       {jsonLd && <JsonLd data={jsonLd} />}
-      <EventDetail initialEvent={data} />
+      <EventDetail initialEvent={data} voteStats={voteStats} />
     </>
   );
 }

--- a/frontend/lib/localized-entity-pages.test.tsx
+++ b/frontend/lib/localized-entity-pages.test.tsx
@@ -1,0 +1,71 @@
+import type { ReactElement, ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/cards/[id]/CardDetail", () => ({ default: function CardDetail() { return null; } }));
+vi.mock("@/app/events/[id]/EventDetail", () => ({ default: function EventDetail() { return null; } }));
+vi.mock("@/app/components/JsonLd", () => ({ default: function JsonLd() { return null; } }));
+vi.mock("next/navigation", () => ({ notFound: vi.fn(), permanentRedirect: vi.fn() }));
+
+import CardDetail from "@/app/cards/[id]/CardDetail";
+import EventDetail from "@/app/events/[id]/EventDetail";
+import JsonLd from "@/app/components/JsonLd";
+import CardPage from "@/app/[lang]/cards/[id]/page";
+import EventPage from "@/app/[lang]/events/[id]/page";
+
+const ok = (body: unknown) => new Response(JSON.stringify(body), { status: 200 });
+
+function stubApi(handler: (url: string) => Response) {
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => handler(String(input))));
+}
+
+function healthy(url: string): Response {
+  if (url.includes("/api/cards/")) return ok({ id: "BASH", name: "Heurt", description: "Frappe.", rarity: "Basic", type: "Attack", color: "IRONCLAD", cost: 2 });
+  if (url.includes("/api/events/")) return ok({ id: "TRIAL", name: "Le procès", description: "Un choix." });
+  if (url.includes("/api/runs/stats/")) return ok({ picks: 10, win_rate: 0.5, total_runs: 100 });
+  if (url.includes("/api/runs/community-stats")) return ok({ events: [{ id: "TRIAL", total: 12, options: [{ id: "A", count: 7 }, { id: "B", count: 5 }] }] });
+  return new Response("", { status: 404 });
+}
+
+function elements(node: ReactNode, out: ReactElement[] = []): ReactElement[] {
+  if (!node || typeof node !== "object") return out;
+  if (Array.isArray(node)) {
+    node.forEach((n) => elements(n, out));
+    return out;
+  }
+  const el = node as ReactElement<{ children?: ReactNode }>;
+  out.push(el);
+  elements(el.props?.children, out);
+  return out;
+}
+
+const props = (lang: string, id: string) => ({ params: Promise.resolve({ lang, id }), searchParams: Promise.resolve({}) });
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("localized entity pages", () => {
+  it("renders the community stats on a localized card page and emits no FAQ schema", async () => {
+    stubApi(healthy);
+    const tree = elements(await CardPage(props("fra", "bash")));
+    const detail = tree.find((el) => el.type === CardDetail) as ReactElement<{ initialStats: unknown }> | undefined;
+    expect(detail?.props.initialStats).toMatchObject({ picks: 10 });
+    const jsonLd = tree.find((el) => el.type === JsonLd) as ReactElement<{ data: unknown }> | undefined;
+    expect(JSON.stringify(jsonLd?.props.data)).not.toContain("FAQPage");
+  });
+
+  it("renders the vote distribution on a localized event page and emits no FAQ schema", async () => {
+    stubApi(healthy);
+    const tree = elements(await EventPage(props("fra", "trial")));
+    const detail = tree.find((el) => el.type === EventDetail) as ReactElement<{ voteStats: unknown }> | undefined;
+    expect(detail?.props.voteStats).toBeTruthy();
+    const jsonLd = tree.find((el) => el.type === JsonLd) as ReactElement<{ data: unknown }> | undefined;
+    expect(JSON.stringify(jsonLd?.props.data)).not.toContain("FAQPage");
+  });
+
+  it("still renders the entity when the stats endpoint fails", async () => {
+    stubApi((url) => (url.includes("/api/runs/") ? new Response("", { status: 503 }) : healthy(url)));
+    const tree = elements(await CardPage(props("fra", "bash")));
+    const detail = tree.find((el) => el.type === CardDetail) as ReactElement<{ initialStats: unknown }> | undefined;
+    expect(detail).toBeTruthy();
+    expect(detail?.props.initialStats).toBeNull();
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,13 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: { "@": dirname(fileURLToPath(import.meta.url)) },
+  },
+  test: {
+    environment: "node",
+    exclude: ["**/node_modules/**", "**/.next/**"],
+  },
+});


### PR DESCRIPTION
Localized card and event pages now server-render the same run stats and event choice distribution as the English pages instead of a bare name and description, and no longer emit English-language FAQPage JSON-LD on non-English URLs.