### PR TITLE
Use links for the site logins

### DIFF
--- a/frontend/app/HomeClient.tsx
+++ b/frontend/app/HomeClient.tsx
@@ -235,11 +235,11 @@ export default function HomeClient({ initialStats, initialTranslations }: HomeCl
         </div>
         <div className="gs-grid" ref={gsTrack} onScroll={onGsScroll}>
           {!user && (
-            <button type="button" onClick={loginSteam} className="act act-signin">
+            <a href={loginSteam} className="act act-signin">
               <span className="act-ico"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M11.979 0C5.678 0 .511 4.86.022 11.037l6.432 2.658a3.387 3.387 0 0 1 1.912-.593c.064 0 .127.003.19.007l2.862-4.146v-.058a4.533 4.533 0 0 1 4.53-4.53 4.533 4.533 0 0 1 4.53 4.53 4.533 4.533 0 0 1-4.53 4.53h-.106l-4.08 2.91c0 .053.003.107.003.161a3.4 3.4 0 0 1-3.4 3.4 3.404 3.404 0 0 1-3.367-2.936L.256 15.21C1.542 20.2 6.218 24 11.979 24 18.627 24 24 18.627 24 11.979 24 5.373 18.627 0 11.979 0z" /></svg></span>
               <span className="act-t">{t("Sign in with Steam")}</span>
               <span className="act-d">{t("Spire Codex keeps track of your runs and tier lists, all while not tracking you.")}</span>
-            </button>
+            </a>
           )}
           {startTiles.map((c) => {
             const inner = (<><span className="act-ico">{c.icon}</span><span className="act-t">{c.title}</span><span className="act-d">{c.desc}</span></>);

--- a/frontend/app/[locale]/giveaway/GiveawayClient.tsx
+++ b/frontend/app/[locale]/giveaway/GiveawayClient.tsx
@@ -188,9 +188,9 @@ export default function GiveawayClient() {
           {hasSteam ? (
             <p className="text-emerald-300">{t("Signed in as")} {user?.username ?? t("your account")}.</p>
           ) : (
-            <button onClick={loginSteam} className={primaryBtn}>
+            <a href={loginSteam} className={primaryBtn}>
               {user ? t("Connect Steam") : t("Sign in with Steam")}
-            </button>
+            </a>
           )}
         </StepCard>
 

--- a/frontend/app/[locale]/leaderboards/submit/SubmitRunClient.tsx
+++ b/frontend/app/[locale]/leaderboards/submit/SubmitRunClient.tsx
@@ -259,13 +259,12 @@ export default function SubmitRunClient() {
             {t("Sign in to automatically associate runs with your account.")}
           </p>
           <div className="flex flex-wrap gap-2">
-            <button
-              onClick={loginSteam}
-              className="inline-flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-card-hover)] transition-colors"
-            >
+            <a
+              href={loginSteam}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-[var(--bg-primary)] border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-card-hover)] transition-colors">
               <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="currentColor"><path d="M11.979 0C5.678 0 .511 4.86.022 11.037l6.432 2.658a3.387 3.387 0 0 1 1.912-.593c.064 0 .127.003.19.007l2.862-4.146v-.058a4.533 4.533 0 0 1 4.53-4.53 4.533 4.533 0 0 1 4.53 4.53 4.533 4.533 0 0 1-4.53 4.53h-.106l-4.08 2.91c0 .053.003.107.003.161a3.4 3.4 0 0 1-3.4 3.4 3.404 3.404 0 0 1-3.367-2.936L.256 15.21C1.542 20.2 6.218 24 11.979 24 18.627 24 24 18.627 24 11.979 24 5.373 18.627 0 11.979 0z"/></svg>
               Steam
-            </button>
+            </a>
           </div>
         </div>
       )}

--- a/frontend/app/[locale]/settings/SettingsClient.tsx
+++ b/frontend/app/[locale]/settings/SettingsClient.tsx
@@ -266,16 +266,15 @@ export default function SettingsClient() {
               </div>
             </div>
           ) : (
-            <button
-              onClick={loginSteam}
-              className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] hover:border-[var(--border-accent)] transition-colors cursor-pointer"
-            >
+            <a
+              href={loginSteam}
+              className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] hover:border-[var(--border-accent)] transition-colors cursor-pointer">
               <div className="flex items-center gap-2">
                 <svg className="w-4 h-4 text-[var(--text-secondary)]" viewBox="0 0 24 24" fill="currentColor"><path d="M11.979 0C5.678 0 .511 4.86.022 11.037l6.432 2.658a3.387 3.387 0 0 1 1.912-.593c.064 0 .127.003.19.007l2.862-4.146v-.058a4.533 4.533 0 0 1 4.53-4.53 4.533 4.533 0 0 1 4.53 4.53 4.533 4.533 0 0 1-4.53 4.53h-.106l-4.08 2.91c0 .053.003.107.003.161a3.4 3.4 0 0 1-3.4 3.4 3.404 3.404 0 0 1-3.367-2.936L.256 15.21C1.542 20.2 6.218 24 11.979 24 18.627 24 24 18.627 24 11.979 24 5.373 18.627 0 11.979 0z"/></svg>
                 <span className="text-sm text-[var(--text-primary)]">Steam</span>
               </div>
               <span className="text-xs text-[var(--text-secondary)]">{t("Connect")}</span>
-            </button>
+            </a>
           )}
           {user.discord_id ? (
             <div className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)]">
