### PR TITLE
Fix Soft 404s on entity pages: keep server data when the client refetch fails, unblock /api/ for rendering

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -360,6 +360,8 @@ class CORSStaticMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
         response.headers["Access-Control-Allow-Origin"] = "*"
         response.headers["X-Content-Type-Options"] = "nosniff"
+        if request.url.path.startswith("/api/"):
+            response.headers["X-Robots-Tag"] = "noindex"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Strict-Transport-Security"] = (
             "max-age=31536000; includeSubDomains"

--- a/backend/tests/test_robots_header.py
+++ b/backend/tests/test_robots_header.py
@@ -1,0 +1,17 @@
+"""API responses carry X-Robots-Tag: noindex so Googlebot may fetch them for rendering without indexing the JSON."""
+
+from fastapi.testclient import TestClient
+
+from app import main as m
+
+client = TestClient(m.app, raise_server_exceptions=False)
+
+
+def test_api_responses_are_noindex():
+    r = client.get("/api/version")
+    assert r.headers.get("x-robots-tag") == "noindex"
+
+
+def test_non_api_responses_have_no_robots_header():
+    r = client.get("/health")
+    assert "x-robots-tag" not in r.headers

--- a/frontend/app/achievements/[id]/AchievementDetail.tsx
+++ b/frontend/app/achievements/[id]/AchievementDetail.tsx
@@ -31,7 +31,9 @@ export default function AchievementDetail({ initialAchievement }: { initialAchie
     if (!id) return;
     cachedFetch<Achievement>(`${API}/api/achievements/${id}?lang=${lang}`)
       .then((data) => setAchievement(data))
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialAchievement) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/acts/[id]/ActDetail.tsx
+++ b/frontend/app/acts/[id]/ActDetail.tsx
@@ -29,7 +29,9 @@ export default function ActDetail({ initialAct }: { initialAct?: Act | null } = 
     if (!id) return;
     cachedFetch<Act>(`${API}/api/acts/${id}?lang=${lang}`)
       .then((data) => setAct(data))
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialAct) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/afflictions/[id]/AfflictionDetail.tsx
+++ b/frontend/app/afflictions/[id]/AfflictionDetail.tsx
@@ -30,7 +30,9 @@ export default function AfflictionDetail({ initialAffliction }: { initialAfflict
     if (!id) return;
     cachedFetch<Affliction>(`${API}/api/afflictions/${id}?lang=${lang}`)
       .then((data) => setAffliction(data))
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialAffliction) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/ascensions/[id]/AscensionDetail.tsx
+++ b/frontend/app/ascensions/[id]/AscensionDetail.tsx
@@ -37,7 +37,9 @@ export default function AscensionDetail({ initialAscension }: { initialAscension
         setAscension(asc);
         setAllAscensions(all);
       })
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialAscension) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/cards/[id]/CardDetail.tsx
+++ b/frontend/app/cards/[id]/CardDetail.tsx
@@ -204,7 +204,9 @@ export default function CardDetail({ initialCard, initialEnchantments, initialSt
           ).then((results) => setSpawnedCards(results.filter(Boolean) as Card[]));
         }
       })
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialCard) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/characters/[id]/CharacterDetail.tsx
+++ b/frontend/app/characters/[id]/CharacterDetail.tsx
@@ -131,7 +131,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
     if (!id) return;
     Promise.all([
       cachedFetch<Character>(`${API}/api/characters/${id}?lang=${lang}`).catch(() => {
-        setNotFound(true);
+        if (!initialCharacter) setNotFound(true);
         return null;
       }),
       cachedFetch<Card[]>(`${API}/api/cards?lang=${lang}`),

--- a/frontend/app/enchantments/[id]/EnchantmentDetail.tsx
+++ b/frontend/app/enchantments/[id]/EnchantmentDetail.tsx
@@ -45,7 +45,9 @@ export default function EnchantmentDetail({
     if (!id) return;
     cachedFetch<Enchantment>(`${API}/api/enchantments/${id}?lang=${lang}`)
       .then((data) => setEnchantment(data))
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialEnchantment) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/encounters/[id]/EncounterDetail.tsx
+++ b/frontend/app/encounters/[id]/EncounterDetail.tsx
@@ -46,7 +46,9 @@ export default function EncounterDetail({ initialEncounter, encounterStat }: { i
     if (!id) return;
     cachedFetch<Encounter>(`${API}/api/encounters/${id}?lang=${lang}`)
       .then((data) => setEncounter(data))
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialEncounter) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/events/[id]/EventDetail.tsx
+++ b/frontend/app/events/[id]/EventDetail.tsx
@@ -84,7 +84,9 @@ export default function EventDetail({
     if (!id) return;
     cachedFetch<GameEvent>(`${API}/api/events/${id}?lang=${lang}`)
       .then((data) => setEvent(data))
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialEvent) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/intents/[id]/IntentDetail.tsx
+++ b/frontend/app/intents/[id]/IntentDetail.tsx
@@ -31,7 +31,9 @@ export default function IntentDetail({ initialIntent }: { initialIntent?: Intent
     if (!id) return;
     cachedFetch<Intent>(`${API}/api/intents/${id}?lang=${lang}`)
       .then((data) => setIntent(data))
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialIntent) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/keywords/[id]/KeywordDetail.tsx
+++ b/frontend/app/keywords/[id]/KeywordDetail.tsx
@@ -80,7 +80,9 @@ export default function KeywordDetail({ initialResult }: { initialResult?: Initi
         // Not a keyword, try glossary
         return cachedFetch<GlossaryTerm>(`${API}/api/glossary/${id}?lang=${lang}`)
           .then((term) => setGlossary(term))
-          .catch(() => setNotFound(true));
+          .catch(() => {
+            if (!initialResult) setNotFound(true);
+          });
       })
       .finally(() => setLoading(false));
   }, [id, lang]);

--- a/frontend/app/modifiers/[id]/ModifierDetail.tsx
+++ b/frontend/app/modifiers/[id]/ModifierDetail.tsx
@@ -30,7 +30,9 @@ export default function ModifierDetail({ initialModifier }: { initialModifier?: 
     if (!id) return;
     cachedFetch<Modifier>(`${API}/api/modifiers/${id}?lang=${lang}`)
       .then((data) => setModifier(data))
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialModifier) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/monsters/[id]/MonsterDetail.tsx
+++ b/frontend/app/monsters/[id]/MonsterDetail.tsx
@@ -367,7 +367,9 @@ export default function MonsterDetail({
     if (!id) return;
     cachedFetch<Monster>(`${API}/api/monsters/${id}?lang=${lang}`)
       .then((data) => setMonster(data))
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialMonster) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/orbs/[id]/OrbDetail.tsx
+++ b/frontend/app/orbs/[id]/OrbDetail.tsx
@@ -31,7 +31,9 @@ export default function OrbDetail({ initialOrb }: { initialOrb?: Orb | null } = 
     if (!id) return;
     cachedFetch<Orb>(`${API}/api/orbs/${id}?lang=${lang}`)
       .then((data) => setOrb(data))
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialOrb) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/potions/[id]/PotionDetail.tsx
+++ b/frontend/app/potions/[id]/PotionDetail.tsx
@@ -70,7 +70,9 @@ export default function PotionDetail({
     if (!id) return;
     cachedFetch<Potion>(`${API}/api/potions/${id}?lang=${lang}`)
       .then((data) => setPotion(data))
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialPotion) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/powers/[id]/PowerDetail.tsx
+++ b/frontend/app/powers/[id]/PowerDetail.tsx
@@ -46,7 +46,9 @@ export default function PowerDetail({ initialPower }: { initialPower?: Power | n
     if (!id) return;
     cachedFetch<Power>(`${API}/api/powers/${id}?lang=${lang}`)
       .then((data) => setPower(data))
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialPower) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/relics/[id]/RelicDetail.tsx
+++ b/frontend/app/relics/[id]/RelicDetail.tsx
@@ -70,7 +70,9 @@ export default function RelicDetail({
           }
         }
       })
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialRelic) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -18,7 +18,7 @@ export default function robots(): MetadataRoute.Robots {
         // JS/CSS chunks to render pages, and a disallow there blocked every
         // asset on every page (crawlers flagged all of them).
         disallow: [
-          "/api/",       // backend JSON + download endpoints
+          "/api/images/", // bulk image download endpoints; the rest of /api/ must stay fetchable so Googlebot can render pages, and it carries X-Robots-Tag: noindex
           "/static/",    // static asset trees (CDN-served)
           "/uninstall",  // Overwolf post-uninstall survey, entered only by the OW client
         ],

--- a/frontend/app/timeline/[id]/EpochDetail.tsx
+++ b/frontend/app/timeline/[id]/EpochDetail.tsx
@@ -51,7 +51,9 @@ export default function EpochDetail({ initialEpoch }: { initialEpoch?: Epoch | n
     if (!id) return;
     cachedFetch<Epoch>(`${API}/api/epochs/${id}?lang=${lang}`)
       .then(setEpoch)
-      .catch(() => setNotFound(true))
+      .catch(() => {
+        if (!initialEpoch) setNotFound(true);
+      })
       .finally(() => setLoading(false));
   }, [id, lang]);
 


### PR DESCRIPTION
Fixes the Soft 404s GSC reports on valid entity pages: the detail clients no longer replace server-rendered content with Not Found when their refetch fails, and robots.txt stops blocking /api/ for Googlebot's renderer (API responses carry X-Robots-Tag: noindex instead).