### PR TITLE
Report the real stats cursor on pulse, and stop adding unrebased hot runs

### DIFF
--- a/backend/app/routers/runs.py
+++ b/backend/app/routers/runs.py
@@ -1302,9 +1302,10 @@ def runs_snapshot_status(request: Request, response: Response):
 @router.get("/pulse", tags=["Runs"])
 @limiter.limit(rate_limit_config.endpoint_limit("runs.runs_pulse", "240/minute"))
 def runs_pulse(request: Request, response: Response):
-    """Live community totals: the snapshot baseline plus the hot overlay's
-    counters, which update within milliseconds of each accepted upload.
-    5s shared cache so the edge absorbs all polling."""
+    """Community totals as of the store cursor, plus the hot overlay's
+    counters. The hot counters are reported, not added: nothing rebases them
+    against the store yet, so adding them counts every upload since the
+    cursor a second time. 5s shared cache so the edge absorbs all polling."""
     response.headers["Cache-Control"] = "public, max-age=5, s-maxage=5"
     from ..services.live_overlay import hot_totals
     from ..services.run_entity_stats import global_totals
@@ -1313,8 +1314,8 @@ def runs_pulse(request: Request, response: Response):
     hot = hot_totals()
     st = snapshot_status()
     return {
-        "total_runs": (base.get("total_runs") or 0) + hot.get("runs", 0),
-        "total_wins": (base.get("total_wins") or 0) + hot.get("wins", 0),
+        "total_runs": base.get("total_runs") or 0,
+        "total_wins": base.get("total_wins") or 0,
         "hot_runs": hot.get("runs", 0),
         "data_through": st.get("data_through"),
     }

--- a/backend/app/services/run_entity_stats.py
+++ b/backend/app/services/run_entity_stats.py
@@ -2170,14 +2170,36 @@ def snapshot_status() -> dict[str, Any]:
     """Cheap in-memory status so the UI can tell "no data" apart from
     "warming up after a deploy". Lake-era: the only warm-up is the entity
     overlay loading from the pulled artifacts."""
+    data_through = (
+        _data_through[0].isoformat()
+        if _data_through and hasattr(_data_through[0], "isoformat")
+        else None
+    )
+    if data_through is None:
+        data_through = _lake_data_through()
     return {
         "building": not _cache,
         "built_at": _cache_built_at or None,
-        "data_through": _data_through[0].isoformat()
-        if _data_through and hasattr(_data_through[0], "isoformat")
-        else None,
+        "data_through": data_through,
         "total_runs": (_global_totals or {}).get("total_runs", 0),
     }
+
+
+def _lake_data_through() -> str | None:
+    """The ingest-built store's cursor, then the cube's. The snapshot-era
+    `_data_through` is never set now that the lake builds the stats."""
+    try:
+        from . import lake_stats
+
+        for hit in (
+            lake_stats.entity_store_with_mtime(),
+            lake_stats._entity_cube_with_mtime(),
+        ):
+            if hit and hit[1].get("data_through"):
+                return str(hit[1]["data_through"])
+    except Exception:
+        logger.warning("lake data_through read failed", exc_info=True)
+    return None
 
 
 _lake_overlay_mtime = 0.0

--- a/backend/tests/test_pulse_cursor.py
+++ b/backend/tests/test_pulse_cursor.py
@@ -1,0 +1,60 @@
+"""/api/runs/pulse reported data_through: null on prod and a total that was
+about 8% high. The cursor was read from a snapshot-era variable nothing sets
+now that the lake builds the stats, and the hot overlay's counters were added
+to the store total even though nothing rebases them against it."""
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.routers import runs as runs_router
+from app.services import lake_stats, live_overlay
+from app.services import run_entity_stats as res
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def test_status_reads_the_store_cursor_when_the_snapshot_has_none(monkeypatch):
+    monkeypatch.setattr(res, "_data_through", None)
+    monkeypatch.setattr(
+        lake_stats,
+        "entity_store_with_mtime",
+        lambda: (1.0, {"data_through": "2026-09-09 12:24:30.722000"}),
+    )
+    assert res.snapshot_status()["data_through"] == "2026-09-09 12:24:30.722000"
+
+
+def test_status_falls_back_to_the_cube_cursor(monkeypatch):
+    monkeypatch.setattr(res, "_data_through", None)
+    monkeypatch.setattr(lake_stats, "entity_store_with_mtime", lambda: None)
+    monkeypatch.setattr(
+        lake_stats,
+        "_entity_cube_with_mtime",
+        lambda: (1.0, {"data_through": "2026-09-09 11:00:00"}),
+    )
+    assert res.snapshot_status()["data_through"] == "2026-09-09 11:00:00"
+
+
+def test_status_stays_null_without_any_cursor(monkeypatch):
+    monkeypatch.setattr(res, "_data_through", None)
+    monkeypatch.setattr(lake_stats, "entity_store_with_mtime", lambda: None)
+    monkeypatch.setattr(lake_stats, "_entity_cube_with_mtime", lambda: None)
+    assert res.snapshot_status()["data_through"] is None
+
+
+def test_pulse_reports_hot_runs_without_adding_them(monkeypatch):
+    monkeypatch.setattr(
+        res, "global_totals", lambda: {"total_runs": 1000, "total_wins": 300}
+    )
+    monkeypatch.setattr(
+        live_overlay, "hot_totals", lambda: {"runs": 126520, "wins": 40000}
+    )
+    monkeypatch.setattr(
+        runs_router, "snapshot_status", lambda: {"data_through": "2026-09-09 12:24:30"}
+    )
+    r = client.get("/api/runs/pulse")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total_runs"] == 1000
+    assert body["total_wins"] == 300
+    assert body["hot_runs"] == 126520
+    assert body["data_through"] == "2026-09-09 12:24:30"