@@ -295,16 +294,15 @@ export default function SettingsClient() {
               </div>
             </div>
           ) : (
-            <button
-              onClick={loginDiscord}
-              className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] hover:border-[var(--border-accent)] transition-colors cursor-pointer"
-            >
+            <a
+              href={loginDiscord}
+              className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] hover:border-[var(--border-accent)] transition-colors cursor-pointer">
               <div className="flex items-center gap-2">
                 <DiscordIcon className="w-4 h-4 text-[var(--text-secondary)]" />
                 <span className="text-sm text-[var(--text-primary)]">Discord</span>
               </div>
               <span className="text-xs text-[var(--text-secondary)]">{t("Connect")}</span>
-            </button>
+            </a>
           )}
           {user.twitch_id ? (
             <div className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)]">
@@ -339,16 +337,15 @@ export default function SettingsClient() {
               </div>
             </div>
           ) : (
-            <button
-              onClick={loginTwitch}
-              className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] hover:border-[var(--border-accent)] transition-colors cursor-pointer"
-            >
+            <a
+              href={loginTwitch}
+              className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] hover:border-[var(--border-accent)] transition-colors cursor-pointer">
               <div className="flex items-center gap-2">
                 <TwitchIcon className="w-4 h-4 text-[var(--text-secondary)]" />
                 <span className="text-sm text-[var(--text-primary)]">Twitch</span>
               </div>
               <span className="text-xs text-[var(--text-secondary)]">{t("Connect")}</span>
-            </button>
+            </a>
           )}
           {user.patreon_id ? (
             <div className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)]">
@@ -373,16 +370,15 @@ export default function SettingsClient() {
               </div>
             </div>
           ) : (
-            <button
-              onClick={loginPatreon}
-              className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] hover:border-[var(--border-accent)] transition-colors cursor-pointer"
-            >
+            <a
+              href={loginPatreon}
+              className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--bg-card)] border border-[var(--border-subtle)] hover:border-[var(--border-accent)] transition-colors cursor-pointer">
               <div className="flex items-center gap-2">
                 <svg className="w-4 h-4 text-[var(--text-secondary)]" viewBox="0 0 24 24" fill="currentColor" aria-hidden><circle cx="14.5" cy="9.5" r="7.5" /><rect x="2" y="2" width="4" height="20" /></svg>
                 <span className="text-sm text-[var(--text-primary)]">Patreon</span>
               </div>
               <span className="text-xs text-[var(--text-secondary)]">{t("Connect")}</span>
-            </button>
+            </a>
           )}
         </div>
         <p className="text-xs text-[var(--text-tertiary)]">

