### PR TITLE
Build the player-count stat slices from the lake

### DIFF
--- a/backend/app/services/lake_stats.py
+++ b/backend/app/services/lake_stats.py
@@ -1915,6 +1915,20 @@ def bracket_elo_for(bracket: str | None) -> dict | None:
 # ── Stats-summary core: the homepage numbers, from the lake ──────────────────
 
 
+def _players_match(pc: int, players: str | None) -> bool:
+    """The stats page's player-count filter against a run's party size,
+    clamped to 4 the way _build_match clamps it (4 means four or more)."""
+    if players is None:
+        return True
+    if players in ("single", "1"):
+        return pc == 1
+    if players == "4":
+        return pc >= 4
+    if players == "multi":
+        return pc > 1
+    return pc == int(players)
+
+
 def _stats_core_results() -> list[tuple[dict, dict]]:
     """(filters, core-result) for every materialized stats combo, computed
     from one pass over runs.parquet with get_stats' core semantics:
@@ -1926,6 +1940,7 @@ def _stats_core_results() -> list[tuple[dict, dict]]:
         ASCENSION_FILTER_COMBOS,
         HOT_FILTER_COMBOS,
         OFFICIAL_CHARACTERS,
+        PLAYERS_FILTER_COMBOS,
     )
 
     con = _connect()
@@ -1934,13 +1949,14 @@ def _stats_core_results() -> list[tuple[dict, dict]]:
             f"""
             SELECT coalesce(upper(r.character), '') AS ch,
               coalesce(r.ascension, 0)::INT AS asc,
+              least(coalesce(r.player_count, 1), 4)::INT AS pc,
               count(*) AS n, count(*) FILTER (r.win) AS w,
               count(*) FILTER (r.was_abandoned) AS ab
             FROM read_parquet('{LAKE_DIR}/runs.parquet') r
             ANTI JOIN read_parquet('{LAKE_DIR}/excluded.parquet') x
               ON r.run_hash = x.run_hash
             WHERE r.ascension BETWEEN 0 AND 10
-            GROUP BY 1, 2
+            GROUP BY 1, 2, 3
             """
         ).fetchall()
     finally:
@@ -1955,41 +1971,48 @@ def _stats_core_results() -> list[tuple[dict, dict]]:
     # table; abandons stay their own visible number, never folded into
     # losses; win_rate remains wins over total attempts.
     cells = [c for c in cells if c[0] in OFFICIAL_CHARACTERS]
-    for f in [*HOT_FILTER_COMBOS, *ASCENSION_FILTER_COMBOS]:
+    for f in [*HOT_FILTER_COMBOS, *ASCENSION_FILTER_COMBOS, *PLAYERS_FILTER_COMBOS]:
         char_f = f.get("character")
         asc_f = int(f["ascension"]) if "ascension" in f else None
+        pl_f = f.get("players")
         filters = {
             "character": char_f,
             "win": None,
             "ascension": f.get("ascension"),
             "game_mode": None,
-            "players": None,
+            "players": pl_f,
             "username": None,
         }
         rows = [
             c
             for c in cells
-            if (char_f is None or c[0] == char_f) and (asc_f is None or c[1] == asc_f)
+            if (char_f is None or c[0] == char_f)
+            and (asc_f is None or c[1] == asc_f)
+            and _players_match(c[2], pl_f)
         ]
-        total = sum(c[2] for c in rows)
+        total = sum(c[3] for c in rows)
         if total == 0:
             out.append((f, {"total_runs": 0, "filters": filters}))
             continue
-        wins = sum(c[3] for c in rows)
-        abandoned = sum(c[4] for c in rows)
-        no_char = [c for c in cells if asc_f is None or c[1] == asc_f]
+        wins = sum(c[4] for c in rows)
+        abandoned = sum(c[5] for c in rows)
+        no_char = [
+            c
+            for c in cells
+            if (asc_f is None or c[1] == asc_f) and _players_match(c[2], pl_f)
+        ]
         char_totals: dict[str, list[int]] = {}
         for c in no_char:
             rec = char_totals.setdefault(c[0], [0, 0, 0])
-            rec[0] += c[2]
-            rec[1] += c[3]
-            rec[2] += c[4]
+            rec[0] += c[3]
+            rec[1] += c[4]
+            rec[2] += c[5]
         asc_totals: dict[int, list[int]] = {}
         for c in rows:
             rec = asc_totals.setdefault(c[1], [0, 0, 0])
-            rec[0] += c[2]
-            rec[1] += c[3]
-            rec[2] += c[4]
+            rec[0] += c[3]
+            rec[1] += c[4]
+            rec[2] += c[5]
         out.append(
             (
                 f,
@@ -2093,17 +2116,19 @@ def _parquet_columns(con, name: str) -> set[str]:
     return {d[0] for d in res.description}
 
 
-def _fold_deep(rows, char_f, asc_f, official):
-    """Sum grouped (character, ascension, key, *counts) rows into one combo's
-    {key: (counts...)} map. The official filter applies even unfiltered,
-    matching get_stats' _build_match."""
+def _fold_deep(rows, char_f, asc_f, official, pl_f=None):
+    """Sum grouped (character, ascension, party size, key, *counts) rows into
+    one combo's {key: (counts...)} map. The official filter applies even
+    unfiltered, matching get_stats' _build_match."""
     out: dict[str, list[int]] = {}
