### PR TITLE
Accept replay versions 2 through 4 on upload

### DIFF
--- a/backend/app/services/replays_db.py
+++ b/backend/app/services/replays_db.py
@@ -29,7 +29,7 @@ REPLAY_DB_NAME = os.environ.get("REPLAY_DB_NAME", "spire_replays")
 MAX_GZ_BYTES = int(os.environ.get("REPLAY_MAX_GZ_BYTES", "") or 2 * 1024 * 1024)
 MAX_RAW_BYTES = int(os.environ.get("REPLAY_MAX_RAW_BYTES", "") or 16 * 1024 * 1024)
 MAX_LINES = int(os.environ.get("REPLAY_MAX_LINES", "") or 200_000)
-KNOWN_REPLAY_VERSIONS = frozenset({1})
+KNOWN_REPLAY_VERSIONS = frozenset({1, 2, 3, 4})
 GZIP_MAGIC = b"\x1f\x8b"
 
 _coll_cache = None

--- a/backend/tests/test_replays_api.py
+++ b/backend/tests/test_replays_api.py
@@ -196,6 +196,21 @@ def test_header_must_match_the_run(env):
     assert _post(_gz(lines[1:2] + lines)).status_code == 400
 
 
+def test_every_shipped_replay_version_passes_the_header_check():
+    from app.services import replays_db
+
+    for version in (1, 2, 3, 4):
+        header = json.dumps(
+            {"t": "header", "replay_version": version, "seed": "S"}
+        ).encode()
+        assert replays_db._parse_header(header)["replay_version"] == version
+    with pytest.raises(replays_db.ReplayRejected) as rejected:
+        replays_db._parse_header(
+            json.dumps({"t": "header", "replay_version": 5}).encode()
+        )
+    assert rejected.value.code == "bad_header"
+
+
 def test_caps_are_enforced_on_decompressed_output(env, monkeypatch):
     monkeypatch.setattr(replays_db, "MAX_LINES", 10)
     assert _post(_gz()).status_code == 413


### PR DESCRIPTION
Fixes replay uploads failing with bad_header since the recorder moved past version 1: the upload validator now accepts every replay version the viewer reads, 1 through 4.