--- a/frontend/app/[locale]/leaderboards/metrics/metrics-data.ts
+++ b/frontend/app/[locale]/leaderboards/metrics/metrics-data.ts
@@ -32,6 +32,7 @@ interface ApiMetricRow {
 
 interface MetricsResponse {
   entity_type: string;
+  bracket?: string;
   baseline_win_rate: number;
   total_runs: number;
   rows: ApiMetricRow[];
@@ -69,7 +70,7 @@ export const BRACKETS = [
 // those in addition to the single brackets above.
 const _PLAYER_KEYS = ["solo", "2p", "3p", "4p"];
 const _SKILL_KEYS = ["a10", "wr30", "wr50", "wr75"];
-function isValidBracket(b: string): boolean {
+export function isValidBracket(b: string): boolean {
   // A trailing ":vX.Y.Z" version segment composes with any base (v20
   // snapshots), and a bare version stands alone. Without this the server
   // silently normalized version brackets to "all", so the dropdown wrote
@@ -81,8 +82,8 @@ function isValidBracket(b: string): boolean {
     return true;
   }
   if (BRACKETS.some((c) => c.key === b)) return true;
-  const [p, s] = b.split(":");
-  return _PLAYER_KEYS.includes(p) && _SKILL_KEYS.includes(s);
+  const parts = b.split(":");
+  return parts.length === 2 && _PLAYER_KEYS.includes(parts[0]) && _SKILL_KEYS.includes(parts[1]);
 }
 
 // Fetch + join the metrics table with card metadata. Shared by the base
@@ -144,7 +145,7 @@ export async function loadMetrics(
     rows,
     baselineWinRate: metrics?.baseline_win_rate ?? 0,
     totalRuns: metrics?.total_runs ?? 0,
-    bracket: valid,
+    bracket: metrics?.bracket || valid,
     character: char,
   };
 }

--- a/frontend/lib/metrics-bracket.test.ts
+++ b/frontend/lib/metrics-bracket.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isValidBracket } from "@/app/[locale]/leaderboards/metrics/metrics-data";
+
+describe("metrics bracket validation", () => {
+  it("accepts the keys the page offers", () => {
+    for (const k of ["all", "solo", "a10", "wr30", "solo:wr30", "4p:a10", "v0.111.0", "solo:a10:v0.111.0"]) {
+      expect(isValidBracket(k)).toBe(true);
+    }
+  });
+
+  it("rejects a second skill tier or trailing junk, which the API would quietly serve as all runs", () => {
+    // The old check only looked at the first two parts, so "solo:a10:wr30"
+    // passed, the API fell back to every run, and the page labelled that as
+    // solo A10 over 30% win rate.
+    expect(isValidBracket("solo:a10:wr30")).toBe(false);
+    expect(isValidBracket("solo:a10:garbage")).toBe(false);
+    expect(isValidBracket("bogus:bracket")).toBe(false);
+  });
+});


### PR DESCRIPTION
Pulse returned data_through null because it read a snapshot-era variable nothing sets anymore, and its total was about 8% high because it added the hot overlay's counters, which nothing rebases (rebase_after_persist has no caller and every upload refreshes the TTL). I made the status fall back to the lake store's cursor and made pulse report the hot count without adding it; on the metrics page I tightened the bracket validator so a key like solo:a10:wr30 no longer shows all-runs data under a specific label.