--- a/frontend/app/[locale]/tier-list-maker/TierListBuilder.tsx
+++ b/frontend/app/[locale]/tier-list-maker/TierListBuilder.tsx
@@ -331,7 +331,7 @@ export default function TierListBuilder({ entityType, entities, initial }: Props
 
   async function handleSave() {
     if (!user) {
-      loginSteam();
+      window.location.href = loginSteam;
       return;
     }
     setSaving(true);

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -468,13 +468,13 @@ export default function Navbar() {
                   className="absolute right-0 top-full mt-2 w-44 max-w-[calc(100vw-1rem)] rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-primary)] shadow-xl shadow-black/30 p-1.5 z-50"
                 >
                   <p className="px-2.5 py-1.5 text-xs text-[var(--text-tertiary)] font-medium">{t("Sign in with")}</p>
-                  <button
-                    onClick={() => { setUserMenuOpen(false); loginSteam(); }}
-                    className="w-full flex items-center gap-2 px-2.5 py-2 text-sm rounded-md hover:bg-[var(--bg-card)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
-                  >
+                  <a
+                    href={loginSteam}
+                    onClick={() => setUserMenuOpen(false)}
+                    className="w-full flex items-center gap-2 px-2.5 py-2 text-sm rounded-md hover:bg-[var(--bg-card)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors">
                     <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="currentColor"><path d="M11.979 0C5.678 0 .511 4.86.022 11.037l6.432 2.658a3.387 3.387 0 0 1 1.912-.593c.064 0 .127.003.19.007l2.862-4.146v-.058a4.533 4.533 0 0 1 4.53-4.53 4.533 4.533 0 0 1 4.53 4.53 4.533 4.533 0 0 1-4.53 4.53h-.106l-4.08 2.91c0 .053.003.107.003.161a3.4 3.4 0 0 1-3.4 3.4 3.404 3.404 0 0 1-3.367-2.936L.256 15.21C1.542 20.2 6.218 24 11.979 24 18.627 24 24 18.627 24 11.979 24 5.373 18.627 0 11.979 0z"/></svg>
                     Steam
-                  </button>
+                  </a>
                 </div>
               )}
 

--- a/frontend/app/contexts/AuthContext.tsx
+++ b/frontend/app/contexts/AuthContext.tsx
@@ -23,21 +23,25 @@ interface User {
 interface AuthContextType {
   user: User | null;
   loading: boolean;
-  loginSteam: () => void;
-  loginDiscord: () => void;
-  loginTwitch: () => void;
-  loginPatreon: () => void;
+  loginSteam: string;
+  loginDiscord: string;
+  loginTwitch: string;
+  loginPatreon: string;
   logout: () => Promise<void>;
   refresh: () => Promise<void>;
 }
 
+const LOGIN_URLS = {
+  loginSteam: `${API_BASE}/api/auth/steam/redirect`,
+  loginDiscord: `${API_BASE}/api/auth/discord/start`,
+  loginTwitch: `${API_BASE}/api/auth/twitch/start`,
+  loginPatreon: `${API_BASE}/api/auth/patreon/start`,
+};
+
 const AuthContext = createContext<AuthContextType>({
+  ...LOGIN_URLS,
   user: null,
   loading: true,
-  loginSteam: () => {},
-  loginDiscord: () => {},
-  loginTwitch: () => {},
-  loginPatreon: () => {},
   logout: async () => {},
   refresh: async () => {},
 });
@@ -105,23 +109,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const loginSteam = useCallback(() => {
-    // Always use redirect flow -- popups are unreliable on mobile
-    // and get blocked by many browsers
-    window.location.href = `${API_BASE}/api/auth/steam/redirect`;
-  }, []);
-
-  const loginDiscord = useCallback(() => {
-    window.location.href = `${API_BASE}/api/auth/discord/start`;
-  }, []);
-
-  const loginTwitch = useCallback(() => {
-    window.location.href = `${API_BASE}/api/auth/twitch/start`;
-  }, []);
-
-  const loginPatreon = useCallback(() => {
-    window.location.href = `${API_BASE}/api/auth/patreon/start`;
-  }, []);
 
   const logout = useCallback(async () => {
     localStorage.removeItem("spire_token");
@@ -138,7 +125,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ user, loading, loginSteam, loginDiscord, loginTwitch, loginPatreon, logout, refresh: fetchMe }}
+      value={{ ...LOGIN_URLS, user, loading, logout, refresh: fetchMe }}
     >
       {children}
     </AuthContext.Provider>


### PR DESCRIPTION
Rebase of #1032 onto main after the next-intl move, with the review fixes: the four providers get their own URLs, the stray node:fs import is gone, and the tier-list save handler keeps its button. Commit authored by MarcosCosmos. Closes #1030.