-    for ch, a, key, *counts in rows:
+    for ch, a, pc, key, *counts in rows:
         if ch not in official:
             continue
         if char_f is not None and ch != char_f:
             continue
         if asc_f is not None and a != asc_f:
+            continue
+        if not _players_match(pc, pl_f):
             continue
         if key is None:
             continue
@@ -2127,6 +2152,7 @@ def build_deep_tables() -> int:
         ASCENSION_FILTER_COMBOS,
         HOT_FILTER_COMBOS,
         OFFICIAL_CHARACTERS,
+        PLAYERS_FILTER_COMBOS,
     )
 
     if not available():
@@ -2142,6 +2168,7 @@ def build_deep_tables() -> int:
             f"""
             SELECT coalesce(upper(r.character), '') AS ch,
               coalesce(r.ascension, 0)::INT AS a,
+              least(coalesce(r.player_count, 1), 4)::INT AS pc,
               coalesce(r.killed_by_encounter, r.killed_by_event) AS kb,
               count(*) AS n
             FROM {runs_p} r
@@ -2153,38 +2180,40 @@ def build_deep_tables() -> int:
               -- counting it crowned "NONE" the deadliest encounter.
               AND coalesce(r.killed_by_encounter, r.killed_by_event)
                   NOT IN ('NONE', '')
-            GROUP BY 1, 2, 3
+            GROUP BY 1, 2, 3, 4
             """
         ).fetchall()
         picks = con.execute(
             f"""
             SELECT p.character AS ch, coalesce(r.ascension, 0)::INT AS a,
+              least(coalesce(r.player_count, 1), 4)::INT AS pc,
               c.cid, count(*) AS offered, count(*) FILTER (c.picked) AS picked
             FROM choice_rows c
             JOIN {players_p} p
               ON c.run_hash = p.run_hash AND c.pidx = p.player_idx
             JOIN {runs_p} r ON c.run_hash = r.run_hash
-            GROUP BY 1, 2, 3
+            GROUP BY 1, 2, 3, 4
             """
         ).fetchall()
 
         def item_rows(table: str, col: str):
             return con.execute(
                 f"""
-                SELECT ch, a, item, sum(copies)::BIGINT,
+                SELECT ch, a, pc, item, sum(copies)::BIGINT,
                   coalesce(sum(copies) FILTER (win), 0)::BIGINT,
                   coalesce(sum(copies) FILTER (NOT win), 0)::BIGINT,
                   count(*)::BIGINT, count(*) FILTER (win)::BIGINT
                 FROM (
                   SELECT d.character AS ch, coalesce(r.ascension, 0)::INT AS a,
+                    least(coalesce(r.player_count, 1), 4)::INT AS pc,
                     d.{col} AS item, d.run_hash, d.player_idx,
                     count(*) AS copies, bool_or(coalesce(r.win, false)) AS win
                   FROM read_parquet('{LAKE_DIR}/{table}.parquet') d
                   JOIN {runs_p} r ON d.run_hash = r.run_hash
                   ANTI JOIN {excl_p} x ON d.run_hash = x.run_hash
                   WHERE r.ascension BETWEEN 0 AND 10 AND d.{col} IS NOT NULL
-                  GROUP BY 1, 2, 3, d.run_hash, d.player_idx
-                ) GROUP BY 1, 2, 3
+                  GROUP BY 1, 2, 3, 4, d.run_hash, d.player_idx
+                ) GROUP BY 1, 2, 3, 4
                 """
             ).fetchall()
 
