### PR TITLE
Design tokens: purpose-named colors for both themes, no raw palette classes in components

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,17 +140,31 @@ mistake at PR review rather than after-the-fact.
 
 ## Colors
 
-We use game-accurate colors sampled from the actual game assets. Don't use generic Tailwind colors for character-specific UI:
+Every color comes from a design token in `frontend/app/globals.css`. Tokens are named by what they mean, not what they look like, so a component says "this is a warning" and the theme (dark or light) picks the color. Never write a raw Tailwind palette class (`text-red-400`, `bg-emerald-950/50`) or a hex value in a component; `frontend/lib/design-tokens.test.ts` fails on both.
 
-| Character   | Color     | Source            |
-|-------------|-----------|-------------------|
-| Ironclad    | `#d53b27` | Energy icon       |
-| Silent      | `#23935b` | Energy icon       |
-| Defect      | `#3873a9` | Energy icon       |
-| Necrobinder | `#bf5a85` | Energy icon       |
-| Regent      | `#f07c1e` | Energy icon       |
+Use the Tailwind utility for the token. Opacity modifiers work on all of them (`bg-danger/10`, `border-info/40`, `text-success/70`).
 
-These are defined as CSS variables (`--color-ironclad`, etc.) in `globals.css`.
+| Meaning | Utilities | Use for |
+|---|---|---|
+| Surfaces | `bg-background`, `bg-surface`, `bg-surface-hover`, `bg-scrim/60` | page ground, cards, hover state, dimming layers over art |
+| Text | `text-fg`, `text-fg-secondary`, `text-fg-muted` | body, supporting, quiet text on a surface |
+| Text on fills | `text-on-accent`, `text-on-fill` | labels on a gold button; labels on a status fill or a scrim |
+| Borders | `border-line`, `border-line-strong` | dividers, inputs, chips |
+| Accent | `text-accent`, `bg-accent`, `text-accent-light` | the site gold, primary buttons, links |
+| Status text/tints | `success`, `danger`, `warning`, `info`, `special` | won / lost / caution / neutral highlight / events and curses. Text, borders and translucent tints only |
+| Status fills | `bg-success-fill` ... `bg-special-fill` | solid backgrounds, paired with `text-on-fill` |
+| Game | `keyword`, `upgrade`, `ironclad`, `silent`, `defect`, `necrobinder`, `regent`, `ancient`, `merchant`, `spire` | anything that must match the game's own colors |
+| Brands | `twitch`, `twitch-light`, `bluesky`, `patreon` | only on that service's sign-in button or link |
+
+Rules of thumb:
+
+- Text goes on its matching surface: `text-fg-*` on `bg-surface`, `text-on-fill` on a `-fill` or scrim, `text-on-accent` on gold.
+- A status color says something happened (a win is `success`, a death is `danger`). Do not pick one because it looks nice.
+- Need a new color? Add a token to both theme blocks in `globals.css` and register it in `@theme inline`, then use the utility. Check the light value against white for WCAG AA (4.5:1).
+- Canvas and chart code cannot read CSS classes. Resolve the token at runtime with `getComputedStyle(document.documentElement).getPropertyValue("--success")` the way `charts/ChartsClient.tsx` does.
+- Legacy `var(--bg-card)` style arbitrary values still work and mean the same thing; prefer the utility in new code.
+
+The character colors are sampled from the game's energy icons: Ironclad `#d53b27`, Silent `#23935b`, Defect `#3873a9`, Necrobinder `#bf5a85`, Regent `#f07c1e`.
 
 ## Localization
 

--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -121,55 +121,55 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
       href: "/cards",
       key: "cards",
       count: stats?.cards ?? "–",
-      color: "#d53b27",  // ironclad red
+      color: "var(--color-ironclad)",
     },
     {
       href: "/characters",
       key: "characters",
       count: stats?.characters ?? "–",
-      color: "#e8b830",  // gold
+      color: "var(--accent-gold)",
     },
     {
       href: "/relics",
       key: "relics",
       count: stats?.relics ?? "–",
-      color: "#bf5a85",  // necrobinder rose
+      color: "var(--color-necrobinder)",
     },
     {
       href: "/monsters",
       key: "monsters",
       count: stats?.monsters ?? "–",
-      color: "#23935b",  // silent green
+      color: "var(--color-silent)",
     },
     {
       href: "/potions",
       key: "potions",
       count: stats?.potions ?? "–",
-      color: "#3873a9",  // defect blue
+      color: "var(--color-defect)",
     },
     {
       href: "/enchantments",
       key: "enchantments",
       count: stats?.enchantments ?? "–",
-      color: "#45cfd8",  // teal
+      color: "var(--accent-teal)",
     },
     {
       href: "/encounters",
       key: "encounters",
       count: stats?.encounters ?? "–",
-      color: "#ac6345",  // spire orange
+      color: "var(--color-spire)",
     },
     {
       href: "/events",
       key: "events",
       count: stats?.events ?? "–",
-      color: "#6b5b8a",  // atmosphere purple
+      color: "var(--color-ancient)",
     },
     {
       href: "/powers",
       key: "powers",
       count: stats?.powers ?? "–",
-      color: "#45cfd8",  // teal
+      color: "var(--accent-teal)",
     },
     {
       href: "/timeline",
@@ -181,7 +181,7 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
       href: "/images",
       key: "images",
       count: stats?.images ?? "–",
-      color: "#f07c1e",  // regent orange
+      color: "var(--color-regent)",
     },
     {
       href: "/reference",
@@ -202,7 +202,7 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
       href: "/badges",
       key: "badges",
       count: stats?.badges ?? "–",
-      color: "#c5894a",  // bronze
+      color: "var(--color-merchant)",
     },
   ];
 
@@ -257,7 +257,7 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
               aria-label={`${i + 1} / ${gsCount}`}
               aria-current={i === gsIndex}
               className={`h-1.5 rounded-full transition-all ${
-                i === gsIndex ? "w-4 bg-white/80" : "w-1.5 bg-white/30 hover:bg-white/50"
+                i === gsIndex ? "w-4 bg-on-fill/80" : "w-1.5 bg-on-fill/30 hover:bg-on-fill/50"
               }`}
             />
           ))}

--- a/frontend/app/[locale]/admin/AdminClient.tsx
+++ b/frontend/app/[locale]/admin/AdminClient.tsx
@@ -137,7 +137,7 @@ export default function AdminClient() {
         ))}
       </div>
 
-      {error && <p className="text-sm text-rose-400 mb-4">{error}</p>}
+      {error && <p className="text-sm text-danger mb-4">{error}</p>}
       {!data && !error && (
         <p className="text-sm text-[var(--text-muted)]">Loading overview...</p>
       )}

--- a/frontend/app/[locale]/admin/analytics/AnalyticsClient.tsx
+++ b/frontend/app/[locale]/admin/analytics/AnalyticsClient.tsx
@@ -72,13 +72,13 @@ export default function AnalyticsClient() {
           </div>
 
           <div className="mb-8 flex flex-wrap items-center gap-4">
-            <div className="flex items-center gap-3 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-5 py-4">
+            <div className="flex items-center gap-3 rounded-lg border border-success/30 bg-success/5 px-5 py-4">
               <span className="relative flex h-3 w-3">
-                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
-                <span className="relative inline-flex h-3 w-3 rounded-full bg-emerald-500" />
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-success-fill opacity-75" />
+                <span className="relative inline-flex h-3 w-3 rounded-full bg-success-fill" />
               </span>
               <div>
-                <div className="text-2xl font-bold tabular-nums text-emerald-400">
+                <div className="text-2xl font-bold tabular-nums text-success">
                   {(data.active ?? 0).toLocaleString()}
                 </div>
                 <div className="text-xs uppercase tracking-wider text-[var(--text-muted)]">

--- a/frontend/app/[locale]/admin/banners/BannersClient.tsx
+++ b/frontend/app/[locale]/admin/banners/BannersClient.tsx
@@ -94,7 +94,7 @@ export default function BannersClient() {
                 <span
                   className={`px-1.5 py-0.5 rounded mr-2 font-semibold ${
                     a.active
-                      ? "bg-emerald-950/60 text-emerald-300 border border-emerald-900/40"
+                      ? "bg-success/10 text-success border border-success/30"
                       : "bg-[var(--bg-primary)] text-[var(--text-muted)] border border-[var(--border-subtle)]"
                   }`}
                 >
@@ -111,7 +111,7 @@ export default function BannersClient() {
                 </button>
                 <button
                   onClick={() => remove(a.id)}
-                  className="px-2.5 py-1 rounded text-xs font-semibold bg-rose-950/60 text-rose-300 border border-rose-900/40 hover:bg-rose-900/60"
+                  className="px-2.5 py-1 rounded text-xs font-semibold bg-danger/10 text-danger border border-danger/30 hover:bg-danger/10"
                 >
                   Delete
                 </button>

--- a/frontend/app/[locale]/admin/cache/CacheClient.tsx
+++ b/frontend/app/[locale]/admin/cache/CacheClient.tsx
@@ -70,7 +70,7 @@ export default function CacheClient() {
         <button
           onClick={() => purge(true)}
           disabled={busy}
-          className="px-4 py-1.5 rounded-lg text-sm font-semibold bg-rose-950/60 text-rose-300 border border-rose-900/40 hover:bg-rose-900/60 disabled:opacity-50"
+          className="px-4 py-1.5 rounded-lg text-sm font-semibold bg-danger/10 text-danger border border-danger/30 hover:bg-danger/10 disabled:opacity-50"
         >
           Purge everything
         </button>

--- a/frontend/app/[locale]/admin/elo/EloClient.tsx
+++ b/frontend/app/[locale]/admin/elo/EloClient.tsx
@@ -43,7 +43,7 @@ function TrajectoryChart({ userId }: { userId: string }) {
       .catch((e) => setErr(String((e as Error)?.message || e)));
   }, [userId]);
 
-  if (err) return <p className="text-xs text-rose-400 py-3">{err}</p>;
+  if (err) return <p className="text-xs text-danger py-3">{err}</p>;
   if (!hist) return <p className="text-xs text-[var(--text-muted)] py-3">Loading trajectory…</p>;
 
   return (
@@ -130,7 +130,7 @@ export default function EloClient() {
               : ""}
           </span>
         )}
-        {note && <span className="text-xs text-rose-400">{note}</span>}
+        {note && <span className="text-xs text-danger">{note}</span>}
       </div>
 
       <div className="overflow-x-auto">

--- a/frontend/app/[locale]/admin/feedback/FeedbackClient.tsx
+++ b/frontend/app/[locale]/admin/feedback/FeedbackClient.tsx
@@ -78,7 +78,7 @@ export default function FeedbackClient() {
               {!i.resolved && (
                 <button
                   onClick={() => resolve(i.id)}
-                  className="px-2.5 py-1 rounded text-xs font-semibold bg-emerald-950/60 text-emerald-300 border border-emerald-900/40 hover:bg-emerald-900/60 shrink-0"
+                  className="px-2.5 py-1 rounded text-xs font-semibold bg-success/10 text-success border border-success/30 hover:bg-success/10 shrink-0"
                 >
                   Resolve
                 </button>

--- a/frontend/app/[locale]/admin/guides/GuidesClient.tsx
+++ b/frontend/app/[locale]/admin/guides/GuidesClient.tsx
@@ -63,7 +63,7 @@ export default function GuidesClient() {
                 </button>
                 <button
                   onClick={() => dismiss(g.id)}
-                  className="px-2.5 py-1 rounded text-xs font-semibold bg-rose-950/60 text-rose-300 border border-rose-900/40 hover:bg-rose-900/60"
+                  className="px-2.5 py-1 rounded text-xs font-semibold bg-danger/10 text-danger border border-danger/30 hover:bg-danger/10"
                 >
                   Dismiss
                 </button>

--- a/frontend/app/[locale]/admin/keys/KeysClient.tsx
+++ b/frontend/app/[locale]/admin/keys/KeysClient.tsx
@@ -34,7 +34,7 @@ function fmt(iso: string | null): string {
 const TIER_BADGE: Record<string, string> = {
   general: "text-[var(--text-secondary)] border-[var(--border-subtle)]",
   registered: "text-[var(--text-primary)] border-[var(--border-subtle)]",
-  academia: "text-blue-400 border-blue-500/40",
+  academia: "text-info border-info/40",
   paid: "text-[var(--accent-gold)] border-[var(--accent-gold)]/40",
 };
 
@@ -117,7 +117,7 @@ export default function KeysClient() {
         )}
       </div>
 
-      {note && <p className="text-sm text-red-400 mb-4">{note}</p>}
+      {note && <p className="text-sm text-danger mb-4">{note}</p>}
       {data === null && !note && (
         <p className="text-sm text-[var(--text-muted)]">Loading…</p>
       )}
@@ -156,7 +156,7 @@ export default function KeysClient() {
                 </div>
               </div>
               {k.revoked ? (
-                <span className="shrink-0 text-xs px-2 py-0.5 rounded-full border border-red-500/40 text-red-400">
+                <span className="shrink-0 text-xs px-2 py-0.5 rounded-full border border-danger/40 text-danger">
                   revoked
                 </span>
               ) : (
@@ -177,7 +177,7 @@ export default function KeysClient() {
                     type="button"
                     disabled={busy === k.id}
                     onClick={() => revoke(k)}
-                    className="shrink-0 text-xs px-2.5 py-1 rounded-lg border border-red-500/40 bg-red-500/10 text-red-400 disabled:opacity-50"
+                    className="shrink-0 text-xs px-2.5 py-1 rounded-lg border border-danger/40 bg-danger/10 text-danger disabled:opacity-50"
                   >
                     Revoke
                   </button>

--- a/frontend/app/[locale]/admin/news/NewsAdminClient.tsx
+++ b/frontend/app/[locale]/admin/news/NewsAdminClient.tsx
@@ -153,7 +153,7 @@ export default function NewsAdminClient() {
                     ev.stopPropagation();
                     remove(e.id);
                   }}
-                  className="px-2 py-1 rounded text-xs border border-red-500/40 bg-red-500/10 text-red-400 shrink-0"
+                  className="px-2 py-1 rounded text-xs border border-danger/40 bg-danger/10 text-danger shrink-0"
                 >
                   ✕
                 </button>

--- a/frontend/app/[locale]/admin/rate-limits/RateLimitsClient.tsx
+++ b/frontend/app/[locale]/admin/rate-limits/RateLimitsClient.tsx
@@ -112,8 +112,8 @@ export default function RateLimitsClient() {
               onClick={() => save({ enabled: !enabled })}
               className={`px-3 py-1.5 rounded-lg text-sm border transition-colors disabled:opacity-50 ${
                 enabled
-                  ? "bg-emerald-500/15 border-emerald-500/40 text-emerald-400"
-                  : "bg-red-500/15 border-red-500/40 text-red-400"
+                  ? "bg-success/15 border-success/40 text-success"
+                  : "bg-danger/15 border-danger/40 text-danger"
               }`}
             >
               {enabled ? "Enabled" : "Disabled"}
@@ -242,7 +242,7 @@ export default function RateLimitsClient() {
                     type="button"
                     disabled={saving}
                     onClick={() => setOverrides(overrides.filter((_, j) => j !== i))}
-                    className="px-2.5 py-2 rounded-lg text-sm border border-red-500/40 bg-red-500/10 text-red-400 disabled:opacity-50"
+                    className="px-2.5 py-2 rounded-lg text-sm border border-danger/40 bg-danger/10 text-danger disabled:opacity-50"
                     aria-label="Remove clamp"
                   >
                     ✕

--- a/frontend/app/[locale]/admin/runs/RunsClient.tsx
+++ b/frontend/app/[locale]/admin/runs/RunsClient.tsx
@@ -271,7 +271,7 @@ export default function RunsClient() {
         <button
           onClick={() => cheatSweep(false)}
           disabled={busy}
-          className="px-4 py-1.5 rounded-lg border border-red-500/40 text-sm font-semibold text-red-400 hover:bg-red-500/10 disabled:opacity-50"
+          className="px-4 py-1.5 rounded-lg border border-danger/40 text-sm font-semibold text-danger hover:bg-danger/10 disabled:opacity-50"
           title="Hide everything the sweep flags"
         >
           Sweep & hide
@@ -309,19 +309,19 @@ export default function RunsClient() {
                       </Link>
                     ) : "-"}
                     {r.hidden_reason && (
-                      <span className="block text-[10px] text-red-400/80 font-mono" title="auto-hide reason">
+                      <span className="block text-[10px] text-danger/80 font-mono" title="auto-hide reason">
                         {r.hidden_reason}
                       </span>
                     )}
                     {r.hidden && (
-                      <span className="ml-1.5 px-1.5 py-0.5 rounded text-[10px] font-bold border bg-rose-950/50 text-rose-300 border-rose-900/50">
+                      <span className="ml-1.5 px-1.5 py-0.5 rounded text-[10px] font-bold border bg-danger/10 text-danger border-danger/30">
                         hidden
                       </span>
                     )}
                     {(r.reasons ?? []).map((reason) => (
                       <span
                         key={reason}
-                        className="ml-1.5 px-1.5 py-0.5 rounded text-[10px] font-bold border bg-amber-950/50 text-amber-300 border-amber-900/50"
+                        className="ml-1.5 px-1.5 py-0.5 rounded text-[10px] font-bold border bg-warning/10 text-warning border-warning/30"
                       >
                         {reason}
                         {reason.startsWith("deck") && r.deck_size ? ` (${r.deck_size})` : ""}
@@ -350,7 +350,7 @@ export default function RunsClient() {
                       {r.run_hash && (
                         <button
                           onClick={() => remove(r.run_hash!)}
-                          className="px-2.5 py-1 rounded text-xs font-semibold bg-rose-950/60 text-rose-300 border border-rose-900/40 hover:bg-rose-900/60"
+                          className="px-2.5 py-1 rounded text-xs font-semibold bg-danger/10 text-danger border border-danger/30 hover:bg-danger/10"
                         >
                           Delete
                         </button>

--- a/frontend/app/[locale]/admin/searches/SearchesClient.tsx
+++ b/frontend/app/[locale]/admin/searches/SearchesClient.tsx
@@ -100,7 +100,7 @@ function QueryTable({
                   {showZeroRate && (
                     <td
                       className={`px-2 py-2 text-right tabular-nums whitespace-nowrap ${
-                        r.zero_rate > 0 ? "text-red-400" : "text-[var(--text-muted)]"
+                        r.zero_rate > 0 ? "text-danger" : "text-[var(--text-muted)]"
                       }`}
                     >
                       {pct(r.zero_rate)} empty
@@ -140,7 +140,7 @@ function VolumeChart({ volume }: { volume: VolRow[] }) {
               className="flex-1 min-w-[2px] flex flex-col justify-end"
             >
               <div
-                className="bg-red-500/70 rounded-t-sm"
+                className="bg-danger/70 rounded-t-sm"
                 style={{ height: `${(v.zero / max) * 100}%` }}
               />
               <div
@@ -198,7 +198,7 @@ export default function SearchesClient() {
         ))}
       </div>
 
-      {note && <p className="text-sm text-red-400 mb-4">{note}</p>}
+      {note && <p className="text-sm text-danger mb-4">{note}</p>}
 
       {s && (
         <div className="grid grid-cols-2 lg:grid-cols-5 gap-3 mb-6">
@@ -245,7 +245,7 @@ export default function SearchesClient() {
                 <span className="text-xs text-[var(--text-muted)] uppercase">{r.lang}</span>
                 <span
                   className={`text-xs tabular-nums whitespace-nowrap ${
-                    r.results === 0 ? "text-red-400" : "text-[var(--text-secondary)]"
+                    r.results === 0 ? "text-danger" : "text-[var(--text-secondary)]"
                   }`}
                 >
                   {r.results} hit{r.results === 1 ? "" : "s"}

--- a/frontend/app/[locale]/admin/users/GiveawayLookup.tsx
+++ b/frontend/app/[locale]/admin/users/GiveawayLookup.tsx
@@ -236,7 +236,7 @@ export default function GiveawayLookup() {
                             </a>
                           ) : (
                             <span
-                              className={`${badge} bg-rose-950/50 text-rose-300 border-rose-900/50`}
+                              className={`${badge} bg-danger/10 text-danger border-danger/30`}
                             >
                               {r.valid ? "private / not found" : "invalid id"}
                             </span>
@@ -249,7 +249,7 @@ export default function GiveawayLookup() {
                           {r.member ? (
                             <span className="flex flex-wrap items-center gap-1">
                               <span
-                                className={`${badge} bg-emerald-950/50 text-emerald-300 border-emerald-900/50`}
+                                className={`${badge} bg-success/10 text-success border-success/30`}
                               >
                                 Member
                               </span>
@@ -259,7 +259,7 @@ export default function GiveawayLookup() {
                               </span>
                               {r.member.is_partner && (
                                 <span
-                                  className={`${badge} bg-amber-950/50 text-amber-300 border-amber-900/50`}
+                                  className={`${badge} bg-warning/10 text-warning border-warning/30`}
                                 >
                                   Partner
                                 </span>

--- a/frontend/app/[locale]/admin/users/UsersClient.tsx
+++ b/frontend/app/[locale]/admin/users/UsersClient.tsx
@@ -37,7 +37,7 @@ function IdentityBadges({ u }: { u: UserRow }) {
     <span className="flex flex-wrap gap-1">
       {u.steam_id && (
         <span
-          className={`${badge} bg-sky-950/50 text-sky-300 border-sky-900/50`}
+          className={`${badge} bg-info/10 text-info border-info/30`}
           title={`Steam ${u.steam_id}`}
         >
           Steam
@@ -45,7 +45,7 @@ function IdentityBadges({ u }: { u: UserRow }) {
       )}
       {u.discord_id && (
         <span
-          className={`${badge} bg-indigo-950/50 text-indigo-300 border-indigo-900/50`}
+          className={`${badge} bg-info/10 text-info border-info/30`}
           title={`Discord ${u.discord_id}`}
         >
           Discord
@@ -53,14 +53,14 @@ function IdentityBadges({ u }: { u: UserRow }) {
       )}
       {u.twitch_id && (
         <span
-          className={`${badge} bg-[#9146FF]/15 text-[#b794ff] border-[#9146FF]/40`}
+          className={`${badge} bg-twitch/15 text-twitch-light border-twitch/40`}
           title={`Twitch ${u.twitch_login ?? u.twitch_id}`}
         >
           Twitch
         </span>
       )}
       {u.is_partner && (
-        <span className={`${badge} bg-amber-950/50 text-amber-300 border-amber-900/50`}>
+        <span className={`${badge} bg-warning/10 text-warning border-warning/30`}>
           Partner
         </span>
       )}
@@ -315,7 +315,7 @@ export default function UsersClient() {
                                 onClick={() => togglePartner(u)}
                                 className={
                                   u.is_partner
-                                    ? "px-2.5 py-1 rounded text-xs font-semibold bg-[#9146FF]/20 text-[#b794ff] border border-[#9146FF]/40 hover:bg-[#9146FF]/30"
+                                    ? "px-2.5 py-1 rounded text-xs font-semibold bg-twitch/20 text-twitch-light border border-twitch/40 hover:bg-twitch/30"
                                     : actionBtn
                                 }
                                 title={
@@ -329,7 +329,7 @@ export default function UsersClient() {
                             )}
                             <button
                               onClick={() => remove(u)}
-                              className="px-2.5 py-1 rounded text-xs font-semibold bg-rose-950/60 text-rose-300 border border-rose-900/40 hover:bg-rose-900/60"
+                              className="px-2.5 py-1 rounded text-xs font-semibold bg-danger/10 text-danger border border-danger/30 hover:bg-danger/10"
                             >
                               Delete
                             </button>

--- a/frontend/app/[locale]/archetypes/page.tsx
+++ b/frontend/app/[locale]/archetypes/page.tsx
@@ -258,7 +258,7 @@ export default async function ArchetypesPage({ params }: Props) {
                           prefetch={false}
                           key={e.id}
                           href={`/relics/${e.id.toLowerCase()}`}
-                          className="text-xs px-2 py-0.5 rounded-md border border-sky-900/50 bg-[var(--bg-primary)] text-sky-300 hover:border-sky-500/60 transition-colors"
+                          className="text-xs px-2 py-0.5 rounded-md border border-info/30 bg-[var(--bg-primary)] text-info hover:border-info/60 transition-colors"
                         >
                           {e.name}
                         </Link>

--- a/frontend/app/[locale]/badges/page.tsx
+++ b/frontend/app/[locale]/badges/page.tsx
@@ -25,9 +25,9 @@ const API =
 const STATIC_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 const TOP_TIER_BORDER: Record<string, string> = {
-  bronze: "border-[#a87a3d]",
-  silver: "border-[#9ca6b4]",
-  gold: "border-[var(--accent-gold)]",
+  bronze: "border-bronze",
+  silver: "border-silver",
+  gold: "border-accent",
 };
 
 type Props = { params: Promise<{ locale: string }> };

--- a/frontend/app/[locale]/beta/DiffSection.tsx
+++ b/frontend/app/[locale]/beta/DiffSection.tsx
@@ -28,17 +28,17 @@ export function SummaryBadge({
   return (
     <div className="flex gap-2 text-xs">
       {added > 0 && (
-        <span className="px-2 py-0.5 rounded bg-emerald-950/50 text-emerald-400 border border-emerald-900/30">
+        <span className="px-2 py-0.5 rounded bg-success/10 text-success border border-success/30">
           +{added} added
         </span>
       )}
       {removed > 0 && (
-        <span className="px-2 py-0.5 rounded bg-red-950/50 text-red-400 border border-red-900/30">
+        <span className="px-2 py-0.5 rounded bg-danger/10 text-danger border border-danger/30">
           -{removed} removed
         </span>
       )}
       {changed > 0 && (
-        <span className="px-2 py-0.5 rounded bg-amber-950/50 text-amber-400 border border-amber-900/30">
+        <span className="px-2 py-0.5 rounded bg-warning/10 text-warning border border-warning/30">
           ~{changed} changed
         </span>
       )}
@@ -93,13 +93,13 @@ export default function DiffSection({
         <div className="border-t border-[var(--border-subtle)] px-4 py-3 space-y-3">
           {added.length > 0 && (
             <div>
-              <h4 className="text-xs font-semibold text-emerald-400 uppercase tracking-wider mb-1.5">
+              <h4 className="text-xs font-semibold text-success uppercase tracking-wider mb-1.5">
                 Added ({added.length})
               </h4>
               <ul className="space-y-1">
                 {added.map((e) => (
                   <li key={e.id} className="text-sm">
-                    <EntryLink entry={e} className="font-medium text-emerald-300" />
+                    <EntryLink entry={e} className="font-medium text-success" />
                   </li>
                 ))}
               </ul>
@@ -108,13 +108,13 @@ export default function DiffSection({
 
           {removed.length > 0 && (
             <div>
-              <h4 className="text-xs font-semibold text-red-400 uppercase tracking-wider mb-1.5">
+              <h4 className="text-xs font-semibold text-danger uppercase tracking-wider mb-1.5">
                 Removed ({removed.length})
               </h4>
               <ul className="space-y-1">
                 {removed.map((e) => (
                   <li key={e.id} className="text-sm">
-                    <EntryLink entry={e} className="text-red-300 line-through" />
+                    <EntryLink entry={e} className="text-danger line-through" />
                   </li>
                 ))}
               </ul>
@@ -123,7 +123,7 @@ export default function DiffSection({
 
           {changed.length > 0 && (
             <div>
-              <h4 className="text-xs font-semibold text-amber-400 uppercase tracking-wider mb-1.5">
+              <h4 className="text-xs font-semibold text-warning uppercase tracking-wider mb-1.5">
                 Changed ({changed.length})
               </h4>
               <ul className="space-y-1.5">

--- a/frontend/app/[locale]/beta/page.tsx
+++ b/frontend/app/[locale]/beta/page.tsx
@@ -132,7 +132,7 @@ export default async function BetaLandingPage({
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <BetaBanner />
       <h1 className="text-3xl font-bold mb-2">
-        <span className="text-emerald-300">{t("Beta")}</span>{" "}
+        <span className="text-success">{t("Beta")}</span>{" "}
         <span className="text-[var(--accent-gold)]">{diff?.beta_version ?? ""}</span>
       </h1>
       <p className="text-sm text-[var(--text-muted)] mb-3">

--- a/frontend/app/[locale]/cards/browse/page.tsx
+++ b/frontend/app/[locale]/cards/browse/page.tsx
@@ -16,24 +16,24 @@ const GROUPS: { title: string; category: SlugEntry["category"]; icon: string }[]
 ];
 
 const characterColors: Record<string, string> = {
-  ironclad: "border-red-700/40 hover:border-red-500",
-  silent: "border-green-700/40 hover:border-green-500",
-  defect: "border-blue-700/40 hover:border-blue-500",
-  necrobinder: "border-purple-700/40 hover:border-purple-500",
-  regent: "border-orange-700/40 hover:border-orange-500",
+  ironclad: "border-danger/40 hover:border-danger",
+  silent: "border-success/40 hover:border-success",
+  defect: "border-info/40 hover:border-info",
+  necrobinder: "border-special/40 hover:border-special",
+  regent: "border-warning/40 hover:border-warning",
 };
 
 const characterTextColors: Record<string, string> = {
-  ironclad: "text-red-400",
-  silent: "text-green-400",
-  defect: "text-blue-400",
-  necrobinder: "text-purple-400",
-  regent: "text-orange-400",
+  ironclad: "text-danger",
+  silent: "text-success",
+  defect: "text-info",
+  necrobinder: "text-special",
+  regent: "text-warning",
 };
 
 const rarityColors: Record<string, string> = {
-  common: "text-gray-300",
-  uncommon: "text-blue-400",
+  common: "text-fg-secondary",
+  uncommon: "text-info",
   rare: "text-[var(--accent-gold)]",
 };
 
@@ -111,7 +111,7 @@ export default async function BrowseHubPage({ params }: Props) {
                   <Link
                     key={slug}
                     href={`/cards/browse/${slug}`}
-                    className={`rounded-lg border ${style.border} bg-[var(--bg-card)] p-4 transition-all hover:bg-[var(--bg-card-hover)] hover:shadow-lg hover:shadow-black/20`}
+                    className={`rounded-lg border ${style.border} bg-[var(--bg-card)] p-4 transition-all hover:bg-[var(--bg-card-hover)] hover:shadow-lg hover:shadow-scrim/20`}
                   >
                     <h3 className={`font-semibold text-sm ${style.text}`}>
                       {entry.label}

--- a/frontend/app/[locale]/cards/page.tsx
+++ b/frontend/app/[locale]/cards/page.tsx
@@ -207,7 +207,7 @@ export default async function CardsPage({ params }: Props) {
           building internal-link surface area to high-intent landing pages
           that compete for long-tail entity queries. */}
       {topByScore.length > 0 && (
-        <section className="mb-10 rounded-2xl border border-[var(--accent-gold)]/25 bg-gradient-to-b from-[var(--accent-gold)]/[0.07] to-[var(--bg-card)] p-5 sm:p-6 shadow-lg shadow-black/20">
+        <section className="mb-10 rounded-2xl border border-[var(--accent-gold)]/25 bg-gradient-to-b from-[var(--accent-gold)]/[0.07] to-[var(--bg-card)] p-5 sm:p-6 shadow-lg shadow-scrim/20">
           <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
             <div>
               <span className="inline-block text-[10px] font-bold uppercase tracking-wider text-[var(--accent-gold)] bg-[var(--accent-gold)]/10 border border-[var(--accent-gold)]/30 rounded px-2 py-0.5 mb-2">

--- a/frontend/app/[locale]/changelog/page.tsx
+++ b/frontend/app/[locale]/changelog/page.tsx
@@ -81,17 +81,17 @@ function SummaryBadge({ added, removed, changed }: { added: number; removed: num
   return (
     <div className="flex gap-2 text-xs">
       {added > 0 && (
-        <span className="px-2 py-0.5 rounded bg-emerald-950/50 text-emerald-400 border border-emerald-900/30">
+        <span className="px-2 py-0.5 rounded bg-success/10 text-success border border-success/30">
           +{t("{n} added", { n: added })}
         </span>
       )}
       {removed > 0 && (
-        <span className="px-2 py-0.5 rounded bg-red-950/50 text-red-400 border border-red-900/30">
+        <span className="px-2 py-0.5 rounded bg-danger/10 text-danger border border-danger/30">
           -{t("{n} removed", { n: removed })}
         </span>
       )}
       {changed > 0 && (
-        <span className="px-2 py-0.5 rounded bg-amber-950/50 text-amber-400 border border-amber-900/30">
+        <span className="px-2 py-0.5 rounded bg-warning/10 text-warning border border-warning/30">
           ~{t("{n} changed", { n: changed })}
         </span>
       )}
@@ -131,7 +131,7 @@ function CategorySection({ cat }: { cat: CategoryDiff }) {
         <div className="border-t border-[var(--border-subtle)] px-4 py-3 space-y-3">
           {cat.added && cat.added.length > 0 && (
             <div>
-              <h4 className="text-xs font-semibold text-emerald-400 uppercase tracking-wider mb-1.5">
+              <h4 className="text-xs font-semibold text-success uppercase tracking-wider mb-1.5">
                 {t("Added")} ({cat.added.length})
               </h4>
               <div className="space-y-1.5">
@@ -142,14 +142,14 @@ function CategorySection({ cat }: { cat: CategoryDiff }) {
                   return (
                     <details key={e.id} className="group">
                       <summary className="text-xs text-[var(--text-secondary)] cursor-pointer hover:text-[var(--text-primary)] transition-colors">
-                        <span className="font-medium text-emerald-300">{e.name}</span>
+                        <span className="font-medium text-success">{e.name}</span>
                       </summary>
                       {fields.length > 0 && (
                         <div className="ml-4 mt-1 space-y-0.5">
                           {fields.map(([k, v]) => (
                             <div key={k} className="text-[11px] text-[var(--text-muted)]">
                               <span className="text-[var(--text-secondary)]">{k}:</span>{" "}
-                              <span className="text-emerald-400/70">{String(v)}</span>
+                              <span className="text-success/70">{String(v)}</span>
                             </div>
                           ))}
                         </div>
@@ -163,12 +163,12 @@ function CategorySection({ cat }: { cat: CategoryDiff }) {
 
           {cat.removed && cat.removed.length > 0 && (
             <div>
-              <h4 className="text-xs font-semibold text-red-400 uppercase tracking-wider mb-1.5">
+              <h4 className="text-xs font-semibold text-danger uppercase tracking-wider mb-1.5">
                 {t("Removed")} ({cat.removed.length})
               </h4>
               <ul className="list-disc list-inside space-y-1">
                 {cat.removed.map((e) => (
-                  <li key={e.id} className="text-sm text-red-300 line-through">
+                  <li key={e.id} className="text-sm text-danger line-through">
                     {e.name}
                   </li>
                 ))}
@@ -178,7 +178,7 @@ function CategorySection({ cat }: { cat: CategoryDiff }) {
 
           {cat.changed && cat.changed.length > 0 && (
             <div>
-              <h4 className="text-xs font-semibold text-amber-400 uppercase tracking-wider mb-1.5">
+              <h4 className="text-xs font-semibold text-warning uppercase tracking-wider mb-1.5">
                 {t("Changed")} ({cat.changed.length})
               </h4>
               <div className="space-y-1.5">
@@ -196,9 +196,9 @@ function CategorySection({ cat }: { cat: CategoryDiff }) {
                       {e.changes.map((c) => (
                         <div key={c.field} className="text-[11px] text-[var(--text-muted)]">
                           <span className="text-[var(--text-secondary)]">{c.field}:</span>{" "}
-                          <span className="text-red-400/70 line-through">{c.old}</span>{" "}
+                          <span className="text-danger/70 line-through">{c.old}</span>{" "}
                           <span className="text-[var(--text-muted)]">→</span>{" "}
-                          <span className="text-emerald-400/70">{c.new}</span>
+                          <span className="text-success/70">{c.new}</span>
                         </div>
                       ))}
                     </div>
@@ -386,13 +386,13 @@ export default function ChangelogPage() {
                   {selected.features && selected.features.length > 0 && (
                     <div className="border border-[var(--border-subtle)] rounded-lg overflow-hidden">
                       <div className="px-4 py-2.5">
-                        <span className="font-semibold text-emerald-400">{t("Features")}</span>
+                        <span className="font-semibold text-success">{t("Features")}</span>
                       </div>
                       <div className="border-t border-[var(--border-subtle)] px-4 py-3">
                         <ul className="space-y-1.5">
                           {selected.features.map((f, i) => (
                             <li key={i} className="text-sm text-[var(--text-secondary)] flex gap-2">
-                              <span className="text-emerald-400 shrink-0">+</span>
+                              <span className="text-success shrink-0">+</span>
                               {f}
                             </li>
                           ))}
@@ -404,13 +404,13 @@ export default function ChangelogPage() {
                   {selected.fixes && selected.fixes.length > 0 && (
                     <div className="border border-[var(--border-subtle)] rounded-lg overflow-hidden">
                       <div className="px-4 py-2.5">
-                        <span className="font-semibold text-amber-400">{t("Fixes")}</span>
+                        <span className="font-semibold text-warning">{t("Fixes")}</span>
                       </div>
                       <div className="border-t border-[var(--border-subtle)] px-4 py-3">
                         <ul className="space-y-1.5">
                           {selected.fixes.map((f, i) => (
                             <li key={i} className="text-sm text-[var(--text-secondary)] flex gap-2">
-                              <span className="text-amber-400 shrink-0">~</span>
+                              <span className="text-warning shrink-0">~</span>
                               {f}
                             </li>
                           ))}
@@ -422,13 +422,13 @@ export default function ChangelogPage() {
                   {selected.api_changes && selected.api_changes.length > 0 && (
                     <div className="border border-[var(--border-subtle)] rounded-lg overflow-hidden">
                       <div className="px-4 py-2.5">
-                        <span className="font-semibold text-cyan-400">{t("API Changes")}</span>
+                        <span className="font-semibold text-info">{t("API Changes")}</span>
                       </div>
                       <div className="border-t border-[var(--border-subtle)] px-4 py-3">
                         <ul className="space-y-1.5">
                           {selected.api_changes.map((f, i) => (
                             <li key={i} className="text-sm text-[var(--text-secondary)] flex gap-2">
-                              <span className="text-cyan-400 shrink-0">&gt;</span>
+                              <span className="text-info shrink-0">&gt;</span>
                               {f}
                             </li>
                           ))}

--- a/frontend/app/[locale]/characters/CharactersClient.tsx
+++ b/frontend/app/[locale]/characters/CharactersClient.tsx
@@ -20,11 +20,11 @@ function cleanDescription(desc: string): string {
 }
 
 const colorStyles: Record<string, string> = {
-  red: "border-red-700/60 from-red-900/20",
-  green: "border-green-700/60 from-green-900/20",
-  blue: "border-blue-700/60 from-blue-900/20",
-  purple: "border-purple-700/60 from-purple-900/20",
-  orange: "border-orange-700/60 from-orange-900/20",
+  red: "border-danger/60 from-danger/10",
+  green: "border-success/60 from-success/10",
+  blue: "border-info/60 from-info/10",
+  purple: "border-special/60 from-special/10",
+  orange: "border-warning/60 from-warning/10",
 };
 
 export default function CharactersClient({ initialCharacters }: { initialCharacters: Character[] }) {
@@ -87,12 +87,12 @@ export default function CharactersClient({ initialCharacters }: { initialCharact
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       {characters.map((char) => {
-        const style = colorStyles[char.color || ""] || "border-[var(--border-subtle)] from-gray-900/20";
+        const style = colorStyles[char.color || ""] || "border-[var(--border-subtle)] from-line-strong/20";
         return (
           <Link
             href={`${bp}/characters/${char.id.toLowerCase()}`}
             key={char.id}
-            className={`rounded-xl border-2 ${style} bg-gradient-to-br to-transparent bg-[var(--bg-card)] p-6 transition-all hover:shadow-lg hover:shadow-black/20 cursor-pointer`}
+            className={`rounded-xl border-2 ${style} bg-gradient-to-br to-transparent bg-[var(--bg-card)] p-6 transition-all hover:shadow-lg hover:shadow-scrim/20 cursor-pointer`}
           >
             <div className="flex items-center gap-3 mb-2">
               <h2 className="text-2xl font-bold text-[var(--text-primary)]">
@@ -113,7 +113,7 @@ export default function CharactersClient({ initialCharacters }: { initialCharact
             <div className="grid grid-cols-3 gap-3 mb-5">
               <div className="bg-[var(--bg-primary)] rounded-lg p-3 text-center">
                 <div className="text-xs text-[var(--text-muted)] mb-1">{t("HP")}</div>
-                <div className="text-xl font-bold text-red-400">
+                <div className="text-xl font-bold text-danger">
                   {char.starting_hp}
                 </div>
               </div>
@@ -125,7 +125,7 @@ export default function CharactersClient({ initialCharacters }: { initialCharact
               </div>
               <div className="bg-[var(--bg-primary)] rounded-lg p-3 text-center">
                 <div className="text-xs text-[var(--text-muted)] mb-1">{t("Energy")}</div>
-                <div className="text-xl font-bold text-amber-400">
+                <div className="text-xl font-bold text-warning">
                   {char.max_energy ?? 3}
                 </div>
               </div>

--- a/frontend/app/[locale]/characters/[id]/CharacterDetail.tsx
+++ b/frontend/app/[locale]/characters/[id]/CharacterDetail.tsx
@@ -304,14 +304,14 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
   });
 
   const rarityBadgeColors: Record<string, string> = {
-    Common: "bg-gray-500/30 text-white",
-    Uncommon: "bg-blue-600/30 text-blue-300",
-    Rare: "bg-amber-600/30 text-amber-300", 
-    Basic: "bg-gray-700/30 text-white",
-    Shop: "bg-green-600/30 text-green-300",
-    Event: "bg-purple-600/30 text-purple-300",
-    Starter: "bg-yellow-600/30 text-yellow-300",
-    Ancient: "bg-red-600/30 text-red-300",
+    Common: "bg-line-strong/30 text-on-fill",
+    Uncommon: "bg-info/30 text-info",
+    Rare: "bg-warning/30 text-warning", 
+    Basic: "bg-surface-hover/30 text-on-fill",
+    Shop: "bg-success/30 text-success",
+    Event: "bg-special/30 text-special",
+    Starter: "bg-warning/30 text-warning",
+    Ancient: "bg-danger/30 text-danger",
   };
 
   const hasDeck = char.starting_deck.length > 0;
@@ -518,7 +518,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
                   {sortedRarities.map((rarity) => (
                     <div key={rarity} className="rar-group">
                       <h3 className="rgh">
-                        <span className={`inline-block px-2 py-0.5 rounded text-xs ${rarityBadgeColors[rarity] ?? "bg-gray-600/30 text-gray-300"}`}>
+                        <span className={`inline-block px-2 py-0.5 rounded text-xs ${rarityBadgeColors[rarity] ?? "bg-line-strong/30 text-fg-secondary"}`}>
                           {rarity}
                         </span>
                         <span className="rgn">({cardsByRarity[rarity].length})</span>
@@ -564,7 +564,7 @@ export default function CharacterDetail({ initialCharacter }: { initialCharacter
                       <div className="kit-body">
                         <div className="kit-name">
                           {relic.name}
-                          <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] ${relic?.rarity_key ? rarityBadgeColors[relic.rarity_key] : "bg-gray-600/30 text-gray-300"}`}>
+                          <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] ${relic?.rarity_key ? rarityBadgeColors[relic.rarity_key] : "bg-line-strong/30 text-fg-secondary"}`}>
                             {relic.rarity}
                           </span>
                         </div>

--- a/frontend/app/[locale]/charts/ChartsClient.tsx
+++ b/frontend/app/[locale]/charts/ChartsClient.tsx
@@ -601,7 +601,7 @@ function ChartsClientInner() {
       {/* Chart card */}
       <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-card)] p-4">
         {error ? (
-          <p className="text-sm text-rose-400 py-12 text-center">{error}</p>
+          <p className="text-sm text-danger py-12 text-center">{error}</p>
         ) : !data || loading ? (
           <div className="h-[420px] flex items-center justify-center text-sm text-[var(--text-muted)]">
             {t("Crunching runs…")}

--- a/frontend/app/[locale]/community-stats/CommunityStatsBody.tsx
+++ b/frontend/app/[locale]/community-stats/CommunityStatsBody.tsx
@@ -373,8 +373,8 @@ export async function CommunityStatsBody({ lang, bracket }: { lang: Locale; brac
           nothing once the beta promotes (the section empties server-side). */}
       {((stats.beta?.deaths?.encounters?.length ?? 0) > 0 || (stats.beta?.deaths?.events?.length ?? 0) > 0) && (
         <section className="mb-10">
-          <h2 className="text-lg font-semibold text-emerald-300 mb-3">{t("From the beta branch")}</h2>
-          <div className="rounded-lg border border-emerald-500/40 bg-emerald-500/10 p-4">
+          <h2 className="text-lg font-semibold text-success mb-3">{t("From the beta branch")}</h2>
+          <div className="rounded-lg border border-success/40 bg-success/10 p-4">
             <p className="text-xs text-[var(--text-muted)] mb-3">
               {t("Deaths to content that only exists in the current beta, counted from beta-branch runs.")}
             </p>
@@ -383,7 +383,7 @@ export async function CommunityStatsBody({ lang, bracket }: { lang: Locale; brac
                 <div key={e.id} className="flex items-center justify-between rounded bg-[var(--bg-card)] px-3 py-2 text-sm">
                   <span className="text-[var(--text-primary)]">
                     {e.name}
-                    <span className="ml-2 text-[10px] px-1.5 py-0.5 rounded-full font-semibold bg-emerald-500/15 text-emerald-400 border border-emerald-500/30">{t("Beta")}</span>
+                    <span className="ml-2 text-[10px] px-1.5 py-0.5 rounded-full font-semibold bg-success/15 text-success border border-success/30">{t("Beta")}</span>
                   </span>
                   <span className="text-[var(--text-secondary)] tabular-nums">{e.count.toLocaleString()} {t("kills")}</span>
                 </div>

--- a/frontend/app/[locale]/compare/[pair]/CompareDetail.tsx
+++ b/frontend/app/[locale]/compare/[pair]/CompareDetail.tsx
@@ -124,18 +124,18 @@ function BarComparison({
   const pctB = maxVal > 0 ? (countB / maxVal) * 100 : 0;
 
   const barColorA: Record<string, string> = {
-    red: "bg-red-500/70",
-    green: "bg-green-500/70",
-    blue: "bg-blue-500/70",
-    purple: "bg-purple-500/70",
-    orange: "bg-orange-500/70",
+    red: "bg-danger/70",
+    green: "bg-success/70",
+    blue: "bg-info/70",
+    purple: "bg-special/70",
+    orange: "bg-warning/70",
   };
   const barColorB: Record<string, string> = {
-    red: "bg-red-500/70",
-    green: "bg-green-500/70",
-    blue: "bg-blue-500/70",
-    purple: "bg-purple-500/70",
-    orange: "bg-orange-500/70",
+    red: "bg-danger/70",
+    green: "bg-success/70",
+    blue: "bg-info/70",
+    purple: "bg-special/70",
+    orange: "bg-warning/70",
   };
 
   return (
@@ -148,13 +148,13 @@ function BarComparison({
       <div className="flex gap-1 h-2">
         <div className="flex-1 flex justify-end">
           <div
-            className={`h-full rounded-l ${barColorA[colorA] || "bg-gray-500/70"} transition-all`}
+            className={`h-full rounded-l ${barColorA[colorA] || "bg-line-strong/70"} transition-all`}
             style={{ width: `${pctA}%` }}
           />
         </div>
         <div className="flex-1">
           <div
-            className={`h-full rounded-r ${barColorB[colorB] || "bg-gray-500/70"} transition-all`}
+            className={`h-full rounded-r ${barColorB[colorB] || "bg-line-strong/70"} transition-all`}
             style={{ width: `${pctB}%` }}
           />
         </div>
@@ -301,11 +301,11 @@ export default function CompareDetail({
         </div>
         <div className="flex items-center justify-center gap-6 mt-2 text-xs text-[var(--text-muted)]">
           <span className="flex items-center gap-1">
-            <span className={`inline-block w-2 h-2 rounded-full ${colorA === "red" ? "bg-red-400" : colorA === "green" ? "bg-green-400" : colorA === "blue" ? "bg-blue-400" : colorA === "purple" ? "bg-purple-400" : "bg-orange-400"}`} />
+            <span className={`inline-block w-2 h-2 rounded-full ${colorA === "red" ? "bg-danger-fill" : colorA === "green" ? "bg-success-fill" : colorA === "blue" ? "bg-info-fill" : colorA === "purple" ? "bg-special-fill" : "bg-warning-fill"}`} />
             {nameA}
           </span>
           <span className="flex items-center gap-1">
-            <span className={`inline-block w-2 h-2 rounded-full ${colorB === "red" ? "bg-red-400" : colorB === "green" ? "bg-green-400" : colorB === "blue" ? "bg-blue-400" : colorB === "purple" ? "bg-purple-400" : "bg-orange-400"}`} />
+            <span className={`inline-block w-2 h-2 rounded-full ${colorB === "red" ? "bg-danger-fill" : colorB === "green" ? "bg-success-fill" : colorB === "blue" ? "bg-info-fill" : colorB === "purple" ? "bg-special-fill" : "bg-warning-fill"}`} />
             {nameB}
           </span>
         </div>

--- a/frontend/app/[locale]/compare/page.tsx
+++ b/frontend/app/[locale]/compare/page.tsx
@@ -88,7 +88,7 @@ export default async function ComparePage({ params }: Props) {
           <Link
             key={pair.slug}
             href={`/compare/${pair.slug}`}
-            className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-card)] p-5 transition-all hover:shadow-lg hover:shadow-black/20 hover:border-[var(--accent-gold)]/40"
+            className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-card)] p-5 transition-all hover:shadow-lg hover:shadow-scrim/20 hover:border-[var(--accent-gold)]/40"
           >
             <div className="flex items-center justify-between gap-3">
               <div className="flex-1 text-center">

--- a/frontend/app/[locale]/deck-lab/DeckLabClient.tsx
+++ b/frontend/app/[locale]/deck-lab/DeckLabClient.tsx
@@ -291,7 +291,7 @@ export default function DeckLabClient() {
                     type="button"
                     onClick={() => removeOne(deck, setDeck, id)}
                     title={t("Click to remove one copy")}
-                    className="text-xs px-2 py-0.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-primary)] text-[var(--text-secondary)] hover:border-red-500/50"
+                    className="text-xs px-2 py-0.5 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-primary)] text-[var(--text-secondary)] hover:border-danger/50"
                   >
                     {names[id] || id}
                     {n > 1 ? ` ×${n}` : ""}
@@ -303,7 +303,7 @@ export default function DeckLabClient() {
                     type="button"
                     onClick={() => removeOne(relics, setRelics, id)}
                     title={t("Click to remove")}
-                    className="text-xs px-2 py-0.5 rounded-md border border-sky-900/50 bg-[var(--bg-primary)] text-sky-300 hover:border-red-500/50"
+                    className="text-xs px-2 py-0.5 rounded-md border border-info/30 bg-[var(--bg-primary)] text-info hover:border-danger/50"
                   >
                     {names[id] || id}
                   </button>
@@ -335,7 +335,7 @@ export default function DeckLabClient() {
                     key={id}
                     type="button"
                     onClick={() => setOffer((o) => o.filter((x) => x !== id))}
-                    className="text-xs px-2 py-0.5 rounded-md border border-[var(--accent-gold)]/40 bg-[var(--bg-primary)] text-[var(--accent-gold)] hover:border-red-500/50"
+                    className="text-xs px-2 py-0.5 rounded-md border border-[var(--accent-gold)]/40 bg-[var(--bg-primary)] text-[var(--accent-gold)] hover:border-danger/50"
                   >
                     {names[id] || id}
                   </button>
@@ -460,7 +460,7 @@ export default function DeckLabClient() {
                     href={`/${it.etype}/${it.id.toLowerCase()}`}
                     className={`text-xs px-2 py-0.5 rounded-md border bg-[var(--bg-primary)] transition-colors ${
                       it.etype === "relics"
-                        ? "border-sky-900/50 text-sky-300 hover:border-sky-500/60"
+                        ? "border-info/30 text-info hover:border-info/60"
                         : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-gold)]/50 hover:text-[var(--accent-gold)]"
                     }`}
                   >

--- a/frontend/app/[locale]/developers/page.tsx
+++ b/frontend/app/[locale]/developers/page.tsx
@@ -358,7 +358,7 @@ export default async function DevelopersPage({ params }: Props) {
               <div className="space-y-1.5 text-sm font-mono">
                 {group.endpoints.map((ep) => (
                   <div key={ep.path} className="flex items-start gap-3">
-                    <span className={`${ep.method === "POST" ? "text-cyan-400" : "text-emerald-400"} w-10 flex-shrink-0`}>{ep.method}</span>
+                    <span className={`${ep.method === "POST" ? "text-info" : "text-success"} w-10 flex-shrink-0`}>{ep.method}</span>
                     <span className="text-[var(--text-primary)]">{ep.path}</span>
                     <span className="text-[var(--text-muted)] font-sans text-xs ml-auto text-right">{ep.desc}</span>
                   </div>

--- a/frontend/app/[locale]/enchantments/EnchantmentsClient.tsx
+++ b/frontend/app/[locale]/enchantments/EnchantmentsClient.tsx
@@ -14,9 +14,9 @@ import { imageUrl } from "@/lib/image-url";
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 const cardTypeColors: Record<string, string> = {
-  Attack: "bg-red-950/50 text-red-300 border-red-900/30",
-  Skill: "bg-blue-950/50 text-blue-300 border-blue-900/30",
-  Power: "bg-purple-950/50 text-purple-300 border-purple-900/30",
+  Attack: "bg-danger/10 text-danger border-danger/30",
+  Skill: "bg-info/10 text-info border-info/30",
+  Power: "bg-special/10 text-special border-special/30",
 };
 
 const cardTypeOptions = [
@@ -93,7 +93,7 @@ function EnchantmentsClientInner({ initialEnchantments }: { initialEnchantments:
             prefetch={false}
             key={ench.id}
             href={`${bp}/enchantments/${ench.id.toLowerCase()}`}
-            className="bg-[var(--bg-card)] rounded-lg border border-cyan-800/40 p-4 hover:bg-[var(--bg-card-hover)] transition-all block"
+            className="bg-[var(--bg-card)] rounded-lg border border-info/30 p-4 hover:bg-[var(--bg-card-hover)] transition-all block"
           >
             <div className="flex items-start gap-3 mb-2">
               {ench.image_url && (
@@ -115,14 +115,14 @@ function EnchantmentsClientInner({ initialEnchantments }: { initialEnchantments:
                     key={type}
                     className={`text-[10px] px-1.5 py-0.5 rounded border ${
                       cardTypeColors[type] ||
-                      "bg-gray-800 text-gray-300 border-gray-700"
+                      "bg-surface text-fg-secondary border-line-strong"
                     }`}
                   >
                     {t(type)}
                   </span>
                 ))}
                 {ench.is_stackable && (
-                  <span className="text-[10px] px-1.5 py-0.5 rounded border bg-cyan-950/50 text-cyan-300 border-cyan-900/30">
+                  <span className="text-[10px] px-1.5 py-0.5 rounded border bg-info/10 text-info border-info/30">
                     {t("Stackable")}
                   </span>
                 )}

--- a/frontend/app/[locale]/encounters/EncountersClient.tsx
+++ b/frontend/app/[locale]/encounters/EncountersClient.tsx
@@ -15,15 +15,15 @@ import BetaBadge from "@/app/components/BetaBadge";
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 const roomTypeColors: Record<string, string> = {
-  Monster: "border-gray-600/40",
-  Elite: "border-amber-600/40",
-  Boss: "border-red-600/40",
+  Monster: "border-line-strong/40",
+  Elite: "border-warning/40",
+  Boss: "border-danger/40",
 };
 
 const roomTypeBadge: Record<string, string> = {
-  Monster: "bg-gray-800 text-gray-300 border-gray-700",
-  Elite: "bg-amber-950/50 text-amber-300 border-amber-900/30",
-  Boss: "bg-red-950/50 text-red-300 border-red-900/30",
+  Monster: "bg-surface text-fg-secondary border-line-strong",
+  Elite: "bg-warning/10 text-warning border-warning/30",
+  Boss: "bg-danger/10 text-danger border-danger/30",
 };
 
 const roomTypeOptions = [
@@ -152,7 +152,7 @@ function EncountersClientInner({ initialEncounters }: { initialEncounters: Encou
               </h3>
               <span
                 className={`text-[10px] px-1.5 py-0.5 rounded border flex-shrink-0 ml-2 ${
-                  roomTypeBadge[enc.room_type] || "bg-gray-800 text-gray-300 border-gray-700"
+                  roomTypeBadge[enc.room_type] || "bg-surface text-fg-secondary border-line-strong"
                 }`}
               >
                 {t(enc.room_type)}
@@ -184,7 +184,7 @@ function EncountersClientInner({ initialEncounters }: { initialEncounters: Encou
                 {enc.tags.map((tag) => (
                   <span
                     key={tag}
-                    className="text-[10px] px-1.5 py-0.5 rounded bg-rose-950/40 text-rose-300 border border-rose-900/20"
+                    className="text-[10px] px-1.5 py-0.5 rounded bg-danger/10 text-danger border border-danger/30"
                   >
                     {tag}
                   </span>

--- a/frontend/app/[locale]/encounters/[id]/EncounterDetail.tsx
+++ b/frontend/app/[locale]/encounters/[id]/EncounterDetail.tsx
@@ -25,9 +25,9 @@ const SPINE_BY_ROOM: Record<string, string> = {
 };
 
 const roomTypeBadge: Record<string, string> = {
-  Monster: "bg-gray-800 text-gray-300 border-gray-700",
-  Elite: "bg-amber-950/50 text-amber-300 border-amber-900/30",
-  Boss: "bg-red-950/50 text-red-300 border-red-900/30",
+  Monster: "bg-surface text-fg-secondary border-line-strong",
+  Elite: "bg-warning/10 text-warning border-warning/30",
+  Boss: "bg-danger/10 text-danger border-danger/30",
 };
 
 

--- a/frontend/app/[locale]/events/EventsClient.tsx
+++ b/frontend/app/[locale]/events/EventsClient.tsx
@@ -14,15 +14,15 @@ import { imageUrl } from "@/lib/image-url";
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 const typeColors: Record<string, string> = {
-  Event: "border-indigo-600/40",
-  Ancient: "border-purple-600/40",
-  Shared: "border-gray-600/40",
+  Event: "border-info/40",
+  Ancient: "border-special/40",
+  Shared: "border-line-strong/40",
 };
 
 const typeBadge: Record<string, string> = {
-  Event: "bg-indigo-950/50 text-indigo-300 border-indigo-900/30",
-  Ancient: "bg-purple-950/50 text-purple-300 border-purple-900/30",
-  Shared: "bg-gray-800 text-gray-300 border-gray-700",
+  Event: "bg-info/10 text-info border-info/30",
+  Ancient: "bg-special/10 text-special border-special/30",
+  Shared: "bg-surface text-fg-secondary border-line-strong",
 };
 
 const typeOptions = [
@@ -39,16 +39,16 @@ const actOptions = [
 ];
 
 const PAGE_COLORS = [
-  "border-l-indigo-500/60",
-  "border-l-cyan-500/60",
-  "border-l-emerald-500/60",
-  "border-l-amber-500/60",
-  "border-l-rose-500/60",
-  "border-l-purple-500/60",
-  "border-l-blue-500/60",
-  "border-l-orange-500/60",
-  "border-l-teal-500/60",
-  "border-l-pink-500/60",
+  "border-l-info/60",
+  "border-l-info/60",
+  "border-l-success/60",
+  "border-l-warning/60",
+  "border-l-danger/60",
+  "border-l-special/60",
+  "border-l-info/60",
+  "border-l-warning/60",
+  "border-l-success/60",
+  "border-l-special/60",
 ];
 
 
@@ -236,7 +236,7 @@ function EventsClientInner({ initialEvents }: { initialEvents: GameEvent[] }) {
                       {event.name}
                     </h3>
                     {event.epithet && (
-                      <p className="text-xs text-purple-400 italic">
+                      <p className="text-xs text-special italic">
                         {event.epithet}
                       </p>
                     )}
@@ -254,7 +254,7 @@ function EventsClientInner({ initialEvents }: { initialEvents: GameEvent[] }) {
                   <span
                     className={`text-[10px] px-1.5 py-0.5 rounded border ${
                       typeBadge[event.type] ||
-                      "bg-gray-800 text-gray-300 border-gray-700"
+                      "bg-surface text-fg-secondary border-line-strong"
                     }`}
                   >
                     {t(event.type)}
@@ -399,8 +399,8 @@ function EventsClientInner({ initialEvents }: { initialEvents: GameEvent[] }) {
                           onClick={(e) => { e.stopPropagation(); toggleDialogue(event.id, group); }}
                           className={`text-[11px] px-2 py-0.5 rounded border transition-colors cursor-pointer ${
                             expandedDialogue[event.id] === group
-                              ? "bg-purple-950/60 text-purple-300 border-purple-800/50"
-                              : "bg-[var(--bg-primary)] text-[var(--text-muted)] border-[var(--border-subtle)] hover:text-[var(--text-secondary)] hover:border-purple-800/30"
+                              ? "bg-special/10 text-special border-special/30"
+                              : "bg-[var(--bg-primary)] text-[var(--text-muted)] border-[var(--border-subtle)] hover:text-[var(--text-secondary)] hover:border-special/30"
                           }`}
                         >
                           {group}
@@ -416,8 +416,8 @@ function EventsClientInner({ initialEvents }: { initialEvents: GameEvent[] }) {
                                 key={i}
                                 className={`text-xs px-2.5 py-1.5 rounded ${
                                   line.speaker === "ancient"
-                                    ? "bg-purple-950/30 text-purple-200 border-l-2 border-purple-700/50"
-                                    : "bg-indigo-950/30 text-indigo-200 border-l-2 border-indigo-700/50 ml-4"
+                                    ? "bg-special/10 text-special border-l-2 border-special/50"
+                                    : "bg-info/10 text-info border-l-2 border-info/50 ml-4"
                                 }`}
                               >
                                 <span className="whitespace-pre-line">

--- a/frontend/app/[locale]/giveaway/GiveawayClient.tsx
+++ b/frontend/app/[locale]/giveaway/GiveawayClient.tsx
@@ -33,7 +33,7 @@ function StepCard({
     <div
       className={`rounded-xl border p-5 transition-colors ${
         done
-          ? "border-emerald-600/40 bg-emerald-950/15"
+          ? "border-success/40 bg-success/10"
           : "border-[var(--border-subtle)] bg-[var(--bg-card)]"
       }`}
     >
@@ -41,7 +41,7 @@ function StepCard({
         <div
           className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-sm font-bold ${
             done
-              ? "bg-emerald-500 text-[var(--bg-primary)]"
+              ? "bg-success-fill text-[var(--bg-primary)]"
               : "bg-[var(--bg-primary)] text-[var(--text-secondary)] border border-[var(--border-subtle)]"
           }`}
           aria-hidden
@@ -90,10 +90,10 @@ export default function GiveawayClient() {
 
   const phaseBadge =
     phase === "upcoming"
-      ? { text: t("Opens July 7"), cls: "bg-amber-500/15 text-amber-300 border-amber-500/30" }
+      ? { text: t("Opens July 7"), cls: "bg-warning/15 text-warning border-warning/30" }
       : phase === "ended"
         ? { text: t("Closed"), cls: "bg-[var(--bg-card)] text-[var(--text-muted)] border-[var(--border-subtle)]" }
-        : { text: t("Open now"), cls: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30" };
+        : { text: t("Open now"), cls: "bg-success/15 text-success border-success/30" };
 
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
@@ -149,7 +149,7 @@ export default function GiveawayClient() {
       <div
         className={`rounded-xl border p-4 mb-8 ${
           entered
-            ? "border-emerald-600/40 bg-emerald-950/20"
+            ? "border-success/40 bg-success/10"
             : "border-[var(--accent-gold)]/30 bg-[var(--accent-gold)]/10"
         }`}
       >
@@ -157,7 +157,7 @@ export default function GiveawayClient() {
           <p className="text-sm text-[var(--text-secondary)]">{t("Checking your entry status...")}</p>
         ) : entered ? (
           <p className="text-sm">
-            <span className="font-semibold text-emerald-300">{t("You are entered.")}</span>{" "}
+            <span className="font-semibold text-success">{t("You are entered.")}</span>{" "}
             <span className="text-[var(--text-secondary)]">
               {t("Good luck. You can keep playing and uploading runs as usual.")}
             </span>
@@ -186,7 +186,7 @@ export default function GiveawayClient() {
             {t("Your Steam sign-in is how we identify your entry and match your uploaded runs.")}
           </p>
           {hasSteam ? (
-            <p className="text-emerald-300">{t("Signed in as")} {user?.username ?? t("your account")}.</p>
+            <p className="text-success">{t("Signed in as")} {user?.username ?? t("your account")}.</p>
           ) : (
             <button onClick={loginSteam} className={primaryBtn}>
               {user ? t("Connect Steam") : t("Sign in with Steam")}
@@ -211,7 +211,7 @@ export default function GiveawayClient() {
             {t("file from your profile.")}
           </p>
           {hasRun ? (
-            <p className="text-emerald-300">
+            <p className="text-success">
               {runCount === 1
                 ? t("{n} run on your account. You are good.", { n: 1 })
                 : t("{n} runs on your account. You are good.", { n: runCount ?? 0 })}

--- a/frontend/app/[locale]/guides/GuidesClient.tsx
+++ b/frontend/app/[locale]/guides/GuidesClient.tsx
@@ -12,9 +12,9 @@ import { useBetaPrefix } from "@/lib/use-lang-prefix";
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 const difficultyColors: Record<string, string> = {
-  beginner: "bg-emerald-900/40 text-emerald-400 border-emerald-700/40",
-  intermediate: "bg-amber-900/40 text-amber-400 border-amber-700/40",
-  advanced: "bg-red-900/40 text-red-400 border-red-700/40",
+  beginner: "bg-success/10 text-success border-success/40",
+  intermediate: "bg-warning/10 text-warning border-warning/40",
+  advanced: "bg-danger/10 text-danger border-danger/40",
 };
 
 const categoryLabels: Record<string, string> = {
@@ -140,7 +140,7 @@ function GuidesClientInner({ initialGuides }: { initialGuides: GuideSummary[] })
               <span className="text-[var(--text-muted)]">{t("by {author}", { author: guide.author })}</span>
               <span className="text-[var(--text-muted)]">&middot;</span>
               <span className="text-[var(--text-muted)]">{guide.date}</span>
-              <span className={`px-2 py-0.5 rounded border text-[10px] font-medium ${difficultyColors[guide.difficulty] || "bg-gray-800 text-gray-400 border-gray-700"}`}>
+              <span className={`px-2 py-0.5 rounded border text-[10px] font-medium ${difficultyColors[guide.difficulty] || "bg-surface text-fg-muted border-line-strong"}`}>
                 {guide.difficulty}
               </span>
               <span className="px-2 py-0.5 rounded bg-[var(--bg-primary)] text-[var(--text-muted)] border border-[var(--border-subtle)] text-[10px]">

--- a/frontend/app/[locale]/guides/[slug]/GuideDetail.tsx
+++ b/frontend/app/[locale]/guides/[slug]/GuideDetail.tsx
@@ -22,9 +22,9 @@ declare global {
 }
 
 const difficultyColors: Record<string, string> = {
-  beginner: "bg-emerald-900/40 text-emerald-400 border-emerald-700/40",
-  intermediate: "bg-amber-900/40 text-amber-400 border-amber-700/40",
-  advanced: "bg-red-900/40 text-red-400 border-red-700/40",
+  beginner: "bg-success/10 text-success border-success/40",
+  intermediate: "bg-warning/10 text-warning border-warning/40",
+  advanced: "bg-danger/10 text-danger border-danger/40",
 };
 
 const categoryLabels: Record<string, string> = {
@@ -191,7 +191,7 @@ export default function GuideDetail({ slug, initialGuide }: { slug: string; init
                 </a>
               )}
               {guide.bluesky && (
-                <a href={guide.bluesky.startsWith("http") ? guide.bluesky : `https://bsky.app/profile/${guide.bluesky}`} target="_blank" rel="noopener noreferrer" title="Bluesky" className="text-[var(--text-muted)] hover:text-[#0085ff] transition-colors">
+                <a href={guide.bluesky.startsWith("http") ? guide.bluesky : `https://bsky.app/profile/${guide.bluesky}`} target="_blank" rel="noopener noreferrer" title="Bluesky" className="text-[var(--text-muted)] hover:text-bluesky transition-colors">
                   <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479.785 2.627 3.6 3.476 6.178 3.126-4.476.742-8.463 3.08-4.724 8.02 4.139 4.476 6.932-1.347 7.922-4.07.99 2.723 2.503 8.198 7.478 4.07 3.738-4.94-.249-7.278-4.724-8.02 2.578.35 5.392-.5 6.178-3.126C19.622 9.418 20 4.458 20 3.768c0-.69-.139-1.86-.902-2.203-.659-.3-1.664-.62-4.3 1.24C12.046 4.747 9.087 8.686 8 10.8h4z" transform="translate(2 2) scale(0.833)"/></svg>
                 </a>
               )}
@@ -201,7 +201,7 @@ export default function GuideDetail({ slug, initialGuide }: { slug: string; init
                 </a>
               )}
               {guide.twitch && (
-                <a href={guide.twitch.startsWith("http") ? guide.twitch : `https://twitch.tv/${guide.twitch}`} target="_blank" rel="noopener noreferrer" title="Twitch" className="text-[var(--text-muted)] hover:text-[#9146FF] transition-colors">
+                <a href={guide.twitch.startsWith("http") ? guide.twitch : `https://twitch.tv/${guide.twitch}`} target="_blank" rel="noopener noreferrer" title="Twitch" className="text-[var(--text-muted)] hover:text-twitch transition-colors">
                   <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0 1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714z" /></svg>
                 </a>
               )}

--- a/frontend/app/[locale]/guides/page.tsx
+++ b/frontend/app/[locale]/guides/page.tsx
@@ -53,7 +53,7 @@ export default async function GuidesPage({ params }: Props) {
         </h1>
         <Link
           href="/guides/submit"
-          className="flex-shrink-0 px-4 py-2 rounded-lg bg-[var(--accent-gold)] text-black font-semibold text-sm hover:brightness-110 transition-all"
+          className="flex-shrink-0 px-4 py-2 rounded-lg bg-[var(--accent-gold)] text-on-accent font-semibold text-sm hover:brightness-110 transition-all"
         >
           {t("Submit a Guide")}
         </Link>

--- a/frontend/app/[locale]/guides/submit/page.tsx
+++ b/frontend/app/[locale]/guides/submit/page.tsx
@@ -103,8 +103,8 @@ export default function SubmitGuidePage() {
   if (status === "success") {
     return (
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="bg-[var(--bg-card)] rounded-lg border border-emerald-700/40 p-8 text-center">
-          <h1 className="text-2xl font-bold text-emerald-400 mb-3">{t("Guide Submitted!")}</h1>
+        <div className="bg-[var(--bg-card)] rounded-lg border border-success/40 p-8 text-center">
+          <h1 className="text-2xl font-bold text-success mb-3">{t("Guide Submitted!")}</h1>
           <p className="text-[var(--text-secondary)] mb-6">
             {t("Thanks for your contribution! We'll review your guide and publish it soon.")}
           </p>
@@ -205,13 +205,13 @@ export default function SubmitGuidePage() {
         </div>
 
         {status === "error" && errorMsg && (
-          <p className="text-sm text-red-400">{errorMsg}</p>
+          <p className="text-sm text-danger">{errorMsg}</p>
         )}
 
         <button
           type="submit"
           disabled={status === "sending"}
-          className="w-full py-2.5 rounded-lg bg-[var(--accent-gold)] text-black font-semibold text-sm hover:brightness-110 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+          className="w-full py-2.5 rounded-lg bg-[var(--accent-gold)] text-on-accent font-semibold text-sm hover:brightness-110 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {status === "sending" ? t("Submitting...") : t("Submit Guide")}
         </button>

--- a/frontend/app/[locale]/leaderboards/metrics/MetricsClient.tsx
+++ b/frontend/app/[locale]/leaderboards/metrics/MetricsClient.tsx
@@ -34,12 +34,12 @@ export interface MetricRow {
 
 // Tier badge colors, kept in sync with TierList.tsx / the scoring page.
 const TIER_CLASS: Record<string, string> = {
-  S: "bg-amber-950/50 border-amber-700/60 text-amber-300",
-  A: "bg-emerald-950/50 border-emerald-700/60 text-emerald-300",
-  B: "bg-sky-950/50 border-sky-700/60 text-sky-300",
-  C: "bg-zinc-800/70 border-zinc-600/60 text-zinc-300",
-  D: "bg-orange-950/50 border-orange-700/60 text-orange-300",
-  F: "bg-rose-950/50 border-rose-800/60 text-rose-300",
+  S: "bg-warning/10 border-warning/60 text-warning",
+  A: "bg-success/10 border-success/60 text-success",
+  B: "bg-info/10 border-info/60 text-info",
+  C: "bg-surface/70 border-line-strong/60 text-fg-secondary",
+  D: "bg-warning/10 border-warning/60 text-warning",
+  F: "bg-danger/10 border-danger/30 text-danger",
 };
 
 const COLOR_FILTERS = [

--- a/frontend/app/[locale]/leaderboards/stats/StatsClient.tsx
+++ b/frontend/app/[locale]/leaderboards/stats/StatsClient.tsx
@@ -1152,11 +1152,11 @@ function OverviewTab({
             <div className="text-xs text-[var(--text-muted)]">{t("Runs")}</div>
           </div>
           <div className="bg-[var(--bg-primary)] rounded-lg p-3">
-            <div className="text-2xl font-bold text-emerald-400">{stats.total_wins}</div>
+            <div className="text-2xl font-bold text-success">{stats.total_wins}</div>
             <div className="text-xs text-[var(--text-muted)]">{t("Wins")}</div>
           </div>
           <div className="bg-[var(--bg-primary)] rounded-lg p-3">
-            <div className="text-2xl font-bold text-red-400">{losses}</div>
+            <div className="text-2xl font-bold text-danger">{losses}</div>
             <div className="text-xs text-[var(--text-muted)]">{t("Losses")}</div>
           </div>
           <div className="bg-[var(--bg-primary)] rounded-lg p-3">
@@ -1262,8 +1262,8 @@ function OverviewTab({
                   <td className="py-2 text-right text-[var(--text-secondary)] tabular-nums">
                     {a.total}
                   </td>
-                  <td className="py-2 text-right text-emerald-400 tabular-nums">{a.wins}</td>
-                  <td className="py-2 text-right text-red-400 tabular-nums">
+                  <td className="py-2 text-right text-success tabular-nums">{a.wins}</td>
+                  <td className="py-2 text-right text-danger tabular-nums">
                     {a.total - a.wins - (a.abandoned || 0)}
                   </td>
                   <td className="py-2 text-right text-[var(--text-secondary)] tabular-nums">
@@ -1896,7 +1896,7 @@ function EncountersTab({ bp, lang }: { bp: string; lang: string }) {
                   {displayName(`ENCOUNTER.${r.encounter_id}`)}
                 </Link>
               </td>
-              <td className="py-2 text-right text-red-400 tabular-nums font-semibold">
+              <td className="py-2 text-right text-danger tabular-nums font-semibold">
                 {r.rate.toFixed(1)}%
               </td>
               <td className="py-2 text-right text-[var(--text-secondary)] tabular-nums text-xs">
@@ -1905,7 +1905,7 @@ function EncountersTab({ bp, lang }: { bp: string; lang: string }) {
               <td className="py-2 pl-4">
                 <div className="h-1.5 rounded-full bg-[var(--bg-primary)] overflow-hidden">
                   <div
-                    className="h-full rounded-full bg-red-400/70"
+                    className="h-full rounded-full bg-danger/70"
                     style={{ width: `${(r.rate / maxRate) * 100}%` }}
                   />
                 </div>

--- a/frontend/app/[locale]/leaderboards/submit/SubmitRunClient.tsx
+++ b/frontend/app/[locale]/leaderboards/submit/SubmitRunClient.tsx
@@ -295,7 +295,7 @@ export default function SubmitRunClient() {
             <span
               className={`text-xs px-1.5 py-0.5 rounded ${
                 insight.win
-                  ? "bg-green-500/15 text-green-400"
+                  ? "bg-success/15 text-success"
                   : "bg-[var(--bg-primary)] text-[var(--text-secondary)]"
               }`}
             >
@@ -332,7 +332,7 @@ export default function SubmitRunClient() {
 
           <Link
             href={`${bp}/runs/${insight.runHash}`}
-            className="inline-flex items-center gap-1.5 px-4 py-2 text-sm rounded-lg bg-[var(--accent-gold)] text-black font-medium hover:opacity-90 transition-opacity"
+            className="inline-flex items-center gap-1.5 px-4 py-2 text-sm rounded-lg bg-[var(--accent-gold)] text-on-accent font-medium hover:opacity-90 transition-opacity"
           >
             {t("See the full breakdown")} →
           </Link>
@@ -387,10 +387,10 @@ export default function SubmitRunClient() {
                   </span>
                   <span className={`shrink-0 text-xs px-1.5 py-0.5 rounded ${
                     run.win
-                      ? "bg-green-500/15 text-green-400"
+                      ? "bg-success/15 text-success"
                       : run.was_abandoned
-                        ? "bg-yellow-500/15 text-yellow-400"
-                        : "bg-red-500/15 text-red-400"
+                        ? "bg-warning/15 text-warning"
+                        : "bg-danger/15 text-danger"
                   }`}>
                     {run.win ? "W" : run.was_abandoned ? "A" : "L"}
                   </span>

--- a/frontend/app/[locale]/live/LiveClient.tsx
+++ b/frontend/app/[locale]/live/LiveClient.tsx
@@ -138,7 +138,7 @@ function PlayerCard({
             </span>
           </div>
           <div className="h-1.5 rounded bg-[var(--bg-primary)]">
-            <div className="h-1.5 rounded bg-rose-500" style={{ width: `${hpPct}%` }} />
+            <div className="h-1.5 rounded bg-danger-fill" style={{ width: `${hpPct}%` }} />
           </div>
         </div>
       )}

--- a/frontend/app/[locale]/live/LiveEventShop.tsx
+++ b/frontend/app/[locale]/live/LiveEventShop.tsx
@@ -51,9 +51,9 @@ export function LiveEventPanel({
   const id = cleanId(ev.id);
   const titleText = ev.title || displayName(`EVENT.${id}`);
   return (
-    <div className="rounded-lg border border-purple-900/50 bg-purple-950/20 p-4">
+    <div className="rounded-lg border border-special/30 bg-special/10 p-4">
       <div className="flex items-center gap-2 mb-2">
-        <span className="text-[10px] font-bold uppercase tracking-wider text-purple-300">{t("Event")}</span>
+        <span className="text-[10px] font-bold uppercase tracking-wider text-special">{t("Event")}</span>
         {safeId(id) ? (
           <Link
             href={`${bp}/events/${id.toLowerCase()}`}
@@ -231,7 +231,7 @@ function ShopSection({
                 {upgraded ? "+" : ""}
               </span>
               {it.on_sale && !sold && (
-                <span className="text-[9px] font-bold uppercase rounded bg-emerald-600 px-1 text-white shrink-0">
+                <span className="text-[9px] font-bold uppercase rounded bg-success-fill px-1 text-on-fill shrink-0">
                   {t("sale")}
                 </span>
               )}
@@ -321,9 +321,9 @@ export function LiveLootPanel({
     return null;
   }
   return (
-    <div className="rounded-lg border border-amber-900/50 bg-amber-950/20 p-4">
+    <div className="rounded-lg border border-warning/30 bg-warning/10 p-4">
       <div className="mb-2 flex items-center gap-2">
-        <span className="text-[10px] font-bold uppercase tracking-wider text-amber-300">
+        <span className="text-[10px] font-bold uppercase tracking-wider text-warning">
           {t("Rewards")}
         </span>
         {hasGold && (
@@ -370,7 +370,7 @@ export function LiveLootPanel({
         <div className="space-y-2">
           {packs.map((pack, pi) => (
             <div key={`pack-${pi}`}>
-              <div className="mb-1 text-[10px] font-bold uppercase tracking-wide text-amber-300/80">
+              <div className="mb-1 text-[10px] font-bold uppercase tracking-wide text-warning/80">
                 {t("Pack {n}", { n: pi + 1 })}
               </div>
               <div className="flex flex-wrap items-start gap-1.5">

--- a/frontend/app/[locale]/live/LiveMap.tsx
+++ b/frontend/app/[locale]/live/LiveMap.tsx
@@ -144,7 +144,7 @@ function RewardList({
               crossOrigin="anonymous"
               onError={hideImg}
             />
-            <span className="tabular-nums text-amber-300">{t("{n} Gold", { n: gold })}</span>
+            <span className="tabular-nums text-warning">{t("{n} Gold", { n: gold })}</span>
           </li>
         ) : null}
         {(items ?? []).map((it, i) => (
@@ -167,10 +167,10 @@ function FloorCard({ f, encounters }: { f: FloorSummary; encounters?: EncounterM
     <div>
       <div className="text-sm font-bold text-[var(--accent-gold)]">{t("Floor {n}", { n: f.floor })}</div>
       <div className="mt-0.5 flex gap-3 text-[11px] tabular-nums">
-        <span className="text-rose-300">
+        <span className="text-danger">
           {f.hp}/{f.max_hp} {t("HP")}
         </span>
-        <span className="text-amber-300">{t("{n} Gold", { n: f.gold })}</span>
+        <span className="text-warning">{t("{n} Gold", { n: f.gold })}</span>
       </div>
 
       <div className="mt-1 text-[11px]">
@@ -180,7 +180,7 @@ function FloorCard({ f, encounters }: { f: FloorSummary; encounters?: EncounterM
               {t(ROOM_LABEL[f.type] ?? "Enemy")}: {encName ?? t("Enemy")}
             </div>
             {f.damage_taken ? (
-              <div className="tabular-nums text-rose-300">{t("{n} Damage", { n: f.damage_taken })}</div>
+              <div className="tabular-nums text-danger">{t("{n} Damage", { n: f.damage_taken })}</div>
             ) : null}
             {f.turns != null ? (
               <div className="tabular-nums text-[var(--text-muted)]">{t("{n} Turns", { n: f.turns })}</div>
@@ -192,10 +192,10 @@ function FloorCard({ f, encounters }: { f: FloorSummary; encounters?: EncounterM
           <div className="text-[var(--text-secondary)]">{t(ROOM_LABEL[f.type] ?? "Room")}</div>
         )}
         {f.healed ? (
-          <div className="tabular-nums text-emerald-300">{t("{n} Healed", { n: f.healed })}</div>
+          <div className="tabular-nums text-success">{t("{n} Healed", { n: f.healed })}</div>
         ) : null}
         {f.gold_spent ? (
-          <div className="tabular-nums text-amber-300/80">{t("Spent {n} Gold", { n: f.gold_spent })}</div>
+          <div className="tabular-nums text-warning/80">{t("Spent {n} Gold", { n: f.gold_spent })}</div>
         ) : null}
       </div>
 

--- a/frontend/app/[locale]/live/[steamId]/LivePlayerClient.tsx
+++ b/frontend/app/[locale]/live/[steamId]/LivePlayerClient.tsx
@@ -119,7 +119,7 @@ function TickerRow({
     case "remove": {
       // A card left the deck (purge at a shop, event, etc.).
       if (!e.v) {
-        body = <span className="text-rose-300">{t("Removed a card")}</span>;
+        body = <span className="text-danger">{t("Removed a card")}</span>;
         break;
       }
       const { id, upgraded } = parseDeckId(e.v);
@@ -137,7 +137,7 @@ function TickerRow({
       }
       body = (
         <>
-          <span className="text-rose-300">{t("Removed")}</span>{" "}
+          <span className="text-danger">{t("Removed")}</span>{" "}
           <CardPill cardId={id} upgraded={upgraded} cardData={cat.cards} bp={bp} className={TICKER_LINK}>
             {info?.name || displayName(`CARD.${id}`)}
             {upgraded ? "+" : ""}
@@ -231,13 +231,13 @@ function TickerRow({
       const verb = e.k === "ancient" ? t("Ancient relic:") : t("Got");
       body = id ? (
         <>
-          <span className="text-amber-300">{verb}</span>{" "}
+          <span className="text-warning">{verb}</span>{" "}
           <RelicPill relicId={id} relicData={cat.relics} bp={bp} className={TICKER_LINK}>
             {info?.name || displayName(`RELIC.${id}`)}
           </RelicPill>
         </>
       ) : (
-        <span className="text-amber-300">
+        <span className="text-warning">
           {e.k === "ancient" ? t("Took an ancient relic") : t("Got a relic")}
         </span>
       );
@@ -296,13 +296,13 @@ function TickerRow({
     }
     case "rest": {
       // Campfire rest (heal). Lights up when the mod ships {"k": "rest"}.
-      body = <span className="text-emerald-300">{t("Rested at a campfire")}</span>;
+      body = <span className="text-success">{t("Rested at a campfire")}</span>;
       break;
     }
     case "upgrade": {
       // A card was upgraded (campfire smith, event, or relic).
       if (!e.v) {
-        body = <span className="text-sky-300">{t("Upgraded a card")}</span>;
+        body = <span className="text-info">{t("Upgraded a card")}</span>;
         break;
       }
       const { id } = parseDeckId(e.v);
@@ -320,7 +320,7 @@ function TickerRow({
       }
       body = (
         <>
-          <span className="text-sky-300">{t("Upgraded")}</span>{" "}
+          <span className="text-info">{t("Upgraded")}</span>{" "}
           <CardPill cardId={id} upgraded cardData={cat.cards} bp={bp} className={TICKER_LINK}>
             {info?.name || displayName(`CARD.${id}`)}
           </CardPill>
@@ -333,15 +333,15 @@ function TickerRow({
       // lights up as soon as the mod ships {"k": "event", "v": EVENT_ID}.
       const id = cleanId(e.v ?? "");
       if (!id) {
-        body = <span className="text-purple-300">{t("Visited an event")}</span>;
+        body = <span className="text-special">{t("Visited an event")}</span>;
         break;
       }
       body = (
         <>
-          <span className="text-purple-300">{t("Event:")}</span>{" "}
+          <span className="text-special">{t("Event:")}</span>{" "}
           <Link
             href={`${bp}/events/${id.toLowerCase()}`}
-            className="inline text-purple-300 hover:text-purple-100"
+            className="inline text-special hover:text-special"
           >
             {cat.events[id]?.name || displayName(`EVENT.${id}`)}
           </Link>
@@ -355,7 +355,7 @@ function TickerRow({
       const encId = e.v ? cleanId(e.v) : "";
       const monId = encId ? encounters[encId]?.monsters?.[0]?.id || encId : "";
       body = (
-        <span className="inline-flex items-center gap-1.5 text-amber-300">
+        <span className="inline-flex items-center gap-1.5 text-warning">
           {t("Fight started")}
           {monId &&<EnemyCircle id={monId} monsters={monsters} className="h-5 w-5" />}
         </span>
@@ -369,7 +369,7 @@ function TickerRow({
         ? encounters[cleanId(won)]?.name || monsterName(won, monsters)
         : "";
       body = (
-        <span className="text-emerald-300">
+        <span className="text-success">
           {wonName ? t("Won the fight against {name}", { name: wonName }) : t("Won the fight")}
         </span>
       );
@@ -378,13 +378,13 @@ function TickerRow({
     case "choice":
       // An event option the player picked; `v` is the resolved option label.
       body = (
-        <span className="text-purple-300">
+        <span className="text-special">
           {e.v ? t("Picked: {option}", { option: e.v }) : t("Picked an option")}
         </span>
       );
       break;
     case "death":
-      body = <span className="text-rose-400 font-semibold">{t("Died")}</span>;
+      body = <span className="text-danger font-semibold">{t("Died")}</span>;
       break;
     case "act":
       body = (
@@ -533,7 +533,7 @@ function LiveCombatPanel({
             const hasCards = (pileCards[label]?.length ?? 0) > 0;
             const chip =
               label === "Exhaust" ? (
-                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-purple-600 text-[11px] font-bold tabular-nums text-white">
+                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-special-fill text-[11px] font-bold tabular-nums text-on-fill">
                   {v}
                 </span>
               ) : (
@@ -574,7 +574,7 @@ function LiveCombatPanel({
       )}
       {openPile && (
         <div
-          className="fixed inset-0 z-[60] flex items-start justify-center overflow-y-auto bg-black/60 p-4"
+          className="fixed inset-0 z-[60] flex items-start justify-center overflow-y-auto bg-scrim/60 p-4"
           onClick={() => setOpenPile(null)}
         >
           <div
@@ -664,13 +664,13 @@ function LiveCoopPanel({ players }: { players: LiveSeat[] }) {
                     </span>
                   )}
                   {s.alive === false && (
-                    <span className="text-[10px] text-rose-400">{t("dead")}</span>
+                    <span className="text-[10px] text-danger">{t("dead")}</span>
                   )}
                 </div>
                 {hpPct != null && (
                   <div className="mt-1 h-1.5 rounded bg-[var(--bg-card)]">
                     <div
-                      className="h-1.5 rounded bg-rose-500"
+                      className="h-1.5 rounded bg-danger-fill"
                       style={{ width: `${hpPct}%` }}
                     />
                   </div>
@@ -680,7 +680,7 @@ function LiveCoopPanel({ players }: { players: LiveSeat[] }) {
                     <span>{t("{hp}/{max} HP", { hp: s.hp, max: s.max_hp ?? "?" })}</span>
                   )}
                   {(s.block ?? 0) > 0 && (
-                    <span className="text-sky-300">{t("Block {n}", { n: s.block ?? 0 })}</span>
+                    <span className="text-info">{t("Block {n}", { n: s.block ?? 0 })}</span>
                   )}
                   {s.gold != null && <span>{t("{n}g", { n: s.gold })}</span>}
                   {s.deck_size != null && <span>{t("{n} cards", { n: s.deck_size })}</span>}
@@ -975,13 +975,13 @@ export default function LivePlayerClient() {
             </span>
           </div>
           <div className="h-2 rounded bg-[var(--bg-primary)]">
-            <div className="h-2 rounded bg-rose-500" style={{ width: `${hpPct}%` }} />
+            <div className="h-2 rounded bg-danger-fill" style={{ width: `${hpPct}%` }} />
           </div>
         </div>
       )}
       {(p.block ?? 0) > 0 && (
         <div className="mt-2 text-xs tabular-nums">
-          <span className="text-sky-300" title={t("Block")}>
+          <span className="text-info" title={t("Block")}>
             {t("Block {n}", { n: p.block ?? 0 })}
           </span>
         </div>

--- a/frontend/app/[locale]/live/[steamId]/LiveScene.tsx
+++ b/frontend/app/[locale]/live/[steamId]/LiveScene.tsx
@@ -87,12 +87,12 @@ function IntentBadge({ intent }: { intent: EnemyIntent }) {
         }}
       />
       {dmg != null ? (
-        <span className="text-xs font-bold tabular-nums text-rose-200">
+        <span className="text-xs font-bold tabular-nums text-danger">
           {dmg}
           {hits}
         </span>
       ) : intent.amount != null ? (
-        <span className="text-xs font-bold tabular-nums text-sky-200">
+        <span className="text-xs font-bold tabular-nums text-info">
           {intent.amount}
         </span>
       ) : null}
@@ -120,7 +120,7 @@ function PowerRow({ powers }: { powers: LivePower[] }) {
             }}
           />
           {pw.amount != null && pw.amount !== 0 && (
-            <span className="absolute -bottom-1 -right-1 rounded bg-black/70 px-0.5 text-[9px] font-bold leading-none text-white tabular-nums">
+            <span className="absolute -bottom-1 -right-1 rounded bg-scrim/70 px-0.5 text-[9px] font-bold leading-none text-on-fill tabular-nums">
               {pw.amount}
             </span>
           )}
@@ -161,7 +161,7 @@ function OrbRow({ orbs, slots }: { orbs: LiveOrb[]; slots?: number | null }) {
               }}
             />
             {orb?.passive != null && (
-              <span className="absolute -bottom-1 -right-1 rounded bg-black/70 px-0.5 text-[9px] font-bold leading-none text-white tabular-nums">
+              <span className="absolute -bottom-1 -right-1 rounded bg-scrim/70 px-0.5 text-[9px] font-bold leading-none text-on-fill tabular-nums">
                 {orb.passive}
               </span>
             )}
@@ -187,15 +187,15 @@ function Vitals({
   return (
     <div className="w-32 max-w-full">
       {pct != null && (
-        <div className="relative h-4 rounded bg-black/50 ring-1 ring-black/40">
-          <div className="h-4 rounded bg-rose-600" style={{ width: `${pct}%` }} />
-          <span className="absolute inset-0 flex items-center justify-center text-[10px] font-bold text-white tabular-nums drop-shadow">
+        <div className="relative h-4 rounded bg-scrim/50 ring-1 ring-scrim/40">
+          <div className="h-4 rounded bg-danger-fill" style={{ width: `${pct}%` }} />
+          <span className="absolute inset-0 flex items-center justify-center text-[10px] font-bold text-on-fill tabular-nums drop-shadow">
             {hp}/{maxHp}
           </span>
         </div>
       )}
       {(block ?? 0) > 0 && (
-        <div className="mt-0.5 flex items-center justify-center gap-1 text-[11px] font-bold text-sky-200">
+        <div className="mt-0.5 flex items-center justify-center gap-1 text-[11px] font-bold text-info">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={imageUrl("/static/images/intents/defend.png")}
@@ -236,7 +236,7 @@ function PartyMate({
           active
             ? "border-[var(--accent-gold)] ring-2 ring-[var(--accent-gold)]/60"
             : down
-              ? "border-rose-500/60 grayscale"
+              ? "border-danger/60 grayscale"
               : "border-[var(--accent-gold)]/40"
         }`}
       >
@@ -247,12 +247,12 @@ function PartyMate({
           {displayName(`CHARACTER.${seat.character ?? ""}`)}
         </span>
         {down && (
-          <span className="text-[10px] font-bold uppercase text-rose-400">
+          <span className="text-[10px] font-bold uppercase text-danger">
             {t("down")}
           </span>
         )}
         {!down && seat.ended_turn && turnSide === "player" && (
-          <span className="text-[10px] text-emerald-400" title={t("Turn locked in")}>
+          <span className="text-[10px] text-success" title={t("Turn locked in")}>
             ✓
           </span>
         )}
@@ -274,9 +274,9 @@ function PetRow({ pets, monsters }: { pets: LivePet[]; monsters: MonsterMap }) {
           <EnemyCircle
             id={pt.id || ""}
             monsters={monsters}
-            className="h-16 w-16 ring-2 ring-emerald-400/60"
+            className="h-16 w-16 ring-2 ring-success/60"
           />
-          <div className="max-w-[6rem] truncate text-xs font-medium text-emerald-200">
+          <div className="max-w-[6rem] truncate text-xs font-medium text-success">
             {pt.name || (pt.id ? monsterName(pt.id, monsters) : t("Pet"))}
           </div>
           <Vitals hp={pt.hp} maxHp={pt.max_hp} block={pt.block} />
@@ -416,10 +416,10 @@ export default function LiveScene({
         )}
         {p.hp != null && (
           <span className="inline-flex items-center gap-1.5">
-            <span className="relative block h-3.5 w-24 overflow-hidden rounded bg-black/40 ring-1 ring-black/30">
-              <span className="block h-full bg-rose-600" style={{ width: `${hpPct}%` }} />
+            <span className="relative block h-3.5 w-24 overflow-hidden rounded bg-scrim/40 ring-1 ring-scrim/30">
+              <span className="block h-full bg-danger-fill" style={{ width: `${hpPct}%` }} />
             </span>
-            <span className="text-xs font-semibold tabular-nums text-rose-200">
+            <span className="text-xs font-semibold tabular-nums text-danger">
               {p.hp}/{p.max_hp}
             </span>
           </span>
@@ -520,7 +520,7 @@ export default function LiveScene({
                 crossOrigin="anonymous"
               />
               {p.deck.length > 0 && (
-                <span className="absolute -bottom-1 -right-1 rounded bg-black/70 px-1 text-[10px] font-bold tabular-nums text-white">
+                <span className="absolute -bottom-1 -right-1 rounded bg-scrim/70 px-1 text-[10px] font-bold tabular-nums text-on-fill">
                   {p.deck.length}
                 </span>
               )}
@@ -585,20 +585,20 @@ export default function LiveScene({
             />
           ))}
           {sceneLayers.length > 0 && (
-            <div className="absolute inset-0 bg-black/20" />
+            <div className="absolute inset-0 bg-scrim/20" />
           )}
           {dead && (
-            <div className="absolute inset-0 bg-gradient-to-t from-rose-950/80 via-rose-900/45 to-rose-900/20" />
+            <div className="absolute inset-0 bg-gradient-to-t from-danger/10 via-danger/10 to-danger/10" />
           )}
         </div>
         <div className="relative w-full px-6 py-8">
           {dead ? (
             <div className="mx-auto flex max-w-lg flex-col items-center gap-3 py-10 text-center">
-              <div className="text-xs font-bold uppercase tracking-[0.3em] text-rose-400">
+              <div className="text-xs font-bold uppercase tracking-[0.3em] text-danger">
                 {t("Defeated")}
               </div>
               {p.death?.line && (
-                <div className="text-2xl font-semibold italic leading-snug text-rose-200">
+                <div className="text-2xl font-semibold italic leading-snug text-danger">
                   “<RichDescriptionSimple text={p.death.line} />”
                 </div>
               )}
@@ -669,8 +669,8 @@ export default function LiveScene({
                       monsters={monsters}
                       className={`h-28 w-28 ring-2 transition ${
                         p.turn_side === "enemy"
-                          ? "ring-rose-400 shadow-[0_0_18px_rgba(244,63,94,0.6)]"
-                          : "ring-rose-500/50"
+                          ? "ring-danger shadow-[0_0_18px_rgba(244,63,94,0.6)]"
+                          : "ring-danger/50"
                       }`}
                     />
                     <div className="max-w-[8rem] truncate text-sm font-semibold text-[var(--text-primary)]">
@@ -722,7 +722,7 @@ export default function LiveScene({
               <span className="inline-flex h-24 w-24 items-center justify-center overflow-hidden rounded-full border-2 border-[var(--accent-gold)]/60 bg-[var(--bg-primary)]">
                 <CharacterIcon character={p.character} className="h-[88%] w-[88%]" />
               </span>
-              <div className="text-base font-semibold text-amber-200">
+              <div className="text-base font-semibold text-warning">
                 {t("Resting at a campfire")}
               </div>
               {p.hp != null && (
@@ -748,7 +748,7 @@ export default function LiveScene({
               ) : null}
             </div>
           ) : (
-            <div className="py-12 text-center text-sm text-white/70">
+            <div className="py-12 text-center text-sm text-on-fill/70">
               {p.screen ? t("On the {screen} screen", { screen: p.screen }) : t("Between rooms")}
             </div>
           )}
@@ -841,7 +841,7 @@ export default function LiveScene({
       {/* Deck / pile viewer (the Deck button + the pile buttons open this). */}
       {openCards && (
         <div
-          className="fixed inset-0 z-[60] flex items-start justify-center overflow-y-auto bg-black/60 p-4"
+          className="fixed inset-0 z-[60] flex items-start justify-center overflow-y-auto bg-scrim/60 p-4"
           onClick={() => setOpenCards(null)}
         >
           <div
@@ -900,7 +900,7 @@ export default function LiveScene({
       {/* Map viewer (the Map button opens this). */}
       {showMap && (
         <div
-          className="fixed inset-0 z-[60] flex items-start justify-center overflow-y-auto bg-black/60 p-4"
+          className="fixed inset-0 z-[60] flex items-start justify-center overflow-y-auto bg-scrim/60 p-4"
           onClick={() => setShowMap(false)}
         >
           <div

--- a/frontend/app/[locale]/live/live-shared.tsx
+++ b/frontend/app/[locale]/live/live-shared.tsx
@@ -422,8 +422,8 @@ export function LiveCardImg({
 export function LiveDot() {
   return (
     <span className="relative flex h-2 w-2">
-      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-      <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-success-fill opacity-75" />
+      <span className="relative inline-flex rounded-full h-2 w-2 bg-success-fill" />
     </span>
   );
 }
@@ -432,7 +432,7 @@ export function LiveDot() {
 export function PartnerBadge() {
   const t = useT();
   return (
-    <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-[#9146FF]/15 text-[#b794ff] border border-[#9146FF]/40">
+    <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-twitch/15 text-twitch-light border border-twitch/40">
       {t("Partner")}
     </span>
   );
@@ -455,7 +455,7 @@ export function WatchOnTwitch({
       href={`https://twitch.tv/${login}`}
       target="_blank"
       rel="noopener noreferrer"
-      className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-[#9146FF] text-white text-xs font-semibold hover:bg-[#7d2ff5] transition-colors ${className}`}
+      className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-twitch text-on-fill text-xs font-semibold hover:bg-twitch/90 transition-colors ${className}`}
     >
       <TwitchIcon className="w-3.5 h-3.5" />
       {t("Watch on Twitch")}
@@ -590,7 +590,7 @@ export function FightingChip({
   const label =
     names.length <= 2 ? names.join(" & ") : `${names[0]} +${names.length - 1}`;
   return (
-    <span className="inline-flex min-w-0 max-w-full items-center gap-1.5 px-2 py-1 rounded-full bg-rose-950/50 border border-rose-900/50 text-xs text-rose-200">
+    <span className="inline-flex min-w-0 max-w-full items-center gap-1.5 px-2 py-1 rounded-full bg-danger/10 border border-danger/30 text-xs text-danger">
       <span className="flex -space-x-2 shrink-0">
         {withOrdinalKeys(groups.slice(0, 3).map((g) => g.id)).map(({ item, key }) => (
           <EnemyCircle key={key} id={item} monsters={monsters} className={circle} />
@@ -598,7 +598,7 @@ export function FightingChip({
       </span>
       <span className="min-w-0 truncate">{t("Fighting {label}", { label })}</span>
       {p.turn != null && p.turn > 0 && (
-        <span className="text-rose-400/80 whitespace-nowrap shrink-0">· {t("Turn {n}", { n: p.turn })}</span>
+        <span className="text-danger/80 whitespace-nowrap shrink-0">· {t("Turn {n}", { n: p.turn })}</span>
       )}
     </span>
   );
@@ -610,17 +610,17 @@ function intentLabel(it: EnemyIntent, t: TFn): { text: string; cls: string } {
   const kind = (it.type || "").toLowerCase();
   const hits = it.hits && it.hits > 1 ? `×${it.hits}` : "";
   const dmg = it.dmg != null ? `${it.dmg}${hits}` : "";
-  const rose = "text-rose-200 bg-rose-950/50 border-rose-900/50";
-  const sky = "text-sky-200 bg-sky-950/50 border-sky-900/50";
-  const emerald = "text-emerald-200 bg-emerald-950/50 border-emerald-900/50";
-  const fuchsia = "text-fuchsia-200 bg-fuchsia-950/50 border-fuchsia-900/50";
-  const amber = "text-amber-200 bg-amber-950/50 border-amber-900/50";
+  const rose = "text-danger bg-danger/10 border-danger/30";
+  const sky = "text-info bg-info/10 border-info/30";
+  const emerald = "text-success bg-success/10 border-success/30";
+  const fuchsia = "text-special bg-special/10 border-special/30";
+  const amber = "text-warning bg-warning/10 border-warning/30";
   const muted = "text-[var(--text-muted)] bg-[var(--bg-primary)] border-[var(--border-subtle)]";
   switch (kind) {
     case "attack":
       return { text: dmg ? t("ATK {dmg}", { dmg }) : t("ATK"), cls: rose };
     case "deathblow":
-      return { text: dmg ? t("LETHAL {dmg}", { dmg }) : t("LETHAL"), cls: "text-rose-100 bg-rose-900/60 border-rose-700/60" };
+      return { text: dmg ? t("LETHAL {dmg}", { dmg }) : t("LETHAL"), cls: "text-danger bg-danger/10 border-danger/60" };
     case "defend":
       return { text: t("BLOCK"), cls: sky };
     case "buff":
@@ -658,11 +658,11 @@ export function LiveEnemiesPanel({ p, monsters }: { p: LivePlayer; monsters: Mon
   if (!enemies.length) return null;
 
   return (
-    <div className="rounded-lg border border-rose-900/50 bg-rose-950/20 p-4">
+    <div className="rounded-lg border border-danger/30 bg-danger/10 p-4">
       <div className="flex items-center gap-2 mb-3">
-        <span className="text-[10px] font-bold uppercase tracking-wider text-rose-300">{t("Fighting")}</span>
+        <span className="text-[10px] font-bold uppercase tracking-wider text-danger">{t("Fighting")}</span>
         {p.turn != null && p.turn > 0 && (
-          <span className="ml-auto text-xs text-rose-300 tabular-nums">{t("Turn {n}", { n: p.turn })}</span>
+          <span className="ml-auto text-xs text-danger tabular-nums">{t("Turn {n}", { n: p.turn })}</span>
         )}
       </div>
       <ul className="space-y-2.5">
@@ -683,9 +683,9 @@ export function LiveEnemiesPanel({ p, monsters }: { p: LivePlayer; monsters: Mon
               )}
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2 flex-wrap">
-                  <span className="text-sm text-rose-100 truncate">{name}</span>
+                  <span className="text-sm text-danger truncate">{name}</span>
                   {(e.block ?? 0) > 0 && (
-                    <span className="text-[10px] text-sky-300 tabular-nums shrink-0" title={t("block")}>
+                    <span className="text-[10px] text-info tabular-nums shrink-0" title={t("block")}>
                       [{e.block}]
                     </span>
                   )}
@@ -705,14 +705,14 @@ export function LiveEnemiesPanel({ p, monsters }: { p: LivePlayer; monsters: Mon
                 </div>
                 {hpPct != null ? (
                   <div className="mt-1">
-                    <div className="flex justify-between text-[9px] text-rose-300/70 tabular-nums">
+                    <div className="flex justify-between text-[9px] text-danger/70 tabular-nums">
                       <span>{t("HP")}</span>
                       <span>
                         {e.hp}/{e.max_hp}
                       </span>
                     </div>
                     <div className="h-1.5 rounded bg-[var(--bg-primary)]">
-                      <div className="h-1.5 rounded bg-rose-500" style={{ width: `${hpPct}%` }} />
+                      <div className="h-1.5 rounded bg-danger-fill" style={{ width: `${hpPct}%` }} />
                     </div>
                   </div>
                 ) : null}

--- a/frontend/app/[locale]/mechanics/page.tsx
+++ b/frontend/app/[locale]/mechanics/page.tsx
@@ -96,9 +96,9 @@ export default async function MechanicsPage({ params }: Props) {
           <Link
             key={s.slug}
             href={`/mechanics/${s.slug}`}
-            className="bg-[var(--bg-card)] rounded-lg border border-emerald-800/30 p-5 hover:bg-[var(--bg-card-hover)] hover:border-emerald-600/50 transition-all cursor-pointer block"
+            className="bg-[var(--bg-card)] rounded-lg border border-success/30 p-5 hover:bg-[var(--bg-card-hover)] hover:border-success/50 transition-all cursor-pointer block"
           >
-            <h3 className="font-semibold text-emerald-400 mb-2">{s.title}</h3>
+            <h3 className="font-semibold text-success mb-2">{s.title}</h3>
             <p className="text-sm text-[var(--text-secondary)] leading-relaxed line-clamp-2">{s.description}</p>
           </Link>
         ))}

--- a/frontend/app/[locale]/merchant/page.tsx
+++ b/frontend/app/[locale]/merchant/page.tsx
@@ -120,8 +120,8 @@ function sortByOrder(rarities: string[], order: string[]): string[] {
 
 const RARITY_COLOR: Record<string, string> = {
   Common: "text-[var(--text-secondary)]",
-  Shop: "text-emerald-400",
-  Uncommon: "text-blue-400",
+  Shop: "text-success",
+  Uncommon: "text-info",
   Rare: "text-[var(--accent-gold)]",
 };
 
@@ -303,7 +303,7 @@ export default async function MerchantPage({ params }: Props) {
                         <td className="p-3 text-right text-[var(--text-primary)]">{r.base}</td>
                         <td className="p-3 text-right text-[var(--accent-gold)]">{r.min}–{r.max}</td>
                         <td className="p-3 text-right text-[var(--text-secondary)]">{colorlessMin}–{colorlessMax}</td>
-                        <td className="p-3 text-right text-emerald-400">{saleMin}–{saleMax}</td>
+                        <td className="p-3 text-right text-success">{saleMin}–{saleMax}</td>
                       </tr>
                     );
                   })}

--- a/frontend/app/[locale]/monsters/MonstersClient.tsx
+++ b/frontend/app/[locale]/monsters/MonstersClient.tsx
@@ -15,15 +15,15 @@ import { imageUrl } from "@/lib/image-url";
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 const typeColors: Record<string, string> = {
-  Normal: "border-gray-600/40",
-  Elite: "border-amber-600/50",
-  Boss: "border-red-600/50",
+  Normal: "border-line-strong/40",
+  Elite: "border-warning/50",
+  Boss: "border-danger/50",
 };
 
 const typeBadge: Record<string, string> = {
-  Normal: "bg-gray-800 text-gray-300",
-  Elite: "bg-amber-900/50 text-amber-400",
-  Boss: "bg-red-900/50 text-red-400",
+  Normal: "bg-surface text-fg-secondary",
+  Elite: "bg-warning/10 text-warning",
+  Boss: "bg-danger/10 text-danger",
 };
 
 const typeOptions = [
@@ -178,7 +178,7 @@ function MonstersClientInner({ initialMonsters }: { initialMonsters: Monster[] }
               <div className="flex items-center gap-3 mb-3">
                 <div className="flex items-center gap-1.5">
                   <span className="text-xs text-[var(--text-muted)]">{t("HP")}</span>
-                  <span className="text-sm font-medium text-red-400">
+                  <span className="text-sm font-medium text-danger">
                     {monster.min_hp}
                     {monster.max_hp && monster.max_hp !== monster.min_hp
                       ? `–${monster.max_hp}`
@@ -190,7 +190,7 @@ function MonstersClientInner({ initialMonsters }: { initialMonsters: Monster[] }
                     <span className="text-xs text-[var(--text-muted)]">
                       {t("A+ HP")}
                     </span>
-                    <span className="text-sm font-medium text-orange-400">
+                    <span className="text-sm font-medium text-warning">
                       {monster.min_hp_ascension}
                       {monster.max_hp_ascension &&
                       monster.max_hp_ascension !== monster.min_hp_ascension
@@ -233,7 +233,7 @@ function MonstersClientInner({ initialMonsters }: { initialMonsters: Monster[] }
                       ([name, val]) => (
                         <span
                           key={name}
-                          className="text-xs px-2 py-0.5 rounded bg-red-950/40 text-red-300 border border-red-900/30"
+                          className="text-xs px-2 py-0.5 rounded bg-danger/10 text-danger border border-danger/30"
                         >
                           {name}: {val.normal}
                           {val.ascension ? ` (A: ${val.ascension})` : ""}

--- a/frontend/app/[locale]/monsters/[id]/MonsterDetail.tsx
+++ b/frontend/app/[locale]/monsters/[id]/MonsterDetail.tsx
@@ -27,23 +27,23 @@ const SPINE_BY_TYPE: Record<string, string> = {
 };
 
 const typeBadge: Record<string, string> = {
-  Normal: "bg-gray-800 text-gray-300",
-  Elite: "bg-amber-900/50 text-amber-400",
-  Boss: "bg-red-900/50 text-red-400",
+  Normal: "bg-surface text-fg-secondary",
+  Elite: "bg-warning/10 text-warning",
+  Boss: "bg-danger/10 text-danger",
 };
 
 const intentColors: Record<string, string> = {
-  Attack: "text-red-400",
-  Defend: "text-blue-400",
-  Buff: "text-green-400",
-  Debuff: "text-purple-400",
-  Status: "text-yellow-400",
-  Summon: "text-cyan-400",
-  Heal: "text-emerald-400",
-  Escape: "text-gray-400",
-  Sleep: "text-indigo-400",
-  Stun: "text-orange-400",
-  Special: "text-pink-400",
+  Attack: "text-danger",
+  Defend: "text-info",
+  Buff: "text-success",
+  Debuff: "text-special",
+  Status: "text-warning",
+  Summon: "text-info",
+  Heal: "text-success",
+  Escape: "text-fg-muted",
+  Sleep: "text-info",
+  Stun: "text-warning",
+  Special: "text-special",
   Unknown: "text-[var(--text-muted)]",
 };
 
@@ -83,8 +83,8 @@ function PowerPill({
       href={`${bp}/powers/${p.power_id.toLowerCase()}`}
       className={`relative text-xs px-2 py-0.5 rounded-full border transition-colors ${
         p.target === "player"
-          ? "border-red-800/50 bg-red-950/30 text-red-300 hover:bg-red-900/40"
-          : "border-green-800/50 bg-green-950/30 text-green-300 hover:bg-green-900/40"
+          ? "border-danger/30 bg-danger/10 text-danger hover:bg-danger/10"
+          : "border-success/30 bg-success/10 text-success hover:bg-success/10"
       }`}
       onMouseEnter={() => setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}
@@ -105,7 +105,7 @@ function PowerPill({
               {power.name}
             </span>
             <span className={`text-[10px] px-1.5 py-0.5 rounded-full ml-auto ${
-              power.type === "Debuff" ? "bg-red-900/50 text-red-300" : "bg-green-900/50 text-green-300"
+              power.type === "Debuff" ? "bg-danger/10 text-danger" : "bg-success/10 text-success"
             }`}>
               {power.type}
             </span>
@@ -243,7 +243,7 @@ function MoveCard({
         {move.damage && (
           <div className="mrow">
             <span className="mk">{t("Damage")}</span>
-            <span className="mval text-red-400">
+            <span className="mval text-danger">
               {move.damage.normal}
               {move.damage.hit_count && move.damage.hit_count > 1
                 ? ` × ${move.damage.hit_count} = ${move.damage.normal * move.damage.hit_count}`
@@ -264,7 +264,7 @@ function MoveCard({
         {move.block != null && (
           <div className="mrow">
             <span className="mk">{t("Block")}</span>
-            <span className="mval text-blue-400">{move.block}</span>
+            <span className="mval text-info">{move.block}</span>
           </div>
         )}
 
@@ -272,7 +272,7 @@ function MoveCard({
         {move.heal != null && (
           <div className="mrow">
             <span className="mk">{t("Heal")}</span>
-            <span className="mval text-emerald-400">{move.heal}</span>
+            <span className="mval text-success">{move.heal}</span>
           </div>
         )}
 
@@ -618,7 +618,7 @@ export default function MonsterDetail({
                           bp={bp}
                         />
                         {p.amount_ascension != null && p.amount_ascension !== p.amount && (
-                          <span className="text-xs text-orange-400">(A: {p.amount_ascension})</span>
+                          <span className="text-xs text-warning">(A: {p.amount_ascension})</span>
                         )}
                       </span>
                     ))}
@@ -772,7 +772,7 @@ export default function MonsterDetail({
                         {enc.room_type}
                       </span>
                       {enc.is_weak && (
-                        <span className="badge bg-green-900/30 text-green-400">{t("Weak")}</span>
+                        <span className="badge bg-success/10 text-success">{t("Weak")}</span>
                       )}
                     </div>
                   </Link>

--- a/frontend/app/[locale]/news/[...slug]/page.tsx
+++ b/frontend/app/[locale]/news/[...slug]/page.tsx
@@ -186,7 +186,7 @@ export default async function NewsArticlePage({ params }: Props) {
             href={canonicalSteamUrl(article.gid)}
             target="_blank"
             rel="noopener noreferrer"
-            className="underline text-[var(--accent-gold)] hover:text-white"
+            className="underline text-[var(--accent-gold)] hover:text-on-fill"
           >
             {canonicalSteamUrl(article.gid)}
           </a>

--- a/frontend/app/[locale]/potions/PotionsClient.tsx
+++ b/frontend/app/[locale]/potions/PotionsClient.tsx
@@ -15,9 +15,9 @@ import { imageUrl } from "@/lib/image-url";
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 const rarityColors: Record<string, string> = {
-  Common: "border-gray-500/40 text-gray-300",
-  Uncommon: "border-blue-600/40 text-blue-400",
-  Rare: "border-amber-600/40 text-[var(--accent-gold)]",
+  Common: "border-line-strong/40 text-fg-secondary",
+  Uncommon: "border-info/40 text-info",
+  Rare: "border-warning/40 text-[var(--accent-gold)]",
 };
 
 const rarityOptions = [
@@ -147,7 +147,7 @@ function PotionsClientInner({ initialPotions }: { initialPotions: Potion[] }) {
           {sortedPotions.map((potion) => {
             const style =
               rarityColors[potion.rarity] ||
-              "border-[var(--border-subtle)] text-gray-400";
+              "border-[var(--border-subtle)] text-fg-muted";
             return (
               <Link
                 prefetch={false}

--- a/frontend/app/[locale]/powers/PowersClient.tsx
+++ b/frontend/app/[locale]/powers/PowersClient.tsx
@@ -15,9 +15,9 @@ import { imageUrl } from "@/lib/image-url";
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 const typeColors: Record<string, string> = {
-  Buff: "border-emerald-600/40 text-emerald-400",
-  Debuff: "border-red-600/40 text-red-400",
-  None: "border-gray-500/40 text-gray-400",
+  Buff: "border-success/40 text-success",
+  Debuff: "border-danger/40 text-danger",
+  None: "border-line-strong/40 text-fg-muted",
 };
 
 const typeOptions = [
@@ -103,7 +103,7 @@ export default function PowersClient({ initialPowers }: { initialPowers: Power[]
         {merged.map((power) => {
           const style =
             typeColors[power.type] ||
-            "border-[var(--border-subtle)] text-gray-400";
+            "border-[var(--border-subtle)] text-fg-muted";
           return (
             <Link
               prefetch={false}

--- a/frontend/app/[locale]/profile/ProfileClient.tsx
+++ b/frontend/app/[locale]/profile/ProfileClient.tsx
@@ -261,10 +261,10 @@ export default function ProfileClient() {
                 key={i}
                 className={`text-xs px-3 py-1.5 rounded flex items-center justify-between ${
                   r.status === "claimed"
-                    ? "bg-green-500/10 text-green-300"
+                    ? "bg-success/10 text-success"
                     : r.status === "duplicate"
-                      ? "bg-yellow-500/10 text-yellow-300"
-                      : "bg-red-500/10 text-red-300"
+                      ? "bg-warning/10 text-warning"
+                      : "bg-danger/10 text-danger"
                 }`}
               >
                 <span className="truncate">{r.filename}</span>

--- a/frontend/app/[locale]/reference/ReferenceClient.tsx
+++ b/frontend/app/[locale]/reference/ReferenceClient.tsx
@@ -119,7 +119,7 @@ export default function ReferenceClient({
       <ReferenceSection<Act>
         title="Acts"
         endpoint="acts"
-        accent="text-emerald-400"
+        accent="text-success"
         initialData={initialData.acts}
         lang={lang}
         linkPrefix={`${bp}/acts`}
@@ -144,14 +144,14 @@ export default function ReferenceClient({
       <ReferenceSection<Ascension>
         title="Ascension Levels"
         endpoint="ascensions"
-        accent="text-rose-400"
+        accent="text-danger"
         initialData={initialData.ascensions}
         lang={lang}
         linkPrefix={`${bp}/ascensions`}
         render={(asc) => (
           <>
             <div className="flex items-baseline gap-2 mb-1">
-              <span className="text-lg font-bold text-rose-400">
+              <span className="text-lg font-bold text-danger">
                 {asc.level}
               </span>
               <h3 className="font-semibold text-[var(--text-primary)]">
@@ -168,7 +168,7 @@ export default function ReferenceClient({
       <ReferenceSection<Keyword>
         title="Keywords"
         endpoint="keywords"
-        accent="text-cyan-400"
+        accent="text-info"
         initialData={initialData.keywords}
         lang={lang}
         linkPrefix={`${bp}/keywords`}
@@ -187,7 +187,7 @@ export default function ReferenceClient({
       <ReferenceSection<Orb>
         title="Orbs"
         endpoint="orbs"
-        accent="text-blue-400"
+        accent="text-info"
         initialData={initialData.orbs}
         lang={lang}
         linkPrefix={`${bp}/orbs`}
@@ -216,7 +216,7 @@ export default function ReferenceClient({
       <ReferenceSection<Affliction>
         title="Afflictions"
         endpoint="afflictions"
-        accent="text-red-400"
+        accent="text-danger"
         initialData={initialData.afflictions}
         lang={lang}
         linkPrefix={`${bp}/afflictions`}
@@ -247,7 +247,7 @@ export default function ReferenceClient({
       <ReferenceSection<Intent>
         title="Intents"
         endpoint="intents"
-        accent="text-amber-400"
+        accent="text-warning"
         initialData={initialData.intents}
         lang={lang}
         linkPrefix={`${bp}/intents`}
@@ -276,7 +276,7 @@ export default function ReferenceClient({
       <ReferenceSection<Modifier>
         title="Modifiers"
         endpoint="modifiers"
-        accent="text-purple-400"
+        accent="text-special"
         initialData={initialData.modifiers}
         lang={lang}
         linkPrefix={`${bp}/modifiers`}
@@ -295,7 +295,7 @@ export default function ReferenceClient({
       <ReferenceSection<Achievement>
         title="Achievements"
         endpoint="achievements"
-        accent="text-yellow-400"
+        accent="text-warning"
         initialData={initialData.achievements}
         lang={lang}
         linkPrefix={`${bp}/achievements`}

--- a/frontend/app/[locale]/relics/RelicsClient.tsx
+++ b/frontend/app/[locale]/relics/RelicsClient.tsx
@@ -17,13 +17,13 @@ import { imageUrl } from "@/lib/image-url";
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 const rarityColors: Record<string, string> = {
-  Starter: "border-gray-600/40 text-gray-400",
-  Common: "border-gray-500/40 text-gray-300",
-  Uncommon: "border-blue-600/40 text-blue-400",
-  Rare: "border-amber-600/40 text-[var(--accent-gold)]",
-  Shop: "border-emerald-600/40 text-emerald-400",
-  Event: "border-cyan-600/40 text-cyan-400",
-  Ancient: "border-purple-600/40 text-purple-400",
+  Starter: "border-line-strong/40 text-fg-muted",
+  Common: "border-line-strong/40 text-fg-secondary",
+  Uncommon: "border-info/40 text-info",
+  Rare: "border-warning/40 text-[var(--accent-gold)]",
+  Shop: "border-success/40 text-success",
+  Event: "border-info/40 text-info",
+  Ancient: "border-special/40 text-special",
 };
 
 const rarityOptions = [
@@ -191,7 +191,7 @@ function RelicsClientInner({ initialRelics }: { initialRelics: Relic[] }) {
         {sortedRelics.map((relic) => {
           const style =
             rarityColors[relic.rarity] ||
-            "border-[var(--border-subtle)] text-gray-400";
+            "border-[var(--border-subtle)] text-fg-muted";
           return (
             <Link
               prefetch={false}

--- a/frontend/app/[locale]/runs/[hash]/RunSummary.tsx
+++ b/frontend/app/[locale]/runs/[hash]/RunSummary.tsx
@@ -130,10 +130,10 @@ const TIER_LABELS: Record<string, string> = {
 };
 
 const TIER_OUTLINE: Record<string, string> = {
-  weak: "ring-1 ring-emerald-500/40",
-  normal: "ring-1 ring-amber-500/40",
-  elite: "ring-1 ring-orange-500/60",
-  boss: "ring-2 ring-rose-500/60",
+  weak: "ring-1 ring-success/40",
+  normal: "ring-1 ring-warning/40",
+  elite: "ring-1 ring-warning/60",
+  boss: "ring-2 ring-danger/60",
 };
 
 
@@ -358,7 +358,7 @@ export default function RunSummary({ run, player, cardData, relicData, potionDat
                 relicId={rid}
                 relicData={relicData}
                 bp={bp}
-                className="w-8 h-8 sm:w-9 sm:h-9 rounded-md bg-black/30 flex items-center justify-center hover:bg-black/50 transition-colors"
+                className="w-8 h-8 sm:w-9 sm:h-9 rounded-md bg-scrim/30 flex items-center justify-center hover:bg-scrim/50 transition-colors"
               >
                 {info?.image_url ? (
                   <img
@@ -523,13 +523,13 @@ function MapNode({
     </div>
   );
 
-  const wrapClass = `relative w-7 h-7 sm:w-8 sm:h-8 rounded-md bg-black/30 flex items-center justify-center ${TIER_OUTLINE[tier] ?? ""}`;
+  const wrapClass = `relative w-7 h-7 sm:w-8 sm:h-8 rounded-md bg-scrim/30 flex items-center justify-center ${TIER_OUTLINE[tier] ?? ""}`;
 
   if (href) {
     return (
       <Link
         href={href}
-        className={`${wrapClass} hover:bg-black/50 hover:ring-2 hover:ring-[var(--accent-gold)]/60 transition-all`}
+        className={`${wrapClass} hover:bg-scrim/50 hover:ring-2 hover:ring-[var(--accent-gold)]/60 transition-all`}
         onMouseEnter={() => setShow(true)}
         onMouseLeave={() => setShow(false)}
       >

--- a/frontend/app/[locale]/runs/[hash]/SharedRunClient.tsx
+++ b/frontend/app/[locale]/runs/[hash]/SharedRunClient.tsx
@@ -252,7 +252,7 @@ export default function SharedRunClient({ initialRun }: { initialRun?: any }) {
         </div>
       </div>
       {showReport && (
-        <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center p-4"
+        <div className="fixed inset-0 z-50 bg-scrim/60 flex items-center justify-center p-4"
           onClick={() => reportState !== "sending" && setShowReport(false)}>
           <div className="bg-[var(--bg-card)] border border-[var(--border-subtle)] rounded-xl p-5 w-full max-w-md"
             onClick={(e) => e.stopPropagation()}>

--- a/frontend/app/[locale]/seed-lab/SeedLabClient.tsx
+++ b/frontend/app/[locale]/seed-lab/SeedLabClient.tsx
@@ -138,7 +138,7 @@ function CountedChips({
           <button
             type="button"
             onClick={() => onRemove(p.id)}
-            className="text-[var(--text-muted)] hover:text-red-400"
+            className="text-[var(--text-muted)] hover:text-danger"
             aria-label={t("Remove")}
           >
             ✕
@@ -362,7 +362,7 @@ export default function SeedLabClient() {
                   key={p.id}
                   type="button"
                   onClick={() => setRelicPicks((ps) => ps.filter((x) => x.id !== p.id))}
-                  className="text-xs px-2 py-0.5 rounded-md border border-sky-900/50 bg-[var(--bg-primary)] text-sky-300 hover:border-red-500/50"
+                  className="text-xs px-2 py-0.5 rounded-md border border-info/30 bg-[var(--bg-primary)] text-info hover:border-danger/50"
                 >
                   {p.name} ✕
                 </button>
@@ -386,7 +386,7 @@ export default function SeedLabClient() {
                   key={p.id}
                   type="button"
                   onClick={() => setEventPicks((ps) => ps.filter((x) => x.id !== p.id))}
-                  className="text-xs px-2 py-0.5 rounded-md border border-purple-900/50 bg-[var(--bg-primary)] text-purple-300 hover:border-red-500/50"
+                  className="text-xs px-2 py-0.5 rounded-md border border-special/30 bg-[var(--bg-primary)] text-special hover:border-danger/50"
                 >
                   {p.name} ✕
                 </button>
@@ -426,7 +426,7 @@ export default function SeedLabClient() {
               <button
                 type="button"
                 onClick={() => setAncientPick(null)}
-                className="text-xs px-2 py-0.5 rounded-md border border-[var(--accent-gold)]/40 bg-[var(--bg-primary)] text-[var(--accent-gold)] hover:border-red-500/50"
+                className="text-xs px-2 py-0.5 rounded-md border border-[var(--accent-gold)]/40 bg-[var(--bg-primary)] text-[var(--accent-gold)] hover:border-danger/50"
               >
                 {ancientPick.name} ✕
               </button>
@@ -439,11 +439,11 @@ export default function SeedLabClient() {
         type="button"
         disabled={!hasPredicates || loading}
         onClick={search}
-        className="px-5 py-2.5 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-black hover:opacity-90 transition-opacity disabled:opacity-40 mb-6"
+        className="px-5 py-2.5 rounded-lg text-sm font-medium bg-[var(--accent-gold)] text-on-accent hover:opacity-90 transition-opacity disabled:opacity-40 mb-6"
       >
         {loading ? (
           <span className="inline-flex items-center gap-2">
-            <span className="w-3.5 h-3.5 rounded-full border-2 border-black/30 border-t-black animate-spin" />
+            <span className="w-3.5 h-3.5 rounded-full border-2 border-scrim/30 border-t-scrim animate-spin" />
             {t("Searching…")}
           </span>
         ) : (
@@ -463,8 +463,8 @@ export default function SeedLabClient() {
       )}
 
       {error && !loading && (
-        <div className={`${card} border-red-500/40`}>
-          <p className="text-sm text-red-400">{error}</p>
+        <div className={`${card} border-danger/40`}>
+          <p className="text-sm text-danger">{error}</p>
         </div>
       )}
 
@@ -475,7 +475,7 @@ export default function SeedLabClient() {
             {result.sampled ? ` ${t("(sampled — add a card kept or relic to search everything)")}` : ""}.
           </div>
           {(result.unknown ?? []).length > 0 ? (
-            <p className="text-sm text-red-400">
+            <p className="text-sm text-danger">
               {t("Unknown ids: {ids} — these don't exist in the game data, check the spelling.", { ids: result.unknown!.join(", ") })}
             </p>
           ) : (result.results ?? []).length === 0 ? (
@@ -511,7 +511,7 @@ export default function SeedLabClient() {
                   </span>
                   <span className="flex flex-wrap gap-1 text-[11px]">
                     {r.matched.map((t) => (
-                      <span key={t} className="px-1.5 py-0.5 rounded bg-green-500/10 text-green-400">
+                      <span key={t} className="px-1.5 py-0.5 rounded bg-success/10 text-success">
                         ✓ {labelFor(t)}
                       </span>
                     ))}

--- a/frontend/app/[locale]/settings/SettingsClient.tsx
+++ b/frontend/app/[locale]/settings/SettingsClient.tsx
@@ -199,16 +199,16 @@ export default function SettingsClient() {
               <span className="absolute right-3 top-2.5 text-xs text-[var(--text-tertiary)]">...</span>
             )}
             {!checkingUsername && usernameAvailable === false && usernameChanged && (
-              <span className="absolute right-3 top-2.5 text-xs text-red-400">{t("Taken")}</span>
+              <span className="absolute right-3 top-2.5 text-xs text-danger">{t("Taken")}</span>
             )}
             {!checkingUsername && usernameAvailable === true && usernameChanged && (
-              <span className="absolute right-3 top-2.5 text-xs text-green-400">{t("Available")}</span>
+              <span className="absolute right-3 top-2.5 text-xs text-success">{t("Available")}</span>
             )}
           </div>
           <button
             onClick={saveUsername}
             disabled={!usernameChanged || saving === "username" || usernameAvailable === false}
-            className="px-4 py-2 text-sm font-medium rounded-lg bg-[var(--border-accent)] text-white hover:opacity-90 disabled:opacity-30 transition-opacity shrink-0"
+            className="px-4 py-2 text-sm font-medium rounded-lg bg-[var(--border-accent)] text-on-fill hover:opacity-90 disabled:opacity-30 transition-opacity shrink-0"
           >
             {saving === "username" ? t("Saving...") : t("Save")}
           </button>
@@ -232,13 +232,13 @@ export default function SettingsClient() {
           <button
             onClick={saveEmail}
             disabled={!emailChanged || saving === "email"}
-            className="px-4 py-2 text-sm font-medium rounded-lg bg-[var(--border-accent)] text-white hover:opacity-90 disabled:opacity-30 transition-opacity shrink-0"
+            className="px-4 py-2 text-sm font-medium rounded-lg bg-[var(--border-accent)] text-on-fill hover:opacity-90 disabled:opacity-30 transition-opacity shrink-0"
           >
             {saving === "email" ? t("Saving...") : t("Save")}
           </button>
         </div>
         {user.needs_email && (
-          <p className="text-xs text-yellow-400">
+          <p className="text-xs text-warning">
             {t("Add an email to unlock API keys and future features.")}
           </p>
         )}
@@ -259,7 +259,7 @@ export default function SettingsClient() {
                 <button
                   onClick={() => disconnect("steam")}
                   disabled={disconnecting === "steam"}
-                  className="text-xs text-[var(--text-secondary)] hover:text-red-400 disabled:opacity-40"
+                  className="text-xs text-[var(--text-secondary)] hover:text-danger disabled:opacity-40"
                 >
                   {disconnecting === "steam" ? "..." : t("Disconnect")}
                 </button>
@@ -288,7 +288,7 @@ export default function SettingsClient() {
                 <button
                   onClick={() => disconnect("discord")}
                   disabled={disconnecting === "discord"}
-                  className="text-xs text-[var(--text-secondary)] hover:text-red-400 disabled:opacity-40"
+                  className="text-xs text-[var(--text-secondary)] hover:text-danger disabled:opacity-40"
                 >
                   {disconnecting === "discord" ? "..." : t("Disconnect")}
                 </button>
@@ -309,20 +309,20 @@ export default function SettingsClient() {
           {user.twitch_id ? (
             <div className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)]">
               <div className="flex items-center gap-2 min-w-0">
-                <TwitchIcon className="w-4 h-4 text-[#9146FF]" />
+                <TwitchIcon className="w-4 h-4 text-twitch" />
                 <span className="text-sm text-[var(--text-primary)] shrink-0">Twitch</span>
                 {user.twitch_login && (
                   <a
                     href={`https://twitch.tv/${user.twitch_login}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-xs text-[var(--text-muted)] truncate hover:text-[#9146FF]"
+                    className="text-xs text-[var(--text-muted)] truncate hover:text-twitch"
                   >
                     @{user.twitch_login}
                   </a>
                 )}
                 {user.is_partner && (
-                  <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-[#9146FF]/15 text-[#9146FF] border border-[#9146FF]/30 shrink-0">
+                  <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-twitch/15 text-twitch border border-twitch/30 shrink-0">
                     {t("Partner")}
                   </span>
                 )}
@@ -332,7 +332,7 @@ export default function SettingsClient() {
                 <button
                   onClick={() => disconnect("twitch")}
                   disabled={disconnecting === "twitch"}
-                  className="text-xs text-[var(--text-secondary)] hover:text-red-400 disabled:opacity-40"
+                  className="text-xs text-[var(--text-secondary)] hover:text-danger disabled:opacity-40"
                 >
                   {disconnecting === "twitch" ? "..." : t("Disconnect")}
                 </button>
@@ -353,7 +353,7 @@ export default function SettingsClient() {
           {user.patreon_id ? (
             <div className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)]">
               <div className="flex items-center gap-2 min-w-0">
-                <svg className="w-4 h-4 text-[#FF424D]" viewBox="0 0 24 24" fill="currentColor" aria-hidden><circle cx="14.5" cy="9.5" r="7.5" /><rect x="2" y="2" width="4" height="20" /></svg>
+                <svg className="w-4 h-4 text-patreon" viewBox="0 0 24 24" fill="currentColor" aria-hidden><circle cx="14.5" cy="9.5" r="7.5" /><rect x="2" y="2" width="4" height="20" /></svg>
                 <span className="text-sm text-[var(--text-primary)] shrink-0">Patreon</span>
                 {user.is_paid && (
                   <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-[var(--accent-gold)]/15 text-[var(--accent-gold)] border border-[var(--accent-gold)]/30 shrink-0">
@@ -366,7 +366,7 @@ export default function SettingsClient() {
                 <button
                   onClick={() => disconnect("patreon")}
                   disabled={disconnecting === "patreon"}
-                  className="text-xs text-[var(--text-secondary)] hover:text-red-400 disabled:opacity-40"
+                  className="text-xs text-[var(--text-secondary)] hover:text-danger disabled:opacity-40"
                 >
                   {disconnecting === "patreon" ? "..." : t("Disconnect")}
                 </button>

--- a/frontend/app/[locale]/showcase/page.tsx
+++ b/frontend/app/[locale]/showcase/page.tsx
@@ -19,12 +19,12 @@ interface ShowcaseProject {
 }
 
 const CATEGORY_COLORS: Record<string, string> = {
-  api: "bg-emerald-500/20 text-emerald-400 border-emerald-500/30",
-  widget: "bg-purple-500/20 text-purple-400 border-purple-500/30",
-  bot: "bg-blue-500/20 text-blue-400 border-blue-500/30",
-  app: "bg-amber-500/20 text-amber-400 border-amber-500/30",
-  tool: "bg-rose-500/20 text-rose-400 border-rose-500/30",
-  content: "bg-red-500/20 text-red-400 border-red-500/30",
+  api: "bg-success/20 text-success border-success/30",
+  widget: "bg-special/20 text-special border-special/30",
+  bot: "bg-info/20 text-info border-info/30",
+  app: "bg-warning/20 text-warning border-warning/30",
+  tool: "bg-danger/20 text-danger border-danger/30",
+  content: "bg-danger/20 text-danger border-danger/30",
 };
 
 async function getShowcaseData(): Promise<ShowcaseProject[]> {
@@ -114,7 +114,7 @@ export default async function ShowcasePage({ params }: Props) {
                 <span
                   className={`text-xs font-medium px-2 py-0.5 rounded-full border ${
                     CATEGORY_COLORS[project.category] ||
-                    "bg-gray-500/20 text-gray-400 border-gray-500/30"
+                    "bg-line-strong/20 text-fg-muted border-line-strong/30"
                   }`}
                 >
                   {project.category}

--- a/frontend/app/[locale]/tier-list-maker/BuilderLoader.tsx
+++ b/frontend/app/[locale]/tier-list-maker/BuilderLoader.tsx
@@ -57,8 +57,8 @@ export default function BuilderLoader({
   if (error !== null) {
     return (
       <div className="mx-auto max-w-2xl px-4 py-12 text-center">
-        <p className="text-red-400">{error || t("Failed to load")}</p>
-        <p className="mt-2 text-sm text-neutral-400">
+        <p className="text-danger">{error || t("Failed to load")}</p>
+        <p className="mt-2 text-sm text-fg-muted">
           {t("If this is your tier list, make sure you are signed in.")}
         </p>
       </div>
@@ -66,7 +66,7 @@ export default function BuilderLoader({
   }
 
   if (!entities || !type) {
-    return <div className="mx-auto max-w-2xl px-4 py-12 text-center text-neutral-400">{t("Loading…")}</div>;
+    return <div className="mx-auto max-w-2xl px-4 py-12 text-center text-fg-muted">{t("Loading…")}</div>;
   }
 
   return <TierListBuilder entityType={type} entities={entities} initial={initial} />;

--- a/frontend/app/[locale]/tier-list-maker/MyTierLists.tsx
+++ b/frontend/app/[locale]/tier-list-maker/MyTierLists.tsx
@@ -62,7 +62,7 @@ export default function MyTierLists() {
         >
           <Link
             href={`/tier-list-maker/${tl.id}`}
-            className="flex-1 truncate text-[var(--text-primary)] hover:text-sky-400"
+            className="flex-1 truncate text-[var(--text-primary)] hover:text-info"
           >
             {tl.title}
             <span className="ml-2 text-xs text-[var(--text-muted)]">
@@ -79,7 +79,7 @@ export default function MyTierLists() {
           )}
           <button
             onClick={() => handleDelete(tl.id)}
-            className="text-sm text-red-400 hover:text-red-300"
+            className="text-sm text-danger hover:text-danger"
           >
             {t("Delete")}
           </button>

--- a/frontend/app/[locale]/tier-list-maker/SharedTierList.tsx
+++ b/frontend/app/[locale]/tier-list-maker/SharedTierList.tsx
@@ -44,7 +44,7 @@ export default function SharedTierList({ shareId }: { shareId: string }) {
     return (
       <div className="mx-auto max-w-2xl px-4 py-12 text-center text-[var(--text-secondary)]">
         <p>{error || t("Not found")}</p>
-        <Link href="/tier-list-maker" className="mt-3 inline-block text-sky-400 hover:underline">
+        <Link href="/tier-list-maker" className="mt-3 inline-block text-info hover:underline">
           {t("Make your own tier list")}
         </Link>
       </div>
@@ -76,7 +76,7 @@ export default function SharedTierList({ shareId }: { shareId: string }) {
         )}
         <Link
           href="/tier-list-maker"
-          className="inline-block rounded bg-sky-600 px-4 py-2 font-semibold text-white hover:bg-sky-500"
+          className="inline-block rounded bg-info-fill px-4 py-2 font-semibold text-on-fill hover:bg-info-fill"
         >
           {t("Make your own")}
         </Link>

--- a/frontend/app/[locale]/tier-list-maker/TierListBuilder.tsx
+++ b/frontend/app/[locale]/tier-list-maker/TierListBuilder.tsx
@@ -517,13 +517,13 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
         <input
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          className="flex-1 min-w-[200px] rounded border border-[var(--border-subtle)] bg-[var(--bg-card)] px-3 py-2 text-lg font-semibold text-[var(--text-primary)] outline-none focus:border-sky-500"
+          className="flex-1 min-w-[200px] rounded border border-[var(--border-subtle)] bg-[var(--bg-card)] px-3 py-2 text-lg font-semibold text-[var(--text-primary)] outline-none focus:border-info"
           placeholder={t("Tier list name")}
           aria-label={t("Tier list name")}
         />
         <button
           onClick={resetBoard}
-          className="rounded border border-[var(--border-accent)] px-4 py-2 font-semibold text-[var(--text-primary)] hover:border-red-500 hover:text-[var(--text-primary)]"
+          className="rounded border border-[var(--border-accent)] px-4 py-2 font-semibold text-[var(--text-primary)] hover:border-danger hover:text-[var(--text-primary)]"
         >
           {t("Reset")}
         </button>
@@ -537,13 +537,13 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
         <button
           onClick={handleSave}
           disabled={saving || authLoading}
-          className="rounded bg-sky-600 px-4 py-2 font-semibold text-white hover:bg-sky-500 disabled:opacity-50"
+          className="rounded bg-info-fill px-4 py-2 font-semibold text-on-fill hover:bg-info-fill disabled:opacity-50"
         >
           {saving ? t("Saving…") : user ? t("Save") : t("Sign in with Steam to save")}
         </button>
       </div>
 
-      {error && <p className="mb-3 text-sm text-red-400">{error}</p>}
+      {error && <p className="mb-3 text-sm text-danger">{error}</p>}
 
       {shareUrl && (
         <div className="mb-4 flex flex-wrap items-center gap-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-card)] p-2">
@@ -561,7 +561,7 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
               setTimeout(() => setCopied(false), 1500);
             }}
             className={`rounded px-3 py-1 text-sm text-[var(--text-primary)] ${
-              copied ? "bg-green-600" : "bg-[var(--bg-card-hover)] hover:bg-[var(--border-accent)]"
+              copied ? "bg-success-fill" : "bg-[var(--bg-card-hover)] hover:bg-[var(--border-accent)]"
             }`}
           >
             {copied ? t("Copied!") : t("Copy")}
@@ -635,7 +635,7 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
                 <select
                   value={cardLang}
                   onChange={(e) => setCardLang(e.target.value)}
-                  className="rounded border border-[var(--border-subtle)] bg-[var(--bg-card)] px-2 py-1 text-sm text-[var(--text-primary)] outline-none focus:border-sky-500"
+                  className="rounded border border-[var(--border-subtle)] bg-[var(--bg-card)] px-2 py-1 text-sm text-[var(--text-primary)] outline-none focus:border-info"
                   aria-label={t("Card language")}
                   title={t("Render the cards in this language")}
                 >
@@ -650,7 +650,7 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
                 <select
                   value={rarityFilter}
                   onChange={(e) => setRarityFilter(e.target.value)}
-                  className="rounded border border-[var(--border-subtle)] bg-[var(--bg-card)] px-2 py-1 text-sm text-[var(--text-primary)] outline-none focus:border-sky-500"
+                  className="rounded border border-[var(--border-subtle)] bg-[var(--bg-card)] px-2 py-1 text-sm text-[var(--text-primary)] outline-none focus:border-info"
                   aria-label={t("Filter by rarity")}
                 >
                   <option value="">{t("All rarities")}</option>
@@ -665,7 +665,7 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder={t("Search…")}
-                className="w-40 rounded border border-[var(--border-subtle)] bg-[var(--bg-card)] px-2 py-1 text-sm text-[var(--text-primary)] outline-none focus:border-sky-500"
+                className="w-40 rounded border border-[var(--border-subtle)] bg-[var(--bg-card)] px-2 py-1 text-sm text-[var(--text-primary)] outline-none focus:border-info"
               />
             </div>
           </div>
@@ -718,7 +718,7 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
 
       {commentFor && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-scrim/60 p-4"
           onClick={() => setCommentFor(null)}
         >
           <div
@@ -748,7 +748,7 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
               maxLength={500}
               rows={4}
               placeholder={t("Why is it ranked here?")}
-              className="w-full resize-none rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] p-2 text-sm text-[var(--text-primary)] outline-none focus:border-sky-500"
+              className="w-full resize-none rounded border border-[var(--border-subtle)] bg-[var(--bg-primary)] p-2 text-sm text-[var(--text-primary)] outline-none focus:border-info"
             />
             <div className="mt-3 flex items-center justify-between gap-2">
               <span className="text-[11px] text-[var(--text-muted)]">{commentDraft.length}/500</span>
@@ -761,7 +761,7 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
                 </button>
                 <button
                   onClick={saveComment}
-                  className="rounded bg-sky-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-sky-500"
+                  className="rounded bg-info-fill px-3 py-1.5 text-sm font-semibold text-on-fill hover:bg-info-fill"
                 >
                   {commentDraft.trim() ? t("Save note") : t("Remove note")}
                 </button>
@@ -791,7 +791,7 @@ function GroupPill({
       onClick={onClick}
       className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
         active
-          ? "border-sky-500 bg-sky-600 text-white"
+          ? "border-info bg-info-fill text-on-fill"
           : "border-[var(--border-subtle)] bg-[var(--bg-card)] text-[var(--text-secondary)] hover:border-[var(--border-accent)] hover:text-[var(--text-primary)]"
       }`}
     >
@@ -811,7 +811,7 @@ function DropArea({
 }) {
   const { setNodeRef, isOver } = useDroppable({ id });
   return (
-    <div ref={setNodeRef} className={`${className ?? ""} ${isOver ? "ring-2 ring-sky-400" : ""}`}>
+    <div ref={setNodeRef} className={`${className ?? ""} ${isOver ? "ring-2 ring-info" : ""}`}>
       {children}
     </div>
   );
@@ -876,7 +876,7 @@ function TierRow({
     <div className="flex items-stretch border-b border-[var(--border-subtle)] last:border-b-0">
       <div
         style={{ background: tier.color }}
-        className="relative flex w-20 shrink-0 flex-col items-center justify-center gap-1 p-1 text-black"
+        className="relative flex w-20 shrink-0 flex-col items-center justify-center gap-1 p-1 text-on-accent"
       >
         <textarea
           ref={labelRef}
@@ -949,7 +949,7 @@ function TierRow({
                 }}
                 placeholder="#rrggbb"
                 spellCheck={false}
-                className="w-full rounded border border-[var(--border-accent)] bg-[var(--bg-secondary)] px-1.5 py-0.5 text-xs text-[var(--text-primary)] outline-none focus:border-sky-500"
+                className="w-full rounded border border-[var(--border-accent)] bg-[var(--bg-secondary)] px-1.5 py-0.5 text-xs text-[var(--text-primary)] outline-none focus:border-info"
                 aria-label={t("Hex color")}
               />
             </div>
@@ -957,7 +957,7 @@ function TierRow({
               <button onClick={() => onMove(tier.id, -1)} disabled={isFirst} className="rounded bg-[var(--bg-card-hover)] px-2 py-1 disabled:opacity-40">↑</button>
               <button onClick={() => onMove(tier.id, 1)} disabled={isLast} className="rounded bg-[var(--bg-card-hover)] px-2 py-1 disabled:opacity-40">↓</button>
               <button onClick={() => onClear(tier.id)} className="rounded bg-[var(--bg-card-hover)] px-2 py-1">{t("Clear")}</button>
-              <button onClick={() => onRemove(tier.id)} className="rounded bg-red-700 px-2 py-1">{t("Delete")}</button>
+              <button onClick={() => onRemove(tier.id)} className="rounded bg-danger-fill px-2 py-1">{t("Delete")}</button>
             </div>
           </div>
         )}

--- a/frontend/app/[locale]/tier-list-maker/TierListHome.tsx
+++ b/frontend/app/[locale]/tier-list-maker/TierListHome.tsx
@@ -25,7 +25,7 @@ export default function TierListHome() {
           <select
             value={type}
             onChange={(e) => setType(e.target.value as EntityType)}
-            className="rounded border border-[var(--border-subtle)] bg-[var(--bg-secondary)] px-3 py-2 text-[var(--text-primary)] outline-none focus:border-sky-500"
+            className="rounded border border-[var(--border-subtle)] bg-[var(--bg-secondary)] px-3 py-2 text-[var(--text-primary)] outline-none focus:border-info"
           >
             {ENTITY_TYPES.map((t) => (
               <option key={t.value} value={t.value}>
@@ -36,7 +36,7 @@ export default function TierListHome() {
         </label>
         <button
           onClick={() => router.push(`/tier-list-maker/new?type=${type}`)}
-          className="rounded bg-sky-600 px-4 py-2 font-semibold text-white hover:bg-sky-500"
+          className="rounded bg-info-fill px-4 py-2 font-semibold text-on-fill hover:bg-info-fill"
         >
           {t("Create tier list")}
         </button>

--- a/frontend/app/[locale]/tier-list-maker/TierListView.tsx
+++ b/frontend/app/[locale]/tier-list-maker/TierListView.tsx
@@ -21,7 +21,7 @@ export default function TierListView({
         <div key={tier.id} className="flex items-stretch border-b border-[var(--border-subtle)] last:border-b-0">
           <div
             style={{ background: tier.color }}
-            className={`flex w-16 shrink-0 items-center justify-center p-2 text-center text-lg font-bold text-black ${
+            className={`flex w-16 shrink-0 items-center justify-center p-2 text-center text-lg font-bold text-on-accent ${
               i === 0 ? "rounded-tl-lg" : ""
             } ${i === lastTier ? "rounded-bl-lg" : ""}`}
           >

--- a/frontend/app/[locale]/tier-list-maker/chip.tsx
+++ b/frontend/app/[locale]/tier-list-maker/chip.tsx
@@ -44,7 +44,7 @@ export const Chip = memo(function Chip({
         // so a commented chip doesn't show two overlapping tooltips.
         title={commentText ? undefined : entity.name}
         className={`relative h-full w-full overflow-hidden rounded ${
-          isCard ? "" : "bg-[var(--bg-secondary)] ring-1 ring-black/40"
+          isCard ? "" : "bg-[var(--bg-secondary)] ring-1 ring-scrim/40"
         } ${dragging ? "shadow-lg" : ""}`}
       >
         {entity.image ? (
@@ -68,13 +68,13 @@ export const Chip = memo(function Chip({
         {hasComment && (
           <span
             aria-label={t("Has a note")}
-            className="absolute right-0.5 top-0.5 h-2.5 w-2.5 rounded-full bg-sky-400 ring-1 ring-black/60"
+            className="absolute right-0.5 top-0.5 h-2.5 w-2.5 rounded-full bg-info-fill ring-1 ring-scrim/60"
           />
         )}
         {entity.beta && (
           <span
             aria-label={t("Beta-only")}
-            className="absolute left-0.5 top-0.5 rounded bg-emerald-500/90 px-1 text-[8px] font-bold leading-tight text-black ring-1 ring-black/60"
+            className="absolute left-0.5 top-0.5 rounded bg-success/90 px-1 text-[8px] font-bold leading-tight text-on-accent ring-1 ring-scrim/60"
           >
             β
           </span>

--- a/frontend/app/[locale]/tier-list/TierListBody.tsx
+++ b/frontend/app/[locale]/tier-list/TierListBody.tsx
@@ -20,19 +20,19 @@ function sections(t: TFn) {
       href: "/tier-list/cards",
       label: t("Card Tier List"),
       description: "All 576 cards ranked S → F. Filter by character (Ironclad, Silent, Defect, Necrobinder, Regent).",
-      accent: "from-amber-500/20 to-amber-700/10 border-amber-700/40",
+      accent: "from-warning/20 to-warning/10 border-warning/40",
     },
     {
       href: "/tier-list/relics",
       label: t("Relic Tier List"),
       description: "289 relics ranked across every pool. Filter by Shared, Boss, Shop, Event, or character.",
-      accent: "from-emerald-500/20 to-emerald-700/10 border-emerald-700/40",
+      accent: "from-success/20 to-success/10 border-success/40",
     },
     {
       href: "/tier-list/potions",
       label: t("Potion Tier List"),
       description: "All 63 potions ranked. Smaller pool, easier to memorize the top picks.",
-      accent: "from-sky-500/20 to-sky-700/10 border-sky-700/40",
+      accent: "from-info/20 to-info/10 border-info/40",
     },
   ];
 }
@@ -339,12 +339,12 @@ export async function TierListBody({ lang }: { lang: Locale }) {
           {t("Each entity is given a 0–100 Codex Score based on the win rate of runs that included it, shrunk toward the global baseline so a 5-pick perfect-record card doesn't outrank a 500-pick reliable one. Scores map to letter grades:")}
         </p>
         <div className="text-xs text-[var(--text-muted)] space-y-1">
-          <div><strong className="text-amber-300">S (90+)</strong> · {t("top of the win-rate signal")}</div>
-          <div><strong className="text-emerald-300">A (78–89)</strong> · {t("wins above baseline reliably")}</div>
-          <div><strong className="text-sky-300">B (65–77)</strong> · {t("above-average")}</div>
-          <div><strong className="text-zinc-300">C (50–64)</strong> · {t("average")}</div>
-          <div><strong className="text-orange-300">D (35–49)</strong> · {t("below average, often niche")}</div>
-          <div><strong className="text-rose-300">F (0–34)</strong> · {t("bottom of the signal, often a high-exposure staple")}</div>
+          <div><strong className="text-warning">S (90+)</strong> · {t("top of the win-rate signal")}</div>
+          <div><strong className="text-success">A (78–89)</strong> · {t("wins above baseline reliably")}</div>
+          <div><strong className="text-info">B (65–77)</strong> · {t("above-average")}</div>
+          <div><strong className="text-fg-secondary">C (50–64)</strong> · {t("average")}</div>
+          <div><strong className="text-warning">D (35–49)</strong> · {t("below average, often niche")}</div>
+          <div><strong className="text-danger">F (0–34)</strong> · {t("bottom of the signal, often a high-exposure staple")}</div>
         </div>
         <p className="text-xs text-[var(--text-muted)] leading-relaxed mt-3">
           {t("This is a naive win-rate signal, not a ruling. It carries known biases, heavily-used staples sink even when they're fine, and late-game rares float because they only show up in runs already going well. Read a low grade as \"high exposure\" as often as \"weak.\"")}

--- a/frontend/app/[locale]/tier-list/relics/page.tsx
+++ b/frontend/app/[locale]/tier-list/relics/page.tsx
@@ -306,7 +306,7 @@ export default async function RelicsTierListPage({ params, searchParams }: PageP
               href={relicHref(pool, opt.value || undefined, act, bracket, ancient)}
               className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
                 isActive
-                  ? "bg-sky-500/10 border-sky-500/40 text-sky-300"
+                  ? "bg-info/10 border-info/40 text-info"
                   : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
               }`}
             >
@@ -326,7 +326,7 @@ export default async function RelicsTierListPage({ params, searchParams }: PageP
               href={relicHref(pool, rarity, act, bracket, opt.value || undefined)}
               className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
                 isActive
-                  ? "bg-purple-500/10 border-purple-500/40 text-purple-300"
+                  ? "bg-special/10 border-special/40 text-special"
                   : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
               }`}
             >
@@ -346,7 +346,7 @@ export default async function RelicsTierListPage({ params, searchParams }: PageP
               href={relicHref(pool, rarity, opt.value || undefined, bracket, ancient)}
               className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
                 isActive
-                  ? "bg-emerald-500/10 border-emerald-500/40 text-emerald-300"
+                  ? "bg-success/10 border-success/40 text-success"
                   : "bg-[var(--bg-card)] border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-accent)]"
               }`}
             >

--- a/frontend/app/[locale]/timeline/TimelineClient.tsx
+++ b/frontend/app/[locale]/timeline/TimelineClient.tsx
@@ -22,36 +22,36 @@ function storyKey(id: string): string {
 }
 
 const storyColors: Record<string, string> = {
-  ironclad: "border-red-600/40",
-  silent: "border-green-600/40",
-  defect: "border-blue-600/40",
-  necrobinder: "border-pink-600/40",
-  regent: "border-orange-600/40",
-  magnumopus: "border-purple-600/40",
-  talesfromthespire: "border-cyan-600/40",
-  reopening: "border-amber-600/40",
+  ironclad: "border-danger/40",
+  silent: "border-success/40",
+  defect: "border-info/40",
+  necrobinder: "border-special/40",
+  regent: "border-warning/40",
+  magnumopus: "border-special/40",
+  talesfromthespire: "border-info/40",
+  reopening: "border-warning/40",
 };
 
 const storyAccent: Record<string, string> = {
-  ironclad: "text-red-400",
-  silent: "text-emerald-400",
-  defect: "text-blue-400",
-  necrobinder: "text-pink-400",
-  regent: "text-orange-400",
-  magnumopus: "text-purple-400",
-  talesfromthespire: "text-cyan-400",
-  reopening: "text-amber-400",
+  ironclad: "text-danger",
+  silent: "text-success",
+  defect: "text-info",
+  necrobinder: "text-special",
+  regent: "text-warning",
+  magnumopus: "text-special",
+  talesfromthespire: "text-info",
+  reopening: "text-warning",
 };
 
 const storyBorderLeft: Record<string, string> = {
-  ironclad: "border-l-red-500/60",
-  silent: "border-l-emerald-500/60",
-  defect: "border-l-blue-500/60",
-  necrobinder: "border-l-pink-500/60",
-  regent: "border-l-orange-500/60",
-  magnumopus: "border-l-purple-500/60",
-  talesfromthespire: "border-l-cyan-500/60",
-  reopening: "border-l-amber-500/60",
+  ironclad: "border-l-danger/60",
+  silent: "border-l-success/60",
+  defect: "border-l-info/60",
+  necrobinder: "border-l-special/60",
+  regent: "border-l-warning/60",
+  magnumopus: "border-l-special/60",
+  talesfromthespire: "border-l-info/60",
+  reopening: "border-l-warning/60",
 };
 
 const storyOptions = [
@@ -80,9 +80,9 @@ function UnlockBadge({
 }) {
   const t = useT();
   const colors = {
-    cards: "bg-blue-950/40 text-blue-300 border-blue-900/20",
-    relics: "bg-amber-950/40 text-amber-300 border-amber-900/20",
-    potions: "bg-emerald-950/40 text-emerald-300 border-emerald-900/20",
+    cards: "bg-info/10 text-info border-info/30",
+    relics: "bg-warning/10 text-warning border-warning/30",
+    potions: "bg-success/10 text-success border-success/30",
   };
   return (
     <div className="flex flex-wrap gap-1">
@@ -279,7 +279,7 @@ export default function TimelineClient({
             const sk = storyKey(storyId);
             const borderColor = storyColors[sk] || "border-[var(--border-subtle)]";
             const accent = storyAccent[sk] || "text-[var(--accent-gold)]";
-            const leftBorder = storyBorderLeft[sk] || "border-l-gray-500/60";
+            const leftBorder = storyBorderLeft[sk] || "border-l-line-strong/60";
 
             return (
               <div key={storyId}>
@@ -394,7 +394,7 @@ export default function TimelineClient({
                                 {epoch.expands_timeline.map((id) => (
                                   <span
                                     key={id}
-                                    className="text-[10px] px-1.5 py-0.5 rounded bg-purple-950/40 text-purple-300 border border-purple-900/20"
+                                    className="text-[10px] px-1.5 py-0.5 rounded bg-special/10 text-special border border-special/30"
                                   >
                                     {epochTitleMap[id] || id.replace(/_EPOCH$/, "").replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
                                   </span>

--- a/frontend/app/[locale]/timeline/[id]/EpochDetail.tsx
+++ b/frontend/app/[locale]/timeline/[id]/EpochDetail.tsx
@@ -14,14 +14,14 @@ import "@/app/meta-extra.css";
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 const storyAccent: Record<string, string> = {
-  ironclad: "text-red-400",
-  silent: "text-emerald-400",
-  defect: "text-blue-400",
-  necrobinder: "text-pink-400",
-  regent: "text-orange-400",
-  magnumopus: "text-purple-400",
-  talesfromthespire: "text-cyan-400",
-  reopening: "text-amber-400",
+  ironclad: "text-danger",
+  silent: "text-success",
+  defect: "text-info",
+  necrobinder: "text-special",
+  regent: "text-warning",
+  magnumopus: "text-special",
+  talesfromthespire: "text-info",
+  reopening: "text-warning",
 };
 
 function storyKey(id: string): string {

--- a/frontend/app/card-revamp.css
+++ b/frontend/app/card-revamp.css
@@ -20,8 +20,8 @@
   --defect: var(--color-defect);
   --necro: var(--color-necrobinder);
   --regent: var(--color-regent);
-  --good: #35c07a;
-  --warn: #d08a3a;
+  --good: var(--success);
+  --warn: var(--warning);
   --serif: var(--font-kreon), Georgia, "Times New Roman", serif;
   --sans: var(--font-kreon), system-ui, -apple-system, sans-serif;
   --mono: var(--font-geist-mono), ui-monospace, monospace;

--- a/frontend/app/components/AlertTicker.tsx
+++ b/frontend/app/components/AlertTicker.tsx
@@ -40,7 +40,7 @@ function renderAnnouncement(message: string): ReactNode[] {
   const re = /\[([^\]]+)\]\(([^)\s]+)\)/g;
   let last = 0;
   let m: RegExpExecArray | null;
-  const linkClass = "font-medium text-green-100 underline hover:text-white transition-colors";
+  const linkClass = "font-medium text-success underline hover:text-on-fill transition-colors";
   while ((m = re.exec(message)) !== null) {
     if (m.index > last) out.push(message.slice(last, m.index));
     const [, label, href] = m;
@@ -80,8 +80,8 @@ export default function AlertTicker() {
   const slots: Slot[] = [
     {
       key: "overwolf",
-      bg: "bg-black/85 backdrop-blur-sm",
-      border: "border-white/10",
+      bg: "bg-scrim/85 backdrop-blur-sm",
+      border: "border-on-fill/10",
       node: (
         <>
           <img
@@ -89,8 +89,8 @@ export default function AlertTicker() {
             alt="Overwolf"
             className="w-7 h-7 sm:w-8 sm:h-8 flex-shrink-0 rounded"
           />
-          <span className="flex-1 min-w-0 text-sm text-white/90 line-clamp-2">
-            <span className="font-semibold text-white">
+          <span className="flex-1 min-w-0 text-sm text-on-fill/90 line-clamp-2">
+            <span className="font-semibold text-on-fill">
               {t("Spire Codex is now on Overwolf.")}
             </span>{" "}
             <span className="hidden sm:inline">
@@ -110,8 +110,8 @@ export default function AlertTicker() {
     },
     {
       key: "mod",
-      bg: "bg-[#1b2838]",
-      border: "border-[#2a475e]",
+      bg: "bg-steam",
+      border: "border-steam-line",
       node: (
         <>
           <img
@@ -119,8 +119,8 @@ export default function AlertTicker() {
             alt="Steam Workshop"
             className="w-7 h-7 sm:w-8 sm:h-8 flex-shrink-0"
           />
-          <span className="flex-1 min-w-0 text-sm text-[#c7d5e0] line-clamp-2">
-            <span className="font-semibold text-white">
+          <span className="flex-1 min-w-0 text-sm text-steam-light line-clamp-2">
+            <span className="font-semibold text-on-fill">
               {t("Spire Codex now has a mod.")}
             </span>{" "}
             <span className="hidden sm:inline">
@@ -142,8 +142,8 @@ export default function AlertTicker() {
     },
     {
       key: "patreon",
-      bg: "bg-emerald-900/40",
-      border: "border-emerald-700/30",
+      bg: "bg-success/10",
+      border: "border-success/30",
       node: (
         <>
           <img
@@ -152,13 +152,13 @@ export default function AlertTicker() {
             className="w-7 h-7 sm:w-8 sm:h-8 object-contain flex-shrink-0 hidden sm:block"
             crossOrigin="anonymous"
           />
-          <span className="flex-1 min-w-0 text-sm text-emerald-200 italic line-clamp-2">
+          <span className="flex-1 min-w-0 text-sm text-success italic line-clamp-2">
             &ldquo;{t("I haven't had a visitor in a millennia! If you wish to support Spire Codex, consider")}{" "}
             <a
               href="https://www.patreon.com/cw/SpireCodex"
               target="_blank"
               rel="noopener noreferrer"
-              className="font-medium not-italic text-emerald-200 underline hover:text-white transition-colors"
+              className="font-medium not-italic text-success underline hover:text-on-fill transition-colors"
             >
               {t("supporting us on Patreon")}
             </a>
@@ -166,7 +166,7 @@ export default function AlertTicker() {
             <Link
               prefetch={false}
               href="/thank-you"
-              className="font-medium not-italic text-emerald-200 underline hover:text-white transition-colors"
+              className="font-medium not-italic text-success underline hover:text-on-fill transition-colors"
             >
               {t("those who've supported us")}
             </Link>
@@ -177,8 +177,8 @@ export default function AlertTicker() {
     },
     ...announcements.map((a) => ({
       key: `ann-${a.id}`,
-      bg: "bg-green-900/40",
-      border: "border-green-700/30",
+      bg: "bg-success/10",
+      border: "border-success/30",
       node: (
         <>
           <img
@@ -186,9 +186,9 @@ export default function AlertTicker() {
             alt="Spire Codex"
             className="w-7 h-7 sm:w-8 sm:h-8 object-contain flex-shrink-0 hidden sm:block"
           />
-          <span className="flex-1 min-w-0 text-sm text-green-200 line-clamp-2">
+          <span className="flex-1 min-w-0 text-sm text-success line-clamp-2">
             {/* green-700, not green-500: white on green-500 is 2.3:1 in every theme */}
-            <span className="mr-2 rounded bg-green-700 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white">
+            <span className="mr-2 rounded bg-success-fill px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-on-fill">
               {t("New")}
             </span>
             {renderAnnouncement(a.message)}
@@ -236,8 +236,8 @@ export default function AlertTicker() {
                 aria-current={i === safeIndex}
                 className={`h-1.5 rounded-full transition-all ${
                   i === safeIndex
-                    ? "w-4 bg-white/80"
-                    : "w-1.5 bg-white/30 hover:bg-white/50"
+                    ? "w-4 bg-on-fill/80"
+                    : "w-1.5 bg-on-fill/30 hover:bg-on-fill/50"
                 }`}
               />
             ))}

--- a/frontend/app/components/ApiKeysSection.tsx
+++ b/frontend/app/components/ApiKeysSection.tsx
@@ -144,7 +144,7 @@ export default function ApiKeysSection() {
         </div>
       )}
 
-      {error && <p className="text-sm text-red-400 mb-3">{error}</p>}
+      {error && <p className="text-sm text-danger mb-3">{error}</p>}
 
       {/* Existing keys */}
       {keys === null ? (
@@ -180,7 +180,7 @@ export default function ApiKeysSection() {
                 type="button"
                 disabled={busy}
                 onClick={() => revokeKey(k.id)}
-                className="shrink-0 text-xs px-2.5 py-1 rounded-lg border border-red-500/40 bg-red-500/10 text-red-400 disabled:opacity-50"
+                className="shrink-0 text-xs px-2.5 py-1 rounded-lg border border-danger/40 bg-danger/10 text-danger disabled:opacity-50"
               >
                 {t("Revoke")}
               </button>

--- a/frontend/app/components/BetaBadge.tsx
+++ b/frontend/app/components/BetaBadge.tsx
@@ -6,7 +6,7 @@ import { useT } from "@/lib/i18n";
 export default function BetaBadge() {
   const t = useT();
   return (
-    <span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded-full font-semibold bg-emerald-500/15 text-emerald-400 border border-emerald-500/30">
+    <span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded-full font-semibold bg-success/15 text-success border border-success/30">
       {t("Beta")}
     </span>
   );

--- a/frontend/app/components/BetaBanner.tsx
+++ b/frontend/app/components/BetaBanner.tsx
@@ -22,8 +22,8 @@ export default function BetaBanner({ stablePath = "/" }: { stablePath?: string }
   }, []);
 
   return (
-    <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 mb-4 flex items-center gap-2 text-xs">
-      <span className="font-semibold text-emerald-300 shrink-0">
+    <div className="rounded-md border border-success/40 bg-success/10 px-3 py-1.5 mb-4 flex items-center gap-2 text-xs">
+      <span className="font-semibold text-success shrink-0">
         Beta{version ? ` ${version}` : ""}
       </span>
       <span className="text-[var(--text-muted)] truncate">
@@ -32,7 +32,7 @@ export default function BetaBanner({ stablePath = "/" }: { stablePath?: string }
       </span>
       <Link
         href={stablePath}
-        className="ml-auto shrink-0 text-emerald-300 hover:text-emerald-200 hover:underline"
+        className="ml-auto shrink-0 text-success hover:text-success hover:underline"
       >
         {t("Switch to main")} →
       </Link>

--- a/frontend/app/components/BetaDiffNotice.tsx
+++ b/frontend/app/components/BetaDiffNotice.tsx
@@ -86,7 +86,7 @@ export default function BetaDiffNotice({
       body = (
         <>
           {t("This is different in the current beta: {fields} changed.", { fields: summarize(changedFields, t) })}{" "}
-          <Link href={counterpartPath} className="text-emerald-300 hover:underline">
+          <Link href={counterpartPath} className="text-success hover:underline">
             {t("View the beta version")} →
           </Link>
         </>
@@ -104,7 +104,7 @@ export default function BetaDiffNotice({
       body = (
         <>
           {t("Differs from main: {fields} changed.", { fields: summarize(changedFields, t) })}{" "}
-          <Link href={counterpartPath} className="text-emerald-300 hover:underline">
+          <Link href={counterpartPath} className="text-success hover:underline">
             {t("View the main version")} →
           </Link>
         </>
@@ -113,7 +113,7 @@ export default function BetaDiffNotice({
       body = (
         <>
           {t("Viewing the beta version of this {noun}.", { noun: t(noun) })}{" "}
-          <Link href={counterpartPath} className="text-emerald-300 hover:underline">
+          <Link href={counterpartPath} className="text-success hover:underline">
             {t("Switch to main")} →
           </Link>
         </>
@@ -122,8 +122,8 @@ export default function BetaDiffNotice({
   }
 
   return (
-    <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 my-3 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-xs text-[var(--text-secondary)]">
-      <span className="font-semibold text-emerald-300">
+    <div className="rounded-md border border-success/40 bg-success/10 px-3 py-2 my-3 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-xs text-[var(--text-secondary)]">
+      <span className="font-semibold text-success">
         {t("Beta")}{diff.beta_version ? ` ${diff.beta_version}` : ""}
       </span>
       {body}

--- a/frontend/app/components/CardGrid.tsx
+++ b/frontend/app/components/CardGrid.tsx
@@ -20,20 +20,20 @@ const colorMap: Record<string, string> = {
   regent: "border-[var(--color-regent)]/60 hover:border-[var(--color-regent)]",
   colorless: "border-[var(--color-colorless)]/60 hover:border-[var(--color-colorless)]",
   curse: "border-[var(--color-curse)]/60 hover:border-[var(--color-curse)]",
-  status: "border-gray-700/60 hover:border-gray-500",
+  status: "border-line-strong/60 hover:border-line-strong",
 };
 
 const rarityColors: Record<string, string> = {
-  Basic: "text-gray-400",
-  Common: "text-gray-300",
-  Uncommon: "text-blue-400",
+  Basic: "text-fg-muted",
+  Common: "text-fg-secondary",
+  Uncommon: "text-info",
   Rare: "text-[var(--accent-gold)]",
-  Ancient: "text-purple-400",
-  Curse: "text-red-400",
-  Status: "text-gray-500",
-  Event: "text-emerald-400",
-  Token: "text-gray-500",
-  Quest: "text-amber-400",
+  Ancient: "text-special",
+  Curse: "text-danger",
+  Status: "text-fg-muted",
+  Event: "text-success",
+  Token: "text-fg-muted",
+  Quest: "text-warning",
 };
 
 const energyIconMap: Record<string, string> = {
@@ -66,8 +66,8 @@ function CardItem({ card }: { card: Card }) {
   return (
     <div
       className={`group relative flex flex-col bg-[var(--bg-card)] rounded-lg border-2 ${
-        isUpgraded ? "border-emerald-700/60 hover:border-emerald-500" : colorMap[card.color] || "border-[var(--border-subtle)] hover:border-[var(--border-accent)]"
-      } p-4 transition-all hover:bg-[var(--bg-card-hover)] hover:shadow-lg hover:shadow-black/20`}
+        isUpgraded ? "border-success/60 hover:border-success" : colorMap[card.color] || "border-[var(--border-subtle)] hover:border-[var(--border-accent)]"
+      } p-4 transition-all hover:bg-[var(--bg-card-hover)] hover:shadow-lg hover:shadow-scrim/20`}
     >
       <Link
         prefetch={false}
@@ -97,17 +97,17 @@ function CardItem({ card }: { card: Card }) {
       {/* Header */}
       <div className="flex items-start justify-between mb-2">
         <h3 className="font-semibold text-[var(--text-primary)] leading-tight flex items-center gap-1.5">
-          {card.name}{isUpgraded && <span className="text-emerald-400">+</span>}
+          {card.name}{isUpgraded && <span className="text-success">+</span>}
           {card.beta && <BetaBadge />}
         </h3>
         <div className="ml-2 flex-shrink-0 flex items-center gap-1">
           <span className={`inline-flex items-center justify-center w-7 h-7 rounded-full bg-[var(--bg-primary)] border text-sm font-bold ${
-            isUpgraded && display.upgrade?.cost != null ? "border-emerald-700/50 text-emerald-400" : "border-[var(--border-subtle)] text-[var(--accent-gold)]"
+            isUpgraded && display.upgrade?.cost != null ? "border-success/50 text-success" : "border-[var(--border-subtle)] text-[var(--accent-gold)]"
           }`}>
             {card.is_x_cost ? "X" : display.cost != null && display.cost < 0 ? "U" : display.cost}
           </span>
           {(card.star_cost != null || card.is_x_star_cost) && (
-            <span className="inline-flex items-center gap-0.5 h-7 px-2 rounded-full bg-[var(--bg-primary)] border border-amber-700/40 text-sm font-bold text-amber-300">
+            <span className="inline-flex items-center gap-0.5 h-7 px-2 rounded-full bg-[var(--bg-primary)] border border-warning/40 text-sm font-bold text-warning">
               {card.is_x_star_cost ? "X" : card.star_cost}
               <img src={imageUrl("/static/images/icons/star_icon.webp")}
                 alt={t("star")} className="w-3.5 h-3.5" crossOrigin="anonymous" />
@@ -122,7 +122,7 @@ function CardItem({ card }: { card: Card }) {
           {card.type}
         </span>
         <span className="text-[var(--text-muted)]">·</span>
-        <span className={rarityColors[card.rarity] || "text-gray-400"}>
+        <span className={rarityColors[card.rarity] || "text-fg-muted"}>
           {card.rarity}
         </span>
         <span className="text-[var(--text-muted)]">·</span>
@@ -149,7 +149,7 @@ function CardItem({ card }: { card: Card }) {
               onClick={(e) => { e.preventDefault(); e.stopPropagation(); setBetaArt(!betaArt); }}
               className={`text-base w-7 h-7 flex items-center justify-center rounded transition-colors ${
                 betaArt
-                  ? "bg-amber-950/60 border border-amber-700/50"
+                  ? "bg-warning/10 border border-warning/50"
                   : "bg-[var(--bg-primary)] border border-[var(--border-subtle)] opacity-50 hover:opacity-100"
               }`}
               title={betaArt ? t("Show normal art") : t("Show beta art")}
@@ -162,7 +162,7 @@ function CardItem({ card }: { card: Card }) {
               onClick={(e) => { e.preventDefault(); e.stopPropagation(); setUpgraded(!upgraded); }}
               className={`text-base w-7 h-7 flex items-center justify-center rounded transition-colors ${
                 upgraded
-                  ? "bg-emerald-950/60 border border-emerald-700/50"
+                  ? "bg-success/10 border border-success/50"
                   : "bg-[var(--bg-primary)] border border-[var(--border-subtle)] opacity-50 hover:opacity-100"
               }`}
               title={upgraded ? t("Show base card") : t("Show upgraded")}

--- a/frontend/app/components/EntityHistory.tsx
+++ b/frontend/app/components/EntityHistory.tsx
@@ -27,9 +27,9 @@ interface EntityHistoryProps {
 }
 
 const actionColors: Record<string, string> = {
-  added: "text-emerald-400",
-  removed: "text-red-400",
-  changed: "text-amber-400",
+  added: "text-success",
+  removed: "text-danger",
+  changed: "text-warning",
 };
 
 const actionLabels: Record<string, string> = {
@@ -39,9 +39,9 @@ const actionLabels: Record<string, string> = {
 };
 
 const dotColors: Record<string, string> = {
-  added: "bg-emerald-500",
-  removed: "bg-red-500",
-  changed: "bg-amber-500",
+  added: "bg-success-fill",
+  removed: "bg-danger-fill",
+  changed: "bg-warning-fill",
 };
 
 /**
@@ -122,7 +122,7 @@ export default function EntityHistory({ entityType, entityId }: EntityHistoryPro
                 <div key={`${entry.version}-${i}`} className="relative pl-6">
                   {/* Timeline dot */}
                   <div
-                    className={`absolute left-0 top-1.5 w-[11px] h-[11px] rounded-full border-2 border-[var(--bg-primary)] ${dotColors[entry.action] || "bg-gray-500"}`}
+                    className={`absolute left-0 top-1.5 w-[11px] h-[11px] rounded-full border-2 border-[var(--bg-primary)] ${dotColors[entry.action] || "bg-line-strong"}`}
                   />
 
                   <div>
@@ -133,7 +133,7 @@ export default function EntityHistory({ entityType, entityId }: EntityHistoryPro
                       >
                         v{entry.version}
                       </Link>
-                      <span className={actionColors[entry.action] || "text-gray-400"}>
+                      <span className={actionColors[entry.action] || "text-fg-muted"}>
                         {actionLabels[entry.action] ? t(actionLabels[entry.action]) : entry.action}
                       </span>
                       <span className="text-[var(--text-muted)]">{entry.date}</span>
@@ -161,16 +161,16 @@ export default function EntityHistory({ entityType, entityId }: EntityHistoryPro
                                 </div>
                                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 ml-3">
                                   <div>
-                                    <div className="text-[10px] uppercase tracking-wider text-red-400/70 mb-0.5">
+                                    <div className="text-[10px] uppercase tracking-wider text-danger/70 mb-0.5">
                                       {t("Before")}
                                     </div>
-                                    <ChangeValue raw={oldStr} color="text-red-400/80" />
+                                    <ChangeValue raw={oldStr} color="text-danger/80" />
                                   </div>
                                   <div>
-                                    <div className="text-[10px] uppercase tracking-wider text-emerald-400/70 mb-0.5">
+                                    <div className="text-[10px] uppercase tracking-wider text-success/70 mb-0.5">
                                       {t("After")}
                                     </div>
-                                    <ChangeValue raw={newStr} color="text-emerald-400/80" />
+                                    <ChangeValue raw={newStr} color="text-success/80" />
                                   </div>
                                 </div>
                               </div>
@@ -184,11 +184,11 @@ export default function EntityHistory({ entityType, entityId }: EntityHistoryPro
                               <span className="text-[var(--text-secondary)] font-medium">
                                 {change.field}
                               </span>
-                              <span className="text-red-400/70 line-through">
+                              <span className="text-danger/70 line-through">
                                 {oldStr}
                               </span>
                               <span className="text-[var(--text-muted)]">&rarr;</span>
-                              <span className="text-emerald-400/70">{newStr}</span>
+                              <span className="text-success/70">{newStr}</span>
                             </div>
                           );
                         })}

--- a/frontend/app/components/EntityProse.tsx
+++ b/frontend/app/components/EntityProse.tsx
@@ -187,7 +187,7 @@ export default function EntityProse(props: Props) {
     // render's green.
     const f = getCardProseFacts(c, !!props.upgraded);
     const green = (v: ReactNode, changed: boolean) =>
-      f.isUpgraded && changed ? <span className="text-emerald-400">{v}</span> : v;
+      f.isUpgraded && changed ? <span className="text-success">{v}</span> : v;
     const sentences: ReactNode[] = [];
     sentences.push(
       <>

--- a/frontend/app/components/EntityUpdateHistory.tsx
+++ b/frontend/app/components/EntityUpdateHistory.tsx
@@ -23,15 +23,15 @@ function patchKind(type: string | null): "beta" | "main" | "pre" {
 }
 
 const kindText: Record<string, string> = {
-  beta: "text-emerald-400",
+  beta: "text-success",
   main: "text-[var(--accent-gold)]",
   pre: "text-[var(--text-muted)]",
 };
 
 const kindDot: Record<string, string> = {
-  beta: "bg-emerald-500",
+  beta: "bg-success-fill",
   main: "bg-[var(--accent-gold)]",
-  pre: "bg-gray-500",
+  pre: "bg-line-strong",
 };
 
 /**

--- a/frontend/app/components/Footer.tsx
+++ b/frontend/app/components/Footer.tsx
@@ -49,15 +49,15 @@ function FeedbackModal({ onClose, page }: { onClose: () => void; page: string })
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4" onClick={onClose}>
-      <div className="absolute inset-0 bg-black/80 backdrop-blur-sm" />
+      <div className="absolute inset-0 bg-scrim/80 backdrop-blur-sm" />
       <div
-        className="relative w-full max-w-md bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] shadow-2xl shadow-black/50 p-6"
+        className="relative w-full max-w-md bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] shadow-2xl shadow-scrim/50 p-6"
         onClick={(e) => e.stopPropagation()}
       >
         <h2 className="text-lg font-bold text-[var(--text-primary)] mb-4">{t("Submit Feedback")}</h2>
 
         {sent ? (
-          <p className="text-emerald-400 text-sm py-4">{t("Sent successfully. Thank you!")}</p>
+          <p className="text-success text-sm py-4">{t("Sent successfully. Thank you!")}</p>
         ) : (
           <>
             <label className="block text-sm text-[var(--text-secondary)] mb-1">{t("Page")}</label>
@@ -79,7 +79,7 @@ function FeedbackModal({ onClose, page }: { onClose: () => void; page: string })
               <option value="Localization">{t("Localization")}</option>
             </select>
 
-            <label className="block text-sm text-[var(--text-secondary)] mb-1">{t("Discord Username or Email")} <span className="text-red-400">*</span></label>
+            <label className="block text-sm text-[var(--text-secondary)] mb-1">{t("Discord Username or Email")} <span className="text-danger">*</span></label>
             <input
               type="text"
               value={contact}
@@ -88,7 +88,7 @@ function FeedbackModal({ onClose, page }: { onClose: () => void; page: string })
               className="w-full mb-4 px-3 py-2 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm focus:outline-none focus:border-[var(--accent-gold)]"
             />
 
-            <label className="block text-sm text-[var(--text-secondary)] mb-1">{t("Contents")} <span className="text-red-400">*</span></label>
+            <label className="block text-sm text-[var(--text-secondary)] mb-1">{t("Contents")} <span className="text-danger">*</span></label>
             <textarea
               value={contents}
               onChange={(e) => setContents(e.target.value)}
@@ -97,7 +97,7 @@ function FeedbackModal({ onClose, page }: { onClose: () => void; page: string })
               className="w-full mb-4 px-3 py-2 rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm focus:outline-none focus:border-[var(--accent-gold)] resize-none"
             />
 
-            {error && <p className="text-red-400 text-sm mb-3">{error}</p>}
+            {error && <p className="text-danger text-sm mb-3">{error}</p>}
 
             <div className="flex justify-end gap-3">
               <button

--- a/frontend/app/components/FullCardGrid.tsx
+++ b/frontend/app/components/FullCardGrid.tsx
@@ -78,8 +78,8 @@ function FullCardItem({ card, stat }: { card: Card; stat?: CardStat }) {
           }}
           className={`absolute bottom-[7%] right-[8%] z-20 w-8 h-8 flex items-center justify-center rounded-full text-base transition-colors ${
             showUpgraded
-              ? "bg-emerald-950/80 border border-emerald-600/60"
-              : "bg-black/50 border border-white/15 opacity-0 group-hover:opacity-100"
+              ? "bg-success/10 border border-success/60"
+              : "bg-scrim/50 border border-on-fill/15 opacity-0 group-hover:opacity-100"
           }`}
           title={showUpgraded ? "Show base card" : "Show upgraded"}
         >

--- a/frontend/app/components/GlobalSearch.tsx
+++ b/frontend/app/components/GlobalSearch.tsx
@@ -489,13 +489,13 @@ export default function GlobalSearch() {
   return (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm flex items-start justify-center px-4 sm:px-6 pt-[10vh] sm:pt-[15vh]"
+      className="fixed inset-0 z-50 bg-scrim/80 backdrop-blur-sm flex items-start justify-center px-4 sm:px-6 pt-[10vh] sm:pt-[15vh]"
       onClick={(e) => {
         if (e.target === overlayRef.current) setOpen(false);
       }}
     >
       <div
-        className="w-full max-w-lg bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] shadow-2xl shadow-black/50 overflow-hidden"
+        className="w-full max-w-lg bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] shadow-2xl shadow-scrim/50 overflow-hidden"
         onKeyDown={handleKeyDown}
       >
         {/* Search input */}

--- a/frontend/app/components/HighestRated.tsx
+++ b/frontend/app/components/HighestRated.tsx
@@ -72,7 +72,7 @@ export default async function HighestRated({
   if (top.length === 0) return null;
 
   return (
-    <section className="mb-10 rounded-2xl border border-[var(--accent-gold)]/25 bg-gradient-to-b from-[var(--accent-gold)]/[0.07] to-[var(--bg-card)] p-5 sm:p-6 shadow-lg shadow-black/20">
+    <section className="mb-10 rounded-2xl border border-[var(--accent-gold)]/25 bg-gradient-to-b from-[var(--accent-gold)]/[0.07] to-[var(--bg-card)] p-5 sm:p-6 shadow-lg shadow-scrim/20">
       <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
         <div>
           <span className="inline-block text-[10px] font-bold uppercase tracking-wider text-[var(--accent-gold)] bg-[var(--accent-gold)]/10 border border-[var(--accent-gold)]/30 rounded px-2 py-0.5 mb-2">

--- a/frontend/app/components/HighlightFeedback.tsx
+++ b/frontend/app/components/HighlightFeedback.tsx
@@ -131,9 +131,9 @@ export default function HighlightFeedback() {
 
       {open && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4" onClick={() => setOpen(false)}>
-          <div className="absolute inset-0 bg-black/80 backdrop-blur-sm" />
+          <div className="absolute inset-0 bg-scrim/80 backdrop-blur-sm" />
           <div
-            className="relative w-full max-w-md bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] shadow-2xl shadow-black/50 p-6"
+            className="relative w-full max-w-md bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] shadow-2xl shadow-scrim/50 p-6"
             onClick={(e) => e.stopPropagation()}
           >
             <h2 className="text-lg font-bold text-[var(--text-primary)] mb-1">{t("Request a change")}</h2>
@@ -195,7 +195,7 @@ export default function HighlightFeedback() {
                     type="button"
                     onClick={submit}
                     disabled={sending || !suggestion.trim() || !contact.trim()}
-                    className="rounded-lg bg-[var(--accent-gold)] px-4 py-2 text-sm font-semibold text-[#1a1205] disabled:opacity-50"
+                    className="rounded-lg bg-[var(--accent-gold)] px-4 py-2 text-sm font-semibold text-on-accent disabled:opacity-50"
                   >
                     {sending ? t("Sending...") : t("Send")}
                   </button>

--- a/frontend/app/components/IconSelect.tsx
+++ b/frontend/app/components/IconSelect.tsx
@@ -106,7 +106,7 @@ export default function IconSelect({ label, value, options, onChange }: IconSele
           id={listId}
           role="listbox"
           aria-label={label}
-          className="absolute left-0 top-full mt-1 min-w-full w-max rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-black/30 z-50 py-1"
+          className="absolute left-0 top-full mt-1 min-w-full w-max rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-scrim/30 z-50 py-1"
         >
           {flat.map((opt, i) => {
             const header =

--- a/frontend/app/components/LanguageSelector.tsx
+++ b/frontend/app/components/LanguageSelector.tsx
@@ -87,7 +87,7 @@ export default function LanguageSelector() {
       {open && (
         <div
           ref={menuRef}
-          className="absolute right-0 top-full mt-2 w-48 max-h-80 overflow-y-auto rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-black/30 z-50"
+          className="absolute right-0 top-full mt-2 w-48 max-h-80 overflow-y-auto rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-scrim/30 z-50"
         >
           <div className="py-1">
             {LANGUAGES.map((l) => (

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -136,27 +136,27 @@ const NAV_GROUPS: NavGroup[] = [
 // Color + live-count metadata so the Database mega reads like a compendium
 // index (color chip + count) instead of a plain link list, matching the redesign.
 const DB_META: Record<string, { color: string; count?: string }> = {
-  "/cards": { color: "#e8b830", count: "cards" },
-  "/relics": { color: "#f07c1e", count: "relics" },
-  "/potions": { color: "#3873a9", count: "potions" },
-  "/enchantments": { color: "#6b5b8a", count: "enchantments" },
-  "/powers": { color: "#bf5a85", count: "powers" },
-  "/keywords": { color: "#23935b", count: "keywords" },
-  "/characters": { color: "#d53b27", count: "characters" },
-  "/monsters": { color: "#d53b27", count: "monsters" },
-  "/encounters": { color: "#3873a9", count: "encounters" },
-  "/events": { color: "#23935b", count: "events" },
-  "/ancients": { color: "#6b5b8a" },
-  "/merchant": { color: "#c5894a" },
-  "/modifiers": { color: "#6b5b8a", count: "modifiers" },
+  "/cards": { color: "var(--accent-gold)", count: "cards" },
+  "/relics": { color: "var(--color-regent)", count: "relics" },
+  "/potions": { color: "var(--color-defect)", count: "potions" },
+  "/enchantments": { color: "var(--color-ancient)", count: "enchantments" },
+  "/powers": { color: "var(--color-necrobinder)", count: "powers" },
+  "/keywords": { color: "var(--color-silent)", count: "keywords" },
+  "/characters": { color: "var(--color-ironclad)", count: "characters" },
+  "/monsters": { color: "var(--color-ironclad)", count: "monsters" },
+  "/encounters": { color: "var(--color-defect)", count: "encounters" },
+  "/events": { color: "var(--color-silent)", count: "events" },
+  "/ancients": { color: "var(--color-ancient)" },
+  "/merchant": { color: "var(--color-merchant)" },
+  "/modifiers": { color: "var(--color-ancient)", count: "modifiers" },
   "/mechanics": { color: "#596068" },
-  "/unlocks": { color: "#c5894a" },
+  "/unlocks": { color: "var(--color-merchant)" },
   "/timeline": { color: "#8a6b3a", count: "epochs" },
-  "/images": { color: "#f07c1e", count: "images" },
+  "/images": { color: "var(--color-regent)", count: "images" },
   "/reference": { color: "#596068" },
-  "/badges": { color: "#c5894a", count: "badges" },
-  "/compare": { color: "#3873a9" },
-  "/guides": { color: "#23935b" },
+  "/badges": { color: "var(--color-merchant)", count: "badges" },
+  "/compare": { color: "var(--color-defect)" },
+  "/guides": { color: "var(--color-silent)" },
 };
 
 // Each nav group opens a multi-column mega panel. Columns reference links by
@@ -295,7 +295,7 @@ export default function Navbar() {
           </svg>
         </button>
         <div className={`absolute ${isLast ? "right-0" : "left-0"} top-full pt-2 hidden group-hover:block group-focus-within:block`}>
-          <div role="menu" className="flex gap-6 rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-secondary)] shadow-2xl shadow-black/40 p-4">
+          <div role="menu" className="flex gap-6 rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-secondary)] shadow-2xl shadow-scrim/40 p-4">
             {cols.map((col, ci) => (
               <div key={ci} className="min-w-[9.5rem]">
                 {col.title && (
@@ -448,7 +448,7 @@ export default function Navbar() {
               {/* Signed-out: login options */}
               {!user && !userMenuOpen && (
                 <div
-                  className="absolute right-0 top-full mt-2 w-44 max-w-[calc(100vw-1rem)] rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-black/30 p-1.5 hidden"
+                  className="absolute right-0 top-full mt-2 w-44 max-w-[calc(100vw-1rem)] rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-scrim/30 p-1.5 hidden"
                   id="login-options"
                 />
               )}
@@ -465,7 +465,7 @@ export default function Navbar() {
               {userMenuOpen && !user && (
                 <div
                   ref={userMenuRef}
-                  className="absolute right-0 top-full mt-2 w-44 max-w-[calc(100vw-1rem)] rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-black/30 p-1.5 z-50"
+                  className="absolute right-0 top-full mt-2 w-44 max-w-[calc(100vw-1rem)] rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-scrim/30 p-1.5 z-50"
                 >
                   <p className="px-2.5 py-1.5 text-xs text-[var(--text-tertiary)] font-medium">{t("Sign in with")}</p>
                   <button
@@ -482,7 +482,7 @@ export default function Navbar() {
               {userMenuOpen && user && (
                 <div
                   ref={userMenuRef}
-                  className="absolute right-0 top-full mt-2 w-48 max-w-[calc(100vw-1rem)] rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-black/30 p-1.5 z-50"
+                  className="absolute right-0 top-full mt-2 w-48 max-w-[calc(100vw-1rem)] rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-scrim/30 p-1.5 z-50"
                 >
                   <div className="px-2.5 py-1.5 border-b border-[var(--border-subtle)] mb-1">
                     <p className="text-sm font-medium text-[var(--text-primary)] truncate">{user.username || t("User")}</p>
@@ -519,7 +519,7 @@ export default function Navbar() {
                   )}
                   <button
                     onClick={() => { setUserMenuOpen(false); logout(); }}
-                    className="w-full flex items-center gap-2 px-2.5 py-2 text-sm rounded-md hover:bg-[var(--bg-card)] text-red-400 hover:text-red-300 transition-colors"
+                    className="w-full flex items-center gap-2 px-2.5 py-2 text-sm rounded-md hover:bg-[var(--bg-card)] text-danger hover:text-danger transition-colors"
                   >
                     {t("Sign Out")}
                   </button>

--- a/frontend/app/components/ProfileInsights.tsx
+++ b/frontend/app/components/ProfileInsights.tsx
@@ -382,7 +382,7 @@ function PercentileSlider({ label, valueText, percentile, lang }: { label: strin
       <div className="relative h-2 rounded-full bg-[var(--bg-primary)]">
         <div className="absolute inset-y-0 left-0 rounded-full opacity-25" style={{ width: `${percentile}%`, backgroundColor: color }} />
         <div
-          className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-5 h-5 rounded-full border-2 border-[var(--bg-card)] flex items-center justify-center text-[8px] font-bold text-white"
+          className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-5 h-5 rounded-full border-2 border-[var(--bg-card)] flex items-center justify-center text-[8px] font-bold text-on-fill"
           style={{ left: `${Math.min(Math.max(percentile, 3), 97)}%`, backgroundColor: color }}
         >
           {percentile}
@@ -396,7 +396,7 @@ function PercentileSlider({ label, valueText, percentile, lang }: { label: strin
 }
 
 function GapBadge({ gap }: { gap: number }) {
-  const cls = gap > 0 ? "text-green-400" : gap < 0 ? "text-red-400" : "text-[var(--text-muted)]";
+  const cls = gap > 0 ? "text-success" : gap < 0 ? "text-danger" : "text-[var(--text-muted)]";
   return (
     <span className={`text-xs font-medium tabular-nums ${cls}`}>
       {gap > 0 ? "+" : ""}
@@ -629,7 +629,7 @@ function DangerTable({ rows, lang }: { rows: NonNullable<Insights["map_danger"]>
                 const better = comm != null && cell.death_rate < comm;
                 return (
                   <td key={ty} className="py-1.5 pl-4 text-right tabular-nums">
-                    <span className={worse ? "text-red-400" : better ? "text-green-400" : "text-[var(--text-primary)]"}>
+                    <span className={worse ? "text-danger" : better ? "text-success" : "text-[var(--text-primary)]"}>
                       {cell.death_rate}%
                     </span>
                     {comm != null && <span className="block text-[10px] text-[var(--text-muted)]">{comm}%</span>}

--- a/frontend/app/components/ProfileStats.tsx
+++ b/frontend/app/components/ProfileStats.tsx
@@ -286,10 +286,10 @@ export default function ProfileStats({
                     </span>
                     <span className={`shrink-0 text-xs px-1.5 py-0.5 rounded ${
                       run.win
-                        ? "bg-green-500/15 text-green-400"
+                        ? "bg-success/15 text-success"
                         : run.was_abandoned
-                          ? "bg-yellow-500/15 text-yellow-400"
-                          : "bg-red-500/15 text-red-400"
+                          ? "bg-warning/15 text-warning"
+                          : "bg-danger/15 text-danger"
                     }`}>
                       {run.win ? "W" : run.was_abandoned ? "A" : "L"}
                     </span>
@@ -311,7 +311,7 @@ export default function ProfileStats({
                       <div className="flex items-center gap-1 shrink-0">
                         <button
                           onClick={() => onDeleteRun(run.run_hash)}
-                          className="text-xs text-red-400 hover:text-red-300"
+                          className="text-xs text-danger hover:text-danger"
                         >
                           {t("Confirm")}
                         </button>
@@ -325,7 +325,7 @@ export default function ProfileStats({
                     ) : (
                       <button
                         onClick={() => onDeleteConfirm(run.run_hash)}
-                        className="text-xs text-[var(--text-tertiary)] hover:text-red-400 transition-colors shrink-0"
+                        className="text-xs text-[var(--text-tertiary)] hover:text-danger transition-colors shrink-0"
                       >
                         {t("Delete")}
                       </button>
@@ -438,7 +438,7 @@ export default function ProfileStats({
             <Link
               prefetch={false}
               href="/tier-list-maker"
-              className="text-sm text-sky-400 hover:underline"
+              className="text-sm text-info hover:underline"
             >
               {t("New tier list")}
             </Link>

--- a/frontend/app/components/RecentlyAdded.tsx
+++ b/frontend/app/components/RecentlyAdded.tsx
@@ -65,17 +65,17 @@ export default async function RecentlyAdded({
   }
 
   return (
-    <section className="mb-8 rounded-xl border border-emerald-700/30 bg-emerald-950/20 p-4 sm:p-6">
+    <section className="mb-8 rounded-xl border border-success/30 bg-success/10 p-4 sm:p-6">
       <div className="flex items-center gap-2 mb-3">
-        <span className="inline-block w-2 h-2 rounded-full bg-emerald-400 animate-pulse" />
-        <h2 className="text-lg font-bold text-emerald-300">
+        <span className="inline-block w-2 h-2 rounded-full bg-success-fill animate-pulse" />
+        <h2 className="text-lg font-bold text-success">
           {t("Recently Added {items}", { items: t(`${label}s`) })}
         </h2>
       </div>
 
       {[...byVersion.entries()].map(([version, group]) => (
         <div key={version} className="mb-3 last:mb-0">
-          <p className="text-xs uppercase tracking-wider text-emerald-400/70 mb-2">
+          <p className="text-xs uppercase tracking-wider text-success/70 mb-2">
             {t("New in v{version}", { version })}
           </p>
           <ul className="flex flex-wrap gap-2">
@@ -84,7 +84,7 @@ export default async function RecentlyAdded({
                 <Link
                   prefetch={false}
                   href={`${pathPrefix}/${item.id.toLowerCase()}`}
-                  className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--bg-card)] border border-emerald-800/40 hover:border-emerald-500/60 text-sm text-[var(--text-primary)] hover:text-emerald-300 transition-colors"
+                  className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[var(--bg-card)] border border-success/30 hover:border-success/60 text-sm text-[var(--text-primary)] hover:text-success transition-colors"
                 >
                   <span className="font-medium">{item.name}</span>
                   {item.rarity && (

--- a/frontend/app/components/RichDescription.tsx
+++ b/frontend/app/components/RichDescription.tsx
@@ -18,13 +18,13 @@ export interface RelatedCard {
 
 const COLOR_CLASSES: Record<string, string> = {
   gold: "text-[var(--accent-gold)]",
-  red: "text-red-400",
-  blue: "text-blue-400",
-  green: "text-emerald-400",
-  purple: "text-purple-400",
-  orange: "text-orange-400",
-  pink: "text-pink-400",
-  aqua: "text-cyan-400",
+  red: "text-danger",
+  blue: "text-info",
+  green: "text-success",
+  purple: "text-special",
+  orange: "text-warning",
+  pink: "text-special",
+  aqua: "text-info",
 };
 
 const EFFECT_CLASSES: Record<string, string> = {

--- a/frontend/app/components/ScoreBadge.tsx
+++ b/frontend/app/components/ScoreBadge.tsx
@@ -24,12 +24,12 @@ interface Tier {
  * backend/app/services/run_entity_stats.py for the underlying math.
  */
 function scoreToTier(score: number): Tier {
-  if (score >= 90) return { letter: "S", label: "Top tier", className: "bg-amber-950/40 border-amber-700/60 text-amber-300" };
-  if (score >= 78) return { letter: "A", label: "Strong",   className: "bg-emerald-950/40 border-emerald-700/60 text-emerald-300" };
-  if (score >= 65) return { letter: "B", label: "Solid",    className: "bg-sky-950/40 border-sky-700/60 text-sky-300" };
-  if (score >= 50) return { letter: "C", label: "Average",  className: "bg-zinc-800/60 border-zinc-600/60 text-zinc-300" };
-  if (score >= 35) return { letter: "D", label: "Below average", className: "bg-orange-950/40 border-orange-700/60 text-orange-300" };
-  return { letter: "F", label: "Underperforming", className: "bg-rose-950/40 border-rose-800/60 text-rose-300" };
+  if (score >= 90) return { letter: "S", label: "Top tier", className: "bg-warning/10 border-warning/60 text-warning" };
+  if (score >= 78) return { letter: "A", label: "Strong",   className: "bg-success/10 border-success/60 text-success" };
+  if (score >= 65) return { letter: "B", label: "Solid",    className: "bg-info/10 border-info/60 text-info" };
+  if (score >= 50) return { letter: "C", label: "Average",  className: "bg-surface/60 border-line-strong/60 text-fg-secondary" };
+  if (score >= 35) return { letter: "D", label: "Below average", className: "bg-warning/10 border-warning/60 text-warning" };
+  return { letter: "F", label: "Underperforming", className: "bg-danger/10 border-danger/30 text-danger" };
 }
 
 export default function ScoreBadge({ score, size = "md", showNumber = false }: ScoreBadgeProps) {

--- a/frontend/app/components/SiteSwitcher.tsx
+++ b/frontend/app/components/SiteSwitcher.tsx
@@ -84,7 +84,7 @@ export default function SiteSwitcher() {
   // "beta v0.107.0" doesn't widen the navbar and push the mobile burger
   // past the viewport edge.
   const buttonClasses = onBeta
-    ? "h-9 px-3 min-w-[7.5rem] rounded-lg text-xs font-semibold bg-emerald-500/15 text-emerald-400 border border-emerald-500/30 hover:bg-emerald-500/25"
+    ? "h-9 px-3 min-w-[7.5rem] rounded-lg text-xs font-semibold bg-success/15 text-success border border-success/30 hover:bg-success/25"
     : "h-9 px-3 rounded-lg text-xs font-semibold bg-[var(--accent-gold)]/15 text-[var(--accent-gold)] border border-[var(--accent-gold)]/30 hover:bg-[var(--accent-gold)]/25";
 
   return (
@@ -116,7 +116,7 @@ export default function SiteSwitcher() {
       {open && (
         <div
           ref={menuRef}
-          className="absolute right-0 top-full mt-2 w-56 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-black/30 z-50"
+          className="absolute right-0 top-full mt-2 w-56 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-scrim/30 z-50"
         >
           <div className="py-1">
             {onBeta ? (
@@ -131,7 +131,7 @@ export default function SiteSwitcher() {
               <Link
                 href={betaHref}
                 onClick={() => setOpen(false)}
-                className="flex items-center justify-between gap-3 px-4 py-2 text-sm font-medium text-emerald-400 transition-colors hover:bg-[var(--bg-card)] hover:text-emerald-300"
+                className="flex items-center justify-between gap-3 px-4 py-2 text-sm font-medium text-success transition-colors hover:bg-[var(--bg-card)] hover:text-success"
               >
                 <span>{betaLabel}</span>
                 <span className="text-xs">{t("what's new")}</span>

--- a/frontend/app/components/StatsRebuildingNotice.tsx
+++ b/frontend/app/components/StatsRebuildingNotice.tsx
@@ -50,8 +50,8 @@ export default function StatsRebuildingNotice() {
 
   if (!building) return null;
   return (
-    <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-2.5 mb-4 text-sm text-[var(--text-secondary)]">
-      <span className="font-semibold text-amber-300 mr-2">{t("Heads up")}</span>
+    <div className="rounded-lg border border-warning/40 bg-warning/10 px-4 py-2.5 mb-4 text-sm text-[var(--text-secondary)]">
+      <span className="font-semibold text-warning mr-2">{t("Heads up")}</span>
       {t("Stats are rebuilding after an update. Charts, metrics, and scores usually fill back in within 15 minutes; no data is lost.")}
     </div>
   );

--- a/frontend/app/components/ThemeToggle.tsx
+++ b/frontend/app/components/ThemeToggle.tsx
@@ -48,7 +48,7 @@ export default function ThemeToggle({ variant = "icon" }: { variant?: "icon" | "
         type="button"
         onClick={() => apply(mode)}
         className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-          theme === mode ? "bg-[var(--accent-gold)] text-[#1a1205]" : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+          theme === mode ? "bg-[var(--accent-gold)] text-on-accent" : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
         }`}
       >
         {icon}

--- a/frontend/app/components/TierList.tsx
+++ b/frontend/app/components/TierList.tsx
@@ -37,12 +37,12 @@ interface Tier {
 // Tier bands match _compute_score in run_entity_stats.py and the
 // scoreToTier function in ScoreBadge. Keep the three in sync.
 const TIERS: Tier[] = [
-  { letter: "S", min: 90, className: "bg-amber-950/40 border-amber-700/60 text-amber-300",     label: "Top tier" },
-  { letter: "A", min: 78, className: "bg-emerald-950/40 border-emerald-700/60 text-emerald-300", label: "Strong" },
-  { letter: "B", min: 65, className: "bg-sky-950/40 border-sky-700/60 text-sky-300",           label: "Solid" },
-  { letter: "C", min: 50, className: "bg-zinc-800/60 border-zinc-600/60 text-zinc-300",        label: "Average" },
-  { letter: "D", min: 35, className: "bg-orange-950/40 border-orange-700/60 text-orange-300",  label: "Below average" },
-  { letter: "F", min: 0,  className: "bg-rose-950/40 border-rose-800/60 text-rose-300",        label: "Underperforming" },
+  { letter: "S", min: 90, className: "bg-warning/10 border-warning/60 text-warning",     label: "Top tier" },
+  { letter: "A", min: 78, className: "bg-success/10 border-success/60 text-success", label: "Strong" },
+  { letter: "B", min: 65, className: "bg-info/10 border-info/60 text-info",           label: "Solid" },
+  { letter: "C", min: 50, className: "bg-surface/60 border-line-strong/60 text-fg-secondary",        label: "Average" },
+  { letter: "D", min: 35, className: "bg-warning/10 border-warning/60 text-warning",  label: "Below average" },
+  { letter: "F", min: 0,  className: "bg-danger/10 border-danger/30 text-danger",        label: "Underperforming" },
 ];
 
 function tierForScore(score: number): Tier {
@@ -135,7 +135,7 @@ export default async function TierList({ route, entities, showUnrated = true, va
             className={`flex-shrink-0 flex sm:flex-col items-center justify-center sm:w-24 px-4 py-3 sm:py-4 border-b sm:border-b-0 sm:border-r ${
               tier
                 ? `${tier.className} border-current/20`
-                : "bg-zinc-900/40 border-zinc-700/40 text-zinc-500"
+                : "bg-surface/40 border-line-strong/40 text-fg-muted"
             }`}
           >
             <span className="text-3xl sm:text-4xl font-bold leading-none">

--- a/frontend/app/components/Toast.tsx
+++ b/frontend/app/components/Toast.tsx
@@ -42,8 +42,8 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const colors: Record<ToastType, string> = {
-    success: "border-green-500/40 bg-green-500/10 text-green-300",
-    error: "border-red-500/40 bg-red-500/10 text-red-300",
+    success: "border-success/40 bg-success/10 text-success",
+    error: "border-danger/40 bg-danger/10 text-danger",
     info: "border-[var(--border-accent)] bg-[var(--bg-card)] text-[var(--text-primary)]",
   };
 
@@ -55,7 +55,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
           {toasts.map((item) => (
             <div
               key={item.id}
-              className={`px-4 py-3 rounded-lg border text-sm shadow-lg shadow-black/20 flex items-start gap-2 animate-in slide-in-from-right ${colors[item.type]}`}
+              className={`px-4 py-3 rounded-lg border text-sm shadow-lg shadow-scrim/20 flex items-start gap-2 animate-in slide-in-from-right ${colors[item.type]}`}
               role="alert"
             >
               <span className="flex-1 break-words">{item.message}</span>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -17,15 +17,69 @@
   src: url("/fonts/kreon_bold.ttf") format("truetype");
 }
 
+/* ═══════════════════════════════════════════════════════════════════════════
+   Design tokens
+   ───────────────────────────────────────────────────────────────────────────
+   Every color on the site comes from one of these variables. They are named
+   by PURPOSE, never by value, so a component says what it means ("this is a
+   warning", "this is the card surface") and the theme decides the color.
+
+   Rules:
+     1. Never write a raw Tailwind palette class (text-red-400, bg-emerald-950/50)
+        or a hex color in a component. lib/design-tokens.test.ts fails the build.
+     2. Text goes on its matching surface: --text-* on --bg-*, --text-on-accent
+        on --accent-gold, --text-on-fill on a --<status>-fill or --scrim layer.
+     3. Status colors carry meaning, not decoration:
+          success  won, positive delta, upgraded/improved
+          danger   lost, died, destructive action, negative delta
+          warning  caution, pending, gold-adjacent emphasis
+          info     neutral highlight, links to tools, "new"
+          special  events, curses, rare/arcane, purple UI
+     4. Game colors (--keyword, --upgrade, --color-<character>) match the game
+        and are shared with the canvas renderers, which read them at runtime
+        with getComputedStyle.
+     5. Need a tint? Use the Tailwind opacity modifier on the token utility:
+        bg-success/10, border-danger/40, text-info/70.
+
+   Both themes define every token. Light values are checked for WCAG AA
+   (4.5:1) against --bg-card. See CONTRIBUTING.md, "Colors".
+   ═══════════════════════════════════════════════════════════════════════════ */
 :root {
+  /* Surfaces, darkest to lightest */
   --bg-primary: #0a1118;
   --bg-secondary: #0f1920;
   --bg-card: #132028;
   --bg-card-hover: #1a2b35;
-  --accent-red: #c41e3a;
+  --scrim: #000000;
+  /* Text on the surfaces above */
+  --text-primary: #e0ddd8;
+  --text-secondary: #bfc4ca;
+  --text-muted: #b1b7be;
+  --text-on-accent: #0a1118;
+  --text-on-fill: #ffffff;
+  /* Borders */
+  --border-subtle: #1e3040;
+  --border-accent: #2a4555;
+  /* Brand accents */
   --accent-gold: #e8b830;
   --accent-gold-light: #fbd91e;
   --accent-teal: #45cfd8;
+  --accent-red: #c41e3a;
+  /* Status: the plain token is for text, borders and tints on a surface;
+     the -fill token is a solid background that takes --text-on-fill */
+  --success: #34d399;
+  --danger: #f87171;
+  --warning: #fbbf24;
+  --info: #38bdf8;
+  --special: #c084fc;
+  --success-fill: #059669;
+  --danger-fill: #dc2626;
+  --warning-fill: #d97706;
+  --info-fill: #0284c7;
+  --special-fill: #7c3aed;
+  /* Game semantics */
+  --keyword: var(--accent-gold);
+  --upgrade: var(--success);
   --color-ironclad: #d53b27;
   --color-silent: #23935b;
   --color-defect: #3873a9;
@@ -33,64 +87,64 @@
   --color-regent: #f07c1e;
   --color-colorless: #6b7280;
   --color-curse: #8b1a1a;
-  --text-primary: #e0ddd8;
-  /* secondary/muted were too dim on the dark ground: muted #506570 was ~2.7:1
-     on the card surface, well below WCAG AA (4.5:1) and hard to read wherever
-     quiet sub-text appears. Lifted both into a high-contrast 8-10:1 band
-     (secondary ~9.5:1, muted ~8.2:1 on the card surface) so sub-text reads
-     clearly everywhere, keeping a step down from primary. Light theme unchanged. */
-  --text-secondary: #bfc4ca;
-  --text-muted: #b1b7be;
-  --border-subtle: #1e3040;
-  --border-accent: #2a4555;
+  --color-ancient: #6b5b8a;
+  --color-merchant: #c5894a;
+  --color-spire: #ac6345;
+  --tier-bronze: #a87a3d;
+  --tier-silver: #9ca6b4;
+  /* Third-party brands, used only on their own sign-in buttons and links */
+  --brand-twitch: #9146ff;
+  --brand-twitch-light: #b794ff;
+  --brand-bluesky: #0085ff;
+  --brand-patreon: #ff424d;
+  --brand-steam: #1b2838;
+  --brand-steam-line: #2a475e;
+  --brand-steam-light: #c7d5e0;
+  --shadow-card: none;
 }
 
-/* Light theme (toggled from the nav). Only the palette flips; token-driven components follow. */
+/* Light theme (toggled from the nav). Catppuccin Latte for the ground and
+   text; status and accent colors are the deep end of each hue so they clear
+   AA on the white card surface. */
 :root[data-theme="light"] {
-  /* Catppuccin Latte (https://catppuccin.com). The page uses Crust as the
-     ground so Base-colored cards (helped by --shadow-card) lift above it;
-     text, borders, and accents are the standard Latte swatches. */
-  --bg-primary: #eff1f5;    /* Base (near-white ground) */
-  --bg-secondary: #e6e9ef;  /* Mantle   */
-  --bg-card: #ffffff;       /* pure white, lifts above the Base ground */
+  --bg-primary: #eff1f5;
+  --bg-secondary: #e6e9ef;
+  --bg-card: #ffffff;
   --bg-card-hover: #f2f4f8;
-  --accent-gold: #df8e1d;       /* Yellow   */
+  --scrim: #1e2030;
+  --text-primary: #4c4f69;
+  --text-secondary: #6c6f85;
+  --text-muted: #8c8fa1;
+  --text-on-accent: #221a05;
+  --text-on-fill: #ffffff;
+  --border-subtle: #ccd0da;
+  --border-accent: #bcc0cc;
+  --accent-gold: #df8e1d;
   --accent-gold-light: #eaa72f;
-  --text-primary: #4c4f69;      /* Text     */
-  --text-secondary: #6c6f85;    /* Subtext0 */
-  --text-muted: #8c8fa1;        /* Overlay1 */
-  --border-subtle: #ccd0da;     /* Surface0 */
-  --border-accent: #bcc0cc;     /* Surface1 */
-  /* Darker than Latte Green (#40a02b): --color-silent doubles as text (the
-     nav Live button, Silent-colored labels) and #40a02b is only 3.0:1 on the
-     Base ground. #2e7d32 clears WCAG AA (4.5:1) while staying clearly green. */
+  --accent-teal: #179299;
+  --success: #2e7d32;
+  --danger: #b91c1c;
+  --warning: #b45309;
+  --info: #1d4ed8;
+  --special: #6d28d9;
+  --success-fill: #2e7d32;
+  --danger-fill: #b91c1c;
+  --warning-fill: #b45309;
+  --info-fill: #1d4ed8;
+  --special-fill: #6d28d9;
   --color-silent: #2e7d32;
-  --accent-teal: #179299;       /* Teal     */
   --shadow-card: 0 1px 2px rgba(76, 79, 105, 0.10), 0 2px 6px rgba(76, 79, 105, 0.08);
 }
 
-/* ── Light-mode contrast fixes ────────────────────────────────────────────
-   The vibrant accent greens/teals that read well on the dark ground are too
-   light on the cream light-mode ground. Darken them (light mode only). */
-:root[data-theme="light"] .wr-sg { color: #40a02b; } /* Latte Green   */
-:root[data-theme="light"] .wr-g { color: #179299; }  /* Latte Teal    */
-:root[data-theme="light"] .wr-r { color: #d20f39; }  /* Latte Red     */
-:root[data-theme="light"] .rvmp,
-:root[data-theme="light"] .card-rvmp { --good: #40a02b; --spine: #40a02b; }
-/* Colored count numbers get their hue from an inline --cc (hardcoded per
-   entity, e.g. the bright teal on Enchantments/Powers). Darken it in light
-   mode without touching the dark theme. */
+/* Light-mode fixes that are about layout, not palette. Palette differences
+   live in the tokens above. */
 :root[data-theme="light"] .bt-count,
 :root[data-theme="light"] .ct-count {
   color: color-mix(in srgb, var(--cc, currentColor), #0a0f14 36%);
 }
-/* Character-card name + win rate are white text over a bottom fade that uses
-   --bg; in light mode that fade goes white and hides them. Force it dark. */
 :root[data-theme="light"] .charp::after {
   background: linear-gradient(180deg, transparent 38%, rgba(12, 18, 26, 0.9));
 }
-/* Slate light: cards, panels, and the search bar lift off the cool ground with
-   a soft shadow so figure/ground reads clearly (the flat cream theme didn't). */
 :root[data-theme="light"] .rvmp .btile,
 :root[data-theme="light"] .rvmp .act,
 :root[data-theme="light"] .rvmp .charp,
@@ -106,75 +160,57 @@
 :root[data-theme="light"] .card-rvmp .hero {
   box-shadow: var(--shadow-card);
 }
-/* The entity-render mat is tuned dark (30% black) for the dark ground; on the
-   light ground that reads as a pronounced gray box that clashes with the art.
-   Lighten the mat and soften its drop-shadow in light mode. */
 :root[data-theme="light"] .card-rvmp .cardimg.render {
   background: color-mix(in srgb, var(--text-primary) 6%, transparent);
   filter: drop-shadow(0 10px 24px rgba(76, 79, 105, 0.20));
 }
-/* ── Light-mode contrast: colored chips, banners, filled buttons ──────────
-   Green/amber/red chips and the announcement ticker hardcode the dark-theme
-   palette (…-900/40 fills with …-200/400 text). On the light ground those
-   fills turn pastel and the bright text disappears into them. Centralized
-   fix instead of editing ~60 components: darken the text utilities to the
-   deep end of each hue and swap the translucent dark fills for solid
-   pastels (light mode only; the dark theme keeps its palette). */
-:root[data-theme="light"] :is(.text-green-100, .text-green-200, .text-green-300,
-  .text-green-400, .text-emerald-200, .text-emerald-300, .text-emerald-400) {
-  color: #14532d; /* green-900 */
-}
-:root[data-theme="light"] :is(.text-amber-300, .text-amber-400, .text-orange-300,
-  .text-orange-400, .text-yellow-300, .text-yellow-400) {
-  color: #92400e; /* amber-800 */
-}
-:root[data-theme="light"] :is(.text-red-300, .text-red-400) {
-  color: #b91c1c; /* red-700 */
-}
-:root[data-theme="light"] :is(.text-blue-300) {
-  color: #193cb8; /* blue-800 */
-}
-:root[data-theme="light"] :is([class*="bg-green-900/"], [class*="bg-green-950/"],
-  [class*="bg-emerald-900/"], [class*="bg-emerald-950/"], [class*="bg-green-500/"],
-  [class*="bg-green-600/"], [class*="bg-emerald-500/"], [class*="bg-emerald-600/"]) {
-  background-color: #dcfce7; /* green-100 */
-}
-:root[data-theme="light"] :is([class*="bg-amber-900/"], [class*="bg-amber-950/"],
-  [class*="bg-orange-900/"], [class*="bg-orange-950/"]) {
-  background-color: #fef3c7; /* amber-100 */
-}
-:root[data-theme="light"] :is([class*="bg-red-900/"], [class*="bg-red-950/"]) {
-  background-color: #fee2e2; /* red-100 */
-}
-/* Solid green fills (giveaway toggles, status dots) keep their color but the
-   label flips dark: they pair with text-[var(--bg-primary)], which is
-   near-white in light mode (2.1:1 on emerald-500). */
-:root[data-theme="light"] :is([class*="bg-emerald-500"], [class*="bg-emerald-600"],
-  [class*="bg-green-500"], [class*="bg-green-600"]) {
-  color: #052e16;
-}
-/* Gold-filled buttons: same text-[var(--bg-primary)] pairing goes near-white
-   on the light theme's orange (#df8e1d), 2.5:1. Force a dark label. */
-:root[data-theme="light"] [class*="bg-[var(--accent-gold)]"] {
-  color: #221a05;
-}
-/* Ticker pager dots are white-on-dark; inside the pastel-ized green slots
-   they vanish. Re-ink them green where the container fill was swapped. */
-:root[data-theme="light"] :is([class*="bg-green-900/"], [class*="bg-emerald-900/"]) [class*="bg-white/80"] {
-  background-color: rgba(20, 83, 45, 0.85);
-}
-:root[data-theme="light"] :is([class*="bg-green-900/"], [class*="bg-emerald-900/"]) [class*="bg-white/30"] {
-  background-color: rgba(20, 83, 45, 0.35);
-}
-/* Links inside those slots hover to white on dark; on the pastel fill hover
-   to the same deep green as the body text instead. */
-:root[data-theme="light"] :is([class*="bg-green-900/"], [class*="bg-emerald-900/"]) a:hover {
-  color: #052e16;
-}
 
 @theme inline {
+  /* Tailwind utilities for the tokens: text-success, bg-danger/10, border-info/40,
+     bg-scrim/60, text-on-fill, text-on-accent, bg-surface, text-fg-muted... */
   --color-background: var(--bg-primary);
   --color-foreground: var(--text-primary);
+  --color-surface: var(--bg-card);
+  --color-surface-hover: var(--bg-card-hover);
+  --color-scrim: var(--scrim);
+  --color-fg: var(--text-primary);
+  --color-fg-secondary: var(--text-secondary);
+  --color-fg-muted: var(--text-muted);
+  --color-on-accent: var(--text-on-accent);
+  --color-on-fill: var(--text-on-fill);
+  --color-line: var(--border-subtle);
+  --color-line-strong: var(--border-accent);
+  --color-accent: var(--accent-gold);
+  --color-accent-light: var(--accent-gold-light);
+  --color-success: var(--success);
+  --color-danger: var(--danger);
+  --color-warning: var(--warning);
+  --color-info: var(--info);
+  --color-special: var(--special);
+  --color-success-fill: var(--success-fill);
+  --color-danger-fill: var(--danger-fill);
+  --color-warning-fill: var(--warning-fill);
+  --color-info-fill: var(--info-fill);
+  --color-special-fill: var(--special-fill);
+  --color-keyword: var(--keyword);
+  --color-upgrade: var(--upgrade);
+  --color-ironclad: var(--color-ironclad);
+  --color-silent: var(--color-silent);
+  --color-defect: var(--color-defect);
+  --color-necrobinder: var(--color-necrobinder);
+  --color-regent: var(--color-regent);
+  --color-ancient: var(--color-ancient);
+  --color-merchant: var(--color-merchant);
+  --color-spire: var(--color-spire);
+  --color-bronze: var(--tier-bronze);
+  --color-silver: var(--tier-silver);
+  --color-twitch: var(--brand-twitch);
+  --color-twitch-light: var(--brand-twitch-light);
+  --color-bluesky: var(--brand-bluesky);
+  --color-patreon: var(--brand-patreon);
+  --color-steam: var(--brand-steam);
+  --color-steam-line: var(--brand-steam-line);
+  --color-steam-light: var(--brand-steam-light);
   /* Kreon (the Slay the Spire 2 typeface) is the site font; Geist stays as the
      sans fallback if Kreon fails to load. Mono keeps Geist Mono for tabular
      alignment of ids and numbers. */

--- a/frontend/app/home-revamp.css
+++ b/frontend/app/home-revamp.css
@@ -23,8 +23,8 @@
   --mono: var(--font-geist-mono), ui-monospace, monospace;
   --radius: 10px;
   --wrap: 80rem;
-  --good: #35c07a;
-  --warn: #d08a3a;
+  --good: var(--success);
+  --warn: var(--warning);
 }
 .rvmp a { text-decoration: none; }
 
@@ -104,9 +104,9 @@
 .rvmp .dtable .num.mono { font-family: var(--mono); font-weight: 500; }
 .rvmp .dtable .dim { color: var(--text-3); font-weight: 500; }
 .rvmp .dot2 { width: 9px; height: 9px; border-radius: 3px; flex: none; }
-.rvmp .wr-sg { color: #35c07a; }
+.rvmp .wr-sg { color: var(--success); }
 .rvmp .wr-loss { color: #e5484d; }
-.rvmp .wr-g { color: #6fae4f; }
+.rvmp .wr-g { color: color-mix(in srgb, var(--success) 70%, var(--text-secondary)); }
 /* Recent runs: fixed layout so the long "died to …" subline truncates in its
    cell instead of widening the table and forcing a horizontal scroll. */
 .rvmp .dtable-fixed { table-layout: fixed; }

--- a/frontend/lib/design-tokens.test.ts
+++ b/frontend/lib/design-tokens.test.ts
@@ -1,0 +1,53 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(__dirname, "..");
+const PALETTE =
+  /(?<![\w-])(?:[a-z-]+:)*(?:text|bg|border(?:-[trblxy])?|from|to|via|ring|fill|stroke|placeholder|divide|outline|shadow|decoration|accent|caret)-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|gray|slate|zinc|neutral|stone|black|white)(?:-\d{2,3})?(?:\/\d{1,3})?(?![\w-])/g;
+const HEX_IN_CLASS = /className=(?:"[^"]*|\{`[^`]*)#[0-9a-fA-F]{3,8}\b/g;
+const ARBITRARY_HEX = /\b(?:text|bg|border|ring|from|to|via|shadow)-\[#[0-9a-fA-F]{3,8}\]/g;
+
+const HEX_ALLOWED: Record<string, string[]> = {
+  "app/[locale]/live/[steamId]/LiveScene.tsx": ["#1a1320", "#120c18", "#0c0810"],
+};
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith(".tsx")) out.push(p);
+  }
+  return out;
+}
+
+describe("design tokens", () => {
+  const files = walk(join(ROOT, "app"));
+
+  it("components use token utilities, not raw Tailwind palette classes", () => {
+    const hits: string[] = [];
+    for (const f of files) {
+      const src = readFileSync(f, "utf8");
+      for (const m of src.matchAll(PALETTE)) {
+        const line = src.slice(0, m.index).split("\n").length;
+        hits.push(`${relative(ROOT, f)}:${line} ${m[0]}`);
+      }
+    }
+    expect(hits, "Use a token utility (text-success, bg-danger/10, text-fg-muted...) instead. See CONTRIBUTING.md, Colors.").toEqual([]);
+  });
+
+  it("components do not hardcode hex colors in classes", () => {
+    const hits: string[] = [];
+    for (const f of files) {
+      const rel = relative(ROOT, f).replace(/\\/g, "/");
+      const allowed = HEX_ALLOWED[rel] ?? [];
+      const src = readFileSync(f, "utf8");
+      for (const m of [...src.matchAll(ARBITRARY_HEX), ...src.matchAll(HEX_IN_CLASS)]) {
+        if (allowed.some((hex) => m[0].includes(hex))) continue;
+        const line = src.slice(0, m.index).split("\n").length;
+        hits.push(`${rel}:${line} ${m[0]}`);
+      }
+    }
+    expect(hits, "Add a token in globals.css instead of a hex color. See CONTRIBUTING.md, Colors.").toEqual([]);
+  });
+});


### PR DESCRIPTION
Adds a purpose-named token layer in globals.css (surfaces, text, borders, accents, five status colors with solid fills, game and brand colors), registers them as Tailwind utilities, replaces all 938 raw palette classes and the brand hex classes across 99 components with tokens by meaning, deletes the 36 light-theme patch rules that only existed to fix those classes, adds a test that fails on any new palette class or hex in a component, and documents the tokens in CONTRIBUTING.md.