@@ -2200,12 +2229,13 @@ def build_deep_tables() -> int:
             used = con.execute(
                 f"""
                 SELECT d.character AS ch, coalesce(r.ascension, 0)::INT AS a,
+                  least(coalesce(r.player_count, 1), 4)::INT AS pc,
                   d.potion AS item, count(*) FILTER (d.was_used)::BIGINT AS used
                 FROM read_parquet('{LAKE_DIR}/potions.parquet') d
                 JOIN {runs_p} r ON d.run_hash = r.run_hash
                 ANTI JOIN {excl_p} x ON d.run_hash = x.run_hash
                 WHERE r.ascension BETWEEN 0 AND 10
-                GROUP BY 1, 2, 3
+                GROUP BY 1, 2, 3, 4
                 """
             ).fetchall()
         shop = []
@@ -2213,6 +2243,7 @@ def build_deep_tables() -> int:
             shop = con.execute(
                 f"""
                 SELECT p.character AS ch, coalesce(r.ascension, 0)::INT AS a,
+                  least(coalesce(r.player_count, 1), 4)::INT AS pc,
                   s.potion AS item, count(*) AS offered,
                   count(*) FILTER (s.was_picked)::BIGINT AS picked
                 FROM read_parquet('{LAKE_DIR}/shop_potions.parquet') s
@@ -2221,7 +2252,7 @@ def build_deep_tables() -> int:
                 JOIN {runs_p} r ON s.run_hash = r.run_hash
                 ANTI JOIN {excl_p} x ON s.run_hash = x.run_hash
                 WHERE r.ascension BETWEEN 0 AND 10
-                GROUP BY 1, 2, 3
+                GROUP BY 1, 2, 3, 4
                 """
             ).fetchall()
     finally:
@@ -2232,13 +2263,14 @@ def build_deep_tables() -> int:
 
     official = frozenset(OFFICIAL_CHARACTERS)
     combos = []
-    for f in [*HOT_FILTER_COMBOS, *ASCENSION_FILTER_COMBOS]:
+    for f in [*HOT_FILTER_COMBOS, *ASCENSION_FILTER_COMBOS, *PLAYERS_FILTER_COMBOS]:
         char_f = f.get("character")
         asc_f = int(f["ascension"]) if "ascension" in f else None
-        d = _fold_deep(deaths, char_f, asc_f, official)
-        pk = _fold_deep(picks, char_f, asc_f, official)
-        cd = _fold_deep(cards, char_f, asc_f, official)
-        rl = _fold_deep(relics, char_f, asc_f, official)
+        pl_f = f.get("players")
+        d = _fold_deep(deaths, char_f, asc_f, official, pl_f)
+        pk = _fold_deep(picks, char_f, asc_f, official, pl_f)
+        cd = _fold_deep(cards, char_f, asc_f, official, pl_f)
+        rl = _fold_deep(relics, char_f, asc_f, official, pl_f)
         tables: dict = {
             "deadliest": [
                 {"encounter": k, "count": v[0]}
@@ -2275,9 +2307,9 @@ def build_deep_tables() -> int:
             ],
         }
         if shop and used:
-            po = _fold_deep(potions_owned, char_f, asc_f, official)
-            us = _fold_deep(used, char_f, asc_f, official)
-            sh = _fold_deep(shop, char_f, asc_f, official)
+            po = _fold_deep(potions_owned, char_f, asc_f, official, pl_f)
+            us = _fold_deep(used, char_f, asc_f, official, pl_f)
+            sh = _fold_deep(shop, char_f, asc_f, official, pl_f)
             tables["top_potions"] = [
                 {
                     "potion_id": k,

--- a/backend/app/services/runs_db_mongo.py
+++ b/backend/app/services/runs_db_mongo.py
@@ -1937,8 +1937,23 @@ _ASCENSION_COMBOS_PER_CYCLE = 2
 
 # Every combo the refresher owns. Reads serve these regardless of age — a
 # minutes-stale doc beats recomputing a multi-aggregation inline.
+# Third tier: the player-count axis the stats page offers (Solo, 2P, 3P, 4P+),
+# alone, per character, and per ascension. Any of these on the live path scans
+# the whole collection and dies at the 20 s cap, so they are lake-built like
+# the ascension slices.
+PLAYERS_FILTER_COMBOS: list[dict] = [
+    {**({"character": c} if c else {}), "players": p}
+    for p in ("1", "2", "3", "4")
+    for c in (None, "IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT")
+] + [
+    {"players": p, "ascension": str(a)}
+    for p in ("1", "2", "3", "4")
+    for a in range(0, 11)
+]
+
 MATERIALIZED_STATS_KEYS = frozenset(
-    _filter_key(**f) for f in (*HOT_FILTER_COMBOS, *ASCENSION_FILTER_COMBOS)
+    _filter_key(**f)
+    for f in (*HOT_FILTER_COMBOS, *ASCENSION_FILTER_COMBOS, *PLAYERS_FILTER_COMBOS)
 )
 
 

--- a/backend/tests/test_deep_tables.py
+++ b/backend/tests/test_deep_tables.py
@@ -8,17 +8,21 @@ from app.services import lake_stats as ls
 
 def test_fold_deep_filters_and_sums():
     rows = [
-        ("IRONCLAD", 10, "STRIKE", 4, 2),
-        ("IRONCLAD", 3, "STRIKE", 2, 1),
-        ("SILENT", 10, "STRIKE", 1, 1),
-        ("MODDED_GUY", 10, "STRIKE", 50, 50),
-        ("IRONCLAD", 10, None, 9, 9),
+        ("IRONCLAD", 10, 1, "STRIKE", 4, 2),
+        ("IRONCLAD", 3, 2, "STRIKE", 2, 1),
+        ("SILENT", 10, 4, "STRIKE", 1, 1),
+        ("MODDED_GUY", 10, 1, "STRIKE", 50, 50),
+        ("IRONCLAD", 10, 1, None, 9, 9),
     ]
     official = frozenset({"IRONCLAD", "SILENT"})
     assert ls._fold_deep(rows, None, None, official) == {"STRIKE": [7, 4]}
     assert ls._fold_deep(rows, "IRONCLAD", None, official) == {"STRIKE": [6, 3]}
     assert ls._fold_deep(rows, None, 10, official) == {"STRIKE": [5, 3]}
     assert ls._fold_deep(rows, "SILENT", 3, official) == {}
+    assert ls._fold_deep(rows, None, None, official, "1") == {"STRIKE": [4, 2]}
+    assert ls._fold_deep(rows, None, None, official, "2") == {"STRIKE": [2, 1]}
+    assert ls._fold_deep(rows, None, None, official, "4") == {"STRIKE": [1, 1]}
+    assert ls._fold_deep(rows, None, None, official, "multi") == {"STRIKE": [3, 2]}
 
 
 @pytest.fixture()
@@ -27,11 +31,11 @@ def tiny_lake(tmp_path, monkeypatch):
     # r1 IRONCLAD a10 win; r2 SILENT a10 loss (killed); r3 hidden -> excluded.
     con.execute(
         f"""COPY (SELECT * FROM (VALUES
-        ('r1', 'IRONCLAD', true, 10, false, NULL::VARCHAR, NULL::VARCHAR),
-        ('r2', 'SILENT', false, 10, false, 'JAW_WORM', NULL::VARCHAR),
-        ('r3', 'IRONCLAD', true, 10, false, NULL::VARCHAR, NULL::VARCHAR))
+        ('r1', 'IRONCLAD', true, 10, false, NULL::VARCHAR, NULL::VARCHAR, 1),
+        ('r2', 'SILENT', false, 10, false, 'JAW_WORM', NULL::VARCHAR, 2),
+        ('r3', 'IRONCLAD', true, 10, false, NULL::VARCHAR, NULL::VARCHAR, 1))
         t(run_hash, character, win, ascension, was_abandoned,
-          killed_by_encounter, killed_by_event))
+          killed_by_encounter, killed_by_event, player_count))
         TO '{tmp_path}/runs.parquet' (FORMAT parquet)"""
     )
     con.execute(
@@ -140,3 +144,23 @@ def test_build_deep_tables_end_to_end(tiny_lake, monkeypatch):
 def test_deep_tables_by_key_missing_artifact(tmp_path, monkeypatch):
     monkeypatch.setattr(ls, "LAKE_DIR", tmp_path)
     assert ls.deep_tables_by_key() == {}
+
+
+def test_player_count_slices_are_built_from_the_same_pass(tiny_lake, monkeypatch):
+    import json
+
+    monkeypatch.setattr(ls, "available", lambda *a: True)
+    ls.build_deep_tables()
+    doc = json.loads((tiny_lake / "deep_tables.json").read_text())
+    two = _tables(doc, {"players": "2"})
+    assert [r["card_id"] for r in two["top_cards"]] == ["STRIKE"]
+    assert two["top_cards"][0]["count"] == 1 and two["top_cards"][0]["in_losses"] == 1
+    assert two["deadliest"] == [{"encounter": "JAW_WORM", "count": 1}]
+    assert two["top_relics"] == []
+    solo = _tables(doc, {"players": "1"})
+    assert solo["top_cards"][0]["count"] == 2 and solo["deadliest"] == []
+    assert _tables(doc, {"players": "4"})["top_cards"] == []
+    assert (
+        _tables(doc, {"players": "2", "character": "SILENT"})["top_cards"][0]["count"]
+        == 1
+    )

--- a/backend/tests/test_lake_stats.py
+++ b/backend/tests/test_lake_stats.py
@@ -72,9 +72,9 @@ def test_lake_entity_overlay(monkeypatch, tmp_path):
 
 def test_stats_core_excludes_modded_characters(monkeypatch):
     cells = [
-        ("IRONCLAD", 0, 100, 30, 5),
-        ("SILENT", 10, 50, 20, 2),
-        ("THE_MODDED_ONE", 0, 40, 39, 0),
+        ("IRONCLAD", 0, 1, 100, 30, 5),
+        ("SILENT", 10, 2, 50, 20, 2),
+        ("THE_MODDED_ONE", 0, 1, 40, 39, 0),
     ]
     monkeypatch.setattr(lake_stats, "_connect", lambda build=False: None)
 
@@ -98,6 +98,13 @@ def test_stats_core_excludes_modded_characters(monkeypatch):
     assert g["total_wins"] == 50
     assert sum(c["total"] for c in g["characters"]) == g["total_runs"]
     assert all("abandoned" in c for c in g["characters"])
+    two = results[(("players", "2"),)]
+    assert two["total_runs"] == 50 and two["total_wins"] == 20
+    assert [c["character"] for c in two["characters"]] == ["SILENT"]
+    assert two["filters"]["players"] == "2"
+    assert results[(("players", "4"),)]["total_runs"] == 0
+    solo_a0 = results[(("ascension", "0"), ("players", "1"))]
+    assert solo_a0["total_runs"] == 100
 
 
 def test_encounter_blob_keys_fold():

--- a/backend/tests/test_stats_players_combos.py
+++ b/backend/tests/test_stats_players_combos.py
@@ -1,0 +1,38 @@
+"""Player-count stat slices must never compute on the request path: any
+players filter on the live aggregation scans the whole collection and dies
+at the 20 s cap, so the lake builds them and reads serve them at any age."""
+
+from datetime import datetime, timedelta, timezone
+
+from app.services import runs_db_mongo
+from app.services.runs_db_mongo import (
+    MATERIALIZED_STATS_KEYS,
+    PLAYERS_FILTER_COMBOS,
+    _filter_key,
+)
+
+
+def test_every_player_count_slice_is_materialized():
+    assert len(PLAYERS_FILTER_COMBOS) == 4 * 6 + 4 * 11
+    for p in ("1", "2", "3", "4"):
+        for c in (None, "IRONCLAD", "SILENT", "DEFECT", "NECROBINDER", "REGENT"):
+            assert _filter_key(character=c, players=p) in MATERIALIZED_STATS_KEYS
+        for a in range(11):
+            assert _filter_key(players=p, ascension=str(a)) in MATERIALIZED_STATS_KEYS
+
+
+class _FakeSummaryColl:
+    def __init__(self, doc):
+        self.doc = doc
+
+    def find_one(self, q):
+        return dict(self.doc) if q.get("_id") == self.doc["_id"] else None
+
+
+def test_reader_serves_a_stale_player_count_doc(monkeypatch):
+    old = datetime.now(timezone.utc) - timedelta(hours=6)
+    key = _filter_key(players="2")
+    fake = _FakeSummaryColl({"_id": key, "updated_at": old, "total_runs": 77})
+    monkeypatch.setattr(runs_db_mongo, "_summary_coll", lambda: fake)
+    out = runs_db_mongo.read_stats_summary(players="2")
+    assert out is not None and out["total_runs"] == 77


### PR DESCRIPTION
Fixes the stats page showing nothing for a player-count filter: those slices ran a live aggregation over every run and timed out, so they are now materialized from the lake like the ascension slices, alone, per character, and per ascension.